### PR TITLE
Enable passthrough IPC in watch mode

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -81,6 +81,7 @@ function start() {
       process.stdout.write(`${red}Failed running ${kCommandStr}${white}\n`);
     }
   });
+  return child;
 }
 
 async function killAndWait(signal = kKillSignal, force = false) {
@@ -113,7 +114,9 @@ function reportGracefulTermination() {
   };
 }
 
-async function stop() {
+async function stop(child) {
+  // Without this line, the child process is still able to receive IPC, but is unable to send additional messages
+  watcher.destroyIPC(child);
   watcher.clearFileFilters();
   const clearGraceReport = reportGracefulTermination();
   await killAndWait();
@@ -121,26 +124,33 @@ async function stop() {
 }
 
 let restarting = false;
-async function restart() {
+async function restart(child) {
   if (restarting) return;
   restarting = true;
   try {
     if (!kPreserveOutput) process.stdout.write(clear);
     process.stdout.write(`${green}Restarting ${kCommandStr}${white}\n`);
-    await stop();
-    start();
+    await stop(child);
+    return start();
   } finally {
     restarting = false;
   }
 }
 
-start();
-watcher
-  .on('changed', restart)
-  .on('error', (error) => {
-    watcher.off('changed', restart);
-    triggerUncaughtException(error, true /* fromPromise */);
-  });
+async function init() {
+  let child = start();
+  const restartChild = async () => {
+    child = await restart(child);
+  };
+  watcher
+    .on('changed', restartChild)
+    .on('error', (error) => {
+      watcher.off('changed', restartChild);
+      triggerUncaughtException(error, true /* fromPromise */);
+    });
+}
+
+init();
 
 // Exiting gracefully to avoid stdout/stderr getting written after
 // parent process is killed.

--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   ArrayPrototypeForEach,
+  Boolean,
   SafeMap,
   SafeSet,
   SafeWeakMap,

--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -31,6 +31,7 @@ class FilesWatcher extends EventEmitter {
   #debounce;
   #mode;
   #signal;
+  #wantsPassthroughIPC = false;
 
   constructor({ debounce = 200, mode = 'filter', signal } = kEmptyObject) {
     super({ __proto__: null, captureRejections: true });
@@ -40,6 +41,7 @@ class FilesWatcher extends EventEmitter {
     this.#debounce = debounce;
     this.#mode = mode;
     this.#signal = signal;
+    this.#wantsPassthroughIPC = !!process.send;
 
     if (signal) {
       addAbortListener(signal, () => this.clear());
@@ -128,7 +130,28 @@ class FilesWatcher extends EventEmitter {
       this.#ownerDependencies.set(owner, dependencies);
     }
   }
+
+
+  #setupIPC(child) {
+    child._ipcMessages = {
+      parentToChild: (message) => child.send(message),
+      childToParent: (message) => process.send(message),
+    };
+    process.on('message', child._ipcMessages.parentToChild);
+    child.on('message', child._ipcMessages.childToParent);
+  }
+
+  destroyIPC(child) {
+    if (this.#wantsPassthroughIPC) {
+      process.off('message', child._ipcMessages.parentToChild);
+      child.off('message', child._ipcMessages.childToParent);
+    }
+  }
+
   watchChildProcessModules(child, key = null) {
+    if (this.#wantsPassthroughIPC) {
+      this.#setupIPC(child);
+    }
     if (this.#mode !== 'filter') {
       return;
     }

--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -32,7 +32,7 @@ class FilesWatcher extends EventEmitter {
   #debounce;
   #mode;
   #signal;
-  #wantsPassthroughIPC = false;
+  #passthroughIPC = false;
   #ipcHandlers = new SafeWeakMap();
 
   constructor({ debounce = 200, mode = 'filter', signal } = kEmptyObject) {
@@ -43,7 +43,7 @@ class FilesWatcher extends EventEmitter {
     this.#debounce = debounce;
     this.#mode = mode;
     this.#signal = signal;
-    this.#wantsPassthroughIPC = Boolean(process.send);
+    this.#passthroughIPC = Boolean(process.send);
 
     if (signal) {
       addAbortListener(signal, () => this.clear());
@@ -147,14 +147,14 @@ class FilesWatcher extends EventEmitter {
 
   destroyIPC(child) {
     const handlers = this.#ipcHandlers.get(child);
-    if (this.#wantsPassthroughIPC && handlers !== undefined) {
+    if (this.#passthroughIPC && handlers !== undefined) {
       process.off('message', handlers.parentToChild);
       child.off('message', handlers.childToParent);
     }
   }
 
   watchChildProcessModules(child, key = null) {
-    if (this.#wantsPassthroughIPC) {
+    if (this.#passthroughIPC) {
       this.#setupIPC(child);
     }
     if (this.#mode !== 'filter') {

--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypeForEach,
   SafeMap,
   SafeSet,
+  SafeWeakMap,
   StringPrototypeStartsWith,
 } = primordials;
 
@@ -32,6 +33,7 @@ class FilesWatcher extends EventEmitter {
   #mode;
   #signal;
   #wantsPassthroughIPC = false;
+  #ipcHandlers = new SafeWeakMap();
 
   constructor({ debounce = 200, mode = 'filter', signal } = kEmptyObject) {
     super({ __proto__: null, captureRejections: true });
@@ -41,7 +43,7 @@ class FilesWatcher extends EventEmitter {
     this.#debounce = debounce;
     this.#mode = mode;
     this.#signal = signal;
-    this.#wantsPassthroughIPC = !!process.send;
+    this.#wantsPassthroughIPC = Boolean(process.send);
 
     if (signal) {
       addAbortListener(signal, () => this.clear());
@@ -133,18 +135,21 @@ class FilesWatcher extends EventEmitter {
 
 
   #setupIPC(child) {
-    child._ipcMessages = {
+    const handlers = {
+      __proto__: null,
       parentToChild: (message) => child.send(message),
       childToParent: (message) => process.send(message),
     };
-    process.on('message', child._ipcMessages.parentToChild);
-    child.on('message', child._ipcMessages.childToParent);
+    this.#ipcHandlers.set(child, handlers);
+    process.on('message', handlers.parentToChild);
+    child.on('message', handlers.childToParent);
   }
 
   destroyIPC(child) {
-    if (this.#wantsPassthroughIPC) {
-      process.off('message', child._ipcMessages.parentToChild);
-      child.off('message', child._ipcMessages.childToParent);
+    const handlers = this.#ipcHandlers.get(child);
+    if (this.#wantsPassthroughIPC && handlers !== undefined) {
+      process.off('message', handlers.parentToChild);
+      child.off('message', handlers.childToParent);
     }
   }
 

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -8,6 +8,7 @@ import { spawn } from 'node:child_process';
 import { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { inspect } from 'node:util';
 import { pathToFileURL } from 'node:url';
+import { once } from 'node:events';
 import { createInterface } from 'node:readline';
 
 if (common.isIBMi)
@@ -342,6 +343,7 @@ console.log(values.random);
     ]);
   });
 
+
   // TODO: Remove skip after https://github.com/nodejs/node/pull/45271 lands
   it('should not watch when running an missing file', {
     skip: !supportsRecursive
@@ -571,6 +573,84 @@ console.log(values.random);
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
+      `Completed running ${inspect(file)}`,
+    ]);
+  });
+  it('should pass IPC messages from a spawning parent to the child and back', async () => {
+    const file = createTmpFile(`console.log('running');
+process.on('message', (message) => {
+  if (message === 'exit') {
+    process.exit(0);
+  } else {
+    console.log('Received:', message);
+    process.send(message);
+  }
+})`);
+
+    const child = spawn(
+      execPath,
+      [
+        '--watch',
+        '--no-warnings',
+        file,
+      ],
+      {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+      },
+    );
+
+    let stderr = '';
+    let stdout = '';
+
+    child.stdout.on('data', (data) => stdout += data);
+    child.stderr.on('data', (data) => stderr += data);
+    async function waitForEcho(msg) {
+      const receivedPromise = new Promise((resolve) => {
+        const fn = (message) => {
+          if (message === msg) {
+            child.off('message', fn);
+            resolve();
+          }
+        };
+        child.on('message', fn);
+      });
+      child.send(msg);
+      await receivedPromise;
+    }
+
+    async function waitForText(text) {
+      const seenPromise = new Promise((resolve) => {
+        const fn = (data) => {
+          if (data.toString().includes(text)) {
+            resolve();
+            child.stdout.off('data', fn);
+          }
+        };
+        child.stdout.on('data', fn);
+      });
+      await seenPromise;
+    }
+
+    await waitForEcho('first message');
+    const stopRestarts = restart(file);
+    await waitForText('running');
+    stopRestarts();
+    await waitForEcho('second message');
+    const exitedPromise = once(child, 'exit');
+    child.send('exit');
+    await waitForText('Completed');
+    child.disconnect();
+    child.kill();
+    await exitedPromise;
+    assert.strictEqual(stderr, '');
+    const lines = stdout.split(/\r?\n/).filter(Boolean);
+    assert.deepStrictEqual(lines, [
+      'running',
+      'Received: first message',
+      `Restarting '${file}'`,
+      'running',
+      'Received: second message',
       `Completed running ${inspect(file)}`,
     ]);
   });

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -632,6 +632,7 @@ process.on('message', (message) => {
       await seenPromise;
     }
 
+    await waitForText("running");
     await waitForEcho('first message');
     const stopRestarts = restart(file);
     await waitForText('running');

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -343,7 +343,6 @@ console.log(values.random);
     ]);
   });
 
-
   // TODO: Remove skip after https://github.com/nodejs/node/pull/45271 lands
   it('should not watch when running an missing file', {
     skip: !supportsRecursive
@@ -576,6 +575,7 @@ console.log(values.random);
       `Completed running ${inspect(file)}`,
     ]);
   });
+
   it('should pass IPC messages from a spawning parent to the child and back', async () => {
     const file = createTmpFile(`console.log('running');
 process.on('message', (message) => {

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -649,7 +649,7 @@ process.on('message', (message) => {
     assert.deepStrictEqual(lines, [
       'running',
       'Received: first message',
-      `Restarting '${inspect(file)}'`,
+      `Restarting ${inspect(file)}`,
       'running',
       'Received: second message',
       `Completed running ${inspect(file)}`,

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -649,7 +649,7 @@ process.on('message', (message) => {
     assert.deepStrictEqual(lines, [
       'running',
       'Received: first message',
-      `Restarting '${file}'`,
+      `Restarting '${inspect(file)}'`,
       'running',
       'Received: second message',
       `Completed running ${inspect(file)}`,

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -632,7 +632,7 @@ process.on('message', (message) => {
       await seenPromise;
     }
 
-    await waitForText("running");
+    await waitForText('running');
     await waitForEcho('first message');
     const stopRestarts = restart(file);
     await waitForText('running');


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/50880

When spawning a node process in watch mode, from another node process, there is currently no way to get IPC between the parent and the child. This PR enables this bi-directional flow:
- parent -> watcher -> child
- child -> watcher -> parent 

This setup is useful in situations where you have a process responsible for building and running a client/server application which needs to be made aware (via IPC) that it's client bundle has changed and needs to be re-served, without restarting the server.