### PR TITLE
meta: add crypto as crypto and webcrypto docs owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,8 @@
 
 # tls/crypto
 
+/doc/api/crypto.md @nodejs/crypto
+/doc/api/webcrypto.md @nodejs/crypto
 /lib/crypto.js @nodejs/crypto
 /lib/internal/crypto/* @nodejs/crypto
 /lib/internal/tls/* @nodejs/crypto @nodejs/net


### PR DESCRIPTION
Adds `@nodejs/crypto` as the owner for /doc/api/crypto.md and /doc/api/webcrypto.md