### PR TITLE
stream: improve `Readable#from` perf

### DIFF
--- a/lib/internal/streams/from.js
+++ b/lib/internal/streams/from.js
@@ -36,6 +36,7 @@ function from(Readable, iterable, opts) {
     throw new ERR_INVALID_ARG_TYPE('iterable', ['Iterable'], iterable);
   }
 
+
   const readable = new Readable({
     objectMode: true,
     highWaterMark: 1,
@@ -46,11 +47,19 @@ function from(Readable, iterable, opts) {
   // Flag to protect against _read
   // being called before last iteration completion.
   let reading = false;
+  let isAsyncValues = false;
 
   readable._read = function() {
     if (!reading) {
       reading = true;
-      next();
+
+      if (isAsync) {
+        nextAsync();
+      } else if (isAsyncValues) {
+        nextSyncWithAsyncValues();
+      } else {
+        nextSyncWithSyncValues();
+      }
     }
   };
 
@@ -78,29 +87,115 @@ function from(Readable, iterable, opts) {
     }
   }
 
-  async function next() {
+  // There are a lot of duplication here, it's done on purpose for performance
+  // reasons - avoid await when not needed.
+
+  function nextSyncWithSyncValues() {
     for (;;) {
       try {
-        const { value, done } = isAsync ?
-          await iterator.next() :
-          iterator.next();
+        const { value, done } = iterator.next();
 
         if (done) {
           readable.push(null);
-        } else {
-          const res = (value &&
-            typeof value.then === 'function') ?
-            await value :
-            value;
-          if (res === null) {
-            reading = false;
-            throw new ERR_STREAM_NULL_VALUES();
-          } else if (readable.push(res)) {
-            continue;
-          } else {
-            reading = false;
-          }
+          return;
         }
+
+        if (value &&
+          typeof value.then === 'function') {
+          return changeToAsyncValues(value);
+        }
+
+        if (value === null) {
+          reading = false;
+          throw new ERR_STREAM_NULL_VALUES();
+        }
+
+        if (readable.push(value)) {
+          continue;
+        }
+
+        reading = false;
+      } catch (err) {
+        readable.destroy(err);
+      }
+      break;
+    }
+  }
+
+  async function changeToAsyncValues(value) {
+    isAsyncValues = true;
+
+    try {
+      const res = await value;
+
+      if (res === null) {
+        reading = false;
+        throw new ERR_STREAM_NULL_VALUES();
+      }
+
+      if (readable.push(res)) {
+        nextSyncWithAsyncValues();
+        return;
+      }
+
+      reading = false;
+    } catch (err) {
+      readable.destroy(err);
+    }
+  }
+
+  async function nextSyncWithAsyncValues() {
+    for (;;) {
+      try {
+        const { value, done } = iterator.next();
+
+        if (done) {
+          readable.push(null);
+          return;
+        }
+
+        const res = (value &&
+          typeof value.then === 'function') ?
+          await value :
+          value;
+
+        if (res === null) {
+          reading = false;
+          throw new ERR_STREAM_NULL_VALUES();
+        }
+
+        if (readable.push(res)) {
+          continue;
+        }
+
+        reading = false;
+      } catch (err) {
+        readable.destroy(err);
+      }
+      break;
+    }
+  }
+
+  async function nextAsync() {
+    for (;;) {
+      try {
+        const { value, done } = await iterator.next();
+
+        if (done) {
+          readable.push(null);
+          return;
+        }
+
+        if (value === null) {
+          reading = false;
+          throw new ERR_STREAM_NULL_VALUES();
+        }
+
+        if (readable.push(value)) {
+          continue;
+        }
+
+        reading = false;
       } catch (err) {
         readable.destroy(err);
       }


### PR DESCRIPTION
## Benchmarks
[Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1458/)

```
15:39:36                                                                             confidence improvement accuracy (*)    (**)   (***)
15:39:36 streams/readable-from.js type='array' n=10000000                                   ***     23.20 %       ±9.27% ±12.34% ±16.09%
15:39:36 streams/readable-from.js type='async-generator' n=10000000                           *      2.28 %       ±1.83%  ±2.44%  ±3.17%
15:39:36 streams/readable-from.js type='sync-generator-with-async-values' n=10000000                 0.48 %       ±1.82%  ±2.42%  ±3.15%
15:39:36 streams/readable-from.js type='sync-generator-with-sync-values' n=10000000         ***     18.26 %       ±2.01%  ±2.68%  ±3.49%
```