### PR TITLE
fs: improve error performance for `readSync`

### DIFF
--- a/benchmark/fs/bench-readSync.js
+++ b/benchmark/fs/bench-readSync.js
@@ -7,19 +7,6 @@ tmpdir.refresh();
 
 const bufferSize = 1024;
 const sectorSize = 512;
-const tmpfile = { name: tmpdir.resolve(`.existing-file-${process.pid}`),
-                  len: bufferSize * 1e4 };
-
-
-tmpfile.contents = Buffer.allocUnsafe(tmpfile.len);
-
-for (let offset = 0; offset < tmpfile.len; offset += sectorSize) {
-  const fillByte = 256 * Math.random();
-  const nBytesToFill = Math.min(sectorSize, tmpfile.len - offset);
-  tmpfile.contents.fill(fillByte, offset, offset + nBytesToFill);
-}
-
-fs.writeFileSync(tmpfile.name, tmpfile.contents);
 
 const bench = common.createBenchmark(main, {
   type: ['existing', 'non-existing'],
@@ -28,6 +15,20 @@ const bench = common.createBenchmark(main, {
 
 function main({ n, type }) {
   let fd;
+
+  const tmpfile = { name: tmpdir.resolve(`.existing-file-${process.pid}`),
+                    len: bufferSize * n };
+
+
+  tmpfile.contents = Buffer.allocUnsafe(tmpfile.len);
+
+  for (let offset = 0; offset < tmpfile.len; offset += sectorSize) {
+    const fillByte = 256 * Math.random();
+    const nBytesToFill = Math.min(sectorSize, tmpfile.len - offset);
+    tmpfile.contents.fill(fillByte, offset, offset + nBytesToFill);
+  }
+
+  fs.writeFileSync(tmpfile.name, tmpfile.contents);
 
   switch (type) {
     case 'existing':

--- a/benchmark/fs/bench-readSync.js
+++ b/benchmark/fs/bench-readSync.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const tmpfile = tmpdir.resolve(`.existing-file-${process.pid}`);
+fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
+
+const bench = common.createBenchmark(main, {
+  type: ['existing', 'non-existing'],
+  paramType: ['offset-and-length', 'no-offset-and-length'],
+  n: [1e4],
+});
+
+function main({ n, type, paramType }) {
+  let fd;
+
+  switch (type) {
+    case 'existing':
+      fd = fs.openSync(tmpfile, 'r', 0o666);
+      break;
+    case 'non-existing':
+      fd = 1 << 30;
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  switch (paramType) {
+    case 'offset-and-length':
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.readSync(fd, Buffer.alloc(1), 0, 1, 0);
+        } catch {
+          // Continue regardless of error.
+        }
+      }
+      break;
+    case 'no-offset-and-length':
+      for (let i = 0; i < n; i++) {
+        try {
+          fs.readSync(fd, Buffer.alloc(1));
+        } catch {
+          // Continue regardless of error.
+        }
+      }
+      break;
+    default:
+      new Error('Invalid type');
+  }
+  bench.end(n);
+
+  if (fd === 'existing') fs.closeSync(fd);
+}

--- a/benchmark/fs/bench-readSync.js
+++ b/benchmark/fs/bench-readSync.js
@@ -53,5 +53,5 @@ function main({ n, type, paramType }) {
   }
   bench.end(n);
 
-  if (fd === 'existing') fs.closeSync(fd);
+  if (type === 'existing') fs.closeSync(fd);
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -751,11 +751,7 @@ function readSync(fd, buffer, offsetOrOptions, length, position) {
     validatePosition(position, 'position', length);
   }
 
-  const ctx = {};
-  const result = binding.read(fd, buffer, offset, length, position,
-                              undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return binding.read(fd, buffer, offset, length, position);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2376,6 +2376,11 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
     const int bytesRead = SyncCallAndThrowOnError(
         env, &req_wrap_sync, uv_fs_read, fd, &uvbuf, 1, pos);
     FS_SYNC_TRACE_END(read, "bytesRead", bytesRead);
+
+    if (is_uv_error(bytesRead)) {
+      return;
+    }
+
     args.GetReturnValue().Set(bytesRead);
   }
 }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2364,17 +2364,17 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   char* buf = buffer_data + off;
   uv_buf_t uvbuf = uv_buf_init(buf, len);
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 5);
-  if (req_wrap_async != nullptr) {  // read(fd, buffer, offset, len, pos, req)
+  if (argc > 5) {  // read(fd, buffer, offset, len, pos, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 5);
+    CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_READ, req_wrap_async)
     AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, &uvbuf, 1, pos);
-  } else {  // read(fd, buffer, offset, len, pos, undefined, ctx)
-    CHECK_EQ(argc, 7);
-    FSReqWrapSync req_wrap_sync;
+  } else {  // read(fd, buffer, offset, len, pos)
+    FSReqWrapSync req_wrap_sync("read");
     FS_SYNC_TRACE_BEGIN(read);
-    const int bytesRead = SyncCall(env, args[6], &req_wrap_sync, "read",
-                                   uv_fs_read, fd, &uvbuf, 1, pos);
+    const int bytesRead = SyncCallAndThrowOnError(
+        env, &req_wrap_sync, uv_fs_read, fd, &uvbuf, 1, pos);
     FS_SYNC_TRACE_END(read, "bytesRead", bytesRead);
     args.GetReturnValue().Set(bytesRead);
   }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -155,7 +155,6 @@ declare namespace InternalFSBinding {
   function openFileHandle(path: StringOrBuffer, flags: number, mode: number, usePromises: typeof kUsePromises): Promise<FileHandle>;
 
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, req: FSReqCallback<number>): void;
-  function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, req: undefined, ctx: FSSyncContext): number;
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, usePromises: typeof kUsePromises): Promise<number>;
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number): number;
 

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -157,6 +157,7 @@ declare namespace InternalFSBinding {
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, req: FSReqCallback<number>): void;
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, req: undefined, ctx: FSSyncContext): number;
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, usePromises: typeof kUsePromises): Promise<number>;
+  function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number): number;
 
   function readBuffers(fd: number, buffers: ArrayBufferView[], position: number, req: FSReqCallback<number>): void;
   function readBuffers(fd: number, buffers: ArrayBufferView[], position: number, req: undefined, ctx: FSSyncContext): number;


### PR DESCRIPTION
- fs.readSync(fd, buffer, offset, length[, position])
- fs.readSync(fd, buffer[, options])
```
                                                 confidence improvement accuracy (*)    (**)   (***)
fs/bench-readSync.js n=10000 type='existing'                     3.73 %       ±6.45%  ±8.58% ±11.17%
fs/bench-readSync.js n=10000 type='non-existing'        ***     84.98 %      ±10.30% ±13.80% ±18.14%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Refs: https://github.com/nodejs/performance/issues/106

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
