### PR TITLE
esm: do not call `getSource` when format is `commonjs`

### DIFF
--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -132,20 +132,21 @@ async function defaultLoad(url, context = kEmptyObject) {
   if (urlInstance.protocol === 'node:') {
     source = null;
     format ??= 'builtin';
-  } else {
-    let contextToPass = context;
+  } else if (format !== 'commonjs' || defaultType === 'module') {
     if (source == null) {
       ({ responseURL, source } = await getSource(urlInstance, context));
-      contextToPass = { __proto__: context, source };
+      context = { __proto__: context, source };
     }
 
-    // Now that we have the source for the module, run `defaultGetFormat` again in case we detect ESM syntax.
-    format ??= await defaultGetFormat(urlInstance, contextToPass);
+    if (format == null) {
+      // Now that we have the source for the module, run `defaultGetFormat` to detect its format.
+      format = await defaultGetFormat(urlInstance, context);
 
-    if (format === 'commonjs' && contextToPass !== context && defaultType !== 'module') {
-      // For backward compatibility reasons, we need to discard the source in
-      // order for the CJS loader to re-fetch it.
-      source = null;
+      if (format === 'commonjs') {
+        // For backward compatibility reasons, we need to discard the source in
+        // order for the CJS loader to re-fetch it.
+        source = null;
+      }
     }
   }
 

--- a/test/es-module/test-esm-dynamic-import-commonjs.js
+++ b/test/es-module/test-esm-dynamic-import-commonjs.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+
+tmpdir.refresh();
+
+const preloadURL = tmpdir.fileURL('preload.cjs');
+const commonjsURL = tmpdir.fileURL('commonjs-module-1.cjs');
+
+(async () => {
+
+    await Promise.all([fs.writeFile(preloadURL, ''), fs.writeFile(commonjsURL, '')]);
+
+    // Make sure that the CommonJS module lexer has been initialized.
+    // See https://github.com/nodejs/node/blob/v21.1.0/lib/internal/modules/esm/translators.js#L61-L81.
+    await import(preloadURL);
+
+    let tickDuringCJSImport = false;
+    process.nextTick(() => { tickDuringCJSImport = true; });
+    await import(commonjsURL);
+    
+    assert(!tickDuringCJSImport);
+
+})().then(common.mustCall());

--- a/test/es-module/test-esm-dynamic-import-commonjs.js
+++ b/test/es-module/test-esm-dynamic-import-commonjs.js
@@ -12,16 +12,16 @@ const commonjsURL = tmpdir.fileURL('commonjs-module-1.cjs');
 
 (async () => {
 
-    await Promise.all([fs.writeFile(preloadURL, ''), fs.writeFile(commonjsURL, '')]);
+  await Promise.all([fs.writeFile(preloadURL, ''), fs.writeFile(commonjsURL, '')]);
 
-    // Make sure that the CommonJS module lexer has been initialized.
-    // See https://github.com/nodejs/node/blob/v21.1.0/lib/internal/modules/esm/translators.js#L61-L81.
-    await import(preloadURL);
+  // Make sure that the CommonJS module lexer has been initialized.
+  // See https://github.com/nodejs/node/blob/v21.1.0/lib/internal/modules/esm/translators.js#L61-L81.
+  await import(preloadURL);
 
-    let tickDuringCJSImport = false;
-    process.nextTick(() => { tickDuringCJSImport = true; });
-    await import(commonjsURL);
-    
-    assert(!tickDuringCJSImport);
+  let tickDuringCJSImport = false;
+  process.nextTick(() => { tickDuringCJSImport = true; });
+  await import(commonjsURL);
+
+  assert(!tickDuringCJSImport);
 
 })().then(common.mustCall());

--- a/test/es-module/test-esm-dynamic-import-commonjs.js
+++ b/test/es-module/test-esm-dynamic-import-commonjs.js
@@ -1,26 +1,18 @@
 'use strict';
 
 const common = require('../common');
-const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
 const assert = require('node:assert');
-const fs = require('node:fs/promises');
-
-tmpdir.refresh();
-
-const preloadURL = tmpdir.fileURL('preload.cjs');
-const commonjsURL = tmpdir.fileURL('commonjs-module-1.cjs');
 
 (async () => {
 
-  await Promise.all([fs.writeFile(preloadURL, ''), fs.writeFile(commonjsURL, '')]);
-
   // Make sure that the CommonJS module lexer has been initialized.
   // See https://github.com/nodejs/node/blob/v21.1.0/lib/internal/modules/esm/translators.js#L61-L81.
-  await import(preloadURL);
+  await import(fixtures.fileURL('empty.js'));
 
   let tickDuringCJSImport = false;
   process.nextTick(() => { tickDuringCJSImport = true; });
-  await import(commonjsURL);
+  await import(fixtures.fileURL('empty.cjs'));
 
   assert(!tickDuringCJSImport);
 

--- a/test/es-module/test-esm-dynamic-import-commonjs.mjs
+++ b/test/es-module/test-esm-dynamic-import-commonjs.mjs
@@ -1,0 +1,16 @@
+import '../common/index.mjs';
+import tmpdir from '../common/tmpdir.js';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+
+tmpdir.refresh();
+
+const commonjsURL = tmpdir.fileURL('commonjs-module-2.cjs');
+
+await fs.writeFile(commonjsURL, '');
+
+let tickDuringCJSImport = false;
+process.nextTick(() => { tickDuringCJSImport = true; });
+await import(commonjsURL);
+
+assert(!tickDuringCJSImport);

--- a/test/es-module/test-esm-dynamic-import-commonjs.mjs
+++ b/test/es-module/test-esm-dynamic-import-commonjs.mjs
@@ -1,16 +1,9 @@
 import '../common/index.mjs';
-import tmpdir from '../common/tmpdir.js';
+import fixtures from '../common/fixtures.js';
 import assert from 'node:assert';
-import fs from 'node:fs/promises';
-
-tmpdir.refresh();
-
-const commonjsURL = tmpdir.fileURL('commonjs-module-2.cjs');
-
-await fs.writeFile(commonjsURL, '');
 
 let tickDuringCJSImport = false;
 process.nextTick(() => { tickDuringCJSImport = true; });
-await import(commonjsURL);
+await import(fixtures.fileURL('empty.cjs'));
 
 assert(!tickDuringCJSImport);

--- a/test/es-module/test-esm-loader-with-source.mjs
+++ b/test/es-module/test-esm-loader-with-source.mjs
@@ -4,7 +4,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import assert from 'assert';
 
 const { default: existingFileSource } = await import(fixtures.fileURL('es-modules', 'cjs-file.cjs'));
-const { default: noSuchFileSource } = await import('file:///no-such-file.cjs');
+const { default: noSuchFileSource } = await import(new URL('./no-such-file.cjs', import.meta.url));
 
 assert.strictEqual(existingFileSource, 'no .cjs file was read to get this source');
 assert.strictEqual(noSuchFileSource, 'no .cjs file was read to get this source');

--- a/test/es-module/test-esm-loader-with-source.mjs
+++ b/test/es-module/test-esm-loader-with-source.mjs
@@ -1,0 +1,10 @@
+// Flags: --experimental-loader ./test/fixtures/es-module-loaders/preset-cjs-source.mjs
+import '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'assert';
+
+const { default: existingFileSource } = await import(fixtures.fileURL('es-modules', 'cjs-file.cjs'));
+const { default: noSuchFileSource } = await import(fixtures.fileURL('no-such-file.cjs'));
+
+assert.strictEqual(existingFileSource, 'no .cjs file was read to get this source');
+assert.strictEqual(noSuchFileSource, 'no .cjs file was read to get this source');

--- a/test/es-module/test-esm-loader-with-source.mjs
+++ b/test/es-module/test-esm-loader-with-source.mjs
@@ -4,7 +4,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import assert from 'assert';
 
 const { default: existingFileSource } = await import(fixtures.fileURL('es-modules', 'cjs-file.cjs'));
-const { default: noSuchFileSource } = await import(fixtures.fileURL('no-such-file.cjs'));
+const { default: noSuchFileSource } = await import('file:///no-such-file.cjs');
 
 assert.strictEqual(existingFileSource, 'no .cjs file was read to get this source');
 assert.strictEqual(noSuchFileSource, 'no .cjs file was read to get this source');

--- a/test/fixtures/es-module-loaders/preset-cjs-source.mjs
+++ b/test/fixtures/es-module-loaders/preset-cjs-source.mjs
@@ -1,0 +1,21 @@
+export function resolve(specifier, context, next) {
+  if (specifier.endsWith('/no-such-file.cjs')) {
+    // Shortcut to avoid ERR_MODULE_NOT_FOUND for non-existing file, but keep the url for the load hook.
+    return {
+      shortCircuit: true,
+      url: specifier,
+    };
+  }
+  return next(specifier);
+}
+
+export function load(href, context, next) {
+  if (href.endsWith('.cjs')) {
+    return {
+      format: 'commonjs',
+      shortCircuit: true,
+      source: 'module.exports = "no .cjs file was read to get this source";',
+    };
+  }
+  return next(href);
+}


### PR DESCRIPTION
This PR ensures that `defaultLoad` does not access the file system to read the source of modules that are known in advance to be in CommonJS format. This is not necessary, since the CommonJS loader can't use the source property and must instead read the file once again.

For context, this was noticed while investigating a test failure in ESLint on Node.js 21.1.0. Our logic (now fixed) was incorrectly assuming that some asynchronous operations would complete in a specific order, and this order has changed from Node.js 21.0.0 to 21.1.0.
The simplest repro I've found is this one:

```js
// index.mjs
await import('./file1.cjs');
process.nextTick(() => console.log('Tick'));
await import('./file2.cjs');
console.log('Done');
```

with `file1.cjs` and `file2.cjs` both empty modules.

This is the output of running `index.mjs` in Node.js 21.0.0:

```console
Done
Tick
```

And this is the output in Node.js 21.1.0:

```console
Tick
Done
```

Here is another similar repro in a single file:

<details>

```js
import { mkdtemp, writeFile }   from 'node:fs/promises';
import { join }                 from 'node:path';
import { pathToFileURL }        from 'node:url';

const dir = await mkdtemp('test');
const file1 = join(dir, 'file1.cjs');
const file2 = join(dir, 'file2.cjs');
await Promise.all([writeFile(file1, ''), await writeFile(file2, '')]);

await import(pathToFileURL(file1));
process.nextTick(() => console.log('Tick'));
await import(pathToFileURL(file2));
console.log('Done');
```
</details>

The reason for the inverted order is [this commit](https://github.com/nodejs/node/commit/02926d3c6aaf70eba6d80423beb2d5df97e1ebc7#diff-bdab80c290d22162f748d1a80a5a2a5211460e5ab3fca7a42af0e8ca128e316dR130-L140) and a later change, which is causing `getSource` to be called even when the format of a module is already known to be `commonjs`, for example because of the `.cjs` extension.
`getSource` accesses the file system and that consistently requires one or more I/O cycles to complete. This allows callbacks scheduled with `process.nextTick` to run in the meantime.

Clearly, importing a CommonJS module is an asynchronous operation which souldn't be assumed to resolve in a specific order or number of phases, but calling `getSource` for known CommonJS modules isn't needed and should be avoided to not occupy the event loop unnecessarily.

Refs: https://github.com/eslint/eslint/pull/17683
