### PR TITLE
src: fix pointer compression build

### DIFF
--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -500,6 +500,7 @@ if (v8_enable_short_builtin_calls == "") {
 if (v8_enable_external_code_space == "") {
   v8_enable_external_code_space =
       v8_enable_pointer_compression &&
+      v8_enable_pointer_compression_shared_cage &&
       (v8_current_cpu == "x64" || v8_current_cpu == "arm64")
 }
 if (v8_enable_maglev == "") {
@@ -682,6 +683,12 @@ assert(!v8_expose_memory_corruption_api || v8_enable_sandbox,
 assert(
     !v8_enable_pointer_compression_shared_cage || v8_enable_pointer_compression,
     "Can't share a pointer compression cage if pointers aren't compressed")
+
+assert(
+    !v8_enable_pointer_compression ||
+        v8_enable_pointer_compression_shared_cage ||
+        !v8_enable_external_code_space,
+    "Multi-cage pointer compression mode is not compatible with external code space")
 
 assert(
     !v8_enable_pointer_compression_shared_cage || v8_current_cpu == "x64" ||

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -9227,6 +9227,14 @@ void Isolate::TerminateExecution() {
 
 bool Isolate::IsExecutionTerminating() {
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(this);
+#ifdef DEBUG
+  // This method might be called on a thread that's not bound to any Isolate
+  // and thus pointer compression schemes might have cage base value unset.
+  // Read-only roots accessors contain type DCHECKs which require access to
+  // V8 heap in order to check the object type. So, allow heap access here
+  // to let the checks work.
+  i::PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
+#endif  // DEBUG
   return i_isolate->is_execution_terminating();
 }
 
@@ -9898,6 +9906,14 @@ void Isolate::LowMemoryNotification() {
     i::NestedTimedHistogramScope idle_notification_scope(
         i_isolate->counters()->gc_low_memory_notification());
     TRACE_EVENT0("v8", "V8.GCLowMemoryNotification");
+#ifdef DEBUG
+    // This method might be called on a thread that's not bound to any Isolate
+    // and thus pointer compression schemes might have cage base value unset.
+    // Read-only roots accessors contain type DCHECKs which require access to
+    // V8 heap in order to check the object type. So, allow heap access here
+    // to let the checks work.
+    i::PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
+#endif  // DEBUG
     i_isolate->heap()->CollectAllAvailableGarbage(
         i::GarbageCollectionReason::kLowMemoryNotification);
   }

--- a/deps/v8/src/common/ptr-compr.h
+++ b/deps/v8/src/common/ptr-compr.h
@@ -55,8 +55,8 @@ class V8HeapCompressionScheme {
  private:
   // These non-inlined accessors to base_ field are used in component builds
   // where cross-component access to thread local variables is not allowed.
-  static Address base_non_inlined();
-  static void set_base_non_inlined(Address base);
+  static V8_EXPORT_PRIVATE Address base_non_inlined();
+  static V8_EXPORT_PRIVATE void set_base_non_inlined(Address base);
 
 #ifdef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
   static V8_EXPORT_PRIVATE uintptr_t base_ V8_CONSTINIT;
@@ -155,6 +155,29 @@ static inline void WriteMaybeUnalignedValue(Address p, V value) {
     base::Memory<V>(p) = value;
   }
 }
+
+// When multi-cage pointer compression mode is enabled this scope object
+// saves current cage's base values and sets them according to given Isolate.
+// For all other configurations this scope object is a no-op.
+class PtrComprCageAccessScope final {
+ public:
+#ifdef V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
+  V8_INLINE explicit PtrComprCageAccessScope(Isolate* isolate);
+  V8_INLINE ~PtrComprCageAccessScope();
+#else
+  V8_INLINE explicit PtrComprCageAccessScope(Isolate* isolate) {}
+  V8_INLINE ~PtrComprCageAccessScope() {}
+#endif
+
+ private:
+#ifdef V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
+  const Address cage_base_;
+#ifdef V8_EXTERNAL_CODE_SPACE
+// In case this configuration is necessary the code cage base must be saved too.
+#error Multi-cage pointer compression with external code space is not supported
+#endif  // V8_EXTERNAL_CODE_SPACE
+#endif  // V8_COMPRESS_POINTERS_IN_ISOLATE_CAGE
+};
 
 }  // namespace v8::internal
 

--- a/deps/v8/src/execution/isolate.cc
+++ b/deps/v8/src/execution/isolate.cc
@@ -3933,6 +3933,14 @@ Isolate::~Isolate() {
 
 void Isolate::InitializeThreadLocal() {
   thread_local_top()->Initialize(this);
+#ifdef DEBUG
+  // This method might be called on a thread that's not bound to any Isolate
+  // and thus pointer compression schemes might have cage base value unset.
+  // Read-only roots accessors contain type DCHECKs which require access to
+  // V8 heap in order to check the object type. So, allow heap access here
+  // to let the checks work.
+  i::PtrComprCageAccessScope ptr_compr_cage_access_scope(this);
+#endif  // DEBUG
   clear_pending_exception();
   clear_pending_message();
   clear_scheduled_exception();

--- a/deps/v8/src/heap/collection-barrier.cc
+++ b/deps/v8/src/heap/collection-barrier.cc
@@ -51,7 +51,12 @@ class BackgroundCollectionInterruptTask : public CancelableTask {
 
  private:
   // v8::internal::CancelableTask overrides.
-  void RunInternal() override { heap_->CheckCollectionRequested(); }
+  void RunInternal() override {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(heap_->isolate());
+    heap_->CheckCollectionRequested();
+  }
 
   Heap* heap_;
 };

--- a/deps/v8/src/heap/concurrent-marking.cc
+++ b/deps/v8/src/heap/concurrent-marking.cc
@@ -153,6 +153,11 @@ class ConcurrentMarking::JobTaskMajor : public v8::JobTask {
 
   // v8::JobTask overrides.
   void Run(JobDelegate* delegate) override {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        concurrent_marking_->heap_->isolate());
+
     if (delegate->IsJoiningThread()) {
       // TRACE_GC is not needed here because the caller opens the right scope.
       concurrent_marking_->RunMajor(delegate, code_flush_mode_,
@@ -197,6 +202,11 @@ class ConcurrentMarking::JobTaskMinor : public v8::JobTask {
 
   // v8::JobTask overrides.
   void Run(JobDelegate* delegate) override {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        concurrent_marking_->heap_->isolate());
+
     if (delegate->IsJoiningThread()) {
       TRACE_GC_WITH_FLOW(concurrent_marking_->heap_->tracer(),
                          GCTracer::Scope::MINOR_MS_MARK_PARALLEL, trace_id_,

--- a/deps/v8/src/heap/incremental-marking-job.cc
+++ b/deps/v8/src/heap/incremental-marking-job.cc
@@ -91,6 +91,9 @@ void IncrementalMarkingJob::Task::RunInternal() {
   VMState<GC> state(isolate());
   TRACE_EVENT_CALL_STATS_SCOPED(isolate(), "v8",
                                 "V8.IncrementalMarkingJob.Task");
+  // In case multi-cage pointer compression mode is enabled ensure that
+  // current thread's cage base values are properly initialized.
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate());
 
   isolate()->stack_guard()->ClearStartIncrementalMarking();
 

--- a/deps/v8/src/heap/local-heap.cc
+++ b/deps/v8/src/heap/local-heap.cc
@@ -48,6 +48,7 @@ void LocalHeap::VerifyCurrent() const {
 LocalHeap::LocalHeap(Heap* heap, ThreadKind kind,
                      std::unique_ptr<PersistentHandles> persistent_handles)
     : heap_(heap),
+      ptr_compr_cage_access_scope_(heap->isolate()),
       is_main_thread_(kind == ThreadKind::kMain),
       state_(ThreadState::Parked()),
       allocation_failed_(false),

--- a/deps/v8/src/heap/local-heap.h
+++ b/deps/v8/src/heap/local-heap.h
@@ -13,6 +13,7 @@
 #include "src/base/platform/condition-variable.h"
 #include "src/base/platform/mutex.h"
 #include "src/common/assert-scope.h"
+#include "src/common/ptr-compr.h"
 #include "src/execution/isolate.h"
 #include "src/handles/global-handles.h"
 #include "src/handles/persistent-handles.h"
@@ -348,6 +349,7 @@ class V8_EXPORT_PRIVATE LocalHeap {
   void SetUpSharedMarking();
 
   Heap* heap_;
+  V8_NO_UNIQUE_ADDRESS PtrComprCageAccessScope ptr_compr_cage_access_scope_;
   bool is_main_thread_;
 
   AtomicThreadState state_;

--- a/deps/v8/src/heap/mark-compact.cc
+++ b/deps/v8/src/heap/mark-compact.cc
@@ -2522,6 +2522,10 @@ class ClearStringTableJobItem final : public ParallelClearingJob::ClearingItem {
                       GCTracer::Scope::MC_CLEAR_STRING_TABLE)) {}
 
   void Run(JobDelegate* delegate) final {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate_);
+
     if (isolate_->OwnsStringTables()) {
       TRACE_GC1_WITH_FLOW(isolate_->heap()->tracer(),
                           GCTracer::Scope::MC_CLEAR_STRING_TABLE,
@@ -4135,6 +4139,11 @@ class PageEvacuationJob : public v8::JobTask {
                   tracer_->CurrentEpoch(GCTracer::Scope::MC_EVACUATE)) {}
 
   void Run(JobDelegate* delegate) override {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        collector_->heap()->isolate());
+
     Evacuator* evacuator = (*evacuators_)[delegate->GetTaskId()].get();
     if (delegate->IsJoiningThread()) {
       TRACE_GC_WITH_FLOW(tracer_, GCTracer::Scope::MC_EVACUATE_COPY_PARALLEL,
@@ -4471,6 +4480,11 @@ class PointersUpdatingJob : public v8::JobTask {
                   tracer_->CurrentEpoch(GCTracer::Scope::MC_EVACUATE)) {}
 
   void Run(JobDelegate* delegate) override {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        collector_->heap()->isolate());
+
     if (delegate->IsJoiningThread()) {
       TRACE_GC_WITH_FLOW(tracer_,
                          GCTracer::Scope::MC_EVACUATE_UPDATE_POINTERS_PARALLEL,

--- a/deps/v8/src/heap/mark-compact.h
+++ b/deps/v8/src/heap/mark-compact.h
@@ -161,6 +161,8 @@ class MarkCompactCollector final {
     return use_background_threads_in_cycle_;
   }
 
+  Heap* heap() { return heap_; }
+
   explicit MarkCompactCollector(Heap* heap);
   ~MarkCompactCollector();
 

--- a/deps/v8/src/heap/scavenger.cc
+++ b/deps/v8/src/heap/scavenger.cc
@@ -200,6 +200,10 @@ ScavengerCollector::JobTask::JobTask(
 
 void ScavengerCollector::JobTask::Run(JobDelegate* delegate) {
   DCHECK_LT(delegate->GetTaskId(), scavengers_->size());
+  // In case multi-cage pointer compression mode is enabled ensure that
+  // current thread's cage base values are properly initialized.
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(outer_->heap_->isolate());
+
   Scavenger* scavenger = (*scavengers_)[delegate->GetTaskId()].get();
   if (delegate->IsJoiningThread()) {
     TRACE_GC_WITH_FLOW(outer_->heap_->tracer(),

--- a/deps/v8/src/heap/sweeper.cc
+++ b/deps/v8/src/heap/sweeper.cc
@@ -144,6 +144,11 @@ class Sweeper::MajorSweeperJob final : public JobTask {
 
  private:
   void RunImpl(JobDelegate* delegate, bool is_joining_thread) {
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        sweeper_->heap_->isolate());
+
     DCHECK(sweeper_->major_sweeping_in_progress());
     const int offset = delegate->GetTaskId();
     DCHECK_LT(offset, concurrent_sweepers.size());
@@ -213,6 +218,11 @@ class Sweeper::MinorSweeperJob final : public JobTask {
         tracer_, sweeper_->GetTracingScope(NEW_SPACE, is_joining_thread),
         is_joining_thread ? ThreadKind::kMain : ThreadKind::kBackground,
         trace_id_, TRACE_EVENT_FLAG_FLOW_IN);
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(
+        sweeper_->heap_->isolate());
+
     if (!concurrent_sweeper.ConcurrentSweepSpace(delegate)) return;
     concurrent_sweeper.ConcurrentSweepPromotedPages(delegate);
   }

--- a/deps/v8/src/wasm/module-compiler.cc
+++ b/deps/v8/src/wasm/module-compiler.cc
@@ -1983,6 +1983,9 @@ class AsyncCompileJSToWasmWrapperJob final
     }
 
     TRACE_EVENT0("v8.wasm", "wasm.JSToWasmWrapperCompilation");
+    // In case multi-cage pointer compression mode is enabled ensure that
+    // current thread's cage base values are properly initialized.
+    PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
     while (true) {
       DCHECK_EQ(isolate, wrapper_unit->isolate());
       wrapper_unit->Execute();

--- a/deps/v8/test/cctest/test-debug-helper.cc
+++ b/deps/v8/test/cctest/test-debug-helper.cc
@@ -126,6 +126,7 @@ TEST(GetObjectProperties) {
   CcTest::InitializeVM();
   v8::Isolate* isolate = CcTest::isolate();
   i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
   v8::HandleScope scope(isolate);
   LocalContext context;
   // Claim we don't know anything about the heap layout.
@@ -470,6 +471,8 @@ static void FrameIterationCheck(
 THREADED_TEST(GetFrameStack) {
   LocalContext env;
   v8::Isolate* isolate = env->GetIsolate();
+  i::Isolate* i_isolate = reinterpret_cast<Isolate*>(isolate);
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(i_isolate);
   v8::HandleScope scope(isolate);
   v8::Local<v8::ObjectTemplate> obj = v8::ObjectTemplate::New(isolate);
   obj->SetAccessor(v8_str("xxx"), FrameIterationCheck);
@@ -490,6 +493,7 @@ TEST(SmallOrderedHashSetGetObjectProperties) {
   LocalContext context;
   Isolate* isolate = reinterpret_cast<Isolate*>((*context)->GetIsolate());
   Factory* factory = isolate->factory();
+  PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
   HandleScope scope(isolate);
 
   Handle<SmallOrderedHashSet> set = factory->NewSmallOrderedHashSet();

--- a/deps/v8/test/cctest/test-serialize.cc
+++ b/deps/v8/test/cctest/test-serialize.cc
@@ -4262,10 +4262,10 @@ UNINITIALIZED_TEST(ReinitializeHashSeedJSCollectionRehashable) {
   create_params.snapshot_blob = &blob;
   v8::Isolate* isolate = v8::Isolate::New(create_params);
   {
+    v8::Isolate::Scope isolate_scope(isolate);
     // Check that rehashing has been performed.
     CHECK_EQ(static_cast<uint64_t>(1337),
              HashSeed(reinterpret_cast<i::Isolate*>(isolate)));
-    v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Context> context = v8::Context::New(isolate);
     CHECK(!context.IsEmpty());
@@ -4330,10 +4330,10 @@ UNINITIALIZED_TEST(ReinitializeHashSeedRehashable) {
   create_params.snapshot_blob = &blob;
   v8::Isolate* isolate = v8::Isolate::New(create_params);
   {
+    v8::Isolate::Scope isolate_scope(isolate);
     // Check that rehashing has been performed.
     CHECK_EQ(static_cast<uint64_t>(1337),
              HashSeed(reinterpret_cast<i::Isolate*>(isolate)));
-    v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
     v8::Local<v8::Context> context = v8::Context::New(isolate);
     CHECK(!context.IsEmpty());

--- a/deps/v8/test/fuzzer/wasm-async.cc
+++ b/deps/v8/test/fuzzer/wasm-async.cc
@@ -54,12 +54,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   Isolate* i_isolate = reinterpret_cast<Isolate*>(isolate);
 
+  v8::Isolate::Scope isolate_scope(isolate);
+
   // Clear any pending exceptions from a prior run.
   if (i_isolate->has_pending_exception()) {
     i_isolate->clear_pending_exception();
   }
 
-  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(support->GetContext());
 

--- a/deps/v8/test/fuzzer/wasm-fuzzer-common.cc
+++ b/deps/v8/test/fuzzer/wasm-fuzzer-common.cc
@@ -811,10 +811,13 @@ void WasmExecutionFuzzer::FuzzWasmModule(base::Vector<const uint8_t> data,
 
   Isolate* i_isolate = reinterpret_cast<Isolate*>(isolate);
 
-  // Clear any pending exceptions from a prior run.
-  i_isolate->clear_pending_exception();
-
   v8::Isolate::Scope isolate_scope(isolate);
+
+  // Clear any pending exceptions from a prior run.
+  if (i_isolate->has_pending_exception()) {
+    i_isolate->clear_pending_exception();
+  }
+
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(support->GetContext());
 

--- a/deps/v8/test/fuzzer/wasm.cc
+++ b/deps/v8/test/fuzzer/wasm.cc
@@ -32,12 +32,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   Isolate* i_isolate = reinterpret_cast<Isolate*>(isolate);
 
+  v8::Isolate::Scope isolate_scope(isolate);
+
   // Clear any pending exceptions from a prior run.
   if (i_isolate->has_pending_exception()) {
     i_isolate->clear_pending_exception();
   }
 
-  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
   v8::Context::Scope context_scope(support->GetContext());
 

--- a/deps/v8/test/wasm-api-tests/serialize.cc
+++ b/deps/v8/test/wasm-api-tests/serialize.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "src/common/ptr-compr-inl.h"
 #include "src/execution/isolate.h"
 #include "src/wasm/c-api.h"
 #include "test/wasm-api-tests/wasm-api-test.h"
@@ -35,12 +36,19 @@ TEST_F(WasmCapiTest, Serialize) {
   // We reset the module and collect it to make sure the NativeModuleCache does
   // not contain it anymore. Otherwise deserialization will not happen.
   ResetModule();
-  Heap* heap =
-      reinterpret_cast<::wasm::StoreImpl*>(store())->i_isolate()->heap();
-  heap->PreciseCollectAllGarbage(GCFlag::kForced,
-                                 GarbageCollectionReason::kTesting);
-  heap->PreciseCollectAllGarbage(GCFlag::kForced,
-                                 GarbageCollectionReason::kTesting);
+  {
+    Isolate* isolate =
+        reinterpret_cast<::wasm::StoreImpl*>(store())->i_isolate();
+    // This method might be called on a thread that's not bound to any Isolate
+    // and thus pointer compression schemes might have cage base value unset.
+    // Ensure cage bases are initialized so that the V8 heap can be accessed.
+    i::PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
+    Heap* heap = isolate->heap();
+    heap->PreciseCollectAllGarbage(GCFlag::kForced,
+                                   GarbageCollectionReason::kTesting);
+    heap->PreciseCollectAllGarbage(GCFlag::kForced,
+                                   GarbageCollectionReason::kTesting);
+  }
   own<Module> deserialized = Module::deserialize(store(), serialized);
 
   // Try to serialize the module again. This can fail if deserialization does

--- a/deps/v8/tools/debug_helper/debug-helper-internal.cc
+++ b/deps/v8/tools/debug_helper/debug-helper-internal.cc
@@ -23,13 +23,13 @@ bool IsPointerCompressed(uintptr_t address) {
 uintptr_t EnsureDecompressed(uintptr_t address,
                              uintptr_t any_uncompressed_ptr) {
   if (!COMPRESS_POINTERS_BOOL || !IsPointerCompressed(address)) return address;
-#ifdef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+#ifdef V8_COMPRESS_POINTERS
   Address base =
       V8HeapCompressionScheme::GetPtrComprCageBaseAddress(any_uncompressed_ptr);
   if (base != V8HeapCompressionScheme::base()) {
     V8HeapCompressionScheme::InitBase(base);
   }
-#endif
+#endif  // V8_COMPRESS_POINTERS
   // TODO(v8:11880): ExternalCodeCompressionScheme might be needed here for
   // decompressing Code pointers from external code space.
   return i::V8HeapCompressionScheme::DecompressTagged(

--- a/deps/v8/tools/debug_helper/get-object-properties.cc
+++ b/deps/v8/tools/debug_helper/get-object-properties.cc
@@ -659,13 +659,13 @@ std::unique_ptr<ObjectPropertiesResult> GetHeapObjectPropertiesMaybeCompressed(
     any_uncompressed_ptr = heap_addresses.old_space_first_page;
   if (any_uncompressed_ptr == 0)
     any_uncompressed_ptr = heap_addresses.read_only_space_first_page;
-#ifdef V8_COMPRESS_POINTERS_IN_SHARED_CAGE
+#ifdef V8_COMPRESS_POINTERS
   Address base =
       V8HeapCompressionScheme::GetPtrComprCageBaseAddress(any_uncompressed_ptr);
   if (base != V8HeapCompressionScheme::base()) {
     V8HeapCompressionScheme::InitBase(base);
   }
-#endif
+#endif  // V8_COMPRESS_POINTERS
   FillInUnknownHeapAddresses(&heap_addresses, any_uncompressed_ptr);
   if (any_uncompressed_ptr == 0) {
     // We can't figure out the heap range. Just check for known objects.

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -313,6 +313,8 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
 
 void SetIsolateUpForNode(v8::Isolate* isolate,
                          const IsolateSettings& settings) {
+  Isolate::Scope isolate_scope(isolate);
+
   SetIsolateErrorHandlers(isolate, settings);
   SetIsolateMiscHandlers(isolate, settings);
 }
@@ -354,6 +356,9 @@ Isolate* NewIsolate(Isolate::CreateParams* params,
 
   SetIsolateCreateParamsForNode(params);
   Isolate::Initialize(isolate, *params);
+
+  Isolate::Scope isolate_scope(isolate);
+
   if (snapshot_data == nullptr) {
     // If in deserialize mode, delay until after the deserialization is
     // complete.
@@ -428,6 +433,8 @@ Environment* CreateEnvironment(
     ThreadId thread_id,
     std::unique_ptr<InspectorParentHandle> inspector_parent_handle) {
   Isolate* isolate = isolate_data->isolate();
+
+  Isolate::Scope isolate_scope(isolate);
   HandleScope handle_scope(isolate);
 
   const bool use_snapshot = context.IsEmpty();

--- a/src/env.cc
+++ b/src/env.cc
@@ -349,6 +349,8 @@ IsolateDataSerializeInfo IsolateData::Serialize(SnapshotCreator* creator) {
 
 void IsolateData::DeserializeProperties(const IsolateDataSerializeInfo* info) {
   size_t i = 0;
+
+  v8::Isolate::Scope isolate_scope(isolate_);
   HandleScope handle_scope(isolate_);
 
   if (per_process::enabled_debug_list.enabled(DebugCategory::MKSNAPSHOT)) {
@@ -431,6 +433,7 @@ void IsolateData::CreateProperties() {
   // One byte because our strings are ASCII and we can safely skip V8's UTF-8
   // decoding step.
 
+  v8::Isolate::Scope isolate_scope(isolate_);
   HandleScope handle_scope(isolate_);
 
 #define V(PropertyName, StringValue)                                           \

--- a/src/json_parser.cc
+++ b/src/json_parser.cc
@@ -17,6 +17,7 @@ bool JSONParser::Parse(const std::string& content) {
   DCHECK(!parsed_);
 
   Isolate* isolate = isolate_.get();
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
 
   Local<Context> context = Context::New(isolate);
@@ -45,6 +46,7 @@ bool JSONParser::Parse(const std::string& content) {
 std::optional<std::string> JSONParser::GetTopLevelStringField(
     std::string_view field) {
   Isolate* isolate = isolate_.get();
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
 
   Local<Context> context = context_.Get(isolate);
@@ -70,6 +72,7 @@ std::optional<std::string> JSONParser::GetTopLevelStringField(
 
 std::optional<bool> JSONParser::GetTopLevelBoolField(std::string_view field) {
   Isolate* isolate = isolate_.get();
+  v8::Isolate::Scope isolate_scope(isolate);
   v8::HandleScope handle_scope(isolate);
 
   Local<Context> context = context_.Get(isolate);

--- a/src/json_parser.h
+++ b/src/json_parser.h
@@ -24,7 +24,7 @@ class JSONParser {
  private:
   // We might want a lighter-weight JSON parser for this use case. But for now
   // using V8 is good enough.
-  RAIIIsolate isolate_;
+  RAIIIsolateWithoutEntering isolate_;
 
   v8::Global<v8::Context> context_;
   v8::Global<v8::Object> content_;

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -414,7 +414,9 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
   RAIIIsolate raii_isolate(SnapshotBuilder::GetEmbeddedSnapshotData());
   Isolate* isolate = raii_isolate.get();
 
+  v8::Isolate::Scope isolate_scope(isolate);
   HandleScope handle_scope(isolate);
+
   Local<Context> context = Context::New(isolate);
   Context::Scope context_scope(context);
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -678,7 +678,7 @@ Local<String> UnionBytes::ToStringChecked(Isolate* isolate) const {
   }
 }
 
-RAIIIsolate::RAIIIsolate(const SnapshotData* data)
+RAIIIsolateWithoutEntering::RAIIIsolateWithoutEntering(const SnapshotData* data)
     : allocator_{ArrayBuffer::Allocator::NewDefaultAllocator()} {
   isolate_ = Isolate::Allocate();
   CHECK_NOT_NULL(isolate_);
@@ -692,9 +692,14 @@ RAIIIsolate::RAIIIsolate(const SnapshotData* data)
   Isolate::Initialize(isolate_, params);
 }
 
-RAIIIsolate::~RAIIIsolate() {
+RAIIIsolateWithoutEntering::~RAIIIsolateWithoutEntering() {
   per_process::v8_platform.Platform()->UnregisterIsolate(isolate_);
   isolate_->Dispose();
 }
+
+RAIIIsolate::RAIIIsolate(const SnapshotData* data)
+    : isolate_{data}, isolate_scope_{isolate_.get()} {}
+
+RAIIIsolate::~RAIIIsolate() {}
 
 }  // namespace node

--- a/src/util.h
+++ b/src/util.h
@@ -969,17 +969,31 @@ void SetConstructorFunction(v8::Isolate* isolate,
                             SetConstructorFunctionFlag flag =
                                 SetConstructorFunctionFlag::SET_CLASS_NAME);
 
-// Simple RAII class to spin up a v8::Isolate instance.
-class RAIIIsolate {
+// Like RAIIIsolate, except doesn't enter the isolate while it's in scope.
+class RAIIIsolateWithoutEntering {
  public:
-  explicit RAIIIsolate(const SnapshotData* data = nullptr);
-  ~RAIIIsolate();
+  explicit RAIIIsolateWithoutEntering(const SnapshotData* data = nullptr);
+  ~RAIIIsolateWithoutEntering();
 
   v8::Isolate* get() const { return isolate_; }
 
  private:
   std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_;
   v8::Isolate* isolate_;
+};
+
+// Simple RAII class to spin up a v8::Isolate instance and enter it
+// immediately.
+class RAIIIsolate {
+ public:
+  explicit RAIIIsolate(const SnapshotData* data = nullptr);
+  ~RAIIIsolate();
+
+  v8::Isolate* get() const { return isolate_.get(); }
+
+ private:
+  RAIIIsolateWithoutEntering isolate_;
+  v8::Isolate::Scope isolate_scope_;
 };
 
 }  // namespace node


### PR DESCRIPTION
These two commits combined fix the pointer compression build. The build was
broken starting in Node v21.0.0 due to upgrading past a regression first
introduced in V8 11.4. See the refs for more information.

#### deps: V8: cherry-pick 475c8cdf9a95

Original commit message:

    [ptr-compr] Fix multi-cage mode

    This CL introduces PtrComprCageAccessScope which sets/restores current
    thread's pointer compression cage base values. It's supposed to be used
    by V8 jobs accessing V8 heap outside of v8::Isolate::Scope or
    i::LocalHeap or i::LocalIsolate scopes (they already ensure that the
    cage base values are properly initialized).
    For all other build modes PtrComprCageAccessScope is a no-op.

    For simplicity reasons the multi-cage mode is made incompatible with
    external code space.

    Bug: v8:13788, v8:14292
    Change-Id: I06c2d19a1eb7254fa7af07a17617e22d98abea9f
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4846592
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Reviewed-by: Jakob Kummerow <jkummerow@chromium.org>
    Commit-Queue: Igor Sheludko <ishell@chromium.org>
    Reviewed-by: Dominik Inführ <dinfuehr@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#90075}

Refs: https://github.com/v8/v8/commit/475c8cdf9a951bb06da3084794a0f659f8ef36c2

#### src: add IsolateScopes before using isolates

The V8 API requires entering an isolate before using it. We were often
not doing this, which worked fine in practice. However when (multi-cage)
pointer compression is enabled, the correct isolate needs to be active
in order to decompress pointers correctly, otherwise it causes crashes.

Fix this by sprinkling in some calls to v8::Isolate::Scope::Scope where
they were missing.

Tested by compiling with `--experimental-enable-pointer-compression`
locally and running all tests.

Refs: https://github.com/nodejs/build/issues/3204#issuecomment-1790213488
Refs: https://bugs.chromium.org/p/v8/issues/detail?id=14292
