### PR TITLE
src: use ostringstream instead of string in `FromFilePath()`

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -418,12 +418,12 @@ void BindingData::RegisterExternalReferences(
 }
 
 std::string FromFilePath(const std::string_view file_path) {
-  std::string escaped_file_path;
+  std::ostringstream escaped_file_path;
   for (size_t i = 0; i < file_path.length(); ++i) {
-    escaped_file_path += file_path[i];
-    if (file_path[i] == '%') escaped_file_path += "25";
+    escaped_file_path << file_path[i];
+    if (file_path[i] == '%') escaped_file_path << "25";
   }
-  return ada::href_from_file(escaped_file_path);
+  return ada::href_from_file(escaped_file_path.str());
 }
 
 }  // namespace url


### PR DESCRIPTION
When performing string concatenation operations, it is more advantageous in terms of performance to use `std::ostringstream` rather than `std::string`. This approach is also used elsewhere, such as `debug_utils` and `node_errors`.

Refs: #46410 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
