### PR TITLE
meta: set owners for lib/internal/webstreams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,7 @@
 /lib/internal/streams/* @nodejs/streams
 /lib/stream.js @nodejs/streams
 /lib/stream/* @nodejs/streams
+/lib/internal/webstreams/* @nodejs/streams @nodejs/web-standards
 
 # net
 


### PR DESCRIPTION
sets owners for the webstream implementation