### PR TITLE
benchmark: update iterations in benchmark/util/to-usv-string.js

### DIFF
--- a/benchmark/util/to-usv-string.js
+++ b/benchmark/util/to-usv-string.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const BASE = 'string\ud801';
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [1e6],
   size: [10, 100, 500],
 });
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:
util/to-usv-string.js n=1000000
util/to-usv-string.js size=10  n=1000000 percent=116.37%
