### PR TITLE
test: improve watch mode test

### DIFF
--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -261,11 +261,12 @@ console.log(values.random);
 
   it('should load --require modules in the watched process, and not in the orchestrator process', async () => {
     const file = createTmpFile();
-    const required = createTmpFile('setImmediate(() => process.exit(0));');
+    const required = createTmpFile('process._rawDebug(\'pid\', process.pid);');
     const args = ['--require', required, file];
-    const { stderr, stdout } = await runWriteSucceed({ file, watchedFile: file, args });
+    const { stdout, pid } = await runWriteSucceed({ file, watchedFile: file, args });
 
-    assert.strictEqual(stderr, '');
+    const importPid = parseInt(stdout[0].split(' ')[1], 10);
+    assert.notStrictEqual(pid, importPid);
     assert.deepStrictEqual(stdout, [
       'running',
       `Completed running ${inspect(file)}`,

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -259,7 +259,7 @@ console.log(values.random);
     ]);
   });
 
-  it('should not load --require modules in main process', async () => {
+  it('should load --require modules in the watched process, and not in the orchestrator process', async () => {
     const file = createTmpFile();
     const required = createTmpFile('setImmediate(() => process.exit(0));');
     const args = ['--require', required, file];
@@ -275,7 +275,7 @@ console.log(values.random);
     ]);
   });
 
-  it('should not load --import modules in main process', async () => {
+  it('should load --import modules in the watched process, and not in the orchestrator process', async () => {
     const file = createTmpFile();
     const imported = "data:text/javascript,process._rawDebug('pid', process.pid);";
     const args = ['--import', imported, file];

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -62,7 +62,7 @@ async function runWriteSucceed({
     child.kill();
     cancelRestarts();
   }
-  return { stdout, stderr };
+  return { stdout, stderr, pid: child.pid };
 }
 
 async function failWriteSucceed({ file, watchedFile }) {
@@ -277,11 +277,12 @@ console.log(values.random);
 
   it('should not load --import modules in main process', async () => {
     const file = createTmpFile();
-    const imported = pathToFileURL(createTmpFile('process._rawDebug("imported");'));
+    const imported = "data:text/javascript,process._rawDebug('pid', process.pid);";
     const args = ['--import', imported, file];
-    const { stderr, stdout } = await runWriteSucceed({ file, watchedFile: file, args });
+    const { stdout, pid } = await runWriteSucceed({ file, watchedFile: file, args });
 
-    assert.strictEqual(stderr, 'imported\nimported\n');
+    const importPid = parseInt(stdout[0].split(' ')[1], 10);
+    assert.notStrictEqual(pid, importPid);
     assert.deepStrictEqual(stdout, [
       'running',
       `Completed running ${inspect(file)}`,


### PR DESCRIPTION
this test was changed to enable landing of https://github.com/nodejs/node/pull/50096
the original intent was to make sure the `--import` is only handled by the inner process spawned by watch mode, and not the outer one.