### PR TITLE
doc: use precise promise terminology in fs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -673,7 +673,7 @@ added: v10.0.0
 * Returns: {Promise}
 
 Change the file system timestamps of the object referenced by the {FileHandle}
-then resolves the promise with no arguments upon success.
+then fulfills the promise with no arguments upon success.
 
 #### `filehandle.write(buffer, offset[, length[, position]])`
 
@@ -699,14 +699,14 @@ changes:
 
 Write `buffer` to the file.
 
-The promise is resolved with an object containing two properties:
+The promise is fulfilled with an object containing two properties:
 
 * `bytesWritten` {integer} the number of bytes written
 * `buffer` {Buffer|TypedArray|DataView} a reference to the
   `buffer` written.
 
 It is unsafe to use `filehandle.write()` multiple times on the same file
-without waiting for the promise to be resolved (or rejected). For this
+without waiting for the promise to be fulfilled (or rejected). For this
 scenario, use [`filehandle.createWriteStream()`][].
 
 On Linux, positional writes do not work when the file is opened in append mode.
@@ -756,13 +756,13 @@ changes:
 Write `string` to the file. If `string` is not a string, the promise is
 rejected with an error.
 
-The promise is resolved with an object containing two properties:
+The promise is fulfilled with an object containing two properties:
 
 * `bytesWritten` {integer} the number of bytes written
 * `buffer` {string} a reference to the `string` written.
 
 It is unsafe to use `filehandle.write()` multiple times on the same file
-without waiting for the promise to be resolved (or rejected). For this
+without waiting for the promise to be fulfilled (or rejected). For this
 scenario, use [`filehandle.createWriteStream()`][].
 
 On Linux, positional writes do not work when the file is opened in append mode.
@@ -793,14 +793,14 @@ changes:
 
 Asynchronously writes data to a file, replacing the file if it already exists.
 `data` can be a string, a buffer, an {AsyncIterable}, or an {Iterable} object.
-The promise is resolved with no arguments upon success.
+The promise is fulfilled with no arguments upon success.
 
 If `options` is a string, then it specifies the `encoding`.
 
 The {FileHandle} has to support writing.
 
 It is unsafe to use `filehandle.writeFile()` multiple times on the same file
-without waiting for the promise to be resolved (or rejected).
+without waiting for the promise to be fulfilled (or rejected).
 
 If one or more `filehandle.write()` calls are made on a file handle and then a
 `filehandle.writeFile()` call is made, the data will be written from the
@@ -821,14 +821,14 @@ added: v12.9.0
 
 Write an array of {ArrayBufferView}s to the file.
 
-The promise is resolved with an object containing a two properties:
+The promise is fulfilled with an object containing a two properties:
 
 * `bytesWritten` {integer} the number of bytes written
 * `buffers` {Buffer\[]|TypedArray\[]|DataView\[]} a reference to the `buffers`
   input.
 
 It is unsafe to call `writev()` multiple times on the same file without waiting
-for the promise to be resolved (or rejected).
+for the promise to be fulfilled (or rejected).
 
 On Linux, positional writes don't work when the file is opened in append mode.
 The kernel ignores the position argument and always appends the data to
@@ -864,7 +864,7 @@ or a mask consisting of the bitwise OR of any of `fs.constants.R_OK`,
 `fs.constants.W_OK | fs.constants.R_OK`). Check [File access constants][] for
 possible values of `mode`.
 
-If the accessibility check is successful, the promise is resolved with no
+If the accessibility check is successful, the promise is fulfilled with no
 value. If any of the accessibility checks fail, the promise is rejected
 with an {Error} object. The following example checks if the file
 `/etc/passwd` can be read and written by the current process.
@@ -1333,7 +1333,7 @@ object with an `encoding` property specifying the character encoding to use for
 the filenames. If the `encoding` is set to `'buffer'`, the filenames returned
 will be passed as {Buffer} objects.
 
-If `options.withFileTypes` is set to `true`, the resolved array will contain
+If `options.withFileTypes` is set to `true`, the returned array will contain
 {fs.Dirent} objects.
 
 ```mjs
@@ -1447,7 +1447,7 @@ added: v10.0.0
 * Returns: {Promise} Fulfills with the `linkString` upon success.
 
 Reads the contents of the symbolic link referred to by `path`. See the POSIX
-readlink(2) documentation for more detail. The promise is resolved with the
+readlink(2) documentation for more detail. The promise is fulfilled with the
 `linkString` upon success.
 
 The optional `options` argument can be a string specifying an encoding, or an
@@ -6339,7 +6339,7 @@ added: v12.12.0
 Asynchronously close the directory's underlying resource handle.
 Subsequent reads will result in errors.
 
-A promise is returned that will be resolved after the resource has been
+A promise is returned that will be fulfilled after the resource has been
 closed.
 
 #### `dir.close(callback)`
@@ -6393,7 +6393,7 @@ added: v12.12.0
 Asynchronously read the next directory entry via readdir(3) as an
 {fs.Dirent}.
 
-A promise is returned that will be resolved with an {fs.Dirent}, or `null`
+A promise is returned that will be fulfilled with an {fs.Dirent}, or `null`
 if there are no more directory entries to read.
 
 Directory entries returned by this function are in no particular order as


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/50028 for context - this also has the added benefit of reducing the amount of times we use resolving a promise vs resolving a path.

Note this document already used `fulfills` in many cases and I kept resolves (for promises) in some cases where it made sense to me from a technical point of view

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
