### PR TITLE
benchmark: increase iteration count of util cases

### DIFF
--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -18,7 +18,7 @@ const inputs = {
 };
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   type: Object.keys(inputs),
 });
 

--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const util = require('util');
 
 const bench = common.createBenchmark(main, {
-  n: [5e2],
+  n: [5e3],
   len: [1e2, 1e5],
   type: [
     'denseArray',

--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -21,7 +21,7 @@ const inputs = [
 
 const bench = common.createBenchmark(main, {
   input: inputs.concat(Object.keys(groupedInputs)),
-  n: [1e5],
+  n: [1e6],
 }, {
   flags: '--expose-internals',
 });

--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   pos: ['start', 'middle', 'end'],
   size: [10, 100, 500],
 }, { flags: ['--expose-internals'] });

--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   ignoreBOM: [0, 1],
   fatal: [0, 1],
   len: [256, 1024 * 16, 1024 * 512],
-  n: [1e2],
+  n: [1e3],
   type: ['SharedArrayBuffer', 'ArrayBuffer', 'Buffer'],
 });
 

--- a/benchmark/util/to-usv-string.js
+++ b/benchmark/util/to-usv-string.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const BASE = 'string\ud801';
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   size: [10, 100, 500],
 });
 

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -29,7 +29,7 @@ const bench = common.createBenchmark(main, {
   type: Object.keys(args),
   version: ['native', 'js'],
   argument: ['true', 'false-primitive', 'false-object'],
-  n: [1e5],
+  n: [1e6],
 }, {
   flags: ['--expose-internals', '--no-warnings'],
 });


### PR DESCRIPTION
Increase the iteratrion count of util cases to 10X to reflect the real performance

Refs: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:

```
util/format.js n=1000000
util/format.js type="string"  n=1000000 percent=154.84%
util/format.js type="string-2"  n=1000000 percent=150.37%
util/format.js type="number"  n=1000000 percent=156.83%
util/format.js type="replace-object"  n=1000000 percent=111.05%
util/format.js type="unknown"  n=1000000 percent=164.63%
util/format.js type="no-replace"  n=1000000 percent=174.30%
util/format.js type="no-replace-2"  n=1000000 percent=168.45%
util/format.js type="many-%"  n=1000000 percent=177.32%
util/format.js type="object-to-string"  n=1000000 percent=139.61%
util/format.js type="object-%s"  n=1000000 percent=110.67%

util/inspect-array.js n=5000
util/inspect-array.js type="denseArray"  n=5000 percent=159.84%
util/inspect-array.js type="sparseArray"  n=5000 percent=245.72%
util/inspect-array.js type="denseArray_showHidden"  n=5000 percent=158.26%
util/inspect-array.js type="denseArray"  n=5000 percent=164.69%
util/inspect-array.js type="denseArray_showHidden"  n=5000 percent=158.53%

util/normalize-encoding.js n=1000000
util/normalize-encoding.js input="":  n=1000000 percent=301.90%
util/normalize-encoding.js input="utf8":  n=1000000 percent=257.18%
util/normalize-encoding.js input="utf-8":  n=1000000 percent=247.71%
util/normalize-encoding.js input="UTF-8":  n=1000000 percent=158.92%
util/normalize-encoding.js input="UTF8":  n=1000000 percent=205.67%
util/normalize-encoding.js input="Utf8":  n=1000000 percent=163.09%
util/normalize-encoding.js input="ucs2":  n=1000000 percent=192.82%
util/normalize-encoding.js input="UCS2":  n=1000000 percent=179.22%
util/normalize-encoding.js input="utf16le":  n=1000000 percent=239.94%
util/normalize-encoding.js input="UTF16LE":  n=1000000 percent=207.57%
util/normalize-encoding.js input="binary":  n=1000000 percent=183.19%
util/normalize-encoding.js input="BINARY":  n=1000000 percent=150.46%
util/normalize-encoding.js input="latin1":  n=1000000 percent=198.72%
util/normalize-encoding.js input="base64":  n=1000000 percent=237.31%
util/normalize-encoding.js input="BASE64":  n=1000000 percent=166.36%
util/normalize-encoding.js input="hex":  n=1000000 percent=231.76%
util/normalize-encoding.js input="HEX":  n=1000000 percent=198.36%
util/normalize-encoding.js input="foo":  n=1000000 percent=192.08%
util/normalize-encoding.js input="undefined":  n=1000000 percent=383.12%
util/normalize-encoding.js input="group_common":  n=1000000 percent=160.35%
util/normalize-encoding.js input="group_upper":  n=1000000 percent=155.27%
util/normalize-encoding.js input="group_uncommon":  n=1000000 percent=250.76%
util/normalize-encoding.js input="group_misc":  n=1000000 percent=169.54%


util/splice-one.js n=1000000
util/splice-one.js size=10 pos="start"  n=1000000 percent=238.22%
util/splice-one.js size=100 pos="start"  n=1000000 percent=115.14%
util/splice-one.js size=10 pos="middle"  n=1000000 percent=320.22%
util/splice-one.js size=100 pos="middle"  n=1000000 percent=130.79%
util/splice-one.js size=10 pos="end"  n=1000000 percent=380.13%
util/splice-one.js size=100 pos="end"  n=1000000 percent=371.70%
util/splice-one.js size=500 pos="end"  n=1000000 percent=373.86%


util/text-decoder.js n=1000
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=205.44%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=204.40%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=200.78%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=467.78%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=454.75%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=122.17%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=112.61%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=111.21%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="utf-8":  n=1000 percent=111.18%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=209.47%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=201.53%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=215.27%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=418.70%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=412.04%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=110.54%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=112.38%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=112.94%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="utf-8":  n=1000 percent=113.47%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=196.30%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=202.12%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=199.95%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=445.26%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=450.84%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=121.83%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=110.47%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="utf-8":  n=1000 percent=110.28%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=197.41%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=208.42%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=202.46%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=401.05%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=416.49%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=110.85%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=111.18%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=112.19%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="utf-8":  n=1000 percent=111.44%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=196.64%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=174.54%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=181.71%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=184.97%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=186.21%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="latin1":  n=1000 percent=188.49%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=182.19%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=177.82%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=163.40%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=183.78%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=184.91%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="latin1":  n=1000 percent=181.00%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=188.57%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=181.86%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=185.64%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=184.58%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=184.20%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="latin1":  n=1000 percent=186.10%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=166.11%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=182.66%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=165.37%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=183.34%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=180.85%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="latin1":  n=1000 percent=182.31%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=183.14%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=192.11%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=167.10%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=184.87%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=192.74%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=174.65%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=170.78%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=168.35%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=180.07%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=187.61%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=175.98%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=126.01%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=0 encoding="iso-8859-3":  n=1000 percent=113.46%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=181.96%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=183.76%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=179.80%
util/text-decoder.js type="SharedArrayBuffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=186.15%
util/text-decoder.js type="ArrayBuffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=181.51%
util/text-decoder.js type="Buffer" fatal=0 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=164.23%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=185.81%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=179.36%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=183.61%
util/text-decoder.js type="SharedArrayBuffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=182.95%
util/text-decoder.js type="ArrayBuffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=183.91%
util/text-decoder.js type="Buffer" fatal=1 ignoreBOM=1 encoding="iso-8859-3":  n=1000 percent=127.63%

util/to-usv-string.js n=1000000
util/to-usv-string.js size=10  n=1000000 percent=116.37%


util/type-check.js n=1000000
util/type-check.js argument="true" type="ArrayBufferView":  n=1000000 percent=758.19%
util/type-check.js argument="false-primitive" type="ArrayBufferView":  n=1000000 percent=745.55%
util/type-check.js argument="false-object" type="ArrayBufferView":  n=1000000 percent=760.94%
util/type-check.js argument="true" type="ArrayBufferView":  n=1000000 percent=793.30%
util/type-check.js argument="false-primitive" type="ArrayBufferView":  n=1000000 percent=772.28%
util/type-check.js argument="false-object" type="ArrayBufferView":  n=1000000 percent=791.04%
util/type-check.js argument="true" type="TypedArray":  n=1000000 percent=568.78%
util/type-check.js argument="false-primitive" type="TypedArray":  n=1000000 percent=644.47%
util/type-check.js argument="false-object" type="TypedArray":  n=1000000 percent=599.05%
util/type-check.js argument="true" type="TypedArray":  n=1000000 percent=587.63%
util/type-check.js argument="false-primitive" type="TypedArray":  n=1000000 percent=623.71%
util/type-check.js argument="false-object" type="TypedArray":  n=1000000 percent=624.70%
util/type-check.js argument="true" type="Uint8Array":  n=1000000 percent=565.48%
util/type-check.js argument="false-primitive" type="Uint8Array":  n=1000000 percent=592.64%
util/type-check.js argument="false-object" type="Uint8Array":  n=1000000 percent=570.08%
util/type-check.js argument="true" type="Uint8Array":  n=1000000 percent=588.70%
util/type-check.js argument="false-primitive" type="Uint8Array":  n=1000000 percent=611.18%
util/type-check.js argument="false-object" type="Uint8Array":  n=1000000 percent=588.04%
```

