### PR TITLE
FIx: typo variable in tools/gyp/pylib/gyp/generator/msvs.py

### DIFF
--- a/tools/gyp/pylib/gyp/generator/msvs.py
+++ b/tools/gyp/pylib/gyp/generator/msvs.py
@@ -3276,7 +3276,7 @@ def _GetMSBuildPropertyGroup(spec, label, properties):
     num_configurations = len(spec["configurations"])
 
     def GetEdges(node):
-        # Use a definition of edges such that user_of_variable -> used_varible.
+        # Use a definition of edges such that user_of_variable -> used_variable.
         # This happens to be easier in this case, since a variable's
         # definition contains all variables it references in a single string.
         edges = set()


### PR DESCRIPTION
This PR fixes typos in **tools/gyp/pylib/gyp/generator/msvs.py** file.

Following typos have been fixed:

`used_varible` -> `used_variable` 

No other changes.