### PR TITLE
benchmark: update iterations in benchmark/crypto/aes-gcm-throughput.js

### DIFF
--- a/benchmark/crypto/aes-gcm-throughput.js
+++ b/benchmark/crypto/aes-gcm-throughput.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 const crypto = require('crypto');
 const keylen = { 'aes-128-gcm': 16, 'aes-192-gcm': 24, 'aes-256-gcm': 32 };
 const bench = common.createBenchmark(main, {
-  n: [500],
+  n: [2500],
   cipher: ['aes-128-gcm', 'aes-192-gcm', 'aes-256-gcm'],
   len: [1024, 4 * 1024, 16 * 1024, 64 * 1024, 256 * 1024, 1024 * 1024],
 });


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/50571

Below is score improvement from 500 to 2500, measured on Cascake server.
Improvement can be a bit more if changing to 5000 but the running time will be notable longer than appropriate duration.

To make it clear, I will submit more PRs one by one to address each case in crypto, and tracked by 50571 issue.

```
crypto/aes-gcm-throughput.js cipher="aes-128-gcm" 554.5625838906785 n=2500 percent=144.46%
crypto/aes-gcm-throughput.js cipher="aes-128-gcm" n=2500 percent=134.25%
crypto/aes-gcm-throughput.js cipher="aes-128-gcm" n=2500 percent=136.22%
crypto/aes-gcm-throughput.js cipher="aes-128-gcm" n=2500 percent=151.78%
crypto/aes-gcm-throughput.js cipher="aes-128-gcm" n=2500 percent=125.49%
crypto/aes-gcm-throughput.js cipher="aes-192-gcm" 557.082005808399 n=2500 percent=131.03%
crypto/aes-gcm-throughput.js cipher="aes-192-gcm" n=2500 percent=131.05%
crypto/aes-gcm-throughput.js cipher="aes-192-gcm" n=2500 percent=136.30%
crypto/aes-gcm-throughput.js cipher="aes-192-gcm" n=2500 percent=149.98%
crypto/aes-gcm-throughput.js cipher="aes-192-gcm" n=2500 percent=123.60%
crypto/aes-gcm-throughput.js cipher="aes-256-gcm" 557.9763934240019 n=2500 percent=130.56%
crypto/aes-gcm-throughput.js cipher="aes-256-gcm" n=2500 percent=130.17%
crypto/aes-gcm-throughput.js cipher="aes-256-gcm" n=2500 percent=135.86%
crypto/aes-gcm-throughput.js cipher="aes-256-gcm" n=2500 percent=148.04%
crypto/aes-gcm-throughput.js cipher="aes-256-gcm" n=2500 percent=123.15%
```