### PR TITLE
doc: fixed misinformation in Buffer.allocUnsafe method

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -808,7 +808,7 @@ A `TypeError` will be thrown if `size` is not a number.
 The `Buffer` module pre-allocates an internal `Buffer` instance of
 size [`Buffer.poolSize`][] that is used as a pool for the fast allocation of new
 `Buffer` instances created using [`Buffer.allocUnsafe()`][], [`Buffer.from(array)`][],
-and [`Buffer.concat()`][] only when `size` is less than or equal to
+and [`Buffer.concat()`][] only when `size` is less than
 `Buffer.poolSize >>> 1` (floor of [`Buffer.poolSize`][] divided by two).
 
 Use of this pre-allocated internal memory pool is a key difference between

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -809,7 +809,7 @@ The `Buffer` module pre-allocates an internal `Buffer` instance of
 size [`Buffer.poolSize`][] that is used as a pool for the fast allocation of new
 `Buffer` instances created using [`Buffer.allocUnsafe()`][], [`Buffer.from(array)`][],
 and [`Buffer.concat()`][] only when `size` is less than or equal to
-`Buffer.poolSize >> 1` (floor of [`Buffer.poolSize`][] divided by two).
+`Buffer.poolSize >>> 1` (floor of [`Buffer.poolSize`][] divided by two).
 
 Use of this pre-allocated internal memory pool is a key difference between
 calling `Buffer.alloc(size, fill)` vs. `Buffer.allocUnsafe(size).fill(fill)`.


### PR DESCRIPTION
issue: #50635

Changes Made:
Corrected the documentation regarding Buffer.allocUnsafe method by adding missing information. The discrepancy was identified in the logic for pre-allocating an internal Buffer. The documentation stated:

... only when size is less than or equal to Buffer.poolSize >> 1 (floor of Buffer.poolSize divided by two).

However, the actual code implementation uses:

```js
if (size < (Buffer.poolSize >>> 1)) {
```
I have updated the documentation to accurately reflect the code logic.

Affected URL(s):

https://nodejs.org/dist/latest-v20.x/docs/api/buffer.html#static-method-bufferallocunsafesize
