### PR TITLE
lib: revokeObjectURL throws error on empty args

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1104,6 +1104,10 @@ function installObjectURLMethods() {
   }
 
   function revokeObjectURL(url) {
+    if (arguments.length === 0) {
+      throw new ERR_MISSING_ARGS('url');
+    }
+
     bindingBlob.revokeObjectURL(`${url}`);
   }
 

--- a/test/parallel/test-url-revokeobjecturl.js
+++ b/test/parallel/test-url-revokeobjecturl.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+
+// Test ensures that the function receives the url argument.
+
+const assert = require('node:assert');
+
+assert.throws(() => {
+  URL.revokeObjectURL();
+}, {
+  code: 'ERR_MISSING_ARGS',
+  name: 'TypeError',
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50432

Added a check to see if url wasnt included as an argument which will then throw an error.