### PR TITLE
policy: add WDAC integration on Windows

### DIFF
--- a/deps/uv/include/uv.h
+++ b/deps/uv/include/uv.h
@@ -1885,6 +1885,9 @@ struct uv_loop_s {
 UV_EXTERN void* uv_loop_get_data(const uv_loop_t*);
 UV_EXTERN void uv_loop_set_data(uv_loop_t*, void* data);
 
+UV_EXTERN int uv_is_file_trusted_by_umci(char*, char*, int*);
+UV_EXTERN int uv_is_node_umci_on_by_policy();
+
 /* Don't export the private CPP symbols. */
 #undef UV_HANDLE_TYPE_PRIVATE
 #undef UV_REQ_TYPE_PRIVATE

--- a/deps/uv/src/unix/core.c
+++ b/deps/uv/src/unix/core.c
@@ -1778,3 +1778,14 @@ unsigned int uv_available_parallelism(void) {
   return (unsigned) rc;
 #endif  /* __linux__ */
 }
+
+int uv_is_file_trusted_by_umci(char * policyFilePath, char * policySignaturePath, int * isFileTrusted) {
+  *isFileTrusted = 0;
+  return 0;
+}
+
+int uv_is_node_umci_on_by_policy() {
+  return 0;
+}
+
+

--- a/deps/uv/src/win/winapi.c
+++ b/deps/uv/src/win/winapi.c
@@ -48,12 +48,18 @@ sSetWinEventHook pSetWinEventHook;
 /* ws2_32.dll function pointer */
 uv_sGetHostNameW pGetHostNameW;
 
+/* Wldp.dll function pointer */
+sWldpCanExecuteFileFromDetachedSignature pWldpCanExecuteFileFromDetachedSignature;
+sWldpGetApplicationSettingBoolean pWldpGetApplicationSettingBoolean;
+sWldpQuerySecurityPolicy pWldpQuerySecurityPolicy;
+
 void uv__winapi_init(void) {
   HMODULE ntdll_module;
   HMODULE powrprof_module;
   HMODULE user32_module;
   HMODULE kernel32_module;
   HMODULE ws2_32_module;
+  HMODULE wldp_module;
 
   ntdll_module = GetModuleHandleA("ntdll.dll");
   if (ntdll_module == NULL) {
@@ -143,5 +149,17 @@ void uv__winapi_init(void) {
     pGetHostNameW = (uv_sGetHostNameW) GetProcAddress(
         ws2_32_module,
         "GetHostNameW");
+  }
+
+  wldp_module = LoadLibraryExA("wldp.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+  if (wldp_module != NULL) {
+    pWldpCanExecuteFileFromDetachedSignature = (sWldpCanExecuteFileFromDetachedSignature)
+      GetProcAddress(wldp_module, "WldpCanExecuteFileFromDetachedSignature");
+
+    pWldpGetApplicationSettingBoolean = (sWldpGetApplicationSettingBoolean)
+      GetProcAddress(wldp_module, "WldpGetApplicationSettingBoolean");
+
+    pWldpQuerySecurityPolicy = (sWldpQuerySecurityPolicy)
+      GetProcAddress(wldp_module, "WldpQuerySecurityPolicy");
   }
 }

--- a/deps/uv/src/win/winapi.h
+++ b/deps/uv/src/win/winapi.h
@@ -4732,6 +4732,67 @@ typedef struct _TCP_INITIAL_RTO_PARAMETERS {
   UCHAR  MaxSynRetransmissions;
 } TCP_INITIAL_RTO_PARAMETERS, *PTCP_INITIAL_RTO_PARAMETERS;
 
+// {0xb5367df1,0xcbac,0x11cf,{0x95,0xca,0x00,0x80,0x5f,0x48,0xa1,0x92}}
+
+#define WLDP_HOST_OTHER \
+    {0x626cbec3, 0xe1fa, 0x4227, {0x98, 0x0, 0xed, 0x21, 0x2, 0x74, 0xcf, 0x7c}};
+
+//
+// Enumeration types for WldpCanExecuteFile
+//
+typedef enum WLDP_EXECUTION_POLICY {
+    WLDP_EXECUTION_POLICY_BLOCKED,
+    WLDP_EXECUTION_POLICY_ALLOWED,
+    WLDP_EXECUTION_POLICY_REQUIRE_SANDBOX,
+} WLDP_EXECUTION_POLICY;
+
+typedef enum WLDP_EXECUTION_EVALUATION_OPTIONS {
+    WLDP_EXECUTION_EVALUATION_OPTION_NONE = 0x0,
+    WLDP_EXECUTION_EVALUATION_OPTION_EXECUTE_IN_INTERACTIVE_SESSION = 0x1,
+} WLDP_EXECUTION_EVALUATION_OPTIONS;
+
+typedef HRESULT(WINAPI *sWldpCanExecuteFileFromDetachedSignature)(
+    _In_ REFGUID host,
+    _In_ WLDP_EXECUTION_EVALUATION_OPTIONS options,
+    _In_ HANDLE contentFileHandle,
+    _In_ HANDLE signatureFileHandle,
+    _In_opt_ PCWSTR auditInfo,
+    _Out_ WLDP_EXECUTION_POLICY *result
+);
+
+typedef HRESULT(WINAPI *sWldpGetApplicationSettingBoolean)(
+    _In_ PCWSTR id,
+    _In_ PCWSTR setting,
+    _Out_ BOOL *result
+    );
+
+typedef enum WLDP_SECURE_SETTING_VALUE_TYPE
+{
+    WLDP_SECURE_SETTING_VALUE_TYPE_BOOLEAN = 0,
+    WLDP_SECURE_SETTING_VALUE_TYPE_ULONG,
+    WLDP_SECURE_SETTING_VALUE_TYPE_BINARY,
+    WLDP_SECURE_SETTING_VALUE_TYPE_STRING
+} WLDP_SECURE_SETTING_VALUE_TYPE, *PWLDP_SECURE_SETTING_VALUE_TYPE;
+
+typedef HRESULT(WINAPI *sWldpQuerySecurityPolicy)(
+    _In_ const UNICODE_STRING * providerName,
+    _In_ const UNICODE_STRING * keyName,
+    _In_ const UNICODE_STRING * valueName,
+    _Out_ PWLDP_SECURE_SETTING_VALUE_TYPE valueType,
+    _Out_writes_bytes_opt_(*valueSize) PVOID valueAddress,
+    _Inout_ PULONG valueSize
+    );
+
+#ifndef DECLARE_CONST_UNICODE_STRING
+#define DECLARE_CONST_UNICODE_STRING(_var, _string) \
+const WCHAR _var ## _buffer[] = _string; \
+__pragma(warning(push)) \
+__pragma(warning(disable:4221)) __pragma(warning(disable:4204)) \
+const UNICODE_STRING _var = { sizeof(_string) - sizeof(WCHAR), sizeof(_string), (PWCH) _var ## _buffer } \
+__pragma(warning(pop))
+#endif
+
+ 
 #ifndef TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS
 # define TCP_INITIAL_RTO_NO_SYN_RETRANSMISSIONS ((UCHAR) -2)
 #endif
@@ -4765,5 +4826,9 @@ typedef int (WINAPI *uv_sGetHostNameW)
             (PWSTR,
              int);
 extern uv_sGetHostNameW pGetHostNameW;
+
+extern sWldpCanExecuteFileFromDetachedSignature pWldpCanExecuteFileFromDetachedSignature;
+extern sWldpGetApplicationSettingBoolean pWldpGetApplicationSettingBoolean;
+extern sWldpQuerySecurityPolicy pWldpQuerySecurityPolicy;
 
 #endif /* UV_WIN_WINAPI_H_ */

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2198,6 +2198,15 @@ A policy manifest resource had an invalid value for one of its dependency
 mappings. Update the manifest entry to match to resolve this error. See the
 documentation for [policy][] manifests for more information.
 
+<a id="ERR_MANIFEST_SYSTEM_CI_VIOLATION"></a>
+
+### `ERR_MANIFEST_SYSTEM_CI_VIOLATION`
+
+The manifest does not match the signature provided or the signature
+does not conform to system code integrity policy.
+
+See the documentation for [policy][] manifests for more information.
+
 <a id="ERR_MANIFEST_PARSE_POLICY"></a>
 
 ### `ERR_MANIFEST_PARSE_POLICY`

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -70,12 +70,20 @@ The policy manifest will be used to enforce constraints on code loaded by
 Node.js.
 
 To mitigate tampering with policy files on disk, an integrity for
-the policy file itself may be provided via `--policy-integrity`.
+the policy file itself may be provided in two ways.
+One, via `--policy-integrity` using a subresource integrity string.
+Or, via `--policy-signature` using a PKCS7 detached signature created with
+a signing key trusted by system code integrity policy.
+
 This allows running `node` and asserting the policy file contents
 even if the file is changed on disk.
 
 ```bash
 node --experimental-policy=policy.json --policy-integrity="sha384-SggXRQHwCG8g+DktYYzxkXRIkTiEYWBHqev0xnpCxYlqMBufKZHAHQM3/boDaI/0" app.js
+```
+
+```bash
+node --experimental-policy=policy.json --policy-signature=policy.json.p7s app.js
 ```
 
 #### Features
@@ -498,8 +506,7 @@ Error: Access to this API has been restricted
     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:24)
     at node:internal/main/run_main_module:23:47 {
   code: 'ERR_ACCESS_DENIED',
-  permission: 'FileSystemRead',
-  resource: '/home/user/index.js'
+  permission: 'FileSystemRead'
 }
 ```
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1534,6 +1534,9 @@ E('ERR_MANIFEST_INVALID_RESOURCE_FIELD',
 E('ERR_MANIFEST_INVALID_SPECIFIER',
   'Manifest resource %s has invalid dependency mapping %s',
   TypeError);
+E('ERR_MANIFEST_SYSTEM_CI_VIOLATION',
+  'The provided manifest does not pass system code integrity validation. "%s"',
+  Error);
 E('ERR_MANIFEST_TDZ', 'Manifest initialization has not yet run', Error);
 E('ERR_MANIFEST_UNKNOWN_ONERROR',
   'Manifest specified unknown error behavior "%s".',

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -39,6 +39,7 @@ const {
 const {
   ERR_INVALID_THIS,
   ERR_MANIFEST_ASSERT_INTEGRITY,
+  ERR_MANIFEST_SYSTEM_CI_VIOLATION,
   ERR_NO_CRYPTO,
   ERR_MISSING_OPTION,
   ERR_ACCESS_DENIED,
@@ -50,6 +51,7 @@ const {
     isBuildingSnapshot,
   },
 } = require('internal/v8/startup_snapshot');
+const { fileURLToPath } = require('internal/url');
 
 function prepareMainThreadExecution(expandArgv1 = false, initializeModules = true) {
   return prepareExecution({
@@ -633,21 +635,54 @@ function initializePermission() {
 }
 
 function readPolicyFromDisk() {
+  const os = require('os');
   const experimentalPolicy = getOptionValue('--experimental-policy');
-  if (experimentalPolicy) {
+
+  const forceCI = os.isCIEnforcedByOS();
+  if (forceCI && !experimentalPolicy) {
+    throw new ERR_MANIFEST_SYSTEM_CI_VIOLATION(
+      'Code integrity is forced by system policy. ' +
+      'A Policy manifest (--experimental-policy) and signature (--policy-signature) are required');
+  }
+
+  if (experimentalPolicy || forceCI) {
     process.emitWarning('Policies are experimental.',
                         'ExperimentalWarning');
     const { pathToFileURL, URL } = require('internal/url');
     // URL here as it is slightly different parsing
     // no bare specifiers for now
-    let manifestURL;
-    if (require('path').isAbsolute(experimentalPolicy)) {
-      manifestURL = pathToFileURL(experimentalPolicy);
-    } else {
+
+    function makeAbsoluteUrl(f) {
+      if (require('path').isAbsolute(f)) {
+        return new URL(`file://${f}`);
+      }
+
       const cwdURL = pathToFileURL(process.cwd());
       cwdURL.pathname += '/';
-      manifestURL = new URL(experimentalPolicy, cwdURL);
+      return new URL(f, cwdURL);
     }
+
+    const manifestURL = makeAbsoluteUrl(experimentalPolicy);
+    const policySignature = getOptionValue('--policy-signature');
+    if (forceCI && !policySignature) {
+      throw new ERR_MANIFEST_SYSTEM_CI_VIOLATION(
+        'Code integrity is forced by system policy. ' +
+        'A Policy manifest (--experimental-policy) and signature (--policy-signature) are required');
+    }
+
+    if (policySignature) {
+      const policySignatureUrl = makeAbsoluteUrl(policySignature);
+
+      const isPolicyTrusted = os.isFileTrustedBySystemCodeIntegrity(
+        fileURLToPath(manifestURL),
+        fileURLToPath(policySignatureUrl));
+
+      if (!isPolicyTrusted) {
+        throw new ERR_MANIFEST_SYSTEM_CI_VIOLATION(
+          'The --policy-signature provided is not valid or does not meet system code integrity requirements');
+      }
+    }
+
     const fs = require('fs');
     const src = fs.readFileSync(manifestURL, 'utf8');
     const experimentalPolicyIntegrity = getOptionValue('--policy-integrity');

--- a/lib/os.js
+++ b/lib/os.js
@@ -58,6 +58,8 @@ const {
   getUptime: _getUptime,
   isBigEndian,
   setPriority: _setPriority,
+  isFileTrustedBySystemCodeIntegrity,
+  isCIEnforcedByOS,
 } = internalBinding('os');
 
 function getCheckedFunction(fn) {
@@ -393,6 +395,8 @@ module.exports = {
   uptime: getUptime,
   version: getOSVersion,
   machine: getMachine,
+  isCIEnforcedByOS,
+  isFileTrustedBySystemCodeIntegrity,
 };
 
 ObjectDefineProperties(module.exports, {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -434,6 +434,15 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_policy_integrity,
             kAllowedInEnvvar);
   Implies("--policy-integrity", "[has_policy_integrity_string]");
+  AddOption("[has_policy_signature]",
+            "",
+            &EnvironmentOptions::has_policy_signature);
+  AddOption("--policy-signature",
+            "ensure the security policy is signed "
+            "by a trusted signer",
+            &EnvironmentOptions::experimental_policy_signature,
+            kAllowedInEnvvar);
+  Implies("--policy-signature", "[has_policy_signature]");
   AddOption("--allow-fs-read",
             "allow permissions to read the filesystem",
             &EnvironmentOptions::allow_fs_read,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -118,7 +118,9 @@ class EnvironmentOptions : public Options {
   std::string type;        // Value of --experimental-default-type
   std::string experimental_policy;
   std::string experimental_policy_integrity;
+  std::string experimental_policy_signature;
   bool has_policy_integrity_string = false;
+  bool has_policy_signature = false;
   bool experimental_permission = false;
   std::vector<std::string> allow_fs_read;
   std::vector<std::string> allow_fs_write;


### PR DESCRIPTION
Last year, I spoke with @bmeck @mhdawson and @RafaelGSS about extending the chain of trust of node policy files into the OS. Work has been done on the OS side to better support language interpreters with code integrity, and now we're ready to integrate this work with NodeJS.

This is intended to be a draft PR to demonstrate what the proposed changes are and to facilitate discussion around OS code integrity integration on Windows. I will submit an issue so we can discuss this in further detail during the next security wg meeting.

**Changes**
Added an alternate option to --policy-integrity so the integrity of the policy can be rooted in the OS.

The alternative option is --policy-signature which is a path to a PKCS7 detached signature of the policy file.

The policy signature is verified using the OS CI policy system. On Windows, this uses WDAC.
On *nix this is stubbed out.

Added a query to WDAC to see if a policy file and signature are mandatory for Node to run.

**Windows Code Integrity (WDAC)**
[Official WDAC docs](https://aka.ms/wdac)

WDAC is Window's code integrity enforcement system. Using WDAC, system administrators can define policy rules that dictate which executables can be run on a system where WDAC is enabled. One of the criteria they can define is a set of valid signing keys. EXEs and DLLs have signatures embedded into them (in headers and other "unused" blocks within the file) which are validated when loaded. Since interpreted languages don't use the standard EXE and DLL loading entry points, and the code which they interpret can be various file types, enforcement by the OS is difficult. There needs to be some cooperation between the OS and the language runtime. 

Node policies seem like a natural point we can integrate with WDAC. In the current form, however, a Node policy manifest can be altered on disk. This can be mitigated with the --policy-integrity option. However, this can be bypassed if an attacker can modify the command parameters. We're proposing linking the chain of trust into something the OS trusts, rather (or in addition to) a command line parameter. To do this, the manifest is signed with a PKCS7 detached signature. This adds another layer of security, since now a trusted signing key would need to be compromised to use NodeJS on a locked-down system.

This can be done with signtool with 
`signtool sign /p7 .\ /p7co 1.2.840.113549.1.7.2 /p7ce Pkcs7DetachedSignedData /fd sha256 /f key.pfx node_policy.json`

Or OpenSSL with
`openssl smime -sign -binary -in policy.json -signer signer.pem -inkey signer.key -outform DER -out policy.json.p7s`

This signature can then be passed in along with a Node policy.

`node.exe --experimental-policy policy.json --policy-signature policy.json.p7s app.js`

If the OS is configured to enforce code integrity for Node, Node will not execute unless both a policy and its signature are provided and pass WDAC's verification. From that point, integrity enforcement is delegated to Node's manifest/policy subsystem.


Some questions that I have:

- I couldn't find where in the Node project calls to OS functions are located, so I put them alongside the other win32 methods in UV. Please let me know if there's a better place
- I have tested this on Windows with a couple VMs on different OS versions. However, I don't know what the best course of action is for adding unit tests, since this is an OS integration feature. I'm open to any suggestions you have. 

