### PR TITLE
benchmark: fix race condition on fs benchs

### DIFF
--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -43,11 +43,17 @@ function main({ len, duration, concurrent, encoding }) {
     const totalOps = reads + zips;
     benchEnded = true;
     bench.end(totalOps);
-    try {
-      fs.unlinkSync(filename);
-    } catch {
-      // Continue regardless of error.
-    }
+
+    // This delay is needed because on windows this can cause
+    // race condition with afterRead, which makes this benchmark
+    // fails to delete the temp file
+    setTimeout(() => {
+      try {
+        fs.unlinkSync(filename);
+      } catch {
+        // Continue regardless of error.
+      }
+    }, 10);
   }, duration * 1000);
 
   function read() {

--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -35,9 +35,9 @@ function main({ len, duration, concurrent, encoding }) {
   const zipData = Buffer.alloc(1024, 'a');
 
   let waitConcurrent = 0;
-  // plus one because of zip
-  let targetConcurrency = concurrent + 1;
 
+  // Plus one because of zip
+  const targetConcurrency = concurrent + 1;
   const startedAt = Date.now();
   const endAt = startedAt + (duration * 1000);
 
@@ -45,7 +45,7 @@ function main({ len, duration, concurrent, encoding }) {
   let zips = 0;
 
   bench.start();
-  
+
   function stop() {
     const totalOps = reads + zips;
     bench.end(totalOps);
@@ -70,7 +70,7 @@ function main({ len, duration, concurrent, encoding }) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === targetConcurrency) {
       stop();
@@ -88,7 +88,7 @@ function main({ len, duration, concurrent, encoding }) {
       throw er;
 
     zips++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === targetConcurrency) {
       stop();

--- a/benchmark/fs/readfile-partitioned.js
+++ b/benchmark/fs/readfile-partitioned.js
@@ -14,7 +14,6 @@ const filename = path.resolve(__dirname,
                               `.removeme-benchmark-garbage-${process.pid}`);
 const fs = require('fs');
 const zlib = require('zlib');
-const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   duration: [5],

--- a/benchmark/fs/readfile-permission-enabled.js
+++ b/benchmark/fs/readfile-permission-enabled.js
@@ -5,7 +5,6 @@
 
 const common = require('../common.js');
 const fs = require('fs');
-const assert = require('assert');
 
 const tmpdir = require('../../test/common/tmpdir');
 tmpdir.refresh();
@@ -42,7 +41,7 @@ function main({ len, duration, concurrent, encoding }) {
   const endAt = startedAt + (duration * 1000);
 
   bench.start();
-  
+
   function stop() {
     bench.end(reads);
 
@@ -68,7 +67,7 @@ function main({ len, duration, concurrent, encoding }) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === concurrent) {
       stop();

--- a/benchmark/fs/readfile-permission-enabled.js
+++ b/benchmark/fs/readfile-permission-enabled.js
@@ -41,12 +41,18 @@ function main({ len, duration, concurrent, encoding }) {
   setTimeout(() => {
     benchEnded = true;
     bench.end(reads);
-    try {
-      fs.unlinkSync(filename);
-    } catch {
-      // Continue regardless of error.
-    }
-    process.exit(0);
+
+    // This delay is needed because on windows this can cause
+    // race condition with afterRead, which makes this benchmark
+    // fails to delete the temp file
+    setTimeout(() => {
+      try {
+        fs.unlinkSync(filename);
+      } catch {
+        // Continue regardless of error.
+      }
+      process.exit(0);
+    }, 10);
   }, duration * 1000);
 
   function read() {

--- a/benchmark/fs/readfile-permission-enabled.js
+++ b/benchmark/fs/readfile-permission-enabled.js
@@ -36,24 +36,24 @@ function main({ len, duration, concurrent, encoding }) {
   data = null;
 
   let reads = 0;
-  let benchEnded = false;
+  let waitConcurrent = 0;
+
+  const startedAt = Date.now();
+  const endAt = startedAt + (duration * 1000);
+
   bench.start();
-  setTimeout(() => {
-    benchEnded = true;
+  
+  function stop() {
     bench.end(reads);
 
-    // This delay is needed because on windows this can cause
-    // race condition with afterRead, which makes this benchmark
-    // fails to delete the temp file
-    setTimeout(() => {
-      try {
-        fs.unlinkSync(filename);
-      } catch {
-        // Continue regardless of error.
-      }
-      process.exit(0);
-    }, 10);
-  }, duration * 1000);
+    try {
+      fs.unlinkSync(filename);
+    } catch {
+      // Continue regardless of error.
+    }
+
+    process.exit(0);
+  }
 
   function read() {
     fs.readFile(filename, encoding, afterRead);
@@ -61,11 +61,6 @@ function main({ len, duration, concurrent, encoding }) {
 
   function afterRead(er, data) {
     if (er) {
-      if (er.code === 'ENOENT') {
-        // Only OK if unlinked by the timer from main.
-        assert.ok(benchEnded);
-        return;
-      }
       throw er;
     }
 
@@ -73,9 +68,14 @@ function main({ len, duration, concurrent, encoding }) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    if (!benchEnded)
+    let benchEnded = Date.now() >= endAt;
+
+    if (benchEnded && (++waitConcurrent) === concurrent) {
+      stop();
+    } else if (!benchEnded) {
       read();
+    }
   }
 
-  while (concurrent--) read();
+  for (let i = 0; i < concurrent; i++) read();
 }

--- a/benchmark/fs/readfile-promises.js
+++ b/benchmark/fs/readfile-promises.js
@@ -35,25 +35,25 @@ function main({ len, duration, concurrent, encoding }) {
   fs.writeFileSync(filename, data);
   data = null;
 
-  let writes = 0;
-  let benchEnded = false;
-  bench.start();
-  setTimeout(() => {
-    benchEnded = true;
-    bench.end(writes);
+  let reads = 0;
+  let waitConcurrent = 0;
 
-    // This delay is needed because on windows this can cause
-    // race condition with afterRead, which makes this benchmark
-    // fails to delete the temp file
-    setTimeout(() => {
-      try {
-        fs.unlinkSync(filename);
-      } catch {
-        // Continue regardless of error.
-      }
-      process.exit(0);
-    }, 10);
-  }, duration * 1000);
+  const startedAt = Date.now();
+  const endAt = startedAt + (duration * 1000);
+
+  bench.start();
+
+  function stop() {
+    bench.end(reads);
+
+    try {
+      fs.unlinkSync(filename);
+    } catch {
+      // Continue regardless of error.
+    }
+
+    process.exit(0);
+  }
 
   function read() {
     fs.promises.readFile(filename, encoding)
@@ -63,21 +63,21 @@ function main({ len, duration, concurrent, encoding }) {
 
   function afterRead(er, data) {
     if (er) {
-      if (er.code === 'ENOENT') {
-        // Only OK if unlinked by the timer from main.
-        assert.ok(benchEnded);
-        return;
-      }
       throw er;
     }
 
     if (data.length !== len)
       throw new Error('wrong number of bytes returned');
 
-    writes++;
-    if (!benchEnded)
+    reads++;
+    let benchEnded = Date.now() >= endAt;
+
+    if (benchEnded && (++waitConcurrent) === concurrent) {
+      stop();
+    } else if (!benchEnded) {
       read();
+    }
   }
 
-  while (concurrent--) read();
+  for (let i = 0; i < concurrent; i++) read();
 }

--- a/benchmark/fs/readfile-promises.js
+++ b/benchmark/fs/readfile-promises.js
@@ -41,12 +41,18 @@ function main({ len, duration, concurrent, encoding }) {
   setTimeout(() => {
     benchEnded = true;
     bench.end(writes);
-    try {
-      fs.unlinkSync(filename);
-    } catch {
-      // Continue regardless of error.
-    }
-    process.exit(0);
+
+    // This delay is needed because on windows this can cause
+    // race condition with afterRead, which makes this benchmark
+    // fails to delete the temp file
+    setTimeout(() => {
+      try {
+        fs.unlinkSync(filename);
+      } catch {
+        // Continue regardless of error.
+      }
+      process.exit(0);
+    }, 10);
   }, duration * 1000);
 
   function read() {

--- a/benchmark/fs/readfile-promises.js
+++ b/benchmark/fs/readfile-promises.js
@@ -5,7 +5,6 @@
 
 const common = require('../common.js');
 const fs = require('fs');
-const assert = require('assert');
 
 const tmpdir = require('../../test/common/tmpdir');
 tmpdir.refresh();
@@ -70,7 +69,7 @@ function main({ len, duration, concurrent, encoding }) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === concurrent) {
       stop();

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -5,8 +5,6 @@
 
 const common = require('../common.js');
 const fs = require('fs');
-const assert = require('assert');
-const { performance } = require('perf_hooks');
 
 const tmpdir = require('../../test/common/tmpdir');
 tmpdir.refresh();
@@ -62,7 +60,7 @@ function main({ len, duration, concurrent, encoding }) {
       throw new Error('wrong number of bytes returned');
 
     reads++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === concurrent) {
       stop();

--- a/benchmark/fs/readfile.js
+++ b/benchmark/fs/readfile.js
@@ -34,12 +34,18 @@ function main({ len, duration, concurrent, encoding }) {
   setTimeout(() => {
     benchEnded = true;
     bench.end(reads);
-    try {
-      fs.unlinkSync(filename);
-    } catch {
-      // Continue regardless of error.
-    }
-    process.exit(0);
+
+    // This delay is needed because on windows this can cause
+    // race condition with afterRead, which makes this benchmark
+    // fails to delete the temp file
+    setTimeout(() => {
+      try {
+        fs.unlinkSync(filename);
+      } catch {
+        // Continue regardless of error.
+      }
+      process.exit(0);
+    }, 10);
   }, duration * 1000);
 
   function read() {

--- a/benchmark/fs/writefile-promises.js
+++ b/benchmark/fs/writefile-promises.js
@@ -43,14 +43,20 @@ function main({ encodingType, duration, concurrent, size }) {
   setTimeout(() => {
     benchEnded = true;
     bench.end(writes);
-    for (let i = 0; i < filesWritten; i++) {
-      try {
-        fs.unlinkSync(`${filename}-${i}`);
-      } catch {
-        // Continue regardless of error.
+
+    // This delay is needed because on windows this can cause
+    // race condition with afterRead, which makes this benchmark
+    // fails to delete the temp file
+    setTimeout(() => {
+      for (let i = 0; i < filesWritten; i++) {
+        try {
+          fs.unlinkSync(`${filename}-${i}`);
+        } catch {
+          // Continue regardless of error.
+        }
       }
-    }
-    process.exit(0);
+      process.exit(0);
+    }, 10);
   }, duration * 1000);
 
   function write() {

--- a/benchmark/fs/writefile-promises.js
+++ b/benchmark/fs/writefile-promises.js
@@ -5,7 +5,6 @@
 
 const common = require('../common.js');
 const fs = require('fs');
-const assert = require('assert');
 const tmpdir = require('../../test/common/tmpdir');
 
 tmpdir.refresh();
@@ -44,7 +43,7 @@ function main({ encodingType, duration, concurrent, size }) {
   const endAt = startedAt + (duration * 1000);
 
   bench.start();
-  
+
   function stop() {
     bench.end(writes);
 
@@ -67,16 +66,11 @@ function main({ encodingType, duration, concurrent, size }) {
 
   function afterWrite(er) {
     if (er) {
-      if (er.code === 'ENOENT') {
-        // Only OK if unlinked by the timer from main.
-        assert.ok(benchEnded);
-        return;
-      }
       throw er;
     }
 
     writes++;
-    let benchEnded = Date.now() >= endAt;
+    const benchEnded = Date.now() >= endAt;
 
     if (benchEnded && (++waitConcurrent) === concurrent) {
       stop();


### PR DESCRIPTION
Some of these benchmarks fails even on main versions of Node.js.

This issue is caused because `afterRead` is being called and is locking the temp file which makes the `.on('exit')` fails to clean the temp file.

If we wait all the concurrent timers to finish, the issue is solved.

First found this issue on: https://github.com/nodejs/node/pull/49962