### PR TITLE
test_runner: Fix mock timer promisified setInterval return value

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -370,7 +370,7 @@ class MockTimers {
     return MockDate;
   }
 
-  async * #setIntervalPromisified(interval, startTime, options) {
+  async * #setIntervalPromisified(interval, result, options) {
     const context = this;
     const emitter = new EventEmitter();
     if (options?.signal) {
@@ -394,8 +394,7 @@ class MockTimers {
 
     const eventIt = EventEmitter.on(emitter, 'data');
     const callback = () => {
-      startTime += interval;
-      emitter.emit('data', startTime);
+      emitter.emit('data', result);
     };
 
     const timerId = this.#createTimer(true, callback, interval, options);

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -407,6 +407,16 @@ describe('Mock Timers Test Suite', () => {
           assert.strictEqual(result, expectedResult);
         });
 
+        it('should always return the same result as the original timers/promises/setTimeout', async (t) => {
+          t.mock.timers.enable({ apis: ['setTimeout'] });
+          for (const expectedResult of [undefined, null, false, true, 0, 0n, 1, 1n, '', 'result', {}]) {
+            const p = nodeTimersPromises.setTimeout(2000, expectedResult);
+            t.mock.timers.tick(2000);
+            const result = await p;
+            assert.strictEqual(result, expectedResult);
+          }
+        });
+
         it('should abort operation if timers/promises/setTimeout received an aborted signal', async (t) => {
           t.mock.timers.enable({ apis: ['setTimeout'] });
           const expectedResult = 'result';
@@ -526,6 +536,19 @@ describe('Mock Timers Test Suite', () => {
           assert.strictEqual(timeResults.length, expectedIterations);
           for (let it = 1; it < expectedIterations; it++) {
             assert.strictEqual(timeResults[it - 1], startedAt + (interval * it));
+          }
+        });
+
+        it('should always return the same result as the original timers/promises/setInterval', async (t) => {
+          t.mock.timers.enable({ apis: ['setInterval'] });
+          for (const expectedResult of [undefined, null, false, true, 0, 0n, 1, 1n, '', 'result', {}]) {
+            const intervalIterator = nodeTimersPromises.setInterval(2000, expectedResult);
+            const p = intervalIterator.next();
+            t.mock.timers.tick(2000);
+            const result = await p;
+            await intervalIterator.return();
+            assert.strictEqual(result.done, false);
+            assert.strictEqual(result.value, expectedResult);
           }
         });
 

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -515,10 +515,11 @@ describe('Mock Timers Test Suite', () => {
 
           const expectedIterations = 5;
           const interval = 1000;
-          const startedAt = Date.now();
+          let time = 0;
           async function run() {
             const times = [];
-            for await (const time of nodeTimersPromises.setInterval(interval, startedAt)) {
+            for await (const _ of nodeTimersPromises.setInterval(interval)) { // eslint-disable-line no-unused-vars
+              time += interval;
               times.push(time);
               if (times.length === expectedIterations) break;
             }
@@ -535,7 +536,7 @@ describe('Mock Timers Test Suite', () => {
           const timeResults = await r;
           assert.strictEqual(timeResults.length, expectedIterations);
           for (let it = 1; it < expectedIterations; it++) {
-            assert.strictEqual(timeResults[it - 1], startedAt + (interval * it));
+            assert.strictEqual(timeResults[it - 1], interval * it);
           }
         });
 
@@ -602,13 +603,12 @@ describe('Mock Timers Test Suite', () => {
           const signal = controller.signal;
           const interval = 200;
           const expectedIterations = 2;
-          const startedAt = Date.now();
-          const timeResults = [];
+          let numIterations = 0;
           async function run() {
-            const it = nodeTimersPromises.setInterval(interval, startedAt, { signal });
-            for await (const time of it) {
-              timeResults.push(time);
-              if (timeResults.length === 5) break;
+            const it = nodeTimersPromises.setInterval(interval, undefined, { signal });
+            for await (const _ of it) { // eslint-disable-line no-unused-vars
+              numIterations += 1;
+              if (numIterations === 5) break;
             }
           }
 
@@ -624,11 +624,7 @@ describe('Mock Timers Test Suite', () => {
           await assert.rejects(() => r, {
             name: 'AbortError',
           });
-          assert.strictEqual(timeResults.length, expectedIterations);
-
-          for (let it = 1; it < expectedIterations; it++) {
-            assert.strictEqual(timeResults[it - 1], startedAt + (interval * it));
-          }
+          assert.strictEqual(numIterations, expectedIterations);
         });
       });
     });


### PR DESCRIPTION
promisified setInterval can be passed a value that is returned by the async iterable. The mocked promisified setInterval used this value for its own purposes. This brings the mocked version in line with the original.