### PR TITLE
stream: add support for `deflate-raw` format to webstreams compression

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -1420,9 +1420,13 @@ changes:
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/50097
+    description: format now accepts `deflate-raw` value.
 -->
 
-* `format` {string} One of either `'deflate'` or `'gzip'`.
+* `format` {string} One of `'deflate'`, `'deflate-raw'`, or `'gzip'`.
 
 #### `compressionStream.readable`
 
@@ -1454,9 +1458,13 @@ changes:
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/50097
+    description: format now accepts `deflate-raw` value.
 -->
 
-* `format` {string} One of either `'deflate'` or `'gzip'`.
+* `format` {string} One of `'deflate'`, `'deflate-raw'`, or `'gzip'`.
 
 #### `decompressionStream.readable`
 

--- a/lib/internal/webstreams/compression.js
+++ b/lib/internal/webstreams/compression.js
@@ -35,12 +35,15 @@ class CompressionStream {
   #transform;
 
   /**
-   * @param {'deflate'|'gzip'} format
+   * @param {'deflate'|'deflate-raw'|'gzip'} format
    */
   constructor(format) {
     switch (format) {
       case 'deflate':
         this.#handle = lazyZlib().createDeflate();
+        break;
+      case 'deflate-raw':
+        this.#handle = lazyZlib().createDeflateRaw();
         break;
       case 'gzip':
         this.#handle = lazyZlib().createGzip();
@@ -80,12 +83,15 @@ class DecompressionStream {
   #transform;
 
   /**
-   * @param {'deflate'|'gzip'} format
+   * @param {'deflate'|'deflate-raw'|'gzip'} format
    */
   constructor(format) {
     switch (format) {
       case 'deflate':
         this.#handle = lazyZlib().createInflate();
+        break;
+      case 'deflate-raw':
+        this.#handle = lazyZlib().createInflateRaw();
         break;
       case 'gzip':
         this.#handle = lazyZlib().createGunzip();

--- a/test/parallel/test-whatwg-webstreams-compression.js
+++ b/test/parallel/test-whatwg-webstreams-compression.js
@@ -38,7 +38,7 @@ async function test(format) {
   ]);
 }
 
-Promise.all(['gzip', 'deflate'].map((i) => test(i))).then(common.mustCall());
+Promise.all(['gzip', 'deflate', 'deflate-raw'].map((i) => test(i))).then(common.mustCall());
 
 [1, 'hello', false, {}].forEach((i) => {
   assert.throws(() => new CompressionStream(i), {


### PR DESCRIPTION
this change makes `deflate-raw` a valid parameter for both CompressionStream and DecompressionStream constructors

it makes node's implementation consistent with what modern browsers support and what specification calls for

see: https://wicg.github.io/compression/#compression-stream

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


Edit: [Notable Change](https://github.com/nodejs/node/pull/50097#issuecomment-1803568323)