### PR TITLE
stream: remove Array.p.shift primordial from hotpath of RS.read()

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -2084,7 +2084,7 @@ function readableStreamFulfillReadRequest(stream, chunk, done) {
     reader,
   } = stream[kState];
   assert(reader[kState].readRequests.length);
-  const readRequest = ArrayPrototypeShift(reader[kState].readRequests);
+  const readRequest = reader[kState].readRequests.shift();
 
   // TODO(@jasnell): It's not clear under what exact conditions done
   // will be true here. The spec requires this check but none of the
@@ -2102,7 +2102,7 @@ function readableStreamFulfillReadIntoRequest(stream, chunk, done) {
     reader,
   } = stream[kState];
   assert(reader[kState].readIntoRequests.length);
-  const readIntoRequest = ArrayPrototypeShift(reader[kState].readIntoRequests);
+  const readIntoRequest = reader[kState].readIntoRequests.shift();
   if (done)
     readIntoRequest[kClose](chunk);
   else


### PR DESCRIPTION
Refs: https://github.com/nodejs/performance/issues/82

A small improvement noticed in performance of read():

```console
                                                   confidence improvement accuracy (*)   (**)  (***)
webstreams/readable-async-iterator.js n=100000                     0.75 %       ±1.93% ±2.57% ±3.35%
webstreams/readable-read.js type='byob' n=100000                   0.69 %       ±1.21% ±1.61% ±2.10%
webstreams/readable-read.js type='normal' n=100000        ***      8.81 %       ±1.55% ±2.07% ±2.70%
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
