### PR TITLE
lchown sync improvement

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2025,7 +2025,7 @@ function lchownSync(path, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
   const ctx = { path };
-  binding.lchown(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
+  binding.lchownSync(pathModule.toNamespacedPath(path), uid, gid, undefined, ctx);
   handleErrorFromBinding(ctx);
 }
 


### PR DESCRIPTION
**Local benchmark**

 I used `bench-chownSync.js`  from this [PR](https://github.com/nodejs/node/pull/49962/files#diff-2977d3e2349ab9427971f700042a4c85d623bdf0d214ffbf5b881bd1a4fda4b1)

```
fs/bench-chownSync.js n=10000 method='lchownSync' type='existing'            ***     25.67 %       ±1.11% ±1.48% ±1.93%
fs/bench-chownSync.js n=10000 method='lchownSync' type='non-existing'        ***      4.90 %       ±1.09% ±1.46% ±1.92%
```

Ref: [nodejs/performance#106](https://github.com/nodejs/performance/issues/106)