### PR TITLE
benchmark: update iterations in benchmark/util/splice-one.js

### DIFF
--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   pos: ['start', 'middle', 'end'],
   size: [10, 100, 500],
 }, { flags: ['--expose-internals'] });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:
util/splice-one.js n=1000000
util/splice-one.js size=10 pos="start"  n=1000000 percent=238.22%
util/splice-one.js size=100 pos="start"  n=1000000 percent=115.14%
util/splice-one.js size=10 pos="middle"  n=1000000 percent=320.22%
util/splice-one.js size=100 pos="middle"  n=1000000 percent=130.79%
util/splice-one.js size=10 pos="end"  n=1000000 percent=380.13%
util/splice-one.js size=100 pos="end"  n=1000000 percent=371.70%
util/splice-one.js size=500 pos="end"  n=1000000 percent=373.86%