### PR TITLE
test: reduce number of repetition in test-heapdump-shadowrealm.js

### DIFF
--- a/test/pummel/test-heapdump-shadow-realm.js
+++ b/test/pummel/test-heapdump-shadow-realm.js
@@ -11,7 +11,7 @@ let counter = 0;
 // snapshot can handle it.
 function createRealms() {
   // Use setImmediate to give GC some time to kick in to avoid OOM.
-  if (counter++ < 100) {
+  if (counter++ < 10) {
     realm = new ShadowRealm();
     realm.evaluate('undefined');
     setImmediate(createRealms);


### PR DESCRIPTION
ShadowRealm garbage-collection is covered in another test. Reduce the
number of repetition in test-heapdump-shadowrealm.js trying to fix the
flakiness of the test.

Refs: #49572