### PR TITLE
meta: add web-standards as web api visibility owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -172,3 +172,6 @@
 /.github/workflows/update-openssl.yml @nodejs/security-wg
 /.github/workflows/update-v8.yml @nodejs/security-wg @nodejs/v8-update
 /tools/dep_updaters/* @nodejs/security-wg
+
+# Web Standards
+/lib/internal/bootstrap/web/* @nodejs/web-standards

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -175,3 +175,4 @@
 
 # Web Standards
 /lib/internal/bootstrap/web/* @nodejs/web-standards
+/lib/internal/navigator.js @nodejs/web-standards


### PR DESCRIPTION
When Web APIs global visibility is changed, ping @nodejs/web-standards.

Refs: https://github.com/nodejs/node/pull/50412#issuecomment-1781542253