### PR TITLE
src: be less conservative in NearHeapLimitCallback

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -925,22 +925,34 @@ Writes a V8 heap snapshot to disk when the V8 heap usage is approaching the
 heap limit. `count` should be a non-negative integer (in which case
 Node.js will write no more than `max_count` snapshots to disk).
 
-When generating snapshots, garbage collection may be triggered and bring
-the heap usage down. Therefore multiple snapshots may be written to disk
-before the Node.js instance finally runs out of memory. These heap snapshots
-can be compared to determine what objects are being allocated during the
-time consecutive snapshots are taken. It's not guaranteed that Node.js will
-write exactly `max_count` snapshots to disk, but it will try
-its best to generate at least one and up to `max_count` snapshots before the
-Node.js instance runs out of memory when `max_count` is greater than `0`.
-
-Generating V8 snapshots takes time and memory (both memory managed by the
+Generating V8 heap snapshots takes time and memory (both memory managed by the
 V8 heap and native memory outside the V8 heap). The bigger the heap is,
-the more resources it needs. Node.js will adjust the V8 heap to accommodate
+the more resources it needs. When generating heap snapshots for this
+feature, Node.js will temporarily raise the V8 heap limit to accommodate
 the additional V8 heap memory overhead, and try its best to avoid using up
 all the memory available to the process. When the process uses
 more memory than the system deems appropriate, the process may be terminated
 abruptly by the system, depending on the system configuration.
+
+Heap snapshot generation could trigger garbage collections. If enough memory
+can be reclaimed after the garbage collection, the heap usage may go down
+and so multiple snapshots may be written to disk before the Node.js instance
+finally runs out of memory. On the other hand, since Node.js temporarily
+raises the heap limit before the heap snapshot is generated, and the limit
+only gets restored when the heap usage falls below it, if the application
+allocates reachable memory faster than what the garbage collector can keep up
+with, the heap usage could also go up and exceed the initial limit quite a bit
+until Node.js stops raising the heap limit.
+
+To control the number of heap snapshots to be written to disk, an integer
+should be passed to `--heapsnapshot-near-heap-limit`. It's not guaranteed
+that Node.js will write exactly `max_count` snapshots to disk, but it will
+try its best to generate at least one and up to `max_count` snapshots
+before the Node.js instance runs out of memory.
+
+When multiple heap snapshots are generated, they can be compared to determine
+what objects are being allocated during the time consecutive snapshots
+are taken.
 
 ```console
 $ node --max-old-space-size=100 --heapsnapshot-near-heap-limit=3 index.js


### PR DESCRIPTION
Previously the callback only considered potential overhead coming from promotion. As it turns out the cache for calculated line ends could also increase heap memory usage during heap snapshot generation. This patch makes the raised limit less conservative using a formula of (young_gen_size + old_gen_size / 2) for the extra leeway given to the heap limit.

Drive-by: use uv_get_available_memory() to calculate the memory available to the process directly and print the memory in MB in the debugging logs.

Refs: https://github.com/nodejs/node/issues/50711

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
