### PR TITLE
tls: use `validateFunction` for `options.SNICallback`

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -909,7 +909,7 @@ TLSSocket.prototype._init = function(socket, wrap) {
       options.SNICallback &&
       (options.SNICallback !== SNICallback ||
        (options.server && options.server._contexts.length))) {
-    assert(typeof options.SNICallback === 'function');
+    validateFunction(options.SNICallback, 'options.SNICallback');
     this._SNICallback = options.SNICallback;
     ssl.enableCertCb();
   }

--- a/test/parallel/test-tls-snicallback-error.js
+++ b/test/parallel/test-tls-snicallback-error.js
@@ -4,11 +4,21 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
+const net = require('net');
 const tls = require('tls');
 
-['fhqwhgads', 42, {}, []].forEach((testValue) => {
-  assert.throws(
-    () => { tls.createServer({ SNICallback: testValue }); },
-    { code: 'ERR_INVALID_ARG_TYPE', message: /\boptions\.SNICallback\b/ }
-  );
-});
+for (const SNICallback of ['fhqwhgads', 42, {}, []]) {
+  assert.throws(() => {
+    tls.createServer({ SNICallback });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+
+  assert.throws(() => {
+    new tls.TLSSocket(new net.Socket(), { isServer: true, SNICallback });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+}


### PR DESCRIPTION
If user uses invalid type for `options.SNICallback` in TLSSocket(), it's not internal issue of Node.js. So validateFunction() is more proper than assert().

Below is shown if we run newly added test case without this PR.
```
=== release test-tls-snicallback-error ===                   
Path: parallel/test-tls-snicallback-error
node:assert:635
      throw err;
      ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  Comparison {
+   code: 'ERR_INTERNAL_ASSERTION',
+   name: 'Error'
-   code: 'ERR_INVALID_ARG_TYPE',
-   name: 'TypeError'
  }
    at Object.<anonymous> (/home/deokjinkim/oss/node2/test/parallel/test-tls-snicallback-error.js:18:10)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: Error [ERR_INTERNAL_ASSERTION]: This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
  Please open an issue with this stack trace at https://github.com/nodejs/node/issues
  
      at assert (node:internal/assert:14:11)
      at TLSSocket._init (node:_tls_wrap:912:5)
      at new TLSSocket (node:_tls_wrap:591:8)
      at assert.throws.code (/home/deokjinkim/oss/node2/test/parallel/test-tls-snicallback-error.js:19:5)
      at getActual (node:assert:756:5)
      at Function.throws (node:assert:902:24)
      at Object.<anonymous> (/home/deokjinkim/oss/node2/test/parallel/test-tls-snicallback-error.js:18:10)
      at Module._compile (node:internal/modules/cjs/loader:1376:14)
      at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
      at Module.load (node:internal/modules/cjs/loader:1207:32) {
    code: 'ERR_INTERNAL_ASSERTION'
  },
  expected: { code: 'ERR_INVALID_ARG_TYPE', name: 'TypeError' },
  operator: 'throws'
}

Node.js v22.0.0-pre
Command: out/Release/node /home/deokjinkim/oss/node2/test/parallel/test-tls-snicallback-error.js
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
