### PR TITLE
src: support child_process synchronous methods in custom snapshot

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -110,6 +110,7 @@ class ExternalReferenceRegistry {
   V(permission)                                                                \
   V(process_methods)                                                           \
   V(process_object)                                                            \
+  V(process_wrap)                                                              \
   V(report)                                                                    \
   V(task_queue)                                                                \
   V(tcp_wrap)                                                                  \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -115,6 +115,7 @@ class ExternalReferenceRegistry {
   V(task_queue)                                                                \
   V(tcp_wrap)                                                                  \
   V(tty_wrap)                                                                  \
+  V(udp_wrap)                                                                  \
   V(url)                                                                       \
   V(util)                                                                      \
   V(pipe_wrap)                                                                 \

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -123,6 +123,7 @@ class ExternalReferenceRegistry {
   V(string_decoder)                                                            \
   V(stream_wrap)                                                               \
   V(signal_wrap)                                                               \
+  V(spawn_sync)                                                                \
   V(trace_events)                                                              \
   V(timers)                                                                    \
   V(types)                                                                     \

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "env-inl.h"
+#include "node_external_reference.h"
 #include "permission/permission.h"
 #include "stream_base-inl.h"
 #include "stream_wrap.h"
@@ -65,6 +66,12 @@ class ProcessWrap : public HandleWrap {
     SetProtoMethod(isolate, constructor, "kill", Kill);
 
     SetConstructorFunction(context, target, "Process", constructor);
+  }
+
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+    registry->Register(New);
+    registry->Register(Spawn);
+    registry->Register(Kill);
   }
 
   SET_NO_MEMORY_INFO()
@@ -325,3 +332,5 @@ class ProcessWrap : public HandleWrap {
 }  // namespace node
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(process_wrap, node::ProcessWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(process_wrap,
+                                node::ProcessWrap::RegisterExternalReferences)

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -22,6 +22,7 @@
 #include "spawn_sync.h"
 #include "debug_utils-inl.h"
 #include "env-inl.h"
+#include "node_external_reference.h"
 #include "node_internals.h"
 #include "string_bytes.h"
 #include "util-inl.h"
@@ -366,6 +367,10 @@ void SyncProcessRunner::Initialize(Local<Object> target,
   SetMethod(context, target, "spawn", Spawn);
 }
 
+void SyncProcessRunner::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(Spawn);
+}
 
 void SyncProcessRunner::Spawn(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1107,3 +1112,5 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(spawn_sync,
                                     node::SyncProcessRunner::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(
+    spawn_sync, node::SyncProcessRunner::RegisterExternalReferences)

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -30,8 +30,7 @@
 
 namespace node {
 
-
-
+class ExternalReferenceRegistry;
 class SyncProcessOutputBuffer;
 class SyncProcessStdioPipe;
 class SyncProcessRunner;
@@ -140,6 +139,7 @@ class SyncProcessRunner {
   };
 
  public:
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -21,10 +21,11 @@
 
 #include "udp_wrap.h"
 #include "env-inl.h"
+#include "handle_wrap.h"
 #include "node_buffer.h"
 #include "node_errors.h"
+#include "node_external_reference.h"
 #include "node_sockaddr-inl.h"
-#include "handle_wrap.h"
 #include "req_wrap-inl.h"
 #include "util-inl.h"
 
@@ -133,6 +134,12 @@ void UDPWrapBase::AddMethods(Environment* env, Local<FunctionTemplate> t) {
   SetProtoMethod(env->isolate(), t, "recvStop", RecvStop);
 }
 
+void UDPWrapBase::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(RecvStart);
+  registry->Register(RecvStop);
+}
+
 UDPWrap::UDPWrap(Environment* env, Local<Object> object)
     : HandleWrap(env,
                  object,
@@ -229,6 +236,34 @@ void UDPWrap::Initialize(Local<Object> target,
               constants).Check();
 }
 
+void UDPWrap::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
+  UDPWrapBase::RegisterExternalReferences(registry);
+  registry->Register(New);
+  registry->Register(GetFD);
+
+  registry->Register(Open);
+  registry->Register(Bind);
+  registry->Register(Connect);
+  registry->Register(Send);
+  registry->Register(Bind6);
+  registry->Register(Connect6);
+  registry->Register(Send6);
+  registry->Register(Disconnect);
+  registry->Register(GetSockOrPeerName<UDPWrap, uv_udp_getpeername>);
+  registry->Register(GetSockOrPeerName<UDPWrap, uv_udp_getsockname>);
+  registry->Register(AddMembership);
+  registry->Register(DropMembership);
+  registry->Register(AddSourceSpecificMembership);
+  registry->Register(DropSourceSpecificMembership);
+  registry->Register(SetMulticastInterface);
+  registry->Register(SetLibuvInt32<uv_udp_set_multicast_ttl>);
+  registry->Register(SetLibuvInt32<uv_udp_set_multicast_loop>);
+  registry->Register(SetLibuvInt32<uv_udp_set_broadcast>);
+  registry->Register(SetLibuvInt32<uv_udp_set_ttl>);
+  registry->Register(BufferSize);
+  registry->Register(GetSendQueueSize);
+  registry->Register(GetSendQueueCount);
+}
 
 void UDPWrap::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
@@ -807,3 +842,5 @@ void UDPWrap::GetSendQueueCount(const FunctionCallbackInfo<Value>& args) {
 }  // namespace node
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(udp_wrap, node::UDPWrap::Initialize)
+NODE_BINDING_EXTERNAL_REFERENCE(udp_wrap,
+                                node::UDPWrap::RegisterExternalReferences)

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -32,6 +32,7 @@
 
 namespace node {
 
+class ExternalReferenceRegistry;
 class UDPWrapBase;
 
 // A listener that can be attached to an `UDPWrapBase` object and generally
@@ -110,6 +111,7 @@ class UDPWrapBase {
   static void RecvStart(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void RecvStop(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddMethods(Environment* env, v8::Local<v8::FunctionTemplate> t);
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 
  private:
   UDPListener* listener_ = nullptr;
@@ -126,6 +128,7 @@ class UDPWrap final : public HandleWrap,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,
                          void* priv);
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
   static void GetFD(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/fixtures/snapshot/child-process-sync.js
+++ b/test/fixtures/snapshot/child-process-sync.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const {
+  setDeserializeMainFunction,
+  isBuildingSnapshot
+} = require('v8').startupSnapshot;
+
+function spawn() {
+  const { spawnSync, execFileSync, execSync } = require('child_process');
+  spawnSync(process.execPath, [ __filename, 'spawnSync' ], { stdio: 'inherit' });
+  execSync(`"${process.execPath}" "${__filename}" "execSync"`, { stdio: 'inherit' });
+  execFileSync(process.execPath, [ __filename, 'execFileSync' ], { stdio: 'inherit' });
+}
+
+if (process.argv[2] !== undefined) {
+  console.log('From child process', process.argv[2]);
+} else {
+  spawn();
+}
+
+if (isBuildingSnapshot()) {
+  setDeserializeMainFunction(() => {
+    spawn();
+  });
+}

--- a/test/parallel/test-snapshot-child-process-sync.js
+++ b/test/parallel/test-snapshot-child-process-sync.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// This tests that process.cwd() is accurate when
+// restoring state from a snapshot
+
+require('../common');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+
+tmpdir.refresh();
+const blobPath = tmpdir.resolve('snapshot.blob');
+const file = fixtures.path('snapshot', 'child-process-sync.js');
+const expected = [
+  'From child process spawnSync',
+  'From child process execSync',
+  'From child process execFileSync',
+];
+
+{
+  // Create the snapshot.
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    file,
+  ], {
+    cwd: tmpdir.path,
+  }, {
+    trim: true,
+    stdout(output) {
+      assert.deepStrictEqual(output.split('\n'), expected);
+      return true;
+    }
+  });
+}
+
+{
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    file,
+  ], {
+    cwd: tmpdir.path,
+  }, {
+    trim: true,
+    stdout(output) {
+      assert.deepStrictEqual(output.split('\n'), expected);
+      return true;
+    }
+  });
+}


### PR DESCRIPTION
#### src: register process_wrap external references

#### src: register spawn_sync external references

#### src: register udp_wrap external references

#### test: test syncrhnous methods of child_process in snapshot

These currently work in snapshot builder scripts. Asynchronous
methods are not supported yet.

Refs: https://github.com/nodejs/node/issues/50924

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
