### PR TITLE
meta: specify tag when using npx

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Make tarball
         run: |
           export DISTTYPE=nightly
@@ -73,7 +73,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Download tarball
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3.0.2
         with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -48,6 +48,6 @@ jobs:
       - name: Install deps
         run: choco install nasm
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: ./vcbuild.bat

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Install gcovr
         run: pip install gcovr==4.2
       - name: Build
@@ -59,7 +59,7 @@ jobs:
       - name: Test
         run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=spec' --measure-flakiness 9" || exit 0
       - name: Report JS
-        run: npx c8 report --check-coverage
+        run: npx c8@8.0.1 report --check-coverage
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Report C++

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Install gcovr
         run: pip install gcovr==4.2
       - name: Build
@@ -59,7 +59,7 @@ jobs:
       - name: Test
         run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j2 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=spec' --measure-flakiness 9" || exit 0
       - name: Report JS
-        run: npx c8 report --check-coverage
+        run: npx c8@8.0.1 report --check-coverage
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Report C++

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install deps
         run: choco install nasm
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: ./vcbuild.bat
       # TODO(bcoe): investigate tests that fail with coverage enabled
@@ -61,11 +61,11 @@ jobs:
         env:
           NODE_V8_COVERAGE: ./coverage/tmp
       - name: Report
-        run: npx c8 report
+        run: npx c8@8.0.1 report
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Clean tmp
-        run: npx rimraf ./coverage/tmp
+        run: npx rimraf@5.0.5 ./coverage/tmp
       - name: Upload
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d  # v3.1.4
         with:

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
 
       # install a version and checkout
       - name: Get latest nightly

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build lto
         run: |
           apt-get update && apt-get install ninja-build python-is-python3 -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: NODE=$(command -v node) make doc-only
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32  # v3.1.3

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Lint addon docs
         run: NODE=$(command -v node) make lint-addon-docs
   lint-cpp:
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Lint C/C++ files
         run: make lint-cpp
   format-cpp:
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Format C/C++ files
         run: |
           make format-cpp-build
@@ -101,7 +101,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Lint JavaScript files
         run: NODE=$(command -v node) make lint-js
       - name: Get release version numbers
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Lint Python
         run: |
           make lint-py-build
@@ -143,7 +143,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Lint YAML
         run: |
           make lint-yaml-build || true

--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check commit message
-        run: npx -q core-validate-commit ${{ github.event.after }} || echo "INVALID_COMMIT_MESSAGE=1" >> $GITHUB_ENV
+        run: npx -q core-validate-commit@4.0.0 ${{ github.event.after }} || echo "INVALID_COMMIT_MESSAGE=1" >> $GITHUB_ENV
       - name: Retrieve PR number if possible
         if: env.INVALID_COMMIT_MESSAGE
         run: |

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test Internet

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.11.0
       # The `npm ci` for this step fails a lot as part of the Test step. Run it
       # now so that we don't have to wait 2 hours for the Build step to pass
       # first before that failure happens. (And if there's something about


### PR DESCRIPTION
> I don't know if I selected the correct subsystem, so feel free to suggest if I selected the wrong one.

Since we pin Github Actions by commit hash, I think is reasonable to pin `npx` packages by version, accords to https://docs.npmjs.com/policies/unpublish is safe to assume those versions will not be changed.

cc @nodejs/security 
