### PR TITLE
events: improve events performance

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -342,7 +342,7 @@ EventEmitter.init = function(opts) {
 
   if (this._events === undefined ||
       this._events === ObjectGetPrototypeOf(this)._events) {
-    this._events = { __proto__: null };
+    this._events = { };
     this._eventsCount = 0;
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -42,15 +42,13 @@ const {
   PromiseReject,
   PromiseResolve,
   ReflectApply,
+  ReflectOwnKeys,
   String,
-  ObjectFromEntries,
-  ArrayFrom,
   StringPrototypeSplit,
   Symbol,
   SymbolFor,
   SymbolAsyncIterator,
   SymbolDispose,
-  SafeMap,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 
@@ -87,7 +85,6 @@ const {
   validateString,
 } = require('internal/validators');
 
-const kEvents = Symbol('kEvents');
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
@@ -265,7 +262,8 @@ ObjectDefineProperty(EventEmitter.prototype, kCapture, {
   enumerable: false,
 });
 
-EventEmitter.prototype[kEvents] = undefined;
+EventEmitter.prototype._events = undefined;
+EventEmitter.prototype._eventsCount = 0;
 EventEmitter.prototype._maxListeners = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
@@ -286,37 +284,6 @@ ObjectDefineProperty(EventEmitter, 'defaultMaxListeners', {
   set: function(arg) {
     validateNumber(arg, 'defaultMaxListeners', 0);
     defaultMaxListeners = arg;
-  },
-});
-
-// _events and _eventsCount are Legacy
-ObjectDefineProperty(EventEmitter.prototype, '_events', {
-  __proto__: null,
-  enumerable: true,
-  get: function() {
-    // TODO - maybe in order to not break the ecosystem, create a Proxy that will update the events map
-    const events = this[kEvents];
-    if (events === undefined) {
-      return undefined;
-    }
-
-    return ObjectFromEntries(events.entries());
-  },
-  set: function(events) {
-    this[kEvents] = new SafeMap(events);
-  },
-});
-
-ObjectDefineProperty(EventEmitter.prototype, '_eventsCount', {
-  __proto__: null,
-  enumerable: true,
-  get: function() {
-    const events = this[kEvents];
-    if (events === undefined) {
-      return 0;
-    }
-
-    return events.size;
   },
 });
 
@@ -372,9 +339,11 @@ EventEmitter.setMaxListeners =
 // If you're updating this function definition, please also update any
 // re-definitions, such as the one in the Domain module (lib/domain.js).
 EventEmitter.init = function(opts) {
-  if (this[kEvents] === undefined ||
-      this[kEvents] === ObjectGetPrototypeOf(this)[kEvents]) {
-    this[kEvents] = new SafeMap();
+
+  if (this._events === undefined ||
+      this._events === ObjectGetPrototypeOf(this)._events) {
+    this._events = { };
+    this._eventsCount = 0;
   }
 
   this._maxListeners = this._maxListeners || undefined;
@@ -493,11 +462,11 @@ function enhanceStackTrace(err, own) {
 EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
-  const events = this[kEvents];
+  const events = this._events;
   if (events !== undefined) {
-    if (doError && events.has(kErrorMonitor))
+    if (doError && events[kErrorMonitor] !== undefined)
       this.emit(kErrorMonitor, ...args);
-    doError = (doError && !events.has('error'));
+    doError = (doError && events.error === undefined);
   } else if (!doError)
     return false;
 
@@ -537,7 +506,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     throw err; // Unhandled 'error' event
   }
 
-  const handler = events.get(type);
+  const handler = events[type];
 
   if (handler === undefined)
     return false;
@@ -578,9 +547,10 @@ function _addListener(target, type, listener, prepend) {
 
   checkListener(listener);
 
-  events = target[kEvents];
+  events = target._events;
   if (events === undefined) {
-    events = target[kEvents] = new SafeMap();
+    events = target._events = { __proto__: null };
+    target._eventsCount = 0;
   } else {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
@@ -588,22 +558,22 @@ function _addListener(target, type, listener, prepend) {
       target.emit('newListener', type,
                   listener.listener ?? listener);
 
-      // TODO - revisit this comment, user can set it to new object?
       // Re-assign `events` because a newListener handler could have caused the
-      // this[kEvents] to be assigned to a new object
-      events = target[kEvents];
+      // this._events to be assigned to a new object
+      events = target._events;
     }
-    existing = events.get(type);
+    existing = events[type];
   }
 
   if (existing === undefined) {
     // Optimize the case of one listener. Don't need the extra array object.
-    events.set(type, listener);
+    events[type] = listener;
+    ++target._eventsCount;
   } else {
     if (typeof existing === 'function') {
       // Adding the second element, need to change to array.
-      existing = prepend ? [listener, existing] : [existing, listener];
-      events.set(type, existing);
+      existing = events[type] =
+        prepend ? [listener, existing] : [existing, listener];
       // If we've already got an array, just append.
     } else if (prepend) {
       existing.unshift(listener);
@@ -707,20 +677,20 @@ EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       checkListener(listener);
 
-      const events = this[kEvents];
+      const events = this._events;
       if (events === undefined)
         return this;
 
-      const list = events.get(type);
+      const list = events[type];
       if (list === undefined)
         return this;
 
       if (list === listener || list.listener === listener) {
-        if (this[kEvents].size === 1)
-          this[kEvents] = new SafeMap();
+        if (--this._eventsCount === 0)
+          this._events = { __proto__: null };
         else {
-          events.delete(type);
-          if (events.has('removeListener'))
+          delete events[type];
+          if (events.removeListener)
             this.emit('removeListener', type, list.listener || listener);
         }
       } else if (typeof list !== 'function') {
@@ -745,9 +715,9 @@ EventEmitter.prototype.removeListener =
         }
 
         if (list.length === 1)
-          events.set(type, list[0]);
+          events[type] = list[0];
 
-        if (events.has('removeListener'))
+        if (events.removeListener !== undefined)
           this.emit('removeListener', type, listener);
       }
 
@@ -765,35 +735,37 @@ EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
  */
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
-      const events = this[kEvents];
+      const events = this._events;
       if (events === undefined)
         return this;
 
       // Not listening for removeListener, no need to emit
-      if (!events.has('removeListener')) {
+      if (events.removeListener === undefined) {
         if (arguments.length === 0) {
-          this[kEvents] = new SafeMap();
-        } else if (events.has(type)) {
-          if (this[kEvents].size === 1)
-            this[kEvents] = new SafeMap();
+          this._events = { __proto__: null };
+          this._eventsCount = 0;
+        } else if (events[type] !== undefined) {
+          if (--this._eventsCount === 0)
+            this._events = { __proto__: null };
           else
-            this[kEvents].delete(type);
+            delete events[type];
         }
         return this;
       }
 
       // Emit removeListener for all listeners on all events
       if (arguments.length === 0) {
-        for (const key of events.keys()) {
+        for (const key of ReflectOwnKeys(events)) {
           if (key === 'removeListener') continue;
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        this[kEvents] = new SafeMap();
+        this._events = { __proto__: null };
+        this._eventsCount = 0;
         return this;
       }
 
-      const listeners = events.get(type);
+      const listeners = events[type];
 
       if (typeof listeners === 'function') {
         this.removeListener(type, listeners);
@@ -808,12 +780,12 @@ EventEmitter.prototype.removeAllListeners =
     };
 
 function _listeners(target, type, unwrap) {
-  const events = target[kEvents];
+  const events = target._events;
 
   if (events === undefined)
     return [];
 
-  const evlistener = events.get(type);
+  const evlistener = events[type];
   if (evlistener === undefined)
     return [];
 
@@ -869,10 +841,10 @@ EventEmitter.prototype.listenerCount = listenerCount;
  * @returns {number}
  */
 function listenerCount(type, listener) {
-  const events = this[kEvents];
+  const events = this._events;
 
   if (events !== undefined) {
-    const evlistener = events.get(type);
+    const evlistener = events[type];
 
     if (typeof evlistener === 'function') {
       if (listener != null) {
@@ -906,7 +878,7 @@ function listenerCount(type, listener) {
  * @returns {any[]}
  */
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this[kEvents].size > 0 ? ArrayFrom(this[kEvents].keys()) : [];
+  return this._eventsCount > 0 ? ReflectOwnKeys(this._events) : [];
 };
 
 function arrayClone(arr) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -42,13 +42,15 @@ const {
   PromiseReject,
   PromiseResolve,
   ReflectApply,
-  ReflectOwnKeys,
   String,
+  ObjectFromEntries,
+  ArrayFrom,
   StringPrototypeSplit,
   Symbol,
   SymbolFor,
   SymbolAsyncIterator,
   SymbolDispose,
+  SafeMap,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 
@@ -85,6 +87,7 @@ const {
   validateString,
 } = require('internal/validators');
 
+const kEvents = Symbol('kEvents');
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
@@ -262,8 +265,7 @@ ObjectDefineProperty(EventEmitter.prototype, kCapture, {
   enumerable: false,
 });
 
-EventEmitter.prototype._events = undefined;
-EventEmitter.prototype._eventsCount = 0;
+EventEmitter.prototype[kEvents] = undefined;
 EventEmitter.prototype._maxListeners = undefined;
 
 // By default EventEmitters will print a warning if more than 10 listeners are
@@ -284,6 +286,37 @@ ObjectDefineProperty(EventEmitter, 'defaultMaxListeners', {
   set: function(arg) {
     validateNumber(arg, 'defaultMaxListeners', 0);
     defaultMaxListeners = arg;
+  },
+});
+
+// _events and _eventsCount are Legacy
+ObjectDefineProperty(EventEmitter.prototype, '_events', {
+  __proto__: null,
+  enumerable: true,
+  get: function() {
+    // TODO - maybe in order to not break the ecosystem, create a Proxy that will update the events map
+    const events = this[kEvents];
+    if (events === undefined) {
+      return undefined;
+    }
+
+    return ObjectFromEntries(events.entries());
+  },
+  set: function(events) {
+    this[kEvents] = new SafeMap(events);
+  },
+});
+
+ObjectDefineProperty(EventEmitter.prototype, '_eventsCount', {
+  __proto__: null,
+  enumerable: true,
+  get: function() {
+    const events = this[kEvents];
+    if (events === undefined) {
+      return 0;
+    }
+
+    return events.size;
   },
 });
 
@@ -339,11 +372,9 @@ EventEmitter.setMaxListeners =
 // If you're updating this function definition, please also update any
 // re-definitions, such as the one in the Domain module (lib/domain.js).
 EventEmitter.init = function(opts) {
-
-  if (this._events === undefined ||
-      this._events === ObjectGetPrototypeOf(this)._events) {
-    this._events = { };
-    this._eventsCount = 0;
+  if (this[kEvents] === undefined ||
+      this[kEvents] === ObjectGetPrototypeOf(this)[kEvents]) {
+    this[kEvents] = new SafeMap();
   }
 
   this._maxListeners = this._maxListeners || undefined;
@@ -462,11 +493,11 @@ function enhanceStackTrace(err, own) {
 EventEmitter.prototype.emit = function emit(type, ...args) {
   let doError = (type === 'error');
 
-  const events = this._events;
+  const events = this[kEvents];
   if (events !== undefined) {
-    if (doError && events[kErrorMonitor] !== undefined)
+    if (doError && events.has(kErrorMonitor))
       this.emit(kErrorMonitor, ...args);
-    doError = (doError && events.error === undefined);
+    doError = (doError && !events.has('error'));
   } else if (!doError)
     return false;
 
@@ -506,7 +537,7 @@ EventEmitter.prototype.emit = function emit(type, ...args) {
     throw err; // Unhandled 'error' event
   }
 
-  const handler = events[type];
+  const handler = events.get(type);
 
   if (handler === undefined)
     return false;
@@ -547,10 +578,9 @@ function _addListener(target, type, listener, prepend) {
 
   checkListener(listener);
 
-  events = target._events;
+  events = target[kEvents];
   if (events === undefined) {
-    events = target._events = { __proto__: null };
-    target._eventsCount = 0;
+    events = target[kEvents] = new SafeMap();
   } else {
     // To avoid recursion in the case that type === "newListener"! Before
     // adding it to the listeners, first emit "newListener".
@@ -558,22 +588,22 @@ function _addListener(target, type, listener, prepend) {
       target.emit('newListener', type,
                   listener.listener ?? listener);
 
+      // TODO - revisit this comment, user can set it to new object?
       // Re-assign `events` because a newListener handler could have caused the
-      // this._events to be assigned to a new object
-      events = target._events;
+      // this[kEvents] to be assigned to a new object
+      events = target[kEvents];
     }
-    existing = events[type];
+    existing = events.get(type);
   }
 
   if (existing === undefined) {
     // Optimize the case of one listener. Don't need the extra array object.
-    events[type] = listener;
-    ++target._eventsCount;
+    events.set(type, listener);
   } else {
     if (typeof existing === 'function') {
       // Adding the second element, need to change to array.
-      existing = events[type] =
-        prepend ? [listener, existing] : [existing, listener];
+      existing = prepend ? [listener, existing] : [existing, listener];
+      events.set(type, existing);
       // If we've already got an array, just append.
     } else if (prepend) {
       existing.unshift(listener);
@@ -677,20 +707,20 @@ EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       checkListener(listener);
 
-      const events = this._events;
+      const events = this[kEvents];
       if (events === undefined)
         return this;
 
-      const list = events[type];
+      const list = events.get(type);
       if (list === undefined)
         return this;
 
       if (list === listener || list.listener === listener) {
-        if (--this._eventsCount === 0)
-          this._events = { __proto__: null };
+        if (this[kEvents].size === 1)
+          this[kEvents] = new SafeMap();
         else {
-          delete events[type];
-          if (events.removeListener)
+          events.delete(type);
+          if (events.has('removeListener'))
             this.emit('removeListener', type, list.listener || listener);
         }
       } else if (typeof list !== 'function') {
@@ -715,9 +745,9 @@ EventEmitter.prototype.removeListener =
         }
 
         if (list.length === 1)
-          events[type] = list[0];
+          events.set(type, list[0]);
 
-        if (events.removeListener !== undefined)
+        if (events.has('removeListener'))
           this.emit('removeListener', type, listener);
       }
 
@@ -735,37 +765,35 @@ EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
  */
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
-      const events = this._events;
+      const events = this[kEvents];
       if (events === undefined)
         return this;
 
       // Not listening for removeListener, no need to emit
-      if (events.removeListener === undefined) {
+      if (!events.has('removeListener')) {
         if (arguments.length === 0) {
-          this._events = { __proto__: null };
-          this._eventsCount = 0;
-        } else if (events[type] !== undefined) {
-          if (--this._eventsCount === 0)
-            this._events = { __proto__: null };
+          this[kEvents] = new SafeMap();
+        } else if (events.has(type)) {
+          if (this[kEvents].size === 1)
+            this[kEvents] = new SafeMap();
           else
-            delete events[type];
+            this[kEvents].delete(type);
         }
         return this;
       }
 
       // Emit removeListener for all listeners on all events
       if (arguments.length === 0) {
-        for (const key of ReflectOwnKeys(events)) {
+        for (const key of events.keys()) {
           if (key === 'removeListener') continue;
           this.removeAllListeners(key);
         }
         this.removeAllListeners('removeListener');
-        this._events = { __proto__: null };
-        this._eventsCount = 0;
+        this[kEvents] = new SafeMap();
         return this;
       }
 
-      const listeners = events[type];
+      const listeners = events.get(type);
 
       if (typeof listeners === 'function') {
         this.removeListener(type, listeners);
@@ -780,12 +808,12 @@ EventEmitter.prototype.removeAllListeners =
     };
 
 function _listeners(target, type, unwrap) {
-  const events = target._events;
+  const events = target[kEvents];
 
   if (events === undefined)
     return [];
 
-  const evlistener = events[type];
+  const evlistener = events.get(type);
   if (evlistener === undefined)
     return [];
 
@@ -841,10 +869,10 @@ EventEmitter.prototype.listenerCount = listenerCount;
  * @returns {number}
  */
 function listenerCount(type, listener) {
-  const events = this._events;
+  const events = this[kEvents];
 
   if (events !== undefined) {
-    const evlistener = events[type];
+    const evlistener = events.get(type);
 
     if (typeof evlistener === 'function') {
       if (listener != null) {
@@ -878,7 +906,7 @@ function listenerCount(type, listener) {
  * @returns {any[]}
  */
 EventEmitter.prototype.eventNames = function eventNames() {
-  return this._eventsCount > 0 ? ReflectOwnKeys(this._events) : [];
+  return this[kEvents].size > 0 ? ArrayFrom(this[kEvents].keys()) : [];
 };
 
 function arrayClone(arr) {


### PR DESCRIPTION
# Benchmarks

## Change `_events` to be a `Map`:
commit: 249c2b8


Notes:
- I'm afraid this can break userland implementation of EventEmitter that are using node `EventEmitter` class functions (cc @ronag )
- This also improves creation by a lot (and therefore improves streams creation)

[Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1464/)

```
15:31:01                                                                  confidence improvement accuracy (*)    (**)   (***)
15:31:01 events/ee-add-remove.js n=1000000 removeListener=0 newListener=0        ***     19.64 %       ±1.57%  ±2.09%  ±2.73%
15:31:01 events/ee-add-remove.js n=1000000 removeListener=0 newListener=1        ***     46.84 %       ±2.02%  ±2.70%  ±3.54%
15:31:01 events/ee-add-remove.js n=1000000 removeListener=1 newListener=0        ***     45.01 %       ±2.68%  ±3.60%  ±4.75%
15:31:01 events/ee-add-remove.js n=1000000 removeListener=1 newListener=1        ***     56.27 %       ±2.72%  ±3.64%  ±4.79%
15:31:01 events/ee-emit.js listeners=1 argc=0 n=2000000                          ***     32.42 %       ±9.82% ±13.07% ±17.02%
15:31:01 events/ee-emit.js listeners=1 argc=10 n=2000000                         ***     36.00 %       ±8.08% ±10.75% ±14.00%
15:31:01 events/ee-emit.js listeners=1 argc=2 n=2000000                          ***     23.57 %       ±9.57% ±12.75% ±16.62%
15:31:01 events/ee-emit.js listeners=1 argc=4 n=2000000                          ***     28.33 %       ±8.95% ±11.92% ±15.52%
15:31:01 events/ee-emit.js listeners=10 argc=0 n=2000000                                  4.48 %       ±7.03%  ±9.35% ±12.17%
15:31:01 events/ee-emit.js listeners=10 argc=10 n=2000000                                 0.02 %       ±4.28%  ±5.70%  ±7.42%
15:31:01 events/ee-emit.js listeners=10 argc=2 n=2000000                          **     -6.22 %       ±4.54%  ±6.06%  ±7.91%
15:31:01 events/ee-emit.js listeners=10 argc=4 n=2000000                          **      6.55 %       ±4.59%  ±6.13%  ±8.00%
15:31:01 events/ee-emit.js listeners=5 argc=0 n=2000000                                   1.39 %       ±9.30% ±12.37% ±16.11%
15:31:01 events/ee-emit.js listeners=5 argc=10 n=2000000                                 -0.34 %       ±7.02%  ±9.35% ±12.18%
15:31:01 events/ee-emit.js listeners=5 argc=2 n=2000000                                   5.45 %       ±8.85% ±11.78% ±15.33%
15:31:01 events/ee-emit.js listeners=5 argc=4 n=2000000                                   0.79 %       ±8.60% ±11.44% ±14.89%
15:31:01 events/ee-listen-unique.js n=1000000 events=1                           ***     30.56 %       ±2.05%  ±2.73%  ±3.56%
15:31:01 events/ee-listen-unique.js n=1000000 events=10                          ***     13.34 %       ±1.21%  ±1.62%  ±2.11%
15:31:01 events/ee-listen-unique.js n=1000000 events=2                           ***     18.32 %       ±1.99%  ±2.67%  ±3.51%
15:31:01 events/ee-listen-unique.js n=1000000 events=20                          ***     13.37 %       ±1.22%  ±1.62%  ±2.12%
15:31:01 events/ee-listen-unique.js n=1000000 events=3                           ***     19.46 %       ±1.15%  ±1.53%  ±2.00%
15:31:01 events/ee-listen-unique.js n=1000000 events=5                           ***     15.05 %       ±1.35%  ±1.80%  ±2.35%
15:31:01 events/ee-listener-count-on-prototype.js n=50000000                     ***     29.98 %       ±5.74%  ±7.70% ±10.14%
15:31:01 events/ee-listeners.js raw='false' listeners=5 n=5000000                        -2.69 %       ±7.61% ±10.13% ±13.18%
15:31:01 events/ee-listeners.js raw='false' listeners=50 n=5000000                        0.48 %       ±1.82%  ±2.42%  ±3.15%
15:31:01 events/ee-listeners.js raw='true' listeners=5 n=5000000                          6.34 %       ±8.35% ±11.12% ±14.49%
15:31:01 events/ee-listeners.js raw='true' listeners=50 n=5000000                        -1.34 %       ±4.45%  ±5.92%  ±7.71%
15:31:01 events/ee-once.js argc=0 n=20000000                                     ***     31.26 %       ±1.10%  ±1.47%  ±1.94%
15:31:01 events/ee-once.js argc=1 n=20000000                                     ***     26.62 %       ±0.60%  ±0.80%  ±1.04%
15:31:01 events/ee-once.js argc=4 n=20000000                                     ***     26.93 %       ±0.65%  ±0.86%  ±1.12%
15:31:01 events/ee-once.js argc=5 n=20000000                                     ***     27.19 %       ±0.76%  ±1.02%  ±1.32%
15:31:01 events/eventtarget-add-remove.js nListener=10 n=1000000                 ***      0.92 %       ±0.38%  ±0.51%  ±0.66%
15:31:01 events/eventtarget-add-remove.js nListener=5 n=1000000                    *      0.87 %       ±0.69%  ±0.91%  ±1.19%
15:31:01 events/eventtarget-creation.js n=1000000                                         0.60 %       ±5.04%  ±6.70%  ±8.73%
15:31:01 events/eventtarget.js listeners=1 n=1000000                                      0.90 %       ±6.28%  ±8.35% ±10.87%
15:31:01 events/eventtarget.js listeners=10 n=1000000                                     0.45 %       ±3.51%  ±4.68%  ±6.09%
15:31:01 events/eventtarget.js listeners=5 n=1000000                                      0.21 %       ±4.80%  ±6.39%  ±8.31%
15:31:01 
15:31:01 Be aware that when doing many comparisons the risk of a false-positive
15:31:01 result increases. In this case, there are 37 comparisons, you can thus
15:31:01 expect the following amount of false-positive results:
15:31:01   1.85 false positives, when considering a   5% risk acceptance (*, **, ***),
15:31:01   0.37 false positives, when considering a   1% risk acceptance (**, ***),
15:31:01   0.04 false positives, when considering a 0.1% risk acceptance (***)
```

I run it on streams as well to see the impact as this was my original intent: [url](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1465/)

### Change to `Map` todos:
- [ ] move all our internal code away from `_events` and use `[kEvents]` instead
- [ ] I saw undici used `_events` so need to migrate as well

<details>
<summary><s>change <code>_events</code> to be without <code>__proto__: null</code></s></summary>


## change `_events` to be without `__proto__: null`
Commit: eb29e97f76c6e2a05f14d217fc9a0711977f3b6f

I think the performance without proto is not fully representative as the event name can be anything so the dictionary mode is not used here

[Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1461/)

```
12:55:39 ++ Rscript benchmark/compare.R
12:55:40                                                                  confidence improvement accuracy (*)    (**)   (***)
12:55:40 events/ee-add-remove.js n=1000000 removeListener=0 newListener=0         **     -2.22 %       ±1.50%  ±2.00%  ±2.60%
12:55:40 events/ee-add-remove.js n=1000000 removeListener=0 newListener=1        ***     30.34 %       ±1.75%  ±2.33%  ±3.04%
12:55:40 events/ee-add-remove.js n=1000000 removeListener=1 newListener=0        ***     22.74 %       ±1.17%  ±1.56%  ±2.03%
12:55:40 events/ee-add-remove.js n=1000000 removeListener=1 newListener=1        ***     10.04 %       ±1.11%  ±1.47%  ±1.92%
12:55:40 events/ee-emit.js listeners=1 argc=0 n=2000000                          ***    159.54 %       ±8.72% ±11.64% ±15.20%
12:55:40 events/ee-emit.js listeners=1 argc=10 n=2000000                         ***    139.14 %      ±12.44% ±16.59% ±21.66%
12:55:40 events/ee-emit.js listeners=1 argc=2 n=2000000                          ***    159.56 %      ±13.83% ±18.46% ±24.15%
12:55:40 events/ee-emit.js listeners=1 argc=4 n=2000000                          ***    148.52 %      ±10.04% ±13.37% ±17.43%
12:55:40 events/ee-emit.js listeners=10 argc=0 n=2000000                         ***     13.34 %       ±7.48%  ±9.96% ±12.96%
12:55:40 events/ee-emit.js listeners=10 argc=10 n=2000000                        ***     11.22 %       ±5.66%  ±7.53%  ±9.81%
12:55:40 events/ee-emit.js listeners=10 argc=2 n=2000000                                  3.11 %       ±6.21%  ±8.27% ±10.77%
12:55:40 events/ee-emit.js listeners=10 argc=4 n=2000000                         ***     12.07 %       ±6.04%  ±8.04% ±10.47%
12:55:40 events/ee-emit.js listeners=5 argc=0 n=2000000                          ***     20.76 %       ±9.34% ±12.44% ±16.24%
12:55:40 events/ee-emit.js listeners=5 argc=10 n=2000000                         ***     17.29 %       ±8.71% ±11.59% ±15.10%
12:55:40 events/ee-emit.js listeners=5 argc=2 n=2000000                            *     13.10 %       ±9.93% ±13.21% ±17.20%
12:55:40 events/ee-emit.js listeners=5 argc=4 n=2000000                            *      9.82 %       ±9.51% ±12.66% ±16.48%
12:55:40 events/ee-listen-unique.js n=1000000 events=1                                    0.24 %       ±1.32%  ±1.76%  ±2.29%
12:55:40 events/ee-listen-unique.js n=1000000 events=10                          ***     -3.02 %       ±1.08%  ±1.44%  ±1.88%
12:55:40 events/ee-listen-unique.js n=1000000 events=2                           ***     -2.28 %       ±0.69%  ±0.92%  ±1.20%
12:55:40 events/ee-listen-unique.js n=1000000 events=20                           **     -2.16 %       ±1.56%  ±2.09%  ±2.73%
12:55:40 events/ee-listen-unique.js n=1000000 events=3                           ***     -2.03 %       ±0.98%  ±1.31%  ±1.71%
12:55:40 events/ee-listen-unique.js n=1000000 events=5                           ***     -4.36 %       ±0.89%  ±1.19%  ±1.55%
12:55:40 events/ee-listener-count-on-prototype.js n=50000000                     ***     -6.40 %       ±3.40%  ±4.53%  ±5.91%
12:55:40 events/ee-listeners.js raw='false' listeners=5 n=5000000                  *     -8.30 %       ±6.34%  ±8.45% ±11.02%
12:55:40 events/ee-listeners.js raw='false' listeners=50 n=5000000                       -1.08 %       ±1.71%  ±2.28%  ±2.97%
12:55:40 events/ee-listeners.js raw='true' listeners=5 n=5000000                         -3.00 %       ±5.69%  ±7.58%  ±9.89%
12:55:40 events/ee-listeners.js raw='true' listeners=50 n=5000000                         3.68 %       ±4.65%  ±6.18%  ±8.05%
12:55:40 events/ee-once.js argc=0 n=20000000                                             -0.21 %       ±0.64%  ±0.85%  ±1.10%
12:55:40 events/ee-once.js argc=1 n=20000000                                              0.06 %       ±0.44%  ±0.59%  ±0.76%
12:55:40 events/ee-once.js argc=4 n=20000000                                             -0.13 %       ±0.62%  ±0.83%  ±1.08%
12:55:40 events/ee-once.js argc=5 n=20000000                                              0.26 %       ±0.69%  ±0.91%  ±1.19%
12:55:40 events/eventtarget-add-remove.js nListener=10 n=1000000                  **      0.71 %       ±0.42%  ±0.56%  ±0.73%
12:55:40 events/eventtarget-add-remove.js nListener=5 n=1000000                           0.30 %       ±0.70%  ±0.94%  ±1.22%
12:55:40 events/eventtarget-creation.js n=1000000                                         1.95 %       ±3.80%  ±5.09%  ±6.72%
12:55:40 events/eventtarget.js listeners=1 n=1000000                                     -0.66 %       ±5.51%  ±7.34%  ±9.55%
12:55:40 events/eventtarget.js listeners=10 n=1000000                                    -0.32 %       ±3.15%  ±4.19%  ±5.46%
12:55:40 events/eventtarget.js listeners=5 n=1000000                                     -0.39 %       ±5.18%  ±6.90%  ±8.98%
12:55:40 
12:55:40 Be aware that when doing many comparisons the risk of a false-positive
12:55:40 result increases. In this case, there are 37 comparisons, you can thus
12:55:40 expect the following amount of false-positive results:
12:55:40   1.85 false positives, when considering a   5% risk acceptance (*, **, ***),
12:55:40   0.37 false positives, when considering a   1% risk acceptance (**, ***),
12:55:40   0.04 false positives, when considering a 0.1% risk acceptance (***)
```

</details>