### PR TITLE
doc (test_runner): shards not supported with watch mode

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1142,6 +1142,11 @@ changes:
       of shards to split the test files to. This option is _required_.
 * Returns: {TestsStream}
 
+**Note:** `shard` is used to horizontally parallelize test running across
+machines or processes, ideal for large-scale executions across varied
+environments. It's incompatible with `watch` mode, tailored for rapid
+code iteration by automatically rerunning tests on file changes.
+
 ```mjs
 import { tap } from 'node:test/reporters';
 import { run } from 'node:test';


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Affected URL: [https://nodejs.org/docs/latest-v20.x/api/test.html#runoptions](https://nodejs.org/docs/latest-v20.x/api/test.html#runoptions)

It's not mention that we can use shard with watch mode.

**Code:**

```js
import { tap } from 'node:test/reporters'
import { run } from 'node:test';
import path from 'node:path'

const options = {
  concurrency: 2, // Run 2 test files in parallel
  files: [path.resolve('./index.mjs')], // Specify the test file to run
  setup: (testStream) => {
    console.log("test stream ==>",testStream)
    // Setup listeners before running tests
    testStream.on('test-start', (test) => {
      console.log(`Starting test: ${test.name}`);
    });
  },
  timeout: 5000, // Set a timeout of 5 seconds for test execution
  watch: true, // Enable watch mode
  shard: {
    index: 1, // Index of the shard to run
    total: 2, // Total number of shards
  },
};

run(options)
  .compose(tap)
  .pipe(process.stdout);

```

**error:**

```bash
node:internal/test_runner/runner:466
      throw new ERR_INVALID_ARG_VALUE('options.shard', watch, 'shards not supported with watch mode');
            ^

TypeError [ERR_INVALID_ARG_VALUE]: The property 'options.shard' shards not supported with watch mode. Received true
    at run (node:internal/test_runner/runner:466:13)
    at file:///Users/pulkitgupta/Desktop/node/index.test.mjs:23:1
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:7)
    at async handleMainPromise (node:internal/modules/run_main:113:12) {
  code: 'ERR_INVALID_ARG_VALUE'
}

Node.js v22.0.0-pre
```

