### PR TITLE
src: fix value cast in ToV8Value

### DIFF
--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -484,8 +484,7 @@ v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
   // These checks should all collapse at compile time.
   if (static_cast<uint32_t>(Limits::max()) <=
           std::numeric_limits<uint32_t>::max() &&
-      static_cast<uint32_t>(Limits::min()) >=
-          std::numeric_limits<uint32_t>::min() && Limits::is_exact) {
+      number >= 0 && Limits::is_exact) {
     return v8::Integer::NewFromUnsigned(isolate, static_cast<uint32_t>(number));
   }
 


### PR DESCRIPTION
In `ToV8Value`, the condition `static_cast<uint32_t>(Limits::min()) >=
          std::numeric_limits<uint32_t>::min())` 
does not work as intended for casting values to unsigned int

Fixes: #50896 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
