### PR TITLE
fs: improve error performance of readvSync

### DIFF
--- a/benchmark/fs/bench-readvSync.js
+++ b/benchmark/fs/bench-readvSync.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const exptectedBuff = Buffer.from('Benchmark Data');
+const expectedLength = exptectedBuff.length;
+
+const bufferArr = [Buffer.alloc(expectedLength)];
+
+const filename = tmpdir.resolve('readv_sync.txt');
+fs.writeFileSync(filename, exptectedBuff);
+
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  n: [1e5],
+});
+
+function main({ n, type }) {
+  let fd;
+  let result;
+
+  switch (type) {
+    case 'valid':
+      fd = fs.openSync(filename, 'r');
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        result = fs.readvSync(fd, bufferArr, 0);
+      }
+
+      bench.end(n);
+      assert.strictEqual(result, expectedLength);
+      fs.closeSync(fd);
+      break;
+    case 'invalid': {
+      fd = 1 << 30;
+      let hasError = false;
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        try {
+          result = fs.readvSync(fd, bufferArr, 0);
+        } catch {
+          hasError = true;
+        }
+      }
+
+      bench.end(n);
+      assert(hasError);
+      break;
+    }
+    default:
+      throw new Error('Invalid type');
+  }
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -805,14 +805,10 @@ function readvSync(fd, buffers, position) {
   fd = getValidatedFd(fd);
   validateBufferArray(buffers);
 
-  const ctx = {};
-
   if (typeof position !== 'number')
     position = null;
 
-  const result = binding.readBuffers(fd, buffers, position, undefined, ctx);
-  handleErrorFromBinding(ctx);
-  return result;
+  return binding.readBuffers(fd, buffers, position);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2483,18 +2483,20 @@ static void ReadBuffers(const FunctionCallbackInfo<Value>& args) {
     iovs[i] = uv_buf_init(Buffer::Data(buffer), Buffer::Length(buffer));
   }
 
-  FSReqBase* req_wrap_async = GetReqWrap(args, 3);
-  if (req_wrap_async != nullptr) {  // readBuffers(fd, buffers, pos, req)
+  if (argc > 3) {  // readBuffers(fd, buffers, pos, req)
+    FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_READ, req_wrap_async)
     AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
               uv_fs_read, fd, *iovs, iovs.length(), pos);
   } else {  // readBuffers(fd, buffers, undefined, ctx)
-    CHECK_EQ(argc, 5);
-    FSReqWrapSync req_wrap_sync;
+    FSReqWrapSync req_wrap_sync("read");
     FS_SYNC_TRACE_BEGIN(read);
-    int bytesRead = SyncCall(env, /* ctx */ args[4], &req_wrap_sync, "read",
-                             uv_fs_read, fd, *iovs, iovs.length(), pos);
+    int bytesRead = SyncCallAndThrowOnError(
+        env, &req_wrap_sync, uv_fs_read, fd, *iovs, iovs.length(), pos);
     FS_SYNC_TRACE_END(read, "bytesRead", bytesRead);
+    if (is_uv_error(bytesRead)) {
+      return;
+    }
     args.GetReturnValue().Set(bytesRead);
   }
 }


### PR DESCRIPTION
Local benchmark:
```
                                                   confidence improvement accuracy (*)    (**)   (***)
fs/bench-readvSync.js n=100000 type='invalid'             ***    123.02 %       ±1.27%  ±1.70%  ±2.24%
fs/bench-readvSync.js n=100000 type='valid'                        2.74 %       ±2.88%  ±3.84%  ±5.01%
```
Ref: https://github.com/nodejs/performance/issues/106