### PR TITLE
stream: lazy allocate back pressure buffer

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -77,6 +77,7 @@ const kErroredValue = Symbol('kErroredValue');
 const kDefaultEncodingValue = Symbol('kDefaultEncodingValue');
 const kWriteCbValue = Symbol('kWriteCbValue');
 const kAfterWriteTickInfoValue = Symbol('kAfterWriteTickInfoValue');
+const kBufferedValue = Symbol('kBufferedValue');
 
 const kObjectMode = 1 << 0;
 const kEnded = 1 << 1;
@@ -108,7 +109,7 @@ const kWriteCb = 1 << 26;
 const kExpectWriteCb = 1 << 27;
 const kAfterWriteTickInfo = 1 << 28;
 const kAfterWritePending = 1 << 29;
-const kHasBuffer = 1 << 30;
+const kBuffered = 1 << 30;
 
 // TODO(benjamingr) it is likely slower to do it this way than with free functions
 function makeBitMapDescriptor(bit) {
@@ -270,6 +271,21 @@ ObjectDefineProperties(WritableState.prototype, {
       }
     },
   },
+
+  buffered: {
+    __proto__: null,
+    enumerable: false,
+    get() { return (this.state & kBuffered) !== 0 ? this[kBufferedValue] : []; },
+    set(value) {
+      this[kBufferedValue] = value;
+      if (value) {
+        this.state |= kBuffered;
+      } else {
+        this.state &= ~kBuffered;
+      }
+    },
+  },
+
 });
 
 function WritableState(options, stream, isDuplex) {
@@ -338,20 +354,20 @@ function WritableState(options, stream, isDuplex) {
 }
 
 function resetBuffer(state) {
-  state.buffered = [];
+  state[kBufferedValue] = null;
   state.bufferedIndex = 0;
   state.state |= kAllBuffers | kAllNoop;
-  state.state &= ~kHasBuffer;
+  state.state &= ~kBuffered;
 }
 
 WritableState.prototype.getBuffer = function getBuffer() {
-  return ArrayPrototypeSlice(this.buffered, this.bufferedIndex);
+  return (this.state & kBuffered) === 0 ? [] : ArrayPrototypeSlice(this.buffered, this.bufferedIndex);
 };
 
 ObjectDefineProperty(WritableState.prototype, 'bufferedRequestCount', {
   __proto__: null,
   get() {
-    return this.buffered.length - this.bufferedIndex;
+    return (this.state & kBuffered) === 0 ? 0 : this[kBufferedValue].length - this.bufferedIndex;
   },
 });
 
@@ -518,8 +534,12 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
   state.length += len;
 
   if ((state.state & (kWriting | kErrored | kCorked | kConstructed)) !== kConstructed) {
-    state.buffered.push({ chunk, encoding, callback });
-    state.state |= kHasBuffer;
+    if ((state.state & kBuffered) === 0) {
+      state.state |= kBuffered;
+      state[kBufferedValue] = [];
+    }
+
+    state[kBufferedValue].push({ chunk, encoding, callback });
     if ((state.state & kAllBuffers) !== 0 && encoding !== 'buffer') {
       state.state &= ~kAllBuffers;
     }
@@ -611,7 +631,7 @@ function onwrite(stream, er) {
       onwriteError(stream, state, er, cb);
     }
   } else {
-    if ((state.state & kHasBuffer) !== 0) {
+    if ((state.state & kBuffered) !== 0) {
       clearBuffer(stream, state);
     }
 
@@ -687,11 +707,13 @@ function errorBuffer(state) {
     return;
   }
 
-  for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
-    const { chunk, callback } = state.buffered[n];
-    const len = (state.state & kObjectMode) !== 0 ? 1 : chunk.length;
-    state.length -= len;
-    callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+  if ((state.state & kBuffered) !== 0) {
+    for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
+      const { chunk, callback } = state[kBufferedValue][n];
+      const len = (state.state & kObjectMode) !== 0 ? 1 : chunk.length;
+      state.length -= len;
+      callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
+    }
   }
 
 
@@ -702,13 +724,12 @@ function errorBuffer(state) {
 
 // If there's something in the buffer waiting, then process it.
 function clearBuffer(stream, state) {
-  if ((state.state & (kDestroyed | kBufferProcessing | kCorked | kHasBuffer)) !== kHasBuffer ||
-    (state.state & kConstructed) === 0) {
+  if ((state.state & (kDestroyed | kBufferProcessing | kCorked | kBuffered)) !== kBuffered) {
     return;
   }
 
   const objectMode = (state.state & kObjectMode) !== 0;
-  const { buffered, bufferedIndex } = state;
+  const { [kBufferedValue]: buffered, bufferedIndex } = state;
   const bufferedLength = buffered.length - bufferedIndex;
 
   if (!bufferedLength) {
@@ -838,10 +859,9 @@ function needFinish(state) {
           kWriting |
           kErrorEmitted |
           kCloseEmitted |
-          kErrored
-    )) === (kEnding | kConstructed) &&
-          state.length === 0 &&
-          state.buffered.length === 0);
+          kErrored |
+          kBuffered
+    )) === (kEnding | kConstructed) && state.length === 0);
 }
 
 function callFinal(stream, state) {
@@ -1083,9 +1103,7 @@ Writable.prototype.destroy = function(err, cb) {
   const state = this._writableState;
 
   // Invoke pending callbacks.
-  if ((state.state & kDestroyed) === 0 &&
-    (state.bufferedIndex < state.buffered.length ||
-      (state.state & kOnFinished) !== 0)) {
+  if ((state.state & (kBuffered | kOnFinished | kDestroyed)) !== kDestroyed) {
     process.nextTick(errorBuffer, state);
   }
 


### PR DESCRIPTION
```
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000              *      7.48 %       ±6.60%  ±8.78% ±11.43%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000           ***      8.19 %       ±3.39%  ±4.51%  ±5.87%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                   -1.00 %       ±3.29%  ±4.43%  ±5.86%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000          ***     12.17 %       ±2.83%  ±3.76%  ±4.90%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000             *      3.61 %       ±3.15%  ±4.24%  ±5.60%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000          ***     13.57 %       ±4.37%  ±5.87%  ±7.77%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000                   1.32 %       ±7.77% ±10.34% ±13.45%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000         ***     21.97 %       ±6.29%  ±8.38% ±10.93%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                    4.20 %       ±7.15%  ±9.53% ±12.43%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                   4.54 %       ±5.10%  ±6.87%  ±9.11%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000          ***      5.74 %       ±2.37%  ±3.15%  ±4.11%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000         ***      9.26 %       ±4.66%  ±6.22%  ±8.11%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000            *      4.16 %       ±3.80%  ±5.10%  ±6.72%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000         ***     11.19 %       ±4.06%  ±5.44%  ±7.16%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000           *      4.35 %       ±4.12%  ±5.52%  ±7.28%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000          *      5.89 %       ±4.74%  ±6.35%  ±8.35%
```