### PR TITLE
esm: spawn only one hooks thread

### DIFF
--- a/test/es-module/test-esm-loader-threads.mjs
+++ b/test/es-module/test-esm-loader-threads.mjs
@@ -1,0 +1,24 @@
+import { spawnPromisified } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { strictEqual } from 'node:assert';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+describe('off-thread hooks', { concurrency: true }, () => {
+  it('uses only one hooks thread to support multiple application threads', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--import',
+      `data:text/javascript,${encodeURIComponent(`
+        import { register } from 'node:module';
+        register(${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-log.mjs'))});
+      `)}`,
+      fixtures.path('es-module-loaders/workers-spawned.mjs'),
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout.split('\n').filter(line => line.startsWith('initialize')).length, 1);
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+});

--- a/test/fixtures/es-module-loaders/hooks-log.mjs
+++ b/test/fixtures/es-module-loaders/hooks-log.mjs
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'node:fs';
+
+let initializeCount = 0;
+let resolveCount = 0;
+let loadCount = 0;
+
+export function initialize() {
+  writeFileSync(1, `initialize ${++initializeCount}\n`);
+}
+
+export function resolve(specifier, context, next) {
+  writeFileSync(1, `resolve ${++resolveCount} ${specifier}\n`);
+  return next(specifier, context);
+}
+
+export function load(url, context, next) {
+  writeFileSync(1, `load ${++loadCount} ${url}\n`);
+  return next(url, context);
+}

--- a/test/fixtures/es-module-loaders/worker-log.mjs
+++ b/test/fixtures/es-module-loaders/worker-log.mjs
@@ -1,0 +1,3 @@
+import { foo } from './module-named-exports.mjs';
+
+console.log(foo);

--- a/test/fixtures/es-module-loaders/workers-spawned.mjs
+++ b/test/fixtures/es-module-loaders/workers-spawned.mjs
@@ -1,0 +1,7 @@
+import { Worker } from 'worker_threads';
+
+const workerURL = new URL('./worker-log.mjs', import.meta.url);
+
+// Spawn two workers
+new Worker(workerURL);
+new Worker(workerURL);


### PR DESCRIPTION
Our intent with moving module customization hooks into a separate thread was that one such “hooks thread” would be spawned regardless of however many worker threads the user’s application code spawned. On current `main` this is not the case; a new hooks thread is created alongside each new worker thread.

This PR aims to fix that, but currently all I have is a test that fails on current `main` but _should_ pass, once this bug is fixed. I’m opening this as a placeholder for when a fix is ready, and I encourage anyone who wants to take a crack at it to help make this test pass. I’m happy to let others push commits on my branch.

cc @nodejs/loaders @nodejs/workers 