### PR TITLE
test: give more time to GC in test-shadow-realm-gc-*

### DIFF
--- a/test/common/gc.js
+++ b/test/common/gc.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const wait = require('timers/promises').setTimeout;
+
 // TODO(joyeecheung): merge ongc.js and gcUntil from common/index.js
 // into this.
 
@@ -65,6 +67,15 @@ async function checkIfCollectable(
   createObject();
 }
 
+// Repeat an operation and give GC some breathing room at every iteration.
+async function runAndBreathe(fn, repeat, waitTime = 20) {
+  for (let i = 0; i < repeat; i++) {
+    await fn();
+    await wait(waitTime);
+  }
+}
+
 module.exports = {
   checkIfCollectable,
+  runAndBreathe,
 };

--- a/test/parallel/test-shadow-realm-gc-module.js
+++ b/test/parallel/test-shadow-realm-gc-module.js
@@ -8,13 +8,11 @@
 
 const common = require('../common');
 const fixtures = require('../common/fixtures');
+const { runAndBreathe } = require('../common/gc');
 
-async function main() {
-  const mod = fixtures.fileURL('es-module-shadow-realm', 'state-counter.mjs');
-  for (let i = 0; i < 100; i++) {
-    const realm = new ShadowRealm();
-    await realm.importValue(mod, 'getCounter');
-  }
-}
+const mod = fixtures.fileURL('es-module-shadow-realm', 'state-counter.mjs');
 
-main().then(common.mustCall());
+runAndBreathe(async () => {
+  const realm = new ShadowRealm();
+  await realm.importValue(mod, 'getCounter');
+}, 100).then(common.mustCall());

--- a/test/parallel/test-shadow-realm-gc.js
+++ b/test/parallel/test-shadow-realm-gc.js
@@ -6,14 +6,16 @@
  */
 
 const common = require('../common');
+const { runAndBreathe } = require('../common/gc');
 const assert = require('assert');
 const { isMainThread, Worker } = require('worker_threads');
 
-for (let i = 0; i < 100; i++) {
+runAndBreathe(() => {
   const realm = new ShadowRealm();
   realm.evaluate('new TextEncoder(); 1;');
-}
+}, 100).then(common.mustCall());
 
+// Test it in worker too.
 if (isMainThread) {
   const worker = new Worker(__filename);
   worker.on('exit', common.mustCall((code) => {


### PR DESCRIPTION
When --node-builtin-modules-path is used, we read and create new strings for builtins in each realm which increases the memory usage. As a result GC may not be able to keep up with the allocation done in the loop in the test.

As a workaround, give GC a bit more time by waiting for a timer in the loop.

Refs: https://github.com/nodejs/node/issues/50726

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
