### PR TITLE
test: set test-worker-nearheaplimit-deadlock flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,6 +12,10 @@ test-crypto-keygen: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41201
 test-fs-rmdir-recursive: PASS, FLAKY
 
+# Windows on x86
+[$system==win32 && $arch==x86]
+test-worker-nearheaplimit-deadlock: PASS, FLAKY
+
 # Windows on ARM
 [$system==win32 && $arch==arm64]
 


### PR DESCRIPTION
The test is only flaky on x86 Windows.

Refs: https://github.com/nodejs/node/pull/49962
Fixes: https://github.com/nodejs/node/issues/50220