### PR TITLE
benchmark: update iterations in benchmark/util/normalize-encoding.js

### DIFF
--- a/benchmark/util/normalize-encoding.js
+++ b/benchmark/util/normalize-encoding.js
@@ -21,7 +21,7 @@ const inputs = [
 
 const bench = common.createBenchmark(main, {
   input: inputs.concat(Object.keys(groupedInputs)),
-  n: [1e5],
+  n: [1e6],
 }, {
   flags: '--expose-internals',
 });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:
util/normalize-encoding.js n=1000000
util/normalize-encoding.js input="":  n=1000000 percent=301.90%
util/normalize-encoding.js input="utf8":  n=1000000 percent=257.18%
util/normalize-encoding.js input="utf-8":  n=1000000 percent=247.71%
util/normalize-encoding.js input="UTF-8":  n=1000000 percent=158.92%
util/normalize-encoding.js input="UTF8":  n=1000000 percent=205.67%
util/normalize-encoding.js input="Utf8":  n=1000000 percent=163.09%
util/normalize-encoding.js input="ucs2":  n=1000000 percent=192.82%
util/normalize-encoding.js input="UCS2":  n=1000000 percent=179.22%
util/normalize-encoding.js input="utf16le":  n=1000000 percent=239.94%
util/normalize-encoding.js input="UTF16LE":  n=1000000 percent=207.57%
util/normalize-encoding.js input="binary":  n=1000000 percent=183.19%
util/normalize-encoding.js input="BINARY":  n=1000000 percent=150.46%
util/normalize-encoding.js input="latin1":  n=1000000 percent=198.72%
util/normalize-encoding.js input="base64":  n=1000000 percent=237.31%
util/normalize-encoding.js input="BASE64":  n=1000000 percent=166.36%
util/normalize-encoding.js input="hex":  n=1000000 percent=231.76%
util/normalize-encoding.js input="HEX":  n=1000000 percent=198.36%
util/normalize-encoding.js input="foo":  n=1000000 percent=192.08%
util/normalize-encoding.js input="undefined":  n=1000000 percent=383.12%
util/normalize-encoding.js input="group_common":  n=1000000 percent=160.35%
util/normalize-encoding.js input="group_upper":  n=1000000 percent=155.27%
util/normalize-encoding.js input="group_uncommon":  n=1000000 percent=250.76%
util/normalize-encoding.js input="group_misc":  n=1000000 percent=169.54%