### PR TITLE
doc: add ReflectConstruct to known perf issues

### DIFF
--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -122,7 +122,8 @@ performance of code in Node.js.
 * `SafePromiseAny`
 * `SafePromiseRace`
 * `SafePromisePrototypeFinally`: use `try {} finally {}` block instead.
-* `ReflectConstruct`: see linked PRs to [nodejs/performance#109](https://github.com/nodejs/performance/issues/109) to learn faster methods.
+* `ReflectConstruct`: see linked PRs to [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
+  to learn faster methods.
 
 In general, when sending or reviewing a PR that makes changes in a hot code
 path, use extra caution and run extensive benchmarks.

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -124,7 +124,7 @@ performance of code in Node.js.
 * `SafePromisePrototypeFinally`: use `try {} finally {}` block instead.
 * `ReflectConstruct`: Also affects `Reflect.construct`.
   `ReflectConstruct` creates new types of classes inside functions.
-  Instead consider creating a shared class. See [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
+  Instead consider creating a shared class. See [nodejs/performance#109](https://github.com/nodejs/performance/issues/109).
 
 In general, when sending or reviewing a PR that makes changes in a hot code
 path, use extra caution and run extensive benchmarks.

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -122,8 +122,9 @@ performance of code in Node.js.
 * `SafePromiseAny`
 * `SafePromiseRace`
 * `SafePromisePrototypeFinally`: use `try {} finally {}` block instead.
-* `ReflectConstruct`: see linked PRs to [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
-  to learn faster methods.
+* `ReflectConstruct`: Also affects `Reflect.construct`.
+  `ReflectConstruct` creates new types of classes inside functions.
+  Instead create a shared class. See [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
 
 In general, when sending or reviewing a PR that makes changes in a hot code
 path, use extra caution and run extensive benchmarks.

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -124,7 +124,7 @@ performance of code in Node.js.
 * `SafePromisePrototypeFinally`: use `try {} finally {}` block instead.
 * `ReflectConstruct`: Also affects `Reflect.construct`.
   `ReflectConstruct` creates new types of classes inside functions.
-  Instead create a shared class. See [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
+  Instead consider creating a shared class. See [nodejs/performance#109](https://github.com/nodejs/performance/issues/109)
 
 In general, when sending or reviewing a PR that makes changes in a hot code
 path, use extra caution and run extensive benchmarks.

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -122,6 +122,7 @@ performance of code in Node.js.
 * `SafePromiseAny`
 * `SafePromiseRace`
 * `SafePromisePrototypeFinally`: use `try {} finally {}` block instead.
+* `ReflectConstruct`: see linked PRs to [nodejs/performance#109](https://github.com/nodejs/performance/issues/109) to learn faster methods.
 
 In general, when sending or reviewing a PR that makes changes in a hot code
 path, use extra caution and run extensive benchmarks.


### PR DESCRIPTION
There are a lot of PRs created initially by https://github.com/nodejs/performance/issues/109 to improve performance issues with this primordial.