### PR TITLE
bootstrap: improve snapshot unsupported builtin warnings

### DIFF
--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -19,7 +19,7 @@ const {
 const { isExperimentalSeaWarningNeeded } = internalBinding('sea');
 
 const { emitExperimentalWarning } = require('internal/util');
-
+const { emitWarningSync } = require('internal/process/warning');
 const {
   getOptionValue,
 } = require('internal/options');
@@ -29,6 +29,7 @@ const {
   namespace: {
     addSerializeCallback,
     addDeserializeCallback,
+    isBuildingSnapshot,
   },
 } = require('internal/v8/startup_snapshot');
 
@@ -119,10 +120,15 @@ function requireForUserSnapshot(id) {
     err.code = 'MODULE_NOT_FOUND';
     throw err;
   }
-  if (!supportedInUserSnapshot(normalizedId)) {
+  if (isBuildingSnapshot() && !supportedInUserSnapshot(normalizedId)) {
     if (!warnedModules.has(normalizedId)) {
-      process.emitWarning(
-        `built-in module ${id} is not yet supported in user snapshots`);
+      emitWarningSync(
+        `It's not yet fully verified whether built-in module "${id}" ` +
+        'works in user snapshot builder scripts.\n' +
+        'It may still work in some cases, but in other cases certain ' +
+        'run-time states may be out-of-sync after snapshot deserialization.\n' +
+        'To request support for the module, use the Node.js issue tracker: ' +
+        'https://github.com/nodejs/node/issues');
       warnedModules.add(normalizedId);
     }
   }

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -122,6 +122,9 @@ function requireForUserSnapshot(id) {
   }
   if (isBuildingSnapshot() && !supportedInUserSnapshot(normalizedId)) {
     if (!warnedModules.has(normalizedId)) {
+      // Emit the warning synchronously in case we don't get to process
+      // the tick and print it before the unsupported built-in causes a
+      // crash.
       emitWarningSync(
         `It's not yet fully verified whether built-in module "${id}" ` +
         'works in user snapshot builder scripts.\n' +


### PR DESCRIPTION
- Only emit warning when the snapshot is built. In general built-ins loaded after the snapshot is built should work as usual.
- Clarify what the warning means

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
