### PR TITLE
src: avoid making JSTransferable wrapper object weak

### DIFF
--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -324,10 +324,16 @@ class MessagePort : public HandleWrap {
 // See e.g. FileHandle in internal/fs/promises.js for an example.
 class JSTransferable : public BaseObject {
  public:
-  static JSTransferable* Wrap(Environment* env, v8::Local<v8::Object> target);
+  static BaseObjectPtr<JSTransferable> Wrap(Environment* env,
+                                            v8::Local<v8::Object> target);
   static bool IsJSTransferable(Environment* env,
                                v8::Local<v8::Context> context,
                                v8::Local<v8::Object> object);
+
+  JSTransferable(Environment* env,
+                 v8::Local<v8::Object> obj,
+                 v8::Local<v8::Object> target);
+  ~JSTransferable();
 
   BaseObject::TransferMode GetTransferMode() const override;
   std::unique_ptr<TransferData> TransferForMessaging() override;
@@ -345,10 +351,6 @@ class JSTransferable : public BaseObject {
   v8::Local<v8::Object> target() const;
 
  private:
-  JSTransferable(Environment* env,
-                 v8::Local<v8::Object> obj,
-                 v8::Local<v8::Object> target);
-
   template <TransferMode mode>
   std::unique_ptr<TransferData> TransferOrClone() const;
 

--- a/test/pummel/test-structuredclone-jstransferable.js
+++ b/test/pummel/test-structuredclone-jstransferable.js
@@ -1,0 +1,8 @@
+// Flags: --max-old-space-size=10
+'use strict';
+require('../common');
+const { createHistogram } = require('perf_hooks');
+
+for (let i = 0; i < 1e4; i++) {
+  structuredClone(createHistogram());
+}


### PR DESCRIPTION
JSTransferable wrapper object is a short-lived wrapper in the scope of
the serialization or the deserialization. Make the JSTransferable
wrapper object pointer as a strongly-referenced detached BaseObjectPtr
so that a JSTransferable wrapper object and its target object will never
be garbage-collected during a ser-des process, and the wrapper object
will be immediately destroyed when the process is completed.

Fixes: https://github.com/nodejs/node/issues/49852
Fixes: https://github.com/nodejs/node/issues/49844