### PR TITLE
Update `--env-file` documentation when a file cannot be found.

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -543,7 +543,8 @@ Loads environment variables from a file relative to the current directory,
 making them available to applications on `process.env`. The [environment
 variables which configure Node.js][environment_variables], such as `NODE_OPTIONS`,
 are parsed and applied. If the same variable is defined in the environment and
-in the file, the value from the environment takes precedence.
+in the file, the value from the environment takes precedence. A file is silently 
+ignored when it cannot be found.
 
 You can pass multiple `--env-file` arguments. Subsequent files override
 pre-existing variables defined in previous files.


### PR DESCRIPTION
Node.js runs normally when the env file cannot be found. I think this behavior is good to be documented.

```sh
echo 'console.log(process.env)' > test.js;
echo 'A=1' > .env;

# does not prints A: '1'
node --env-file=not-found-env-file.env test.js;
node --env-file=not-found-env-file.env -e 'console.log(process.env)';

# prints A: '1'
node --env-file=.env test.js;
node --env-file=.env test.js -e 'console.log(process.env)';
```