### PR TITLE
benchmark: update iterations of benchmark/util/type-check.js

### DIFF
--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -29,7 +29,7 @@ const bench = common.createBenchmark(main, {
   type: Object.keys(args),
   version: ['native', 'js'],
   argument: ['true', 'false-primitive', 'false-object'],
-  n: [1e5],
+  n: [1e6],
 }, {
   flags: ['--expose-internals', '--no-warnings'],
 });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50571

Belowing are the score improvement after 10X iteration change:
util/type-check.js n=1000000
util/type-check.js argument="true" type="ArrayBufferView":  n=1000000 percent=758.19%
util/type-check.js argument="false-primitive" type="ArrayBufferView":  n=1000000 percent=745.55%
util/type-check.js argument="false-object" type="ArrayBufferView":  n=1000000 percent=760.94%
util/type-check.js argument="true" type="ArrayBufferView":  n=1000000 percent=793.30%
util/type-check.js argument="false-primitive" type="ArrayBufferView":  n=1000000 percent=772.28%
util/type-check.js argument="false-object" type="ArrayBufferView":  n=1000000 percent=791.04%
util/type-check.js argument="true" type="TypedArray":  n=1000000 percent=568.78%
util/type-check.js argument="false-primitive" type="TypedArray":  n=1000000 percent=644.47%
util/type-check.js argument="false-object" type="TypedArray":  n=1000000 percent=599.05%
util/type-check.js argument="true" type="TypedArray":  n=1000000 percent=587.63%
util/type-check.js argument="false-primitive" type="TypedArray":  n=1000000 percent=623.71%
util/type-check.js argument="false-object" type="TypedArray":  n=1000000 percent=624.70%
util/type-check.js argument="true" type="Uint8Array":  n=1000000 percent=565.48%
util/type-check.js argument="false-primitive" type="Uint8Array":  n=1000000 percent=592.64%
util/type-check.js argument="false-object" type="Uint8Array":  n=1000000 percent=570.08%
util/type-check.js argument="true" type="Uint8Array":  n=1000000 percent=588.70%
util/type-check.js argument="false-primitive" type="Uint8Array":  n=1000000 percent=611.18%
util/type-check.js argument="false-object" type="Uint8Array":  n=1000000 percent=588.04%