### PR TITLE
lib,src: use built-in array buffer detach

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  ArrayBufferPrototypeGetByteLength,
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypePush,
@@ -54,7 +53,6 @@ const {
 } = require('internal/errors');
 const { signals } = internalBinding('constants').os;
 const {
-  isArrayBufferDetached: _isArrayBufferDetached,
   guessHandleType: _guessHandleType,
   privateSymbols: {
     arrow_message_private_symbol,
@@ -776,15 +774,6 @@ function SideEffectFreeRegExpPrototypeSymbolSplit(regex, string, limit = undefin
   return getCrossRelmRegex(regex)[SymbolSplit](string, limit);
 }
 
-
-function isArrayBufferDetached(value) {
-  if (ArrayBufferPrototypeGetByteLength(value) === 0) {
-    return _isArrayBufferDetached(value);
-  }
-
-  return false;
-}
-
 /**
  * Helper function to lazy-load an initialize-once value.
  * @template T Return value of initializer
@@ -888,7 +877,6 @@ module.exports = {
   getSystemErrorMap,
   getSystemErrorName,
   guessHandleType,
-  isArrayBufferDetached,
   isError,
   isInsideNodeModules,
   join,

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -105,7 +105,6 @@ const {
   isBrandCheck,
   resetQueue,
   setPromiseHandled,
-  transferArrayBuffer,
   nonOpCancel,
   nonOpPull,
   nonOpStart,
@@ -1954,7 +1953,7 @@ function readableByteStreamControllerConvertPullIntoDescriptor(desc) {
   if (bytesFilled > byteLength)
     throw new ERR_INVALID_STATE.RangeError('The buffer size is invalid');
   assert(!(bytesFilled % elementSize));
-  const transferredBuffer = transferArrayBuffer(buffer);
+  const transferredBuffer = buffer.transfer();
 
   if (ctor === Buffer) {
     return Buffer.from(transferredBuffer, byteOffset, bytesFilled / elementSize);
@@ -2623,7 +2622,7 @@ function readableByteStreamControllerPullInto(
 
   let transferredBuffer;
   try {
-    transferredBuffer = transferArrayBuffer(buffer);
+    transferredBuffer = buffer.transfer();
   } catch (error) {
     readIntoRequest[kError](error);
     return;
@@ -2715,7 +2714,7 @@ function readableByteStreamControllerRespond(controller, bytesWritten) {
       throw new ERR_INVALID_ARG_VALUE.RangeError('bytesWritten', bytesWritten);
   }
 
-  desc.buffer = transferArrayBuffer(desc.buffer);
+  desc.buffer = desc.buffer.transfer();
 
   readableByteStreamControllerRespondInternal(controller, bytesWritten);
 }
@@ -2765,7 +2764,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
   if (closeRequested || stream[kState].state !== 'readable')
     return;
 
-  const transferredBuffer = transferArrayBuffer(buffer);
+  const transferredBuffer = buffer.transfer();
 
   if (pendingPullIntos.length) {
     const firstPendingPullInto = pendingPullIntos[0];
@@ -2778,9 +2777,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
 
     readableByteStreamControllerInvalidateBYOBRequest(controller);
 
-    firstPendingPullInto.buffer = transferArrayBuffer(
-      firstPendingPullInto.buffer,
-    );
+    firstPendingPullInto.buffer = firstPendingPullInto.buffer.transfer();
 
     if (firstPendingPullInto.type === 'none') {
       readableByteStreamControllerEnqueueDetachedPullIntoToQueue(
@@ -3075,7 +3072,7 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   if (bufferByteLength !== viewBufferByteLength)
     throw new ERR_INVALID_ARG_VALUE.RangeError('view', view);
 
-  desc.buffer = transferArrayBuffer(viewBuffer);
+  desc.buffer = viewBuffer.transfer();
 
   readableByteStreamControllerRespondInternal(controller, viewByteLength);
 }

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -48,7 +48,6 @@ const {
 const {
   createDeferredPromise,
   customInspectSymbol: kInspect,
-  isArrayBufferDetached,
   kEmptyObject,
   kEnumerableProperty,
   SideEffectFreeRegExpPrototypeSymbolReplace,
@@ -103,7 +102,6 @@ const {
   extractHighWaterMark,
   extractSizeAlgorithm,
   lazyTransfer,
-  isViewedArrayBufferDetached,
   isBrandCheck,
   resetQueue,
   setPromiseHandled,
@@ -712,7 +710,7 @@ class ReadableStreamBYOBRequest {
     const viewBuffer = ArrayBufferViewGetBuffer(view);
     const viewBufferByteLength = ArrayBufferPrototypeGetByteLength(viewBuffer);
 
-    if (isArrayBufferDetached(viewBuffer)) {
+    if (viewBuffer.detached) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
 
@@ -739,7 +737,7 @@ class ReadableStreamBYOBRequest {
 
     validateBuffer(view, 'view');
 
-    if (isViewedArrayBufferDetached(view)) {
+    if (ArrayBufferViewGetBuffer(view).detached) {
       throw new ERR_INVALID_STATE.TypeError('Viewed ArrayBuffer is detached');
     }
 
@@ -2772,7 +2770,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
   if (pendingPullIntos.length) {
     const firstPendingPullInto = pendingPullIntos[0];
 
-    if (isArrayBufferDetached(firstPendingPullInto.buffer)) {
+    if (firstPendingPullInto.buffer.detached) {
       throw new ERR_INVALID_STATE.TypeError(
         'Destination ArrayBuffer is detached',
       );

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -47,7 +47,6 @@ const {
 } = internalBinding('util');
 
 const assert = require('internal/assert');
-const { isArrayBufferDetached } = require('internal/util');
 
 const {
   validateFunction,
@@ -130,13 +129,6 @@ function transferArrayBuffer(buffer) {
       'The ArrayBuffer could not be transferred');
   }
   return res;
-}
-
-function isViewedArrayBufferDetached(view) {
-  return (
-    ArrayBufferViewGetByteLength(view) === 0 &&
-    isArrayBufferDetached(ArrayBufferViewGetBuffer(view))
-  );
 }
 
 function dequeueValue(controller) {
@@ -284,7 +276,6 @@ module.exports = {
   lazyTransfer,
   isBrandCheck,
   isPromisePending,
-  isViewedArrayBufferDetached,
   peekQueueValue,
   resetQueue,
   setPromiseHandled,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -21,14 +21,12 @@ const {
 const {
   codes: {
     ERR_INVALID_ARG_VALUE,
-    ERR_OPERATION_FAILED,
     ERR_INVALID_STATE,
   },
 } = require('internal/errors');
 
 const {
   copyArrayBuffer,
-  detachArrayBuffer,
 } = internalBinding('buffer');
 
 const {
@@ -120,15 +118,6 @@ function isBrandCheck(brand) {
            value[kState] !== undefined &&
            value[kType] === brand;
   };
-}
-
-function transferArrayBuffer(buffer) {
-  const res = detachArrayBuffer(buffer);
-  if (res === undefined) {
-    throw new ERR_OPERATION_FAILED.TypeError(
-      'The ArrayBuffer could not be transferred');
-  }
-  return res;
 }
 
 function dequeueValue(controller) {
@@ -279,7 +268,6 @@ module.exports = {
   peekQueueValue,
   resetQueue,
   setPromiseHandled,
-  transferArrayBuffer,
   nonOpCancel,
   nonOpFlush,
   nonOpPull,

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -157,15 +157,6 @@ static void GetCallerLocation(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(Array::New(args.GetIsolate(), ret, arraysize(ret)));
 }
 
-static void IsArrayBufferDetached(const FunctionCallbackInfo<Value>& args) {
-  if (args[0]->IsArrayBuffer()) {
-    auto buffer = args[0].As<v8::ArrayBuffer>();
-    args.GetReturnValue().Set(buffer->WasDetached());
-    return;
-  }
-  args.GetReturnValue().Set(false);
-}
-
 static void PreviewEntries(const FunctionCallbackInfo<Value>& args) {
   if (!args[0]->IsObject())
     return;
@@ -278,7 +269,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(GetPromiseDetails);
   registry->Register(GetProxyDetails);
   registry->Register(GetCallerLocation);
-  registry->Register(IsArrayBufferDetached);
   registry->Register(PreviewEntries);
   registry->Register(GetOwnNonIndexProperties);
   registry->Register(GetConstructorName);
@@ -377,8 +367,6 @@ void Initialize(Local<Object> target,
   SetMethodNoSideEffect(context, target, "getProxyDetails", GetProxyDetails);
   SetMethodNoSideEffect(
       context, target, "getCallerLocation", GetCallerLocation);
-  SetMethodNoSideEffect(
-      context, target, "isArrayBufferDetached", IsArrayBufferDetached);
   SetMethodNoSideEffect(context, target, "previewEntries", PreviewEntries);
   SetMethodNoSideEffect(
       context, target, "getOwnNonIndexProperties", GetOwnNonIndexProperties);


### PR DESCRIPTION
This change requires v8 11.8, therefore can't be backported to v18 and v20