### PR TITLE
benchmark: increase iteration counts for 4 cases

### DIFF
--- a/benchmark/perf_hooks/performance-observer.js
+++ b/benchmark/perf_hooks/performance-observer.js
@@ -13,7 +13,7 @@ function randomFn() {
 }
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   pending: [1, 10],
 }, {
   options: ['--expose-internals'],

--- a/benchmark/perf_hooks/resourcetiming.js
+++ b/benchmark/perf_hooks/resourcetiming.js
@@ -50,7 +50,7 @@ function createTimingInfo({
 }
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   observe: ['resource'],
 });
 

--- a/benchmark/perf_hooks/timerfied.js
+++ b/benchmark/perf_hooks/timerfied.js
@@ -13,7 +13,7 @@ function randomFn() {
 }
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   observe: ['function'],
 });
 

--- a/benchmark/perf_hooks/usertiming.js
+++ b/benchmark/perf_hooks/usertiming.js
@@ -8,7 +8,7 @@ const {
 } = require('perf_hooks');
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   observe: ['all', 'measure'],
 });
 


### PR DESCRIPTION
Increase the iteration counts to 10X to reflect real performance of perf hooks timing.

Refs: https://github.com/nodejs/node/issues/50571

Belowing are the improved ratio with 10X iteration:

performance-observer.js
./node/benchmark//perf_hooks/performance-observer.js n=1000000
perf_hooks/performance-observer.js pending=1 n=1000000 percent=111.33%
perf_hooks/performance-observer.js pending=10 n=1000000 percent=127.58%

resourcetiming.js
./node/benchmark//perf_hooks/resourcetiming.js n=1000000
perf_hooks/resourcetiming.js observe="resource" n=1000000 percent=135.24%

timerfied.js
./node/benchmark//perf_hooks/timerfied.js n=1000000
perf_hooks/timerfied.js observe="function" n=1000000 percent=116.11%

usertiming.js
./node/benchmark//perf_hooks/usertiming.js n=1000000
perf_hooks/usertiming.js observe="all" n=1000000 percent=823.76%
perf_hooks/usertiming.js observe="measure" n=1000000 percent=1039.62%