### PR TITLE
benchmark: add misc/startup-cli-version benchmark

### DIFF
--- a/benchmark/misc/startup-cli-version.js
+++ b/benchmark/misc/startup-cli-version.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common.js');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+// This benchmarks the startup of various CLI tools that are already
+// checked into the source code. We use --version because the output
+// tends to be minimal and fewer operations are done to generate
+// these so that the startup cost is still dominated by a more
+// indispensible part of the CLI.
+const bench = common.createBenchmark(main, {
+  cli: [
+    'tools/node_modules/eslint/bin/eslint.js',
+    'deps/npm/bin/npm-cli.js',
+    'deps/corepack/dist/corepack.js',
+  ],
+  count: [30],
+});
+
+function spawnProcess(cli, bench, state) {
+  const cmd = process.execPath || process.argv[0];
+  while (state.finished < state.count) {
+    const child = spawnSync(cmd, [cli, '--version'], {
+      env: { npm_config_loglevel: 'silent', ...process.env },
+    });
+    // Log some information for debugging if it fails, which it shouldn't.
+    if (child.status !== 0) {
+      console.log('---- STDOUT ----');
+      console.log(child.stdout.toString());
+      console.log('---- STDERR ----');
+      console.log(child.stderr.toString());
+      throw new Error(`Child process stopped with exit code ${child.status}`);
+    }
+    state.finished++;
+    if (state.finished === 0) {
+      // Finished warmup.
+      bench.start();
+    }
+
+    if (state.finished === state.count) {
+      bench.end(state.count);
+    }
+  }
+}
+
+function main({ count, cli }) {
+  cli = path.resolve(__dirname, '../../', cli);
+  const warmup = 3;
+  const state = { count, finished: -warmup };
+  spawnProcess(cli, bench, state);
+}


### PR DESCRIPTION
This benchmarks the startup of various CLI tools that are already checked into the source code. We use --version because the output tends to be minimal and fewer operations are done to generate these so that the startup cost is still dominated by a more indispensible part of the CLI.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
