### PR TITLE
deps: escape Python strings correctly

### DIFF
--- a/deps/openssl/openssl_common.gypi
+++ b/deps/openssl/openssl_common.gypi
@@ -26,7 +26,7 @@
     }, 'OS=="win"', {
       'defines': [
         ## default of Win. See INSTALL in openssl repo.
-        'OPENSSLDIR="C:\\\Program\ Files\\\Common\ Files\\\SSL"',
+        'OPENSSLDIR="C:\\\\Program\\ Files\\\\Common\\ Files\\\\SSL"',
         'ENGINESDIR="NUL"',
         'OPENSSL_SYS_WIN32', 'WIN32_LEAN_AND_MEAN', 'L_ENDIAN',
         '_CRT_SECURE_NO_DEPRECATE', 'UNICODE', '_UNICODE',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50671
