### PR TITLE
src: fix backtrace with [[noreturn]] abort

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -734,7 +734,7 @@ Maybe<bool> InitializeContextRuntime(Local<Context> context) {
     }
   } else if (per_process::cli_options->disable_proto != "") {
     // Validated in ProcessGlobalArgs
-    OnFatalError("InitializeContextRuntime()", "invalid --disable-proto mode");
+    UNREACHABLE("invalid --disable-proto mode");
   }
 
   return Just(true);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -36,9 +36,6 @@
 namespace node {
 namespace inspector {
 namespace {
-
-using node::OnFatalError;
-
 using v8::Context;
 using v8::Function;
 using v8::HandleScope;
@@ -917,8 +914,7 @@ void Agent::ToggleAsyncHook(Isolate* isolate, Local<Function> fn) {
   USE(fn->Call(context, Undefined(isolate), 0, nullptr));
   if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
     PrintCaughtException(isolate, context, try_catch);
-    OnFatalError("\nnode::inspector::Agent::ToggleAsyncHook",
-                 "Cannot toggle Inspector's AsyncHook, please report this.");
+    UNREACHABLE("Cannot toggle Inspector's AsyncHook, please report this.");
   }
 }
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -21,8 +21,11 @@ void AppendExceptionLine(Environment* env,
 
 // This function calls backtrace, it should have not be marked as [[noreturn]].
 // But it is a public API, removing the attribute can break.
+// Prefer UNREACHABLE() internally instead, it doesn't need manually set
+// location.
 [[noreturn]] void OnFatalError(const char* location, const char* message);
-// This function calls backtrace, do not mark as [[noreturn]].
+// This function calls backtrace, do not mark as [[noreturn]]. Read more in the
+// ABORT macro.
 void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
 
 // Helpers to construct errors similar to the ones provided by

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -19,9 +19,11 @@ void AppendExceptionLine(Environment* env,
                          v8::Local<v8::Message> message,
                          enum ErrorHandlingMode mode);
 
+// This function calls backtrace, it should have not be marked as [[noreturn]].
+// But it is a public API, removing the attribute can break.
 [[noreturn]] void OnFatalError(const char* location, const char* message);
-[[noreturn]] void OOMErrorHandler(const char* location,
-                                  const v8::OOMDetails& details);
+// This function calls backtrace, do not mark as [[noreturn]].
+void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
 
 // Helpers to construct errors similar to the ones provided by
 // lib/internal/errors.js.

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -64,7 +64,7 @@ Mutex umask_mutex;
 #define NANOS_PER_SEC 1000000000
 
 static void Abort(const FunctionCallbackInfo<Value>& args) {
-  Abort();
+  ABORT();
 }
 
 // For internal testing only, not exposed to userland.

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -45,7 +45,7 @@ Watchdog::Watchdog(v8::Isolate* isolate, uint64_t ms, bool* timed_out)
   int rc;
   rc = uv_loop_init(&loop_);
   if (rc != 0) {
-    OnFatalError("node::Watchdog::Watchdog()", "Failed to initialize uv loop.");
+    UNREACHABLE("Failed to initialize uv loop.");
   }
 
   rc = uv_async_init(&loop_, &async_, [](uv_async_t* signal) {

--- a/src/util.h
+++ b/src/util.h
@@ -126,9 +126,11 @@ void DumpJavaScriptBacktrace(FILE* fp);
 #define ABORT_NO_BACKTRACE() abort()
 #endif
 
-// A function calls a [[noreturn]] function will print an incorrect
-// call stack because the frame pc was advanced to an invalid op at the call
-// site, which may vary on different platforms.
+// Caller of this macro must not be marked as [[noreturn]]. Printing of
+// backtraces may not work correctly in [[noreturn]] functions because
+// when generating code for them the compiler can choose not to
+// maintain the frame pointers or link registers that are necessary for
+// correct backtracing. 
 // `ABORT` must be a macro and not a [[noreturn]] function to make sure the
 // backtrace is correct.
 #define ABORT()                                                                \

--- a/src/util.h
+++ b/src/util.h
@@ -130,7 +130,7 @@ void DumpJavaScriptBacktrace(FILE* fp);
 // backtraces may not work correctly in [[noreturn]] functions because
 // when generating code for them the compiler can choose not to
 // maintain the frame pointers or link registers that are necessary for
-// correct backtracing. 
+// correct backtracing.
 // `ABORT` must be a macro and not a [[noreturn]] function to make sure the
 // backtrace is correct.
 #define ABORT()                                                                \


### PR DESCRIPTION
A function calls [[noreturn]] node::Abort will print an incorrect
call stack because the frame pc was advanced to an invalid op
when calling node::Abort, which may vary on different platforms.

Dumps the backtrace in the ABORT macro instead to avoid calling
backtrace in a [[noreturn]] call. Removes the [[noreturn]]
attribute if a function calls backtrace.

[[noreturn]] attribute of public functions like `napi_fatal_error` and
`node::OnFatalError` can not be removed as compilers may complain
about no return values after the removal.

Refs: https://github.com/nodejs/node/issues/50761
