### PR TITLE
buffer: improve `Buffer.equals` performance

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -860,11 +860,11 @@ Buffer.prototype.equals = function equals(otherBuffer) {
 
   if (this === otherBuffer)
     return true;
-
-  if (this.byteLength !== otherBuffer.byteLength)
+  const len = TypedArrayPrototypeGetByteLength(this);
+  if (len !== TypedArrayPrototypeGetByteLength(otherBuffer))
     return false;
 
-  return this.byteLength === 0 || _compare(this, otherBuffer) === 0;
+  return len === 0 || _compare(this, otherBuffer) === 0;
 };
 
 let INSPECT_MAX_BYTES = 50;


### PR DESCRIPTION
improve `Buffer.equals` performance:

```shell
                                                              confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-equals.js n=1000000 difflen='false' size=0            ***    147.60 %       ±1.94% ±2.58% ±3.37%
buffers/buffer-equals.js n=1000000 difflen='false' size=16386        ***      5.47 %       ±2.92% ±3.93% ±5.22%
buffers/buffer-equals.js n=1000000 difflen='false' size=512          ***     34.73 %       ±0.85% ±1.13% ±1.48%
buffers/buffer-equals.js n=1000000 difflen='true' size=0             ***     82.37 %       ±3.70% ±4.98% ±6.60%
buffers/buffer-equals.js n=1000000 difflen='true' size=16386         ***     85.01 %       ±1.84% ±2.45% ±3.19%
buffers/buffer-equals.js n=1000000 difflen='true' size=512           ***     82.84 %       ±3.14% ±4.20% ±5.53%
```

As mentioned in #50620 , the performance regression of `Buffer.byteLength` might be due 
to `ArrayBufferView.byteLength`, reduce the property access of `Buffer.byteLength`
helps to reduce regression for `Buffer.equals`

Inspired by the comment from @aduh95, using `TypedArrayPrototypeGetByteLength `
also improves performance.

Refs: #50620 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
