### PR TITLE
src: use v8::Isolate::TryGetCurrent() in DumpJavaScriptBacktrace()

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -319,7 +319,7 @@ void DumpNativeBacktrace(FILE* fp) {
 }
 
 void DumpJavaScriptBacktrace(FILE* fp) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Isolate* isolate = v8::Isolate::TryGetCurrent();
   if (isolate == nullptr) {
     return;
   }

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -299,3 +299,8 @@ TEST(UtilTest, SPrintF) {
   const std::string with_zero = std::string("a") + '\0' + 'b';
   EXPECT_EQ(SPrintF("%s", with_zero), with_zero);
 }
+
+
+TEST(UtilTest, DumpJavaScriptStackWithNoIsolate) {
+  node::DumpJavaScriptBacktrace(stderr);
+}

--- a/test/cctest/test_util.cc
+++ b/test/cctest/test_util.cc
@@ -300,7 +300,6 @@ TEST(UtilTest, SPrintF) {
   EXPECT_EQ(SPrintF("%s", with_zero), with_zero);
 }
 
-
 TEST(UtilTest, DumpJavaScriptStackWithNoIsolate) {
   node::DumpJavaScriptBacktrace(stderr);
 }


### PR DESCRIPTION
It was using Isolate::GetCurrent() which DCHECK on nullptr, even though what we wanted was to return early if it is nullptr.

Refs: https://github.com/nodejs/node/pull/50242

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
