### PR TITLE
Add fsPromises.existing API

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -904,6 +904,39 @@ condition, since other processes may change the file's state between the two
 calls. Instead, user code should open/read/write the file directly and handle
 the error raised if the file is not accessible.
 
+### `fsPromises.existing(path)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|Buffer|URL}
+* Returns: {Promise} Fulfills with `string` representing path upon success.
+
+Tests a user's accessibility for the file or directory specified by `path`.
+
+If the accessibility check is successful, the promise is fulfilled with the
+path that was passed to it. If any of the accessibility checks fail, the promise
+is fulfilled with empty string.
+
+The following example checks if the file `/etc/passwd` can be read and written
+by the current process:
+
+```mjs
+import { existing } from 'node:fs/promises';
+
+const existingPasswdFilepath = await existing('/etc/passwd');
+if(existingPasswdFilepath){
+  ... do something with the existingPasswdFilepath
+}
+```
+
+Using `fsPromises.existing()` to check for the accessibility of a file before
+calling `fsPromises.open()` is not recommended. Doing so introduces a race
+condition, since other processes may change the file's state between the two
+calls. Instead, user code should open/read/write the file directly and handle
+the error raised if the file is not accessible.
+
 ### `fsPromises.appendFile(path, data[, options])`
 
 <!-- YAML

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -607,6 +607,17 @@ async function access(path, mode = F_OK) {
   );
 }
 
+async function existing(path) {
+  if (!path)
+    return '';
+  try {
+    await access(path);
+    return path;
+  } catch {
+    return '';
+  }
+}
+
 async function cp(src, dest, options) {
   options = validateCpOptions(options);
   src = pathModule.toNamespacedPath(getValidatedPath(src, 'src'));
@@ -1272,6 +1283,7 @@ module.exports = {
     access,
     copyFile,
     cp,
+    existing,
     open,
     opendir: promisify(opendir),
     rename,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Allows to pick existing path:

`existing(path1) || existing(path2)`