### PR TITLE
http: add writeFile to OutgoingMessage 

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2604,6 +2604,13 @@ An attempt was made to call [`stream.pipe()`][] on a [`Writable`][] stream.
 A stream method was called that cannot complete because the stream was
 destroyed using `stream.destroy()`.
 
+<a id="ERR_STREAM_LOCKED"></a>
+
+### `ERR_STREAM_LOCKED`
+
+A stream method was called that cannot complete because the stream was
+locked.
+
 <a id="ERR_STREAM_NULL_VALUES"></a>
 
 ### `ERR_STREAM_NULL_VALUES`

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3193,7 +3193,9 @@ outgoingMessage.removeHeader('Content-Encoding');
 added: REPLACEME
 -->
 
-* `file` {string|number|URL} file path, URL or descriptor.
+> Stability: 1.1 - Active development.
+
+* `file` {string|URL|number} file path, URL or descriptor.
 * `options` {Object}
   * `start` {integer}
   * `end` {integer} **Default:** `Infinity`
@@ -3205,7 +3207,7 @@ descriptor then it's the callers responsibility to close it.
 `options` can include `start` and `end` values to read a range of bytes from
 the file instead of the entire file. Both `start` and `end` are inclusive and
 start counting at 0, allowed values are in the
-[0, [`Number.MAX_SAFE_INTEGER`][]] range. If `path` is a file descriptor and
+\[0, \[`Number.MAX_SAFE_INTEGER`]\[]] range. If `path` is a file descriptor and
 and `start` is omitted or `undefined`, `fs.createReadStream()` reads
 sequentially from the current file position.
 
@@ -4252,6 +4254,7 @@ Set the maximum number of idle HTTP parsers.
 [`net.Socket`]: net.md#class-netsocket
 [`net.createConnection()`]: net.md#netcreateconnectionoptions-connectlistener
 [`new URL()`]: url.md#new-urlinput-base
+[`Number.MAX_SAFE_INTEGER`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 [`outgoingMessage.setHeader(name, value)`]: #outgoingmessagesetheadername-value
 [`outgoingMessage.setHeaders()`]: #outgoingmessagesetheadersheaders
 [`outgoingMessage.socket`]: #outgoingmessagesocket

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -26,6 +26,7 @@ const {
   ArrayIsArray,
   ArrayPrototypeJoin,
   MathFloor,
+  MathMin,
   NumberPrototypeToString,
   ObjectDefineProperty,
   ObjectKeys,
@@ -66,21 +67,36 @@ const {
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_CHAR,
     ERR_METHOD_NOT_IMPLEMENTED,
+    ERR_OUT_OF_RANGE,
     ERR_STREAM_CANNOT_PIPE,
     ERR_STREAM_ALREADY_FINISHED,
     ERR_STREAM_WRITE_AFTER_END,
+    ERR_STREAM_LOCKED,
     ERR_STREAM_NULL_VALUES,
     ERR_STREAM_DESTROYED,
   },
   hideStackFrames,
 } = require('internal/errors');
-const { validateString } = require('internal/validators');
+const {
+  validateInteger,
+  validateObject,
+  validateFunction,
+  validateString,
+} = require('internal/validators');
 const { isUint8Array } = require('internal/util/types');
+const {
+  getValidatedFd,
+  getValidatedPath,
+} = require('internal/fs/utils');
+const fs = require('fs');
+const { setImmediate } = require('timers');
+const { isURL } = require('internal/url');
 
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
 
+const kLocked = Symbol('kLocked');
 const kCorked = Symbol('corked');
 const kSocket = Symbol('kSocket');
 const kChunkedBuffer = Symbol('kChunkedBuffer');
@@ -158,6 +174,7 @@ function OutgoingMessage(options) {
   this[kErrored] = null;
   this[kHighWaterMark] = options?.highWaterMark ?? getDefaultHighWaterMark();
   this[kRejectNonStandardBodyWrites] = options?.rejectNonStandardBodyWrites ?? false;
+  this[kLocked] = false;
 }
 ObjectSetPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 ObjectSetPrototypeOf(OutgoingMessage, Stream);
@@ -874,6 +891,10 @@ ObjectDefineProperty(OutgoingMessage.prototype, 'writableNeedDrain', {
 
 const crlf_buf = Buffer.from('\r\n');
 OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
+  if (this[kLocked]) {
+    throw new ERR_STREAM_LOCKED('write');
+  }
+
   if (typeof encoding === 'function') {
     callback = encoding;
     encoding = null;
@@ -1005,6 +1026,131 @@ function connectionCorkNT(conn) {
   conn.uncork();
 }
 
+OutgoingMessage.prototype.writeFile = function writeFile(file, opts, callback) {
+  if (this[kLocked]) {
+    throw new ERR_STREAM_LOCKED('writeFile');
+  }
+
+  let start;
+  let end = Infinity;
+
+  if (typeof opts === 'function') {
+    callback = opts;
+    opts = null;
+  } else if (opts != null) {
+    validateObject(opts, 'opts');
+
+    start = opts.start;
+    if (start !== undefined) {
+      validateInteger(start, 'opts.start', 0);
+    }
+
+    end = opts.end;
+    if (end === undefined) {
+      end = Infinity;
+    } else if (end !== Infinity) {
+      validateInteger(end, 'opts.end', 0);
+
+      if (start !== undefined && start > end) {
+        throw new ERR_OUT_OF_RANGE('start', `<= "end" (here: ${end})`, start);
+      }
+    }
+
+    validateFunction(callback, 'callback');
+  }
+
+  try {
+    this[kLocked] = true;
+    if (typeof file === 'number') {
+      _writeFile(getValidatedFd(file), this, start, end, (err, bytesWritten) => {
+        this[kLocked] = false;
+        callback(err, bytesWritten);
+      });
+    } else if (typeof file === 'string' || isURL(file)) {
+      fs.open(getValidatedPath(file), (err, fd) => {
+        if (err) {
+          this[kLocked] = false;
+          callback(err);
+        } else {
+          _writeFile(fd, this, start, end, (err, bytesWritten) => {
+            fs.close(fd, (er) => {
+              this[kLocked] = false;
+              callback(er || err || null, bytesWritten);
+            });
+          });
+        }
+      });
+    } else {
+      // TODO (fix): Support FileHandle?
+      throw new ERR_INVALID_ARG_TYPE('file', ['string', 'number', 'URL'], file);
+    }
+  } catch (err) {
+    this[kLocked] = false;
+    throw err;
+  }
+};
+
+function _writeFile(fd, res, start, end, callback) {
+  const hwm = res.writableHighWaterMark;
+
+  let pos = start;
+  let drain = null;
+  let bytesWritten = 0;
+
+  const next = (err, bytesRead, buf) => {
+    try {
+      if (pos !== undefined) {
+        pos += bytesRead;
+      }
+      bytesWritten += bytesRead;
+
+      // TODO (perf): Use FastBuffer constructor instead of Buffer.subarray.
+      // TODO (perf): Is there a way we can re-use buffers that have already
+      // been flushed to the socket?
+      buf = bytesRead === 0 ? null : bytesRead < buf.byteLength ? buf.subarray(0, bytesRead) : buf;
+
+      const wState = res.socket && res.socket._writableState;
+
+      if (err && err.code === 'EAGAIN' && !res.destroyed) {
+        setImmediate(read);
+      } else if (err || buf === null || res.destroyed) {
+        if (drain != null) {
+          res.off('drain', drain);
+        }
+        callback(err, bytesWritten);
+      } else if (write_(res, buf, null, null, false)) {
+        read();
+      } else if (wState && wState.length - wState.writelen < hwm) {
+        // In order to ensure we don't stall we need to continue
+        // reading the file while the socket is writing.
+        read();
+      } else if (drain == null) {
+        res[kNeedDrain] = true;
+        drain = read;
+        res.on('drain', drain);
+      }
+    } catch (err) {
+      callback(err, bytesWritten);
+    }
+  };
+
+  const read = () => {
+    const n = pos !== undefined ?
+      MathMin(end - pos + 1, hwm) :
+      MathMin(end - bytesWritten + 1, hwm);
+
+    assert(n >= 0);
+
+    if (n === 0) {
+      next(null, 0, null);
+    } else {
+      fs.read(fd, Buffer.allocUnsafe(n), 0, n, pos, next);
+    }
+  };
+
+  read();
+}
+
 OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   this._trailer = '';
   const keys = ObjectKeys(headers);
@@ -1056,6 +1202,10 @@ function onFinish(outmsg) {
 }
 
 OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
+  if (this[kLocked]) {
+    throw new ERR_STREAM_LOCKED('end');
+  }
+
   if (typeof chunk === 'function') {
     callback = chunk;
     chunk = null;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -1062,6 +1062,7 @@ OutgoingMessage.prototype.writeFile = function writeFile(file, opts, callback) {
   try {
     this[kLocked] = true;
     if (typeof file === 'number') {
+      // File is a number if it is a file descriptor
       _writeFile(getValidatedFd(file), this, start, end, (err, bytesWritten) => {
         this[kLocked] = false;
         callback(err, bytesWritten);
@@ -1094,7 +1095,7 @@ function _writeFile(fd, res, start, end, callback) {
   const hwm = res.writableHighWaterMark;
 
   let pos = start;
-  let drain = null;
+  let resume = null;
   let bytesWritten = 0;
 
   const next = (err, bytesRead, buf) => {
@@ -1114,8 +1115,10 @@ function _writeFile(fd, res, start, end, callback) {
       if (err && err.code === 'EAGAIN' && !res.destroyed) {
         setImmediate(read);
       } else if (err || buf === null || res.destroyed) {
-        if (drain != null) {
-          res.off('drain', drain);
+        if (resume != null) {
+          res
+            .off('drain', resume)
+            .off('close', resume);
         }
         callback(err, bytesWritten);
       } else if (write_(res, buf, null, null, false)) {
@@ -1124,10 +1127,12 @@ function _writeFile(fd, res, start, end, callback) {
         // In order to ensure we don't stall we need to continue
         // reading the file while the socket is writing.
         read();
-      } else if (drain == null) {
+      } else if (resume == null) {
         res[kNeedDrain] = true;
-        drain = read;
-        res.on('drain', drain);
+        resume = read;
+        res
+          .on('drain', resume)
+          .on('close', resume);
       }
     } catch (err) {
       callback(err, bytesWritten);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1692,6 +1692,7 @@ E('ERR_STREAM_ALREADY_FINISHED',
   Error);
 E('ERR_STREAM_CANNOT_PIPE', 'Cannot pipe, not readable', Error);
 E('ERR_STREAM_DESTROYED', 'Cannot call %s after a stream was destroyed', Error);
+E('ERR_STREAM_LOCKED', 'Cannot call %s while a stream is locked', Error);
 E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);
 E('ERR_STREAM_PREMATURE_CLOSE', 'Premature close', Error);
 E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF', Error);

--- a/test/parallel/test-http-send-file-fd.js
+++ b/test/parallel/test-http-send-file-fd.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const fs = require('fs');
+
+const fname = fixtures.path('elipses.txt');
+
+const expected = fs.readFileSync(fname, 'utf8');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.resume();
+  fs.open(fname, (err, fd) => {
+    assert(!err);
+    res.writeFile(fd, (err) => {
+      assert(!err);
+      fs.close(fd, (err) => {
+        assert(!err);
+        res.end();
+      });
+    });
+  });
+}));
+
+server.listen(0, () => {
+  const client = http.request(`http://localhost:${server.address().port}`, common.mustCall(async (res) => {
+    let result = '';
+    res.setEncoding('utf-8');
+    for await (const chunk of res) {
+      result += chunk;
+    }
+    assert.strictEqual(expected.length, result.length);
+    assert.strictEqual(expected, result);
+    server.close();
+    client.destroy();
+  })).end();
+});

--- a/test/parallel/test-http-send-file.js
+++ b/test/parallel/test-http-send-file.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const fs = require('fs');
+
+const fname = fixtures.path('elipses.txt');
+
+const expected = fs.readFileSync(fname, 'utf8');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.resume();
+  res.writeFile(fname, (err) => {
+    assert(!err);
+    res.end();
+  });
+}));
+
+server.listen(0, () => {
+  const client = http.request(`http://localhost:${server.address().port}`, common.mustCall(async (res) => {
+    let result = '';
+    for await (const chunk of res) {
+      result += chunk;
+    }
+    assert.strictEqual(expected, result);
+    server.close();
+    client.destroy();
+  })).end();
+});


### PR DESCRIPTION
Provide an optimized path for sending files over HTTP. Removes the entire memory and processing overhead of creating and operating an intermediate Readable.