### PR TITLE
sea: add ability to embed auxiliary data asset for use with sea

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -54,6 +54,8 @@ const {
   overrideStackTrace,
 } = require('internal/errors');
 const { signals } = internalBinding('constants').os;
+const { getEmbeddedData } = internalBinding('sea');
+
 const {
   isArrayBufferDetached: _isArrayBufferDetached,
   guessHandleType: _guessHandleType,
@@ -874,6 +876,7 @@ class WeakReference {
 }
 
 module.exports = {
+  getEmbeddedData,
   getLazy,
   assertCrypto,
   cachedResult,

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,6 +77,7 @@ const {
   promisify,
   toUSVString,
   defineLazyProperties,
+  getEmbeddedData
 } = require('internal/util');
 
 let abortController;
@@ -440,4 +441,10 @@ defineLazyProperties(
   module.exports,
   'internal/mime',
   ['MIMEType', 'MIMEParams'],
+);
+
+defineLazyProperties(
+  module.exports,
+  'internal/util',
+  ['getEmbeddedData']
 );

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,7 +77,7 @@ const {
   promisify,
   toUSVString,
   defineLazyProperties,
-  getEmbeddedData
+  getEmbeddedData,
 } = require('internal/util');
 
 let abortController;
@@ -385,6 +385,7 @@ module.exports = {
   formatWithOptions,
   getSystemErrorMap,
   getSystemErrorName,
+  getEmbeddedData,
   inherits,
   inspect,
   isArray: ArrayIsArray,
@@ -441,10 +442,4 @@ defineLazyProperties(
   module.exports,
   'internal/mime',
   ['MIMEType', 'MIMEParams'],
-);
-
-defineLazyProperties(
-  module.exports,
-  'internal/util',
-  ['getEmbeddedData']
 );

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -257,30 +257,31 @@ void GetCodeCache(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(data_view);
 }
 
-
 #define POSTJECT_SENTINEL_EMBED "NODE_EMBED_fce680ab2cc467b6e072b8b5df1996b2"
 static inline bool hasEmbeddedData() {
   static const volatile char* sentinel = POSTJECT_SENTINEL_EMBED ":0";
   return sentinel[sizeof(POSTJECT_SENTINEL_EMBED)] == '1';
 }
 #undef POSTJECT_SENTINEL_EMBED
-void GetEmbeddedData(const FunctionCallbackInfo<Value> &args) {
+void GetEmbeddedData(const FunctionCallbackInfo<Value>& args) {
   if (!hasEmbeddedData()) {
     return;
   }
 
   Isolate* isolate = args.GetIsolate();
   size_t size = 0;
-  #ifdef __APPLE__
-    postject_options options;
-    postject_options_init(&options);
-    options.macho_segment_name = "NODE_SEA";
-    const void* data = postject_find_resource("NODE_EMBEDDED_DATA", &size, &options);
-  #else
-    const void* data = postject_find_resource("NODE_EMBEDDED_DATA", &size, nullptr);
-  #endif
+#ifdef __APPLE__
+  postject_options options;
+  postject_options_init(&options);
+  options.macho_segment_name = "NODE_SEA";
+  const void* data =
+      postject_find_resource("NODE_EMBEDDED_DATA", &size, &options);
+#else
+  const void* data =
+      postject_find_resource("NODE_EMBEDDED_DATA", &size, nullptr);
+#endif
 
-   std::shared_ptr<BackingStore> backing_store = ArrayBuffer::NewBackingStore(
+  std::shared_ptr<BackingStore> backing_store = ArrayBuffer::NewBackingStore(
       const_cast<void*>(static_cast<const void*>(data)),
       size,
       [](void* /* data */, size_t /* length */, void* /* deleter_data */) {


### PR DESCRIPTION
When bundling code into a single executable application sometimes it is necessary to include non-code assets. While this is possible to do as base64 encoded blobs in the code itself, adding these assets as a separate resource makes things a lot smaller.

<!--
Before submitting a pull request, please read:

✅ the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
✅ the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

✅Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
    
(previously signed and submitted by myself as well as Bloomberg)
-->
