### PR TITLE
test: correctly resolve path of embedtest binary

### DIFF
--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -14,12 +14,11 @@ tmpdir.refresh();
 common.allowGlobals(global.require);
 common.allowGlobals(global.embedVars);
 
-function resolveBuiltBinary(bin) {
-  let binary = `out/${common.buildType}/${bin}`;
+function resolveBuiltBinary(binary) {
   if (common.isWindows) {
     binary += '.exe';
   }
-  return path.resolve(__dirname, '..', '..', binary);
+  return path.join(path.dirname(process.execPath), binary);
 }
 
 const binary = resolveBuiltBinary('embedtest');


### PR DESCRIPTION
The `embedtest` binary is usually generated under the same directory with the `node` binary.

The `out` directory is not necessarily in the source code directory, so current way will fail when Node.js is built as a component of other projects.