### PR TITLE
test: report ERROR wpt test results

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -838,6 +838,16 @@ class WPTRunner {
       this.fail(spec, { name: 'WPT testharness timeout' }, kTimeout);
       // Mark the whole test as TIMEOUT in wpt.fyi report.
       reportResult?.finish('TIMEOUT');
+    } else if (status !== kPass) {
+      // No need to record this synthetic failure with wpt.fyi.
+      this.fail(spec, {
+        status: status,
+        name: 'WPT test harness error',
+        message: harnessStatus.message,
+        stack: harnessStatus.stack,
+      }, status);
+      // Mark the whole test as ERROR in wpt.fyi report.
+      reportResult?.finish('ERROR');
     } else {
       reportResult?.finish();
     }

--- a/test/wpt/status/console.json
+++ b/test/wpt/status/console.json
@@ -7,5 +7,8 @@
         "console namespace: operation dir(optional any, optional object?)"
       ]
     }
+  },
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
   }
 }

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -39,6 +39,9 @@
   "idlharness.any.js": {
     "skip": "No implementation of TextDecoderStream and TextEncoderStream"
   },
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
+  },
   "replacement-encodings.any.js": {
     "skip": "decoding-helpers.js needs XMLHttpRequest"
   },

--- a/test/wpt/status/hr-time.json
+++ b/test/wpt/status/hr-time.json
@@ -6,6 +6,9 @@
       ]
     }
   },
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
+  },
   "window-worker-timeOrigin.window.js": {
     "skip": "depends on URL.createObjectURL(blob)"
   }

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -6,6 +6,9 @@
       ]
     }
   },
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
+  },
   "piping/general-addition.any.js": {
     "fail": {
       "expected": [

--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -1,4 +1,7 @@
 {
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
+  },
   "percent-encoding.window.js": {
     "skip": "TODO: port from .window.js"
   },

--- a/test/wpt/status/user-timing.json
+++ b/test/wpt/status/user-timing.json
@@ -1,4 +1,7 @@
 {
+  "idlharness-shadowrealm.window.js": {
+    "skip": "ShadowRealm support is not enabled"
+  },
   "invoke_with_timing_attributes.worker.js": {
     "skip": "importScripts not supported"
   },


### PR DESCRIPTION
When a wpt test file is exited for uncaught error, its result should be
recorded in the `wptreport.json` and uploaded to wpt.fyi.

For instance, `html/webappapis/timers/evil-spec-example.any.js` is
exited for uncaught error in Node.js but it shows as "MISSING" at
https://wpt.fyi/results/html/webappapis/timers?label=master&label=experimental&product=chrome&product=node.js&aligned.