### PR TITLE
doc: fix fs.writeFileSync return value documentation

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6256,7 +6256,8 @@ changes:
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
   * `flush` {boolean} If all data is successfully written to the file, and
     `flush` is `true`, `fs.fsyncSync()` is used to flush the data.
-    Returns `undefined`.
+
+Returns `undefined`.
 
 The `mode` option only affects the newly created file. See [`fs.open()`][]
 for more details.


### PR DESCRIPTION
In https://github.com/nodejs/node/pull/50009, the return value was accidentally made part of `flush` option bullet point.
