### PR TITLE
benchmark: update iteration and size in benchmark/crypto/randomBytes.js

### DIFF
--- a/benchmark/crypto/randomBytes.js
+++ b/benchmark/crypto/randomBytes.js
@@ -3,7 +3,7 @@
 const common = require('../common.js');
 const { randomBytes } = require('crypto');
 
-// add together with imports
+// Add together with imports
 const assert = require('assert');
 
 let _cryptoResult;

--- a/benchmark/crypto/randomBytes.js
+++ b/benchmark/crypto/randomBytes.js
@@ -3,6 +3,11 @@
 const common = require('../common.js');
 const { randomBytes } = require('crypto');
 
+// add together with imports
+const assert = require('assert');
+
+let _cryptoResult;
+
 const bench = common.createBenchmark(main, {
   size: [64, 1024, 8 * 1024, 16 * 1024],
   n: [1e5],
@@ -11,6 +16,8 @@ const bench = common.createBenchmark(main, {
 function main({ n, size }) {
   bench.start();
   for (let i = 0; i < n; ++i)
-    randomBytes(size);
+    _cryptoResult = randomBytes(size);
   bench.end(n);
+  // Avoid V8 deadcode (elimination)
+  assert.ok(_cryptoResult);
 }

--- a/benchmark/crypto/randomBytes.js
+++ b/benchmark/crypto/randomBytes.js
@@ -4,8 +4,8 @@ const common = require('../common.js');
 const { randomBytes } = require('crypto');
 
 const bench = common.createBenchmark(main, {
-  size: [64, 1024, 8192, 512 * 1024],
-  n: [1e3],
+  size: [64, 1024, 8 * 1024, 16 * 1024],
+  n: [1e5],
 });
 
 function main({ n, size }) {


### PR DESCRIPTION
Increase iteration value from 1000 to 10000 to reflect real performance of randomBytes generation. The randomInt has no need to apply this.

Fixes: https://github.com/nodejs/node/issues/50571

Below is the score improvment measured on cascadelake server:
```
crypto/randomBytes.js size=64:  n=10000 percent=137.85%
crypto/randomBytes.js size=1024:  n=10000 percent=130.66%
crypto/randomBytes.js size=8192:  n=10000 percent=136.31%
crypto/randomBytes.js size=524288:  n=10000 percent=166.50%
```