### PR TITLE
util: improve performance of normalizeEncoding

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -220,13 +220,13 @@ function slowCases(enc) {
     case 4:
       if (enc === 'UTF8') return 'utf8';
       if (enc === 'ucs2' || enc === 'UCS2') return 'utf16le';
-      enc = `${enc}`.toLowerCase();
+      enc = StringPrototypeToLowerCase(enc);
       if (enc === 'utf8') return 'utf8';
       if (enc === 'ucs2') return 'utf16le';
       break;
     case 3:
       if (enc === 'hex' || enc === 'HEX' ||
-          `${enc}`.toLowerCase() === 'hex')
+      StringPrototypeToLowerCase(enc) === 'hex')
         return 'hex';
       break;
     case 5:
@@ -235,7 +235,7 @@ function slowCases(enc) {
       if (enc === 'UTF-8') return 'utf8';
       if (enc === 'ASCII') return 'ascii';
       if (enc === 'UCS-2') return 'utf16le';
-      enc = `${enc}`.toLowerCase();
+      enc = StringPrototypeToLowerCase(enc);
       if (enc === 'utf-8') return 'utf8';
       if (enc === 'ascii') return 'ascii';
       if (enc === 'ucs-2') return 'utf16le';
@@ -245,23 +245,23 @@ function slowCases(enc) {
       if (enc === 'latin1' || enc === 'binary') return 'latin1';
       if (enc === 'BASE64') return 'base64';
       if (enc === 'LATIN1' || enc === 'BINARY') return 'latin1';
-      enc = `${enc}`.toLowerCase();
+      enc = StringPrototypeToLowerCase(enc);
       if (enc === 'base64') return 'base64';
       if (enc === 'latin1' || enc === 'binary') return 'latin1';
       break;
     case 7:
       if (enc === 'utf16le' || enc === 'UTF16LE' ||
-          `${enc}`.toLowerCase() === 'utf16le')
+      StringPrototypeToLowerCase(enc) === 'utf16le')
         return 'utf16le';
       break;
     case 8:
       if (enc === 'utf-16le' || enc === 'UTF-16LE' ||
-        `${enc}`.toLowerCase() === 'utf-16le')
+      StringPrototypeToLowerCase(enc) === 'utf-16le')
         return 'utf16le';
       break;
     case 9:
       if (enc === 'base64url' || enc === 'BASE64URL' ||
-          `${enc}`.toLowerCase() === 'base64url')
+      StringPrototypeToLowerCase(enc) === 'base64url')
         return 'base64url';
       break;
     default:


### PR DESCRIPTION
improve performance of `normalizeEncoding` by using primordials.

on my local:

```shell
                                                           confidence improvement accuracy (*)   (**)   (***)
util/normalize-encoding.js n=100000 input=''                      ***     16.04 %       ±3.32% ±4.43%  ±5.80%
util/normalize-encoding.js n=100000 input='base64'                ***     10.97 %       ±3.39% ±4.52%  ±5.88%
util/normalize-encoding.js n=100000 input='BASE64'                ***      3.95 %       ±1.89% ±2.53%  ±3.33%
util/normalize-encoding.js n=100000 input='binary'                        -0.10 %       ±4.92% ±6.59%  ±8.69%
util/normalize-encoding.js n=100000 input='BINARY'                         3.31 %       ±5.43% ±7.24%  ±9.46%
util/normalize-encoding.js n=100000 input='foo'                   ***     24.75 %       ±1.47% ±1.96%  ±2.55%
util/normalize-encoding.js n=100000 input='group_common'          ***     17.56 %       ±3.99% ±5.37%  ±7.11%
util/normalize-encoding.js n=100000 input='group_misc'            ***     29.32 %       ±4.60% ±6.11%  ±7.96%
util/normalize-encoding.js n=100000 input='group_uncommon'        ***     30.51 %       ±3.20% ±4.28%  ±5.62%
util/normalize-encoding.js n=100000 input='group_upper'           ***     27.14 %       ±4.33% ±5.82%  ±7.69%
util/normalize-encoding.js n=100000 input='hex'                   ***     11.43 %       ±2.53% ±3.37%  ±4.39%
util/normalize-encoding.js n=100000 input='HEX'                    **      9.09 %       ±5.56% ±7.40%  ±9.66%
util/normalize-encoding.js n=100000 input='latin1'                ***      8.76 %       ±2.58% ±3.43%  ±4.46%
util/normalize-encoding.js n=100000 input='ucs2'                  ***      8.16 %       ±4.15% ±5.57%  ±7.34%
util/normalize-encoding.js n=100000 input='UCS2'                   **      8.91 %       ±5.81% ±7.75% ±10.11%
util/normalize-encoding.js n=100000 input='undefined'             ***      6.62 %       ±3.32% ±4.42%  ±5.75%
util/normalize-encoding.js n=100000 input='utf-8'                         -3.23 %       ±4.56% ±6.10%  ±8.01%
util/normalize-encoding.js n=100000 input='UTF-8'                          2.12 %       ±4.41% ±5.87%  ±7.64%
util/normalize-encoding.js n=100000 input='utf16le'               ***     10.29 %       ±4.55% ±6.06%  ±7.89%
util/normalize-encoding.js n=100000 input='UTF16LE'                **      7.69 %       ±4.64% ±6.17%  ±8.03%
util/normalize-encoding.js n=100000 input='utf8'                           3.51 %       ±4.46% ±5.97%  ±7.82%
util/normalize-encoding.js n=100000 input='Utf8'                  ***     25.00 %       ±5.56% ±7.41%  ±9.67%
util/normalize-encoding.js n=100000 input='UTF8'                  ***     11.27 %       ±3.03% ±4.04%  ±5.27%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 23 comparisons, you can thus expect the following amount of false-positive results:
  1.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.23 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
