### PR TITLE
module: initialize hook returns load, resolve

### DIFF
--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -6,6 +6,7 @@ const {
   AtomicsLoad,
   AtomicsWait,
   AtomicsWaitAsync,
+  FunctionPrototypeBind,
   Int32Array,
   ObjectAssign,
   ObjectDefineProperty,
@@ -162,7 +163,7 @@ class Hooks {
    * to the worker.
    * @returns {any | Promise<any>} User data, ignored unless it's a promise, in which case it will be awaited.
    */
-  addCustomLoader(url, exports, data) {
+  async addCustomLoader(url, exports, data) {
     const {
       initialize,
       resolve,
@@ -177,7 +178,30 @@ class Hooks {
       const next = this.#chains.load[this.#chains.load.length - 1];
       ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: load, url, next });
     }
-    return initialize?.(data);
+
+    const hooks = await initialize?.(data);
+
+    if (hooks?.resolve) {
+      if (resolve) {
+        throw new ERR_INTERNAL_ASSERTION(
+          `ESM custom loader '${url}' exposed a 'resolve' hook and returned an object with a 'resolve' hook.`,
+        );
+      }
+      const next = this.#chains.resolve[this.#chains.resolve.length - 1];
+      const boundResolve = FunctionPrototypeBind(hooks.resolve, hooks);
+      ArrayPrototypePush(this.#chains.resolve, { __proto__: null, fn: boundResolve, url, next });
+    }
+
+    if (hooks?.load) {
+      if (load) {
+        throw new ERR_INTERNAL_ASSERTION(
+          `ESM custom loader '${url}' exposed a 'load' hook and returned an object with a 'load' hook.`,
+        );
+      }
+      const next = this.#chains.load[this.#chains.load.length - 1];
+      const boundLoad = FunctionPrototypeBind(hooks.load, hooks);
+      ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: boundLoad, url, next });
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This commit allows the `initialize()` hook to optionally return an object having the `resolve()` and `load()` hooks as properties. This allows state passed into `initialize()` to be shared with the `resolve()` and `load()` hooks either via closure or class instance.

In addition to developer ergonomics, supporting this model will make it easier to write tests against a loader module. The existing design 
forces state to be shared at the module level which puts the burden of invalidating the ESM module cache on anyone hoping to write isolated 
tests against a loader module.

TODO:
- [ ] Obtain consent / consensus to explore this api.
- [ ] Write tests.

Fixes: #50042