### PR TITLE
http: preserve raw header duplicates in writeHead after setHeader calls

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -373,9 +373,18 @@ function writeHead(statusCode, reason, obj) {
         throw new ERR_INVALID_ARG_VALUE('headers', obj);
       }
 
+      // Headers in obj should override previous headers but still
+      // allow explicit duplicates. To do so, we first remove any
+      // existing conflicts, then use appendHeader.
+
       for (let n = 0; n < obj.length; n += 2) {
         k = obj[n + 0];
-        if (k) this.setHeader(k, obj[n + 1]);
+        this.removeHeader(k);
+      }
+
+      for (let n = 0; n < obj.length; n += 2) {
+        k = obj[n + 0];
+        if (k) this.appendHeader(k, obj[n + 1]);
       }
     } else if (obj) {
       const keys = ObjectKeys(obj);

--- a/test/parallel/test-http-write-head-after-set-header.js
+++ b/test/parallel/test-http-write-head-after-set-header.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+const Countdown = require('../common/countdown');
+const assert = require('assert');
+const { createServer, request } = require('http');
+
+const server = createServer(common.mustCall((req, res) => {
+  if (req.url.includes('setHeader')) {
+    res.setHeader('set-val', 'abc');
+  }
+
+  res.writeHead(200, [
+    'array-val', '1',
+    'array-val', '2',
+  ]);
+
+  res.end();
+}, 2));
+
+const countdown = new Countdown(2, () => server.close());
+
+server.listen(0, common.mustCall(() => {
+  request({
+    port: server.address().port
+  }, common.mustCall((res) => {
+    assert.deepStrictEqual(res.rawHeaders.slice(0, 4), [
+      'array-val', '1',
+      'array-val', '2',
+    ]);
+
+    countdown.dec();
+  })).end();
+
+  request({
+    port: server.address().port,
+    path: '/?setHeader'
+  }, common.mustCall((res) => {
+    assert.deepStrictEqual(res.rawHeaders.slice(0, 6), [
+      'set-val', 'abc',
+      'array-val', '1',
+      'array-val', '2',
+    ]);
+
+    countdown.dec();
+  })).end();
+}));


### PR DESCRIPTION
Fixes #50387

`writeHead` accepts a raw header array (flattened as `[k1, v1, k2, v2, k3, v3, ...]`) which is allows directly specifying raw header data - preserving ordering, duplicates and header key casing. When used by itself this works totally fine.

However, if `setHeader` was called first, it effectively changes the behaviour of subsequent `writeHead` calls, so that even if a raw header array was provided, duplicates are collapsed and lost entirely.

This change preserves the duplicate headers passed to `writeHead`, while still maintaining the 'writeHead overwrites setHeader' behaviour from [the docs](https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers) which say:

> When headers have been set with response.setHeader(), they will be merged with any headers passed to response.writeHead(), **with the headers passed to response.writeHead() given precedence**.

This works by switching from setHeader to appendHeader, which does support duplicates. Unfortunately doing that by itself would break the above constraint, because it would merge all setHeader headers with writeHead headers (instead of overwriting them) so instead we first remove conflicting cases (i.e. all the setHeader headers that would be overwritten) and then we can use appendHeader safely, since there are now no remaining conflicts.

An extra loop here may have a small performance implications and I'm sure that writing server responses is a high-sensitivity area there, but notably this is in the section already marked "Slow-case" directly above. In performance sensitive scenarios, applications shouldn't really mix headers between setHeader and writeHead regardless.

Any suggestions to improve that (or anything else) very welcome!

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
