### PR TITLE
benchmark: update iterations in benchmark/crypto/get-ciphers.js

### DIFF
--- a/benchmark/crypto/get-ciphers.js
+++ b/benchmark/crypto/get-ciphers.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  n: [1, 5000],
+  n: [1, 500000],
   v: ['crypto', 'tls'],
 });
 


### PR DESCRIPTION
Increase the 500 iteration to 50000 to reflect the real ciphers perf. The single iteration n=1 can not make the score reasonable.

Refs: https://github.com/nodejs/node/issues/50571

before:
crypto/get-ciphers.js v="crypto" n=1: 1,852.3492419260726
crypto/get-ciphers.js v="tls" n=1: 1,405.8034377517265
crypto/get-ciphers.js v="crypto" n=5000: 6,147,294.084090065
crypto/get-ciphers.js v="tls" n=5000: 4,488,971.047034541

after
crypto/get-ciphers.js v="crypto" n=1: 1,879.232972270038
crypto/get-ciphers.js v="tls" n=1: 1,430.8526164570944
crypto/get-ciphers.js v="crypto" n=500000: 9,035,846.449813219
crypto/get-ciphers.js v="tls" n=500000: 19,212,295.13113179