### PR TITLE
esm: improve check for ESM syntax

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -90,6 +90,7 @@ const {
   makeContextifyScript,
   runScriptInThisContext,
 } = require('internal/vm');
+const { containsModuleSyntax } = internalBinding('contextify');
 
 const assert = require('internal/assert');
 const fs = require('fs');
@@ -104,7 +105,6 @@ const {
 const {
   getCjsConditions,
   initializeCjsConditions,
-  hasEsmSyntax,
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,
@@ -1315,7 +1315,7 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
   } catch (err) {
     if (process.mainModule === cjsModuleInstance) {
       const { enrichCJSError } = require('internal/modules/esm/translators');
-      enrichCJSError(err, content);
+      enrichCJSError(err, content, filename);
     }
     throw err;
   }
@@ -1400,10 +1400,11 @@ Module._extensions['.js'] = function(module, filename) {
     const pkg = packageJsonReader.readPackageScope(filename) || { __proto__: null };
     // Function require shouldn't be used in ES modules.
     if (pkg.data?.type === 'module') {
+      // This is an error path because `require` of a `.js` file in a `"type": "module"` scope is not allowed.
       const parent = moduleParentCache.get(module);
       const parentPath = parent?.filename;
       const packageJsonPath = path.resolve(pkg.path, 'package.json');
-      const usesEsm = hasEsmSyntax(content);
+      const usesEsm = containsModuleSyntax(content, filename);
       const err = new ERR_REQUIRE_ESM(filename, usesEsm, parentPath,
                                       packageJsonPath);
       // Attempt to reconstruct the parent require frame.

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -30,11 +30,11 @@ function lazyTypes() {
   return _TYPES = require('internal/util/types');
 }
 
+const { containsModuleSyntax } = internalBinding('contextify');
 const assert = require('internal/assert');
 const { readFileSync } = require('fs');
 const { dirname, extname, isAbsolute } = require('path');
 const {
-  hasEsmSyntax,
   loadBuiltinModule,
   stripBOM,
 } = require('internal/modules/helpers');
@@ -166,11 +166,11 @@ translators.set('module', async function moduleStrategy(url, source, isMain) {
  * Provide a more informative error for CommonJS imports.
  * @param {Error | any} err
  * @param {string} [content] Content of the file, if known.
- * @param {string} [filename] Useful only if `content` is unknown.
+ * @param {string} [filename] The filename of the erroring module.
  */
 function enrichCJSError(err, content, filename) {
   if (err != null && ObjectGetPrototypeOf(err) === SyntaxErrorPrototype &&
-      hasEsmSyntax(content || readFileSync(filename, 'utf-8'))) {
+      containsModuleSyntax(content, filename ?? '')) {
     // Emit the warning synchronously because we are in the middle of handling
     // a SyntaxError that will throw and likely terminate the process before an
     // asynchronous warning would be emitted.
@@ -217,7 +217,7 @@ function loadCJSModule(module, source, url, filename) {
       importModuleDynamically,        // importModuleDynamically
     ).function;
   } catch (err) {
-    enrichCJSError(err, source, url);
+    enrichCJSError(err, source, filename);
     throw err;
   }
 
@@ -344,7 +344,7 @@ translators.set('commonjs', async function commonjsStrategy(url, source,
       assert(module === CJSModule._cache[filename]);
       CJSModule._load(filename);
     } catch (err) {
-      enrichCJSError(err, source, url);
+      enrichCJSError(err, source, filename);
       throw err;
     }
   } : loadCJSModule;

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -170,7 +170,7 @@ translators.set('module', async function moduleStrategy(url, source, isMain) {
  */
 function enrichCJSError(err, content, filename) {
   if (err != null && ObjectGetPrototypeOf(err) === SyntaxErrorPrototype &&
-      containsModuleSyntax(content, filename ?? '')) {
+      containsModuleSyntax(content, filename)) {
     // Emit the warning synchronously because we are in the middle of handling
     // a SyntaxError that will throw and likely terminate the process before an
     // asynchronous warning would be emitted.

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -3,7 +3,6 @@
 const {
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
-  ArrayPrototypeSome,
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   SafeMap,
@@ -299,32 +298,10 @@ function normalizeReferrerURL(referrer) {
   return new URL(referrer).href;
 }
 
-/**
- * For error messages only, check if ESM syntax is in use.
- * @param {string} code
- */
-function hasEsmSyntax(code) {
-  debug('Checking for ESM syntax');
-  const parser = require('internal/deps/acorn/acorn/dist/acorn').Parser;
-  let root;
-  try {
-    root = parser.parse(code, { sourceType: 'module', ecmaVersion: 'latest' });
-  } catch {
-    return false;
-  }
-
-  return ArrayPrototypeSome(root.body, (stmt) =>
-    stmt.type === 'ExportDefaultDeclaration' ||
-    stmt.type === 'ExportNamedDeclaration' ||
-    stmt.type === 'ImportDeclaration' ||
-    stmt.type === 'ExportAllDeclaration');
-}
-
 module.exports = {
   addBuiltinLibsToObject,
   getCjsConditions,
   initializeCjsConditions,
-  hasEsmSyntax,
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -83,6 +83,16 @@ class ContextifyContext : public BaseObject {
   static void IsContext(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CompileFunction(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static v8::Local<v8::Object> CompileFunctionAndCacheResult(
+      Environment* env,
+      v8::Local<v8::Context> parsing_context,
+      const v8::ScriptCompiler::Source& source,
+      std::vector<v8::Local<v8::String>> params,
+      std::vector<v8::Local<v8::Object>> context_extensions,
+      v8::ScriptCompiler::CompileOptions options,
+      bool produce_cached_data,
+      v8::Local<v8::Symbol> id_symbol,
+      const errors::TryCatchScope& try_catch);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -93,6 +93,18 @@ class ContextifyContext : public BaseObject {
       bool produce_cached_data,
       v8::Local<v8::Symbol> id_symbol,
       const errors::TryCatchScope& try_catch);
+  static v8::Local<v8::PrimitiveArray> GetHostDefinedOptions(
+      v8::Isolate* isolate, v8::Local<v8::Symbol> id_symbol);
+  static v8::ScriptCompiler::Source GetCommonJSSourceInstance(
+      v8::Isolate* isolate,
+      v8::Local<v8::String> code,
+      v8::Local<v8::String> filename,
+      int line_offset,
+      int column_offset,
+      v8::Local<v8::PrimitiveArray> host_defined_options,
+      v8::ScriptCompiler::CachedData* cached_data);
+  static v8::ScriptCompiler::CompileOptions GetCompileOptions(
+      const v8::ScriptCompiler::Source& source);
   static void ContainsModuleSyntax(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void WeakCallback(

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -93,6 +93,8 @@ class ContextifyContext : public BaseObject {
       bool produce_cached_data,
       v8::Local<v8::Symbol> id_symbol,
       const errors::TryCatchScope& try_catch);
+  static void ContainsModuleSyntax(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -86,7 +86,7 @@ class ContextifyContext : public BaseObject {
   static v8::Local<v8::Object> CompileFunctionAndCacheResult(
       Environment* env,
       v8::Local<v8::Context> parsing_context,
-      const v8::ScriptCompiler::Source& source,
+      v8::ScriptCompiler::Source* source,
       std::vector<v8::Local<v8::String>> params,
       std::vector<v8::Local<v8::Object>> context_extensions,
       v8::ScriptCompiler::CompileOptions options,


### PR DESCRIPTION
This PR speeds up and simplifies the error path for when users `require` ES modules. In particular, the previous `hasEsmSyntax` helper used Acorn to parse the required module’s source code to find ESM syntax. In this refactor, the check moves into C++ and relies on V8 throwing a `SyntaxError` with one of the error messages that we know are caused by ESM syntax in a module compiled as CommonJS. This allows us to eliminate one use of Acorn from the codebase.

This also creates the helper function that https://github.com/nodejs/node/pull/50096 needs.

@nodejs/loaders @nodejs/cpp-reviewers 