### PR TITLE
benchmark: rewrite import.meta benchmark

### DIFF
--- a/benchmark/esm/import-meta.js
+++ b/benchmark/esm/import-meta.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const path = require('path');
+const common = require('../common');
+const assert = require('assert');
+const bench = common.createBenchmark(main, {
+  n: [1000],
+});
+
+const file = path.resolve(__filename, '../../fixtures/esm-dir-file.mjs');
+async function load(array, n) {
+  for (let i = 0; i < n; i++) {
+    array[i] = await import(`${file}?i=${i}`);
+  }
+  return array;
+}
+
+function main({ n }) {
+  const array = [];
+  for (let i = 0; i < n; ++i) {
+    array.push({ dirname: '', filename: '', i: 0 });
+  }
+
+  bench.start();
+  load(array, n).then((arr) => {
+    bench.end(n);
+    assert.strictEqual(arr[n - 1].filename, file);
+  });
+}

--- a/benchmark/esm/import-meta.js
+++ b/benchmark/esm/import-meta.js
@@ -1,13 +1,16 @@
 'use strict';
 
 const path = require('path');
+const { pathToFileURL, fileURLToPath } = require('url');
 const common = require('../common');
 const assert = require('assert');
 const bench = common.createBenchmark(main, {
   n: [1000],
 });
 
-const file = path.resolve(__filename, '../../fixtures/esm-dir-file.mjs');
+const file = pathToFileURL(
+  path.resolve(__filename, '../../fixtures/esm-dir-file.mjs'),
+);
 async function load(array, n) {
   for (let i = 0; i < n; i++) {
     array[i] = await import(`${file}?i=${i}`);
@@ -24,6 +27,6 @@ function main({ n }) {
   bench.start();
   load(array, n).then((arr) => {
     bench.end(n);
-    assert.strictEqual(arr[n - 1].filename, file);
+    assert.strictEqual(arr[n - 1].filename, fileURLToPath(file));
   });
 }

--- a/benchmark/fixtures/esm-dir-file.mjs
+++ b/benchmark/fixtures/esm-dir-file.mjs
@@ -1,3 +1,2 @@
-import assert from 'assert';
-assert.ok(import.meta.dirname);
-assert.ok(import.meta.filename);
+export const dirname = import.meta.dirname;
+export const filename = import.meta.filename;

--- a/benchmark/fixtures/load-esm-dir-file.js
+++ b/benchmark/fixtures/load-esm-dir-file.js
@@ -1,5 +1,0 @@
-(async function () {
-  for (let i = 0; i < 1000; i += 1) {
-    await import(`./esm-dir-file.mjs?i=${i}`);
-  }
-}());

--- a/benchmark/misc/startup.js
+++ b/benchmark/misc/startup.js
@@ -9,7 +9,6 @@ const bench = common.createBenchmark(main, {
   script: [
     'benchmark/fixtures/require-builtins',
     'test/fixtures/semicolon',
-    'benchmark/fixtures/load-esm-dir-file',
   ],
   mode: ['process', 'worker'],
   count: [30],


### PR DESCRIPTION
benchmark: rewrite import.meta benchmark

This is a ESM benchmark, rewrite it so that we are directly
benchmarking the ESM import.meta paths and using number of
loads for op/s calculation, instead of doing it in startup
benchmarks and nesting number of process/workers spawn
for op/s calculation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
