### PR TITLE
test: improve code coverage of diagnostics_channel

### DIFF
--- a/test/parallel/test-diagnostics-channel-tracing-channel-args-types.js
+++ b/test/parallel/test-diagnostics-channel-tracing-channel-args-types.js
@@ -1,0 +1,39 @@
+'use strict';
+
+require('../common');
+const dc = require('diagnostics_channel');
+const assert = require('assert');
+
+let channel;
+
+// tracingChannel creating with name
+channel = dc.tracingChannel('test');
+assert.strictEqual(channel.start.name, 'tracing:test:start');
+
+// tracingChannel creating with channels
+channel = dc.tracingChannel({
+  start: dc.channel('tracing:test:start'),
+  end: dc.channel('tracing:test:end'),
+  asyncStart: dc.channel('tracing:test:asyncStart'),
+  asyncEnd: dc.channel('tracing:test:asyncEnd'),
+  error: dc.channel('tracing:test:error'),
+});
+
+// tracingChannel creating without nameOrChannels must throw TypeError
+assert.throws(() => (channel = dc.tracingChannel(0)), {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError',
+  message:
+    /The "nameOrChannels" argument must be of type string or an instance of Channel or Object/,
+});
+
+// tracingChannel creating without instance of Channel must throw error
+assert.throws(() => (channel = dc.tracingChannel({ start: '' })), {
+  code: 'ERR_INVALID_ARG_TYPE',
+  message: /The "nameOrChannels\.start" property must be an instance of Channel/,
+});
+
+// tracingChannel creating with empty nameOrChannels must throw error
+assert.throws(() => (channel = dc.tracingChannel({})), {
+  message: /Cannot convert undefined or null to object/,
+});


### PR DESCRIPTION
test: improve code coverage of diagnostics_channel

<img width="1309" alt="Screenshot 2023-10-06 at 12 51 32 am" src="https://github.com/nodejs/node/assets/26359740/79d37a5d-fe2a-4a8e-8c75-c8d5ab14fc8e">

Current coverage report: https://app.codecov.io/gh/nodejs/node/blob/main/lib%2Fdiagnostics_channel.js

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
