### PR TITLE
lib: make event static properties non writable and configurable

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayFrom,
+  ArrayPrototypeReduce,
   Boolean,
   Error,
   FunctionPrototypeCall,
@@ -314,11 +315,6 @@ class Event {
       throw new ERR_INVALID_THIS('Event');
     this.#propagationStopped = true;
   }
-
-  static NONE = 0;
-  static CAPTURING_PHASE = 1;
-  static AT_TARGET = 2;
-  static BUBBLING_PHASE = 3;
 }
 
 ObjectDefineProperties(
@@ -353,6 +349,22 @@ ObjectDefineProperties(
     // browsers.
     isTrusted: isTrustedDescriptor,
   });
+
+const staticProps = ['NONE', 'CAPTURING_PHASE', 'AT_TARGET', 'BUBBLING_PHASE'];
+
+ObjectDefineProperties(
+  Event,
+  ArrayPrototypeReduce(staticProps, (result, staticProp, index = 0) => {
+    result[staticProp] = {
+      __proto__: null,
+      writable: false,
+      configurable: false,
+      enumerable: true,
+      value: index,
+    };
+    return result;
+  }, {}),
+);
 
 function isCustomEvent(value) {
   return isEvent(value) && (value?.[kDetail] !== undefined);

--- a/test/parallel/test-event-target.js
+++ b/test/parallel/test-event-target.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+const eventPhases = {
+  'NONE': 0,
+  'CAPTURING_PHASE': 1,
+  'AT_TARGET': 2,
+  'BUBBLING_PHASE': 3
+};
+
+for (const [prop, value] of Object.entries(eventPhases)) {
+  // Check if the value of the property matches the expected value
+  assert.strictEqual(Event[prop], value, `Expected Event.${prop} to be ${value}, but got ${Event[prop]}`);
+
+  const desc = Object.getOwnPropertyDescriptor(Event, prop);
+  assert.strictEqual(desc.writable, false, `${prop} should not be writable`);
+  assert.strictEqual(desc.configurable, false, `${prop} should not be configurable`);
+  assert.strictEqual(desc.enumerable, true, `${prop} should be enumerable`);
+}


### PR DESCRIPTION
The idl definition for Event makes the properties constants, this means that they shouldn't be configurable. However, they were, and this commit fixes that.

Fixes: https://github.com/nodejs/node/issues/50417

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
