### PR TITLE
esm: bypass CJS loader in default load under `--default-type=module`

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -610,19 +610,21 @@ not possible to replace the value of a Node.js builtin (core) module.
 
 Omitting vs providing a `source` for `'commonjs'` has very different effects:
 
-* When a `source` is provided, all `require` calls from this module will be
-  processed by the ESM loader with registered `resolve` and `load` hooks; all
-  `require.resolve` calls from this module will be processed by the ESM loader
-  with registered `resolve` hooks; only a subset of the CommonJS API will be
-  available (e.g. no `require.extensions`, no `require.cache`, no
+* When a `source` is provided, or when running `node` with
+  `--experimental-default-type=module`, all `require` calls from this module
+  will be processed by the ESM loader with registered `resolve` and `load`
+  hooks; all `require.resolve` calls from this module will be processed by the
+  ESM loader with registered `resolve` hooks; only a subset of the CommonJS API
+  will be available (e.g. no `require.extensions`, no `require.cache`, no
   `require.resolve.paths`) and monkey-patching on the CommonJS module loader
   will not apply.
-* If `source` is undefined or `null`, it will be handled by the CommonJS module
-  loader and `require`/`require.resolve` calls will not go through the
-  registered hooks. This behavior for nullish `source` is temporary — in the
-  future, nullish `source` will not be supported.
+* If `source` is undefined or `null`, and `node` is run with
+  `--experimental-default-type=commonjs`, it will be handled by the CommonJS
+  module loader and `require`/`require.resolve` calls will not go through the
+  registered hooks.
 
-The Node.js internal `load` implementation, which is the value of `next` for the
+When `node` is run with `--experimental-default-type=commonjs`, the Node.js
+internal `load` implementation, which is the value of `next` for the
 last hook in the `load` chain, returns `null` for `source` when `format` is
 `'commonjs'` for backward compatibility. Here is an example hook that would
 opt-in to using the non-default behavior:

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -610,18 +610,17 @@ not possible to replace the value of a Node.js builtin (core) module.
 
 Omitting vs providing a `source` for `'commonjs'` has very different effects:
 
-* When a `source` is provided, or when running `node` with
-  `--experimental-default-type=module`, all `require` calls from this module
-  will be processed by the ESM loader with registered `resolve` and `load`
-  hooks; all `require.resolve` calls from this module will be processed by the
-  ESM loader with registered `resolve` hooks; only a subset of the CommonJS API
-  will be available (e.g. no `require.extensions`, no `require.cache`, no
+* When a `source` is provided, all `require` calls from this module will be
+  processed by the ESM loader with registered `resolve` and `load` hooks; all
+  `require.resolve` calls from this module will be processed by the ESM loader
+  with registered `resolve` hooks; only a subset of the CommonJS API will be
+  available (e.g. no `require.extensions`, no `require.cache`, no
   `require.resolve.paths`) and monkey-patching on the CommonJS module loader
   will not apply.
-* If `source` is undefined or `null`, and `node` is run with
-  `--experimental-default-type=commonjs`, it will be handled by the CommonJS
-  module loader and `require`/`require.resolve` calls will not go through the
-  registered hooks.
+* If `source` is undefined or `null`, it will be handled by the CommonJS module
+  loader and `require`/`require.resolve` calls will not go through the
+  registered hooks. This behavior for nullish `source` is temporary — in the
+  future, nullish `source` will not be supported.
 
 When `node` is run with `--experimental-default-type=commonjs`, the Node.js
 internal `load` implementation, which is the value of `next` for the

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -18,6 +18,8 @@ const policy = getOptionValue('--experimental-policy') ?
   null;
 const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
+const defaultType =
+  getOptionValue('--experimental-default-type');
 
 const { Buffer: { from: BufferFrom } } = require('buffer');
 
@@ -140,7 +142,7 @@ async function defaultLoad(url, context = kEmptyObject) {
     // Now that we have the source for the module, run `defaultGetFormat` again in case we detect ESM syntax.
     format ??= await defaultGetFormat(urlInstance, contextToPass);
 
-    if (format === 'commonjs' && contextToPass !== context) {
+    if (format === 'commonjs' && contextToPass !== context && defaultType !== 'module') {
       // For backward compatibility reasons, we need to discard the source in
       // order for the CJS loader to re-fetch it.
       source = null;

--- a/test/es-module/test-esm-type-flag-errors.mjs
+++ b/test/es-module/test-esm-type-flag-errors.mjs
@@ -30,7 +30,7 @@ describe('--experimental-default-type=module', { concurrency: true }, () => {
     });
   });
 
-  it('should affect CJS .js files', async () => {
+  it('should affect CJS .js files (imported, required, entry points)', async () => {
     const result = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',
       fixtures.path('es-modules/package-type-commonjs/echo-require-cache.js'),

--- a/test/es-module/test-esm-type-flag-errors.mjs
+++ b/test/es-module/test-esm-type-flag-errors.mjs
@@ -59,14 +59,14 @@ describe('--experimental-default-type=module', { concurrency: true }, () => {
     });
   });
 
-  it('should not affect entry point .cjs files (with no hooks)', async () => {
+  it('should affect entry point .cjs files (with no hooks)', async () => {
     const { stderr, stdout, code } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',
       fixtures.path('es-module-require-cache/echo.cjs'),
     ]);
 
     strictEqual(stderr, '');
-    match(stdout, /^\[Object: null prototype\] \{(\n .+)+\n\}\n$/);
+    match(stdout, /^undefined\n$/);
     strictEqual(code, 0);
   });
 

--- a/test/es-module/test-esm-type-flag-errors.mjs
+++ b/test/es-module/test-esm-type-flag-errors.mjs
@@ -1,31 +1,101 @@
 import { spawnPromisified } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
-import { match, strictEqual } from 'node:assert';
+import { deepStrictEqual, match, strictEqual } from 'node:assert';
 
-describe('--experimental-default-type=module should not affect the interpretation of files with unknown extensions',
-         { concurrency: true }, () => {
-           it('should error on an entry point with an unknown extension', async () => {
-             const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-               '--experimental-default-type=module',
-               fixtures.path('es-modules/package-type-module/extension.unknown'),
-             ]);
+describe('--experimental-default-type=module', { concurrency: true }, () => {
+  describe('should not affect the interpretation of files with unknown extensions', { concurrency: true }, () => {
+    it('should error on an entry point with an unknown extension', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+        '--experimental-default-type=module',
+        fixtures.path('es-modules/package-type-module/extension.unknown'),
+      ]);
 
-             match(stderr, /ERR_UNKNOWN_FILE_EXTENSION/);
-             strictEqual(stdout, '');
-             strictEqual(code, 1);
-             strictEqual(signal, null);
-           });
+      match(stderr, /ERR_UNKNOWN_FILE_EXTENSION/);
+      strictEqual(stdout, '');
+      strictEqual(code, 1);
+      strictEqual(signal, null);
+    });
 
-           it('should error on an import with an unknown extension', async () => {
-             const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-               '--experimental-default-type=module',
-               fixtures.path('es-modules/package-type-module/imports-unknownext.mjs'),
-             ]);
+    it('should error on an import with an unknown extension', async () => {
+      const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+        '--experimental-default-type=module',
+        fixtures.path('es-modules/package-type-module/imports-unknownext.mjs'),
+      ]);
 
-             match(stderr, /ERR_UNKNOWN_FILE_EXTENSION/);
-             strictEqual(stdout, '');
-             strictEqual(code, 1);
-             strictEqual(signal, null);
-           });
-         });
+      match(stderr, /ERR_UNKNOWN_FILE_EXTENSION/);
+      strictEqual(stdout, '');
+      strictEqual(code, 1);
+      strictEqual(signal, null);
+    });
+  });
+
+  it('should affect CJS .js files', async () => {
+    const result = await spawnPromisified(process.execPath, [
+      '--experimental-default-type=module',
+      fixtures.path('es-modules/package-type-commonjs/echo-require-cache.js'),
+    ]);
+
+    deepStrictEqual(result, {
+      code: 0,
+      stderr: '',
+      stdout: 'undefined\n',
+      signal: null,
+    });
+  });
+
+  it('should affect .cjs files that are imported', async () => {
+    const result = await spawnPromisified(process.execPath, [
+      '--experimental-default-type=module',
+      '-e',
+      `import ${JSON.stringify(fixtures.fileURL('es-module-require-cache/echo.cjs'))}`,
+    ]);
+
+    deepStrictEqual(result, {
+      code: 0,
+      stderr: '',
+      stdout: 'undefined\n',
+      signal: null,
+    });
+  });
+
+  it('should not affect entry point .cjs files (with no hooks)', async () => {
+    const { stderr, stdout, code } = await spawnPromisified(process.execPath, [
+      '--experimental-default-type=module',
+      fixtures.path('es-module-require-cache/echo.cjs'),
+    ]);
+
+    strictEqual(stderr, '');
+    match(stdout, /^\[Object: null prototype\] \{(\n .+)+\n\}\n$/);
+    strictEqual(code, 0);
+  });
+
+  it('should affect entry point .cjs files (when any hooks is registered)', async () => {
+    const result = await spawnPromisified(process.execPath, [
+      '--experimental-default-type=module',
+      '--import',
+      'data:text/javascript,import{register}from"node:module";register("data:text/javascript,");',
+      fixtures.path('es-module-require-cache/echo.cjs'),
+    ]);
+
+    deepStrictEqual(result, {
+      code: 0,
+      stderr: '',
+      stdout: 'undefined\n',
+      signal: null,
+    });
+  });
+
+  it('should not affect CJS from input-type', async () => {
+    const { stderr, stdout, code } = await spawnPromisified(process.execPath, [
+      '--experimental-default-type=module',
+      '--input-type=commonjs',
+      '-p',
+      'require.cache',
+    ]);
+
+    strictEqual(stderr, '');
+    match(stdout, /^\[Object: null prototype\] \{\}\n$/);
+    strictEqual(code, 0);
+  });
+});

--- a/test/fixtures/es-module-require-cache/echo.cjs
+++ b/test/fixtures/es-module-require-cache/echo.cjs
@@ -1,0 +1,1 @@
+console.log(require.cache);

--- a/test/fixtures/es-modules/package-type-commonjs/echo-require-cache.js
+++ b/test/fixtures/es-modules/package-type-commonjs/echo-require-cache.js
@@ -1,0 +1,1 @@
+console.log(require.cache);


### PR DESCRIPTION
This allows user to opt-out from using the monkey-patchable CJS loader to load CJS modules.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
