### PR TITLE
test: v8: Add test-linux-perf-logger test suite

### DIFF
--- a/test/fixtures/linux-perf-logger.js
+++ b/test/fixtures/linux-perf-logger.js
@@ -1,0 +1,17 @@
+'use strict';
+
+process.stdout.write(`${process.pid}`);
+
+const testRegex = /test-regex/gi;
+
+function functionOne() {
+  for (let i = 0; i < 100; i++) {
+    const match = testRegex.exec(Math.random().toString());
+  }
+}
+
+function functionTwo() {
+  functionOne();
+}
+
+functionTwo();

--- a/test/v8-updates/test-linux-perf-logger.js
+++ b/test/v8-updates/test-linux-perf-logger.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// --- About this test suite
+//
+// JIT support for perf(1) was added in 2009 (see https://lkml.org/lkml/2009/6/8/499).
+// It works by looking for a perf map file in /tmp/perf-<pid>.map, where <pid> is the
+// PID of the target process.
+//
+// The structure of this file is stable. Perf expects each line to specify a symbol
+// in the form:
+//
+//     <start> <length> <name>
+//
+// where <start> is the hex representation of the instruction pointer for the beginning
+// of the function, <length> is the byte length of the function, and <name> is the
+// readable JIT name used for reporting.
+//
+// This file asserts that a node script run with the appropriate flags will produce
+// a compliant perf map.
+//
+// NOTE: This test runs only on linux, as that is the only platform supported by perf, and
+// accordingly the only platform where `perf-basic-prof*` v8 flags are available.
+
+
+const common = require('../common');
+if (!common.isLinux) {
+  common.skip('--perf-basic-prof* is statically defined as linux-only');
+}
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { readFileSync } = require('fs');
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const testCases = [
+  {
+    title: '--perf-basic-prof interpreted',
+    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--no-opt'],
+    matches: [
+      '~functionOne .+/linux-perf-logger.js',
+      '~functionTwo .+/linux-perf-logger.js',
+      'test-regex',
+    ],
+    noMatches: ['\\*functionOne', '\\*functionTwo'],
+  },
+  {
+    title: '--perf-basic-prof compiled',
+    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-opt'],
+    matches: [
+      'test-regex',
+      '~functionOne .+/linux-perf-logger.js',
+      '~functionTwo .+/linux-perf-logger.js',
+      '\\*functionOne .+/linux-perf-logger.js',
+      '\\*functionTwo .+/linux-perf-logger.js',
+    ],
+    noMatches: [],
+  },
+  {
+    title: '--perf-basic-prof-only-functions interpreted',
+    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--no-opt'],
+    matches: ['~functionOne .+/linux-perf-logger.js', '~functionTwo .+/linux-perf-logger.js'],
+    noMatches: ['\\*functionOne', '\\*functionTwo', 'test-regex'],
+  },
+  {
+    title: '--perf-basic-prof-only-functions compiled',
+    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-opt'],
+    matches: [
+      '~functionOne .+/linux-perf-logger.js',
+      '~functionTwo .+/linux-perf-logger.js',
+      '\\*functionOne .+/linux-perf-logger.js',
+      '\\*functionTwo .+/linux-perf-logger.js',
+    ],
+    noMatches: ['test-regex'],
+  },
+];
+
+function runTest(test) {
+  const report = {
+    title: test.title,
+    perfMap: '[uninitialized]',
+    errors: [],
+  };
+
+  const args = test.nodeFlags.concat(fixtures.path('linux-perf-logger.js'));
+  const run = spawnSync(process.execPath, args, {cwd: tmpdir.path, encoding: 'utf8'});
+  if (run.error) {
+    report.errors.push(run.error.stack);
+    return report;
+  }
+  if (run.status !== 0) {
+    report.errors.push(`running script:\n${run.stderr}`);
+    return report;
+  }
+
+  try {
+    report.perfMap = readFileSync(`/tmp/perf-${run.pid}.map`, 'utf8');
+  } catch (err) {
+    report.errors.push(`reading perf map: ${err.stack}`);
+    return report;
+  }
+
+  const hexRegex = '[a-fA-F0-9]+';
+  for (const testRegex of test.matches) {
+    const lineRegex = new RegExp(`${hexRegex} ${hexRegex}.*:${testRegex}`);
+    if (!lineRegex.test(report.perfMap)) {
+      report.errors.push(`Expected to match ${lineRegex}`);
+    }
+  }
+
+  for (const regex of test.noMatches) {
+    const noMatch = new RegExp(regex);
+    if (noMatch.test(report.perfMap)) {
+      report.errors.push(`Expected not to match ${noMatch}`);
+    }
+  }
+
+  return report;
+}
+
+function serializeError(report, index) {
+  return `[ERROR ${index+1}] ${report.title}
+Errors:
+${report.errors.map((err, i) => `${i+1}. ${err}`).join('\n')}
+Perf map content:
+${report.perfMap}
+</end perf map content>
+`
+}
+
+function runSuite() {
+  const failures = [];
+
+  for (const tc of testCases) {
+    const report = runTest(tc);
+    if (report.errors.length > 0) {
+      failures.push(report);
+    }
+  }
+
+  const errorsToReport = failures.map(serializeError).join('\n--------\n');
+
+  assert.strictEqual(failures.length, 0, `${failures.length} tests failed\n\n${errorsToReport}`);
+}
+
+runSuite();

--- a/test/v8-updates/test-linux-perf-logger.js
+++ b/test/v8-updates/test-linux-perf-logger.js
@@ -85,7 +85,7 @@ function runTest(test) {
   };
 
   const args = test.nodeFlags.concat(fixtures.path('linux-perf-logger.js'));
-  const run = spawnSync(process.execPath, args, {cwd: tmpdir.path, encoding: 'utf8'});
+  const run = spawnSync(process.execPath, args, { cwd: tmpdir.path, encoding: 'utf8' });
   if (run.error) {
     report.errors.push(run.error.stack);
     return report;
@@ -121,13 +121,13 @@ function runTest(test) {
 }
 
 function serializeError(report, index) {
-  return `[ERROR ${index+1}] ${report.title}
+  return `[ERROR ${index + 1}] ${report.title}
 Errors:
-${report.errors.map((err, i) => `${i+1}. ${err}`).join('\n')}
+${report.errors.map((err, i) => `${i + 1}. ${err}`).join('\n')}
 Perf map content:
 ${report.perfMap}
 </end perf map content>
-`
+`;
 }
 
 function runSuite() {


### PR DESCRIPTION
This patch adds test coverage for the `--perf-prof-basic*` v8 flags. 

This ports the repro from #50225, which is fixed in main as of https://github.com/nodejs/node/commit/f6f681b62a0eb5cd9b162b545ba5d91cb8bf1379.

Relatedly, but out of scope here: I believe this also enables removal of the flaky perf(1) integration tests reported in #50079. Those tests missed the bug reported in #50225. They also don't strictly need to integrate with perf, as far as I can tell. The integration point (the perf map file) is done out-of-band from the perf recording; it is enabled via the v8 flags. See [`dso__load_perf_map`](https://github.com/torvalds/linux/blob/9c5d00cb7b6bbc5a7965d9ab7d223b5402d1f02c/tools/perf/util/symbol.c#L1603-L1658) for details on how it is consumed.