### PR TITLE
tools: run coverage CI only on relevant files

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -5,18 +5,24 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
   push:
     branches:
       - main
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
 
 concurrency:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -3,23 +3,21 @@ name: Coverage Linux (without intl)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/**
-      - doc/**
-      - .github/**
-      - '!.github/workflows/coverage-linux-without-intl.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-linux-without-intl.yml
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/**
-      - doc/**
-      - .github/**
-      - '!.github/workflows/coverage-linux-without-intl.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-linux-without-intl.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -3,23 +3,21 @@ name: Coverage Linux
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/*
-      - doc/**
-      - .github/**
-      - '!.github/workflows/coverage-linux.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-linux.yml
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/**
-      - doc/**
-      - .github/**
-      - '!.github/workflows/coverage-linux.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-linux.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -5,18 +5,24 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-linux.yml
   push:
     branches:
       - main
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-linux.yml
 
 concurrency:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -5,18 +5,24 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-windows.yml
   push:
     branches:
       - main
     paths:
       - lib/**/*.js
+      - Makefile
       - src/**/*.cc
       - src/**/*.h
-      - test/**/*
+      - test/**
+      - tools/gyp/**
+      - tools/test.py
       - .github/workflows/coverage-windows.yml
 
 concurrency:

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -3,25 +3,21 @@ name: Coverage Windows
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/**
-      - doc/**
-      - tools/**
-      - .github/**
-      - '!.github/workflows/coverage-windows.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-windows.yml
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - benchmark/**
-      - deps/**
-      - doc/**
-      - tools/**
-      - .github/**
-      - '!.github/workflows/coverage-windows.yml'
+    paths:
+      - lib/**/*.js
+      - src/**/*.cc
+      - src/**/*.h
+      - test/**/*
+      - .github/workflows/coverage-windows.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
I think it makes sense to restrict run of coverage jobs only on files that can affect its result, so that's what this PR is trying to do.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
