### PR TITLE
docs: more explicit slice vs subarray message directly on buffer.slice

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3467,14 +3467,16 @@ changes:
   **Default:** [`buf.length`][].
 * Returns: {Buffer}
 
-> Stability: 0 - Deprecated: Use [`buf.subarray`][] instead.
+> Stability: 0 - Deprecated: Instead, use either [`buf.subarray`][] for a
+> mutable view or `Uint8Array.prototype.slice.call(buf, ...)` for a new copy.
 
 Returns a new `Buffer` that references the same memory as the original, but
 offset and cropped by the `start` and `end` indices.
 
-This method is not compatible with the `Uint8Array.prototype.slice()`,
-which is a superclass of `Buffer`. To copy the slice, use
-`Uint8Array.prototype.slice()`.
+Although `Uint8Array` is a superclass of `Buffer`, the `.slice` method
+has different behavior. `Uint8Array.prototype.slice()` makes a copy of
+memory, but `Buffer.prototype.slice()` does not. To copy memory, always
+use `Uint8Array.prototype.slice.call`.
 
 ```mjs
 import { Buffer } from 'node:buffer';

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -3475,7 +3475,7 @@ offset and cropped by the `start` and `end` indices.
 
 Although `Uint8Array` is a superclass of `Buffer`, the `.slice` method
 has different behavior. `Uint8Array.prototype.slice()` makes a copy of
-memory, but `Buffer.prototype.slice()` does not. To copy memory, always
+memory, but `Buffer.prototype.slice()` does not. To copy memory,
 use `Uint8Array.prototype.slice.call`.
 
 ```mjs


### PR DESCRIPTION
There was already a detailed message on the page about Buffer vs Uint8Array, but not much detail on the buf.slice method itself. I added more detail there, because usually that's the only thing you'll see.

Feel free of course to make any changes to this as you see fit; no need to check with me.