### PR TITLE
doc: document non-node_modules-only runtime deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -10,10 +10,11 @@ Node.js APIs might be deprecated for any of the following reasons:
 * An improved alternative API is available.
 * Breaking changes to the API are expected in a future major release.
 
-Node.js uses three kinds of Deprecations:
+Node.js uses four kinds of Deprecations:
 
 * Documentation-only
-* Runtime
+* Runtime (non-`node_modules` code only)
+* Runtime (all code)
 * End-of-Life
 
 A Documentation-only deprecation is one that is expressed only within the
@@ -25,10 +26,17 @@ deprecations below. Documentation-only deprecations that support that flag
 are explicitly labeled as such in the
 [list of Deprecated APIs](#list-of-deprecated-apis).
 
-A Runtime deprecation will, by default, generate a process warning that will
-be printed to `stderr` the first time the deprecated API is used. When the
-[`--throw-deprecation`][] command-line flag is used, a Runtime deprecation will
-cause an error to be thrown.
+A Runtime deprecation for only non-`node_modules` code will, by default,
+generate a process warning that will be printed to `stderr` the first time
+the deprecated API is used in code that's not loaded from `node_modules`.
+When the [`--throw-deprecation`][] command-line flag is used, a Runtime
+deprecation will cause an error to be thrown. When
+[`--pending-deprecation`][] is used, warnings will also be emitted for
+code loaded from `node_modules`.
+
+A runtime deprecation for all code is similar to the runtime deprecation
+for non-`node_modules` code, except that it also emits a warning for
+code loaded from `node_modules`.
 
 An End-of-Life deprecation is used when functionality is or will soon be removed
 from Node.js.
@@ -140,7 +148,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime (supports [`--pending-deprecation`][])
+Type: Runtime (non-`node_modules` code only)
 
 The `Buffer()` function and `new Buffer()` constructor are deprecated due to
 API usability issues that can lead to accidental security issues.


### PR DESCRIPTION
We already have this special kind of runtime deprecation for Buffer constructors which does not fit into the original description of runtiem deprecations. Document this kind of deprecation separately.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
