### PR TITLE
src: make ModifyCodeGenerationFromStrings more robust

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -616,8 +616,18 @@ v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(
     bool is_code_like) {
   HandleScope scope(context->GetIsolate());
 
+  if (context->GetNumberOfEmbedderDataFields() <=
+      ContextEmbedderIndex::kAllowCodeGenerationFromStrings) {
+    // The context is not (yet) configured by Node.js for this. We don't
+    // have enough information to make a decision, just allow it which is
+    // the default.
+    return {true, {}};
+  }
   Environment* env = Environment::GetCurrent(context);
-  if (env->source_maps_enabled()) {
+  if (env == nullptr) {
+    return {true, {}};
+  }
+  if (env->source_maps_enabled() && env->can_call_into_js()) {
     // We do not expect the maybe_cache_generated_source_map to throw any more
     // exceptions. If it does, just ignore it.
     errors::TryCatchScope try_catch(env);


### PR DESCRIPTION
1. Fallback to true when the context is not (yet) initialized with the kAllowCodeGenerationFromStrings field.
2. Fallback to true when the Environment isn't assigned to the context or when the Environment cannot call into JavaScript.

Refs: https://github.com/nodejs/node/issues/50761

I don't think this PR could actually fix the referenced issue but the guards should've been added anyway.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
