### PR TITLE
benchmark: update iterations in benchmark/util/format.js

### DIFF
--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -18,7 +18,7 @@ const inputs = {
 };
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   type: Object.keys(inputs),
 });
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:

```
util/format.js n=1000000
util/format.js type="string"  n=1000000 percent=154.84%
util/format.js type="string-2"  n=1000000 percent=150.37%
util/format.js type="number"  n=1000000 percent=156.83%
util/format.js type="replace-object"  n=1000000 percent=111.05%
util/format.js type="unknown"  n=1000000 percent=164.63%
util/format.js type="no-replace"  n=1000000 percent=174.30%
util/format.js type="no-replace-2"  n=1000000 percent=168.45%
util/format.js type="many-%"  n=1000000 percent=177.32%
util/format.js type="object-to-string"  n=1000000 percent=139.61%
util/format.js type="object-%s"  n=1000000 percent=110.67%
```