### PR TITLE
test: skip test-diagnostics-channel-memory-leak.js

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -5,6 +5,9 @@ prefix parallel
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+# https://github.com/nodejs/node/pull/50327
+# Currently there's no reliable way to test it.
+test-diagnostics-channel-memory-leak: SKIP
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/41206


### PR DESCRIPTION
test: skip test-diagnostics-channel-memory-leak.js

There is currently no reliable way to detect this leak because:

1. We cannot reliably get a reference to the channel from the
  API to detect finalization without creating another strong reference.
2. This test does gc() and then checks memory usage - however the
  use of gc() disables code aging which can actually lead to increased
  memory usage overall, as it is not intended to be used to lower
  memory usage in the first place.
3. The implementation of diagnostics channels relies on ephemeron gc
  which is inefficient, it's not reliable to use the typical "create
  a lot of objects and see if it crashes" trick to check leaks.

Skip the test for now until we find a way to test it reliably.

To avoid flakiness in the CI, it's better to remove an unreliable
test altogether.

I found this issue from an integration test run in https://chromium-review.googlesource.com/c/v8/v8/+/4962094
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
