### PR TITLE
lib: reduce overhead of blob clone

### DIFF
--- a/benchmark/blob/clone.js
+++ b/benchmark/blob/clone.js
@@ -7,14 +7,17 @@ const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   n: [50e3],
+  bytes: [128, 1024, 1024 ** 2],
 });
 
 let _cloneResult;
 
-function main({ n }) {
+function main({ n, bytes }) {
+  const buff = Buffer.allocUnsafe(bytes);
+  const blob = new Blob(buff);
   bench.start();
   for (let i = 0; i < n; ++i)
-    _cloneResult = structuredClone(new Blob(['hello']));
+    _cloneResult = structuredClone(blob);
   bench.end(n);
 
   // Avoid V8 deadcode (elimination)

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -200,7 +200,7 @@ class Blob {
     const length = this[kLength];
     return {
       data: { handle, type, length },
-      deserializeInfo: 'internal/blob:ClonedBlob',
+      deserializeInfo: 'internal/blob:CloneableBlob',
     };
   }
 
@@ -397,25 +397,27 @@ class Blob {
   }
 }
 
-function ClonedBlob() {
-  return ReflectConstruct(function() {
+class CloneableBlob extends Blob {
+  static {
     markTransferMode(this, true, false);
-  }, [], Blob);
+    this[kDeserialize] = () => {};
+  }
 }
-ClonedBlob.prototype[kDeserialize] = () => {};
 
-function TransferrableBlob(handle, length, type = '') {
+CloneableBlob.prototype.constructor = Blob;
+
+function TransferableBlob(handle, length, type = '') {
   markTransferMode(this, true, false);
   this[kHandle] = handle;
   this[kType] = type;
   this[kLength] = length;
 }
 
-ObjectSetPrototypeOf(TransferrableBlob.prototype, Blob.prototype);
-ObjectSetPrototypeOf(TransferrableBlob, Blob);
+ObjectSetPrototypeOf(TransferableBlob.prototype, Blob.prototype);
+ObjectSetPrototypeOf(TransferableBlob, Blob);
 
 function createBlob(handle, length, type = '') {
-  const transferredBlob = new TransferrableBlob(handle, length, type);
+  const transferredBlob = new TransferableBlob(handle, length, type);
 
   // Fix issues like: https://github.com/nodejs/node/pull/49730#discussion_r1331720053
   transferredBlob.constructor = Blob;
@@ -489,7 +491,7 @@ function createBlobFromFilePath(path, options) {
 
 module.exports = {
   Blob,
-  ClonedBlob,
+  CloneableBlob,
   createBlob,
   createBlobFromFilePath,
   isBlob,

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -8,7 +8,6 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   PromiseReject,
-  ReflectConstruct,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   StringPrototypeToLowerCase,

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -199,7 +199,7 @@ class Blob {
     const length = this[kLength];
     return {
       data: { handle, type, length },
-      deserializeInfo: 'internal/blob:CloneableBlob',
+      deserializeInfo: 'internal/blob:Blob',
     };
   }
 
@@ -396,15 +396,6 @@ class Blob {
   }
 }
 
-class CloneableBlob extends Blob {
-  static {
-    markTransferMode(this, true, false);
-    this[kDeserialize] = () => {};
-  }
-}
-
-CloneableBlob.prototype.constructor = Blob;
-
 function TransferableBlob(handle, length, type = '') {
   markTransferMode(this, true, false);
   this[kHandle] = handle;
@@ -490,7 +481,6 @@ function createBlobFromFilePath(path, options) {
 
 module.exports = {
   Blob,
-  CloneableBlob,
   createBlob,
   createBlobFromFilePath,
   isBlob,

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -480,3 +480,13 @@ assert.throws(() => new Blob({}), {
   assert.ok(blob.slice(0, 1).constructor === Blob);
   assert.ok(blob.slice(0, 1) instanceof Blob);
 }
+
+(async () => {
+  const blob = new Blob(['hello']);
+
+  assert.ok(structuredClone(blob).constructor === Blob);
+  assert.ok(structuredClone(blob) instanceof Blob);
+  assert.ok(structuredClone(blob).size === blob.size);
+  assert.ok(structuredClone(blob).size === blob.size);
+  assert.ok((await structuredClone(blob).text()) === (await blob.text()));
+})().then(common.mustCall());


### PR DESCRIPTION
Continuing the work started on https://github.com/nodejs/performance/issues/109

```
                                    confidence improvement accuracy (*)   (**)  (***)
blob/clone.js bytes=1024 n=50000           ***     60.74 %       ±1.58% ±2.11% ±2.75%
blob/clone.js bytes=1048576 n=50000        ***     50.70 %       ±1.84% ±2.46% ±3.23%
blob/clone.js bytes=128 n=50000            ***     62.57 %       ±1.43% ±1.91% ±2.49%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 3 comparisons, you can thus
expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

/cc @nodejs/performance