### PR TITLE
fs: fix to not return for void function

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -530,7 +530,7 @@ function close(fd, callback = defaultCloseCallback) {
 function closeSync(fd) {
   fd = getValidatedFd(fd);
 
-  return binding.close(fd);
+  binding.close(fd);
 }
 
 /**
@@ -782,7 +782,7 @@ function readv(fd, buffers, position, callback) {
   if (typeof position !== 'number')
     position = null;
 
-  return binding.readBuffers(fd, buffers, position, req);
+  binding.readBuffers(fd, buffers, position, req);
 }
 
 ObjectDefineProperty(readv, kCustomPromisifyArgsSymbol,
@@ -858,7 +858,8 @@ function write(fd, buffer, offsetOrOptions, length, position, callback) {
 
     const req = new FSReqCallback();
     req.oncomplete = wrapper;
-    return binding.writeBuffer(fd, buffer, offset, length, position, req);
+    binding.writeBuffer(fd, buffer, offset, length, position, req);
+    return;
   }
 
   validateStringAfterArrayBufferView(buffer, 'buffer');
@@ -879,7 +880,7 @@ function write(fd, buffer, offsetOrOptions, length, position, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = wrapper;
-  return binding.writeString(fd, str, offset, length, req);
+  binding.writeString(fd, str, offset, length, req);
 }
 
 ObjectDefineProperty(write, kCustomPromisifyArgsSymbol,
@@ -969,7 +970,7 @@ function writev(fd, buffers, position, callback) {
   if (typeof position !== 'number')
     position = null;
 
-  return binding.writeBuffers(fd, buffers, position, req);
+  binding.writeBuffers(fd, buffers, position, req);
 }
 
 ObjectDefineProperty(writev, kCustomPromisifyArgsSymbol, {
@@ -1175,7 +1176,8 @@ function rmdir(path, options, callback) {
         if (err === false) {
           const req = new FSReqCallback();
           req.oncomplete = callback;
-          return binding.rmdir(path, req);
+          binding.rmdir(path, req);
+          return;
         }
         if (err) {
           return callback(err);
@@ -1188,7 +1190,7 @@ function rmdir(path, options, callback) {
     validateRmdirOptions(options);
     const req = new FSReqCallback();
     req.oncomplete = callback;
-    return binding.rmdir(path, req);
+    binding.rmdir(path, req);
   }
 }
 
@@ -1294,7 +1296,7 @@ function fdatasync(fd, callback) {
  */
 function fdatasyncSync(fd) {
   fd = getValidatedFd(fd);
-  return binding.fdatasync(fd);
+  binding.fdatasync(fd);
 }
 
 /**
@@ -1319,7 +1321,7 @@ function fsync(fd, callback) {
  */
 function fsyncSync(fd) {
   fd = getValidatedFd(fd);
-  return binding.fsync(fd);
+  binding.fsync(fd);
 }
 
 /**
@@ -1868,7 +1870,7 @@ function unlink(path, callback) {
  */
 function unlinkSync(path) {
   path = pathModule.toNamespacedPath(getValidatedPath(path));
-  return binding.unlink(path);
+  binding.unlink(path);
 }
 
 /**
@@ -2909,7 +2911,7 @@ realpath.native = (path, options, callback) => {
   path = getValidatedPath(path);
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  return binding.realpath(pathModule.toNamespacedPath(path), options.encoding, req);
+  binding.realpath(pathModule.toNamespacedPath(path), options.encoding, req);
 };
 
 /**


### PR DESCRIPTION
APIs with return type defined as `void` in jsdoc and document have been modified to not return a value.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
