### PR TITLE
tools: fix --v8-non-optimized-debug for v18.x

### DIFF
--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -76,6 +76,11 @@
     # Set to 1 to enable DCHECKs in release builds.
     'dcheck_always_on%': 0,
 
+    # For v18.x, disable SLOW_DCHECKs because they don't compile without
+    # the patches in https://bugs.chromium.org/p/v8/issues/detail?id=12887
+    # if used in constexpr, which can happen in other floated patches.
+    'v8_enable_slow_dchecks%': 0,
+
     # Sets -DV8_ENABLE_FUTURE.
     'v8_enable_future%': 0,
 


### PR DESCRIPTION
Disable SLOW_DCHECKs on v18.x because they don't compile without the patches in https://bugs.chromium.org/p/v8/issues/detail?id=12887 if used in constexpr, which can happen in other floated patches.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
