### PR TITLE
dns: call handle.setServers() with a valid array

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypeForEach,
-  ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   FunctionPrototypeBind,
@@ -143,12 +142,15 @@ class ResolverBase {
   }
 
   [kSetServersInteral](newSet, servers) {
-    const orig = this._handle.getServers() || [];
+    const orig = ArrayPrototypeMap(this._handle.getServers() || [], (val) => {
+      val.unshift(isIP(val[0]));
+      return val;
+    });
     const errorNumber = this._handle.setServers(newSet);
 
     if (errorNumber !== 0) {
       // Reset the servers to the old servers, because ares probably unset them.
-      this._handle.setServers(ArrayPrototypeJoin(orig, ','));
+      this._handle.setServers(orig);
       const { strerror } = lazyBinding();
       const err = strerror(errorNumber);
       throw new ERR_DNS_SET_SERVERS_FAILED(err, servers);


### PR DESCRIPTION
`handle.setServers()` takes an array, not a string.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
