### PR TITLE
stream: pre-allocate _events

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -87,6 +87,7 @@ const {
 
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
+const kShapeMode = Symbol('shapeMode');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
   Symbol('events.maxEventTargetListenersWarned');
@@ -344,6 +345,9 @@ EventEmitter.init = function(opts) {
       this._events === ObjectGetPrototypeOf(this)._events) {
     this._events = { __proto__: null };
     this._eventsCount = 0;
+    this[kShapeMode] = false;
+  } else {
+    this[kShapeMode] = true;
   }
 
   this._maxListeners = this._maxListeners || undefined;
@@ -686,9 +690,13 @@ EventEmitter.prototype.removeListener =
         return this;
 
       if (list === listener || list.listener === listener) {
-        if (--this._eventsCount === 0)
+        this._eventsCount -= 1;
+
+        if (this[kShapeMode]) {
+          events[type] = undefined;
+        } else if (this._eventsCount === 0) {
           this._events = { __proto__: null };
-        else {
+        } else {
           delete events[type];
           if (events.removeListener)
             this.emit('removeListener', type, list.listener || listener);
@@ -750,6 +758,7 @@ EventEmitter.prototype.removeAllListeners =
           else
             delete events[type];
         }
+        this[kShapeMode] = false;
         return this;
       }
 
@@ -762,6 +771,7 @@ EventEmitter.prototype.removeAllListeners =
         this.removeAllListeners('removeListener');
         this._events = { __proto__: null };
         this._eventsCount = 0;
+        this[kShapeMode] = false;
         return this;
       }
 

--- a/lib/internal/streams/duplex.js
+++ b/lib/internal/streams/duplex.js
@@ -63,6 +63,24 @@ function Duplex(options) {
   if (!(this instanceof Duplex))
     return new Duplex(options);
 
+  this._events ??= {
+    close: undefined,
+    error: undefined,
+    prefinish: undefined,
+    finish: undefined,
+    drain: undefined,
+    data: undefined,
+    end: undefined,
+    readable: undefined,
+    // Skip uncommon events...
+    // pause: undefined,
+    // resume: undefined,
+    // pipe: undefined,
+    // unpipe: undefined,
+    // [destroyImpl.kConstruct]: undefined,
+    // [destroyImpl.kDestroy]: undefined,
+  };
+
   this._readableState = new Readable.ReadableState(options, this, true);
   this._writableState = new Writable.WritableState(options, this, true);
 

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -316,6 +316,21 @@ function Readable(options) {
   if (!(this instanceof Readable))
     return new Readable(options);
 
+  this._events ??= {
+    close: undefined,
+    error: undefined,
+    data: undefined,
+    end: undefined,
+    readable: undefined,
+    // Skip uncommon events...
+    // pause: undefined,
+    // resume: undefined,
+    // pipe: undefined,
+    // unpipe: undefined,
+    // [destroyImpl.kConstruct]: undefined,
+    // [destroyImpl.kDestroy]: undefined,
+  };
+
   this._readableState = new ReadableState(options, this, false);
 
   if (options) {

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -382,6 +382,17 @@ function Writable(options) {
   if (!(this instanceof Writable))
     return new Writable(options);
 
+  this._events ??= {
+    close: undefined,
+    error: undefined,
+    prefinish: undefined,
+    finish: undefined,
+    drain: undefined,
+    // Skip uncommon events...
+    // [destroyImpl.kConstruct]: undefined,
+    // [destroyImpl.kDestroy]: undefined,
+  };
+
   this._writableState = new WritableState(options, this, false);
 
   if (options) {

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -44,7 +44,7 @@ class FakeInput extends EventEmitter {
 function isWarned(emitter) {
   for (const name in emitter) {
     const listeners = emitter[name];
-    if (listeners.warned) return true;
+    if (listeners && listeners.warned) return true;
   }
   return false;
 }

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -22,7 +22,7 @@ class FakeInput extends EventEmitter {
 function isWarned(emitter) {
   for (const name in emitter) {
     const listeners = emitter[name];
-    if (listeners.warned) return true;
+    if (listeners && listeners.warned) return true;
   }
   return false;
 }


### PR DESCRIPTION
```
19:50:22 streams/creation.js kind='duplex' n=50000000                                                    ***      8.93 %       ±1.20% ±1.60%  ±2.10%
19:50:22 streams/creation.js kind='readable' n=50000000                                                  ***      3.39 %       ±1.30% ±1.74%  ±2.30%
19:50:22 streams/creation.js kind='transform' n=50000000                                                 ***     58.62 %       ±1.72% ±2.29%  ±2.99%
19:50:22 streams/creation.js kind='writable' n=50000000                                                  ***     11.96 %       ±1.20% ±1.60%  ±2.08%
19:50:22 streams/destroy.js kind='duplex' n=1000000                                                      ***      5.30 %       ±2.48% ±3.30%  ±4.29%
19:50:22 streams/destroy.js kind='readable' n=1000000                                                    ***      7.73 %       ±2.38% ±3.17%  ±4.12%
19:50:22 streams/destroy.js kind='transform' n=1000000                                                   ***     16.09 %       ±1.93% ±2.57%  ±3.34%
19:50:22 streams/destroy.js kind='writable' n=1000000                                                    ***      6.01 %       ±2.11% ±2.80%  ±3.65%
19:50:22 streams/pipe-object-mode.js n=5000000                                                           ***     14.94 %       ±5.86% ±7.80% ±10.17%
19:50:22 streams/pipe.js n=5000000                                                                       ***     14.50 %       ±4.97% ±6.62%  ±8.64%
19:50:22 streams/readable-async-iterator.js sync='no' n=100000                                                   -0.00 %       ±5.84% ±7.78% ±10.12%
19:50:22 streams/readable-async-iterator.js sync='yes' n=100000                                           **      5.06 %       ±3.67% ±4.94%  ±6.54%
19:50:22 streams/readable-bigread.js n=1000                                                               **      4.02 %       ±2.77% ±3.71%  ±4.87%
19:50:22 streams/readable-bigunevenread.js n=1000                                                                 0.81 %       ±1.80% ±2.40%  ±3.14%
19:50:22 streams/readable-boundaryread.js type='buffer' n=2000                                           ***     22.18 %       ±1.51% ±2.02%  ±2.63%
19:50:22 streams/readable-boundaryread.js type='string' n=2000                                           ***      4.77 %       ±1.36% ±1.81%  ±2.35%
19:50:22 streams/readable-from.js type='array' n=10000000                                                ***     23.14 %       ±4.33% ±5.76%  ±7.51%
19:50:22 streams/readable-from.js type='async-generator' n=10000000                                      ***      6.25 %       ±0.79% ±1.05%  ±1.36%
19:50:22 streams/readable-from.js type='sync-generator-with-async-values' n=10000000                     ***      8.63 %       ±1.02% ±1.35%  ±1.76%
19:50:22 streams/readable-from.js type='sync-generator-with-sync-values' n=10000000                      ***     12.72 %       ±3.93% ±5.24%  ±6.82%
19:50:22 streams/readable-readall.js n=5000                                                                      -1.10 %       ±5.57% ±7.41%  ±9.64%
19:50:22 streams/readable-unevenread.js n=1000                                                           ***      6.29 %       ±0.49% ±0.65%  ±0.85%
19:50:22 streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                    -0.78 %       ±0.99% ±1.31%  ±1.71%
19:50:22 streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000             *      3.11 %       ±2.41% ±3.21%  ±4.18%
19:50:22 streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                    0.90 %       ±1.75% ±2.33%  ±3.03%
19:50:22 streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000            *     -2.74 %       ±2.45% ±3.27%  ±4.25%
19:50:22 streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                    0.12 %       ±0.88% ±1.18%  ±1.54%
19:50:22 streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                  -0.57 %       ±1.86% ±2.49%  ±3.25%
19:50:22 streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000                  -2.04 %       ±2.35% ±3.14%  ±4.10%
19:50:22 streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                 -1.62 %       ±2.09% ±2.78%  ±3.62%
19:50:22 streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                    1.42 %       ±2.64% ±3.55%  ±4.67%
19:50:22 streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                   0.52 %       ±2.67% ±3.56%  ±4.63%
19:50:22 streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                   2.15 %       ±2.44% ±3.27%  ±4.31%
19:50:22 streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                 -0.64 %       ±2.51% ±3.34%  ±4.35%
19:50:22 streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                   2.31 %       ±2.56% ±3.43%  ±4.52%
19:50:22 streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                 -0.01 %       ±2.33% ±3.10%  ±4.04%
19:50:22 streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                  0.73 %       ±2.70% ±3.62%  ±4.76%
19:50:22 streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                 1.68 %       ±2.08% ±2.77%  ±3.61%
```