### PR TITLE
benchmark: update the number of iteration on util/inspect.js

### DIFF
--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -9,7 +9,7 @@ const opts = {
   none: undefined,
 };
 const bench = common.createBenchmark(main, {
-  n: [2e4],
+  n: [8e4],
   method: [
     'Object',
     'Object_empty',


### PR DESCRIPTION
Compare to v18.x and 22.x, in the benchmark for `util.inspect`,
 when `obj ` is `Date`, as `n` increases, 
the difference in benchmark results gradually grows larger, 
possibly also due to the influence of V8 JIT.

```shell
n = [2e4]:
                                                          confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=20000            ***    -21.01 %       ±1.95% ±2.60% ±3.39%
util/inspect.js option='none' method='Date' n=20000              ***    -24.24 %       ±1.64% ±2.19% ±2.86%
util/inspect.js option='showHidden' method='Date' n=20000        ***    -21.55 %       ±1.32% ±1.76% ±2.30%

n = [4e4]:
                                                          confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=40000            ***    -25.63 %       ±1.88% ±2.50% ±3.26%
util/inspect.js option='none' method='Date' n=40000              ***    -29.94 %       ±1.20% ±1.60% ±2.09%
util/inspect.js option='showHidden' method='Date' n=40000        ***    -23.07 %       ±2.99% ±4.01% ±5.30%

n = [6e4]:
                                                          confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=60000            ***    -28.01 %       ±1.49% ±1.99% ±2.61%
util/inspect.js option='none' method='Date' n=60000              ***    -32.91 %       ±1.53% ±2.05% ±2.71%
util/inspect.js option='showHidden' method='Date' n=60000        ***    -27.59 %       ±2.30% ±3.07% ±4.01%

n = [8e4]:
                                                          confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=80000            ***    -31.34 %       ±1.55% ±2.07% ±2.70%
util/inspect.js option='none' method='Date' n=80000              ***    -32.49 %       ±1.48% ±1.98% ±2.59%
util/inspect.js option='showHidden' method='Date' n=80000        ***    -28.80 %       ±1.76% ±2.34% ±3.05%


n = [1e5]:
                                                           confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=100000            ***    -30.87 %       ±2.19% ±2.92% ±3.80%
util/inspect.js option='none' method='Date' n=100000              ***    -33.26 %       ±1.79% ±2.39% ±3.12%
util/inspect.js option='showHidden' method='Date' n=100000        ***    -28.31 %       ±2.07% ±2.75% ±3.58%

n = [12e4]:
                                                           confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=120000            ***    -31.74 %       ±1.84% ±2.45% ±3.21%
util/inspect.js option='none' method='Date' n=120000              ***    -32.62 %       ±1.30% ±1.73% ±2.26%
util/inspect.js option='showHidden' method='Date' n=120000        ***    -30.19 %       ±1.89% ±2.51% ±3.27%

n = [14e4]:
                                                           confidence improvement accuracy (*)   (**)  (***)
util/inspect.js option='colors' method='Date' n=140000            ***    -29.44 %       ±1.78% ±2.37% ±3.08%
util/inspect.js option='none' method='Date' n=140000              ***    -34.54 %       ±1.45% ±1.94% ±2.57%
util/inspect.js option='showHidden' method='Date' n=140000        ***    -29.27 %       ±2.12% ±2.83% ±3.68%
```

Refs: #50571 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
