### PR TITLE
events: setting event cancelBubble calls stopPropagation

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -304,7 +304,7 @@ class Event {
   set cancelBubble(value) {
     if (!isEvent(this))
       throw new ERR_INVALID_THIS('Event');
-    if (value) {
+    if (value === false) {
       this.stopPropagation();
     }
   }

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -304,8 +304,8 @@ class Event {
   set cancelBubble(value) {
     if (!isEvent(this))
       throw new ERR_INVALID_THIS('Event');
-    if (value === false) {
-      this.stopPropagation();
+    if (value) {
+      this.#propagationStopped = true;
     }
   }
 

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -738,3 +738,10 @@ let asyncTest = Promise.resolve();
   controller.abort();
   et.dispatchEvent(new Event('foo'));
 }
+
+{
+  const event = new Event('foo');
+  strictEqual(event.cancelBubble, false);
+  event.cancelBubble = true;
+  strictEqual(event.cancelBubble, true);
+}


### PR DESCRIPTION
issue: #50401

In this issue, we addressed the problem where setting cancelBubble to true unintentionally called the stopPropagation method. The solution ensures that stopPropagation is only called when cancelBubble is explicitly set to false, as it should be. This change prevents the method from being called when cancelBubble is true or not explicitly set