### PR TITLE
stream: improve readable stream read perf

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -284,77 +284,164 @@ Readable.prototype[SymbolAsyncDispose] = function() {
 // similar to how Writable.write() returns true if you should
 // write() some more.
 Readable.prototype.push = function(chunk, encoding) {
-  return readableAddChunk(this, chunk, encoding, false);
+  debug('push', chunk);
+
+  const state = this._readableState;
+  return (state[kState] & kObjectMode) === 0 ?
+    readableAddChunkPushByteMode(this, state, chunk, encoding) :
+    readableAddChunkPushObjectMode(this, state, chunk, encoding);
 };
 
 // Unshift should *always* be something directly out of read().
 Readable.prototype.unshift = function(chunk, encoding) {
-  return readableAddChunk(this, chunk, encoding, true);
+  debug('unshift', chunk);
+  const state = this._readableState;
+  return (state[kState] & kObjectMode) === 0 ?
+    readableAddChunkUnshiftByteMode(this, state, chunk, encoding) :
+    readableAddChunkUnshiftObjectMode(this, state, chunk);
 };
 
-function readableAddChunk(stream, chunk, encoding, addToFront) {
-  debug('readableAddChunk', chunk);
-  const state = stream._readableState;
 
-  let err;
-  if ((state[kState] & kObjectMode) === 0) {
-    if (typeof chunk === 'string') {
-      encoding = encoding || state.defaultEncoding;
-      if (state.encoding !== encoding) {
-        if (addToFront && state.encoding) {
-          // When unshifting, if state.encoding is set, we have to save
-          // the string in the BufferList with the state encoding.
-          chunk = Buffer.from(chunk, encoding).toString(state.encoding);
-        } else {
-          chunk = Buffer.from(chunk, encoding);
-          encoding = '';
-        }
-      }
-    } else if (chunk instanceof Buffer) {
-      encoding = '';
-    } else if (Stream._isUint8Array(chunk)) {
-      chunk = Stream._uint8ArrayToBuffer(chunk);
-      encoding = '';
-    } else if (chunk != null) {
-      err = new ERR_INVALID_ARG_TYPE(
-        'chunk', ['string', 'Buffer', 'Uint8Array'], chunk);
-    }
-  }
-
-  if (err) {
-    errorOrDestroy(stream, err);
-  } else if (chunk === null) {
+function readableAddChunkUnshiftByteMode(stream, state, chunk, encoding) {
+  if (chunk === null) {
     state[kState] &= ~kReading;
     onEofChunk(stream, state);
-  } else if (((state[kState] & kObjectMode) !== 0) || (chunk && chunk.length > 0)) {
-    if (addToFront) {
-      if ((state[kState] & kEndEmitted) !== 0)
-        errorOrDestroy(stream, new ERR_STREAM_UNSHIFT_AFTER_END_EVENT());
-      else if (state.destroyed || state.errored)
-        return false;
-      else
-        addChunk(stream, state, chunk, true);
-    } else if (state.ended) {
-      errorOrDestroy(stream, new ERR_STREAM_PUSH_AFTER_EOF());
-    } else if (state.destroyed || state.errored) {
-      return false;
-    } else {
-      state[kState] &= ~kReading;
-      if (state.decoder && !encoding) {
-        chunk = state.decoder.write(chunk);
-        if (state.objectMode || chunk.length !== 0)
-          addChunk(stream, state, chunk, false);
-        else
-          maybeReadMore(stream, state);
-      } else {
-        addChunk(stream, state, chunk, false);
-      }
-    }
-  } else if (!addToFront) {
-    state[kState] &= ~kReading;
-    maybeReadMore(stream, state);
+
+    return false;
   }
 
+  if (typeof chunk === 'string') {
+    encoding = encoding || state.defaultEncoding;
+    if (state.encoding !== encoding) {
+      if (state.encoding) {
+        // When unshifting, if state.encoding is set, we have to save
+        // the string in the BufferList with the state encoding.
+        chunk = Buffer.from(chunk, encoding).toString(state.encoding);
+      } else {
+        chunk = Buffer.from(chunk, encoding);
+      }
+    }
+  } else if (Stream._isUint8Array(chunk)) {
+    chunk = Stream._uint8ArrayToBuffer(chunk);
+  } else if (chunk !== undefined && !(chunk instanceof Buffer)) {
+    errorOrDestroy(stream, new ERR_INVALID_ARG_TYPE(
+      'chunk', ['string', 'Buffer', 'Uint8Array'], chunk));
+    return false;
+  }
+
+
+  if (!(chunk && chunk.length > 0)) {
+    return canPushMore(state);
+  }
+
+  return readableAddChunkUnshiftValue(stream, state, chunk);
+}
+
+function readableAddChunkUnshiftObjectMode(stream, state, chunk) {
+  if (chunk === null) {
+    state[kState] &= ~kReading;
+    onEofChunk(stream, state);
+
+    return false;
+  }
+
+  return readableAddChunkUnshiftValue(stream, state, chunk);
+}
+
+function readableAddChunkUnshiftValue(stream, state, chunk) {
+  if ((state[kState] & kEndEmitted) !== 0)
+    errorOrDestroy(stream, new ERR_STREAM_UNSHIFT_AFTER_END_EVENT());
+  else if (state.destroyed || state.errored)
+    return false;
+  else
+    addChunk(stream, state, chunk, true);
+
+  return canPushMore(state);
+}
+
+function readableAddChunkPushByteMode(stream, state, chunk, encoding) {
+  if (chunk === null) {
+    state[kState] &= ~kReading;
+    onEofChunk(stream, state);
+
+    return false;
+  }
+
+  if (typeof chunk === 'string') {
+    encoding = encoding || state.defaultEncoding;
+    if (state.encoding !== encoding) {
+      chunk = Buffer.from(chunk, encoding);
+      encoding = '';
+    }
+  } else if (chunk instanceof Buffer) {
+    encoding = '';
+  } else if (Stream._isUint8Array(chunk)) {
+    chunk = Stream._uint8ArrayToBuffer(chunk);
+    encoding = '';
+  } else if (chunk !== undefined) {
+    errorOrDestroy(stream, new ERR_INVALID_ARG_TYPE(
+      'chunk', ['string', 'Buffer', 'Uint8Array'], chunk));
+    return false;
+  }
+
+  if (!chunk || chunk.length <= 0) {
+    state[kState] &= ~kReading;
+    maybeReadMore(stream, state);
+
+    return canPushMore(state);
+  }
+
+  if (state.ended) {
+    errorOrDestroy(stream, new ERR_STREAM_PUSH_AFTER_EOF());
+
+    return false;
+  }
+
+  if (state.destroyed || state.errored) {
+    return false;
+  }
+
+  state[kState] &= ~kReading;
+  if (state.decoder && !encoding) {
+    chunk = state.decoder.write(chunk);
+    if (chunk.length === 0) {
+      maybeReadMore(stream, state);
+
+      return canPushMore(state);
+    }
+  }
+
+  addChunk(stream, state, chunk, false);
+  return canPushMore(state);
+}
+
+function readableAddChunkPushObjectMode(stream, state, chunk, encoding) {
+  if (chunk === null) {
+    state[kState] &= ~kReading;
+    onEofChunk(stream, state);
+
+    return false;
+  }
+
+  if (state.ended) {
+    errorOrDestroy(stream, new ERR_STREAM_PUSH_AFTER_EOF());
+    return false;
+  }
+
+  if (state.destroyed || state.errored) {
+    return false;
+  }
+
+  state[kState] &= ~kReading;
+  if (state.decoder && !encoding) {
+    chunk = state.decoder.write(chunk);
+  }
+
+  addChunk(stream, state, chunk, false);
+  return canPushMore(state);
+}
+
+function canPushMore(state) {
   // We can push more data if we are below the highWaterMark.
   // Also, if we have no data yet, we can stand some more bytes.
   // This is to work around cases where hwm=0, such as the repl.


### PR DESCRIPTION
Performance improvement for `readable.read` by around ~10%

### Benchmarks
> [Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1444)

```
                                                                                         confidence improvement accuracy (*)    (**)   (***)
streams/creation.js kind='duplex' n=50000000                                                             0.05 %       ±1.22%  ±1.62%  ±2.12%
streams/creation.js kind='readable' n=50000000                                                          -1.00 %       ±1.12%  ±1.49%  ±1.95%
streams/creation.js kind='transform' n=50000000                                                          2.30 %       ±4.02%  ±5.35%  ±6.96%
streams/creation.js kind='writable' n=50000000                                                          -0.14 %       ±0.90%  ±1.20%  ±1.57%
streams/destroy.js kind='duplex' n=1000000                                                              -1.51 %       ±1.88%  ±2.50%  ±3.25%
streams/destroy.js kind='readable' n=1000000                                                            -1.95 %       ±2.02%  ±2.69%  ±3.51%
streams/destroy.js kind='transform' n=1000000                                                           -0.28 %       ±1.45%  ±1.93%  ±2.51%
streams/destroy.js kind='writable' n=1000000                                                            -0.03 %       ±2.02%  ±2.69%  ±3.50%
streams/pipe-object-mode.js n=5000000                                                                    1.40 %       ±3.61%  ±4.81%  ±6.26%
streams/pipe.js n=5000000                                                                               -0.57 %       ±2.60%  ±3.47%  ±4.53%
streams/readable-async-iterator.js sync='no' n=100000                                                    1.39 %       ±3.39%  ±4.55%  ±6.01%
streams/readable-async-iterator.js sync='yes' n=100000                                                  -1.66 %       ±2.95%  ±3.97%  ±5.25%
streams/readable-bigread.js n=1000                                                                      -0.36 %       ±7.13%  ±9.49% ±12.35%
streams/readable-bigunevenread.js n=1000                                                                 0.72 %       ±1.64%  ±2.18%  ±2.84%
streams/readable-boundaryread.js type='buffer' n=2000                                           ***      6.36 %       ±1.25%  ±1.67%  ±2.17%
streams/readable-boundaryread.js type='string' n=2000                                           ***      2.66 %       ±1.42%  ±1.90%  ±2.49%
streams/readable-from.js n=10000000                                                                     -4.26 %       ±8.28% ±11.05% ±14.45%
streams/readable-readall.js n=5000                                                              ***     10.08 %       ±5.50%  ±7.33%  ±9.57%
streams/readable-unevenread.js n=1000                                                                   -0.15 %       ±2.90%  ±3.86%  ±5.02%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                    -0.37 %       ±3.01%  ±4.01%  ±5.22%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000                    0.54 %       ±2.45%  ±3.26%  ±4.25%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                   -0.02 %       ±2.75%  ±3.68%  ±4.82%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000                   0.35 %       ±2.39%  ±3.18%  ±4.14%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                    0.78 %       ±2.31%  ±3.11%  ±4.11%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000            *      2.81 %       ±2.52%  ±3.36%  ±4.37%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000            *     -2.73 %       ±2.48%  ±3.29%  ±4.29%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                 -1.59 %       ±2.34%  ±3.12%  ±4.06%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                   -1.57 %       ±2.72%  ±3.66%  ±4.83%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                  -0.27 %       ±2.67%  ±3.55%  ±4.62%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                  -2.95 %       ±3.00%  ±4.03%  ±5.32%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                  0.94 %       ±2.69%  ±3.57%  ±4.65%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                  -0.42 %       ±2.25%  ±3.01%  ±3.96%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                  0.03 %       ±2.43%  ±3.23%  ±4.20%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                  0.18 %       ±2.33%  ±3.12%  ±4.13%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                -0.37 %       ±2.42%  ±3.22%  ±4.19%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 35 comparisons, you can thus
expect the following amount of false-positive results:
  1.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.35 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
```
