### PR TITLE
[v18.x backport] url test

### DIFF
--- a/test/parallel/test-url-is-url.js
+++ b/test/parallel/test-url-is-url.js
@@ -9,3 +9,8 @@ const { isURL } = require('internal/url');
 
 assert.strictEqual(isURL(new URL('https://www.nodejs.org')), true);
 assert.strictEqual(isURL(parse('https://www.nodejs.org')), false);
+assert.strictEqual(isURL({
+  href: 'https://www.nodejs.org',
+  protocol: 'https:',
+  path: '/',
+}), false);

--- a/test/parallel/test-url-is-url.js
+++ b/test/parallel/test-url-is-url.js
@@ -1,0 +1,11 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+
+const { URL, parse } = require('url');
+const assert = require('assert');
+const { isURL } = require('internal/url');
+
+assert.strictEqual(isURL(new URL('https://www.nodejs.org')), true);
+assert.strictEqual(isURL(parse('https://www.nodejs.org')), false);


### PR DESCRIPTION
Backport of:

- https://github.com/nodejs/node/pull/47886
- https://github.com/nodejs/node/pull/48928

The `lib/` changes do not apply, so there's just the test left, but we may still want to land it so we're sure that there's no regression in future backports.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
