### PR TITLE
doc: remove flicker on page load on dark theme

### DIFF
--- a/doc/api_assets/api.js
+++ b/doc/api_assets/api.js
@@ -24,12 +24,6 @@
           );
         }
       }
-
-      if (mq.matches) {
-        document.documentElement.classList.add('dark-mode');
-      }
-    } else if (storedTheme === 'dark') {
-      document.documentElement.classList.add('dark-mode');
     }
 
     if (themeToggleButton) {

--- a/doc/template.html
+++ b/doc/template.html
@@ -10,6 +10,19 @@
   <link rel="stylesheet" href="assets/hljs.css">
   <link rel="canonical" href="https://nodejs.org/api/__FILENAME__.html">
   <script async defer src="assets/api.js" type="text/javascript"></script>
+  <script>
+      const storedTheme = localStorage.getItem('theme');
+
+      // Follow operating system theme preference
+      if (storedTheme === null && window.matchMedia) {
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        if (mq.matches) {
+          document.documentElement.classList.add('dark-mode');
+        }
+      } else if (storedTheme === 'dark') {
+        document.documentElement.classList.add('dark-mode');
+      }
+  </script>
   __JS_FLAVORED_DYNAMIC_CSS__
 </head>
 <body class="alt apidoc" id="api-section-__FILENAME__">


### PR DESCRIPTION
Theme applying logic gets loaded and executed in async mode, so often there is a
delay in applying the proper theme to a page which leads to flicker on dark theme. 

Resolved by moving critical logic to the page head (sync script). No impact on performance was detected.

**Before:**
UI
![flicker_before](https://github.com/nodejs/node/assets/5207710/59ac2cef-f4b0-4340-a8bf-eebce31a78cf)


Performance

<img width="557" alt="image" src="https://github.com/nodejs/node/assets/5207710/186c3372-abb8-4d5b-8c54-af654ca9a420">


**After:**

UI
![flicker_after](https://github.com/nodejs/node/assets/5207710/36d83fc7-b8c9-41b5-8a27-b9be2bb3b2f4)


Performance

<img width="569" alt="image" src="https://github.com/nodejs/node/assets/5207710/57cca709-071d-441d-b947-665fd8397123">
