### PR TITLE
tools: use OSX Keychain profile to notarize the releases

### DIFF
--- a/tools/osx-notarize.sh
+++ b/tools/osx-notarize.sh
@@ -34,15 +34,10 @@ then
     exit 1
 fi
 
-# Submit the package for notarization
-# TODO(@ulisesGascon): refactor to use --keychain-profile
-# when https://github.com/nodejs/build/issues/3385#issuecomment-1729281269 is ready
 echo "Submitting node-$pkgid.pkg for notarization..."
 
 xcrun notarytool submit \
-  --apple-id "$NOTARIZATION_ID" \
-  --password "$NOTARIZATION_PASSWORD" \
-  --team-id "$NOTARIZATION_TEAM_ID" \
+  --keychain-profile "NODE_RELEASE_PROFILE" \
   --wait \
   "node-$pkgid.pkg"
 


### PR DESCRIPTION
### Main Changes

Use a OSX Keychain profile to retrieve the secrets in order to do the notarization with Notarytool

cc: @nodejs/build @nodejs/releasers 

### Context

- Another PR related is https://github.com/nodejs/build/pull/3569
- Close https://github.com/nodejs/build/issues/3545

### Notes
You can find more information in this amazing article https://tonygo.ghost.io/notarization-for-macos-app-with-notarytool/ by @tony-go and this comment: https://github.com/nodejs/node/pull/48701#discussion_r1257298703

### Test

This was tested in `iojs+release-ulises-experimental` pipeline in jenkins ci release.

Full log available [here](https://ci-release.nodejs.org/job/iojs+release-ulises-experimental/15/nodes=osx11-release-pkg/console)

```
20:05:51 sh tools/osx-notarize.sh v22.0.0-test202311136410f3bf0d
20:05:51 Notarization process is done with Notarytool.
20:05:51 Submitting node-v22.0.0-test202311136410f3bf0d.pkg for notarization...
20:05:51 Conducting pre-submission checks for node-v22.0.0-test202311136410f3bf0d.pkg and initiating connection to the Apple notary service...
20:05:52 Submission ID received
20:05:52   id: cb5ac9d6-9646-4226-bfa8-23b9c3e0995d
20:06:08 Successfully uploaded file
20:06:08   id: cb5ac9d6-9646-4226-bfa8-23b9c3e0995d
20:06:08   path: /Users/iojs/build/ws/node-v22.0.0-test202311136410f3bf0d.pkg
20:06:08 Waiting for processing to complete.
20:06:14 
Current status: In Progress...
[...redacted...]
Current status: Accepted.............Processing complete
20:07:31   id: cb5ac9d6-9646-4226-bfa8-23b9c3e0995d
20:07:31   status: Accepted
20:07:31 
20:07:31 Notarization node-v22.0.0-test202311136410f3bf0d.pkg submitted successfully.
20:07:31 Processing: /Users/iojs/build/ws/node-v22.0.0-test202311136410f3bf0d.pkg
20:07:32 Processing: /Users/iojs/build/ws/node-v22.0.0-test202311136410f3bf0d.pkg
20:07:32 The staple and validate action worked!
20:07:32 Stapler was successful.
[...redacted...]
20:09:07 Finished: SUCCESS
```
