### PR TITLE
tools: add --rerun-failures option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -524,7 +524,7 @@ endif
 # Related CI job: node-test-commit-arm-fanned
 test-ci-native: LOGLEVEL := info
 test-ci-native: | benchmark/napi/.buildstamp test/addons/.buildstamp test/js-native-api/.buildstamp test/node-api/.buildstamp
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --rerun-failures=3 -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_NATIVE_SUITES)
 
@@ -532,7 +532,7 @@ test-ci-native: | benchmark/napi/.buildstamp test/addons/.buildstamp test/js-nat
 # This target should not use a native compiler at all
 # Related CI job: node-test-commit-arm-fanned
 test-ci-js: | clear-stalled
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --rerun-failures=3 -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES)
 	$(info Clean up any leftover processes, error if found.)
@@ -547,7 +547,7 @@ test-ci-js: | clear-stalled
 test-ci: LOGLEVEL := info
 test-ci: | clear-stalled bench-addons-build build-addons build-js-native-api-tests build-node-api-tests doc-only
 	out/Release/cctest --gtest_output=xml:out/junit/cctest.xml
-	$(PYTHON) tools/test.py $(PARALLEL_ARGS) -p tap --logfile test.tap \
+	$(PYTHON) tools/test.py $(PARALLEL_ARGS) --rerun-failures=3 -p tap --logfile test.tap \
 		--mode=$(BUILDTYPE_LOWER) --flaky-tests=$(FLAKY_TESTS) \
 		$(TEST_CI_ARGS) $(CI_JS_SUITES) $(CI_NATIVE_SUITES) $(CI_DOC)
 	$(NODE) ./test/embedding/test-embedding.js

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -96,8 +96,8 @@ if /i "%1"=="nocorepack"    set nocorepack=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
 if /i "%1"=="licensertf"    set licensertf=1&goto arg-ok
 if /i "%1"=="test"          set test_args=%test_args% %common_test_suites%&set lint_cpp=1&set lint_js=1&set lint_md=1&goto arg-ok
-if /i "%1"=="test-ci-native" set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set cctest_args=%cctest_args% --gtest_output=xml:cctest.junit.xml&goto arg-ok
-if /i "%1"=="test-ci-js"    set test_args=%test_args% %test_ci_args% -p tap --logfile test.tap %CI_JS_SUITES%&set no_cctest=1&goto arg-ok
+if /i "%1"=="test-ci-native" set test_args=%test_args% %test_ci_args% --rerun-failures=3 -p tap --logfile test.tap %CI_NATIVE_SUITES% %CI_DOC%&set build_addons=1&set build_js_native_api_tests=1&set build_node_api_tests=1&set cctest_args=%cctest_args% --gtest_output=xml:cctest.junit.xml&goto arg-ok
+if /i "%1"=="test-ci-js"    set test_args=%test_args% %test_ci_args% --rerun-failures=3 -p tap --logfile test.tap %CI_JS_SUITES%&set no_cctest=1&goto arg-ok
 if /i "%1"=="build-addons"   set build_addons=1&goto arg-ok
 if /i "%1"=="build-js-native-api-tests"   set build_js_native_api_tests=1&goto arg-ok
 if /i "%1"=="build-node-api-tests"   set build_node_api_tests=1&goto arg-ok


### PR DESCRIPTION
### What problem does this PR solve?
Currently, in the test CI, we have some tests that fail from time to time which aren't marked as flaky. They can get very annoying, especially when running for PRs, and in some cases, multiple reruns are needed for PR to pass all of the CI checks. This PR aims to at least minimize if not completely remove, the reruns needed.

### How does this PR solve the problem?
A new parameter, called `--rerun-failures`, is added in the `tools/test.py` script. The inspiration was taken from the `--measure-flakiness` parameter, but while it only measures the flakiness, the new one marks the test as passed if any of the reruns (or the initial run) passes and it only reruns until a rerun passes. When one of the reruns passes the test, that is noted in the output together with a suggestion to mark the test as flaky, and in the diagnostic part, all failed runs previous to that one are logged. Implementation is made in a way that lets us use `--rerun-failures`, `--measure-flakiness`, or both of them together without interfering with each other. `vcbuild.bat` and `Makefile` are changed so that when tests are started from the CI `--rerun-failures=3` is used. 3 is a magic number, which seemed OK as it is neither too low, nor too high, but I'm open to suggestions.