### PR TITLE
src: implement FastByteLengthUtf8 with simdutf::utf8_length_from_latin1

### DIFF
--- a/benchmark/buffers/buffer-bytelength-string.js
+++ b/benchmark/buffers/buffer-bytelength-string.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 
 const bench = common.createBenchmark(main, {
-  type: ['one_byte', 'two_bytes', 'three_bytes', 'four_bytes'],
+  type: ['one_byte', 'two_bytes', 'three_bytes', 'four_bytes', 'latin1'],
   encoding: ['utf8', 'base64'],
   repeat: [1, 2, 16, 256], // x16
   n: [4e6],
@@ -14,6 +14,7 @@ const chars = {
   two_bytes: 'ΰαβγδεζηθικλμνξο',
   three_bytes: '挰挱挲挳挴挵挶挷挸挹挺挻挼挽挾挿',
   four_bytes: '𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷𠺝𠺢',
+  latin1: 'Un homme sage est supérieur à toutes les insultes qui peuvent lui être adressées, et la meilleure réponse est la patience et la modération.'
 };
 
 function getInput(type, repeat, encoding) {

--- a/benchmark/buffers/buffer-bytelength-string.js
+++ b/benchmark/buffers/buffer-bytelength-string.js
@@ -2,7 +2,8 @@
 const common = require('../common');
 
 const bench = common.createBenchmark(main, {
-  type: ['one_byte', 'two_bytes', 'three_bytes', 'four_bytes', 'latin1'],
+  type: ['one_byte', 'two_bytes', 'three_bytes',
+         'four_bytes', 'latin1'],
   encoding: ['utf8', 'base64'],
   repeat: [1, 2, 16, 256], // x16
   n: [4e6],
@@ -14,7 +15,8 @@ const chars = {
   two_bytes: 'ΰαβγδεζηθικλμνξο',
   three_bytes: '挰挱挲挳挴挵挶挷挸挹挺挻挼挽挾挿',
   four_bytes: '𠜎𠜱𠝹𠱓𠱸𠲖𠳏𠳕𠴕𠵼𠵿𠸎𠸏𠹷𠺝𠺢',
-  latin1: 'Un homme sage est supérieur à toutes les insultes qui peuvent lui être adressées, et la meilleure réponse est la patience et la modération.'
+  latin1: 'Un homme sage est supérieur à toutes ' +
+    'les insultes qui peuvent lui être adressées, et la meilleure réponse est la patience et la modération.',
 };
 
 function getInput(type, repeat, encoding) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -745,7 +745,7 @@ uint32_t FastByteLengthUtf8(Local<Value> receiver,
                             const v8::FastOneByteString& source) {
   // For short inputs, the function call overhead to simdutf is maybe
   // not worth it, reserve simdutf for long strings.
-  if(source.length > 128) {
+  if (source.length > 128) {
     return simdutf::utf8_length_from_latin1(source.data, source.length);
   }
   uint32_t length = source.length;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -743,14 +743,7 @@ void SlowByteLengthUtf8(const FunctionCallbackInfo<Value>& args) {
 
 uint32_t FastByteLengthUtf8(Local<Value> receiver,
                             const v8::FastOneByteString& source) {
-  uint32_t result = 0;
-  uint32_t length = source.length;
-  const uint8_t* data = reinterpret_cast<const uint8_t*>(source.data);
-  for (uint32_t i = 0; i < length; ++i) {
-    result += (data[i] >> 7);
-  }
-  result += length;
-  return result;
+  return simdutf::utf8_length_from_latin1(source.data, source.length);
 }
 
 static v8::CFunction fast_byte_length_utf8(


### PR DESCRIPTION
This PR proposes to replace the conventional FastByteLengthUtf8 implementation by `simdutf::utf8_length_from_latin1`. Internally, the simdutf library implements specific functions. The results are presented in the following blog posts...

* [Computing the UTF-8 size of a Latin 1 string quickly (ARM NEON edition)](https://lemire.me/blog/2023/05/15/computing-the-utf-8-size-of-a-latin-1-string-quickly-arm-neon-edition/)
* [Computing the UTF-8 size of a Latin 1 string quickly (AVX edition)](https://lemire.me/blog/2023/02/16/computing-the-utf-8-size-of-a-latin-1-string-quickly-avx-edition/)

The speed can be 30x better in some instances.

This PR actually reduces the total number of lines of code.