### PR TITLE
cli: add flag for disabling globals

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -443,6 +443,32 @@ Affects the default output directory of:
 * [`--heap-prof-dir`][]
 * [`--redirect-warnings`][]
 
+### `--disable-global=name`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.2 - Release candidate
+
+Remove specified global variables from the global scope. This flag can be used
+multiple times to remove multiple variables.
+
+Not all global variables can be removed. The currently supported variables are:
+
+<!-- Keep alphabetized -->
+- `CustomEvent`
+- `fetch`; removing this also removes `FormData`, `Headers`, `Request`, and
+  `Response`
+- `navigator`
+- `WebSocket`
+
+```bash
+node --disable-global=CustomEvent --disable-global=navigator \
+  --eval 'console.log(typeof CustomEvent, typeof navigator)'
+undefined undefined
+```
+
 ### `--disable-proto=mode`
 
 <!-- YAML

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -52,10 +52,6 @@ exposeLazyInterfaces(globalThis, 'perf_hooks', [
 
 defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 
-// https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
-exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator']);
-defineReplaceableLazyAttribute(globalThis, 'internal/navigator', ['navigator'], false);
-
 // https://w3c.github.io/FileAPI/#creating-revoking
 const { installObjectURLMethods } = require('internal/url');
 installObjectURLMethods();

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypeMap,
   Date,
   DatePrototypeGetDate,
   DatePrototypeGetFullYear,
@@ -14,8 +15,10 @@ const {
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   SafeMap,
+  SafeSet,
   String,
   StringPrototypeStartsWith,
+  StringPrototypeToLowerCase,
   Symbol,
   SymbolAsyncDispose,
   SymbolDispose,
@@ -78,9 +81,7 @@ function prepareExecution(options) {
   setupTraceCategoryState();
   setupInspectorHooks();
   setupWarningHandler();
-  setupUndici();
-  setupWebCrypto();
-  setupCustomEvent();
+  setupWebGlobals();
   setupCodeCoverage();
   setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
@@ -278,13 +279,51 @@ function setupWarningHandler() {
   }
 }
 
-// https://fetch.spec.whatwg.org/
-// https://websockets.spec.whatwg.org/
-function setupUndici() {
+function setupWebGlobals() {
   if (getEmbedderOptions().noBrowserGlobals) {
     return;
   }
 
+  if (!getOptionValue('--no-experimental-global-webcrypto')) {
+    // `--no-experimental-global-webcrypto` doesn't disable the `crypto` global, it just changes what
+    // `globalThis.crypto` refers to. There is currently no way to disable the `crypto` global.
+    setupWebCrypto();
+  }
+
+  const disabledGlobalsLowercased = new SafeSet(ArrayPrototypeMap(
+    getOptionValue('--disable-global'), value => StringPrototypeToLowerCase(value)));
+
+  // `CustomEvent`
+  if (!getOptionValue('--no-experimental-global-customevent') &&
+    !disabledGlobalsLowercased.has('customevent')) {
+    setupCustomEvent();
+  }
+
+  // `navigator`
+  if (!disabledGlobalsLowercased.has('navigator')) {
+    setupNavigator();
+  }
+
+  // `fetch`, `FormData`, `Headers`, `Request`, `Response`
+  const setupFetch = !getOptionValue('--no-experimental-fetch') &&
+    !disabledGlobalsLowercased.has('fetch');
+  // `WebSocket`
+  const setupWebSocket = getOptionValue('--experimental-websocket') &&
+    !disabledGlobalsLowercased.has('websocket');
+  if (setupFetch || setupWebSocket) {
+    setupUndici(setupFetch, setupWebSocket);
+  }
+}
+
+function setupNavigator() {
+  // https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
+  exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator']);
+  defineReplaceableLazyAttribute(globalThis, 'internal/navigator', ['navigator'], false);
+}
+
+// https://fetch.spec.whatwg.org/
+// https://websockets.spec.whatwg.org/
+function setupUndici(setupFetch = true, setupWebSocket = true) {
   let undici;
   function lazyUndici() {
     if (undici) {
@@ -308,7 +347,7 @@ function setupUndici() {
     };
   }
 
-  if (!getOptionValue('--no-experimental-fetch')) {
+  if (setupFetch) {
     // Fetch is meant to return a Promise, but not be async.
     function fetch(input, init = undefined) {
       return lazyUndici().fetch(input, init);
@@ -329,21 +368,14 @@ function setupUndici() {
     });
   }
 
-  if (getOptionValue('--experimental-websocket')) {
+  if (setupWebSocket) {
     ObjectDefineProperties(globalThis, {
       WebSocket: lazyInterface('WebSocket'),
     });
   }
 }
 
-// TODO(aduh95): move this to internal/bootstrap/web/* when the CLI flag is
-//               removed.
 function setupWebCrypto() {
-  if (getEmbedderOptions().noBrowserGlobals ||
-      getOptionValue('--no-experimental-global-webcrypto')) {
-    return;
-  }
-
   if (internalBinding('config').hasOpenSSL) {
     defineReplaceableLazyAttribute(
       globalThis,
@@ -384,13 +416,7 @@ function setupCodeCoverage() {
   }
 }
 
-// TODO(daeyeon): move this to internal/bootstrap/web/* when the CLI flag is
-//                removed.
 function setupCustomEvent() {
-  if (getEmbedderOptions().noBrowserGlobals ||
-      getOptionValue('--no-experimental-global-customevent')) {
-    return;
-  }
   const { CustomEvent } = require('internal/event_target');
   exposeInterface(globalThis, 'CustomEvent', CustomEvent);
 }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -357,6 +357,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             " (default: current working directory)",
             &EnvironmentOptions::diagnostic_dir,
             kAllowedInEnvvar);
+  AddOption("--disable-global",
+            "remove global variable",
+            &EnvironmentOptions::disable_global,
+            kAllowedInEnvvar);
   AddOption("--dns-result-order",
             "set default value of verbatim in dns.lookup. Options are "
             "'ipv4first' (IPv4 addresses are placed before IPv6 addresses) "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -105,6 +105,7 @@ class EnvironmentOptions : public Options {
   bool abort_on_uncaught_exception = false;
   std::vector<std::string> conditions;
   bool detect_module = false;
+  std::vector<std::string> disable_global;
   std::string dns_result_order;
   bool enable_source_maps = false;
   bool experimental_fetch = true;

--- a/test/parallel/test-cli-disable-global.mjs
+++ b/test/parallel/test-cli-disable-global.mjs
@@ -1,0 +1,56 @@
+import { spawnPromisified } from '../common/index.mjs';
+import { describe, it } from 'node:test';
+import { strictEqual } from 'node:assert';
+
+
+describe('--disable-global', { concurrency: true }, () => {
+  it('disables one global', async () => {
+    const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+      '--disable-global', 'navigator',
+      '--eval', 'console.log(typeof navigator)',
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout, 'undefined\n');
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+
+  it('disables all the globals in the supported list', async () => {
+    const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+      '--disable-global', 'CustomEvent',
+      '--disable-global', 'fetch',
+      '--disable-global', 'navigator',
+      '--disable-global', 'WebSocket',
+      '--print',
+      `[
+        'CustomEvent',
+        'fetch', 'FormData', 'Headers', 'Request', 'Response',
+        'navigator',
+        'WebSocket',
+      ].filter(name => typeof globalThis[name] !== 'undefined')`,
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout, '[]\n');
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+
+  it('is case insensitive', async () => {
+    const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+      '--disable-global', 'customevent',
+      '--disable-global', 'websocket',
+      '--print',
+      `[
+        'CustomEvent',
+        'WebSocket',
+      ].filter(name => typeof globalThis[name] !== 'undefined')`,
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout, '[]\n');
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+});


### PR DESCRIPTION
Per https://github.com/nodejs/node/pull/50412#issuecomment-1783405435, this creates a new flag `--disable-global` to provide the user a way to disable certain global APIs. The globals that can be disabled include `CustomEvent`, `fetch` (and its associated `FormData`, `Headers`, `Request`, and `Response`), `navigator`, and `WebSocket`.

The motivation for this flag is both to provide a compatibility escape hatch and also to abstract this ability for future global APIs. We currently have several flags for specific web APIs, like `--no-experimental-fetch` and `--no-experimental-global-customevent`; as we continue to add web APIs, which are often globals, these per-API flags will proliferate. Rather than continue to grow our long list of CLI flags, a single flag that takes multiple options seems preferable.

@nodejs/web-standards @nodejs/tsc 