### PR TITLE
deps: avx512 in base64 for x32 cpus

### DIFF
--- a/deps/base64/base64.gyp
+++ b/deps/base64/base64.gyp
@@ -49,6 +49,7 @@
             'HAVE_SSE42=1',
             'HAVE_AVX=1',
             'HAVE_AVX2=1',
+            'HAVE_AVX512=1'
           ],
           'dependencies': [
             'base64_ssse3',
@@ -56,6 +57,7 @@
             'base64_sse42',
             'base64_avx',
             'base64_avx2',
+            'base64_avx512',
           ],
         }, {
           'sources': [
@@ -64,6 +66,7 @@
             'base64/lib/arch/sse42/codec.c',
             'base64/lib/arch/avx/codec.c',
             'base64/lib/arch/avx2/codec.c',
+            'base64/lib/arch/avx512/codec.c',
           ],
         }],
       ],
@@ -158,6 +161,30 @@
             'VCCLCompilerTool': {
               'AdditionalOptions': [
                 '/arch:AVX2'
+              ],
+            },
+          },
+        }],
+      ],
+    },
+
+    {
+      'target_name': 'base64_avx512',
+      'type': 'static_library',
+      'include_dirs': [ 'base64/include', 'base64/lib' ],
+      'sources': [ 'base64/lib/arch/avx512/codec.c' ],
+      'defines': [ 'BASE64_STATIC_DEFINE', 'HAVE_AVX512=1' ],
+      'conditions': [
+        [ 'OS!="win"', {
+          'cflags': [ '-mavx512' ],
+          'xcode_settings': {
+            'OTHER_CFLAGS': [ '-mavx512' ]
+          },
+        }, {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': [
+                '/arch:AVX512'
               ],
             },
           },


### PR DESCRIPTION
This should activate avx512 in base64. My cpu has no avx512 support, so I couldnt test it.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
