### PR TITLE
benchmark: update iterations in benchmark/util/splice-one.js

### DIFF
--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [5e6],
   pos: ['start', 'middle', 'end'],
   size: [10, 100, 500],
 }, { flags: ['--expose-internals'] });


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/50571

In case `util/splice-one.js`, when only `pos=end` I found that the performance gap between **node-21.x** and **node-20.x** increased from -15% to 5% after I changed iterations from default `1e5` to `5e6`. **(node-20.x is the baseline.)**

To make sure there was no problem with this modification, I tested the other 8 situations in this case (there are 9 situations in total, 3 types of `pos`, 3 types of `size`).

Here is the tests data and the **new binary is `node 21.x`**.
 
## node-21.x vs node-20.x
- pos=end
```
util/splice-one.js size=10 pos='end' n=100000        ***    -15.03 %       ±0.82% ±1.09% ±1.42%
util/splice-one.js size=10 pos='end' n=1000000        ***     -1.63 %       ±0.36% ±0.49% ±0.63%
util/splice-one.js size=10 pos='end' n=5000000        ***      5.07 %       ±0.52% ±0.70% ±0.93%

util/splice-one.js size=100 pos='end' n=100000        ***    -14.96 %       ±0.91% ±1.21% ±1.58%
util/splice-one.js size=100 pos='end' n=1000000        ***     -1.85 %       ±0.38% ±0.51% ±0.67%
util/splice-one.js size=100 pos='end' n=5000000        ***      4.59 %       ±0.20% ±0.26% ±0.35%

util/splice-one.js size=500 pos='end' n=100000        ***    -16.60 %       ±0.84% ±1.12% ±1.47%
util/splice-one.js size=500 pos='end' n=1000000        ***     -1.60 %       ±0.45% ±0.60% ±0.79%
util/splice-one.js size=500 pos='end' n=5000000        ***      4.61 %       ±0.20% ±0.26% ±0.35%
```

- pos=middle
```
util/splice-one.js size=10 pos='middle' n=100000        ***     -4.40 %       ±0.84% ±1.12% ±1.46%
util/splice-one.js size=10 pos='middle' n=1000000                -0.70 %       ±2.08% ±2.79% ±3.69%
util/splice-one.js size=10 pos='middle' n=5000000        ***      2.64 %       ±0.37% ±0.50% ±0.65%

util/splice-one.js size=100 pos='middle' n=100000        ***     -1.69 %       ±0.43% ±0.58% ±0.75%
util/splice-one.js size=100 pos='middle' n=1000000         **      1.49 %       ±1.00% ±1.35% ±1.79%
util/splice-one.js size=100 pos='middle' n=5000000         **      1.60 %       ±1.05% ±1.42% ±1.88%

util/splice-one.js size=500 pos='middle' n=100000        ***     -0.79 %       ±0.28% ±0.37% ±0.49%
util/splice-one.js size=500 pos='middle' n=1000000        ***     -0.17 %       ±0.06% ±0.08% ±0.10%
util/splice-one.js size=500 pos='middle' n=5000000        ***     -0.11 %       ±0.04% ±0.06% ±0.07%
```

- pos=start
```
util/splice-one.js size=10 pos='start' n=100000        ***     -4.13 %       ±0.57% ±0.75% ±0.98%
util/splice-one.js size=10 pos='start' n=1000000          *     -1.17 %       ±0.89% ±1.20% ±1.59%
util/splice-one.js size=10 pos='start' n=5000000        ***      0.36 %       ±0.16% ±0.22% ±0.28%

util/splice-one.js size=100 pos='start' n=100000        ***     -0.65 %       ±0.31% ±0.41% ±0.54%
util/splice-one.js size=100 pos='start' n=1000000         **      0.83 %       ±0.49% ±0.65% ±0.87%
util/splice-one.js size=100 pos='start' n=5000000        ***      1.16 %       ±0.52% ±0.69% ±0.92%

util/splice-one.js size=500 pos='start' n=100000          *     -0.14 %       ±0.12% ±0.15% ±0.20%
util/splice-one.js size=500 pos='start' n=1000000                -0.02 %       ±0.07% ±0.09% ±0.12%
util/splice-one.js size=500 pos='start' n=5000000                 0.02 %       ±0.11% ±0.14% ±0.19%
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
