### PR TITLE
lib: use primordials for navigator.userAgent

### DIFF
--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -2,6 +2,8 @@
 
 const {
   ObjectDefineProperties,
+  StringPrototypeIndexOf,
+  StringPrototypeSlice,
   Symbol,
 } = primordials;
 
@@ -23,7 +25,7 @@ const nodeVersion = process.version;
 class Navigator {
   // Private properties are used to avoid brand validations.
   #availableParallelism;
-  #userAgent = `Node.js/${nodeVersion.slice(1, nodeVersion.indexOf('.'))}`;
+  #userAgent = `Node.js/${StringPrototypeSlice(nodeVersion, 1, StringPrototypeIndexOf(nodeVersion, '.'))}`;
 
   constructor() {
     if (arguments[0] === kInitialize) {


### PR DESCRIPTION
@anonrig 
@ljharb 

I got the PR comment, that [we should use primordials for userAgent by ljharb](https://github.com/nodejs/node/pull/50229#pullrequestreview-1702805010) As that line was not touched by my PR I want to mark it as resolved, but not lose the information. So here I provide the corresponding PR and resolve that remark in my PR ;)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
