### PR TITLE
src: use find instead of char-by-char in FromFilePath()

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -423,7 +423,7 @@ std::string FromFilePath(std::string_view file_path) {
   if (pos == std::string_view::npos) {
     return ada::href_from_file(file_path);
   }
-  // escape '%' characters to a temporary string
+  // Escape '%' characters to a temporary string.
   std::string escaped_file_path;
   do {
     escaped_file_path += file_path.substr(0, pos + 1);

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -430,7 +430,7 @@ std::string FromFilePath(std::string_view file_path) {
     escaped_file_path += "25";
     file_path = file_path.substr(pos + 1);
     pos = 0;
-  } while((pos = file_path.find('%', pos)) != std::string_view::npos);
+  } while ((pos = file_path.find('%', pos)) != std::string_view::npos);
   escaped_file_path += file_path;
   return ada::href_from_file(escaped_file_path);
 }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -429,8 +429,8 @@ std::string FromFilePath(std::string_view file_path) {
     escaped_file_path += file_path.substr(0, pos + 1);
     escaped_file_path += "25";
     file_path = file_path.substr(pos + 1);
-    pos = 0;
-  } while ((pos = file_path.find('%', pos)) != std::string_view::npos);
+    pos = file_path.empty() ? std::string_view::npos : file_path.find('%');
+  } while (pos != std::string_view::npos);
   escaped_file_path += file_path;
   return ada::href_from_file(escaped_file_path);
 }

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -417,12 +417,16 @@ void BindingData::RegisterExternalReferences(
   }
 }
 
-std::string FromFilePath(const std::string_view file_path) {
+std::string FromFilePath(std::string_view file_path) {
   std::string escaped_file_path;
-  for (size_t i = 0; i < file_path.length(); ++i) {
-    escaped_file_path += file_path[i];
-    if (file_path[i] == '%') escaped_file_path += "25";
+  size_t pos = 0;
+  while ((pos = file_path.find('%', pos)) != std::string_view::npos) {
+    escaped_file_path += file_path.substr(0, pos + 1);
+    escaped_file_path += "25";
+    file_path = file_path.substr(pos + 1);
+    pos = 0;
   }
+  escaped_file_path += file_path;
   return ada::href_from_file(escaped_file_path);
 }
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -418,7 +418,7 @@ void BindingData::RegisterExternalReferences(
 }
 
 std::string FromFilePath(std::string_view file_path) {
-  // avoid unnecessary allocations
+  // Avoid unnecessary allocations.
   size_t pos = file_path.empty() ? std::string_view::npos : file_path.find('%');
   if (pos == std::string_view::npos) {
     return ada::href_from_file(file_path);

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -418,14 +418,19 @@ void BindingData::RegisterExternalReferences(
 }
 
 std::string FromFilePath(std::string_view file_path) {
+  // avoid unnecessary allocations
+  size_t pos = file_path.empty() ? std::string_view::npos : file_path.find('%');
+  if (pos == std::string_view::npos) {
+    return ada::href_from_file(file_path);
+  }
+  // escape '%' characters to a temporary string
   std::string escaped_file_path;
-  size_t pos = 0;
-  while ((pos = file_path.find('%', pos)) != std::string_view::npos) {
+  do {
     escaped_file_path += file_path.substr(0, pos + 1);
     escaped_file_path += "25";
     file_path = file_path.substr(pos + 1);
     pos = 0;
-  }
+  } while((pos = file_path.find('%', pos)) != std::string_view::npos);
   escaped_file_path += file_path;
   return ada::href_from_file(escaped_file_path);
 }

--- a/src/node_url.h
+++ b/src/node_url.h
@@ -81,7 +81,7 @@ class BindingData : public SnapshotableObject {
                               std::optional<std::string> base);
 };
 
-std::string FromFilePath(const std::string_view file_path);
+std::string FromFilePath(std::string_view file_path);
 
 }  // namespace url
 


### PR DESCRIPTION
In PR https://github.com/nodejs/node/pull/50253/files, an optimization was proposed for the FromFilePath() function. This function replaces every occurence of the '%' character by the string '%25'. The expectation is that in this function (FromFilePath), strings typically do not contain the '%', or if they do, they have few such characters. It lead me to write a blog post and write a non-trivial benchmark and realistic data: [For processing strings, streams in C++ can be slow](https://lemire.me/blog/2023/10/19/for-processing-strings-streams-in-c-can-be-slow/). My work suggests that a loop calling `find` is faster. Furthermore, we can do one better and avoid the allocation of a temporary `std::string` in the common case where the '%' is not found.

[If you use my benchmarking code](https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/2023/10/18), you find that code similar to the PR is several times more efficient the current code (5 GB/s vs 0.34 GB/s) (note: the benchmark does not include the URL parsing which is considered separate). Here are my numbers of my macBook with LLVM 14 ([you can run your own benchmarks](https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/2023/10/18)):

<img width="1118" alt="Capture d’écran, le 2023-10-22 à 12 52 02" src="https://github.com/nodejs/node/assets/391987/f93a880d-8465-4164-a11d-ac124fe43831">

Clang compiles the second inner loop to the following:

```asm
.LBB0_12: # =>This Inner Loop Header: Depth=1
  lea r14, [r13 + 1]
  cmp r15, r14
  mov rdx, r14
  cmovb rdx, r15
  mov rax, rbp
  sub rax, qword ptr [rbx + 8]
  cmp rax, rdx
  jb .LBB0_13
  mov rdi, rbx
  mov rsi, r12
  call std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long)@PLT
  mov rax, qword ptr [rbx + 8]
  and rax, -2
  cmp rax, qword ptr [rsp + 16] # 8-byte Folded Reload
  je .LBB0_17
  mov edx, 2
  mov rdi, rbx
  lea rsi, [rip + .L.str]
  call std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_append(char const*, unsigned long)@PLT
  cmp r15, r13
  jbe .LBB0_21
  add r12, r14
  sub r15, r14
  je .LBB0_24
  mov rdi, r12
  mov esi, 37
  mov rdx, r15
  call memchr@PLT
  test rax, rax
  je .LBB0_27
  mov r13, rax
  sub r13, r12
  cmp r13, -1
  jne .LBB0_12
```

There are two calls to string append, as you'd expect. Otherwise, there is no allocation. E.g., for example, there are calls to a `std::string_view` constructor because it gets optimized away. Remember that `std::string_view` instances are non-allocating. That's why, for example, we pass them by value (not by reference), typically.

The adversarial scenario is one where the entire string is made of '%'. [You can benchmark this case using my code](https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/2023/10/18), while passing `--adversarial` to the benchmark program (`benchmark --adversarial`).  In that scenario, the repeated calls to `find` are not a positive. All tested functions are slow in this adversarial case, but the new code is about 50% slower. That's to be expected. If you do expect strings to contain a large fraction of '%' characters, then the PR is not beneficial. But the point of the PR is that on realistic inputs, the PR can multiply the performance by 10x.

Results on my macBook (LLVM14, you can [run your own benchmarks](https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/2023/10/18)):

<img width="1103" alt="Capture d’écran, le 2023-10-22 à 12 52 55" src="https://github.com/nodejs/node/assets/391987/34c959fb-539b-4844-8e67-1f59f44fd188">

It is possible to use a slightly more complicated function that does a first pass, counting the number of '%' characters and allocates accordingly. Empirically (see the `_count` results in the screenshot), it does not make much of a difference in the performance, whether you are in the realistic or adversarial case. However, requiring two passes over the data is slightly more complex so I opt for the simplest efficient implementation.

Note that [appending to an std::string, even character by character, has linear complexity](https://lemire.me/blog/2023/10/23/appending-to-an-stdstring-character-by-character-how-does-the-capacity-grow/). Each append does not translate into a new allocation. Rather the complexity grows exponentially, doubling a few times.
