### PR TITLE
bootstrap: make snapshot reproducible

### DIFF
--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -8,7 +8,7 @@
 
 namespace node {
 
-typedef size_t AliasedBufferIndex;
+typedef uint64_t AliasedBufferIndex;
 
 template <typename NativeT, typename V8T>
 AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -9,7 +9,7 @@
 
 namespace node {
 
-typedef size_t AliasedBufferIndex;
+typedef uint64_t AliasedBufferIndex;
 
 /**
  * Do not use this class directly when creating instances of it - use the

--- a/src/base_object_types.h
+++ b/src/base_object_types.h
@@ -42,10 +42,13 @@ namespace node {
   SERIALIZABLE_NON_BINDING_TYPES(V)
 
 #define V(TypeId, NativeType) k_##TypeId,
-enum class BindingDataType : uint8_t { BINDING_TYPES(V) kBindingDataTypeCount };
+// To avoid padding, the enums are uint64_t.
+enum class BindingDataType : uint64_t {
+  BINDING_TYPES(V) kBindingDataTypeCount
+};
 // Make sure that we put the bindings first so that we can also use the enums
 // for the bindings as index to the binding data store.
-enum class EmbedderObjectType : uint8_t {
+enum class EmbedderObjectType : uint64_t {
   BINDING_TYPES(V) SERIALIZABLE_NON_BINDING_TYPES(V)
   // We do not need to know about all the unserializable non-binding types for
   // now so we do not list them.

--- a/src/blob_serializer_deserializer-inl.h
+++ b/src/blob_serializer_deserializer-inl.h
@@ -238,7 +238,8 @@ size_t BlobSerializer<Impl>::WriteVector(const std::vector<T>& data) {
   if (is_debug) {
     std::string str = std::is_arithmetic_v<T> ? "" : ToStr(data);
     std::string name = GetName<T>();
-    Debug("\nWriteVector<%s>() (%d-byte), count=%d: %s\n",
+    Debug("\nAt 0x%x: WriteVector<%s>() (%d-byte), count=%d: %s\n",
+          sink.size(),
           name.c_str(),
           sizeof(T),
           data.size(),
@@ -270,7 +271,10 @@ size_t BlobSerializer<Impl>::WriteVector(const std::vector<T>& data) {
 template <typename Impl>
 size_t BlobSerializer<Impl>::WriteStringView(std::string_view data,
                                              StringLogMode mode) {
-  Debug("WriteStringView(), length=%zu: %p\n", data.size(), data.data());
+  Debug("At 0x%x: WriteStringView(), length=%zu: %p\n",
+        sink.size(),
+        data.size(),
+        data.data());
   size_t written_total = WriteArithmetic<size_t>(data.size());
 
   size_t length = data.size();
@@ -294,6 +298,8 @@ size_t BlobSerializer<Impl>::WriteString(const std::string& data) {
   return WriteStringView(data, StringLogMode::kAddressAndContent);
 }
 
+static size_t kPreviewCount = 16;
+
 // Helper for writing an array of numeric types.
 template <typename Impl>
 template <typename T>
@@ -301,10 +307,18 @@ size_t BlobSerializer<Impl>::WriteArithmetic(const T* data, size_t count) {
   static_assert(std::is_arithmetic_v<T>, "Arithmetic type");
   DCHECK_GT(count, 0);  // Should not write contents for vectors of size 0.
   if (is_debug) {
-    std::string str =
-        "{ " + std::to_string(data[0]) + (count > 1 ? ", ... }" : " }");
+    size_t preview_count = count < kPreviewCount ? count : kPreviewCount;
+    std::string str = "{ ";
+    for (size_t i = 0; i < preview_count; ++i) {
+      str += (std::to_string(data[i]) + ",");
+    }
+    if (count > preview_count) {
+      str += "...";
+    }
+    str += "}";
     std::string name = GetName<T>();
-    Debug("Write<%s>() (%zu-byte), count=%zu: %s",
+    Debug("At 0x%x: Write<%s>() (%zu-byte), count=%zu: %s",
+          sink.size(),
           name.c_str(),
           sizeof(T),
           count,

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -18,6 +18,12 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex encode_into_results_buffer;
   };
 
+  // Make sure that there's no padding in the struct since we will memcpy
+  // them into the snapshot blob and they need to be reproducible.
+  static_assert(sizeof(InternalFieldInfo) ==
+                    sizeof(InternalFieldInfoBase) + sizeof(AliasedBufferIndex),
+                "InternalFieldInfo should have no padding");
+
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,
               InternalFieldInfo* info = nullptr);

--- a/src/node.cc
+++ b/src/node.cc
@@ -1288,18 +1288,24 @@ ExitCode GenerateAndWriteSnapshotData(const SnapshotData** snapshot_data_ptr,
       return exit_code;
     }
   } else {
+    std::optional<std::string> builder_script_content;
     // Otherwise, load and run the specified builder script.
     std::unique_ptr<SnapshotData> generated_data =
         std::make_unique<SnapshotData>();
-    std::string builder_script_content;
-    int r = ReadFileSync(&builder_script_content, builder_script.c_str());
-    if (r != 0) {
-      FPrintF(stderr,
-              "Cannot read builder script %s for building snapshot. %s: %s",
-              builder_script,
-              uv_err_name(r),
-              uv_strerror(r));
-      return ExitCode::kGenericUserError;
+    if (builder_script != "node:generate_default_snapshot") {
+      builder_script_content = std::string();
+      int r = ReadFileSync(&(builder_script_content.value()),
+                           builder_script.c_str());
+      if (r != 0) {
+        FPrintF(stderr,
+                "Cannot read builder script %s for building snapshot. %s: %s\n",
+                builder_script,
+                uv_err_name(r),
+                uv_strerror(r));
+        return ExitCode::kGenericUserError;
+      }
+    } else {
+      snapshot_config.builder_script_path = std::nullopt;
     }
 
     exit_code = node::SnapshotBuilder::Generate(generated_data.get(),

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -64,6 +64,12 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex statfs_field_bigint_array;
   };
 
+  // Make sure that there's no padding in the struct since we will memcpy
+  // them into the snapshot blob and they need to be reproducible.
+  static_assert(sizeof(InternalFieldInfo) == sizeof(InternalFieldInfoBase) +
+                                                 sizeof(AliasedBufferIndex) * 4,
+                "InternalFieldInfo should have no padding");
+
   enum class FilePathIsFileReturnType {
     kIsFile = 0,
     kIsNotFile,

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -54,6 +54,12 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex hrtime_buffer;
   };
 
+  // Make sure that there's no padding in the struct since we will memcpy
+  // them into the snapshot blob and they need to be reproducible.
+  static_assert(sizeof(InternalFieldInfo) ==
+                    sizeof(InternalFieldInfoBase) + sizeof(AliasedBufferIndex),
+                "InternalFieldInfo should have no padding");
+
   static void AddMethods(v8::Isolate* isolate,
                          v8::Local<v8::ObjectTemplate> target);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -282,9 +282,9 @@ size_t SnapshotSerializer::Write(const PropInfo& data) {
 }
 
 // Layout of AsyncHooks::SerializeInfo
-// [ 4/8 bytes ]  snapshot index of async_ids_stack
-// [ 4/8 bytes ]  snapshot index of fields
-// [ 4/8 bytes ]  snapshot index of async_id_fields
+// [ 8 bytes ]  snapshot index of async_ids_stack
+// [ 8 bytes ]  snapshot index of fields
+// [ 8 bytes ]  snapshot index of async_id_fields
 // [ 4/8 bytes ]  snapshot index of js_execution_async_resources
 // [ 4/8 bytes ]  length of native_execution_async_resources
 // [   ...     ]  snapshot indices of each element in
@@ -387,9 +387,9 @@ size_t SnapshotSerializer::Write(const ImmediateInfo::SerializeInfo& data) {
 }
 
 // Layout of PerformanceState::SerializeInfo
-// [ 4/8 bytes ]  snapshot index of root
-// [ 4/8 bytes ]  snapshot index of milestones
-// [ 4/8 bytes ]  snapshot index of observers
+// [ 8 bytes ]  snapshot index of root
+// [ 8 bytes ]  snapshot index of milestones
+// [ 8 bytes ]  snapshot index of observers
 template <>
 performance::PerformanceState::SerializeInfo SnapshotDeserializer::Read() {
   Debug("Read<PerformanceState::SerializeInfo>()\n");

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -599,16 +599,17 @@ std::vector<char> SnapshotData::ToBlob() const {
   size_t written_total = 0;
 
   // Metadata
-  w.Debug("Write magic %" PRIx32 "\n", kMagic);
+  w.Debug("0x%x: Write magic %" PRIx32 "\n", w.sink.size(), kMagic);
   written_total += w.WriteArithmetic<uint32_t>(kMagic);
-  w.Debug("Write metadata\n");
+  w.Debug("0x%x: Write metadata\n", w.sink.size());
   written_total += w.Write<SnapshotMetadata>(metadata);
-
+  w.Debug("0x%x: Write snapshot blob\n", w.sink.size());
   written_total += w.Write<v8::StartupData>(v8_snapshot_blob_data);
-  w.Debug("Write isolate_data_indices\n");
+  w.Debug("0x%x: Write IsolateDataSerializeInfo\n", w.sink.size());
   written_total += w.Write<IsolateDataSerializeInfo>(isolate_data_info);
+  w.Debug("0x%x: Write EnvSerializeInfo\n", w.sink.size());
   written_total += w.Write<EnvSerializeInfo>(env_info);
-  w.Debug("Write code_cache\n");
+  w.Debug("0x%x: Write CodeCacheInfo\n", w.sink.size());
   written_total += w.WriteVector<builtins::CodeCacheInfo>(code_cache);
   w.Debug("SnapshotData::ToBlob() Wrote %d bytes\n", written_total);
 

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -23,6 +23,13 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex heap_space_statistics_buffer;
     AliasedBufferIndex heap_code_statistics_buffer;
   };
+
+  // Make sure that there's no padding in the struct since we will memcpy
+  // them into the snapshot blob and they need to be reproducible.
+  static_assert(sizeof(InternalFieldInfo) == sizeof(InternalFieldInfoBase) +
+                                                 sizeof(AliasedBufferIndex) * 3,
+                "InternalFieldInfo should have no padding");
+
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,
               InternalFieldInfo* info = nullptr);

--- a/test/parallel/test-snapshot-reproducible.js
+++ b/test/parallel/test-snapshot-reproducible.js
@@ -1,0 +1,70 @@
+'use strict';
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const assert = require('assert');
+
+// When the test fails this helper can be modified to write outputs
+// differently and aid debugging.
+function log(line) {
+  console.log(line);
+}
+
+function generateSnapshot() {
+  tmpdir.refresh();
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [
+      '--random_seed=42',
+      '--predictable',
+      '--build-snapshot',
+      'node:generate_default_snapshot',
+    ],
+    {
+      env: { ...process.env, NODE_DEBUG_NATIVE: 'SNAPSHOT_SERDES' },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        const lines = output.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('0x')) {
+            log(line);
+          }
+        }
+      },
+    }
+  );
+  const blobPath = tmpdir.resolve('snapshot.blob');
+  return fs.readFileSync(blobPath);
+}
+
+const buf1 = generateSnapshot();
+const buf2 = generateSnapshot();
+
+const diff = [];
+let offset = 0;
+const step = 16;
+do {
+  const length = Math.min(buf1.length - offset, step);
+  const slice1 = buf1.slice(offset, offset + length).toString('hex');
+  const slice2 = buf2.slice(offset, offset + length).toString('hex');
+  if (slice1 !== slice2) {
+    diff.push({ offset: '0x' + (offset).toString(16), slice1, slice2 });
+  }
+  offset += length;
+} while (offset < buf1.length);
+
+assert.strictEqual(offset, buf1.length);
+if (offset < buf2.length) {
+  const length = Math.min(buf2.length - offset, step);
+  const slice2 = buf2.slice(offset, offset + length).toString('hex');
+  diff.push({ offset, slice1: '', slice2 });
+  offset += length;
+} while (offset < buf2.length);
+
+assert.deepStrictEqual(diff, []);
+assert.strictEqual(buf1.length, buf2.length);


### PR DESCRIPTION
#### src: return non-empty data in context data serializer

For pointer values in the context data, we need to return
non-empty data in the serializer so that V8 does not
serialize them verbatim, making the snapshot unreproducible.

#### src: make sure that memcpy-ed structs in snapshot have no padding

To make the snapshots reproducible, this patch updates the size
of a few types and adds some static assertions to ensure that
there are no padding in the memcpy-ed structs.

#### src: add utilities to help debugging reproducibility of snapshots

- Print offsets in blob serializer
- Add a special node:generate_default_snapshot ID to generate
  the built-in snapshot.
- Improve logging
- Add a test to check the reproducibilty of the snapshot

Refs: https://github.com/nodejs/build/issues/3043

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
