### PR TITLE
sea: support embedding assets

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2367,6 +2367,17 @@ error indicates that the idle loop has failed to stop.
 An attempt was made to use operations that can only be used when building
 V8 startup snapshot even though Node.js isn't building one.
 
+<a id="ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION"></a>
+
+### `ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The operation cannot be performed when it's not in a single-executable
+application.
+
 <a id="ERR_NOT_SUPPORTED_IN_SNAPSHOT"></a>
 
 ### `ERR_NOT_SUPPORTED_IN_SNAPSHOT`
@@ -2512,6 +2523,17 @@ and HTTP/2 `Server` instances.
 The [`server.close()`][] method was called when a `net.Server` was not
 running. This applies to all instances of `net.Server`, including HTTP, HTTPS,
 and HTTP/2 `Server` instances.
+
+<a id="ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND"></a>
+
+### `ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+A key was passed to single executable application APIs to identify an asset,
+but no match could be found.
 
 <a id="ERR_SOCKET_ALREADY_BOUND"></a>
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -219,6 +219,8 @@ const image = getAsset('a.jpg');
 const text = getAsset('b.txt', 'utf8');
 // Returns a Blob containing the asset.
 const blob = getAssetAsBlob('a.jpg');
+// Returns an ArrayBuffer containing the raw asset without copying.
+const raw = getRawAsset('a.jpg');
 ```
 
 See documentation of the [`sea.getAsset()`][] and [`sea.getAssetAsBlob()`][]
@@ -315,6 +317,27 @@ An error is thrown when no matching asset can be found.
 * `options` {Object}
   * `type` {string} An optional mime type for the blob.
 * Returns: {Blob}
+
+### `sea.getRawAsset(key)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+This method can be used to retrieve the assets configured to be bundled into the
+single-executable application at build time.
+An error is thrown when no matching asset can be found.
+
+Unlike `sea.getRawAsset()` or `sea.getAssetAsBlob()`, this method does not
+return a copy. Instead, it returns the raw asset bundled inside the executable.
+
+For now, users should avoid writing to the returned array buffer. If the
+injected section is not marked as writable or not aligned properly,
+writes to the returned array buffer is likely to result in a crash.
+
+* `key`  {string} the key for the asset in the dictionary specified by the
+  `assets` field in the single-executable application configuration.
+* Returns: {string|ArrayBuffer}
 
 ### `require(id)` in the injected main script is not file based
 

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -128,6 +128,7 @@ const legacyWrapperList = new SafeSet([
 // beginning with "internal/".
 // Modules that can only be imported via the node: scheme.
 const schemelessBlockList = new SafeSet([
+  'sea',
   'test',
   'test/reporters',
 ]);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1632,6 +1632,8 @@ E('ERR_NETWORK_IMPORT_DISALLOWED',
   "import of '%s' by %s is not supported: %s", Error);
 E('ERR_NOT_BUILDING_SNAPSHOT',
   'Operation cannot be invoked when not building startup snapshot', Error);
+E('ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION',
+  'Operation cannot be invoked when not in a single-executable application', Error);
 E('ERR_NOT_SUPPORTED_IN_SNAPSHOT', '%s is not supported in startup snapshot', Error);
 E('ERR_NO_CRYPTO',
   'Node.js is not compiled with OpenSSL crypto support', Error);
@@ -1715,6 +1717,8 @@ E('ERR_SCRIPT_EXECUTION_INTERRUPTED',
 E('ERR_SERVER_ALREADY_LISTEN',
   'Listen method has been called more than once without closing.', Error);
 E('ERR_SERVER_NOT_RUNNING', 'Server is not running.', Error);
+E('ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND',
+  'Cannot find asset %s for the single executable application', Error);
 E('ERR_SOCKET_ALREADY_BOUND', 'Socket is already bound', Error);
 E('ERR_SOCKET_BAD_BUFFER_SIZE',
   'Buffer size must be a positive integer', TypeError);

--- a/lib/sea.js
+++ b/lib/sea.js
@@ -71,5 +71,6 @@ function getAssetAsBlob(key, options) {
 module.exports = {
   isSea,
   getAsset,
+  getRawAsset,
   getAssetAsBlob,
 };

--- a/lib/sea.js
+++ b/lib/sea.js
@@ -1,0 +1,75 @@
+'use strict';
+const {
+  ArrayBufferPrototypeSlice,
+} = primordials;
+
+const { isSea, getAsset: getAssetInternal } = internalBinding('sea');
+const { TextDecoder } = require('internal/encoding');
+const { validateString } = require('internal/validators');
+const {
+  ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION,
+  ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND,
+} = require('internal/errors').codes;
+const { Blob } = require('internal/blob');
+
+/**
+ * Look for the asset in the injected SEA blob using the key. If
+ * no matching asset is found an error is thrown. The returned
+ * ArrayBuffer should not be mutated or otherwise the process
+ * can crash due to access violation.
+ * @param {string} key
+ * @returns {ArrayBuffer}
+ */
+function getRawAsset(key) {
+  validateString(key, 'key');
+
+  if (!isSea()) {
+    throw new ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION();
+  }
+
+  const asset = getAssetInternal(key);
+  if (asset === undefined) {
+    throw new ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND(key);
+  }
+  return asset;
+}
+
+/**
+ * Look for the asset in the injected SEA blob using the key. If the
+ * encoding is specified, return a string decoded from it by TextDecoder,
+ * otherwise return *a copy* of the original data in an ArrayBuffer. If
+ * no matching asset is found an error is thrown.
+ * @param {string} key
+ * @param {string|undefined} encoding
+ * @returns {string|ArrayBuffer}
+ */
+function getAsset(key, encoding) {
+  if (encoding !== undefined) {
+    validateString(encoding, 'encoding');
+  }
+  const asset = getRawAsset(key);
+  if (encoding === undefined) {
+    return ArrayBufferPrototypeSlice(asset);
+  }
+  const decoder = new TextDecoder(encoding);
+  return decoder.decode(asset);
+}
+
+/**
+ * Look for the asset in the injected SEA blob using the key. If
+ * no matching asset is found an error is thrown. The data is returned
+ * in a Blob. If no matching asset is found an error is thrown.
+ * @param {string} key
+ * @param {object|undefined} options
+ * @returns {Blob}
+ */
+function getAssetAsBlob(key, options) {
+  const asset = getRawAsset(key);
+  return new Blob([asset], options);
+}
+
+module.exports = {
+  isSea,
+  getAsset,
+  getAssetAsBlob,
+};

--- a/lib/sea.js
+++ b/lib/sea.js
@@ -60,7 +60,7 @@ function getAsset(key, encoding) {
  * no matching asset is found an error is thrown. The data is returned
  * in a Blob. If no matching asset is found an error is thrown.
  * @param {string} key
- * @param {object|undefined} options
+ * @param {ConstructorParameters<Blob>[1]} [options]
  * @returns {Blob}
  */
 function getAssetAsBlob(key, options) {

--- a/src/blob_serializer_deserializer-inl.h
+++ b/src/blob_serializer_deserializer-inl.h
@@ -140,10 +140,11 @@ std::string_view BlobDeserializer<Impl>::ReadStringView(StringLogMode mode) {
   Debug("ReadStringView(), length=%zu: ", length);
 
   std::string_view result(sink.data() + read_total, length);
-  Debug("%p, read %zu bytes\n", result.data(), result.size());
+  Debug("%p, read %zu bytes", result.data(), result.size());
   if (mode == StringLogMode::kAddressAndContent) {
-    Debug("%s", result);
+    Debug(", content:%s%s", length > 32 ? "\n" : " ", result);
   }
+  Debug("\n");
 
   read_total += length;
   return result;

--- a/src/json_parser.cc
+++ b/src/json_parser.cc
@@ -4,6 +4,7 @@
 #include "util-inl.h"
 
 namespace node {
+using v8::Array;
 using v8::Context;
 using v8::Isolate;
 using v8::Local;
@@ -99,6 +100,53 @@ std::optional<bool> JSONParser::GetTopLevelBoolField(std::string_view field) {
     return {};
   }
   return value->BooleanValue(isolate);
+}
+
+std::optional<JSONParser::StringDict> JSONParser::GetTopLevelStringDict(
+    std::string_view field) {
+  Isolate* isolate = isolate_.get();
+  v8::HandleScope handle_scope(isolate);
+  Local<Context> context = context_.Get(isolate);
+  Local<Object> content_object = content_.Get(isolate);
+  Local<Value> value;
+  bool has_field;
+  // It's not a real script, so don't print the source line.
+  errors::PrinterTryCatch bootstrapCatch(
+      isolate, errors::PrinterTryCatch::kDontPrintSourceLine);
+  Local<Value> field_local;
+  if (!ToV8Value(context, field, isolate).ToLocal(&field_local)) {
+    return std::nullopt;
+  }
+  if (!content_object->Has(context, field_local).To(&has_field)) {
+    return std::nullopt;
+  }
+  if (!has_field) {
+    return StringDict();
+  }
+  if (!content_object->Get(context, field_local).ToLocal(&value) ||
+      !value->IsObject()) {
+    return std::nullopt;
+  }
+  Local<Object> dict = value.As<Object>();
+  Local<Array> keys;
+  if (!dict->GetOwnPropertyNames(context).ToLocal(&keys)) {
+    return std::nullopt;
+  }
+  std::unordered_map<std::string, std::string> result;
+  uint32_t length = keys->Length();
+  for (uint32_t i = 0; i < length; ++i) {
+    Local<Value> key;
+    Local<Value> value;
+    if (!keys->Get(context, i).ToLocal(&key) || !key->IsString())
+      return StringDict();
+    if (!dict->Get(context, key).ToLocal(&value) || !value->IsString())
+      return StringDict();
+
+    Utf8Value key_utf8(isolate, key);
+    Utf8Value value_utf8(isolate, value);
+    result.emplace(*key_utf8, *value_utf8);
+  }
+  return result;
 }
 
 }  // namespace node

--- a/src/json_parser.h
+++ b/src/json_parser.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include "util.h"
 #include "v8.h"
 
@@ -15,11 +16,13 @@ namespace node {
 // complicates things.
 class JSONParser {
  public:
+  using StringDict = std::unordered_map<std::string, std::string>;
   JSONParser();
   ~JSONParser() = default;
   bool Parse(const std::string& content);
   std::optional<std::string> GetTopLevelStringField(std::string_view field);
   std::optional<bool> GetTopLevelBoolField(std::string_view field);
+  std::optional<StringDict> GetTopLevelStringDict(std::string_view field);
 
  private:
   // We might want a lighter-weight JSON parser for this use case. But for now

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "node_exit_code.h"
@@ -27,6 +28,7 @@ enum class SeaFlags : uint32_t {
   kDisableExperimentalSeaWarning = 1 << 0,
   kUseSnapshot = 1 << 1,
   kUseCodeCache = 1 << 2,
+  kIncludeAssets = 1 << 3,
 };
 
 struct SeaResource {
@@ -34,6 +36,7 @@ struct SeaResource {
   std::string_view code_path;
   std::string_view main_code_or_snapshot;
   std::optional<std::string_view> code_cache;
+  std::unordered_map<std::string_view, std::string_view> assets;
 
   bool use_snapshot() const;
   static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags);

--- a/test/fixtures/sea/get-asset-raw.js
+++ b/test/fixtures/sea/get-asset-raw.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { isSea, getAsset, getRawAsset } = require('node:sea');
+const { readFileSync } = require('fs');
+const assert = require('assert');
+
+assert(isSea());
+
+{
+  assert.throws(() => getRawAsset('nonexistent'), {
+    code: 'ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND'
+  });
+  assert.throws(() => getRawAsset(null), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => getRawAsset(1), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+}
+
+{
+  // Check that the asset embedded is the same as the original.
+  const assetOnDisk = readFileSync(process.env.__TEST_PERSON_JPG);
+  const assetCopy = getAsset('person.jpg')
+  const assetCopyBuffer = Buffer.from(assetCopy);
+  assert.deepStrictEqual(assetCopyBuffer, assetOnDisk);
+
+  // Check that the copied asset is the same as the raw one.
+  const rawAsset = getRawAsset('person.jpg');
+  assert.deepStrictEqual(rawAsset, assetCopy);
+}

--- a/test/fixtures/sea/get-asset.js
+++ b/test/fixtures/sea/get-asset.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const { isSea, getAsset, getAssetAsBlob } = require('node:sea');
+const { readFileSync } = require('node:fs');
+const assert = require('node:assert');
+
+assert(isSea());
+
+// Test invalid getAsset() calls.
+{
+  assert.throws(() => getAsset('utf8_test_text.txt', 'invalid'), {
+    code: 'ERR_ENCODING_NOT_SUPPORTED'
+  });
+
+  [
+    1,
+    1n,
+    Symbol(),
+    false,
+    () => {},
+    {},
+    [],
+    null,
+    undefined,
+  ].forEach(arg => assert.throws(() => getAsset(arg), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  }));
+
+  assert.throws(() => getAsset('nonexistent'), {
+    code: 'ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND'
+  });
+}
+
+// Test invalid getAssetAsBlob() calls.
+{
+  // Invalid options argument.
+  [
+    123,
+    123n,
+    Symbol(),
+    '',
+    true,
+  ].forEach(arg => assert.throws(() => {
+    getAssetAsBlob('utf8_test_text.txt', arg)
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  }));
+
+  assert.throws(() => getAssetAsBlob('nonexistent'), {
+    code: 'ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND'
+  });
+}
+
+const textAssetOnDisk = readFileSync(process.env.__TEST_UTF8_TEXT_PATH, 'utf8');
+const binaryAssetOnDisk = readFileSync(process.env.__TEST_PERSON_JPG);
+
+// Check getAsset() buffer copies.
+{
+  // Check that the asset embedded is the same as the original.
+  const assetCopy1 = getAsset('person.jpg')
+  const assetCopyBuffer1 = Buffer.from(assetCopy1);
+  assert.deepStrictEqual(assetCopyBuffer1, binaryAssetOnDisk);
+
+  const assetCopy2 = getAsset('person.jpg');
+  const assetCopyBuffer2 = Buffer.from(assetCopy2);
+  assert.deepStrictEqual(assetCopyBuffer2, binaryAssetOnDisk);
+
+  // Zero-fill copy1.
+  assetCopyBuffer1.fill(0);
+
+  // Test that getAsset() returns an immutable copy.
+  assert.deepStrictEqual(assetCopyBuffer2, binaryAssetOnDisk);
+  assert.notDeepStrictEqual(assetCopyBuffer1, binaryAssetOnDisk);
+}
+
+// Check getAsset() with encoding.
+{
+  const actualAsset = getAsset('utf8_test_text.txt', 'utf8')
+  assert.strictEqual(actualAsset, textAssetOnDisk);
+  console.log(actualAsset);
+}
+
+// Check getAssetAsBlob().
+{
+  let called = false;
+  async function test() {
+    const blob = getAssetAsBlob('person.jpg');
+    const buffer = await blob.arrayBuffer();
+    assert.deepStrictEqual(Buffer.from(buffer), binaryAssetOnDisk);
+    const blob2 = getAssetAsBlob('utf8_test_text.txt');
+    const text = await blob2.text();
+    assert.strictEqual(text, textAssetOnDisk);
+  }
+  test().then(() => {
+    called = true;
+  });
+  process.on('exit', () => {
+    assert(called);
+  });
+}

--- a/test/fixtures/sea/get-asset.js
+++ b/test/fixtures/sea/get-asset.js
@@ -77,6 +77,9 @@ const binaryAssetOnDisk = readFileSync(process.env.__TEST_PERSON_JPG);
 {
   const actualAsset = getAsset('utf8_test_text.txt', 'utf8')
   assert.strictEqual(actualAsset, textAssetOnDisk);
+  // Log it out so that the test could compare it and see if
+  // it's encoded/decoded correctly in the SEA.
+  console.log(actualAsset);
 }
 
 // Check getAssetAsBlob().

--- a/test/fixtures/sea/get-asset.js
+++ b/test/fixtures/sea/get-asset.js
@@ -77,7 +77,6 @@ const binaryAssetOnDisk = readFileSync(process.env.__TEST_PERSON_JPG);
 {
   const actualAsset = getAsset('utf8_test_text.txt', 'utf8')
   assert.strictEqual(actualAsset, textAssetOnDisk);
-  console.log(actualAsset);
 }
 
 // Check getAssetAsBlob().

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -49,6 +49,7 @@ test-performance-eventloopdelay: PASS, FLAKY
 
 [$system==linux && $arch==ppc64]
 # https://github.com/nodejs/node/issues/50740
+test-single-executable-application-assets: PASS, FLAKY
 test-single-executable-application-disable-experimental-sea-warning: PASS, FLAKY
 test-single-executable-application-empty: PASS, FLAKY
 test-single-executable-application-snapshot-and-code-cache: PASS, FLAKY

--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -49,6 +49,7 @@ test-performance-eventloopdelay: PASS, FLAKY
 
 [$system==linux && $arch==ppc64]
 # https://github.com/nodejs/node/issues/50740
+test-single-executable-application-assets-raw: PASS, FLAKY
 test-single-executable-application-assets: PASS, FLAKY
 test-single-executable-application-disable-experimental-sea-warning: PASS, FLAKY
 test-single-executable-application-empty: PASS, FLAKY

--- a/test/sequential/test-single-executable-application-assets-raw.js
+++ b/test/sequential/test-single-executable-application-assets-raw.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  injectAndCodeSign,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the snapshot support in single executable applications.
+const tmpdir = require('../common/tmpdir');
+
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const {
+  spawnSyncAndExitWithoutError
+} = require('../common/child_process');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+
+tmpdir.refresh();
+if (!tmpdir.hasEnoughSpace(120 * 1024 * 1024)) {
+  common.skip('Not enough disk space');
+}
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+{
+  tmpdir.refresh();
+  copyFileSync(fixtures.path('sea', 'get-asset-raw.js'), tmpdir.resolve('sea.js'));
+  copyFileSync(fixtures.path('person.jpg'), tmpdir.resolve('person.jpg'));
+  writeFileSync(configFile, `
+  {
+    "main": "sea.js",
+    "output": "sea-prep.blob",
+    "assets": {
+      "person.jpg": "person.jpg"
+    }
+  }
+  `, 'utf8');
+
+  spawnSyncAndExitWithoutError(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      env: {
+        NODE_DEBUG_NATIVE: 'SEA',
+        ...process.env,
+      },
+      cwd: tmpdir.path
+    },
+    {});
+
+  assert(existsSync(seaPrepBlob));
+
+  copyFileSync(process.execPath, outputFile);
+  injectAndCodeSign(outputFile, seaPrepBlob);
+
+  spawnSyncAndExitWithoutError(
+    outputFile,
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'SEA',
+        __TEST_PERSON_JPG: fixtures.path('person.jpg'),
+      }
+    },
+    { }
+  );
+}

--- a/test/sequential/test-single-executable-application-assets-raw.js
+++ b/test/sequential/test-single-executable-application-assets-raw.js
@@ -14,7 +14,7 @@ const tmpdir = require('../common/tmpdir');
 
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
 const {
-  spawnSyncAndExitWithoutError
+  spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');

--- a/test/sequential/test-single-executable-application-assets.js
+++ b/test/sequential/test-single-executable-application-assets.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const common = require('../common');
+
+const {
+  injectAndCodeSign,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the snapshot support in single executable applications.
+const tmpdir = require('../common/tmpdir');
+
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const {
+  spawnSyncAndExit,
+  spawnSyncAndExitWithoutError
+} = require('../common/child_process');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+
+tmpdir.refresh();
+if (!tmpdir.hasEnoughSpace(120 * 1024 * 1024)) {
+  common.skip('Not enough disk space');
+}
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+{
+  tmpdir.refresh();
+  copyFileSync(fixtures.path('sea', 'get-asset.js'), tmpdir.resolve('sea.js'));
+  writeFileSync(configFile, `
+  {
+    "main": "sea.js",
+    "output": "sea-prep.blob",
+    "assets": "invalid"
+  }
+  `);
+
+  spawnSyncAndExit(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    },
+    {
+      status: 1,
+      signal: null,
+      stderr: /"assets" field of sea-config\.json is not a map of strings/
+    });
+}
+
+{
+  tmpdir.refresh();
+  copyFileSync(fixtures.path('sea', 'get-asset.js'), tmpdir.resolve('sea.js'));
+  writeFileSync(configFile, `
+  {
+    "main": "sea.js",
+    "output": "sea-prep.blob",
+    "assets": {
+      "nonexistent": "nonexistent.txt"
+    }
+  }
+  `);
+
+  spawnSyncAndExit(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    },
+    {
+      status: 1,
+      signal: null,
+      stderr: /Cannot read asset nonexistent\.txt: no such file or directory/
+    });
+}
+
+{
+  tmpdir.refresh();
+  copyFileSync(fixtures.path('sea', 'get-asset.js'), tmpdir.resolve('sea.js'));
+  copyFileSync(fixtures.utf8TestTextPath, tmpdir.resolve('utf8_test_text.txt'));
+  copyFileSync(fixtures.path('person.jpg'), tmpdir.resolve('person.jpg'));
+  writeFileSync(configFile, `
+  {
+    "main": "sea.js",
+    "output": "sea-prep.blob",
+    "assets": {
+      "utf8_test_text.txt": "utf8_test_text.txt",
+      "person.jpg": "person.jpg"
+    }
+  }
+  `, 'utf8');
+
+  spawnSyncAndExitWithoutError(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      env: {
+        NODE_DEBUG_NATIVE: 'SEA',
+        ...process.env,
+      },
+      cwd: tmpdir.path
+    },
+    {});
+
+  assert(existsSync(seaPrepBlob));
+
+  copyFileSync(process.execPath, outputFile);
+  injectAndCodeSign(outputFile, seaPrepBlob);
+
+  spawnSyncAndExitWithoutError(
+    outputFile,
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'SEA',
+        __TEST_PERSON_JPG: fixtures.path('person.jpg'),
+        __TEST_UTF8_TEXT_PATH: fixtures.path('utf8_test_text.txt'),
+      }
+    },
+    {
+      trim: true,
+      stdout: fixtures.utf8TestText,
+    }
+  );
+}

--- a/test/sequential/test-single-executable-application-assets.js
+++ b/test/sequential/test-single-executable-application-assets.js
@@ -15,7 +15,7 @@ const tmpdir = require('../common/tmpdir');
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
 const {
   spawnSyncAndExit,
-  spawnSyncAndExitWithoutError
+  spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
### src: print string content better in BlobDeserializer

When it's a short string, print it inline, otherwise print it
from a separate line. Also add the missing line breaks finally.

### sea: support embedding assets

With this patch:

Users can now include assets by adding a key-path dictionary
to the configuration as the `assets` field. At build time, Node.js
would read the assets from the specified paths and bundle them into
the preparation blob. In the generated executable, users can retrieve
the assets using the `sea.getAsset()` and `sea.getAssetAsBlob()` API.

```json
{
  "main": "/path/to/bundled/script.js",
  "output": "/path/to/write/the/generated/blob.blob",
  "assets": {
    "a.jpg": "/path/to/a.jpg",
    "b.txt": "/path/to/b.txt"
  }
}
```

The single-executable application can access the assets as follows:

```cjs
const { getAsset } = require('node:sea');
// Returns a copy of the data in an ArrayBuffer
const image = getAsset('a.jpg');
// Returns a string decoded from the asset as UTF8.
const text = getAsset('b.txt', 'utf8');
// Returns a Blob containing the asset without copying.
const blob = getAssetAsBlob('a.jpg');
```

Drive-by: update the  documentation to include a section dedicated
to the injected main script and refer to it as "injected main
script" instead of "injected module" because it's a script, not
a module.

Refs: https://github.com/nodejs/single-executable/issues/68

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
