### PR TITLE
inspector: use private fields instead of symbols

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -4,7 +4,6 @@ const {
   JSONParse,
   JSONStringify,
   SafeMap,
-  Symbol,
   SymbolDispose,
 } = primordials;
 
@@ -45,28 +44,19 @@ const {
   console,
 } = internalBinding('inspector');
 
-const connectionSymbol = Symbol('connectionProperty');
-const messageCallbacksSymbol = Symbol('messageCallbacks');
-const nextIdSymbol = Symbol('nextId');
-const onMessageSymbol = Symbol('onMessage');
-
 class Session extends EventEmitter {
-  constructor() {
-    super();
-    this[connectionSymbol] = null;
-    this[nextIdSymbol] = 1;
-    this[messageCallbacksSymbol] = new SafeMap();
-  }
+  #connection = null;
+  #nextId = 1;
+  #messageCallbacks = new SafeMap();
 
   /**
    * Connects the session to the inspector back-end.
    * @returns {void}
    */
   connect() {
-    if (this[connectionSymbol])
+    if (this.#connection)
       throw new ERR_INSPECTOR_ALREADY_CONNECTED('The inspector session');
-    this[connectionSymbol] =
-      new Connection((message) => this[onMessageSymbol](message));
+    this.#connection = new Connection((message) => this.#onMessage(message));
   }
 
   /**
@@ -77,23 +67,24 @@ class Session extends EventEmitter {
   connectToMainThread() {
     if (isMainThread)
       throw new ERR_INSPECTOR_NOT_WORKER();
-    if (this[connectionSymbol])
+    if (this.#connection)
       throw new ERR_INSPECTOR_ALREADY_CONNECTED('The inspector session');
-    this[connectionSymbol] =
+    this.#connection =
       new MainThreadConnection(
-        (message) => queueMicrotask(() => this[onMessageSymbol](message)));
+        (message) => queueMicrotask(() => this.#onMessage(message)));
   }
 
-  [onMessageSymbol](message) {
+  #onMessage(message) {
     const parsed = JSONParse(message);
     try {
       if (parsed.id) {
-        const callback = this[messageCallbacksSymbol].get(parsed.id);
-        this[messageCallbacksSymbol].delete(parsed.id);
+        const callback = this.#messageCallbacks.get(parsed.id);
+        this.#messageCallbacks.delete(parsed.id);
         if (callback) {
           if (parsed.error) {
-            return callback(new ERR_INSPECTOR_COMMAND(parsed.error.code,
-                                                      parsed.error.message));
+            return callback(
+              new ERR_INSPECTOR_COMMAND(parsed.error.code, parsed.error.message),
+            );
           }
 
           callback(null, parsed.result);
@@ -127,18 +118,18 @@ class Session extends EventEmitter {
       validateFunction(callback, 'callback');
     }
 
-    if (!this[connectionSymbol]) {
+    if (!this.#connection) {
       throw new ERR_INSPECTOR_NOT_CONNECTED();
     }
-    const id = this[nextIdSymbol]++;
+    const id = this.#nextId++;
     const message = { id, method };
     if (params) {
       message.params = params;
     }
     if (callback) {
-      this[messageCallbacksSymbol].set(id, callback);
+      this.#messageCallbacks.set(id, callback);
     }
-    this[connectionSymbol].dispatch(JSONStringify(message));
+    this.#connection.dispatch(JSONStringify(message));
   }
 
   /**
@@ -148,16 +139,16 @@ class Session extends EventEmitter {
    * @returns {void}
    */
   disconnect() {
-    if (!this[connectionSymbol])
+    if (!this.#connection)
       return;
-    this[connectionSymbol].disconnect();
-    this[connectionSymbol] = null;
-    const remainingCallbacks = this[messageCallbacksSymbol].values();
+    this.#connection.disconnect();
+    this.#connection = null;
+    const remainingCallbacks = this.#messageCallbacks.values();
     for (const callback of remainingCallbacks) {
       process.nextTick(callback, new ERR_INSPECTOR_CLOSED());
     }
-    this[messageCallbacksSymbol].clear();
-    this[nextIdSymbol] = 1;
+    this.#messageCallbacks.clear();
+    this.#nextId = 1;
   }
 }
 


### PR DESCRIPTION
A small refactor to replace Symbols with private properties