### PR TITLE
fs: do not throw error on cpSync internals

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -116,17 +116,9 @@ function checkPathsSync(src, dest, opts) {
 }
 
 function getStatsSync(src, dest, opts) {
-  let destStat;
-  const statFunc = opts.dereference ?
-    (file) => statSync(file, { bigint: true }) :
-    (file) => lstatSync(file, { bigint: true });
-  const srcStat = statFunc(src);
-  try {
-    destStat = statFunc(dest);
-  } catch (err) {
-    if (err.code === 'ENOENT') return { srcStat, destStat: null };
-    throw err;
-  }
+  const statFunc = opts.dereference ? statSync : lstatSync;
+  const srcStat = statFunc(src, { bigint: true, throwIfNoEntry: true });
+  const destStat = statFunc(dest, { bigint: true, throwIfNoEntry: false });
   return { srcStat, destStat };
 }
 
@@ -134,13 +126,12 @@ function checkParentPathsSync(src, srcStat, dest) {
   const srcParent = resolve(dirname(src));
   const destParent = resolve(dirname(dest));
   if (destParent === srcParent || destParent === parse(destParent).root) return;
-  let destStat;
-  try {
-    destStat = statSync(destParent, { bigint: true });
-  } catch (err) {
-    if (err.code === 'ENOENT') return;
-    throw err;
+  const destStat = statSync(destParent, { bigint: true, throwIfNoEntry: false });
+
+  if (destStat === undefined) {
+    return;
   }
+
   if (areIdentical(srcStat, destStat)) {
     throw new ERR_FS_CP_EINVAL({
       message: `cannot copy ${src} to a subdirectory of self ${dest}`,


### PR DESCRIPTION
Since we have throwIfNoEntry flag in statSync right now, we can use it to avoid having try/catch blocks in cpSync.