### PR TITLE
deps: V8: cherry-pick 0f9ebbc672c7

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -298,7 +298,6 @@ DEFINE_WEAK_IMPLICATION(harmony_rab_gsab_transfer, harmony_rab_gsab)
 #define HARMONY_SHIPPING_BASE(V)                                       \
   V(harmony_import_assertions, "harmony import assertions")            \
   V(harmony_change_array_by_copy, "harmony change-Array-by-copy")      \
-  V(harmony_string_is_well_formed, "harmony String#{is,to}WellFormed") \
   V(harmony_rab_gsab,                                                  \
     "harmony ResizableArrayBuffer / GrowableSharedArrayBuffer")        \
   V(harmony_regexp_unicode_sets, "harmony RegExp Unicode Sets")        \

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -2158,6 +2158,8 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
                           Builtin::kStringPrototypeIncludes, 1, false);
     SimpleInstallFunction(isolate_, prototype, "indexOf",
                           Builtin::kStringPrototypeIndexOf, 1, false);
+    SimpleInstallFunction(isolate(), prototype, "isWellFormed",
+                          Builtin::kStringPrototypeIsWellFormed, 0, false);
     SimpleInstallFunction(isolate_, prototype, "italics",
                           Builtin::kStringPrototypeItalics, 0, false);
     SimpleInstallFunction(isolate_, prototype, "lastIndexOf",
@@ -2214,6 +2216,8 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
                           Builtin::kStringPrototypeStartsWith, 1, false);
     SimpleInstallFunction(isolate_, prototype, "toString",
                           Builtin::kStringPrototypeToString, 0, true);
+    SimpleInstallFunction(isolate(), prototype, "toWellFormed",
+                          Builtin::kStringPrototypeToWellFormed, 0, false);
     SimpleInstallFunction(isolate_, prototype, "trim",
                           Builtin::kStringPrototypeTrim, 0, false);
 
@@ -5060,18 +5064,6 @@ void Genesis::InitializeGlobal_harmony_rab_gsab() {
                       Builtin::kSharedArrayBufferPrototypeGetGrowable, false);
   SimpleInstallFunction(isolate(), shared_array_buffer_prototype, "grow",
                         Builtin::kSharedArrayBufferPrototypeGrow, 1, true);
-}
-
-void Genesis::InitializeGlobal_harmony_string_is_well_formed() {
-  if (!v8_flags.harmony_string_is_well_formed) return;
-  Handle<JSFunction> string_function(native_context()->string_function(),
-                                     isolate());
-  Handle<JSObject> string_prototype(
-      JSObject::cast(string_function->initial_map()->prototype()), isolate());
-  SimpleInstallFunction(isolate(), string_prototype, "isWellFormed",
-                        Builtin::kStringPrototypeIsWellFormed, 0, false);
-  SimpleInstallFunction(isolate(), string_prototype, "toWellFormed",
-                        Builtin::kStringPrototypeToWellFormed, 0, false);
 }
 
 void Genesis::InitializeGlobal_harmony_temporal() {


### PR DESCRIPTION
Original commit message:

    [flags] Remove --harmony-string-is-well-formed

    The String.prototype.isWellFormed and toWellFormed have shipped
    since M111.

    Bug: v8:13557
    Change-Id: I27e332d2fde0f9ea8ad649c016a84d2d3e0bf592
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4931269
    Reviewed-by: Shu-yu Guo <syg@chromium.org>
    Commit-Queue: Chengzhong Wu (legendecas) <legendecas@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#90398}

Refs: https://github.com/v8/v8/commit/0f9ebbc672c77594feb9176cf52601116aa7c34c

This patch has been released in v8 12.0. Cherry-pick to unblock https://github.com/nodejs/node/pull/47342.