### PR TITLE
assert,crypto: make KeyObject and CryptoKey testable for equality

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -703,32 +703,81 @@ ObjectDefineProperties(CryptoKey.prototype, {
   },
 });
 
+/**
+ * @param {InternalCryptoKey} key
+ * @param {KeyObject} keyObject
+ * @param {object} algorithm
+ * @param {boolean} extractable
+ * @param {Set<string>} keyUsages
+ */
+function defineCryptoKeyProperties(
+  key,
+  keyObject,
+  algorithm,
+  extractable,
+  keyUsages,
+) {
+  // Using symbol properties here currently instead of private
+  // properties because (for now) the performance penalty of
+  // private fields is still too high.
+  ObjectDefineProperties(key, {
+    [kKeyObject]: {
+      __proto__: null,
+      value: keyObject,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    },
+    [kAlgorithm]: {
+      __proto__: null,
+      value: algorithm,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    },
+    [kExtractable]: {
+      __proto__: null,
+      value: extractable,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    },
+    [kKeyUsages]: {
+      __proto__: null,
+      value: keyUsages,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    },
+  });
+}
+
 // All internal code must use new InternalCryptoKey to create
 // CryptoKey instances. The CryptoKey class is exposed to end
 // user code but is not permitted to be constructed directly.
 // Using markTransferMode also allows the CryptoKey to be
 // cloned to Workers.
 class InternalCryptoKey {
-  constructor(
-    keyObject,
-    algorithm,
-    keyUsages,
-    extractable) {
+  constructor(keyObject, algorithm, keyUsages, extractable) {
     markTransferMode(this, true, false);
-    // Using symbol properties here currently instead of private
-    // properties because (for now) the performance penalty of
-    // private fields is still too high.
-    this[kKeyObject] = keyObject;
-    this[kAlgorithm] = algorithm;
-    this[kExtractable] = extractable;
-    this[kKeyUsages] = keyUsages;
+    // When constructed during transfer the properties get assigned
+    // in the kDeserialize call.
+    if (keyObject) {
+      defineCryptoKeyProperties(
+        this,
+        keyObject,
+        algorithm,
+        extractable,
+        keyUsages,
+      );
+    }
   }
 
   [kClone]() {
     const keyObject = this[kKeyObject];
-    const algorithm = this.algorithm;
-    const extractable = this.extractable;
-    const usages = this.usages;
+    const algorithm = this[kAlgorithm];
+    const extractable = this[kExtractable];
+    const usages = this[kKeyUsages];
 
     return {
       data: {
@@ -742,10 +791,7 @@ class InternalCryptoKey {
   }
 
   [kDeserialize]({ keyObject, algorithm, usages, extractable }) {
-    this[kKeyObject] = keyObject;
-    this[kAlgorithm] = algorithm;
-    this[kKeyUsages] = usages;
-    this[kExtractable] = extractable;
+    defineCryptoKeyProperties(this, keyObject, algorithm, extractable, usages);
   }
 }
 InternalCryptoKey.prototype.constructor = CryptoKey;

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -43,6 +43,8 @@ const {
   isSymbolObject,
   isFloat32Array,
   isFloat64Array,
+  isKeyObject,
+  isCryptoKey,
 } = types;
 const {
   constants: {
@@ -59,6 +61,8 @@ const kNoIterator = 0;
 const kIsArray = 1;
 const kIsSet = 2;
 const kIsMap = 3;
+
+let kKeyObject;
 
 // Check if they have the same source and flags
 function areSimilarRegExps(a, b) {
@@ -249,6 +253,20 @@ function innerDeepEqual(val1, val2, strict, memos) {
              isNativeError(val2) ||
              val2 instanceof Error) {
     return false;
+  } else if (isKeyObject(val1)) {
+    if (!isKeyObject(val2) || !val1.equals(val2)) {
+      return false;
+    }
+  } else if (isCryptoKey(val1)) {
+    kKeyObject ??= require('internal/crypto/util').kKeyObject;
+    if (!isCryptoKey(val2) ||
+      val1.extractable !== val2.extractable ||
+      !innerDeepEqual(val1.algorithm, val2.algorithm, strict, memos) ||
+      !innerDeepEqual(val1.usages, val2.usages, strict, memos) ||
+      !innerDeepEqual(val1[kKeyObject], val2[kKeyObject], strict, memos)
+    ) {
+      return false;
+    }
   }
   return keyCheck(val1, val2, strict, memos, kNoIterator);
 }


### PR DESCRIPTION
This makes CryptoKey and KeyObject instances testable using `assert.deepStrictEqual` and `assert.deepEqual`.

The state before was that
- deepEqual did not check extractable, algorithm, usages
- neither deepEqual or deepStrict equal compared the key material, so two different keys with the other properties matching evaluated as equal