### PR TITLE
tools: exempt FastApiCallbackOptions from runtime/references lint check

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -5798,9 +5798,10 @@ def CheckForNonConstReference(filename, clean_lines, linenum,
   # We also accept & in static_assert, which looks like a function but
   # it's actually a declaration expression.
   allowed_functions = (r'(?:[sS]wap(?:<\w:+>)?|'
-                           r'operator\s*[<>][<>]|'
-                           r'static_assert|COMPILE_ASSERT'
-                           r')\s*\(')
+                       r'operator\s*[<>][<>]|'
+                       r'static_assert|'
+                       r'COMPILE_ASSERT)\s*\(|'
+                       r'FastApiCallbackOptions&')
   if Search(allowed_functions, line):
     return
   elif not Search(r'\S+\([^)]*$', line):


### PR DESCRIPTION
The non-const reference is required by a V8 function signature.

Fixes: #45761