### PR TITLE
test_runner: fixed test object is incorrectly passed to setup()

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -20,10 +20,10 @@ const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 const { kEmptyObject } = require('internal/util');
 const { kCancelledByParent, Test, Suite } = require('internal/test_runner/test');
 const {
-  colorizeTestFiles,
   parseCommandLine,
   reporterScope,
   setupTestReporters,
+  shouldColorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { bigint: hrtime } = process.hrtime;
 
@@ -207,7 +207,7 @@ function getGlobalRoot() {
       }
     });
     reportersSetup = setupTestReporters(globalRoot.reporter);
-    colorizeTestFiles(globalRoot);
+    globalRoot.harness.shouldColorizeTestFiles ||= shouldColorizeTestFiles(globalRoot);
   }
   return globalRoot;
 }

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -23,6 +23,7 @@ const {
   parseCommandLine,
   reporterScope,
   setupTestReporters,
+  colorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { bigint: hrtime } = process.hrtime;
 
@@ -205,7 +206,8 @@ function getGlobalRoot() {
         process.exitCode = kGenericUserError;
       }
     });
-    reportersSetup = setupTestReporters(globalRoot);
+    reportersSetup = setupTestReporters(globalRoot.reporter);
+    colorizeTestFiles(globalRoot);
   }
   return globalRoot;
 }

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -20,10 +20,10 @@ const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 const { kEmptyObject } = require('internal/util');
 const { kCancelledByParent, Test, Suite } = require('internal/test_runner/test');
 const {
+  colorizeTestFiles,
   parseCommandLine,
   reporterScope,
   setupTestReporters,
-  colorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { bigint: hrtime } = process.hrtime;
 

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -70,6 +70,7 @@ const {
   convertStringToRegExp,
   countCompletedTest,
   kDefaultPattern,
+  colorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { Glob } = require('internal/fs/glob');
 const { once } = require('events');
@@ -491,6 +492,7 @@ function run(options = kEmptyObject) {
     return root.reporter;
   }
   let testFiles = files ?? createTestFileList();
+  colorizeTestFiles(root);
 
   if (shard) {
     testFiles = ArrayPrototypeFilter(testFiles, (_, index) => index % shard.total === shard.index - 1);
@@ -512,7 +514,7 @@ function run(options = kEmptyObject) {
     });
   };
 
-  PromisePrototypeThen(PromisePrototypeThen(PromiseResolve(setup?.(root)), runFiles), postRun);
+  PromisePrototypeThen(PromisePrototypeThen(PromiseResolve(setup?.(root.reporter)), runFiles), postRun);
 
   return root.reporter;
 }

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -488,11 +488,12 @@ function run(options = kEmptyObject) {
   }
 
   const root = createTestTree({ __proto__: null, concurrency, timeout, signal });
+  colorizeTestFiles(root);
+
   if (process.env.NODE_TEST_CONTEXT !== undefined) {
     return root.reporter;
   }
   let testFiles = files ?? createTestFileList();
-  colorizeTestFiles(root);
 
   if (shard) {
     testFiles = ArrayPrototypeFilter(testFiles, (_, index) => index % shard.total === shard.index - 1);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -67,10 +67,10 @@ const {
 } = require('internal/test_runner/test');
 
 const {
+  colorizeTestFiles,
   convertStringToRegExp,
   countCompletedTest,
   kDefaultPattern,
-  colorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { Glob } = require('internal/fs/glob');
 const { once } = require('events');

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -67,10 +67,10 @@ const {
 } = require('internal/test_runner/test');
 
 const {
-  colorizeTestFiles,
   convertStringToRegExp,
   countCompletedTest,
   kDefaultPattern,
+  shouldColorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { Glob } = require('internal/fs/glob');
 const { once } = require('events');
@@ -488,7 +488,7 @@ function run(options = kEmptyObject) {
   }
 
   const root = createTestTree({ __proto__: null, concurrency, timeout, signal });
-  colorizeTestFiles(root);
+  root.harness.shouldColorizeTestFiles ||= shouldColorizeTestFiles(root);
 
   if (process.env.NODE_TEST_CONTEXT !== undefined) {
     return root.reporter;

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -132,7 +132,7 @@ function tryBuiltinReporter(name) {
 function colorizeTestFiles(rootTest) {
   const { reporters, destinations } = parseCommandLine();
   ArrayPrototypeForEach(reporters, (_, index) => {
-    const destination = kBuiltinDestinations.get(destinations[index]) ?? createWriteStream(destinations[index]);
+    const destination = kBuiltinDestinations.get(destinations[index]);
     rootTest.harness.shouldColorizeTestFiles ||= shouldColorize(destination);
   });
 }

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -3,6 +3,7 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypeFlatMap,
+  ArrayPrototypeForEach,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
   ObjectGetOwnPropertyDescriptor,
@@ -128,10 +129,17 @@ function tryBuiltinReporter(name) {
   return require(builtinPath);
 }
 
-async function getReportersMap(reporters, destinations, rootTest) {
+function colorizeTestFiles(rootTest) {
+  const { reporters, destinations } = parseCommandLine();
+  ArrayPrototypeForEach(reporters, (_, index) => {
+    const destination = kBuiltinDestinations.get(destinations[index]) ?? createWriteStream(destinations[index]);
+    rootTest.harness.shouldColorizeTestFiles ||= shouldColorize(destination);
+  });
+}
+
+async function getReportersMap(reporters, destinations) {
   return SafePromiseAllReturnArrayLike(reporters, async (name, i) => {
     const destination = kBuiltinDestinations.get(destinations[i]) ?? createWriteStream(destinations[i]);
-    rootTest.harness.shouldColorizeTestFiles ||= shouldColorize(destination);
 
     // Load the test reporter passed to --test-reporter
     let reporter = tryBuiltinReporter(name);
@@ -166,12 +174,12 @@ async function getReportersMap(reporters, destinations, rootTest) {
 }
 
 const reporterScope = new AsyncResource('TestReporterScope');
-const setupTestReporters = reporterScope.bind(async (rootTest) => {
+const setupTestReporters = reporterScope.bind(async (rootReporter) => {
   const { reporters, destinations } = parseCommandLine();
-  const reportersMap = await getReportersMap(reporters, destinations, rootTest);
+  const reportersMap = await getReportersMap(reporters, destinations);
   for (let i = 0; i < reportersMap.length; i++) {
     const { reporter, destination } = reportersMap[i];
-    compose(rootTest.reporter, reporter).pipe(destination);
+    compose(rootReporter, reporter).pipe(destination);
   }
 });
 
@@ -413,6 +421,7 @@ function getCoverageReport(pad, summary, symbol, color, table) {
 }
 
 module.exports = {
+  colorizeTestFiles,
   convertStringToRegExp,
   countCompletedTest,
   createDeferredCallback,

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -3,9 +3,9 @@ const {
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
   ArrayPrototypeFlatMap,
-  ArrayPrototypeForEach,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
+  ArrayPrototypeSome,
   ObjectGetOwnPropertyDescriptor,
   MathFloor,
   MathMax,
@@ -129,11 +129,12 @@ function tryBuiltinReporter(name) {
   return require(builtinPath);
 }
 
-function colorizeTestFiles(rootTest) {
+function shouldColorizeTestFiles(rootTest) {
+  // This function assumes only built-in destinations (stdout/stderr) supports coloring
   const { reporters, destinations } = parseCommandLine();
-  ArrayPrototypeForEach(reporters, (_, index) => {
+  return ArrayPrototypeSome(reporters, (_, index) => {
     const destination = kBuiltinDestinations.get(destinations[index]);
-    rootTest.harness.shouldColorizeTestFiles ||= shouldColorize(destination);
+    return destination && shouldColorize(destination);
   });
 }
 
@@ -421,7 +422,6 @@ function getCoverageReport(pad, summary, symbol, color, table) {
 }
 
 module.exports = {
-  colorizeTestFiles,
   convertStringToRegExp,
   countCompletedTest,
   createDeferredCallback,
@@ -430,5 +430,6 @@ module.exports = {
   parseCommandLine,
   reporterScope,
   setupTestReporters,
+  shouldColorizeTestFiles,
   getCoverageReport,
 };

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -155,4 +155,23 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.strictEqual(child.stdout.toString(), 'Going to throw an error\n');
     assert.match(child.stderr.toString(), /Emitted 'error' event on Duplex instance/);
   });
+
+  it('should support stdout as a destination with spec reporter', async () => {
+    process.env.FORCE_COLOR = '1';
+    const file = tmpdir.resolve(`${tmpFiles++}.txt`);
+    const child = spawnSync(process.execPath,
+                            ['--test', '--test-reporter', 'spec', '--test-reporter-destination', file, testFile]);
+    assert.strictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.stdout.toString(), '');
+    const fileConent = fs.readFileSync(file, 'utf8');
+    assert.match(fileConent, /▶ nested/);
+    assert.match(fileConent, /✔ ok/);
+    assert.match(fileConent, /✖ failing/);
+    assert.match(fileConent, /ℹ tests 4/);
+    assert.match(fileConent, /ℹ pass 2/);
+    assert.match(fileConent, /ℹ fail 2/);
+    assert.match(fileConent, /ℹ cancelled 0/);
+    assert.match(fileConent, /ℹ skipped 0/);
+    assert.match(fileConent, /ℹ todo 0/);
+  });
 });

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -1,14 +1,10 @@
-// Flags: --expose-internals
-
 import * as common from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { join } from 'node:path';
 import { describe, it, run } from 'node:test';
 import { dot, spec, tap } from 'node:test/reporters';
 import assert from 'node:assert';
-import stream from 'internal/test_runner/tests_stream';
 
-const { TestsStream } = stream;
 const testFixtures = fixtures.path('test-runner');
 
 describe('require(\'node:test\').run', { concurrency: true }, () => {
@@ -474,7 +470,7 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       const stream = run({
         files: [join(testFixtures, 'default-behavior/test/random.cjs')],
         setup: common.mustCall((root) => {
-          assert(root instanceof TestsStream);
+          assert.strictEqual(root.constructor.name, "TestsStream");
         }),
       });
       stream.on('test:fail', common.mustNotCall());

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -470,7 +470,7 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       const stream = run({
         files: [join(testFixtures, 'default-behavior/test/random.cjs')],
         setup: common.mustCall((root) => {
-          assert.strictEqual(root.constructor.name, "TestsStream");
+          assert.strictEqual(root.constructor.name, 'TestsStream');
         }),
       });
       stream.on('test:fail', common.mustNotCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix #48809 

pass `testStream` to setup instead `testRoot`.
