### PR TITLE
http: handle multi-value content-disposition header correctly

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -600,7 +600,14 @@ function processHeader(self, state, key, value, validate) {
   // https://www.rfc-editor.org/rfc/rfc6266#section-4.3
   // Refs: https://github.com/nodejs/node/pull/46528
   if (isContentDispositionField(key) && self._contentLength) {
-    value = Buffer.from(value, 'latin1');
+    // The value could be an array here
+    if (ArrayIsArray(value)) {
+      for (let i = 0; i < value.length; i++) {
+        value[i] = Buffer.from(value[i], 'latin1');
+      }
+    } else {
+      value = Buffer.from(value, 'latin1');
+    }
   }
 
   if (ArrayIsArray(value)) {

--- a/test/parallel/test-http-server-non-utf8-header.js
+++ b/test/parallel/test-http-server-non-utf8-header.js
@@ -27,6 +27,27 @@ const nonUtf8ToLatin1 = Buffer.from(nonUtf8Header).toString('latin1');
 }
 
 {
+  // Test multi-value header
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeHead(200, [
+      'content-disposition',
+      [Buffer.from(nonUtf8Header).toString('binary')],
+    ]);
+    res.end('hello');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers['content-disposition'], nonUtf8ToLatin1);
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
   const server = http.createServer(common.mustCall((req, res) => {
     res.writeHead(200, [
       'Content-Length', '5',


### PR DESCRIPTION
This change fixes a bug introduced by an earlier PR #46528. Basically, in the earlier PR the code was written with the assumption that content-disposition header will always have a scalar string value but in fact Node.js allows users to provide an array as a value for a header.

If you provide an array value for content-disposition header, then the Buffer string would contain characters that are invalid for headers and that results in a `ERR_INVALID_HTTP_RESPONSE` error. 