### PR TITLE
test: enable idlharness tests for encoding

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -617,7 +617,7 @@ class WPTRunner {
       'ReadableStreamBYOBReader', 'ReadableStreamBYOBRequest',
       'ReadableByteStreamController', 'ReadableStreamDefaultController',
       'ByteLengthQueuingStrategy', 'CountQueuingStrategy',
-      'TextEncoderStream', 'TextDecoderStream',
+      'TextEncoder', 'TextDecoder', 'TextEncoderStream', 'TextDecoderStream',
       'CompressionStream', 'DecompressionStream',
     ];
     if (Boolean(process.versions.openssl) && !process.env.NODE_SKIP_CRYPTO) {

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -37,7 +37,7 @@
     "skip": "The iso-8859-16 encoding is not supported"
   },
   "idlharness.any.js": {
-    "skip": "No implementation of TextDecoderStream and TextEncoderStream"
+    "requires": ["small-icu"]
   },
   "idlharness-shadowrealm.window.js": {
     "skip": "ShadowRealm support is not enabled"

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -3,7 +3,6 @@
 const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 
-// Set a script that will be executed in the worker before running the tests.
 runner.pretendGlobalThisAs('Window');
 
 runner.runJsTests();

--- a/test/wpt/test-encoding.js
+++ b/test/wpt/test-encoding.js
@@ -3,4 +3,7 @@
 const { WPTRunner } = require('../common/wpt');
 const runner = new WPTRunner('encoding');
 
+// Set a script that will be executed in the worker before running the tests.
+runner.pretendGlobalThisAs('Window');
+
 runner.runJsTests();


### PR DESCRIPTION
`TextDecoderStream` and `TextEncoderStream` are now exposed as globals, so we can run the entire Encoding idlharness test suite.