### PR TITLE
docs: add Cluster documentation

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -843,6 +843,66 @@ Spawn a new worker process.
 
 This can only be called from the primary process.
 
+```mjs
+import http from 'node:http';
+import cluster from 'node:cluster';
+import os from 'node:os';
+
+const numCPUs = os.cpus().length;
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < numCPUs; i++) {
+    // Workers will be created depending on the CPUs numbers.
+    const worker = cluster.fork();
+
+    // Received messages from the created worker.
+    worker.on('message', (msg) => {
+      console.log(`Received message from worker: ${msg}`);
+    });
+  }
+} else {
+  const server = http.createServer((req, res) => {
+    process.send(process.pid);
+
+    res.writeHead(200);
+    res.end(`Hello World from worker: ${process.pid}`);
+  });
+
+  server.listen(3000, () => {
+    console.log(`Worker ${process.pid} listening on the port 3000`);
+  });
+}
+```
+
+```cjs
+const http = require('node:http');
+const cluster = require('node:cluster');
+const numCPUs = require('node:os').cpus().length;
+
+if (cluster.isPrimary) {
+  for (let i = 0; i < numCPUs; i++) {
+    // Workers will be created depending on the CPUs numbers.
+    const worker = cluster.fork();
+
+    // Received messages from the created worker.
+    worker.on('message', (msg) => {
+      console.log(`Received message from worker: ${msg}`);
+    });
+  }
+} else {
+  const server = http.createServer((req, res) => {
+    process.send(process.pid);
+
+    res.writeHead(200);
+    res.end(`Hello World from worker: ${process.pid}`);
+  });
+
+  server.listen(3000, () => {
+    console.log(`Worker ${process.pid} listening on the port 3000`);
+  });
+}
+```
+
 ## `cluster.isMaster`
 
 <!-- YAML

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -830,6 +830,66 @@ finished.
 
 This can only be called from the primary process.
 
+```mjs
+import http from 'node:http';
+import cluster from 'node:cluster';
+import process from 'node:process';
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+
+  worker.on('message', (msg) => {
+    if (msg === 'shutdown') {
+      // Workers will be killed once finished the callback will be called.
+      cluster.disconnect(() => {
+        console.log('All workers killed');
+      });
+    }
+  });
+} else {
+  const server = http.createServer((req, res) => {
+    process.send('shutdown');
+
+    res.writeHead(200);
+    res.end(`Hello World from worker: ${process.pid}`);
+  });
+
+  server.listen(3000, () => {
+    console.log(`Worker ${process.pid} listening on the port 3000`);
+  });
+}
+```
+
+```cjs
+const http = require('node:http');
+const cluster = require('node:cluster');
+const process = require('node:process');
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+
+  worker.on('message', (msg) => {
+    if (msg === 'shutdown') {
+      // Workers will be killed once finished the callback will be called.
+      cluster.disconnect(() => {
+        console.log('All workers killed');
+      });
+    }
+  });
+} else {
+  const server = http.createServer((req, res) => {
+    process.send('shutdown');
+
+    res.writeHead(200);
+    res.end(`Hello World from worker: ${process.pid}`);
+  });
+
+  server.listen(3000, () => {
+    console.log(`Worker ${process.pid} listening on the port 3000`);
+  });
+}
+```
+
 ## `cluster.fork([env])`
 
 <!-- YAML
@@ -847,6 +907,7 @@ This can only be called from the primary process.
 import http from 'node:http';
 import cluster from 'node:cluster';
 import os from 'node:os';
+import process from 'node:process';
 
 const numCPUs = os.cpus().length;
 
@@ -878,6 +939,7 @@ if (cluster.isPrimary) {
 const http = require('node:http');
 const cluster = require('node:cluster');
 const numCPUs = require('node:os').cpus().length;
+const process = require('node:process');
 
 if (cluster.isPrimary) {
   for (let i = 0; i < numCPUs; i++) {


### PR DESCRIPTION
This PR adds update the `Cluster` documentation for  the `cluster.fork` and  `cluster.disconnect([callback])` sections