### PR TITLE
Revert "test: set `test-esm-loader-resolve-type` as flaky"

### DIFF
--- a/test/es-module/es-module.status
+++ b/test/es-module/es-module.status
@@ -5,8 +5,6 @@ prefix es-module
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
-# https://github.com/nodejs/node/issues/50040
-test-esm-loader-resolve-type: PASS, FLAKY
 
 [$system==linux || $system==freebsd]
 # https://github.com/nodejs/node/issues/47836


### PR DESCRIPTION
Reverts nodejs/node#50226 because https://github.com/nodejs/node/pull/50273 has landed