### PR TITLE
module: add `releaseLoadedModule`

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -107,6 +107,18 @@ changes:
 Register a module that exports [hooks][] that customize Node.js module
 resolution and loading behavior. See [Customization hooks][].
 
+### `module.releaseResolvedModule(resolvedURL)`
+
+<!-- YAML
+added: x.x.x
+-->
+
+> Stability: 1 - Experimental
+
+* `resolvedURL` {string} The fully-resolved URL of a module.
+
+Clears the given module from the ESM resolve and load caches.
+
 ### `module.syncBuiltinESMExports()`
 
 <!-- YAML

--- a/lib/internal/modules/esm/assert.js
+++ b/lib/internal/modules/esm/assert.js
@@ -17,6 +17,7 @@ const {
 
 // The HTML spec has an implied default type of `'javascript'`.
 const kImplicitAssertType = 'javascript';
+const kAnyAssertType = '';
 
 /**
  * Define a map of module formats to import attributes types (the value of
@@ -112,5 +113,6 @@ function handleInvalidType(url, type) {
 
 module.exports = {
   kImplicitAssertType,
+  kAnyAssertType,
   validateAttributes,
 };

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -20,6 +20,7 @@ const {
   ERR_REQUIRE_ESM,
   ERR_UNKNOWN_MODULE_FORMAT,
 } = require('internal/errors').codes;
+const { kAnyAssertType } = require('internal/modules/esm/assert');
 const { getOptionValue } = require('internal/options');
 const { pathToFileURL, isURL } = require('internal/url');
 const { emitExperimentalWarning } = require('internal/util');
@@ -224,22 +225,11 @@ class ModuleLoader {
   }
 
   /**
-   * Evict saved result of `resolve` and `load` for the given import parameters.
+   * Evict saved result of `resolve` and `load` for the given resolved URL.
    */
-  evict(specifier, parentURL, importAttributes = {}) {
-    let resolved;
-    try {
-      resolved = this.resolveSync(specifier, parentURL, importAttributes);
-    } catch {
-      return false;
-    }
-    const requestKey = this.#resolveCache.serializeKey(specifier, importAttributes);
-    let didEvict = this.#resolveCache.delete(requestKey, parentURL);
-    if (this.loadCache.delete(resolved.url, importAttributes.type)) {
-      // nb: Careful with short-circuits here, we want to run both deletes unconditionally.
-      didEvict = true;
-    }
-    return didEvict;
+  evict(resolvedURL) {
+    this.#resolveCache.clearResolvedURL(resolvedURL);
+    this.loadCache.delete(resolvedURL, kAnyAssertType);
   }
 
   /**
@@ -638,16 +628,17 @@ function register(specifier, parentURL = undefined, options) {
 }
 
 /**
- * Release saved results of `resolve` and `load` for the given import parameters.
+ * Release saved results of `resolve` and `load` for the given resolved module
+ * URL.
  */
-function releaseLoadedModule(specifier, parentURL, importAssertions) {
+function releaseResolvedModule(resolvedURL) {
   const moduleLoader = require('internal/process/esm_loader').esmLoader;
-  return moduleLoader.evict(specifier, parentURL, importAssertions);
+  return moduleLoader.evict(resolvedURL);
 }
 
 module.exports = {
   createModuleLoader,
   getHooksProxy,
   register,
-  releaseLoadedModule,
+  releaseResolvedModule,
 };

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -224,6 +224,25 @@ class ModuleLoader {
   }
 
   /**
+   * Evict saved result of `resolve` and `load` for the given import parameters.
+   */
+  evict(specifier, parentURL, importAttributes = {}) {
+    let resolved;
+    try {
+      resolved = this.resolveSync(specifier, parentURL, importAttributes);
+    } catch {
+      return false;
+    }
+    const requestKey = this.#resolveCache.serializeKey(specifier, importAttributes);
+    let didEvict = this.#resolveCache.delete(requestKey, parentURL);
+    if (this.loadCache.delete(resolved.url, importAttributes.type)) {
+      // nb: Careful with short-circuits here, we want to run both deletes unconditionally.
+      didEvict = true;
+    }
+    return didEvict;
+  }
+
+  /**
    * Get a (possibly still pending) module job from the cache,
    * or create one and return its Promise.
    * @param {string} specifier The string after `from` in an `import` statement,
@@ -618,8 +637,17 @@ function register(specifier, parentURL = undefined, options) {
   );
 }
 
+/**
+ * Release saved results of `resolve` and `load` for the given import parameters.
+ */
+function releaseLoadedModule(specifier, parentURL, importAssertions) {
+  const moduleLoader = require('internal/process/esm_loader').esmLoader;
+  return moduleLoader.evict(specifier, parentURL, importAssertions);
+}
+
 module.exports = {
   createModuleLoader,
   getHooksProxy,
   register,
+  releaseLoadedModule,
 };

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -8,7 +8,10 @@ const {
   ObjectKeys,
   SafeMap,
 } = primordials;
-const { kImplicitAssertType } = require('internal/modules/esm/assert');
+const {
+  kImplicitAssertType,
+  kAnyAssertType,
+} = require('internal/modules/esm/assert');
 let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
@@ -60,14 +63,24 @@ class ResolveCache extends SafeMap {
   }
 
   /**
-   * @param {string} serializedKey
    * @param {string} parentURL
-   * @returns {boolean}
    */
-  delete(serializedKey, parentURL) {
-    const has = this.has(serializedKey, parentURL);
-    delete this.#getModuleCachedImports(parentURL)[serializedKey];
-    return has;
+  clearResolvedURL(resolvedURL) {
+    for (const entry of this.entries()) {
+      const internalCache = entry[1];
+      let isEmpty = true;
+      for (const serializedKey of ObjectKeys(internalCache)) {
+        if (internalCache[serializedKey].url === resolvedURL) {
+          delete internalCache[serializedKey];
+        } else {
+          isEmpty = false;
+        }
+      }
+      if (isEmpty) {
+        const parentURL = entry[0];
+        this.delete(parentURL);
+      }
+    }
   }
 
   /**
@@ -104,6 +117,10 @@ class LoadCache extends SafeMap {
     validateString(type, 'type');
     const cachedJobsForUrl = super.get(url);
     if (cachedJobsForUrl) {
+      if (type === kAnyAssertType) {
+        super.delete(url);
+        return true;
+      }
       const has = type in cachedJobsForUrl;
       delete cachedJobsForUrl[type];
       return has;

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -62,6 +62,17 @@ class ResolveCache extends SafeMap {
   /**
    * @param {string} serializedKey
    * @param {string} parentURL
+   * @returns {boolean}
+   */
+  delete(serializedKey, parentURL) {
+    const has = this.has(serializedKey, parentURL);
+    delete this.#getModuleCachedImports(parentURL)[serializedKey];
+    return has;
+  }
+
+  /**
+   * @param {string} serializedKey
+   * @param {string} parentURL
    * @returns {import('./loader').ModuleExports | Promise<import('./loader').ModuleExports>}
    */
   get(serializedKey, parentURL) {
@@ -88,6 +99,18 @@ class ResolveCache extends SafeMap {
  */
 class LoadCache extends SafeMap {
   constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+  delete(url, type = kImplicitAssertType) {
+    validateString(url, 'url');
+    validateString(type, 'type');
+    const cachedJobsForUrl = super.get(url);
+    if (cachedJobsForUrl) {
+      const has = type in cachedJobsForUrl;
+      delete cachedJobsForUrl[type];
+      return has;
+    } else {
+      return false;
+    }
+  }
   get(url, type = kImplicitAssertType) {
     validateString(url, 'url');
     validateString(type, 'type');

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -63,7 +63,7 @@ class ResolveCache extends SafeMap {
   }
 
   /**
-   * @param {string} parentURL
+   * @param {string} resolvedURL
    */
   clearResolvedURL(resolvedURL) {
     for (const entry of this.entries()) {

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -107,9 +107,8 @@ class LoadCache extends SafeMap {
       const has = type in cachedJobsForUrl;
       delete cachedJobsForUrl[type];
       return has;
-    } else {
-      return false;
     }
+    return false;
   }
   get(url, type = kImplicitAssertType) {
     validateString(url, 'url');

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,11 +2,11 @@
 
 const { findSourceMap } = require('internal/source_map/source_map_cache');
 const { Module } = require('internal/modules/cjs/loader');
-const { releaseLoadedModule, register } = require('internal/modules/esm/loader');
+const { releaseResolvedModule, register } = require('internal/modules/esm/loader');
 const { SourceMap } = require('internal/source_map/source_map');
 
 Module.findSourceMap = findSourceMap;
 Module.register = register;
-Module.releaseLoadedModule = releaseLoadedModule;
+Module.releaseResolvedModule = releaseResolvedModule;
 Module.SourceMap = SourceMap;
 module.exports = Module;

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,10 +2,11 @@
 
 const { findSourceMap } = require('internal/source_map/source_map_cache');
 const { Module } = require('internal/modules/cjs/loader');
-const { register } = require('internal/modules/esm/loader');
+const { releaseLoadedModule, register } = require('internal/modules/esm/loader');
 const { SourceMap } = require('internal/source_map/source_map');
 
 Module.findSourceMap = findSourceMap;
 Module.register = register;
+Module.releaseLoadedModule = releaseLoadedModule;
 Module.SourceMap = SourceMap;
 module.exports = Module;

--- a/test/es-module/test-esm-evict.mjs
+++ b/test/es-module/test-esm-evict.mjs
@@ -1,0 +1,16 @@
+import { strictEqual } from 'node:assert';
+import { releaseLoadedModule } from 'node:module';
+
+const specifier = "data:application/javascript,export default globalThis.value;";
+
+globalThis.value = 1;
+const instance1 = await import(specifier);
+strictEqual(instance1.default, 1);
+globalThis.value = 2;
+const instance2 = await import(specifier);
+strictEqual(instance2.default, 1);
+
+strictEqual(releaseLoadedModule(specifier, import.meta.url), true);
+strictEqual(releaseLoadedModule(specifier, import.meta.url), false);
+const instance3 = await import(specifier);
+strictEqual(instance3.default, 2);

--- a/test/es-module/test-esm-evict.mjs
+++ b/test/es-module/test-esm-evict.mjs
@@ -1,6 +1,6 @@
 import '../common/index.mjs';
 import { strictEqual } from 'node:assert';
-import { releaseLoadedModule } from 'node:module';
+import { releaseResolvedModule } from 'node:module';
 
 const specifier = 'data:application/javascript,export default globalThis.value;';
 
@@ -11,7 +11,7 @@ globalThis.value = 2;
 const instance2 = await import(specifier);
 strictEqual(instance2.default, 1);
 
-strictEqual(releaseLoadedModule(specifier, import.meta.url), true);
-strictEqual(releaseLoadedModule(specifier, import.meta.url), false);
+releaseResolvedModule(specifier);
 const instance3 = await import(specifier);
 strictEqual(instance3.default, 2);
+delete globalThis.value;

--- a/test/es-module/test-esm-evict.mjs
+++ b/test/es-module/test-esm-evict.mjs
@@ -1,7 +1,8 @@
+import '../common/index.mjs';
 import { strictEqual } from 'node:assert';
 import { releaseLoadedModule } from 'node:module';
 
-const specifier = "data:application/javascript,export default globalThis.value;";
+const specifier = 'data:application/javascript,export default globalThis.value;';
 
 globalThis.value = 1;
 const instance1 = await import(specifier);


### PR DESCRIPTION
This is a new utility as discussed in #49442 which provides the ability to release a loaded module. Releasing a module means that it can be garbage collected (if it is abandoned) and reloaded (by importing it again with the same specifier).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
