### PR TITLE
tools: remove no-return-await lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -256,7 +256,6 @@ module.exports = {
         message: 'Use `globalThis.crypto`.',
       },
     ],
-    'no-return-await': 'error',
     'no-self-compare': 'error',
     'no-tabs': 'error',
     'no-template-curly-in-string': 'error',


### PR DESCRIPTION
no-return-await rule was deprecated in ESLint 8.46.0. According to the ESLint docs removing `await` can make the code slower.

Refs: https://eslint.org/docs/latest/rules/no-return-await

This rule was added in https://github.com/nodejs/node/pull/17265.
`return await` is sometimes necessary to create a better stacktrace (https://github.com/nodejs/node/pull/49849#discussion_r1348357793).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
