### PR TITLE
doc: fix release process table of contents

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -32,9 +32,8 @@ official release builds for Node.js, hosted on <https://nodejs.org/>.
   * [16. Check the release](#16-check-the-release)
   * [17. Create a blog post](#17-create-a-blog-post)
   * [18. Create the release on GitHub](#18-create-the-release-on-github)
-  * [19. Cleanup](#19-cleanup)
-  * [20. Announce](#20-announce)
-  * [21. Celebrate](#21-celebrate)
+  * [19. Announce](#19-announce)
+  * [20. Celebrate](#20-celebrate)
 * [LTS releases](#lts-releases)
 * [Major releases](#major-releases)
 


### PR DESCRIPTION
The table of contents for the release process still references a deleted section. Remove that reference, and renumber the following table of contents entries so that they link through to the correct sections.

Refs: https://github.com/nodejs/node/pull/45858