### PR TITLE
win,tools: upgrade Windows signing to smctl

### DIFF
--- a/tools/sign.bat
+++ b/tools/sign.bat
@@ -1,15 +1,12 @@
 @echo off
 
-set timeservers=(http://timestamp.globalsign.com/scripts/timestamp.dll http://timestamp.comodoca.com/authenticode http://timestamp.verisign.com/scripts/timestamp.dll http://tsa.starfieldtech.com)
-
-for %%s in %timeservers% do (
-    signtool sign /a /d "Node.js" /du "https://nodejs.org" /fd SHA256 /t %%s %1
-    if not ERRORLEVEL 1 (
-        echo Successfully signed %1 using timeserver %%s
-        exit /b 0
-    )
-    echo Signing %1 failed using %%s
+@REM From December 2023, new certificates use DigiCert cloud HSM service for EV signing.
+@REM They provide a client side app smctl.exe for managing certificates and signing process.
+@REM Release CI machines are configured to have it in the PATH so this can be used safely.
+smctl sign -k key_nodejs -i %1
+if not ERRORLEVEL 1 (
+    echo Successfully signed %1 using smctl
+    exit /b 0
 )
-
-echo Could not sign %1 using any available timeserver
+echo Could not sign %1 using smctl
 exit /b 1


### PR DESCRIPTION
This PR introduces a new signing process on Windows based on new requirements for it to be valid. It relies on DigiCert's cloud HSM service called KeyLocker and the new certificate stored there.

The signing tool is changed (in a way) from `signtool` to `smctl`. That is a DigiCert client-side tool for various operations, one of which is signing files. Under the hood, `smctl` calls `signtool` with the key from KeyLocker, so in its essence, the signing tool is still the same. The decision to use `smctl` instead of `signtool` directly came down to it being part of the mandatory DigiCert client-side tools and needing less configuring and simpler command to run.

There is a [release CI job](https://ci-release.nodejs.org/job/iojs+release_new_cert/) testing these changes and all 6 Windows release machines are prepared for signing with the new certificate. These changes should also be landed on all LTS versions (v18 and v20) for future releases. I will also update the docs, and write new ones where needed to describe the entire process after the process is over.

cc @nodejs/build @nodejs/platform-windows @nodejs/releasers 
Fixes: https://github.com/nodejs/build/issues/3491