### PR TITLE
lib: fix assert throwing different error messages in ESM and CJS

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -73,6 +73,7 @@ const CallTracker = require('internal/assert/calltracker');
 const {
   validateFunction,
 } = require('internal/validators');
+const { fileURLToPath } = require('internal/url');
 
 let isDeepEqual;
 let isDeepStrictEqual;
@@ -296,7 +297,7 @@ function getErrMessage(message, fn) {
   overrideStackTrace.set(err, (_, stack) => stack);
   const call = err.stack[0];
 
-  const filename = call.getFileName();
+  let filename = call.getFileName();
   const line = call.getLineNumber() - 1;
   let column = call.getColumnNumber() - 1;
   let identifier;
@@ -330,6 +331,14 @@ function getErrMessage(message, fn) {
         const { StringDecoder } = require('string_decoder');
         decoder = new StringDecoder('utf8');
       }
+
+      // ESM file prop is a file proto. Convert that to path.
+      // This ensure opensync will not throw ENOENT for ESM files.
+      const fileProtoPrefix = 'file://';
+      if (StringPrototypeStartsWith(filename, fileProtoPrefix)) {
+        filename = fileURLToPath(filename);
+      }
+
       fd = openSync(filename, 'r', 0o666);
       // Reset column and message.
       ({ 0: column, 1: message } = getCode(fd, line, column));

--- a/test/parallel/test-assert-esm-cjs-message-verify.js
+++ b/test/parallel/test-assert-esm-cjs-message-verify.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { spawnPromisified } = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const { writeFileSync, unlink } = require('fs');
+const { describe, after, it } = require('node:test');
+
+tmpdir.refresh();
+
+const fileImports = {
+  cjs: 'const assert = require("assert");',
+  mjs: 'import assert from "assert";',
+};
+
+const fileNames = [];
+
+for (const [ext, header] of Object.entries(fileImports)) {
+  const fileName = `test-file.${ext}`;
+  // Store the generated filesnames in an array
+  fileNames.push(`${tmpdir.path}/${fileName}`);
+
+  writeFileSync(tmpdir.resolve(fileName), `${header}\nassert.ok(0 === 2);`);
+}
+
+describe('ensure the assert.ok throwing similar error messages for esm and cjs files', () => {
+  const nodejsPath = `${process.execPath}`;
+  const errorsMessages = [];
+
+  it('should return code 1 for each command', async () => {
+    for (const fileName of fileNames) {
+      const { stderr, code } = await spawnPromisified(nodejsPath, [fileName]);
+      assert.strictEqual(code, 1);
+      // For each error message, filter the lines which will starts with AssertionError
+      errorsMessages.push(
+        stderr.split('\n').find((s) => s.startsWith('AssertionError'))
+      );
+    }
+  });
+
+  after(() => {
+    assert.strictEqual(errorsMessages.length, 2);
+    assert.deepStrictEqual(errorsMessages[0], errorsMessages[1]);
+
+    for (const fileName of fileNames) {
+      unlink(fileName, () => {});
+    }
+
+    tmpdir.refresh();
+  });
+});


### PR DESCRIPTION
This PR addresses issue #50593, which was caused by the design in the ESM loader.
The ESM loader was modifying the file path and replacing the 'file' property with the file proto in the stack trace.
This, in turn, led to unhandled exceptions when the assert module attempted to open the file to display erroneous code.

The changes in this PR resolve this issue by handling the file path correctly, ensuring that the remaining message formatting code can execute as expected.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
