### PR TITLE
lib: refactor to use `validateNumber` in `buffer`

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -11,7 +11,6 @@ const {
 
 const {
   ERR_BUFFER_OUT_OF_BOUNDS,
-  ERR_INVALID_ARG_TYPE,
   ERR_OUT_OF_RANGE,
 } = require('internal/errors').codes;
 const { validateNumber } = require('internal/validators');
@@ -168,8 +167,7 @@ function readBigInt64BE(offset = 0) {
 }
 
 function readUIntLE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
+  validateNumber(offset, 'offset');
   if (byteLength === 6)
     return readUInt48LE(this, offset);
   if (byteLength === 5)
@@ -257,8 +255,7 @@ function readUInt8(offset = 0) {
 }
 
 function readUIntBE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
+  validateNumber(offset, 'offset');
   if (byteLength === 6)
     return readUInt48BE(this, offset);
   if (byteLength === 5)
@@ -337,8 +334,7 @@ function readUInt16BE(offset = 0) {
 }
 
 function readIntLE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
+  validateNumber(offset, 'offset');
   if (byteLength === 6)
     return readInt48LE(this, offset);
   if (byteLength === 5)
@@ -429,8 +425,7 @@ function readInt8(offset = 0) {
 }
 
 function readIntBE(offset, byteLength) {
-  if (offset === undefined)
-    throw new ERR_INVALID_ARG_TYPE('offset', 'number', offset);
+  validateNumber(offset, 'offset');
   if (byteLength === 6)
     return readInt48BE(this, offset);
   if (byteLength === 5)


### PR DESCRIPTION
Use `validateNumber()` to remove duplicate implementation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
