### PR TITLE
Reduce TLS 'close' event listener warnings caused by autoSelectFamily

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -713,7 +713,12 @@ TLSSocket.prototype._wrapHandle = function(wrap, handle, wrapHasActiveWriteFromP
   this[kRes] = res;
   defineHandleReading(this, handle);
 
-  this.on('close', onSocketCloseDestroySSL);
+  // Guard against adding multiple listeners, as this method may be called
+  // repeatedly on the same socket by reinitializeHandle
+  if (this.listenerCount('close', onSocketCloseDestroySSL) === 0) {
+    this.on('close', onSocketCloseDestroySSL);
+  }
+
   if (wrap) {
     wrap.on('close', () => this.destroy());
   }

--- a/test/parallel/test-tls-reinitialize-listeners.js
+++ b/test/parallel/test-tls-reinitialize-listeners.js
@@ -1,0 +1,42 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const events = require('events');
+const fixtures = require('../common/fixtures');
+const tls = require('tls');
+const { kReinitializeHandle } = require('internal/net');
+
+// Test that repeated calls to kReinitializeHandle() do not result in repeatedly
+// adding new listeners on the socket (i.e. no MaxListenersExceededWarnings)
+
+process.on('warning', common.mustNotCall());
+
+const server = tls.createServer({
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
+});
+
+server.listen(0, common.mustCall(function() {
+  const socket = tls.connect({
+    port: this.address().port,
+    rejectUnauthorized: false
+  });
+
+  socket.on('secureConnect', common.mustCall(function() {
+    for (let i = 0; i < events.defaultMaxListeners + 1; i++) {
+      socket[kReinitializeHandle]();
+    }
+
+    socket.destroy();
+  }));
+
+  socket.on('close', function() {
+    server.close();
+  });
+}));


### PR DESCRIPTION
There's been quite a few reports of TLSSocket MaxListenersExceededWarning errors for 'close' events in Node v20, particularly with npm (https://github.com/npm/cli/issues/6763#issuecomment-1714257930, https://github.com/nodejs/node/issues/49955, https://github.com/nodejs/node/issues/49337, https://github.com/nodejs/node/issues/49269). I've also seen this myself in my node code when using TLS sockets heavily after updating to Node v20.

This is intermittent and hard to reliably reproduce. That said, this PR fixes a clear small bug that adds duplicate close listeners to many TLS sockets, which is probably a significant factor here (could be the whole problem, hard to say). Anecdotally, with this change testing locally I haven't seen any more of these messages.

The specific line changed here is referenced by quite a few of the reports and in my own output, here's an example stacktrace:

```
(node:19864) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [TLSSocket]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:588:17)
    at TLSSocket.addListener (node:events:606:10)
    at Readable.on (node:internal/streams/readable:904:35)
    at TLSSocket._wrapHandle (node:_tls_wrap:706:8)
    at TLSSocket.reinitializeHandle (node:_tls_wrap:715:22)
    at internalConnectMultiple (node:net:1123:30)
    at Timeout.internalConnectMultipleTimeout (node:net:1687:3)
    at listOnTimeout (node:internal/timers:575:11)
    at process.processTimers (node:internal/timers:514:7)
```

In this specific case, reinitializeHandle is called as part of the autoselect family logic (notably enabled by default in Node v20) where sockets are reinitialized repeatedly to test different addresses.

This calls _wrapHandle, which adds a close listener to `this` (the TLS socket) every time. Since this is called repeatedly when testing addresses, that results in adding one additional close listener for the same callback for every reinitialization (i.e. for each detect IPv4 or IPV6 address of the target host). I think there's no functional impact to this bug (it effectively calls destroy multiple times on close, which does nothing after the first call) but it does potentially add lots of unnecessary listeners.

This PR fixes that, so it now only registers this close listener if one is not already present (I think `listenerCount` is the best way to do that, but better alternatives are welcome).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
