### PR TITLE
http2: allow streams to complete gracefully after goaway

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -2358,8 +2358,11 @@ class Http2Stream extends Duplex {
     // This notifies the session that this stream has been destroyed and
     // gives the session the opportunity to clean itself up. The session
     // will destroy if it has been closed and there are no other open or
-    // pending streams.
-    session[kMaybeDestroy]();
+    // pending streams. Delay with setImmediate so we don't do it on the
+    // nghttp2 stack.
+    setImmediate(() => {
+      session[kMaybeDestroy]();
+    });
     callback(err);
   }
   // The Http2Stream can be destroyed if it has closed and if the readable

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -179,10 +179,13 @@ class JSStreamSocket extends Socket {
       // anything. doClose will call finishWrite with ECANCELED for us shortly.
       this[kCurrentWriteRequest] = req; // Store req, for doClose to cancel
       return 0;
+    } else if (this._handle === null) {
+      // If this._handle is already null, there is nothing left to do with a
+      // pending write request, so we discard it.
+      return 0;
     }
 
     const handle = this._handle;
-    assert(handle !== null);
 
     const self = this;
 

--- a/test/parallel/test-http2-exceeds-server-trailer-size.js
+++ b/test/parallel/test-http2-exceeds-server-trailer-size.js
@@ -43,9 +43,13 @@ server.listen(0, () => {
   const clientStream = clientSession.request();
 
   clientStream.on('close', common.mustCall());
-  // These events mustn't be called once the frame size error is from the server
+  clientStream.on('error', common.expectsError({
+    code: 'ERR_HTTP2_STREAM_ERROR',
+    name: 'Error',
+    message: 'Stream closed with error code NGHTTP2_FRAME_SIZE_ERROR'
+  }));
+  // This event mustn't be called once the frame size error is from the server
   clientStream.on('frameError', common.mustNotCall());
-  clientStream.on('error', common.mustNotCall());
 
   clientStream.end();
 });

--- a/test/parallel/test-http2-trailers-after-session-close.js
+++ b/test/parallel/test-http2-trailers-after-session-close.js
@@ -3,9 +3,6 @@
 // Fixes: https://github.com/nodejs/node/issues/42713
 const common = require('../common');
 if (!common.hasCrypto) {
-  // Remove require('assert').fail when issue is fixed and test
-  // is moved out of the known_issues directory.
-  require('assert').fail('missing crypto');
   common.skip('missing crypto');
 }
 const assert = require('assert');


### PR DESCRIPTION
A detailed analysis of the cause of this bug is in my linked comment on the corresponding issue. The primary fix is the new setImmediate call in Http2Stream#_destroy, which prevents a re-entrant call into Http2Session::SendPendingData when sending trailers after the Http2Session has been shut down, allowing the trailer data to be flushed properly before the socket is closed.

As a result of this change, writes can be initiated later in the lifetime of the Http2Session. So, when a JSStreamSocket is used as the underlying socket reference for an Http2Session, it needs to be able to accept write calls after it is closed.

In addition, now that outgoing data can be flushed differently after a session is closed, in two tests clients receive errors that they previously did not receive. I believe the new errors are more correct, so I changed the tests to match.

Fixes: https://github.com/nodejs/node/issues/42713
Refs: https://github.com/nodejs/node/issues/42713#issuecomment-1756140062

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
