### PR TITLE
doc: correct attribution in v20.6.0 changelog

### DIFF
--- a/doc/changelogs/CHANGELOG_V20.md
+++ b/doc/changelogs/CHANGELOG_V20.md
@@ -490,7 +490,7 @@ node --import ./file-that-calls-register.js ./app.js
 
 Using `--import` ensures that the customization hooks are registered before any application code runs, even the entry point.
 
-This feature was contributed by Izaak Schroeder in <https://github.com/nodejs/node/pull/48842> and <https://github.com/nodejs/node/pull/48559>
+This feature was contributed by João Lenon and Jacob Smith in <https://github.com/nodejs/node/pull/46826>, Izaak Schroeder and Jacob Smith in <https://github.com/nodejs/node/pull/48842> and <https://github.com/nodejs/node/pull/48559>
 
 #### Module customization `load` hook can now support CommonJS
 


### PR DESCRIPTION
Not sure what happened when these were generated, but the original PR that introduced the feature was omitted and co-authorship on both PRs was ignored.

Related: https://github.com/nodejs/nodejs.org/pull/6095