### PR TITLE
perf: optimize Writable

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -108,6 +108,7 @@ const kWriteCb = 1 << 26;
 const kExpectWriteCb = 1 << 27;
 const kAfterWriteTickInfo = 1 << 28;
 const kAfterWritePending = 1 << 29;
+const kHasBuffer = 1 << 30;
 
 // TODO(benjamingr) it is likely slower to do it this way than with free functions
 function makeBitMapDescriptor(bit) {
@@ -340,6 +341,7 @@ function resetBuffer(state) {
   state.buffered = [];
   state.bufferedIndex = 0;
   state.state |= kAllBuffers | kAllNoop;
+  state.state &= ~kHasBuffer;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
@@ -396,11 +398,13 @@ function Writable(options) {
   destroyImpl.construct(this, () => {
     const state = this._writableState;
 
-    if (!state.writing) {
+    if ((state.state & kWriting) === 0) {
       clearBuffer(this, state);
     }
 
-    finishMaybe(this, state);
+    if ((state.state & kEnding) !== 0) {
+      finishMaybe(this, state);
+    }
   });
 }
 
@@ -523,6 +527,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
 
   if ((state.state & (kWriting | kErrored | kCorked | kConstructed)) !== kConstructed) {
     state.buffered.push({ chunk, encoding, callback });
+    state.state |= kHasBuffer;
     if ((state.state & kAllBuffers) !== 0 && encoding !== 'buffer') {
       state.state &= ~kAllBuffers;
     }
@@ -591,8 +596,9 @@ function onwrite(stream, er) {
     // Avoid V8 leak, https://github.com/nodejs/node/pull/34103#issuecomment-652002364
     er.stack; // eslint-disable-line no-unused-expressions
 
-    if (!state.errored) {
-      state.errored = er;
+    if ((state.state & kErrored) === 0) {
+      state[kErroredValue] = er;
+      state.state |= kErrored;
     }
 
     // In case of duplex streams we need to notify the readable side of the
@@ -607,12 +613,12 @@ function onwrite(stream, er) {
       onwriteError(stream, state, er, cb);
     }
   } else {
-    if (state.buffered.length > state.bufferedIndex) {
+    if ((state.state & kHasBuffer) !== 0) {
       clearBuffer(stream, state);
     }
 
     if (sync) {
-      const needDrain = state.length === 0 && (state.state & kNeedDrain) !== 0;
+      const needDrain = (state.state & kNeedDrain) !== 0 && state.length === 0;
       const needTick = needDrain || (state.state & kDestroyed !== 0) || cb !== nop;
 
       // It is a common case that the callback passed to .write() is always
@@ -625,7 +631,9 @@ function onwrite(stream, er) {
           state.state |= kAfterWritePending;
         } else {
           state.pendingcb--;
-          finishMaybe(stream, state, true);
+          if ((state.state & kEnding) !== 0) {
+            finishMaybe(stream, state, true);
+          }
         }
       } else if ((state.state & kAfterWriteTickInfo) !== 0 &&
                  state[kAfterWriteTickInfoValue].cb === cb) {
@@ -636,7 +644,9 @@ function onwrite(stream, er) {
         state.state |= (kAfterWritePending | kAfterWriteTickInfo);
       } else {
         state.pendingcb--;
-        finishMaybe(stream, state, true);
+        if ((state.state & kEnding) !== 0) {
+          finishMaybe(stream, state, true);
+        }
       }
     } else {
       afterWrite(stream, state, 1, cb);
@@ -668,7 +678,9 @@ function afterWrite(stream, state, count, cb) {
     errorBuffer(state);
   }
 
-  finishMaybe(stream, state);
+  if ((state.state & kEnding) !== 0) {
+    finishMaybe(stream, state, true);
+  }
 }
 
 // If there's something in the buffer waiting, then invoke callbacks.
@@ -692,7 +704,7 @@ function errorBuffer(state) {
 
 // If there's something in the buffer waiting, then process it.
 function clearBuffer(stream, state) {
-  if ((state.state & (kDestroyed | kBufferProcessing | kCorked)) !== 0 ||
+  if ((state.state & (kDestroyed | kBufferProcessing | kCorked | kHasBuffer)) !== kHasBuffer ||
     (state.state & kConstructed) === 0) {
     return;
   }


### PR DESCRIPTION
Try to inline condition checks and try to avoid read state properties in hot paths.

```
                                                                                          confidence improvement accuracy (*)   (**)  (***)
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000            ***      8.14 %       ±4.15% ±5.56% ±7.29%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000           ***     11.35 %       ±2.60% ±3.46% ±4.50%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000             *      2.04 %       ±2.03% ±2.71% ±3.54%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000          ***     17.89 %       ±2.05% ±2.73% ±3.56%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000           ***      5.99 %       ±2.28% ±3.04% ±3.97%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000          ***     11.62 %       ±2.35% ±3.13% ±4.08%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000          ***      3.82 %       ±1.59% ±2.12% ±2.78%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000         ***     14.31 %       ±3.41% ±4.56% ±5.99%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000           ***      6.87 %       ±2.67% ±3.55% ±4.63%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000          ***      7.86 %       ±2.17% ±2.90% ±3.79%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000          ***      8.60 %       ±4.29% ±5.74% ±7.53%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000         ***      7.28 %       ±2.42% ±3.24% ±4.26%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000          ***      6.23 %       ±1.55% ±2.07% ±2.69%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000         ***     10.18 %       ±1.71% ±2.28% ±2.98%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000         ***      5.76 %       ±1.70% ±2.26% ±2.95%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000        ***     10.23 %       ±2.66% ±3.55% ±4.64%
```