### PR TITLE
doc: update email to reflect affiliation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -583,6 +583,7 @@ xiaoyu <306766053@qq.com>
 Xu Meng <dmabupt@gmail.com> <mengxumx@cn.ibm.com>
 Xuguang Mei <meixuguang@gmail.com> <meixg@foxmail.com>
 Yael Hermon <yaelherm@gmail.com> <yaelhe@wix.com>
+Yagiz Nizipli <yagiz@nizipli.com> <yagiz.nizipli@sentry.io>
 Yang Guo <yangguo@chromium.org>
 Yash Ladha <yash@yashladha.in> <18033231+yashLadha@users.noreply.github.com>
 Yash Ladha <yash@yashladha.in> <yashladhapankajladha123@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -583,7 +583,7 @@ xiaoyu <306766053@qq.com>
 Xu Meng <dmabupt@gmail.com> <mengxumx@cn.ibm.com>
 Xuguang Mei <meixuguang@gmail.com> <meixg@foxmail.com>
 Yael Hermon <yaelherm@gmail.com> <yaelhe@wix.com>
-Yagiz Nizipli <yagiz@nizipli.com> <yagiz.nizipli@sentry.io>
+Yagiz Nizipli <yagiz.nizipli@sentry.io> <yagiz@nizipli.com>
 Yang Guo <yangguo@chromium.org>
 Yash Ladha <yash@yashladha.in> <18033231+yashLadha@users.noreply.github.com>
 Yash Ladha <yash@yashladha.in> <yashladhapankajladha123@gmail.com>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ For information about the governance of the Node.js project, see
 * [aduh95](https://github.com/aduh95) -
   **Antoine du Hamel** <<duhamelantoine1995@gmail.com>> (he/him)
 * [anonrig](https://github.com/anonrig) -
-  **Yagiz Nizipli** <<yagiz@nizipli.com>> (he/him)
+  **Yagiz Nizipli** <<yagiz.nizipli@sentry.io>> (he/him)
 * [apapirovski](https://github.com/apapirovski) -
   **Anatoli Papirovski** <<apapirovski@mac.com>> (he/him)
 * [benjamingr](https://github.com/benjamingr) -
@@ -288,7 +288,7 @@ For information about the governance of the Node.js project, see
 * [aduh95](https://github.com/aduh95) -
   **Antoine du Hamel** <<duhamelantoine1995@gmail.com>> (he/him)
 * [anonrig](https://github.com/anonrig) -
-  **Yagiz Nizipli** <<yagiz@nizipli.com>> (he/him)
+  **Yagiz Nizipli** <<yagiz.nizipli@sentry.io>> (he/him)
 * [antsmartian](https://github.com/antsmartian) -
   **Anto Aravinth** <<anto.aravinth.cse@gmail.com>> (he/him)
 * [apapirovski](https://github.com/apapirovski) -


### PR DESCRIPTION
Updating my email address on README to reflect my affiliation with Sentry (https://sentry.io). They're sponsoring my work to Node.js starting from November 20.

cc @nodejs/tsc