### PR TITLE
[v18.x backport] test: fix edge snapshot stack traces

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -8,6 +8,10 @@ const assert = require('node:assert/strict');
 const stackFramesRegexp = /(\s+)((.+?)\s+\()?(?:\(?(.+?):(\d+)(?::(\d+))?)\)?(\s+\{)?(\[\d+m)?(\n|$)/g;
 const windowNewlineRegexp = /\r/g;
 
+function replaceNodeVersion(str) {
+  return str.replaceAll(process.version, '*');
+}
+
 function replaceStackTrace(str, replacement = '$1*$7$8\n') {
   return str.replace(stackFramesRegexp, replacement);
 }
@@ -69,6 +73,7 @@ async function spawnAndAssert(filename, transform = (x) => x, { tty = false, ...
 module.exports = {
   assertSnapshot,
   getSnapshotPath,
+  replaceNodeVersion,
   replaceStackTrace,
   replaceWindowsLineEndings,
   replaceWindowsPaths,

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -4,11 +4,11 @@ throw new Error('Should include grayed stack trace')
 
 Error: Should include grayed stack trace
     at Object.<anonymous> [90m(/[39mtest*force_colors.js:1:7[90m)[39m
-[90m    at Module._compile (node:internal*modules*cjs*loader:1256:14)[39m
-[90m    at Module._extensions..js (node:internal*modules*cjs*loader:1310:10)[39m
-[90m    at Module.load (node:internal*modules*cjs*loader:1119:32)[39m
-[90m    at Module._load (node:internal*modules*cjs*loader:960:12)[39m
-[90m    at Function.executeUserEntryPoint [as runMain] (node:internal*modules*run_main:86:12)[39m
-[90m    at node:internal*main*run_main_module:23:47[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
 
 Node.js *

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -10,12 +10,13 @@ const skipForceColors =
   (common.isWindows && (Number(os.release().split('.')[0]) !== 10 || Number(os.release().split('.')[2]) < 14393)); // See https://github.com/nodejs/node/pull/33132
 
 
-function replaceNodeVersion(str) {
-  return str.replaceAll(process.version, '*');
-}
-
 function replaceStackTrace(str) {
   return snapshot.replaceStackTrace(str, '$1at *$7\n');
+}
+
+function replaceForceColorsStackTrace(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replaceAll(/(\[90m\W+)at .*node:.*/g, '$1at *[39m');
 }
 
 describe('errors output', { concurrency: true }, () => {
@@ -28,9 +29,12 @@ describe('errors output', { concurrency: true }, () => {
   }
   const common = snapshot
     .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths);
-  const defaultTransform = snapshot.transform(common, normalize, replaceNodeVersion);
-  const errTransform = snapshot.transform(common, normalizeNoNumbers, replaceNodeVersion);
-  const promiseTransform = snapshot.transform(common, replaceStackTrace, normalizeNoNumbers, replaceNodeVersion);
+  const defaultTransform = snapshot.transform(common, normalize, snapshot.replaceNodeVersion);
+  const errTransform = snapshot.transform(common, normalizeNoNumbers, snapshot.replaceNodeVersion);
+  const promiseTransform = snapshot.transform(common, replaceStackTrace,
+                                              normalizeNoNumbers, snapshot.replaceNodeVersion);
+  const forceColorsTransform = snapshot.transform(common, normalize,
+                                                  replaceForceColorsStackTrace, snapshot.replaceNodeVersion);
 
   const tests = [
     { name: 'errors/async_error_eval_cjs.js' },
@@ -50,7 +54,11 @@ describe('errors output', { concurrency: true }, () => {
     { name: 'errors/throw_in_line_with_tabs.js', transform: errTransform },
     { name: 'errors/throw_non_error.js', transform: errTransform },
     { name: 'errors/promise_always_throw_unhandled.js', transform: promiseTransform },
-    !skipForceColors ? { name: 'errors/force_colors.js', env: { FORCE_COLOR: 1 } } : null,
+    !skipForceColors ? {
+      name: 'errors/force_colors.js',
+      transform: forceColorsTransform,
+      env: { FORCE_COLOR: 1 }
+    } : null,
   ].filter(Boolean);
   for (const { name, transform, env } of tests) {
     it(name, async () => {

--- a/test/parallel/test-node-output-sourcemaps.mjs
+++ b/test/parallel/test-node-output-sourcemaps.mjs
@@ -4,10 +4,6 @@ import * as snapshot from '../common/assertSnapshot.js';
 import * as path from 'node:path';
 import { describe, it } from 'node:test';
 
-function replaceNodeVersion(str) {
-  return str.replaceAll(process.version, '*');
-}
-
 describe('sourcemaps output', { concurrency: true }, () => {
   function normalize(str) {
     const result = str
@@ -16,7 +12,8 @@ describe('sourcemaps output', { concurrency: true }, () => {
     .replaceAll('/Users/bencoe/oss/coffee-script-test', '')
     .replaceAll(/\/(\w)/g, '*$1')
     .replaceAll('*test*', '*')
-    .replaceAll('*fixtures*source-map*', '*');
+    .replaceAll('*fixtures*source-map*', '*')
+    .replaceAll(/(\W+).*node:internal\*modules.*/g, '$1*');
     if (common.isWindows) {
       const currentDeviceLetter = path.parse(process.cwd()).root.substring(0, 1).toLowerCase();
       const regex = new RegExp(`${currentDeviceLetter}:/?`, 'gi');
@@ -25,7 +22,8 @@ describe('sourcemaps output', { concurrency: true }, () => {
     return result;
   }
   const defaultTransform = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize, replaceNodeVersion);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths,
+               normalize, snapshot.replaceNodeVersion);
 
   const tests = [
     { name: 'source-map/output/source_map_disabled_by_api.js' },


### PR DESCRIPTION
Backporting https://github.com/nodejs/node/pull/49659 - it's affecting Electron in 18 and it'd help us a fair bit for this to land.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
