### PR TITLE
tools: add staple to macOS notarized binaries

### DIFF
--- a/tools/osx-notarize.sh
+++ b/tools/osx-notarize.sh
@@ -53,3 +53,6 @@ else
   echo "Notarization node-$pkgid.pkg failed."
   exit 1
 fi
+
+xcrun stapler staple "node-$pkgid.pkg"
+echo "Stapler was successful."

--- a/tools/osx-notarize.sh
+++ b/tools/osx-notarize.sh
@@ -48,7 +48,6 @@ xcrun notarytool submit \
 
 if [ $? -eq 0 ]; then
   echo "Notarization node-$pkgid.pkg submitted successfully."
-  exit 0
 else
   echo "Notarization node-$pkgid.pkg failed."
   exit 1


### PR DESCRIPTION
### Main Changes

Added Staple for the notarized binaries in macOS.

cc: @nodejs/build @nodejs/releasers 

### Context

> [Gatekeeper](https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web?ref=tonygo.ghost.io) will perform a check for a notarization ticket online. If it can't reach the server (due to no internet connection, for example), and if the ticket isn't stapled to the app, macOS will prevent the app from running because it can't verify that it is notarized.

You can find more information in this amazing article https://tonygo.ghost.io/notarization-for-macos-app-with-notarytool/ by @tony-go

### Notes

I am working in a separate PR for the validation of the binaries


### Test

This was tested in `iojs+release-ulises-experimental` pipeline in jenkins ci release.

Full log available [here](https://ci-release.nodejs.org/job/iojs+release-ulises-experimental/12/nodes=osx11-release-pkg/console)

```
14:27:03 sh tools/osx-notarize.sh v22.0.0-test202311086410f3bf0d
14:27:03 Notarization process is done with Notarytool.
14:27:03 Submitting node-v22.0.0-test202311086410f3bf0d.pkg for notarization...
14:27:03 Conducting pre-submission checks for node-v22.0.0-test202311086410f3bf0d.pkg and initiating connection to the Apple notary service...
14:27:05 Submission ID received
14:27:05   id: 28708d84-5489-4e4a-b1cc-fe1fa5d840d9
14:27:11 Successfully uploaded file
14:27:11   id: 28708d84-5489-4e4a-b1cc-fe1fa5d840d9
14:27:11   path: /Users/iojs/build/ws/node-v22.0.0-test202311086410f3bf0d.pkg
14:27:11 Waiting for processing to complete.
14:27:17 
Current status: In Progress...
Current status: In Progress....
Current status: In Progress.....
Current status: In Progress......
Current status: In Progress.......
Current status: In Progress........
Current status: In Progress.........
Current status: In Progress..........
Current status: In Progress...........
Current status: In Progress............
Current status: In Progress.............
Current status: In Progress..............
Current status: Accepted...............Processing complete
14:28:57   id: 28708d84-5489-4e4a-b1cc-fe1fa5d840d9
14:28:57   status: Accepted
14:28:57 
14:28:57 Notarization node-v22.0.0-test202311086410f3bf0d.pkg submitted successfully.
14:28:57 Processing: /Users/iojs/build/ws/node-v22.0.0-test202311086410f3bf0d.pkg
14:28:57 Processing: /Users/iojs/build/ws/node-v22.0.0-test202311086410f3bf0d.pkg
14:28:58 The staple and validate action worked!
14:28:58 Stapler was successful.
[...redacted...]
14:29:10 Finished: SUCCESS
```