### PR TITLE
fs: fix value of `dirent.path`

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -254,29 +254,29 @@ function getDirents(path, { 0: names, 1: types }, callback) {
     callback = once(callback);
     for (i = 0; i < len; i++) {
       const type = types[i];
+      const name = names[i];
+      let filepath;
+      try {
+        filepath = join(path, name);
+      } catch (err) {
+        callback(err);
+        return;
+      }
       if (type === UV_DIRENT_UNKNOWN) {
-        const name = names[i];
         const idx = i;
         toFinish++;
-        let filepath;
-        try {
-          filepath = join(path, name);
-        } catch (err) {
-          callback(err);
-          return;
-        }
         lazyLoadFs().lstat(filepath, (err, stats) => {
           if (err) {
             callback(err);
             return;
           }
-          names[idx] = new DirentFromStats(name, stats, path);
+          names[idx] = new DirentFromStats(name, stats, filepath);
           if (--toFinish === 0) {
             callback(null, names);
           }
         });
       } else {
-        names[i] = new Dirent(names[i], types[i], path);
+        names[i] = new Dirent(names[i], types[i], filepath);
       }
     }
     if (toFinish === 0) {
@@ -292,15 +292,15 @@ function getDirents(path, { 0: names, 1: types }, callback) {
 }
 
 function getDirent(path, name, type, callback) {
+  let filepath;
+  try {
+    filepath = join(path, name);
+  } catch (err) {
+    callback(err);
+    return;
+  }
   if (typeof callback === 'function') {
     if (type === UV_DIRENT_UNKNOWN) {
-      let filepath;
-      try {
-        filepath = join(path, name);
-      } catch (err) {
-        callback(err);
-        return;
-      }
       lazyLoadFs().lstat(filepath, (err, stats) => {
         if (err) {
           callback(err);
@@ -309,14 +309,13 @@ function getDirent(path, name, type, callback) {
         callback(null, new DirentFromStats(name, stats, filepath));
       });
     } else {
-      callback(null, new Dirent(name, type, path));
+      callback(null, new Dirent(name, type, filepath));
     }
   } else if (type === UV_DIRENT_UNKNOWN) {
-    const filepath = join(path, name);
     const stats = lazyLoadFs().lstatSync(filepath);
-    return new DirentFromStats(name, stats, path);
+    return new DirentFromStats(name, stats, filepath);
   } else {
-    return new Dirent(name, type, path);
+    return new Dirent(name, type, filepath);
   }
 }
 

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -48,9 +48,10 @@ const invalidCallbackObj = {
   const entries = files.map(() => {
     const dirent = dir.readSync();
     assertDirent(dirent);
-    return dirent.name;
-  });
-  assert.deepStrictEqual(files, entries.sort());
+    return { name: dirent.name, path: dirent.path, toString() { return dirent.name; } };
+  }).sort();
+  assert.deepStrictEqual(entries.map((d) => d.name), files);
+  assert.deepStrictEqual(entries.map((d) => d.path), files.map((name) => path.join(testDir, name)));
 
   // dir.read should return null when no more entries exist
   assert.strictEqual(dir.readSync(), null);


### PR DESCRIPTION
To my understanding, this property should contain the full path to that dirent (as it is the case on v18.x), not the path to its parent directory (as it's the case on v20.x+). This PR aligns to v18.x behavior.

/cc @nodejs/fs 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
