### PR TITLE
test: deflake `test-esm-loader-resolve-type`

### DIFF
--- a/test/fixtures/es-module-loaders/hook-resolve-type-loader.mjs
+++ b/test/fixtures/es-module-loaders/hook-resolve-type-loader.mjs
@@ -1,7 +1,14 @@
-/** @type {MessagePort} */
-let port;
-export function initialize(data) {
-  port = data.port;
+/** @type {Uint8Array} */
+let data;
+/** @type {number} */
+let ESM_MODULE_INDEX;
+/** @type {number} */
+let CJS_MODULE_INDEX;
+
+export function initialize({ sab, ESM_MODULE_INDEX:e, CJS_MODULE_INDEX:c }) {
+  data = new Uint8Array(sab);
+  ESM_MODULE_INDEX = e;
+  CJS_MODULE_INDEX = c;
 }
 
 export async function resolve(specifier, context, next) {
@@ -9,9 +16,9 @@ export async function resolve(specifier, context, next) {
   const { format } = nextResult;
 
   if (format === 'module' || specifier.endsWith('.mjs')) {
-    port.postMessage({ type: 'module' });
+    Atomics.add(data, ESM_MODULE_INDEX, 1);
   } else if (format == null || format === 'commonjs') {
-    port.postMessage({ type: 'commonjs' });
+    Atomics.add(data, CJS_MODULE_INDEX, 1);
   }
 
   return nextResult;


### PR DESCRIPTION
Sending messages cross threads is inherently flaky as there's no guarantee the other thread will receive the message in a timely manner. Thankfully JS exposes the `SharedArrayBuffer`+`Atomics` API for this exact use case.

Fixes: https://github.com/nodejs/node/issues/50040

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
