### PR TITLE
os: lazily load `getOSInformation`

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -74,7 +74,11 @@ function getCheckedFunction(fn) {
 let type, version, release, machine;
 
 function lazyGetOSInformation() {
-  [type, version, release, machine] = _getOSInformation();
+  const info = _getOSInformation();
+  type = info[0];
+  version = info[1];
+  release = info[2];
+  machine = info[3];
 }
 
 const getHomeDirectory = getCheckedFunction(_getHomeDirectory);
@@ -88,14 +92,14 @@ const getUptime = getCheckedFunction(_getUptime);
 const getOSRelease = () => {
   if (release === undefined) lazyGetOSInformation();
   return release;
-}
+};
 /**
  * @returns {string}
  */
 const getOSType = () => {
   if (type === undefined) lazyGetOSInformation();
   return type;
-}
+};
 /**
  * @returns {string}
  */

--- a/lib/os.js
+++ b/lib/os.js
@@ -71,12 +71,11 @@ function getCheckedFunction(fn) {
   });
 }
 
-const {
-  0: type,
-  1: version,
-  2: release,
-  3: machine,
-} = _getOSInformation();
+let type, version, release, machine;
+
+function lazyGetOSInformation() {
+  [type, version, release, machine] = _getOSInformation();
+}
 
 const getHomeDirectory = getCheckedFunction(_getHomeDirectory);
 const getHostname = getCheckedFunction(_getHostname);
@@ -86,19 +85,31 @@ const getUptime = getCheckedFunction(_getUptime);
 /**
  * @returns {string}
  */
-const getOSRelease = () => release;
+const getOSRelease = () => {
+  if (release === undefined) lazyGetOSInformation();
+  return release;
+}
 /**
  * @returns {string}
  */
-const getOSType = () => type;
+const getOSType = () => {
+  if (type === undefined) lazyGetOSInformation();
+  return type;
+}
 /**
  * @returns {string}
  */
-const getOSVersion = () => version;
+const getOSVersion = () => {
+  if (version === undefined) lazyGetOSInformation();
+  return version;
+};
 /**
  * @returns {string}
  */
-const getMachine = () => machine;
+const getMachine = () => {
+  if (machine === undefined) lazyGetOSInformation();
+  return machine;
+};
 
 getAvailableParallelism[SymbolToPrimitive] = () => getAvailableParallelism();
 getFreeMem[SymbolToPrimitive] = () => getFreeMem();


### PR DESCRIPTION
changes the strategy for obtaining operating system information
by implementing a lazy loading approach. Instead of immediately 
invoking `_getOSInformation()` upon module load.

Fixes: #50525 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
