### PR TITLE
benchmark: add undici websocket benchmark

### DIFF
--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -10,7 +10,8 @@ const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 const configs = {
   size: [64, 16 * 1024, 128 * 1024, 1024 * 1024],
   useBinary: ['true', 'false'],
-  roundtrips: [5000, 1000, 100],};
+  roundtrips: [5000, 1000, 100],
+};
 
 const bench = common.createBenchmark(main, configs);
 

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -43,7 +43,7 @@ function createFrame(data, opcode) {
 }
 
 function main(conf) {
-  const frame = createFrame(Buffer.alloc(conf.size).fill('.'), conf.useBinary === 'true');
+  const frame = createFrame(Buffer.alloc(conf.size).fill('.'), conf.useBinary === 'true' ? 2 : 1);
   const server = http.createServer();
   server.on('upgrade', (req, socket) => {
     const key = crypto
@@ -98,6 +98,4 @@ function main(conf) {
       ws.send(event.data);
     });
   });
-
-
 }

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const common = require('../common.js');
+const http = require('http');
+const WebSocketServer = require('ws');
+const { WebSocket } = require('undici');
+
+const port = 8181;
+const path = '';
+
+const configs = {
+  useBinary: ['true', 'false'],
+  roundtrips: [5000, 1000, 100, 1],
+  size: [64, 16 * 1024, 128 * 1024, 1024 * 1024],
+};
+
+const bench = common.createBenchmark(main, configs);
+
+function main(conf) {
+  const server = http.createServer();
+  const wss = new WebSocketServer.Server({
+    maxPayload: 600 * 1024 * 1024,
+    perMessageDeflate: false,
+    clientTracking: false,
+    server,
+  });
+
+  wss.on('connection', (ws) => {
+    ws.on('message', (data, isBinary) => {
+      ws.send(data, { binary: isBinary });
+    });
+  });
+
+  server.listen(path ? { path } : { port });
+  const url = path ? `ws+unix://${path}` : `ws://localhost:${port}`;
+  const wsc = new WebSocket(url);
+  const data = Buffer.allocUnsafe(conf.size).fill('.'); // Pre-fill data for testing
+
+  let roundtrip = 0;
+
+  wsc.addEventListener('error', (err) => {
+    throw err;
+  });
+
+  bench.start();
+
+  wsc.addEventListener('open', () => {
+    wsc.send(data, { binary: conf.useBinary });
+  });
+
+  wsc.addEventListener('close', () => {
+    wss.close(() => {
+      server.close();
+    });
+  });
+
+  wsc.addEventListener('message', () => {
+    if (++roundtrip !== conf.roundtrips) {
+      wsc.send(data, { binary: conf.useBinary });
+    } else {
+      bench.end(conf.roundtrips);
+      wsc.close();
+    }
+  });
+}

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -1,65 +1,100 @@
 'use strict';
 
 const common = require('../common.js');
+const crypto = require('crypto');
 const http = require('http');
-const WebSocketServer = require('ws');
 const { WebSocket } = require('undici');
 
-const port = 8181;
-const path = '';
+const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 
 const configs = {
+  size: [64, 16 * 1024, 128 * 1024, 1024 * 1024],
   useBinary: ['true', 'false'],
   roundtrips: [5000, 1000, 100, 1],
-  size: [64, 16 * 1024, 128 * 1024, 1024 * 1024],
 };
 
 const bench = common.createBenchmark(main, configs);
 
+function createFrame(data, opcode) {
+  let infoLength = 2;
+  let payloadLength = data.length;
+
+  if (payloadLength >= 65536) {
+    infoLength += 8;
+    payloadLength = 127;
+  } else if (payloadLength > 125) {
+    infoLength += 2;
+    payloadLength = 126;
+  }
+
+  const info = Buffer.alloc(infoLength);
+
+  info[0] = opcode | 0x80;
+  info[1] = payloadLength;
+
+  if (payloadLength === 126) {
+    info.writeUInt16BE(data.length, 2);
+  } else if (payloadLength === 127) {
+    info[2] = info[3] = 0;
+    info.writeUIntBE(data.length, 4, 6);
+  }
+
+  return Buffer.concat([info, data]);
+}
+
 function main(conf) {
+  const frame = createFrame(Buffer.alloc(conf.size).fill('.'), 1);
+
   const server = http.createServer();
-  const wss = new WebSocketServer.Server({
-    maxPayload: 600 * 1024 * 1024,
-    perMessageDeflate: false,
-    clientTracking: false,
-    server,
-  });
+  server.on('upgrade', (req, socket) => {
+    const key = crypto
+      .createHash('sha1')
+      .update(req.headers['sec-websocket-key'] + GUID)
+      .digest('base64');
 
-  wss.on('connection', (ws) => {
-    ws.on('message', (data, isBinary) => {
-      ws.send(data, { binary: isBinary });
+    let bytesReceived = 0;
+    let roundtrip = 0;
+
+    socket.on('data', function onData(chunk) {
+      bytesReceived += chunk.length;
+
+      if (bytesReceived === frame.length + 4) { // +4 for the mask.
+        // Message completely received.
+        bytesReceived = 0;
+
+        if (++roundtrip === conf.roundtrips) {
+          socket.removeListener('data', onData);
+          socket.resume();
+          socket.end();
+          server.close();
+
+          bench.end(conf.roundtrips);
+        } else {
+          socket.write(frame);
+        }
+      }
     });
+
+    socket.write(
+      [
+        'HTTP/1.1 101 Switching Protocols',
+        'Upgrade: websocket',
+        'Connection: Upgrade',
+        `Sec-WebSocket-Accept: ${key}`,
+        '\r\n',
+      ].join('\r\n'),
+    );
+
+    socket.write(frame);
   });
 
-  server.listen(path ? { path } : { port });
-  const url = path ? `ws+unix://${path}` : `ws://localhost:${port}`;
-  const wsc = new WebSocket(url);
-  const data = Buffer.allocUnsafe(conf.size).fill('.'); // Pre-fill data for testing
+  server.listen(8080, () => {
+    const ws = new WebSocket('ws://localhost:8080');
 
-  let roundtrip = 0;
-
-  wsc.addEventListener('error', (err) => {
-    throw err;
+    ws.addEventListener('message', (event) => {
+      ws.send(event.data);
+    });
   });
 
   bench.start();
-
-  wsc.addEventListener('open', () => {
-    wsc.send(data, { binary: conf.useBinary });
-  });
-
-  wsc.addEventListener('close', () => {
-    wss.close(() => {
-      server.close();
-    });
-  });
-
-  wsc.addEventListener('message', () => {
-    if (++roundtrip !== conf.roundtrips) {
-      wsc.send(data, { binary: conf.useBinary });
-    } else {
-      bench.end(conf.roundtrips);
-      wsc.close();
-    }
-  });
 }

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -43,8 +43,7 @@ function createFrame(data, opcode) {
 }
 
 function main(conf) {
-  const frame = createFrame(Buffer.alloc(conf.size).fill('.'), 1);
-
+  const frame = createFrame(Buffer.alloc(conf.size).fill('.'), conf.useBinary === 'true');
   const server = http.createServer();
   server.on('upgrade', (req, socket) => {
     const key = crypto
@@ -91,10 +90,14 @@ function main(conf) {
   server.listen(8080, () => {
     const ws = new WebSocket('ws://localhost:8080');
 
+    ws.addEventListener('open', () => {
+      bench.start();
+    });
+
     ws.addEventListener('message', (event) => {
       ws.send(event.data);
     });
   });
 
-  bench.start();
+
 }

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 const crypto = require('crypto');
 const http = require('http');
-const { WebSocket } = require('undici');
+const { WebSocket } = require('../../deps/undici/undici');
 
 const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 

--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -10,8 +10,7 @@ const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 const configs = {
   size: [64, 16 * 1024, 128 * 1024, 1024 * 1024],
   useBinary: ['true', 'false'],
-  roundtrips: [5000, 1000, 100, 1],
-};
+  roundtrips: [5000, 1000, 100],};
 
 const bench = common.createBenchmark(main, configs);
 
@@ -87,9 +86,8 @@ function main(conf) {
     socket.write(frame);
   });
 
-  server.listen(8080, () => {
-    const ws = new WebSocket('ws://localhost:8080');
-
+  server.listen(0, () => {
+    const ws = new WebSocket(`ws://localhost:${server.address().port}`);
     ws.addEventListener('open', () => {
       bench.start();
     });

--- a/test/benchmark/test-benchmark-websocket.js
+++ b/test/benchmark/test-benchmark-websocket.js
@@ -4,10 +4,6 @@ const common = require('../common');
 if (!common.enoughTestMem)
   common.skip('Insufficient memory for Websocket benchmark test');
 
-// Because the websocket benchmarks use hardcoded ports, this should be in sequential
-// rather than parallel to make sure it does not conflict with tests that choose
-// random available ports.
-
 const runBenchmark = require('../common/benchmark');
 
 runBenchmark('websocket', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });

--- a/test/benchmark/test-benchmark-websocket.js
+++ b/test/benchmark/test-benchmark-websocket.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const common = require('../common');
+if (!common.enoughTestMem)
+  common.skip('Insufficient memory for Websocket benchmark test');
+
+// Because the websocket benchmarks use hardcoded ports, this should be in sequential
+// rather than parallel to make sure it does not conflict with tests that choose
+// random available ports.
+
+const runBenchmark = require('../common/benchmark');
+
+runBenchmark('websocket', { NODEJS_BENCHMARK_ZERO_ALLOWED: 1 });


### PR DESCRIPTION
Refs: https://github.com/nodejs/performance/issues/114

I added a simple benchmark for the undici websocket. I modified the client in https://github.com/websockets/ws/blob/master/bench/speed.js to use undici instead.

**Platform**
Linux benchmark-S2600WFT 5.15.0-41-generic #44-Ubuntu SMP Wed Jun 22 14:20:53 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

**20.x vs 21.x**
```
➜  websocket git: ✗ node-benchmark-compare compare-v20-v21.csv
                                                                   confidence improvement accuracy (*)    (**)   (***)
websocket/simple.js size=1048576 roundtrips=1 useBinary='false'           ***     -4.76 %       ±2.08%  ±3.06%  ±4.65%
websocket/simple.js size=1048576 roundtrips=1 useBinary='true'            ***     -3.67 %       ±0.89%  ±1.42%  ±2.50%
websocket/simple.js size=1048576 roundtrips=100 useBinary='false'         ***      3.80 %       ±1.05%  ±1.57%  ±2.47%
websocket/simple.js size=1048576 roundtrips=100 useBinary='true'                   2.15 %       ±2.42%  ±3.61%  ±5.65%
websocket/simple.js size=1048576 roundtrips=1000 useBinary='false'                 2.45 %       ±3.38%  ±5.38%  ±9.37%
websocket/simple.js size=1048576 roundtrips=1000 useBinary='true'         ***      2.92 %       ±0.96%  ±1.41%  ±2.15%
websocket/simple.js size=1048576 roundtrips=5000 useBinary='false'          *      3.18 %       ±3.04%  ±4.56%  ±7.20%
websocket/simple.js size=1048576 roundtrips=5000 useBinary='true'           *      2.19 %       ±2.03%  ±3.05%  ±4.82%
websocket/simple.js size=131072 roundtrips=1 useBinary='false'             **     -7.30 %       ±4.48%  ±6.73% ±10.66%
websocket/simple.js size=131072 roundtrips=1 useBinary='true'              **     -7.36 %       ±3.40%  ±4.99%  ±7.60%
websocket/simple.js size=131072 roundtrips=100 useBinary='false'          ***     10.01 %       ±3.04%  ±4.94%  ±8.92%
websocket/simple.js size=131072 roundtrips=100 useBinary='true'           ***     10.70 %       ±4.10%  ±6.30% ±10.37%
websocket/simple.js size=131072 roundtrips=1000 useBinary='false'                  1.93 %       ±1.97%  ±2.88%  ±4.35%
websocket/simple.js size=131072 roundtrips=1000 useBinary='true'            *      1.97 %       ±1.73%  ±2.58%  ±4.03%
websocket/simple.js size=131072 roundtrips=5000 useBinary='false'                  0.78 %       ±2.01%  ±2.94%  ±4.46%
websocket/simple.js size=131072 roundtrips=5000 useBinary='true'            *      1.79 %       ±1.67%  ±2.53%  ±4.09%
websocket/simple.js size=16384 roundtrips=1 useBinary='false'              **     -2.66 %       ±1.57%  ±2.29%  ±3.44%
websocket/simple.js size=16384 roundtrips=1 useBinary='true'                      -1.60 %       ±3.18%  ±5.06%  ±8.81%
websocket/simple.js size=16384 roundtrips=100 useBinary='false'            **     11.25 %       ±4.08%  ±6.69% ±12.23%
websocket/simple.js size=16384 roundtrips=100 useBinary='true'            ***     12.92 %       ±4.48%  ±6.53%  ±9.81%
websocket/simple.js size=16384 roundtrips=1000 useBinary='false'           **      6.52 %       ±3.31%  ±5.26%  ±9.16%
websocket/simple.js size=16384 roundtrips=1000 useBinary='true'           ***      6.92 %       ±0.66%  ±0.97%  ±1.47%
websocket/simple.js size=16384 roundtrips=5000 useBinary='false'                   2.79 %       ±4.68%  ±6.88% ±10.51%
websocket/simple.js size=16384 roundtrips=5000 useBinary='true'                    3.22 %       ±3.66%  ±6.05% ±11.24%
websocket/simple.js size=64 roundtrips=1 useBinary='false'                  *     -3.62 %       ±2.36%  ±3.78%  ±6.64%
websocket/simple.js size=64 roundtrips=1 useBinary='true'                   *     -3.05 %       ±2.39%  ±3.72%  ±6.28%
websocket/simple.js size=64 roundtrips=100 useBinary='false'              ***     12.20 %       ±5.13%  ±7.46% ±11.23%
websocket/simple.js size=64 roundtrips=100 useBinary='true'                **     10.84 %       ±4.84%  ±7.83% ±14.05%
websocket/simple.js size=64 roundtrips=1000 useBinary='false'             ***      9.51 %       ±0.92%  ±1.42%  ±2.32%
websocket/simple.js size=64 roundtrips=1000 useBinary='true'                *      7.52 %       ±6.22% ±10.26% ±19.04%
websocket/simple.js size=64 roundtrips=5000 useBinary='false'              **      1.62 %       ±0.90%  ±1.31%  ±1.97%
websocket/simple.js size=64 roundtrips=5000 useBinary='true'                *      1.33 %       ±1.06%  ±1.54%  ±2.34%
 
Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 32 comparisons, you can thus expect the following amount of false-positive results:
  1.60 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.32 false positives, when considering a   1% risk acceptance (**, ***),
  0.03 false positives, when considering a 0.1% risk acceptance (***)
```