### PR TITLE
lib: set default ICU locale per cli option `--icu-locale`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1364,6 +1364,19 @@ added: v0.1.3
 Print node command-line options.
 The output of this option is less detailed than this document.
 
+### `--icu-locale`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Set the default locale used by ICU (`Intl` object). It expects a string
+representing the language version as defined in [RFC 5646][] (also known as
+BCP 47).
+
+Examples of valid language codes include "en", "en-US", "fr", "fr-FR", "es-ES",
+etc.
+
 ### `--icu-data-dir=file`
 
 <!-- YAML
@@ -2948,6 +2961,7 @@ one is included in the list below.
 * `--heapsnapshot-signal`
 * `--http-parser`
 * `--icu-data-dir`
+* `--icu-locale`
 * `--import`
 * `--input-type`
 * `--insecure-http-parser`
@@ -3457,6 +3471,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [OSSL_PROVIDER-legacy]: https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html
 [Permission Model]: permissions.md#permission-model
 [REPL]: repl.md
+[RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.txt
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [ShadowRealm]: https://github.com/tc39/proposal-shadowrealm
 [Source Map]: https://sourcemaps.info/spec.html

--- a/src/node.cc
+++ b/src/node.cc
@@ -963,6 +963,10 @@ static ExitCode InitializeNodeWithArgsInternal(
   }
 # endif
 
+  if (!per_process::cli_options->icu_locale.empty()) {
+    i18n::SetDefaultLocale(per_process::cli_options->icu_locale.c_str());
+  }
+
 #endif  // defined(NODE_HAVE_I18N_SUPPORT)
 
   // We should set node_is_initialized here instead of in node::Start,

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -54,6 +54,7 @@
 #include "util-inl.h"
 #include "v8.h"
 
+#include <unicode/locid.h>
 #include <unicode/putil.h>
 #include <unicode/timezone.h>
 #include <unicode/uchar.h>
@@ -61,6 +62,7 @@
 #include <unicode/ucnv.h>
 #include <unicode/udata.h>
 #include <unicode/uidna.h>
+#include <unicode/uloc.h>
 #include <unicode/ulocdata.h>
 #include <unicode/urename.h>
 #include <unicode/ustring.h>
@@ -599,6 +601,37 @@ void SetDefaultTimeZone(const char* tzid) {
   u_charsToUChars(tzid, id.out(), tzidlen);
   // This is threadsafe:
   ucal_setDefaultTimeZone(id.out(), &status);
+  CHECK(U_SUCCESS(status));
+}
+
+void SetDefaultLocale(const char* localeid) {
+  UErrorCode status = U_ZERO_ERROR;
+
+  // Set the locale to the requested locale, no matter if it is
+  // supported or not. Let ICU handle the conversion to a supported locale.
+  // E.g. "en_US" and "en-US" will be internally converted to "en_US".
+  uloc_setDefault(localeid, &status);
+  CHECK(U_SUCCESS(status));
+
+  // Now check if the locale was actually set to a supported locale.
+  // We iterate over all supported locales and check if the default locale
+  // is among them. If so, we can finish here.
+  const char* newDefaultLocale = uloc_getDefault();
+  int newDefaultLocaleLen = strlen(newDefaultLocale);
+  int32_t locCount = 0;
+  const icu::Locale* supportedLocales =
+      icu::Locale::getAvailableLocales(locCount);
+  for (int32_t i = 0; i < locCount; ++i) {
+    if (strncmp(newDefaultLocale,
+                supportedLocales[i].getName(),
+                newDefaultLocaleLen) == 0) {
+      return;
+    }
+  }
+
+  // The default locale is not supported. We need to set it to a supported
+  // locale. We use the root locale as a fallback.
+  uloc_setDefault(nullptr, &status);
   CHECK(U_SUCCESS(status));
 }
 

--- a/src/node_i18n.h
+++ b/src/node_i18n.h
@@ -42,6 +42,8 @@ bool InitializeICUDirectory(const std::string& path, std::string* error);
 
 void SetDefaultTimeZone(const char* tzid);
 
+void SetDefaultLocale(const char* localid);
+
 enum class idna_mode {
   // Default mode for maximum compatibility.
   kDefault,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1018,6 +1018,11 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             ,
             &PerProcessOptions::icu_data_dir,
             kAllowedInEnvvar);
+
+  AddOption("--icu-locale",
+            "Set the locale of the ICU used by the node instance",
+            &PerProcessOptions::icu_locale,
+            kAllowedInEnvvar);
 #endif
 
 #if HAVE_OPENSSL

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -313,6 +313,7 @@ class PerProcessOptions : public Options {
 
 #ifdef NODE_HAVE_I18N_SUPPORT
   std::string icu_data_dir;
+  std::string icu_locale;
 #endif
 
   // Per-process because they affect singleton OpenSSL shared library state,

--- a/test/parallel/test-icu-locale.js
+++ b/test/parallel/test-icu-locale.js
@@ -1,0 +1,203 @@
+'use strict';
+const common = require('../common');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const assert = require('assert');
+
+if (!common.hasIntl)
+  common.skip('Intl not present.');
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=fr-FR',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'fr-FR\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en-GB',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'en-GB\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en_GB',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'en-GB\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'en\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=de-DE',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'de-DE\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=invalid',
+      '-p',
+      'Intl?.Collator().resolvedOptions().locale',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'en-US\n');
+}
+
+// NumberFormat
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    ['--icu-locale=de-DE', '-p', '(123456.789).toLocaleString(undefined, { style: "currency", currency: "EUR" })']
+  );
+  assert.strictEqual(child.stdout.toString(), '123.456,79\xa0€\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=ja-JP',
+      '-p',
+      '(123456.789).toLocaleString(undefined, { style: "currency", currency: "JPY" })',
+    ]);
+  assert.strictEqual(child.stdout.toString(), '￥123,457\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en-IN',
+      '-p',
+      '(123456.789).toLocaleString(undefined, { maximumSignificantDigits: 3  })',
+    ]);
+  assert.strictEqual(child.stdout.toString(), '1,23,000\n');
+}
+// DateTimeFormat
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en-GB',
+      '-p',
+      'new Date(Date.UTC(2012, 11, 20, 3, 0, 0)).toLocaleString(undefined,  { timeZone: "UTC" })',
+    ]);
+  assert.strictEqual(child.stdout.toString(), '20/12/2012, 03:00:00\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=ko-KR',
+      '-p',
+      'new Date(Date.UTC(2012, 11, 20, 3, 0, 0)).toLocaleString(undefined,  { timeZone: "UTC" })',
+    ]);
+  assert.strictEqual(child.stdout.toString(), '2012. 12. 20. 오전 3:00:00\n');
+}
+
+// ListFormat
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en-US',
+      '-p',
+      'new Intl.ListFormat(undefined, {style: "long", type:"conjunction"}).format(["a", "b", "c"])',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'a, b, and c\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=de-DE',
+      '-p',
+      'new Intl.ListFormat(undefined, {style: "long", type:"conjunction"}).format(["a", "b", "c"])',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'a, b und c\n');
+}
+
+// RelativeTimeFormat
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=en',
+      '-p',
+      'new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(3, "quarter")',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'in 3 quarters\n');
+}
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=es',
+      '-p',
+      'new Intl.RelativeTimeFormat(undefined, { numeric: "auto" }).format(2, "day")',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'pasado mañana\n');
+}
+
+// Collator
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=de',
+      '-p',
+      '["Z", "a", "z", "ä"].sort(new Intl.Collator().compare).join(",")',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'a,ä,z,Z\n');
+}
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=sv',
+      '-p',
+      '["Z", "a", "z", "ä"].sort(new Intl.Collator().compare).join(",")',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'a,z,Z,ä\n');
+}
+
+{
+  const { child } = spawnSyncAndExitWithoutError(
+    process.execPath,
+    [
+      '--icu-locale=de',
+      '-p',
+      '["Z", "a", "z", "ä"].sort(new Intl.Collator(undefined, { caseFirst: "upper" }).compare).join(",")',
+    ]);
+  assert.strictEqual(child.stdout.toString(), 'a,ä,Z,z\n');
+}


### PR DESCRIPTION
This PR adds a standardized way via the cli option `--icu-locale` to set the default locale of the ICU used in node process. 

How to use:

```sh
node --icu-locale=fr-FR
```

then in the repl you can do

```js
console.log(Intl?.Collator().resolvedOptions().locale) // output is 'fr-FR'
```

Todo:
- [ ] get feedback if it is implemented correctly from other maintainers
- [x] add tests
- [x] add documentation