### PR TITLE
fs: replace deprecated `path._makeLong` in copyFile

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2981,8 +2981,8 @@ function copyFile(src, dest, mode, callback) {
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
 
-  src = pathModule._makeLong(src);
-  dest = pathModule._makeLong(dest);
+  src = pathModule.toNamespacedPath(src);
+  dest = pathModule.toNamespacedPath(dest);
   mode = getValidMode(mode, 'copyFile');
   callback = makeCallback(callback);
 


### PR DESCRIPTION
Tiny fix, noticed whilst doing something else :)