### PR TITLE
test: replace forEach in whatwg-encoding-custom-interop

### DIFF
--- a/test/parallel/test-whatwg-encoding-custom-interop.js
+++ b/test/parallel/test-whatwg-encoding-custom-interop.js
@@ -56,9 +56,9 @@ assert(TextEncoder);
   encodingGetter.call(instance);
 
   const invalidThisArgs = [{}, [], true, 1, '', new TextDecoder()];
-  invalidThisArgs.forEach((i) => {
+  for (const i of invalidThisArgs) {
     assert.throws(() => inspectFn.call(i, Infinity, {}), expectedError);
     assert.throws(() => encodeFn.call(i), expectedError);
     assert.throws(() => encodingGetter.call(i), expectedError);
-  });
+  }
 }


### PR DESCRIPTION
Replaced forEach with for of in `test/parallel/test-whatwg-encoding-custom-interop.js`.

[#nodeConfEu](https://nodeconf.eu/)