### PR TITLE
loader: speed up line length calculation used by moduleProvider

### DIFF
--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const {
-  ArrayPrototypeMap,
+  ArrayPrototypePush,
   JSONParse,
   ObjectKeys,
   RegExpPrototypeExec,
-  RegExpPrototypeSymbolSplit,
   SafeMap,
+  StringPrototypeCodePointAt,
   StringPrototypeSplit,
 } = primordials;
 
@@ -205,13 +205,25 @@ function dataFromUrl(sourceURL, sourceMappingURL) {
 // from. This allows translation from byte offset V8 coverage reports,
 // to line/column offset Source Map V3.
 function lineLengths(content) {
-  // We purposefully keep \r as part of the line-length calculation, in
-  // cases where there is a \r\n separator, so that this can be taken into
-  // account in coverage calculations.
-  return ArrayPrototypeMap(RegExpPrototypeSymbolSplit(/\n|\u2028|\u2029/, content), (line) => {
-    return line.length;
-  });
+  const contentLength = content.length;
+  const output = [];
+  let lineLength = 0;
+  for (let i = 0; i < contentLength; i++, lineLength++) {
+    const codePoint = StringPrototypeCodePointAt(content, i);
+
+    // We purposefully keep \r as part of the line-length calculation, in
+    // cases where there is a \r\n separator, so that this can be taken into
+    // account in coverage calculations.
+    // codepoints for \n (new line), \u2028 (line separator) and \u2029 (paragraph separator)
+    if (codePoint === 10 || codePoint === 0x2028 || codePoint === 0x2029) {
+      ArrayPrototypePush(output, lineLength);
+      lineLength = -1; // To not count the matched codePoint such as \n character
+    }
+  }
+  ArrayPrototypePush(output, lineLength);
+  return output;
 }
+
 
 function sourceMapFromFile(mapURL) {
   try {


### PR DESCRIPTION
When using a loader, for e.g., say TypeScript, the esm loader invokes the `lineLengths` function via `maybeCacheSourceMap` when sourcemaps are enabled. Therefore, `lineLengths` ends up getting called quite often when running large servers written in TypeScript for example. Making `lineLengths` faster should therefore speed up server startup times for anyone using a loader with node with sourcemaps enabled.

The change itself is fairly simple and is all about removing creation of unnecessary memory and iterating the whole source content only once with the hope of making the function cache friendly.

- [x] `make -j4 test` passes

Alongside that, below are the `cpuprofile`s of node 20.9.0 vs node `main` with this patch taken during the startup of large server (from work) written in TypeScript loaded using [esno](https://github.com/esbuild-kit/esno) (a proxy to [esbuild-register](https://github.com/egoist/esbuild-register)) showing a **~98% reduction in time taken by `moduleProvider`**.

## node 20.9.0
<img width="1792" alt="image" src="https://github.com/nodejs/node/assets/635512/4b8cd7fc-3e35-4493-b233-bd0a9670d5d7">


## node `main` + patch from this PR
<img width="1792" alt="image" src="https://github.com/nodejs/node/assets/635512/19ab65f2-3a01-4489-931c-3092b63bb76a">


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
