### PR TITLE
tools: add macOS notarization verification step

### DIFF
--- a/tools/osx-notarize.sh
+++ b/tools/osx-notarize.sh
@@ -53,5 +53,12 @@ else
   exit 1
 fi
 
+if ! xcrun spctl --assess --type install --context context:primary-signature --ignore-cache --verbose=2 "node-$pkgid.pkg"; then
+  echo "error: Signature will not be accepted by Gatekeeper!" 1>&2
+  exit 1
+else
+  echo "Verification was successful."
+fi
+
 xcrun stapler staple "node-$pkgid.pkg"
 echo "Stapler was successful."


### PR DESCRIPTION
### Main Changes

Add a verification step to validate the notarized binaries generated for macOS.

### Context

This change was previously defined in #50628, but due git issues I re-generated the PR.