### PR TITLE
src: return error --env-file if file is missing

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -866,7 +866,9 @@ static ExitCode InitializeNodeWithArgsInternal(
 
     for (const auto& file_path : file_paths) {
       std::string path = cwd + kPathSeparator + file_path;
-      per_process::dotenv_file.ParsePath(path);
+      auto path_exists = per_process::dotenv_file.ParsePath(path);
+
+      if (!path_exists) errors->push_back(file_path + ": not found");
     }
 
     per_process::dotenv_file.AssignNodeOptionsIfAvailable(&node_options);

--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -64,14 +64,14 @@ void Dotenv::SetEnvironment(node::Environment* env) {
   }
 }
 
-void Dotenv::ParsePath(const std::string_view path) {
+bool Dotenv::ParsePath(const std::string_view path) {
   uv_fs_t req;
   auto defer_req_cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
 
   uv_file file = uv_fs_open(nullptr, &req, path.data(), 0, 438, nullptr);
   if (req.result < 0) {
     // req will be cleaned up by scope leave.
-    return;
+    return false;
   }
   uv_fs_req_cleanup(&req);
 
@@ -89,7 +89,7 @@ void Dotenv::ParsePath(const std::string_view path) {
     auto r = uv_fs_read(nullptr, &req, file, &buf, 1, -1, nullptr);
     if (req.result < 0) {
       // req will be cleaned up by scope leave.
-      return;
+      return false;
     }
     uv_fs_req_cleanup(&req);
     if (r <= 0) {
@@ -104,6 +104,7 @@ void Dotenv::ParsePath(const std::string_view path) {
   for (const auto& line : lines) {
     ParseLine(line);
   }
+  return true;
 }
 
 void Dotenv::AssignNodeOptionsIfAvailable(std::string* node_options) {

--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -18,7 +18,7 @@ class Dotenv {
   Dotenv& operator=(const Dotenv& d) = default;
   ~Dotenv() = default;
 
-  void ParsePath(const std::string_view path);
+  bool ParsePath(const std::string_view path);
   void AssignNodeOptionsIfAvailable(std::string* node_options);
   void SetEnvironment(Environment* env);
 

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -34,8 +34,8 @@ describe('.env supports edge cases', () => {
       [ '--env-file=.env', '--eval', code ],
       { cwd: __dirname },
     );
-    assert.strictEqual(child.stderr, '');
-    assert.strictEqual(child.code, 0);
+    assert.notStrictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.code, 9);
   });
 
   it('should not override existing environment variables but introduce new vars', async () => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Motivated by https://github.com/nodejs/node/issues/50536

NodeJS currently supports env file parsing. However, in cases where the file is missing, the process continues to execute. Since the env file is a crucial file, I propose that we return an error if the env file is missing. This will prevent errors in the future and allow us to detect them as early as possible. 

Testing Scenario:

Given files tree:
```
└── test/
    ├── hello.js
    └── test.env
```
run:  `node --env-file=test.env hello.js  `   
output: it will executed

```

└── test/
    ├── hello.js
    └── test.env
```
run:  `node --env-file=oops.env hello.js  `   
output: node: oops.env not found

```

└── test/
    ├── hello.js
    └── test.env
    └── test1.env
```
run:  `node --env-file=test.env --env-file=test1.env hello.js  `   
output: it will executed

```
└── test/
    ├── hello.js
    └── test.env
    └── test1.env
```

run:  `node --env-file=test.env --env-file=oops.env hello.js  `   
output: node: oops.env not found
