### PR TITLE
test: set `test-emit-after-on-destroyed` as flaky

### DIFF
--- a/test/async-hooks/async-hooks.status
+++ b/test/async-hooks/async-hooks.status
@@ -21,3 +21,5 @@ test-callback-error: PASS, FLAKY
 [$system==freebsd]
 
 [$system==aix]
+# https://github.com/nodejs/node/issues/50245
+test-emit-after-on-destroyed: PASS, FLAKY


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/50245

cc @nodejs/async_hooks 