### PR TITLE
fs: improve error performance of fs.writeSync

### DIFF
--- a/benchmark/fs/bench-writeFileSync.js
+++ b/benchmark/fs/bench-writeFileSync.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const bench = common.createBenchmark(main, {
+  n: [1e4],
+});
+
+function main({ n, type }) {
+  const path = tmpdir.resolve(`new-file-${process.pid}`);
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    fs.writeFileSync(path, 'Benchmark data.');
+  }
+  bench.end(n);
+}

--- a/benchmark/fs/bench-writeSync.js
+++ b/benchmark/fs/bench-writeSync.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const tmpdir = require('../../test/common/tmpdir');
+tmpdir.refresh();
+
+const path = tmpdir.resolve(`new-file-${process.pid}`);
+fs.writeFileSync(path, 'Some content.');
+
+const bench = common.createBenchmark(main, {
+  type: ['valid', 'invalid'],
+  dataType: ['string', 'buffer'],
+  n: [1e5],
+});
+
+const stringData = 'Benchmark data.';
+const bufferData = Buffer.from(stringData);
+
+function main({ n, type, dataType }) {
+  const fd = type === 'valid' ? fs.openSync(path, 'r+') : 1 << 30;
+  const data = dataType === 'string' ? stringData : bufferData;
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      fs.writeSync(fd, data);
+    } catch {
+      // Continue regardless of error.
+    }
+  }
+  bench.end(n);
+  if (type === 'valid') fs.closeSync(fd);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -900,7 +900,6 @@ ObjectDefineProperty(write, kCustomPromisifyArgsSymbol,
  */
 function writeSync(fd, buffer, offsetOrOptions, length, position) {
   fd = getValidatedFd(fd);
-  const ctx = {};
   let result;
 
   let offset = offsetOrOptions;
@@ -922,18 +921,15 @@ function writeSync(fd, buffer, offsetOrOptions, length, position) {
     if (typeof length !== 'number')
       length = buffer.byteLength - offset;
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
-    result = binding.writeBuffer(fd, buffer, offset, length, position,
-                                 undefined, ctx);
+    result = binding.writeBuffer(fd, buffer, offset, length, position);
   } else {
     validateStringAfterArrayBufferView(buffer, 'buffer');
     validateEncoding(buffer, length);
 
     if (offset === undefined)
       offset = null;
-    result = binding.writeString(fd, buffer, offset, length,
-                                 undefined, ctx);
+    result = binding.writeString(fd, buffer, offset, length);
   }
-  handleErrorFromBinding(ctx);
   return result;
 }
 


### PR DESCRIPTION
Benchmark on my system:
```csv
                                                                confidence improvement accuracy (*)   (**)  (***)
fs/bench-writeSync.js n=100000 dataType='buffer' type='invalid'        ***     81.88 %       ±1.24% ±1.66% ±2.19%
fs/bench-writeSync.js n=100000 dataType='buffer' type='valid'            *      1.49 %       ±1.38% ±1.85% ±2.43%
fs/bench-writeSync.js n=100000 dataType='string' type='invalid'        ***     81.60 %       ±2.34% ±3.15% ±4.16%
fs/bench-writeSync.js n=100000 dataType='string' type='valid'                   0.35 %       ±2.10% ±2.82% ±3.70%
fs/bench-writeFileSync.js n=10000                                              -0.12 %       ±3.45% ±4.59% ±5.98%
```
Ref: https://github.com/nodejs/performance/issues/106
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
