### PR TITLE
src: fix compatility with upcoming V8 12.1 APIs

### DIFF
--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -775,11 +775,16 @@ inline void Environment::ThrowRangeError(const char* errmsg) {
   ThrowError(v8::Exception::RangeError, errmsg);
 }
 
-inline void Environment::ThrowError(
-    v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
-    const char* errmsg) {
+inline void Environment::ThrowError(V8ExceptionConstructorOld fun,
+                                    const char* errmsg) {
   v8::HandleScope handle_scope(isolate());
   isolate()->ThrowException(fun(OneByteString(isolate(), errmsg)));
+}
+
+inline void Environment::ThrowError(V8ExceptionConstructorNew fun,
+                                    const char* errmsg) {
+  v8::HandleScope handle_scope(isolate());
+  isolate()->ThrowException(fun(OneByteString(isolate(), errmsg), {}));
 }
 
 inline void Environment::ThrowErrnoException(int errorno,

--- a/src/env.h
+++ b/src/env.h
@@ -1016,8 +1016,14 @@ class Environment : public MemoryRetainer {
   };
 
  private:
-  inline void ThrowError(v8::Local<v8::Value> (*fun)(v8::Local<v8::String>),
-                         const char* errmsg);
+  // V8 has changed the constructor of exceptions, support both APIs before Node
+  // updates to V8 12.1.
+  using V8ExceptionConstructorOld =
+      v8::Local<v8::Value> (*)(v8::Local<v8::String>);
+  using V8ExceptionConstructorNew =
+      v8::Local<v8::Value> (*)(v8::Local<v8::String>, v8::Local<v8::Value>);
+  inline void ThrowError(V8ExceptionConstructorOld fun, const char* errmsg);
+  inline void ThrowError(V8ExceptionConstructorNew fun, const char* errmsg);
   void TrackContext(v8::Local<v8::Context> context);
   void UntrackContext(v8::Local<v8::Context> context);
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -968,11 +968,8 @@ napi_define_class(napi_env env,
             env, p->setter, p->data, &setter_tpl));
       }
 
-      tpl->PrototypeTemplate()->SetAccessorProperty(property_name,
-                                                    getter_tpl,
-                                                    setter_tpl,
-                                                    attributes,
-                                                    v8::AccessControl::DEFAULT);
+      tpl->PrototypeTemplate()->SetAccessorProperty(
+          property_name, getter_tpl, setter_tpl, attributes);
     } else if (p->method != nullptr) {
       v8::Local<v8::FunctionTemplate> t;
       STATUS_CALL(v8impl::FunctionCallbackWrapper::NewTemplate(

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -680,37 +680,38 @@ void BuiltinLoader::CreatePerIsolateProperties(IsolateData* isolate_data,
                                                Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
 
-  target->SetAccessor(isolate_data->config_string(),
-                      ConfigStringGetter,
-                      nullptr,
-                      Local<Value>(),
-                      DEFAULT,
-                      None,
-                      SideEffectType::kHasNoSideEffect);
+  target->SetNativeDataProperty(isolate_data->config_string(),
+                                ConfigStringGetter,
+                                nullptr,
+                                Local<Value>(),
+                                None,
+                                DEFAULT,
+                                SideEffectType::kHasNoSideEffect);
 
-  target->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
-                      BuiltinIdsGetter,
-                      nullptr,
-                      Local<Value>(),
-                      DEFAULT,
-                      None,
-                      SideEffectType::kHasNoSideEffect);
+  target->SetNativeDataProperty(FIXED_ONE_BYTE_STRING(isolate, "builtinIds"),
+                                BuiltinIdsGetter,
+                                nullptr,
+                                Local<Value>(),
+                                None,
+                                DEFAULT,
+                                SideEffectType::kHasNoSideEffect);
 
-  target->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
-                      GetBuiltinCategories,
-                      nullptr,
-                      Local<Value>(),
-                      DEFAULT,
-                      None,
-                      SideEffectType::kHasNoSideEffect);
+  target->SetNativeDataProperty(
+      FIXED_ONE_BYTE_STRING(isolate, "builtinCategories"),
+      GetBuiltinCategories,
+      nullptr,
+      Local<Value>(),
+      None,
+      DEFAULT,
+      SideEffectType::kHasNoSideEffect);
 
-  target->SetAccessor(FIXED_ONE_BYTE_STRING(isolate, "natives"),
-                      GetNatives,
-                      nullptr,
-                      Local<Value>(),
-                      DEFAULT,
-                      None,
-                      SideEffectType::kHasNoSideEffect);
+  target->SetNativeDataProperty(FIXED_ONE_BYTE_STRING(isolate, "natives"),
+                                GetNatives,
+                                nullptr,
+                                Local<Value>(),
+                                None,
+                                DEFAULT,
+                                SideEffectType::kHasNoSideEffect);
 
   SetMethod(isolate, target, "getCacheUsage", BuiltinLoader::GetCacheUsage);
   SetMethod(isolate, target, "compileFunction", BuiltinLoader::CompileFunction);


### PR DESCRIPTION
In the upcoming V8 11.10 there are a few API changes will break building of Node, this PR makes the code compatible with both old and new APIs.

This PR is needed because [V8's node-ci repo](https://chromium.googlesource.com/v8/node-ci/) tests latest Node with latest V8, and without this change V8 has to patch Node in their own fork.