### PR TITLE
vm: use v8::DeserializeInternalFieldsCallback explicitly

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -208,21 +208,24 @@ MaybeLocal<Context> ContextifyContext::CreateV8Context(
 
   Local<Context> ctx;
   if (snapshot_data == nullptr) {
-    ctx = Context::New(isolate,
-                       nullptr,  // extensions
-                       object_template,
-                       {},  // global object
-                       {},  // deserialization callback
-                       queue);
+    ctx = Context::New(
+        isolate,
+        nullptr,  // extensions
+        object_template,
+        {},                                       // global object
+        v8::DeserializeInternalFieldsCallback(),  // deserialization callback
+        queue);
     if (ctx.IsEmpty() || InitializeBaseContextForSnapshot(ctx).IsNothing()) {
       return MaybeLocal<Context>();
     }
-  } else if (!Context::FromSnapshot(isolate,
-                                    SnapshotData::kNodeVMContextIndex,
-                                    {},       // deserialization callback
-                                    nullptr,  // extensions
-                                    {},       // global object
-                                    queue)
+  } else if (!Context::FromSnapshot(
+                  isolate,
+                  SnapshotData::kNodeVMContextIndex,
+                  v8::DeserializeInternalFieldsCallback(),  // deserialization
+                                                            // callback
+                  nullptr,                                  // extensions
+                  {},                                       // global object
+                  queue)
                   .ToLocal(&ctx)) {
     return MaybeLocal<Context>();
   }

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -687,7 +687,12 @@ TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
   std::unique_ptr<v8::MicrotaskQueue> queue = v8::MicrotaskQueue::New(
       isolate_, v8::MicrotasksPolicy::kExplicit);
   v8::Local<v8::Context> context = v8::Context::New(
-      isolate_, nullptr, {}, {}, {}, queue.get());
+      isolate_,
+      nullptr,
+      {},
+      {},
+      v8::DeserializeInternalFieldsCallback(),
+      queue.get());
   node::InitializeContext(context);
   v8::Context::Scope context_scope(context);
 

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -686,13 +686,13 @@ TEST_F(EnvironmentTest, NestedMicrotaskQueue) {
 
   std::unique_ptr<v8::MicrotaskQueue> queue = v8::MicrotaskQueue::New(
       isolate_, v8::MicrotasksPolicy::kExplicit);
-  v8::Local<v8::Context> context = v8::Context::New(
-      isolate_,
-      nullptr,
-      {},
-      {},
-      v8::DeserializeInternalFieldsCallback(),
-      queue.get());
+  v8::Local<v8::Context> context =
+      v8::Context::New(isolate_,
+                       nullptr,
+                       {},
+                       {},
+                       v8::DeserializeInternalFieldsCallback(),
+                       queue.get());
   node::InitializeContext(context);
   v8::Context::Scope context_scope(context);
 


### PR DESCRIPTION
To avoid ambiguity in the signature.

This is necessary for the integration tests in https://chromium-review.googlesource.com/c/v8/v8/+/5074252 to pass which in turn unblocks https://github.com/nodejs/node/pull/50983

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
