### PR TITLE
lib: add navigator.onLine

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -629,6 +629,32 @@ logical processors available to the current Node.js instance.
 console.log(`This process is running on ${navigator.hardwareConcurrency}`);
 ```
 
+### `navigator.onLine`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+The [`navigator.onLine`](https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-online-dev)
+read-only property returns the online status available
+of the current Node.js instance. If the Node.js instance is not able to detect
+to a local area network (LAN) or a router, it is offline; all other conditions
+return true. So while you can assume that the Node.js instance is offline when
+it returns a false value, you cannot assume that a true value necessarily
+means that the Node.js instance can access the internet. You could be getting
+false positives, such as in cases where the computer is running a
+virtualization software that has virtual ethernet adapters that are always
+"connected."
+
+Therefore, if you really want to determine the online status of the Node.js
+instance, you should develop additional means for checking.
+
+```js
+console.log(`This process is ${navigator.onLine ? 'online' : 'offline'}`);
+```
+
 ## `PerformanceEntry`
 
 <!-- YAML

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -15,6 +15,7 @@ const {
 
 const {
   getAvailableParallelism,
+  getOnLineStatus,
 } = internalBinding('os');
 
 const kInitialize = Symbol('kInitialize');
@@ -37,10 +38,18 @@ class Navigator {
     this.#availableParallelism ??= getAvailableParallelism();
     return this.#availableParallelism;
   }
+
+  /**
+   * @return {boolean}
+   */
+  get onLine() {
+    return getOnLineStatus();
+  }
 }
 
 ObjectDefineProperties(Navigator.prototype, {
   hardwareConcurrency: kEnumerableProperty,
+  onLine: kEnumerableProperty,
 });
 
 module.exports = {

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -13,3 +13,5 @@ const is = {
 is.number(+navigator.hardwareConcurrency, 'hardwareConcurrency');
 is.number(navigator.hardwareConcurrency, 'hardwareConcurrency');
 assert.ok(navigator.hardwareConcurrency > 0);
+
+assert.strictEqual(typeof navigator.onLine, 'boolean');

--- a/typings/internalBinding/os.d.ts
+++ b/typings/internalBinding/os.d.ts
@@ -10,6 +10,7 @@ export interface OSBinding {
   getFreeMem(): number;
   getCPUs(): Array<string | number>;
   getInterfaceAddresses(ctx: InternalOSBinding.OSContext): Array<string | number | boolean> | undefined;
+  getOnLineStatus(): boolean;
   getHomeDirectory(ctx: InternalOSBinding.OSContext): string | undefined;
   getUserInfo(options: { encoding?: string } | undefined, ctx: InternalOSBinding.OSContext): {
     uid: number;


### PR DESCRIPTION
Motivated by #50200 

I did not add the ability to listen on a status change, as I expect that it is problematical as getting the online status is slow.

Using following benchmark I get 2600 ops/s. I could add to `process` the events `online` and `offline`, if we listen to `online` or `offline`. And then i would set a setInterval with lets say 50ms or 250 ms, and check if there was a status change and emit the corresponding event. Maybe if we have listeners, than instead of directly calling `getOnlineStatus`, we use the last value derived in the `setInterval`. 

But for now, this is an proposal. Maybe you dont like it and we can stomp this PR into the trashbin :P

```js
'use strict';

const common = require('../common.js');
const assert = require('assert');

const bench = common.createBenchmark(main, {
  n: [1e4],
});

// Warm up.
const length = 1024;
const array = [];
for (let i = 0; i < length; ++i) {
  array.push(global.navigator.onLine);
}

function main({ n }) {
  bench.start();
  for (let i = 0; i < n; ++i) {
    const index = i % length;
    array[index] = global.navigator.onLine;
  }
  bench.end(n);

  // Verify the entries to prevent dead code elimination from making
  // the benchmark invalid.
  for (let i = 0; i < length; ++i) {
    assert.strictEqual(typeof array[i], 'boolean');
  }
}

```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
