### PR TITLE
util: fix wrong argument of `ERR_INVALID_MIME_SYNTAX`

### DIFF
--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -70,7 +70,7 @@ function parseTypeAndSubtype(str) {
   const invalidSubtypeIndex = SafeStringPrototypeSearch(trimmedSubtype,
                                                         NOT_HTTP_TOKEN_CODE_POINT);
   if (trimmedSubtype === '' || invalidSubtypeIndex !== -1) {
-    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
+    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, invalidSubtypeIndex);
   }
   const subtype = toASCIILower(trimmedSubtype);
   return [


### PR DESCRIPTION
Third argument of ERR_INVALID_MIME_SYNTAX is invalid index (not string).

https://github.com/nodejs/node/blob/cde3296f5f6c7054c0bcb1dd9e1ee8a43ec3b3f1/lib/internal/errors.js#L1419-L1422

When I tested with below example,
```
const { MIMEType } = require('node:util');
const myMIME = new MIMEType('text/javascript,');
```

Before
```
node:internal/mime:73
    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
    ^

TypeError [ERR_INVALID_MIME_SYNTAX]: The MIME syntax for a subtype in "text/javascript," is invalid at javascript,
    at parseTypeAndSubtype (node:internal/mime:73:11)
    at new MIMEType (node:internal/mime:332:18)
```

After
```
node:internal/mime:73
    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, invalidSubtypeIndex);
    ^

TypeError [ERR_INVALID_MIME_SYNTAX]: The MIME syntax for a subtype in "text/javascript," is invalid at 10
    at parseTypeAndSubtype (node:internal/mime:73:11)
    at new MIMEType (node:internal/mime:332:18)
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
