### PR TITLE
crypto: account for disabled `SharedArrayBuffer`

### DIFF
--- a/lib/internal/crypto/webidl.js
+++ b/lib/internal/crypto/webidl.js
@@ -184,7 +184,10 @@ function isNonSharedArrayBuffer(V) {
 }
 
 function isSharedArrayBuffer(V) {
-  return ObjectPrototypeIsPrototypeOf(SharedArrayBuffer.prototype, V);
+  // SharedArrayBuffers can be disabled with --no-harmony-sharedarraybuffer.
+  if (SharedArrayBuffer !== undefined)
+    return ObjectPrototypeIsPrototypeOf(SharedArrayBuffer.prototype, V);
+  return false;
 }
 
 converters.Uint8Array = (V, opts = kEmptyObject) => {


### PR DESCRIPTION
Xref https://github.com/electron/electron/pull/40070

It's possible for `SharedArrayBuffer`s to be disabled with `--no-harmony-sharedarraybuffer`. If they _are_ disabled and a user goes to use for example `webcrypto.subtle.importKey`, they will see the following error:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'prototype')
    at isSharedArrayBuffer (node:internal/crypto/webidl:187:57)
    at Object.BufferSource (node:internal/crypto/webidl:208:9)
    at SubtleCrypto.importKey (node:internal/crypto/webcrypto:585:36)
    at worker.js:6:18
```

This handles that case similarly to how it's handled [elsewhere in the codebase](https://github.com/nodejs/node/blob/7df27582bbb896ebb72697da58209976a0b4daf6/lib/internal/worker.js#L103-L112).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
