### PR TITLE
meta: replace build-windows for test-windows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,11 +1,11 @@
-name: Build Windows
+name: Test Windows
 
 on:
   pull_request:
     paths-ignore:
       - README.md
       - .github/**
-      - '!.github/workflows/build-windows.yml'
+      - '!.github/workflows/test-windows.yml'
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
@@ -16,7 +16,7 @@ on:
     paths-ignore:
       - README.md
       - .github/**
-      - '!.github/workflows/build-windows.yml'
+      - '!.github/workflows/test-windows.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -30,13 +30,9 @@ permissions:
   contents: read
 
 jobs:
-  build-windows:
+  test-windows:
     if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        windows: [windows-2022]
-      fail-fast: false
-    runs-on: ${{ matrix.windows }}
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:
@@ -45,9 +41,17 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install deps
-        run: choco install nasm
       - name: Environment Information
         run: npx envinfo
+      - name: Install deps
+        run: choco install nasm
       - name: Build
         run: ./vcbuild.bat
+      - name: Test CI JS
+        run: ./vcbuild.bat release noprojgen nobuild ignore-flaky test-ci-js
+        env:
+          test_ci_args: --mode=release --flaky-tests=dontcare --measure-flakiness 9 -p actions default pummel
+      - name: Test CI Native
+        run: ./vcbuild.bat release noprojgen nobuild ignore-flaky test-ci-native
+        env:
+          test_ci_args: --mode=release --flaky-tests=dontcare --measure-flakiness 9 -p actions addons js-native-api node-api benchmark doctool

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -53,7 +53,13 @@ fs.writeFile(`${tmpPath}\\test file`, 'Test', common.mustSucceed(() => {
           }));
 }));
 
-// Test Bash (from WSL and Git), if available
+const skipPaths = [
+  // Skip bash from WSL because of
+  // https://github.com/nodejs/node/pull/50519#issuecomment-1791806986
+  'usr\\bin\\bash.exe',
+];
+
+// Test Bash (Git), if available
 cp.exec('where bash', common.mustCall((error, stdout) => {
   if (error) {
     return;
@@ -61,6 +67,8 @@ cp.exec('where bash', common.mustCall((error, stdout) => {
   const lines = stdout.trim().split(/[\r\n]+/g);
   for (let i = 0; i < lines.length; ++i) {
     const bashPath = lines[i].trim();
+    if (skipPaths.some((path) => path.endsWith(bashPath)))
+      continue;
     test(bashPath);
     testCopy(`bash_${i}.exe`, bashPath);
   }


### PR DESCRIPTION
Closes #50489

As the reference to build and test, I used the following files:

- https://github.com/nodejs/build/blob/main/jenkins/scripts/windows/ci-run.cmd
- https://github.com/nodejs/build/blob/main/jenkins/scripts/windows/node-test-binary-windows-js-suites.cmd
- https://github.com/nodejs/build/blob/main/jenkins/scripts/windows/node-test-binary-windows-native-suites.cmd
- https://ci.nodejs.org/job/node-test-commit-windows-fanned/configure
- https://ci.nodejs.org/job/node-test-binary-windows-js-suites/configure
- https://ci.nodejs.org/job/node-test-binary-windows-native-suites/nodes=win11-vs2022-arm64-COMPILED_BY-vs2022-arm64/20185/consoleFull
- https://ci.nodejs.org/job/node-test-binary-windows-js-suites/RUN_SUBSET=0,nodes=win2016-COMPILED_BY-vs2022-x86/24289/console