### PR TITLE
stream: avoid buffering in sync path

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -362,8 +362,7 @@ function readableAddChunk(stream, chunk, encoding, addToFront) {
 }
 
 function addChunk(stream, state, chunk, addToFront) {
-  if (state.flowing && state.length === 0 && !state.sync &&
-      stream.listenerCount('data') > 0) {
+  if (state.flowing && state.length === 0 && stream.listenerCount('data') > 0) {
     // Use the guard to avoid creating `Set()` repeatedly
     // when we have multiple pipes.
     if ((state.state & kMultiAwaitDrain) !== 0) {


### PR DESCRIPTION
Just an experiment to see if this provides any significant gains without breaking.