### PR TITLE
crypto: use X509_ALGOR accessors instead of reaching into X509_ALGOR

### DIFF
--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -577,7 +577,9 @@ Maybe<bool> GetRsaKeyDetail(
       int64_t salt_length = 20;
 
       if (params->hashAlgorithm != nullptr) {
-        hash_nid = OBJ_obj2nid(params->hashAlgorithm->algorithm);
+        const ASN1_OBJECT* hash_obj;
+        X509_ALGOR_get0(&hash_obj, nullptr, nullptr, params->hashAlgorithm);
+        hash_nid = OBJ_obj2nid(hash_obj);
       }
 
       if (target
@@ -590,9 +592,13 @@ Maybe<bool> GetRsaKeyDetail(
       }
 
       if (params->maskGenAlgorithm != nullptr) {
-        mgf_nid = OBJ_obj2nid(params->maskGenAlgorithm->algorithm);
+        const ASN1_OBJECT* mgf_obj;
+        X509_ALGOR_get0(&mgf_obj, nullptr, nullptr, params->maskGenAlgorithm);
+        mgf_nid = OBJ_obj2nid(mgf_obj);
         if (mgf_nid == NID_mgf1) {
-          mgf1_hash_nid = OBJ_obj2nid(params->maskHash->algorithm);
+          const ASN1_OBJECT* mgf1_hash_obj;
+          X509_ALGOR_get0(&mgf1_hash_obj, nullptr, nullptr, params->maskHash);
+          mgf1_hash_nid = OBJ_obj2nid(mgf1_hash_obj);
         }
       }
 


### PR DESCRIPTION
While the struct is still public in OpenSSL, there is a (somewhat inconvenient) accessor. Use it to remain compatible if it becomes opaque in the future.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
