### PR TITLE
node-api: segregate nogc APIs from rest via type system

### DIFF
--- a/doc/contributing/adding-new-napi-api.md
+++ b/doc/contributing/adding-new-napi-api.md
@@ -51,3 +51,16 @@ Node-API.
       to the decision to take an API out of experimental status.
     * The API **must** be implemented in a Node.js implementation with an
       alternate VM.
+
+Since the adoption of the policy whereby moving to a later version of Node-API
+from an earlier version may entail rework of existing code, it is possible to
+introduce modifications to already-released Node-APIs, as long as the
+modifications affect neither the ABI nor the API of earlier versions. Such
+modifications **must** be accompanied by an opt-out flag. This provides add-on
+maintainers who take advantage of the initial compile-time flag to track
+impending changes to Node-API with
+
+* a quick fix to the breakage caused,
+* a notification that such breakage is impending, and thus
+* a buffer to adoption above and beyond the one provided by the initial
+  compile-time flag.

--- a/doc/contributing/releases-node-api.md
+++ b/doc/contributing/releases-node-api.md
@@ -84,7 +84,11 @@ define guards on the declaration of the new Node-API. Check for these guards
 with:
 
 ```bash
-grep NAPI_EXPERIMENTAL src/js_native_api{_types,}.h src/node_api{_types,}.h
+grep                           \
+  -E                           \
+  'N(ODE_)?API_EXPERIMENTAL'   \
+  src/js_native_api{_types,}.h \
+  src/node_api{_types,}.h
 ```
 
 and update the define version guards with the release version:
@@ -101,6 +105,9 @@ and update the define version guards with the release version:
 ```
 
 Remove any feature flags of the form `NODE_API_EXPERIMENTAL_HAS_<FEATURE>`.
+
+Remove any additional `NODE_API_EXPERIMENTAL_*` guards along with
+`NAPI_EXPERIMENTAL`.
 
 Also, update the Node-API version value of the `napi_get_version` test in
 `test/js-native-api/test_general/test.js` with the release version `x`:
@@ -130,7 +137,11 @@ commits should already include `NAPI_EXPERIMENTAL` definition for the tests.
 Check for these definitions with:
 
 ```bash
-grep NAPI_EXPERIMENTAL test/node-api/*/{*.{h,c},binding.gyp} test/js-native-api/*/{*.{h,c},binding.gyp}
+grep                                    \
+  -E                                    \
+  'N(ODE_)?API_EXPERIMENTAL'            \
+  test/node-api/*/{*.{h,c},binding.gyp} \
+  test/js-native-api/*/{*.{h,c},binding.gyp}
 ```
 
 and substitute the `NAPI_EXPERIMENTAL` with the release version
@@ -140,6 +151,8 @@ and substitute the `NAPI_EXPERIMENTAL` with the release version
 - #define NAPI_EXPERIMENTAL
 + #define NAPI_VERSION 10
 ```
+
+Remove any `NODE_API_EXPERIMENTAL_*` flags.
 
 #### Step 4. Update document
 

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -49,8 +49,8 @@
 
 EXTERN_C_START
 
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_get_last_error_info(napi_env env, const napi_extended_error_info** result);
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_last_error_info(
+    node_api_nogc_env env, const napi_extended_error_info** result);
 
 // Getters for defined singletons
 NAPI_EXTERN napi_status NAPI_CDECL napi_get_undefined(napi_env env,
@@ -98,7 +98,7 @@ NAPI_EXTERN napi_status NAPI_CDECL
 node_api_create_external_string_latin1(napi_env env,
                                        char* str,
                                        size_t length,
-                                       napi_finalize finalize_callback,
+                                       node_api_nogc_finalize finalize_callback,
                                        void* finalize_hint,
                                        napi_value* result,
                                        bool* copied);
@@ -106,7 +106,7 @@ NAPI_EXTERN napi_status NAPI_CDECL
 node_api_create_external_string_utf16(napi_env env,
                                       char16_t* str,
                                       size_t length,
-                                      napi_finalize finalize_callback,
+                                      node_api_nogc_finalize finalize_callback,
                                       void* finalize_hint,
                                       napi_value* result,
                                       bool* copied);
@@ -290,7 +290,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_instanceof(napi_env env,
 
 // Gets all callback info in a single call. (Ugly, but faster.)
 NAPI_EXTERN napi_status NAPI_CDECL napi_get_cb_info(
-    napi_env env,               // [in] NAPI environment handle
+    napi_env env,               // [in] Node-API environment handle
     napi_callback_info cbinfo,  // [in] Opaque callback-info handle
     size_t* argc,      // [in-out] Specifies the size of the provided argv array
                        // and receives the actual count of args.
@@ -314,7 +314,7 @@ napi_define_class(napi_env env,
 NAPI_EXTERN napi_status NAPI_CDECL napi_wrap(napi_env env,
                                              napi_value js_object,
                                              void* native_object,
-                                             napi_finalize finalize_cb,
+                                             node_api_nogc_finalize finalize_cb,
                                              void* finalize_hint,
                                              napi_ref* result);
 NAPI_EXTERN napi_status NAPI_CDECL napi_unwrap(napi_env env,
@@ -326,7 +326,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_remove_wrap(napi_env env,
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external(napi_env env,
                      void* data,
-                     napi_finalize finalize_cb,
+                     node_api_nogc_finalize finalize_cb,
                      void* finalize_hint,
                      napi_value* result);
 NAPI_EXTERN napi_status NAPI_CDECL napi_get_value_external(napi_env env,
@@ -425,7 +425,7 @@ NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external_arraybuffer(napi_env env,
                                  void* external_data,
                                  size_t byte_length,
-                                 napi_finalize finalize_cb,
+                                 node_api_nogc_finalize finalize_cb,
                                  void* finalize_hint,
                                  napi_value* result);
 #endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
@@ -467,7 +467,7 @@ napi_get_dataview_info(napi_env env,
                        size_t* byte_offset);
 
 // version management
-NAPI_EXTERN napi_status NAPI_CDECL napi_get_version(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_version(node_api_nogc_env env,
                                                     uint32_t* result);
 
 // Promises
@@ -491,7 +491,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_run_script(napi_env env,
 
 // Memory management
 NAPI_EXTERN napi_status NAPI_CDECL napi_adjust_external_memory(
-    napi_env env, int64_t change_in_bytes, int64_t* adjusted_value);
+    node_api_nogc_env env, int64_t change_in_bytes, int64_t* adjusted_value);
 
 #if NAPI_VERSION >= 5
 
@@ -509,12 +509,13 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_get_date_value(napi_env env,
                                                        double* result);
 
 // Add finalizer for pointer
-NAPI_EXTERN napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
-                                                      napi_value js_object,
-                                                      void* finalize_data,
-                                                      napi_finalize finalize_cb,
-                                                      void* finalize_hint,
-                                                      napi_ref* result);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_add_finalizer(napi_env env,
+                   napi_value js_object,
+                   void* finalize_data,
+                   node_api_nogc_finalize finalize_cb,
+                   void* finalize_hint,
+                   napi_ref* result);
 
 #endif  // NAPI_VERSION >= 5
 
@@ -522,7 +523,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
 #define NODE_API_EXPERIMENTAL_HAS_POST_FINALIZER
 
 NAPI_EXTERN napi_status NAPI_CDECL
-node_api_post_finalizer(napi_env env,
+node_api_post_finalizer(node_api_nogc_env env,
                         napi_finalize finalize_cb,
                         void* finalize_data,
                         void* finalize_hint);
@@ -566,10 +567,13 @@ napi_get_all_property_names(napi_env env,
                             napi_value* result);
 
 // Instance data
-NAPI_EXTERN napi_status NAPI_CDECL napi_set_instance_data(
-    napi_env env, void* data, napi_finalize finalize_cb, void* finalize_hint);
+NAPI_EXTERN napi_status NAPI_CDECL
+napi_set_instance_data(node_api_nogc_env env,
+                       void* data,
+                       napi_finalize finalize_cb,
+                       void* finalize_hint);
 
-NAPI_EXTERN napi_status NAPI_CDECL napi_get_instance_data(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_get_instance_data(node_api_nogc_env env,
                                                           void** data);
 #endif  // NAPI_VERSION >= 6
 

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -4,7 +4,7 @@
 #include "js_native_api_types.h"
 #include "js_native_api_v8_internals.h"
 
-inline napi_status napi_clear_last_error(napi_env env);
+inline napi_status napi_clear_last_error(node_api_nogc_env env);
 
 namespace v8impl {
 
@@ -172,7 +172,8 @@ struct napi_env__ {
   virtual ~napi_env__() = default;
 };
 
-inline napi_status napi_clear_last_error(napi_env env) {
+inline napi_status napi_clear_last_error(node_api_nogc_env nogc_env) {
+  napi_env env = const_cast<napi_env>(nogc_env);
   env->last_error.error_code = napi_ok;
   env->last_error.engine_error_code = 0;
   env->last_error.engine_reserved = nullptr;
@@ -180,10 +181,11 @@ inline napi_status napi_clear_last_error(napi_env env) {
   return napi_ok;
 }
 
-inline napi_status napi_set_last_error(napi_env env,
+inline napi_status napi_set_last_error(node_api_nogc_env nogc_env,
                                        napi_status error_code,
                                        uint32_t engine_error_code = 0,
                                        void* engine_reserved = nullptr) {
+  napi_env env = const_cast<napi_env>(nogc_env);
   env->last_error.error_code = error_code;
   env->last_error.engine_error_code = engine_error_code;
   env->last_error.engine_reserved = engine_reserved;

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -765,7 +765,7 @@ void NAPI_CDECL napi_module_register(napi_module* mod) {
   node::node_module_register(nm);
 }
 
-napi_status NAPI_CDECL napi_add_env_cleanup_hook(napi_env env,
+napi_status NAPI_CDECL napi_add_env_cleanup_hook(node_api_nogc_env env,
                                                  napi_cleanup_hook fun,
                                                  void* arg) {
   CHECK_ENV(env);
@@ -776,7 +776,7 @@ napi_status NAPI_CDECL napi_add_env_cleanup_hook(napi_env env,
   return napi_ok;
 }
 
-napi_status NAPI_CDECL napi_remove_env_cleanup_hook(napi_env env,
+napi_status NAPI_CDECL napi_remove_env_cleanup_hook(node_api_nogc_env env,
                                                     napi_cleanup_hook fun,
                                                     void* arg) {
   CHECK_ENV(env);
@@ -823,10 +823,11 @@ struct napi_async_cleanup_hook_handle__ {
 };
 
 napi_status NAPI_CDECL
-napi_add_async_cleanup_hook(napi_env env,
+napi_add_async_cleanup_hook(node_api_nogc_env nogc_env,
                             napi_async_cleanup_hook hook,
                             void* arg,
                             napi_async_cleanup_hook_handle* remove_handle) {
+  napi_env env = const_cast<napi_env>(nogc_env);
   CHECK_ENV(env);
   CHECK_ARG(env, hook);
 
@@ -1037,12 +1038,14 @@ napi_status NAPI_CDECL napi_create_buffer(napi_env env,
   return GET_RETURN_STATUS(env);
 }
 
-napi_status NAPI_CDECL napi_create_external_buffer(napi_env env,
-                                                   size_t length,
-                                                   void* data,
-                                                   napi_finalize finalize_cb,
-                                                   void* finalize_hint,
-                                                   napi_value* result) {
+napi_status NAPI_CDECL
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            node_api_nogc_finalize nogc_finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result) {
+  napi_finalize finalize_cb = reinterpret_cast<napi_finalize>(nogc_finalize_cb);
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
@@ -1126,7 +1129,7 @@ napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status NAPI_CDECL napi_get_node_version(napi_env env,
+napi_status NAPI_CDECL napi_get_node_version(node_api_nogc_env env,
                                              const napi_node_version** result) {
   CHECK_ENV(env);
   CHECK_ARG(env, result);
@@ -1270,14 +1273,16 @@ napi_status NAPI_CDECL napi_delete_async_work(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status NAPI_CDECL napi_get_uv_event_loop(napi_env env, uv_loop_t** loop) {
+napi_status NAPI_CDECL napi_get_uv_event_loop(node_api_nogc_env nogc_env,
+                                              uv_loop_t** loop) {
+  napi_env env = const_cast<napi_env>(nogc_env);
   CHECK_ENV(env);
   CHECK_ARG(env, loop);
   *loop = reinterpret_cast<node_napi_env>(env)->node_env()->event_loop();
   return napi_clear_last_error(env);
 }
 
-napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
+napi_status NAPI_CDECL napi_queue_async_work(node_api_nogc_env env,
                                              napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
@@ -1292,7 +1297,7 @@ napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
   return napi_clear_last_error(env);
 }
 
-napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
+napi_status NAPI_CDECL napi_cancel_async_work(node_api_nogc_env env,
                                               napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
@@ -1312,10 +1317,12 @@ napi_create_threadsafe_function(napi_env env,
                                 size_t max_queue_size,
                                 size_t initial_thread_count,
                                 void* thread_finalize_data,
-                                napi_finalize thread_finalize_cb,
+                                node_api_nogc_finalize nogc_thread_finalize_cb,
                                 void* context,
                                 napi_threadsafe_function_call_js call_js_cb,
                                 napi_threadsafe_function* result) {
+  napi_finalize thread_finalize_cb =
+      reinterpret_cast<napi_finalize>(nogc_thread_finalize_cb);
   CHECK_ENV_NOT_IN_GC(env);
   CHECK_ARG(env, async_resource_name);
   RETURN_STATUS_IF_FALSE(env, initial_thread_count > 0, napi_invalid_arg);
@@ -1397,20 +1404,21 @@ napi_status NAPI_CDECL napi_release_threadsafe_function(
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Release(mode);
 }
 
-napi_status NAPI_CDECL
-napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
+napi_status NAPI_CDECL napi_unref_threadsafe_function(
+    node_api_nogc_env env, napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Unref();
 }
 
-napi_status NAPI_CDECL
-napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func) {
+napi_status NAPI_CDECL napi_ref_threadsafe_function(
+    node_api_nogc_env env, napi_threadsafe_function func) {
   CHECK_NOT_NULL(func);
   return reinterpret_cast<v8impl::ThreadSafeFunction*>(func)->Ref();
 }
 
-napi_status NAPI_CDECL node_api_get_module_file_name(napi_env env,
+napi_status NAPI_CDECL node_api_get_module_file_name(node_api_nogc_env nogc_env,
                                                      const char** result) {
+  napi_env env = const_cast<napi_env>(nogc_env);
   CHECK_ENV(env);
   CHECK_ARG(env, result);
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -131,7 +131,7 @@ NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_external_buffer(napi_env env,
                             size_t length,
                             void* data,
-                            napi_finalize finalize_cb,
+                            node_api_nogc_finalize finalize_cb,
                             void* finalize_hint,
                             napi_value* result);
 #endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
@@ -159,20 +159,20 @@ napi_create_async_work(napi_env env,
                        napi_async_work* result);
 NAPI_EXTERN napi_status NAPI_CDECL napi_delete_async_work(napi_env env,
                                                           napi_async_work work);
-NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(node_api_nogc_env env,
                                                          napi_async_work work);
-NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(node_api_nogc_env env,
                                                           napi_async_work work);
 
 // version management
 NAPI_EXTERN napi_status NAPI_CDECL
-napi_get_node_version(napi_env env, const napi_node_version** version);
+napi_get_node_version(node_api_nogc_env env, const napi_node_version** version);
 
 #if NAPI_VERSION >= 2
 
 // Return the current libuv event loop for a given environment
 NAPI_EXTERN napi_status NAPI_CDECL
-napi_get_uv_event_loop(napi_env env, struct uv_loop_s** loop);
+napi_get_uv_event_loop(node_api_nogc_env env, struct uv_loop_s** loop);
 
 #endif  // NAPI_VERSION >= 2
 
@@ -181,11 +181,11 @@ napi_get_uv_event_loop(napi_env env, struct uv_loop_s** loop);
 NAPI_EXTERN napi_status NAPI_CDECL napi_fatal_exception(napi_env env,
                                                         napi_value err);
 
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_add_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_add_env_cleanup_hook(
+    node_api_nogc_env env, napi_cleanup_hook fun, void* arg);
 
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_remove_env_cleanup_hook(napi_env env, napi_cleanup_hook fun, void* arg);
+NAPI_EXTERN napi_status NAPI_CDECL napi_remove_env_cleanup_hook(
+    node_api_nogc_env env, napi_cleanup_hook fun, void* arg);
 
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_open_callback_scope(napi_env env,
@@ -209,7 +209,7 @@ napi_create_threadsafe_function(napi_env env,
                                 size_t max_queue_size,
                                 size_t initial_thread_count,
                                 void* thread_finalize_data,
-                                napi_finalize thread_finalize_cb,
+                                node_api_nogc_finalize thread_finalize_cb,
                                 void* context,
                                 napi_threadsafe_function_call_js call_js_cb,
                                 napi_threadsafe_function* result);
@@ -228,18 +228,18 @@ napi_acquire_threadsafe_function(napi_threadsafe_function func);
 NAPI_EXTERN napi_status NAPI_CDECL napi_release_threadsafe_function(
     napi_threadsafe_function func, napi_threadsafe_function_release_mode mode);
 
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+NAPI_EXTERN napi_status NAPI_CDECL napi_unref_threadsafe_function(
+    node_api_nogc_env env, napi_threadsafe_function func);
 
-NAPI_EXTERN napi_status NAPI_CDECL
-napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+NAPI_EXTERN napi_status NAPI_CDECL napi_ref_threadsafe_function(
+    node_api_nogc_env env, napi_threadsafe_function func);
 
 #endif  // NAPI_VERSION >= 4
 
 #if NAPI_VERSION >= 8
 
 NAPI_EXTERN napi_status NAPI_CDECL
-napi_add_async_cleanup_hook(napi_env env,
+napi_add_async_cleanup_hook(node_api_nogc_env env,
                             napi_async_cleanup_hook hook,
                             void* arg,
                             napi_async_cleanup_hook_handle* remove_handle);
@@ -252,7 +252,7 @@ napi_remove_async_cleanup_hook(napi_async_cleanup_hook_handle remove_handle);
 #if NAPI_VERSION >= 9
 
 NAPI_EXTERN napi_status NAPI_CDECL
-node_api_get_module_file_name(napi_env env, const char** result);
+node_api_get_module_file_name(node_api_nogc_env env, const char** result);
 
 #endif  // NAPI_VERSION >= 9
 

--- a/test/js-native-api/common.h
+++ b/test/js-native-api/common.h
@@ -2,6 +2,7 @@
 #define JS_NATIVE_API_COMMON_H_
 
 #include <js_native_api.h>
+#include <stdlib.h>  // abort()
 
 // Empty value so that macros here are able to return NULL or void
 #define NODE_API_RETVAL_NOTHING  // Intentionally blank #define
@@ -22,6 +23,19 @@
     }                                                                    \
   } while (0)
 
+// The nogc version of GET_AND_THROW_LAST_ERROR. We cannot access any
+// exceptions and we cannot fail by way of JS exception, so we abort.
+#define FATALLY_FAIL_WITH_LAST_ERROR(env)                                      \
+  do {                                                                         \
+    const napi_extended_error_info* error_info;                                \
+    napi_get_last_error_info((env), &error_info);                              \
+    const char* err_message = error_info->error_message;                       \
+    const char* error_message =                                                \
+        err_message != NULL ? err_message : "empty error message";             \
+    fprintf(stderr, "%s\n", error_message);                                    \
+    abort();                                                                   \
+  } while (0)
+
 #define NODE_API_ASSERT_BASE(env, assertion, message, ret_val)           \
   do {                                                                   \
     if (!(assertion)) {                                                  \
@@ -31,6 +45,15 @@
           "assertion (" #assertion ") failed: " message);                \
       return ret_val;                                                    \
     }                                                                    \
+  } while (0)
+
+#define NODE_API_NOGC_ASSERT_BASE(assertion, message, ret_val)                 \
+  do {                                                                         \
+    if (!(assertion)) {                                                        \
+      fprintf(stderr, "assertion (" #assertion ") failed: " message);          \
+      abort();                                                                 \
+      return ret_val;                                                          \
+    }                                                                          \
   } while (0)
 
 // Returns NULL on failed assertion.
@@ -43,12 +66,23 @@
 #define NODE_API_ASSERT_RETURN_VOID(env, assertion, message)             \
   NODE_API_ASSERT_BASE(env, assertion, message, NODE_API_RETVAL_NOTHING)
 
+#define NODE_API_NOGC_ASSERT_RETURN_VOID(assertion, message)                   \
+  NODE_API_NOGC_ASSERT_BASE(assertion, message, NODE_API_RETVAL_NOTHING)
+
 #define NODE_API_CALL_BASE(env, the_call, ret_val)                       \
   do {                                                                   \
     if ((the_call) != napi_ok) {                                         \
       GET_AND_THROW_LAST_ERROR((env));                                   \
       return ret_val;                                                    \
     }                                                                    \
+  } while (0)
+
+#define NODE_API_NOGC_CALL_BASE(env, the_call, ret_val)                        \
+  do {                                                                         \
+    if ((the_call) != napi_ok) {                                               \
+      FATALLY_FAIL_WITH_LAST_ERROR((env));                                     \
+      return ret_val;                                                          \
+    }                                                                          \
   } while (0)
 
 // Returns NULL if the_call doesn't return napi_ok.
@@ -58,6 +92,9 @@
 // Returns empty if the_call doesn't return napi_ok.
 #define NODE_API_CALL_RETURN_VOID(env, the_call)                         \
   NODE_API_CALL_BASE(env, the_call, NODE_API_RETVAL_NOTHING)
+
+#define NODE_API_NOGC_CALL_RETURN_VOID(env, the_call)                          \
+  NODE_API_NOGC_CALL_BASE(env, the_call, NODE_API_RETVAL_NOTHING)
 
 #define NODE_API_CHECK_STATUS(the_call)                                   \
   do {                                                                         \

--- a/test/js-native-api/test_finalizer/test_finalizer.c
+++ b/test/js-native-api/test_finalizer/test_finalizer.c
@@ -11,17 +11,17 @@ typedef struct {
   napi_ref js_func;
 } FinalizerData;
 
-static void finalizerOnlyCallback(napi_env env,
+static void finalizerOnlyCallback(node_api_nogc_env env,
                                   void* finalize_data,
                                   void* finalize_hint) {
   FinalizerData* data = (FinalizerData*)finalize_data;
   int32_t count = ++data->finalize_count;
 
   // It is safe to access instance data
-  NODE_API_CALL_RETURN_VOID(env, napi_get_instance_data(env, (void**)&data));
-  NODE_API_ASSERT_RETURN_VOID(env,
-                              count = data->finalize_count,
-                              "Expected to be the same FinalizerData");
+  NODE_API_NOGC_CALL_RETURN_VOID(env,
+                                 napi_get_instance_data(env, (void**)&data));
+  NODE_API_NOGC_ASSERT_RETURN_VOID(count = data->finalize_count,
+                                   "Expected to be the same FinalizerData");
 }
 
 static void finalizerCallingJSCallback(napi_env env,
@@ -40,18 +40,20 @@ static void finalizerCallingJSCallback(napi_env env,
 }
 
 // Schedule async finalizer to run JavaScript-touching code.
-static void finalizerWithJSCallback(napi_env env,
+static void finalizerWithJSCallback(node_api_nogc_env env,
                                     void* finalize_data,
                                     void* finalize_hint) {
-  NODE_API_CALL_RETURN_VOID(
+  NODE_API_NOGC_CALL_RETURN_VOID(
       env,
       node_api_post_finalizer(
           env, finalizerCallingJSCallback, finalize_data, finalize_hint));
 }
 
-static void finalizerWithFailedJSCallback(napi_env env,
+static void finalizerWithFailedJSCallback(node_api_nogc_env nogc_env,
                                           void* finalize_data,
                                           void* finalize_hint) {
+  // Intentionally cast to a napi_env to test the fatal failure.
+  napi_env env = (napi_env)nogc_env;
   napi_value obj;
   FinalizerData* data = (FinalizerData*)finalize_data;
   ++data->finalize_count;

--- a/test/js-native-api/test_string/test_string.c
+++ b/test/js-native-api/test_string/test_string.c
@@ -88,7 +88,7 @@ static napi_value TestTwoByteImpl(napi_env env,
   return output;
 }
 
-static void free_string(napi_env env, void* data, void* hint) {
+static void free_string(node_api_nogc_env env, void* data, void* hint) {
   free(data);
 }
 

--- a/test/node-api/test_reference_by_node_api_version/test_reference_by_node_api_version.c
+++ b/test/node-api/test_reference_by_node_api_version/test_reference_by_node_api_version.c
@@ -4,12 +4,12 @@
 
 static uint32_t finalizeCount = 0;
 
-static void FreeData(napi_env env, void* data, void* hint) {
-  NODE_API_ASSERT_RETURN_VOID(env, data != NULL, "Expects non-NULL data.");
+static void FreeData(node_api_nogc_env env, void* data, void* hint) {
+  NODE_API_NOGC_ASSERT_RETURN_VOID(data != NULL, "Expects non-NULL data.");
   free(data);
 }
 
-static void Finalize(napi_env env, void* data, void* hint) {
+static void Finalize(node_api_nogc_env env, void* data, void* hint) {
   ++finalizeCount;
 }
 
@@ -61,7 +61,7 @@ static napi_value ToUInt32Value(napi_env env, uint32_t value) {
 static napi_status InitRefArray(napi_env env) {
   // valueRefs array has one entry per napi_valuetype
   napi_ref* valueRefs = malloc(sizeof(napi_ref) * ((int)napi_bigint + 1));
-  return napi_set_instance_data(env, valueRefs, &FreeData, NULL);
+  return napi_set_instance_data(env, valueRefs, (napi_finalize)&FreeData, NULL);
 }
 
 static napi_value CreateExternal(napi_env env, napi_callback_info info) {

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception.c
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception.c
@@ -16,6 +16,18 @@ static void ThreadSafeFunctionFinalize(napi_env env,
   NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, js_func_ref));
 }
 
+static void ThreadSafeFunctionNogcFinalize(node_api_nogc_env env,
+                                           void* data,
+                                           void* hint) {
+#ifdef NAPI_EXPERIMENTAL
+  NODE_API_NOGC_CALL_RETURN_VOID(
+      env,
+      node_api_post_finalizer(env, ThreadSafeFunctionFinalize, data, hint));
+#else
+  ThreadSafeFunctionFinalize(env, data, hint);
+#endif
+}
+
 // Testing calling into JavaScript
 static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
   size_t argc = 4;
@@ -34,7 +46,7 @@ static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
                                                 0,
                                                 1,
                                                 finalize_func,
-                                                ThreadSafeFunctionFinalize,
+                                                ThreadSafeFunctionNogcFinalize,
                                                 NULL,
                                                 NULL,
                                                 &tsfn));

--- a/tools/build-addons.mjs
+++ b/tools/build-addons.mjs
@@ -58,6 +58,8 @@ const jobs = [];
 for await (const dirent of await fs.opendir(directory)) {
   if (dirent.isDirectory()) {
     jobs.push(() => buildAddon(path.join(directory, dirent.name)));
+  } else if (dirent.isFile() && dirent.name === 'binding.gyp') {
+    jobs.push(() => buildAddon(directory));
   }
 }
 await parallel(jobs, parallelization);


### PR DESCRIPTION
We define a new type called `node_api_nogc_env` as the `const` version of `napi_env` and `node_api_nogc_finalize` as a variant of `napi_finalize` that accepts a `node_api_nogc_env` as its first argument.

We then modify those APIs which do not affect GC state as accepting a `node_api_nogc_env`. APIs accepting finalizer callbacks are modified to accept `node_api_nogc_finalize` callbacks. Thus, the only way to attach a `napi_finalize` callback, wherein Node-APIs affecting GC state may be called is to call `node_api_post_finalizer` from a `node_api_nogc_finalize` callback.

In keeping with the process of introducing new Node-APIs, this feature is guarded by `NAPI_EXPERIMENTAL`. Since this feature modifies APIs already marked as stable, it is additionally guared by `NODE_API_EXPERIMENTAL_NOGC_ENV`, so as to provide a further buffer to adoption. Nevertheless, both guards must be removed upon releasing a new version of Node-API.
