### PR TITLE
build: update gn build flags for deps

### DIFF
--- a/deps/simdjson/unofficial.gni
+++ b/deps/simdjson/unofficial.gni
@@ -18,5 +18,10 @@ template("simdjson_gn_build") {
     forward_variables_from(invoker, "*")
     public_configs = [ ":simdjson_config" ]
     sources = gypi_values.simdjson_sources
+    if (is_clang || !is_win) {
+      cflags_cc = [
+        "-Wno-unreachable-code-return",
+      ]
+    }
   }
 }

--- a/deps/simdutf/unofficial.gni
+++ b/deps/simdutf/unofficial.gni
@@ -27,6 +27,7 @@ template("simdutf_gn_build") {
       cflags_cc = [
         "-Wno-#pragma-messages",
         "-Wno-ambiguous-reversed-operator",
+        "-Wno-unreachable-code",
         "-Wno-unreachable-code-break",
         "-Wno-unused-const-variable",
         "-Wno-unused-function",


### PR DESCRIPTION
V8 recently updated [node-ci](https://chromium.googlesource.com/v8/node-ci/) to use a newer version of clang, which requires us to disable a few warnings in deps.