### PR TITLE
doc: make theme consistent across api and other docs (from nodejs.org repo)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -462,12 +462,11 @@ make docopen
 This will open a file URL to a one-page version of all the browsable HTML
 documents using the default browser.
 
-
 ```bash
 make docclean
 ```
 
-This will clean previously built doc. 
+This will clean previously built doc.
 
 To test if Node.js was built correctly:
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -462,6 +462,13 @@ make docopen
 This will open a file URL to a one-page version of all the browsable HTML
 documents using the default browser.
 
+
+```bash
+make docclean
+```
+
+This will clean previously built doc. 
+
 To test if Node.js was built correctly:
 
 ```bash

--- a/doc/api_assets/api.js
+++ b/doc/api_assets/api.js
@@ -2,11 +2,11 @@
 
 {
   function setupTheme() {
-    const kCustomPreference = 'customDarkTheme';
-    const userSettings = sessionStorage.getItem(kCustomPreference);
+    const storedTheme = localStorage.getItem('theme');
     const themeToggleButton = document.getElementById('theme-toggle-btn');
 
-    if (userSettings === null && window.matchMedia) {
+    // Follow operating system theme preference
+    if (storedTheme === null && window.matchMedia) {
       const mq = window.matchMedia('(prefers-color-scheme: dark)');
 
       if ('onchange' in mq) {
@@ -28,16 +28,16 @@
       if (mq.matches) {
         document.documentElement.classList.add('dark-mode');
       }
-    } else if (userSettings === 'true') {
+    } else if (storedTheme === 'dark') {
       document.documentElement.classList.add('dark-mode');
     }
 
     if (themeToggleButton) {
       themeToggleButton.hidden = false;
       themeToggleButton.addEventListener('click', function() {
-        sessionStorage.setItem(
-          kCustomPreference,
-          document.documentElement.classList.toggle('dark-mode'),
+        localStorage.setItem(
+          'theme',
+          document.documentElement.classList.toggle('dark-mode') ? 'dark' : 'light',
         );
       });
     }

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -532,7 +532,7 @@ The TSC serves as the final arbiter where required.
    [build](https://github.com/nodejs/build/issues) repositories, open new
    issues. Run a new CI any time someone pushes new code to the pull request.
 4. Check that the commit message adheres to [commit message guidelines][].
-5. Add all necessary [metadata](#metadata) to commit messages before landing. If
+5. Add all necessary [metadata](git-node-metadata) to commit messages before landing. If
    you are unsure exactly how to format the commit messages, use the commit log
    as a reference. See [this commit][commit-example] as an example.
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -532,9 +532,10 @@ The TSC serves as the final arbiter where required.
    [build](https://github.com/nodejs/build/issues) repositories, open new
    issues. Run a new CI any time someone pushes new code to the pull request.
 4. Check that the commit message adheres to [commit message guidelines][].
-5. Add all necessary [metadata](git-node-metadata) to commit messages before landing. If
-   you are unsure exactly how to format the commit messages, use the commit log
-   as a reference. See [this commit][commit-example] as an example.
+5. Add all necessary [metadata][git-node-metadata] to commit messages before
+   landing. If you are unsure exactly how to format the commit messages, use
+   the commit log as a reference. See [this commit][commit-example] as an
+   example.
 
 For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git


### PR DESCRIPTION
**Problem**: since the website is based on 2 different repos (this and nodejs.org), there was an inconsistency in theme selection, so we had 2 independent theme props (one in session storage and another in local storage). With these changes, only one stored in local storage (`theme: light | dark`) is a single source of truth across all pages.

**Before:**
![theme_before](https://github.com/nodejs/node/assets/5207710/ce7e5f57-8e84-40ca-998f-e673b14931a1)

**After:**
![theme_after](https://github.com/nodejs/node/assets/5207710/0215e327-2404-444c-9bf3-199be9eb9f13)
