### PR TITLE
test: fix crypto-dh error message for OpenSSL 3.x

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -85,11 +85,15 @@ const crypto = require('crypto');
     }, wrongBlockLength);
   }
 
-  assert.throws(() => {
-    dh3.computeSecret('');
-  }, { message: common.hasOpenSSL3 ?
-    'error:02800080:Diffie-Hellman routines::invalid secret' :
-    'Supplied key is too small' });
+  {
+    const v = crypto.constants.OPENSSL_VERSION_NUMBER;
+    const hasOpenSSL3WithNewErrorMessage = (v >= 0x300000c0 && v <= 0x30100000) || (v >= 0x30100040 && v <= 0x30200000);
+    assert.throws(() => {
+      dh3.computeSecret('');
+    }, { message: common.hasOpenSSL3 && !hasOpenSSL3WithNewErrorMessage ?
+      'error:02800080:Diffie-Hellman routines::invalid secret' :
+      'Supplied key is too small' });
+  }
 }
 
 // Through a fluke of history, g=0 defaults to DH_GENERATOR (2).


### PR DESCRIPTION
OpenSSL 3.0.12 and 3.1.4 changes the type of error short keys and IVs cause.

Error message change is test-only and uses the right error message for versions >= 3.0.12 in 3.0.x and >= 3.1.4 in 3.1.x series.

With these changes to OpenSSL, error message in XX test is now `'Supplied key is too small'` instead of `'error:02800080:Diffie-Hellman routines::invalid secret'`.

* ref. https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=0df40630850fb2740e6be6890bb905d3fc623b2d 
* ref. https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=5f69f5c65e483928c4b28ed16af6e5742929f1ee 
* ref. https://www.openssl.org/news/vulnerabilities.html#CVE-2023-5363

--

Sample failure:

```
Path: parallel/test-crypto-dh
node:assert:635
      throw err;
      ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  Comparison {
+   message: 'Supplied key is too small'
-   message: 'error:02800080:Diffie-Hellman routines::invalid secret'
  }
    at Object.<anonymous> (/src/node-v20.8.1/test/parallel/test-crypto-dh.js:88:10)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: RangeError: Supplied key is too small
      at DiffieHellman.dhComputeSecret [as computeSecret] (node:internal/crypto/diffiehellman:156:29)
      at assert.throws.message (/src/node-v20.8.1/test/parallel/test-crypto-dh.js:89:9)
      at getActual (node:assert:756:5)
      at Function.throws (node:assert:902:24)
      at Object.<anonymous> (/src/node-v20.8.1/test/parallel/test-crypto-dh.js:88:10)
      at Module._compile (node:internal/modules/cjs/loader:1241:14)
      at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
      at Module.load (node:internal/modules/cjs/loader:1091:32)
      at Module._load (node:internal/modules/cjs/loader:938:12)
      at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12) {
    code: 'ERR_CRYPTO_INVALID_KEYLEN'
  },
  expected: { message: 'error:02800080:Diffie-Hellman routines::invalid secret' },
  operator: 'throws'
}
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
