### PR TITLE
lib: add navigator legacy attributes

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -622,6 +622,43 @@ global before app code runs:
 node --import 'data:text/javascript,delete globalThis.navigator' app.js
 ```
 
+### `navigator.appCodeName`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.appCodeName` read-only property returns "Mozilla".
+
+This property is kept only for compatibility purposes.
+
+### `navigator.appName`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.appName` read-only property returns "Netscape".
+
+This property is kept only for compatibility purposes.
+
+### `navigator.appVersion`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.appVersion` read-only property returns the app version
+consisting of the runtime name and major version number.
+
+This property is kept only for compatibility purposes.
+
 ### `navigator.hardwareConcurrency`
 
 <!-- YAML
@@ -637,6 +674,30 @@ logical processors available to the current Node.js instance.
 console.log(`This process is running on ${navigator.hardwareConcurrency} logical processors`);
 ```
 
+### `navigator.product`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.product` read-only property returns "Gecko".
+
+This property is kept only for compatibility purposes.
+
+### `navigator.productSub`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.productSub` read-only property returns "20030107".
+
+This property is kept only for compatibility purposes.
+
 ### `navigator.userAgent`
 
 <!-- YAML
@@ -651,6 +712,30 @@ consisting of the runtime name and major version number.
 ```js
 console.log(`The user-agent is ${navigator.userAgent}`); // Prints "Node.js/21"
 ```
+
+### `navigator.vendor`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.vendor` read-only property returns an empty string.
+
+This property is kept only for compatibility purposes.
+
+### `navigator.vendorSub`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string}
+
+The `navigator.vendorSub` read-only property returns an empty string.
+
+This property is kept only for compatibility purposes.
 
 ## `PerformanceEntry`
 

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -33,6 +33,27 @@ class Navigator {
   }
 
   /**
+   * @return {'Mozilla'}
+   */
+  get appCodeName() {
+    return 'Mozilla';
+  }
+
+  /**
+   * @return {'Netscape'}
+   */
+  get appName() {
+    return 'Netscape';
+  }
+
+  /**
+   * @return {string}
+   */
+  get appVersion() {
+    return this.#userAgent;
+  }
+
+  /**
    * @return {number}
    */
   get hardwareConcurrency() {
@@ -41,10 +62,38 @@ class Navigator {
   }
 
   /**
+   * @return {'Gecko'}
+   */
+  get product() {
+    return 'Gecko';
+  }
+
+  /**
+   * @return {'20030107'}
+   */
+  get productSub() {
+    return '20030107';
+  }
+
+  /**
    * @return {string}
    */
   get userAgent() {
     return this.#userAgent;
+  }
+
+  /**
+   * @return {''}
+   */
+  get vendor() {
+    return '';
+  }
+
+  /**
+   * @return {''}
+   */
+  get vendorSub() {
+    return '';
   }
 }
 

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -15,3 +15,11 @@ is.number(navigator.hardwareConcurrency, 'hardwareConcurrency');
 assert.ok(navigator.hardwareConcurrency > 0);
 assert.strictEqual(typeof navigator.userAgent, 'string');
 assert.match(navigator.userAgent, /^Node\.js\/\d+$/);
+
+assert.strictEqual(navigator.appCodeName, 'Mozilla');
+assert.strictEqual(navigator.appName, 'Netscape');
+assert.match(navigator.appVersion, /^Node\.js\/\d+$/);
+assert.strictEqual(navigator.product, 'Gecko');
+assert.strictEqual(navigator.productSub, '20030107');
+assert.strictEqual(navigator.vendor, '');
+assert.strictEqual(navigator.vendorSub, '');


### PR DESCRIPTION
This PR adds the "dummy" attributes to the navigator instance, like navigator.product or navigator.appName.

I know this PR will get alot of heat and I am just providing this just for the sake of completeness and for discussion. 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
