### PR TITLE
fixup! test: set test-worker-nearheaplimit-deadlock flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -15,7 +15,7 @@ test-fs-rmdir-recursive: PASS, FLAKY
 test-runner-watch-mode: PASS, FLAKY
 
 # Windows on x86
-[$system==win32 && $arch==x86]
+[$system==win32 && $arch==ia32]
 test-worker-nearheaplimit-deadlock: PASS, FLAKY
 
 # Windows on ARM


### PR DESCRIPTION
The test is only flaky on x86 Windows.

This is a fixup to https://github.com/nodejs/node/pull/50238 because `process.arch` returns `ia32` and not `x86` on x86 node.exe on Windows.
