### PR TITLE
src: support configurable snapshot

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -323,6 +323,30 @@ Currently the support for run-time snapshot is experimental in that:
    a report in the [Node.js issue tracker][] and link to it in the
    [tracking issue for user-land snapshots][].
 
+### `--build-snapshot-config`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Specifies the path to a JSON configuration file which configures snapshot
+creation behavior.
+
+The following options are currently supported:
+
+* `builder` {string} Required. Provides the name to the script that is executed
+  before building the snapshot, as if [`--build-snapshot`][] had been passed
+  with `builder` as the main script name.
+* `withoutCodeCache` {boolean} Optional. Including the code cache reduces the
+  time spent on compiling functions included in the snapshot at the expense
+  of a bigger snapshot size and potentially breaking portability of the
+  snapshot.
+
+When using this flag, additional script files provided on the command line will
+not be executed and instead be interpreted as regular command line arguments.
+
 ### `-c`, `--check`
 
 <!-- YAML
@@ -2861,6 +2885,7 @@ done
 [`--allow-fs-read`]: #--allow-fs-read
 [`--allow-fs-write`]: #--allow-fs-write
 [`--allow-worker`]: #--allow-worker
+[`--build-snapshot`]: #--build-snapshot
 [`--cpu-prof-dir`]: #--cpu-prof-dir
 [`--diagnostic-dir`]: #--diagnostic-dirdirectory
 [`--experimental-default-type=module`]: #--experimental-default-typetype

--- a/src/env.cc
+++ b/src/env.cc
@@ -285,6 +285,12 @@ std::ostream& operator<<(std::ostream& output,
   return output;
 }
 
+std::ostream& operator<<(std::ostream& output, const SnapshotFlags& flags) {
+  output << "static_cast<SnapshotFlags>(" << static_cast<uint32_t>(flags)
+         << ")";
+  return output;
+}
+
 std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& i) {
   output << "{\n"
          << "  "
@@ -296,6 +302,7 @@ std::ostream& operator<<(std::ostream& output, const SnapshotMetadata& i) {
          << "  \"" << i.node_arch << "\", // node_arch\n"
          << "  \"" << i.node_platform << "\", // node_platform\n"
          << "  " << i.v8_cache_version_tag << ", // v8_cache_version_tag\n"
+         << "  " << i.flags << ", // flags\n"
          << "}";
   return output;
 }
@@ -806,8 +813,14 @@ Environment::Environment(IsolateData* isolate_data,
         isolate_data->worker_context()->env()->builtin_loader());
   } else if (isolate_data->snapshot_data() != nullptr) {
     // ... otherwise, if a snapshot was provided, use its code cache.
-    builtin_loader()->RefreshCodeCache(
-        isolate_data->snapshot_data()->code_cache);
+    size_t cache_size = isolate_data->snapshot_data()->code_cache.size();
+    per_process::Debug(DebugCategory::CODE_CACHE,
+                       "snapshot contains %zu code cache\n",
+                       cache_size);
+    if (cache_size > 0) {
+      builtin_loader()->RefreshCodeCache(
+          isolate_data->snapshot_data()->code_cache);
+    }
   }
 
   // We'll be creating new objects so make sure we've entered the context.

--- a/src/node.cc
+++ b/src/node.cc
@@ -1206,10 +1206,39 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
   // nullptr indicates there's no snapshot data.
   DCHECK_NULL(*snapshot_data_ptr);
 
+  SnapshotConfig snapshot_config;
+  const std::string& config_path =
+      per_process::cli_options->per_isolate->build_snapshot_config;
+  // For snapshot config read from JSON, we fix up process.argv[1] using the
+  // "builder" field.
+  std::vector<std::string> args_maybe_patched;
+  args_maybe_patched.reserve(result->args().size() + 1);
+  if (!config_path.empty()) {
+    std::optional<SnapshotConfig> optional_config =
+        ReadSnapshotConfig(config_path.c_str());
+    if (!optional_config.has_value()) {
+      return ExitCode::kGenericUserError;
+    }
+    snapshot_config = std::move(optional_config.value());
+    DCHECK(snapshot_config.builder_script_path.has_value());
+    args_maybe_patched.emplace_back(result->args()[0]);
+    args_maybe_patched.emplace_back(
+        snapshot_config.builder_script_path.value());
+    if (result->args().size() > 1) {
+      args_maybe_patched.insert(args_maybe_patched.end(),
+                                result->args().begin() + 1,
+                                result->args().end());
+    }
+  } else {
+    snapshot_config.builder_script_path = result->args()[1];
+    args_maybe_patched = result->args();
+  }
+  DCHECK(snapshot_config.builder_script_path.has_value());
+  const std::string& builder_script =
+      snapshot_config.builder_script_path.value();
   // node:embedded_snapshot_main indicates that we are using the
   // embedded snapshot and we are not supposed to clean it up.
-  const std::string& main_script = result->args()[1];
-  if (main_script == "node:embedded_snapshot_main") {
+  if (builder_script == "node:embedded_snapshot_main") {
     *snapshot_data_ptr = SnapshotBuilder::GetEmbeddedSnapshotData();
     if (*snapshot_data_ptr == nullptr) {
       // The Node.js binary is built without embedded snapshot
@@ -1221,24 +1250,25 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
       return exit_code;
     }
   } else {
-    // Otherwise, load and run the specified main script.
+    // Otherwise, load and run the specified builder script.
     std::unique_ptr<SnapshotData> generated_data =
         std::make_unique<SnapshotData>();
-    std::string main_script_content;
-    int r = ReadFileSync(&main_script_content, main_script.c_str());
+    std::string builder_script_content;
+    int r = ReadFileSync(&builder_script_content, builder_script.c_str());
     if (r != 0) {
       FPrintF(stderr,
-              "Cannot read main script %s for building snapshot. %s: %s",
-              main_script,
+              "Cannot read builder script %s for building snapshot. %s: %s",
+              builder_script,
               uv_err_name(r),
               uv_strerror(r));
       return ExitCode::kGenericUserError;
     }
 
     exit_code = node::SnapshotBuilder::Generate(generated_data.get(),
-                                                result->args(),
+                                                args_maybe_patched,
                                                 result->exec_args(),
-                                                main_script_content);
+                                                builder_script_content,
+                                                snapshot_config);
     if (exit_code == ExitCode::kNoFailure) {
       *snapshot_data_ptr = generated_data.release();
     } else {
@@ -1368,7 +1398,8 @@ static ExitCode StartInternal(int argc, char** argv) {
 
   // --build-snapshot indicates that we are in snapshot building mode.
   if (per_process::cli_options->per_isolate->build_snapshot) {
-    if (result->args().size() < 2) {
+    if (per_process::cli_options->per_isolate->build_snapshot_config.empty() &&
+        result->args().size() < 2) {
       fprintf(stderr,
               "--build-snapshot must be used with an entry point script.\n"
               "Usage: node --build-snapshot /path/to/entry.js\n");

--- a/src/node.h
+++ b/src/node.h
@@ -80,6 +80,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 #include <ostream>
 
 // We cannot use __POSIX__ in this header because that's only defined when
@@ -659,6 +660,33 @@ enum Flags : uint64_t {
 };
 }  // namespace EnvironmentFlags
 
+enum class SnapshotFlags : uint32_t {
+  kDefault = 0,
+  // Whether code cache should be generated as part of the snapshot.
+  // Code cache reduces the time spent on compiling functions included
+  // in the snapshot at the expense of a bigger snapshot size and
+  // potentially breaking portability of the snapshot.
+  kWithoutCodeCache = 1 << 0,
+};
+
+struct SnapshotConfig {
+  SnapshotFlags flags = SnapshotFlags::kDefault;
+
+  // When builder_script_path is std::nullopt, the snapshot is generated as a
+  // built-in snapshot instead of a custom one, and it's expected that the
+  // built-in snapshot only contains states that reproduce in every run of the
+  // application. The event loop won't be run when generating a built-in
+  // snapshot, so asynchronous operations should be avoided.
+  //
+  // When builder_script_path is an std::string, it should match args[1]
+  // passed to CreateForSnapshotting(). The embedder is also expected to use
+  // LoadEnvironment() to run a script matching this path. In that case the
+  // snapshot is generated as a custom snapshot and the event loop is run, so
+  // the snapshot builder can execute asynchronous operations as long as they
+  // are run to completion when the snapshot is taken.
+  std::optional<std::string> builder_script_path;
+};
+
 struct InspectorParentHandle {
   virtual ~InspectorParentHandle() = default;
 };
@@ -870,7 +898,8 @@ class NODE_EXTERN CommonEnvironmentSetup {
       MultiIsolatePlatform* platform,
       std::vector<std::string>* errors,
       const std::vector<std::string>& args = {},
-      const std::vector<std::string>& exec_args = {});
+      const std::vector<std::string>& exec_args = {},
+      const SnapshotConfig& snapshot_config = {});
   EmbedderSnapshotData::Pointer CreateSnapshot();
 
   struct uv_loop_s* event_loop() const;
@@ -905,7 +934,8 @@ class NODE_EXTERN CommonEnvironmentSetup {
       std::vector<std::string>*,
       const EmbedderSnapshotData*,
       uint32_t flags,
-      std::function<Environment*(const CommonEnvironmentSetup*)>);
+      std::function<Environment*(const CommonEnvironmentSetup*)>,
+      const SnapshotConfig* config = nullptr);
 };
 
 // Implementation for CommonEnvironmentSetup::Create

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -418,6 +418,7 @@ std::string Basename(const std::string& str, const std::string& extension);
 
 node_module napi_module_to_node_module(const napi_module* mod);
 
+std::ostream& operator<<(std::ostream& output, const SnapshotFlags& flags);
 std::ostream& operator<<(std::ostream& output,
                          const std::vector<SnapshotIndex>& v);
 std::ostream& operator<<(std::ostream& output,

--- a/src/node_main_instance.cc
+++ b/src/node_main_instance.cc
@@ -56,8 +56,6 @@ NodeMainInstance::NodeMainInstance(const SnapshotData* snapshot_data,
                         platform,
                         array_buffer_allocator_.get(),
                         snapshot_data->AsEmbedderWrapper().get()));
-  isolate_data_->set_is_building_snapshot(
-      per_process::cli_options->per_isolate->build_snapshot);
 
   isolate_data_->max_young_gen_size =
       isolate_params_->constraints.max_young_generation_size_in_bytes();

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -850,6 +850,12 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "Generate a snapshot blob when the process exits.",
             &PerIsolateOptions::build_snapshot,
             kDisallowedInEnvvar);
+  AddOption("--build-snapshot-config",
+            "Generate a snapshot blob when the process exits using a"
+            "JSON configuration in the specified path.",
+            &PerIsolateOptions::build_snapshot_config,
+            kDisallowedInEnvvar);
+  Implies("--build-snapshot-config", "--build-snapshot");
 
   Insert(eop, &PerIsolateOptions::get_per_env_options);
 }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -235,6 +235,7 @@ class PerIsolateOptions : public Options {
   bool experimental_shadow_realm = false;
   std::string report_signal = "SIGUSR2";
   bool build_snapshot = false;
+  std::string build_snapshot_config;
   inline EnvironmentOptions* get_per_env_options();
   void CheckOptions(std::vector<std::string>* errors,
                     std::vector<std::string>* argv) override;

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -377,14 +377,18 @@ std::optional<SeaConfig> ParseSingleExecutableConfig(
 ExitCode GenerateSnapshotForSEA(const SeaConfig& config,
                                 const std::vector<std::string>& args,
                                 const std::vector<std::string>& exec_args,
-                                const std::string& main_script,
+                                const std::string& builder_script_content,
+                                const SnapshotConfig& snapshot_config,
                                 std::vector<char>* snapshot_blob) {
   SnapshotData snapshot;
   // TODO(joyeecheung): make the arguments configurable through the JSON
   // config or a programmatic API.
   std::vector<std::string> patched_args = {args[0], config.main_path};
-  ExitCode exit_code = SnapshotBuilder::Generate(
-      &snapshot, patched_args, exec_args, main_script);
+  ExitCode exit_code = SnapshotBuilder::Generate(&snapshot,
+                                                 patched_args,
+                                                 exec_args,
+                                                 builder_script_content,
+                                                 snapshot_config);
   if (exit_code != ExitCode::kNoFailure) {
     return exit_code;
   }
@@ -481,8 +485,11 @@ ExitCode GenerateSingleExecutableBlob(
   bool builds_snapshot_from_main =
       static_cast<bool>(config.flags & SeaFlags::kUseSnapshot);
   if (builds_snapshot_from_main) {
+    // TODO(joyeecheung): allow passing snapshot configuration in SEA configs.
+    SnapshotConfig snapshot_config;
+    snapshot_config.builder_script_path = main_script;
     ExitCode exit_code = GenerateSnapshotForSEA(
-        config, args, exec_args, main_script, &snapshot_blob);
+        config, args, exec_args, main_script, snapshot_config, &snapshot_blob);
     if (exit_code != ExitCode::kNoFailure) {
       return exit_code;
     }

--- a/src/node_snapshot_builder.h
+++ b/src/node_snapshot_builder.h
@@ -16,20 +16,25 @@ namespace node {
 class ExternalReferenceRegistry;
 struct SnapshotData;
 
+std::optional<SnapshotConfig> ReadSnapshotConfig(const char* path);
+
 class NODE_EXTERN_PRIVATE SnapshotBuilder {
  public:
-  static ExitCode GenerateAsSource(
-      const char* out_path,
+  static ExitCode GenerateAsSource(const char* out_path,
+                                   const std::vector<std::string>& args,
+                                   const std::vector<std::string>& exec_args,
+                                   const SnapshotConfig& config,
+                                   bool use_array_literals = false);
+
+  // Generate the snapshot into out. builder_script_content should match
+  // config.builder_script_path. This is passed separately
+  // in case the script is already read for other purposes.
+  static ExitCode Generate(
+      SnapshotData* out,
       const std::vector<std::string>& args,
       const std::vector<std::string>& exec_args,
-      std::optional<std::string_view> main_script_path = std::nullopt,
-      bool use_array_literals = false);
-
-  // Generate the snapshot into out.
-  static ExitCode Generate(SnapshotData* out,
-                           const std::vector<std::string>& args,
-                           const std::vector<std::string>& exec_args,
-                           std::optional<std::string_view> main_script);
+      std::optional<std::string_view> builder_script_content,
+      const SnapshotConfig& config);
 
   // If nullptr is returned, the binary is not built with embedded
   // snapshot.
@@ -39,10 +44,8 @@ class NODE_EXTERN_PRIVATE SnapshotBuilder {
 
   static const std::vector<intptr_t>& CollectExternalReferences();
 
-  static ExitCode CreateSnapshot(
-      SnapshotData* out,
-      CommonEnvironmentSetup* setup,
-      /*SnapshotMetadata::Type*/ uint8_t snapshot_type);
+  static ExitCode CreateSnapshot(SnapshotData* out,
+                                 CommonEnvironmentSetup* setup);
 
  private:
   static std::unique_ptr<ExternalReferenceRegistry> registry_;

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -25,6 +25,9 @@ struct PropInfo {
 
 typedef size_t SnapshotIndex;
 
+bool WithoutCodeCache(const SnapshotFlags& flags);
+bool WithoutCodeCache(const SnapshotConfig& config);
+
 // When serializing an embedder object, we'll serialize the native states
 // into a chunk that can be mapped into a subclass of InternalFieldInfoBase,
 // and pass it into the V8 callback as the payload of StartupData.
@@ -154,7 +157,6 @@ class BindingData : public SnapshotableObject {
   AliasedUint8Array is_building_snapshot_buffer_;
   InternalFieldInfo* internal_field_info_ = nullptr;
 };
-
 }  // namespace mksnapshot
 
 }  // namespace node

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -78,7 +78,9 @@ function getReadFileCodeForPath(path) {
 }
 
 // Basic snapshot support
-for (const extraSnapshotArgs of [[], ['--embedder-snapshot-as-file']]) {
+for (const extraSnapshotArgs of [
+  [], ['--embedder-snapshot-as-file'], ['--without-code-cache'],
+]) {
   // readSync + eval since snapshots don't support userland require() (yet)
   const snapshotFixture = fixtures.path('snapshot', 'echo-args.js');
   const blobPath = tmpdir.resolve('embedder-snapshot.blob');

--- a/test/parallel/test-snapshot-config.js
+++ b/test/parallel/test-snapshot-config.js
@@ -1,0 +1,138 @@
+'use strict';
+
+// This tests --build-snapshot-config.
+
+require('../common');
+const assert = require('assert');
+const {
+  spawnSyncAndExitWithoutError,
+  spawnSyncAndExit,
+} = require('../common/child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+
+const blobPath = tmpdir.resolve('snapshot.blob');
+const builderScript = fixtures.path('snapshot', 'mutate-fs.js');
+const checkFile = fixtures.path('snapshot', 'check-mutate-fs.js');
+const configPath = tmpdir.resolve('snapshot.json');
+tmpdir.refresh();
+{
+  // Relative path.
+  spawnSyncAndExit(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot-config',
+    'snapshot.json',
+  ], {
+    cwd: tmpdir.path
+  }, {
+    signal: null,
+    status: 1,
+    trim: true,
+    stderr: /Cannot read snapshot configuration from snapshot\.json/
+  });
+
+  // Absolute path.
+  spawnSyncAndExit(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot-config',
+    configPath,
+  ], {
+    cwd: tmpdir.path
+  }, {
+    signal: null,
+    status: 1,
+    trim: true,
+    stderr: /Cannot read snapshot configuration from .+snapshot\.json/
+  });
+}
+
+function writeConfig(config) {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+}
+
+{
+  tmpdir.refresh();
+  // Config without "builder" field should be rejected.
+  writeConfig({});
+  spawnSyncAndExit(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot-config',
+    configPath,
+  ], {
+    cwd: tmpdir.path
+  }, {
+    signal: null,
+    status: 1,
+    trim: true,
+    stderr: /"builder" field of .+snapshot\.json is not a non-empty string/
+  });
+}
+
+let sizeWithCache;
+{
+  tmpdir.refresh();
+  // Create a working snapshot.
+  writeConfig({ builder: builderScript });
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot-config',
+    configPath,
+  ], {
+    cwd: tmpdir.path
+  }, {});
+  const stats = fs.statSync(blobPath);
+  assert(stats.isFile());
+  sizeWithCache = stats.size;
+
+  // Check the snapshot.
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    checkFile,
+  ], {
+    cwd: tmpdir.path
+  });
+}
+
+let sizeWithoutCache;
+{
+  tmpdir.refresh();
+  // Create a working snapshot.
+  writeConfig({ builder: builderScript, withoutCodeCache: true });
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot-config',
+    configPath,
+  ], {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'CODE_CACHE'
+    },
+    cwd: tmpdir.path
+  }, {});
+  const stats = fs.statSync(blobPath);
+  assert(stats.isFile());
+  sizeWithoutCache = stats.size;
+  assert(sizeWithoutCache < sizeWithCache,
+         `sizeWithoutCache = ${sizeWithoutCache} >= sizeWithCache ${sizeWithCache}`);
+  // Check the snapshot.
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    checkFile,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'CODE_CACHE'
+    },
+  }, {
+    stderr: /snapshot contains 0 code cache/
+  });
+}

--- a/tools/snapshot/node_mksnapshot.cc
+++ b/tools/snapshot/node_mksnapshot.cc
@@ -70,9 +70,9 @@ int BuildSnapshot(int argc, char* argv[]) {
   CHECK_EQ(result->exit_code(), 0);
 
   std::string out_path;
-  std::optional<std::string_view> main_script_path = std::nullopt;
+  std::optional<std::string_view> builder_script_path = std::nullopt;
   if (node::per_process::cli_options->per_isolate->build_snapshot) {
-    main_script_path = result->args()[1];
+    builder_script_path = result->args()[1];
     out_path = result->args()[2];
   } else {
     out_path = result->args()[1];
@@ -84,11 +84,20 @@ int BuildSnapshot(int argc, char* argv[]) {
   bool use_array_literals = false;
 #endif
 
+  node::SnapshotConfig snapshot_config;
+  snapshot_config.builder_script_path = builder_script_path;
+
+#ifdef NODE_USE_NODE_CODE_CACHE
+  snapshot_config.flags = node::SnapshotFlags::kDefault;
+#else
+  snapshot_config.flags = node::SnapshotFlags::kWithoutCodeCache;
+#endif
+
   node::ExitCode exit_code =
       node::SnapshotBuilder::GenerateAsSource(out_path.c_str(),
                                               result->args(),
                                               result->exec_args(),
-                                              main_script_path,
+                                              snapshot_config,
                                               use_array_literals);
 
   node::TearDownOncePerProcess();


### PR DESCRIPTION
- Add support for --build-snapshot-config which allows passing snapshot configurations via a JSON configuration file.
- Add support for node::SnapshotConfig in the embedder API

The initial configurable options are:

- "builder" (SnapshotConfig::builder_script_path): path to the builder script.
- "withoutCodeCache" (SnapshotFlags::kWithoutCodeCache): disable code cache generation.

Refs: https://github.com/nodejs/node/issues/42566

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
