### PR TITLE
doc: move permission model to Active Development

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -106,7 +106,7 @@ If this flag is passed, the behavior can still be set to not abort through
 added: v20.0.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 When using the [Permission Model][], the process will not be able to spawn any
 child process by default.
@@ -151,7 +151,7 @@ changes:
     description: Paths delimited by comma (`,`) are no longer allowed.
 -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 This flag configures file system read permissions using
 the [Permission Model][].
@@ -205,7 +205,7 @@ changes:
     description: Paths delimited by comma (`,`) are no longer allowed.
 -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 This flag configures file system write permissions using
 the [Permission Model][].
@@ -229,7 +229,7 @@ Relative paths are NOT supported through the CLI flag.
 added: v20.0.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 When using the [Permission Model][], the process will not be able to create any
 worker threads by default.
@@ -642,7 +642,7 @@ Enable experimental support for the `https:` protocol in `import` specifiers.
 added: v20.0.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 Enable the Permission Model for current process. When enabled, the
 following permissions are restricted:

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -468,7 +468,7 @@ Additionally, import maps only work on `import` so it may be desirable to add a
 
 <!-- type=misc -->
 
-> Stability: 1 - Experimental
+> Stability: 1.1 - Active development
 
 <!-- name=permission-model -->
 


### PR DESCRIPTION
We've recently changed the stability of experimental features to include more layers. This PR updates the permission model stability to the Active Development.