### PR TITLE
test: add WPT report test duration

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -59,10 +59,13 @@ function codeUnitStr(char) {
 }
 
 class ReportResult {
+  #startTime;
+
   constructor(name) {
     this.test = name;
     this.status = 'OK';
     this.subtests = [];
+    this.#startTime = Date.now();
   }
 
   addSubtest(name, status, message) {
@@ -81,6 +84,7 @@ class ReportResult {
 
   finish(status) {
     this.status = status ?? 'OK';
+    this.duration = Date.now() - this.#startTime;
   }
 }
 


### PR DESCRIPTION
This adds a duration entry for every ReportResult in the WPT Report.

<img width="1411" alt="Screenshot 2023-11-06 at 11 49 37" src="https://github.com/nodejs/node/assets/241506/5b42eb83-7ef2-4012-a161-c5b653e309b0">
