### PR TITLE
esm: backport dirname and filename to v20

### DIFF
--- a/benchmark/fixtures/esm-dir-file.mjs
+++ b/benchmark/fixtures/esm-dir-file.mjs
@@ -1,0 +1,3 @@
+import assert from 'assert';
+assert.ok(import.meta.dirname);
+assert.ok(import.meta.filename);

--- a/benchmark/fixtures/load-esm-dir-file.js
+++ b/benchmark/fixtures/load-esm-dir-file.js
@@ -1,0 +1,5 @@
+(async function () {
+  for (let i = 0; i < 1000; i += 1) {
+    await import(`./esm-dir-file.mjs?i=${i}`);
+  }
+}());

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -9,6 +9,7 @@ const bench = common.createBenchmark(main, {
   script: [
     'benchmark/fixtures/require-builtins',
     'test/fixtures/semicolon',
+    'benchmark/fixtures/load-esm-dir-file',
   ],
   mode: ['process', 'worker'],
   count: [30],

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -308,6 +308,35 @@ modules it can be used to load ES modules.
 The `import.meta` meta property is an `Object` that contains the following
 properties.
 
+### `import.meta.dirname`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.2 - Release candidate
+
+* {string} The directory name of the current module. This is the same as the
+  [`path.dirname()`][] of the [`import.meta.filename`][].
+
+> **Caveat**: only present on `file:` modules.
+
+### `import.meta.filename`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.2 - Release candidate
+
+* {string} The full absolute path and filename of the current module, with
+* symlinks resolved.
+* This is the same as the [`url.fileURLToPath()`][] of the
+* [`import.meta.url`][].
+
+> **Caveat** only local modules support this property. Modules not using the
+> `file:` protocol will not provide it.
+
 ### `import.meta.url`
 
 * {string} The absolute `file:` URL of the module.
@@ -502,7 +531,7 @@ If needed, a `require` function can be constructed within an ES module using
 These CommonJS variables are not available in ES modules.
 
 `__filename` and `__dirname` use cases can be replicated via
-[`import.meta.url`][].
+[`import.meta.filename`][] and [`import.meta.dirname`][].
 
 #### No Addon Loading
 
@@ -1063,13 +1092,17 @@ resolution for ESM specifiers is [commonjs-extension-resolution-loader][].
 [`data:` URLs]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
 [`export`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
 [`import()`]: #import-expressions
+[`import.meta.dirname`]: #importmetadirname
+[`import.meta.filename`]: #importmetafilename
 [`import.meta.resolve`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve
 [`import.meta.url`]: #importmetaurl
 [`import`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 [`module.createRequire()`]: module.md#modulecreaterequirefilename
 [`module.syncBuiltinESMExports()`]: module.md#modulesyncbuiltinesmexports
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
+[`path.dirname()`]: path.md#pathdirnamepath
 [`process.dlopen`]: process.md#processdlopenmodule-filename-flags
+[`url.fileURLToPath()`]: url.md#urlfileurltopathurl
 [cjs-module-lexer]: https://github.com/nodejs/cjs-module-lexer/tree/1.2.2
 [commonjs-extension-resolution-loader]: https://github.com/nodejs/loaders-test/tree/main/commonjs-extension-resolution-loader
 [custom https loader]: module.md#import-from-https

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -1,6 +1,9 @@
 'use strict';
 
+const { StringPrototypeStartsWith } = primordials;
 const { getOptionValue } = require('internal/options');
+const { fileURLToPath } = require('internal/url');
+const { dirname } = require('path');
 const experimentalImportMetaResolve = getOptionValue('--experimental-import-meta-resolve');
 
 /**
@@ -45,12 +48,20 @@ function createImportMetaResolve(defaultParentURL, loader, allowParentURL) {
  * @param {object} meta
  * @param {{url: string}} context
  * @param {typeof import('./loader.js').ModuleLoader} loader Reference to the current module loader
- * @returns {{url: string, resolve?: Function}}
+ * @returns {{dirname?: string, filename?: string, url: string, resolve?: Function}}
  */
 function initializeImportMeta(meta, context, loader) {
   const { url } = context;
 
   // Alphabetical
+  if (StringPrototypeStartsWith(url, 'file:') === true) {
+    // These only make sense for locally loaded modules,
+    // i.e. network modules are not supported.
+    const filePath = fileURLToPath(url);
+    meta.dirname = dirname(filePath);
+    meta.filename = filePath;
+  }
+
   if (!loader || loader.allowImportMetaResolve) {
     meta.resolve = createImportMetaResolve(url, loader, experimentalImportMetaResolve);
   }

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,8 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-const keys = ['resolve', 'url'];
+
+const keys = ['dirname', 'filename', 'resolve', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);
@@ -18,3 +19,17 @@ for (const descriptor of Object.values(descriptors)) {
 
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
 assert(import.meta.url.match(urlReg));
+
+// Match *nix paths: `/some/path/test/es-module`
+// Match Windows paths: `d:\\some\\path\\test\\es-module`
+const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module$/;
+assert.match(import.meta.dirname, dirReg);
+
+// Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
+// Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
+const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module(\/|\\)test-esm-import-meta\.mjs$/;
+assert.match(import.meta.filename, fileReg);
+
+// Verify that `data:` imports do not behave like `file:` imports.
+import dataDirname from 'data:text/javascript,export default "dirname" in import.meta';
+assert.strictEqual(dataDirname, false);

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -3,7 +3,6 @@ import assert from 'assert';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
-
 const keys = ['dirname', 'filename', 'resolve', 'url'];
 assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 


### PR DESCRIPTION
This adds `import.meta.dirname` and `import.meta.filename` to the v20 release line. It is a backport of https://github.com/nodejs/node/pull/48740.