### PR TITLE
lib: send the `argv` to the ESM worker thread loader

### DIFF
--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -497,14 +497,17 @@ class HooksProxy {
 
   #isReady = false;
 
-  constructor() {
+  constructor(execArgv) {
     const { InternalWorker } = require('internal/worker');
     MessageChannel ??= require('internal/worker/io').MessageChannel;
 
     const lock = new SharedArrayBuffer(SHARED_MEMORY_BYTE_LENGTH);
     this.#lock = new Int32Array(lock);
 
+    // This needs to inherits the parent's argc/argv
+    // See: https://github.com/nodejs/node/issues/50885
     this.#worker = new InternalWorker(loaderWorkerId, {
+      execArgv,
       stderr: false,
       stdin: false,
       stdout: false,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -338,8 +338,11 @@ class ModuleLoader {
       // `CustomizedModuleLoader` is defined at the bottom of this file and
       // available well before this line is ever invoked. This is here in
       // order to preserve the git diff instead of moving the class.
+
+      // Send the `process.execArgv`
+      // See: https://github.com/nodejs/node/issues/50885
       // eslint-disable-next-line no-use-before-define
-      this.setCustomizations(new CustomizedModuleLoader());
+      this.setCustomizations(new CustomizedModuleLoader(process.execArgv));
     }
     return this.#customizations.register(`${specifier}`, `${parentURL}`, data, transferList);
   }
@@ -460,8 +463,8 @@ class CustomizedModuleLoader {
   /**
    * Instantiate a module loader that uses user-provided custom loader hooks.
    */
-  constructor() {
-    getHooksProxy();
+  constructor(execArgv) {
+    getHooksProxy(execArgv);
   }
 
   /**
@@ -565,10 +568,10 @@ function createModuleLoader() {
  * Get the HooksProxy instance. If it is not defined, then create a new one.
  * @returns {HooksProxy}
  */
-function getHooksProxy() {
+function getHooksProxy(execArgv) {
   if (!hooksProxy) {
     const { HooksProxy } = require('internal/modules/esm/hooks');
-    hooksProxy = new HooksProxy();
+    hooksProxy = new HooksProxy(execArgv);
   }
 
   return hooksProxy;

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -265,6 +265,7 @@ class Worker extends EventEmitter {
     setupPortReferencing(this[kPublicPort], this, 'message');
     this[kPort].postMessage({
       argv,
+      execArgv: options.execArgv,
       type: messageTypes.LOAD_SCRIPT,
       filename,
       doEval,

--- a/test/parallel/test-worker-execargv.js
+++ b/test/parallel/test-worker-execargv.js
@@ -20,11 +20,12 @@ if (!process.env.HAS_STARTED_WORKER) {
     );
   }));
 
+  // Refs: https://github.com/nodejs/node/issues/50885
   new Worker(
     "require('worker_threads').parentPort.postMessage(process.execArgv)",
-    { eval: true, execArgv: ['--trace-warnings'] })
+    { eval: true, execArgv: ['--trace-warnings', '--conditions', 'meow'] })
     .on('message', common.mustCall((data) => {
-      assert.deepStrictEqual(data, ['--trace-warnings']);
+      assert.deepStrictEqual(data, ['--trace-warnings', '--conditions', 'meow']);
     }));
 } else {
   process.emitWarning('some warning');


### PR DESCRIPTION
When the `--conditions` is sent to a worker thread, it should affect the worker thread with the ESM loader on it. This patch sends the `execArgv` to the ESM worker.


Fixes: https://github.com/nodejs/node/issues/50885