### PR TITLE
perf_hooks: reducing overhead of performance observer entry list

### DIFF
--- a/benchmark/perf_hooks/performance-observer.js
+++ b/benchmark/perf_hooks/performance-observer.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../common.js');
+
+const {
+  PerformanceObserver,
+  performance,
+} = require('perf_hooks');
+
+function randomFn() {
+  return Math.random();
+}
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  pending: [1, 10],
+}, {
+  options: ['--expose-internals']
+});
+
+let _result;
+
+function fillQueue(timerfied, pending) {
+  for (let i = 0; i < pending; i++) {
+    _result = timerfied();
+  }
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_result);
+}
+
+function main({ n, pending }) {
+  const timerfied = performance.timerify(randomFn);
+
+  let count = 0;
+  const obs = new PerformanceObserver((entries) => {
+    count += entries.getEntries().length;
+
+    if (count >= n) {
+      bench.end(count);
+    } else {
+      fillQueue(timerfied, pending);
+    }
+  });
+  obs.observe({ entryTypes: ['function'], buffered: true });
+
+  bench.start();
+  fillQueue(timerfied, pending);
+}

--- a/benchmark/perf_hooks/performance-observer.js
+++ b/benchmark/perf_hooks/performance-observer.js
@@ -16,7 +16,7 @@ const bench = common.createBenchmark(main, {
   n: [1e5],
   pending: [1, 10],
 }, {
-  options: ['--expose-internals']
+  options: ['--expose-internals'],
 });
 
 let _result;

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -15,7 +15,6 @@ const {
   ObjectDefineProperties,
   ObjectFreeze,
   ObjectKeys,
-  ReflectConstruct,
   SafeMap,
   SafeSet,
   Symbol,

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -171,9 +171,18 @@ function maybeIncrementObserverCount(type) {
   }
 }
 
+const kSkipThrow = Symbol('kSkipThrow');
+const performanceObserverSorter = (first, second) => {
+  return first.startTime - second.startTime;
+};
+
 class PerformanceObserverEntryList {
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  constructor(skipThrowSymbol = undefined, entries = []) {
+    if (skipThrowSymbol !== kSkipThrow) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
+
+    this[kBuffer] = ArrayPrototypeSort(entries, performanceObserverSorter);
   }
 
   getEntries() {
@@ -233,11 +242,7 @@ ObjectDefineProperties(PerformanceObserverEntryList.prototype, {
 });
 
 function createPerformanceObserverEntryList(entries) {
-  return ReflectConstruct(function PerformanceObserverEntryList() {
-    this[kBuffer] = ArrayPrototypeSort(entries, (first, second) => {
-      return first.startTime - second.startTime;
-    });
-  }, [], PerformanceObserverEntryList);
+  return new PerformanceObserverEntryList(kSkipThrow, entries);
 }
 
 class PerformanceObserver {
@@ -523,9 +528,7 @@ function filterBufferMapByNameAndType(name, type) {
     bufferList = ArrayPrototypeSlice(bufferList);
   }
 
-  return ArrayPrototypeSort(bufferList, (first, second) => {
-    return first.startTime - second.startTime;
-  });
+  return ArrayPrototypeSort(bufferList, performanceObserverSorter);
 }
 
 function observerCallback(name, type, startTime, duration, details) {

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -240,10 +240,6 @@ ObjectDefineProperties(PerformanceObserverEntryList.prototype, {
   },
 });
 
-function createPerformanceObserverEntryList(entries) {
-  return new PerformanceObserverEntryList(kSkipThrow, entries);
-}
-
 class PerformanceObserver {
   #buffer = [];
   #entryTypes = new SafeSet();
@@ -353,8 +349,9 @@ class PerformanceObserver {
   }
 
   [kDispatch]() {
-    this.#callback(createPerformanceObserverEntryList(this.takeRecords()),
-                   this);
+    const entryList = new PerformanceObserverEntryList(kSkipThrow, this.takeRecords());
+
+    this.#callback(entryList, this);
   }
 
   [kInspect](depth, options) {


### PR DESCRIPTION
Continuing the work started on https://github.com/nodejs/performance/issues/109.

```
                                                       confidence improvement accuracy (*)   (**)  (***)
perf_hooks/performance-observer.js pending=1 n=100000         ***    147.63 %       ±3.89% ±5.23% ±6.89%
perf_hooks/performance-observer.js pending=10 n=100000        ***    104.54 %       ±5.69% ±7.60% ±9.92%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 2 comparisons, you can thus
expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

cc @nodejs/performance 
