### PR TITLE
doc: Correct note on behavior of stats.isDirectory

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6970,8 +6970,9 @@ added: v0.1.10
 
 Returns `true` if the {fs.Stats} object describes a file system directory.
 
-If the {fs.Stats} object was obtained from [`fs.lstat()`][], this method will
-always return `false`. This is because [`fs.lstat()`][] returns information
+If the {fs.Stats} object was obtained from calling [`fs.lstat()`][] on a
+symbolic link which resolves to a directory, this method will return false.
+This is because [`fs.lstat()`][] returns information
 about a symbolic link itself and not the path it resolves to.
 
 #### `stats.isFIFO()`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6971,7 +6971,7 @@ added: v0.1.10
 Returns `true` if the {fs.Stats} object describes a file system directory.
 
 If the {fs.Stats} object was obtained from calling [`fs.lstat()`][] on a
-symbolic link which resolves to a directory, this method will return false.
+symbolic link which resolves to a directory, this method will return `false`.
 This is because [`fs.lstat()`][] returns information
 about a symbolic link itself and not the path it resolves to.
 


### PR DESCRIPTION
Original author incorrectly assumed that lstat can _only_ be used on symbolic links

The note incorrectly stated that `.isDirectory()` _always_ returns false when the stats object was obtained from `fs.lstat()`. `lstat` can be used on any type of object -- not just symbolic links. When stats are obtained using lstat for a regular directory (not a link), `.isDirectory()` will return true.

```shell
$ mkdir -p /tmp/foo
```
```javascript
const fs = require('fs');
const lstats = await fs.promises.lstat('/tmp/foo');
lstats.isDirectory(); // true
```