### PR TITLE
doc: add CanadaHonk to triagers

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,8 @@ maintaining the Node.js project.
   **Qingyu Deng** <<i@ayase-lab.com>>
 * [bmuenzenmeyer](https://github.com/bmuenzenmeyer) -
   **Brian Muenzenmeyer** <<brian.muenzenmeyer@gmail.com>> (he/him)
+* [CanadaHonk](https://github.com/CanadaHonk) -
+  **Oliver Medhurst** <<honk@goose.icu>> (they/them)
 * [daeyeon](https://github.com/daeyeon) -
   **Daeyeon Jeong** <<daeyeon.dev@gmail.com>> (he/him)
 * [F3n67u](https://github.com/F3n67u) -


### PR DESCRIPTION
I started [making PRs](https://github.com/nodejs/node/pulls?q=is%3Apr+author%3ACanadaHonk) and discussing in issues a few months ago, mostly perf related. Becoming a triager helps the workflow and is more of a commitment for the future :)

I have read the [Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md) plus [Triage Guide](https://github.com/nodejs/node/blob/main/doc/contributing/issues.md#triaging-a-bug-report) and agree to both. Thank you!