### PR TITLE
lib: streamline process.binding() handling

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -140,7 +140,7 @@ const experimentalModuleList = new SafeSet();
 
   process.binding = function binding(module) {
     module = String(module);
-    let mod = bindingObj[module];
+    const mod = bindingObj[module];
     if (typeof mod === 'object') {
       return mod;
     }

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -87,34 +87,26 @@ ObjectDefineProperty(process, 'moduleLoadList', {
 // more, we just implement them as legacy wrappers instead. See the
 // legacyWrapperList.
 const processBindingAllowList = new SafeSet([
-  'async_wrap',
   'buffer',
   'cares_wrap',
   'config',
   'constants',
   'contextify',
-  'crypto',
   'fs',
   'fs_event_wrap',
-  'http_parser',
   'icu',
   'inspector',
   'js_stream',
-  'natives',
   'os',
   'pipe_wrap',
   'process_wrap',
-  'signal_wrap',
   'spawn_sync',
   'stream_wrap',
   'tcp_wrap',
   'tls_wrap',
   'tty_wrap',
   'udp_wrap',
-  'url',
-  'util',
   'uv',
-  'v8',
   'zlib',
 ]);
 
@@ -148,19 +140,23 @@ const experimentalModuleList = new SafeSet();
 
   process.binding = function binding(module) {
     module = String(module);
+    let mod = bindingObj[module];
+    if (typeof mod === 'object') {
+      return mod;
+    }
     // Deprecated specific process.binding() modules, but not all, allow
     // selective fallback to internalBinding for the deprecated ones.
+    if (runtimeDeprecatedList.has(module)) {
+      process.emitWarning(
+        `Access to process.binding('${module}') is deprecated.`,
+        'DeprecationWarning',
+        'DEP0111');
+      return internalBinding(module);
+    }
+    if (legacyWrapperList.has(module)) {
+      return requireBuiltin('internal/legacy/processbinding')[module]();
+    }
     if (processBindingAllowList.has(module)) {
-      if (runtimeDeprecatedList.has(module)) {
-        runtimeDeprecatedList.delete(module);
-        process.emitWarning(
-          `Access to process.binding('${module}') is deprecated.`,
-          'DeprecationWarning',
-          'DEP0111');
-      }
-      if (legacyWrapperList.has(module)) {
-        return requireBuiltin('internal/legacy/processbinding')[module]();
-      }
       return internalBinding(module);
     }
     // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
- Make processBindingAllowList a separate list from runtimeDeprecatedList and legacyWrapperList instead of being an umbrella one, so it's easier to see the stages the bindings are in.
- Cache process.binding() results so we don't need to mutate runtimeDeprecatedList.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
