### PR TITLE
stream: allow pass stream class to `stream.compose`

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -85,6 +85,11 @@ module.exports = function duplexify(body, name) {
   if (typeof body === 'function') {
     const { value, write, final, destroy } = fromAsyncGen(body);
 
+    // body might be a constructor function instead of an async generator function.
+    if (isDuplexNodeStream(value)) {
+      return value;
+    }
+
     if (isIterable(value)) {
       return from(Duplexify, value, {
         // TODO (ronag): highWaterMark?

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -85,7 +85,7 @@ module.exports = function duplexify(body, name) {
   if (typeof body === 'function') {
     const { value, write, final, destroy } = fromAsyncGen(body);
 
-    // body might be a constructor function instead of an async generator function.
+    // Body might be a constructor function instead of an async generator function.
     if (isDuplexNodeStream(value)) {
       return value;
     }

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -96,6 +96,16 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       assert.match(stringResults[1], /tests 1/);
       assert.match(stringResults[1], /pass 1/);
     });
+
+    it('spec', async () => {
+      const result = await run({
+        files: [join(testFixtures, 'default-behavior/test/random.cjs')]
+      }).compose(spec).toArray();
+      const stringResults = result.map((bfr) => bfr.toString());
+      assert.match(stringResults[0], /this should pass/);
+      assert.match(stringResults[1], /tests 1/);
+      assert.match(stringResults[1], /pass 1/);
+    })
   });
 
   it('should be piped with tap', async () => {

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -105,7 +105,7 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       assert.match(stringResults[0], /this should pass/);
       assert.match(stringResults[1], /tests 1/);
       assert.match(stringResults[1], /pass 1/);
-    })
+    });
   });
 
   it('should be piped with tap', async () => {


### PR DESCRIPTION
```js
class A extends Transform {
  // ...
}

stream.compose(A) // old behavior: A will be called as a normal function and nothing will happen
```

Fixes: https://github.com/nodejs/node/issues/50176

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
