### PR TITLE
fs: fix incorrect function call `fs.promises.appendFile()`

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -163,7 +163,7 @@ class FileHandle extends EventEmitter {
   }
 
   appendFile(data, options) {
-    return fsCall(writeFile, this, data, options);
+    return fsCall(appendFile, this, data, options);
   }
 
   chmod(mode) {


### PR DESCRIPTION
I corrected the part where the `writeFile()` function was being called incorrectly when calling `appendFile()` in `FileHandle`.
If `appendFile()` is performed without an option, writing is performed using the `w` option, which is different from the document and may result in incorrect operation.
https://github.com/nodejs/node/blob/36ecf8ca656063060421e5b5440ac056f3a51e20/doc/api/fs.md?plain=1#L900-L919

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
