### PR TITLE
net: check pipe mode and path

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -2014,6 +2014,12 @@ Server.prototype.listen = function(...args) {
   // (path[, backlog][, cb]) or (options[, cb])
   // where path or options.path is a UNIX domain socket or Windows pipe
   if (options.path && isPipeName(options.path)) {
+    // We can not call fchmod on abstract unix socket
+    if (options.path[0] === '\0' &&
+        (options.readableAll || options.writableAll)) {
+      const msg = 'can not set readableAll or writableAllt to true when path is abstract unix socket';
+      throw new ERR_INVALID_ARG_VALUE('options', options, msg);
+    }
     const pipeName = this._pipeName = options.path;
     backlog = options.backlog || backlogFromArgs;
     listenInCluster(this,

--- a/test/parallel/test-pipe-abstract-socket.js
+++ b/test/parallel/test-pipe-abstract-socket.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+if (!common.isLinux) common.skip();
+
+const path = '\0abstract';
+const message = /can not set readableAll or writableAllt to true when path is abstract unix socket/;
+
+assert.throws(() => {
+  const server = net.createServer(common.mustNotCall());
+  server.listen({
+    path,
+    readableAll: true
+  });
+}, message);
+
+assert.throws(() => {
+  const server = net.createServer(common.mustNotCall());
+  server.listen({
+    path,
+    writableAll: true
+  });
+}, message);
+
+assert.throws(() => {
+  const server = net.createServer(common.mustNotCall());
+  server.listen({
+    path,
+    readableAll: true,
+    writableAll: true
+  });
+}, message);


### PR DESCRIPTION
test code(on Linux):
```js
require('net').createServer().listen({ path: '\0abstract', readableAll: true, writableAll: true});
```

error message:
```

net.js:1495
        throw errnoException(err, 'uv_pipe_chmod');
        ^
Error: uv_pipe_chmod ENOENT
    at Server.listen (net.js:1495:15)
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
