### PR TITLE
lib: remove deprecated string methods

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -38,7 +38,7 @@ const {
   StringPrototypeIndexOf,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
-  StringPrototypeSubstr,
+  StringPrototypeSubstring,
   Symbol,
 } = primordials;
 
@@ -363,7 +363,7 @@ function calculateServerName(options, req) {
         // Leading '[', but no ']'. Need to do something...
         servername = hostHeader;
       } else {
-        servername = StringPrototypeSubstr(hostHeader, 1, index - 1);
+        servername = StringPrototypeSubstring(hostHeader, 1, index);
       }
     } else {
       servername = StringPrototypeSplit(hostHeader, ':', 1)[0];

--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -11,7 +11,7 @@ const {
   RegExpPrototypeSymbolReplace,
   StringPrototypeLocaleCompare,
   StringPrototypeSlice,
-  StringPrototypeTrimLeft,
+  StringPrototypeTrimStart,
   StringPrototypeRepeat,
   SafeMap,
 } = primordials;
@@ -180,7 +180,7 @@ function format(
     else
       text += StringPrototypeRepeat(' ', firstColumn - displayName.length);
 
-    text += StringPrototypeTrimLeft(
+    text += StringPrototypeTrimStart(
       indent(fold(displayHelpText, secondColumn), firstColumn)) + '\n';
   }
 

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -90,7 +90,7 @@ const {
   StringPrototypeSplit,
   StringPrototypeStartsWith,
   StringPrototypeTrim,
-  StringPrototypeTrimLeft,
+  StringPrototypeTrimStart,
   StringPrototypeToLocaleLowerCase,
   Symbol,
   SyntaxError,
@@ -1326,7 +1326,7 @@ function complete(line, callback) {
   let completeOn, group;
 
   // Ignore right whitespace. It could change the outcome.
-  line = StringPrototypeTrimLeft(line);
+  line = StringPrototypeTrimStart(line);
 
   let filter = '';
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Below String methods are deprecated
* substr - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
* trimleft

