### PR TITLE
esm: mordernise old tests

### DIFF
--- a/test/es-module/test-esm-type-field-errors.js
+++ b/test/es-module/test-esm-type-field-errors.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const exec = require('child_process').execFile;
+const { describe, it } = require('node:test');
 
 const mjsFile = require.resolve('../fixtures/es-modules/mjs-file.mjs');
 const cjsFile = require.resolve('../fixtures/es-modules/cjs-file.cjs');
@@ -13,25 +14,48 @@ const packageTypeModuleMain =
   require.resolve('../fixtures/es-modules/package-type-module/index.js');
 
 // Check that running `node` without options works
-expect('', mjsFile, '.mjs file');
-expect('', cjsFile, '.cjs file');
-expect('', packageTypeModuleMain, 'package-type-module');
-expect('', packageTypeCommonJsMain, 'package-type-commonjs');
-expect('', packageWithoutTypeMain, 'package-without-type');
+describe('ESM type field errors', { concurrency: true }, () => {
+  it('.cjs file', () => {
+    expect('', cjsFile, '.cjs file');
+  });
 
-// Check that --input-type isn't allowed for files
-expect('--input-type=module', packageTypeModuleMain,
-       'ERR_INPUT_TYPE_NOT_ALLOWED', true);
+  it('.mjs file', () => {
+    expect('', mjsFile, '.mjs file');
+  });
 
-try {
-  require('../fixtures/es-modules/package-type-module/index.js');
-  assert.fail('Expected CJS to fail loading from type: module package.');
-} catch (e) {
-  assert.strictEqual(e.name, 'Error');
-  assert.strictEqual(e.code, 'ERR_REQUIRE_ESM');
-  assert(e.toString().match(/require\(\) of ES Module/g));
-  assert(e.message.match(/require\(\) of ES Module/g));
-}
+  it('package.json with "type": "module"', () => {
+    expect('', packageTypeModuleMain, 'package-type-module');
+  });
+
+  it('package.json with "type": "commonjs"', () => {
+    expect('', packageTypeCommonJsMain, 'package-type-commonjs');
+  });
+
+  it('package.json with no "type" field', () => {
+    expect('', packageWithoutTypeMain, 'package-without-type');
+  });
+
+  it('--input-type=module disallowed for files', () => {
+    expect(
+      '--input-type=module',
+      packageTypeModuleMain,
+      'ERR_INPUT_TYPE_NOT_ALLOWED',
+      true,
+    );
+  });
+
+  it('--input-type=module disallowed for directories', () => {
+    try {
+      require('../fixtures/es-modules/package-type-module/index.js');
+      assert.fail('Expected CJS to fail loading from type: module package.');
+    } catch (e) {
+      assert.match(e.toString(), /require\(\) of ES Module/g);
+      assert.match(e.message, /require\(\) of ES Module/g);
+      assert.strictEqual(e.code, 'ERR_REQUIRE_ESM');
+      assert.strictEqual(e.name, 'Error');
+    }
+  });
+});
 
 function expect(opt = '', inputFile, want, wantsError = false) {
   const argv = [inputFile];


### PR DESCRIPTION
My goal is to improve DX and performance. The way old tests were written makes them very difficult to figure out what they're even asserting and, when they're failing, why.

Converting them to node's test runner in concurrent mode should on its own improve run-time (the first test I ported, which is quite a small test, improved its run-time by ~10%).