### PR TITLE
build: disable flag v8_scriptormodule_legacy_lifetime

### DIFF
--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -270,7 +270,7 @@
     # Enable global allocation site tracking.
     'v8_allocation_site_tracking%': 1,
 
-    'v8_scriptormodule_legacy_lifetime%': 1,
+    'v8_scriptormodule_legacy_lifetime%': 0,
 
     # Change code emission and runtime features to be CET shadow-stack compliant
     # (incomplete and experimental).


### PR DESCRIPTION
Usages of `v8::ScriptOrModule` were removed in https://github.com/nodejs/node/pull/44198
so the flag can be disabled by default.