### PR TITLE
tools: avoid npm install in deps installation

### DIFF
--- a/tools/dep_updaters/update-acorn-walk.sh
+++ b/tools/dep_updaters/update-acorn-walk.sh
@@ -8,14 +8,13 @@
 set -ex
 
 BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
-ROOT=$(cd "$(dirname "$0")/../.." && pwd)
-[ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
+[ -z "$NODE" ] && NODE="$BASE_DIR/out/Release/node"
 [ -x "$NODE" ] || NODE=$(command -v node)
-NPM="$ROOT/deps/npm/bin/npm-cli.js"
+NPM="$BASE_DIR/deps/npm/bin/npm-cli.js"
 DEPS_DIR="$BASE_DIR/deps"
 
 # shellcheck disable=SC1091
-. "$ROOT/tools/dep_updaters/utils.sh"
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 NEW_VERSION=$("$NODE" "$NPM" view acorn-walk dist-tags.latest)
 CURRENT_VERSION=$("$NODE" -p "require('./deps/acorn/acorn-walk/package.json').version")
@@ -39,7 +38,7 @@ trap cleanup INT TERM EXIT
 
 cd "$WORKSPACE"
 
-echo "Fetching ada source archive..."
+echo "Fetching acorn-walk source archive..."
 
 DIST_URL=$(curl -sL "https://registry.npmjs.org/acorn-walk/$NEW_VERSION" | perl -n -e '/"dist".*?"tarball":"(.*?)"/ && print $1')
 

--- a/tools/dep_updaters/update-acorn-walk.sh
+++ b/tools/dep_updaters/update-acorn-walk.sh
@@ -7,10 +7,12 @@
 
 set -ex
 
+BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 [ -z "$NODE" ] && NODE="$ROOT/out/Release/node"
 [ -x "$NODE" ] || NODE=$(command -v node)
 NPM="$ROOT/deps/npm/bin/npm-cli.js"
+DEPS_DIR="$BASE_DIR/deps"
 
 # shellcheck disable=SC1091
 . "$ROOT/tools/dep_updaters/utils.sh"
@@ -23,21 +25,37 @@ compare_dependency_version "acorn-walk" "$NEW_VERSION" "$CURRENT_VERSION"
 
 cd "$( dirname "$0" )/../.." || exit
 
-rm -rf deps/acorn/acorn-walk
+echo "Making temporary workspace..."
 
-(
-    rm -rf acorn-walk-tmp
-    mkdir acorn-walk-tmp
-    cd acorn-walk-tmp || exit
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
 
-    "$NODE" "$NPM" init --yes
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
 
-    "$NODE" "$NPM" install --global-style --no-bin-links --ignore-scripts "acorn-walk@$NEW_VERSION"
-)
+trap cleanup INT TERM EXIT
 
-mv acorn-walk-tmp/node_modules/acorn-walk deps/acorn
+cd "$WORKSPACE"
 
-rm -rf acorn-walk-tmp/
+echo "Fetching ada source archive..."
+
+DIST_URL=$(curl -sL "https://registry.npmjs.org/acorn-walk/$NEW_VERSION" | perl -n -e '/"dist".*?"tarball":"(.*?)"/ && print $1')
+
+ACORN_WALK_TGZ="acorn-walk.tgz"
+
+curl -sL -o "$ACORN_WALK_TGZ" "$DIST_URL"
+
+log_and_verify_sha256sum "acorn-walk" "$ACORN_WALK_TGZ"
+
+rm -r "$DEPS_DIR/acorn/acorn-walk"/*
+
+tar -xf "$ACORN_WALK_TGZ"
+
+mv "$WORKSPACE/package"/* "$DEPS_DIR/acorn/acorn-walk"
+
+rm "$ACORN_WALK_TGZ"
 
 echo "All done!"
 echo ""


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/49747
To avoid doing:
- `npm init`
- `npm install acorn-walk`
- move /node_modules/acor-walk to dep/acornwalk
we can download the tarball directly from npm
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
