### PR TITLE
src: fix unix abstract socket path for trace event

### DIFF
--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -230,11 +230,15 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
   if (err) {
     delete req_wrap;
   } else {
-    TRACE_EVENT_NESTABLE_ASYNC_BEGIN1(TRACING_CATEGORY_NODE2(net, native),
+    const char* path_type = (*name)[0] == '\0' ? "abstract socket" : "file";
+    const char* pipe_path = (*name)[0] == '\0' ? (*name) + 1 : *name;
+    TRACE_EVENT_NESTABLE_ASYNC_BEGIN2(TRACING_CATEGORY_NODE2(net, native),
                                       "connect",
                                       req_wrap,
+                                      "path_type",
+                                      path_type,
                                       "pipe_path",
-                                      TRACE_STR_COPY(*name));
+                                      TRACE_STR_COPY(pipe_path));
   }
 
   args.GetReturnValue().Set(err);

--- a/test/parallel/test-trace-events-net-abstract-socket.js
+++ b/test/parallel/test-trace-events-net-abstract-socket.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+if (!common.isLinux) common.skip();
+
+const CODE = `
+  const net = require('net');
+  net.connect('${common.PIPE}').on('error', () => {});
+  net.connect('\\0${common.PIPE}').on('error', () => {});
+`;
+
+tmpdir.refresh();
+const FILE_NAME = tmpdir.resolve('node_trace.1.log');
+
+const proc = cp.spawn(process.execPath,
+                      [ '--trace-events-enabled',
+                        '--trace-event-categories', 'node.net.native',
+                        '-e', CODE ],
+                      { cwd: tmpdir.path });
+
+proc.once('exit', common.mustCall(() => {
+  assert(fs.existsSync(FILE_NAME));
+  fs.readFile(FILE_NAME, common.mustCall((err, data) => {
+    const traces = JSON.parse(data.toString()).traceEvents;
+    assert(traces.length > 0);
+    let count = 0;
+    traces.forEach((trace) => {
+      if (trace.cat === 'node,node.net,node.net.native' &&
+          trace.name === 'connect') {
+        count++;
+        if (trace.ph === 'b') {
+          assert.ok(!!trace.args.path_type);
+          assert.ok(!!trace.args.pipe_path);
+        }
+      }
+    });
+    assert.strictEqual(count, 4);
+  }));
+}));


### PR DESCRIPTION
`'\0'` in the unix abstract socket causes the `path` in the trace event to be empty. We'll skip the `'\0'` and mark the path type with `path_type`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
