### PR TITLE
deps: V8: cherry-pick f7d000a7ae7b

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -178,6 +178,7 @@ Kyounga Ra <kyounga@alticast.com>
 Loo Rong Jie <loorongjie@gmail.com>
 Lu Yahan <yahan@iscas.ac.cn>
 Luis Reis <luis.m.reis@gmail.com>
+Luke Albao <lukealbao@gmail.com>
 Luke Zarko <lukezarko@gmail.com>
 Ma Aiguo <maaiguo@uniontech.com>
 Maciej Małecki <me@mmalecki.com>

--- a/deps/v8/src/diagnostics/perf-jit.cc
+++ b/deps/v8/src/diagnostics/perf-jit.cc
@@ -43,6 +43,7 @@
 #include "src/codegen/assembler.h"
 #include "src/codegen/source-position-table.h"
 #include "src/diagnostics/eh-frame.h"
+#include "src/objects/code-kind.h"
 #include "src/objects/objects-inl.h"
 #include "src/objects/shared-function-info.h"
 #include "src/snapshot/embedded/embedded-data.h"
@@ -225,9 +226,7 @@ void LinuxPerfJitLogger::LogRecordedBuffer(
   DisallowGarbageCollection no_gc;
   if (v8_flags.perf_basic_prof_only_functions) {
     CodeKind code_kind = abstract_code->kind(isolate_);
-    if (code_kind != CodeKind::INTERPRETED_FUNCTION &&
-        code_kind != CodeKind::TURBOFAN && code_kind != CodeKind::MAGLEV &&
-        code_kind != CodeKind::BASELINE) {
+    if (!CodeKindIsJSFunction(code_kind)) {
       return;
     }
   }

--- a/deps/v8/src/logging/log.cc
+++ b/deps/v8/src/logging/log.cc
@@ -446,7 +446,7 @@ void LinuxPerfBasicLogger::LogRecordedBuffer(Tagged<AbstractCode> code,
   DisallowGarbageCollection no_gc;
   PtrComprCageBase cage_base(isolate_);
   if (v8_flags.perf_basic_prof_only_functions &&
-      CodeKindIsBuiltinOrJSFunction(code->kind(cage_base))) {
+      !CodeKindIsBuiltinOrJSFunction(code->kind(cage_base))) {
     return;
   }
 


### PR DESCRIPTION
Original commit message:

    [logging] Bugfix: LinuxPerfBasicLogger should log JS functions

    This patch fixes a typo that was introduced in commit
    c51041f45400928cd64fbc8f389c0dd0dd15f82f /
    https://chromium-review.googlesource.com/c/v8/v8/+/2336793, which reversed the behavior of the perf_basic_prof_only_functions flag.

    This also refactors the equivalent guard in LinuxPerfJitLogger to use the same inline CodeKind API for identifying JS Functions. This is unrelated to the bug, but it seems a fair rider to add on here.

    Bug: v8:14387
    Change-Id: I25766b0d45f4c65dfec5ae01e094a1ed94111054
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4954225
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Camillo Bruni <cbruni@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#90501}

Refs: https://github.com/v8/v8/commit/f7d000a7ae7b731805338338eb51a81fbcfe2628

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
