### PR TITLE
test: fix timeout of test-cpu-prof-dir-worker.js in LoongArch devices

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -915,6 +915,7 @@ class LiteralTestSuite(TestSuite):
 TIMEOUT_SCALEFACTOR = {
     'arm'       : { 'debug' :  8, 'release' : 3 }, # The ARM buildbots are slow.
     'riscv64'   : { 'debug' :  8, 'release' : 3 }, # The riscv devices are slow.
+    'loong64'   : { 'debug' :  4, 'release' : 1 },
     'ia32'      : { 'debug' :  4, 'release' : 1 },
     'ppc'       : { 'debug' :  4, 'release' : 1 },
     's390'      : { 'debug' :  4, 'release' : 1 } }

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -99,6 +99,8 @@ def GuessArchitecture():
     return 's390'
   elif id == 'riscv64':
     return 'riscv64'
+  elif id == 'loong64':
+    return 'loong64'
   else:
     id = platform.processor()
     if id == 'powerpc':


### PR DESCRIPTION
fix timeout of test-cpu-prof-dir-worker.js in LoongArch devices