### PR TITLE
test_runner: fix #50665 `.skip`, `.todo` and `.only` missing in subtests

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -215,6 +215,44 @@ class TestContext {
 
   constructor(test) {
     this.#test = test;
+
+    this.test = (name, options, fn) => {
+      const overrides = {
+        __proto__: null,
+        loc: getCallerLocation(),
+      };
+
+      const { plan } = this.#test;
+      if (plan !== null) {
+        plan.actual++;
+      }
+
+      const subtest = this.#test.createSubtest(
+        // eslint-disable-next-line no-use-before-define
+        Test, name, options, fn, overrides,
+      );
+
+      return subtest.start();
+    };
+
+    ArrayPrototypeForEach(['skip', 'todo', 'only'], (keyword) => {
+      this.test[keyword] = (name, options, fn) => {
+        const overrides = {
+          __proto__: null,
+          [keyword]: true,
+          loc: getCallerLocation(),
+        };
+
+        const { plan } = this.#test;
+        if (plan !== null) {
+          plan.actual++;
+        }
+
+        // eslint-disable-next-line no-use-before-define
+        const subtest = this.#test.createSubtest(Test, name, options, fn, overrides);
+        return subtest.start();
+      };
+    });
   }
 
   get signal() {

--- a/test/fixtures/test-runner/output/only_tests.js
+++ b/test/fixtures/test-runner/output/only_tests.js
@@ -119,3 +119,9 @@ describe('describe only = false, with nested only subtests', { only: false }, co
     test.only('nested test should run', common.mustNotCall());
   }));
 }));
+
+test('only = true, with subtests and test.only', { only: true }, async (t) => {
+  await t.test('skipped subtest 1');
+  await t.test.skip('skipped subtest 2');
+  await t.test.only('running subtest 3');
+});

--- a/test/fixtures/test-runner/output/sub_tests.js
+++ b/test/fixtures/test-runner/output/sub_tests.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../../../common');
+const { test } = require('node:test');
+
+test('parent 1', async (t) => {
+  await t.test('running subtest 1');
+  await t.test.skip('skipped subtest 2');
+  await t.test.todo('mark subtest 3 as todo');
+});

--- a/test/fixtures/test-runner/output/sub_tests.snapshot
+++ b/test/fixtures/test-runner/output/sub_tests.snapshot
@@ -1,0 +1,31 @@
+TAP version 13
+# Subtest: parent 1
+    # Subtest: running subtest 1
+    ok 1 - running subtest 1
+      ---
+      duration_ms: *
+      ...
+    # Subtest: skipped subtest 2
+    ok 2 - skipped subtest 2 # SKIP
+      ---
+      duration_ms: *
+      ...
+    # Subtest: mark subtest 3 as todo
+    ok 3 - mark subtest 3 as todo # TODO
+      ---
+      duration_ms: *
+      ...
+    1..3
+ok 1 - parent 1
+  ---
+  duration_ms: *
+  ...
+1..1
+# tests 4
+# suites 0
+# pass 2
+# fail 0
+# cancelled 0
+# skipped 1
+# todo 1
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -110,6 +110,7 @@ const tests = [
   { name: 'test-runner/output/no_refs.js' },
   { name: 'test-runner/output/no_tests.js' },
   { name: 'test-runner/output/only_tests.js' },
+  { name: 'test-runner/output/sub_tests.js' },
   { name: 'test-runner/output/dot_reporter.js', transform: specTransform },
   { name: 'test-runner/output/junit_reporter.js', transform: junitTransform },
   { name: 'test-runner/output/spec_reporter_successful.js', transform: specTransform },


### PR DESCRIPTION
Fix #50665

