### PR TITLE
test: use requires instead of flaky in console WPT status

### DIFF
--- a/test/wpt/status/console.json
+++ b/test/wpt/status/console.json
@@ -1,12 +1,7 @@
 {
   "idlharness.any.js": {
-    "fail": {
-      "flaky": [
-        "console namespace: operation assert(optional boolean, any...)",
-        "console namespace: operation table(optional any, optional sequence<DOMString>)",
-        "console namespace: operation dir(optional any, optional object?)"
-      ]
-    }
+    "note": "https://github.com/nodejs/node/issues/44185",
+    "requires": ["crypto", "small-icu"]
   },
   "idlharness-shadowrealm.window.js": {
     "skip": "ShadowRealm support is not enabled"


### PR DESCRIPTION
These tests are not flaky, they just have requirements, see https://github.com/nodejs/node/issues/44185#issuecomment-1219388742