### PR TITLE
benchmark: add warmup to accessSync bench

### DIFF
--- a/benchmark/fs/bench-accessSync.js
+++ b/benchmark/fs/bench-accessSync.js
@@ -13,6 +13,16 @@ const bench = common.createBenchmark(main, {
   n: [1e5],
 });
 
+function runBench(n, path) {
+  for (let i = 0; i < n; i++) {
+    try {
+      fs.accessSync(path);
+    } catch {
+      // do nothing
+    }
+  }
+}
+
 function main({ n, type }) {
   let path;
 
@@ -29,14 +39,10 @@ function main({ n, type }) {
     default:
       new Error('Invalid type');
   }
+  // warmup
+  runBench(n, path);
 
   bench.start();
-  for (let i = 0; i < n; i++) {
-    try {
-      fs.accessSync(path);
-    } catch {
-      // do nothing
-    }
-  }
+  runBench(n, path);
   bench.end(n);
 }


### PR DESCRIPTION
Following-up: https://github.com/nodejs/node/pull/49593#discussion_r1328052487.

Turns out, it does have a difference for the first run @anonrig. See:

```
➜  node git:(main) ✗ node benchmark/fs/bench-accessSync.js # firstRun
fs/bench-accessSync.js n=100000 type="existing": 1,522,375.115877485
fs/bench-accessSync.js n=100000 type="non-existing": 343,903.4938015694
fs/bench-accessSync.js n=100000 type="non-flat-existing": 1,375,793.3804884679
➜  node git:(main) ✗ node benchmark/fs/bench-accessSync.js
fs/bench-accessSync.js n=100000 type="existing": 1,316,668.6965309072
fs/bench-accessSync.js n=100000 type="non-existing": 330,345.1784036734
fs/bench-accessSync.js n=100000 type="non-flat-existing": 1,365,020.780120842
➜  node git:(main) ✗ node benchmark/fs/bench-accessSync.js
fs/bench-accessSync.js n=100000 type="existing": 1,348,179.7766454385
fs/bench-accessSync.js n=100000 type="non-existing": 294,858.29814902286
fs/bench-accessSync.js n=100000 type="non-flat-existing": 1,407,337.381426724
```

To get a similar behaviour you need to ensure the fs cache isn't affected (usually waiting a bit before rerunning the bench). With the warmup, the results are more consistent (tested in a dedicated machine too).