### PR TITLE
test: relax version check with shared OpenSSL

### DIFF
--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -75,13 +75,17 @@ assert.match(process.versions.modules, /^\d+$/);
 assert.match(process.versions.cjs_module_lexer, commonTemplate);
 
 if (common.hasCrypto) {
-  const versionRegex = common.hasOpenSSL3 ?
-    // The following also matches a development version of OpenSSL 3.x which
-    // can be in the format '3.0.0-alpha4-dev'. This can be handy when building
-    // and linking against the main development branch of OpenSSL.
-    /^\d+\.\d+\.\d+(?:[-+][a-z0-9]+)*$/ :
-    /^\d+\.\d+\.\d+[a-z]?(\+quic)?(-fips)?$/;
-  assert.match(process.versions.openssl, versionRegex);
+  if (process.config.variables.node_shared_openssl) {
+    assert.ok(process.versions.openssl);
+  } else {
+    const versionRegex = common.hasOpenSSL3 ?
+      // The following also matches a development version of OpenSSL 3.x which
+      // can be in the format '3.0.0-alpha4-dev'. This can be handy when
+      // building and linking against the main development branch of OpenSSL.
+      /^\d+\.\d+\.\d+(?:[-+][a-z0-9]+)*$/ :
+      /^\d+\.\d+\.\d+[a-z]?(\+quic)?(-fips)?$/;
+    assert.match(process.versions.openssl, versionRegex);
+  }
 }
 
 for (let i = 0; i < expected_keys.length; i++) {


### PR DESCRIPTION
Relax the OpenSSL version check when Node.js is built with the `--shared-openssl` option. Verify only that `process.versions.openssl` is truthy.

Fixes: https://github.com/nodejs/node/issues/43078

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
