### PR TITLE
fs: use w flag for writeFileSync with utf8 encoding when flag not specified

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2343,6 +2343,8 @@ function writeFileSync(path, data, options) {
 
   validateBoolean(flush, 'options.flush');
 
+  const flag = options.flag || 'w';
+
   // C++ fast path for string data and UTF8 encoding
   if (typeof data === 'string' && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
     if (!isInt32(path)) {
@@ -2351,7 +2353,7 @@ function writeFileSync(path, data, options) {
 
     return binding.writeFileUtf8(
       path, data,
-      stringToFlags(options.flag),
+      stringToFlags(flag),
       parseFileMode(options.mode, 'mode', 0o666),
     );
   }
@@ -2360,8 +2362,6 @@ function writeFileSync(path, data, options) {
     validateStringAfterArrayBufferView(data, 'data');
     data = Buffer.from(data, options.encoding || 'utf8');
   }
-
-  const flag = options.flag || 'w';
 
   const isUserFd = isFd(path); // File descriptor ownership
   const fd = isUserFd ? path : fs.openSync(path, flag, options.mode);

--- a/test/parallel/test-fs-write-file-sync.js
+++ b/test/parallel/test-fs-write-file-sync.js
@@ -101,6 +101,22 @@ tmpdir.refresh();
   assert.strictEqual(content, 'hello world!');
 }
 
+// Test writeFileSync with no flags
+{
+  const utf8Data = 'hello world!';
+  for (const test of [
+    { data: utf8Data },
+    { data: utf8Data, options: { encoding: 'utf8' } },
+    { data: Buffer.from(utf8Data, 'utf8').toString('hex'), options: { encoding: 'hex' } },
+  ]) {
+    const file = tmpdir.resolve(`testWriteFileSyncNewFile_${Math.random()}.txt`);
+    fs.writeFileSync(file, test.data, test.options);
+
+    const content = fs.readFileSync(file, { encoding: 'utf-8' });
+    assert.strictEqual(content, utf8Data);
+  }
+}
+
 // Test writeFileSync with an invalid input
 {
   const file = tmpdir.resolve('testWriteFileSyncInvalid.txt');


### PR DESCRIPTION
PR https://github.com/nodejs/node/pull/49884 seems to have accidentally changed the behavior for `fs.writeFileSync` with utf-8 encoding when the file does not exist, as compared to previous node versions.

On a low level, it seems we are not passing the `O_CREAT` flag to `uvlib` anymore.

Examples: 

In node 16.16.0: ✅
```
❯ nvm use 16.16
Now using node v16.16.0 (npm v8.11.0)
❯ node
Welcome to Node.js v16.16.0.
Type ".help" for more information.
> fs.writeFileSync('./test.txt', 'test', {encoding: 'utf8'});
undefined
> fs.readFileSync('./test.txt');
<Buffer 74 65 73 74>
```

In node 21.2.0: ✅
```
❯ nvm use 21.2
Now using node v21.2.0 (npm v10.2.3)
❯ node
Welcome to Node.js v21.2.0.
Type ".help" for more information.
> fs.writeFileSync('./test.txt', 'test', {encoding: 'utf8'});
undefined
> fs.readFileSync('./test.txt');
<Buffer 74 65 73 74>
```

In node 21.3.0 (currently latest): ❌ 
```
❯ nvm use 21.3
Now using node v21.3.0 (npm v10.2.4)
❯ node
Welcome to Node.js v21.3.0.
Type ".help" for more information.
> fs.writeFileSync('./test.txt', 'test', {encoding: 'utf8'});
Uncaught Error: ENOENT: no such file or directory, open './test.txt'
    at Object.writeFileSync (node:fs:2352:20) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: './test.txt'
}
```

Currently, a workaround for 21.3.0 is to pass the `w` flag (which includes `O_CREAT`) explicitly when calling `writeFileSync`. e.g:
```
fs.writeFileSync('./test.txt', 'test', {encoding: 'utf8', flag: 'w'}); --> works
fs.writeFileSync('./test.txt', 'test', {encoding: 'utf8'}); --> does not work
```

This PR will just set the `w` flag back as the default value when it is not specified, so its the same behavior from previous node versions.

Fixes https://github.com/nodejs/node/issues/50989

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->