### PR TITLE
lib: fix Module check when monkey patching

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -128,13 +128,13 @@ const urlToFileCache = new SafeMap();
 function makeRequireFunction(mod, redirects) {
   // lazy due to cycle
   const Module = lazyModule();
-  if (mod instanceof Module !== true) {
-    throw new ERR_INVALID_ARG_TYPE('mod', 'Module', mod);
-  }
 
   /** @type {RequireFunction} */
   let require;
   if (redirects) {
+    if (mod instanceof Module !== true) {
+      throw new ERR_INVALID_ARG_TYPE('mod', 'Module', mod);
+    }
     const id = mod.filename || mod.id;
     const conditions = getCjsConditions();
     const { resolve, reaction } = redirects;


### PR DESCRIPTION
Apparently, the last security release broke the coverage of reports of `nyc`. I'm still waiting for a reproducible example so I can create a test for that, but I am confident this should fix the problem.

Fixes: https://github.com/istanbuljs/nyc/issues/1530

cc: @bmeck 