### PR TITLE
node-api: introduce experimental feature flags

### DIFF
--- a/doc/contributing/adding-new-napi-api.md
+++ b/doc/contributing/adding-new-napi-api.md
@@ -34,6 +34,10 @@ Node-API.
   * Experimental APIs **must** be documented as such.
   * Experimental APIs **must** require an explicit compile-time flag
     (`#define`) to be set to opt-in.
+  * A feature flag of the form `NODE_API_EXPERIMENTAL_HAS_<FEATURE>` **must**
+    be added with each experimental feature in order to allow code to
+    distinguish between experimental features as present in one version of
+    Node.js versus another.
   * Experimental APIs **must** be considered for backport.
   * Experimental status exit criteria **must** involve at least the
     following:

--- a/doc/contributing/releases-node-api.md
+++ b/doc/contributing/releases-node-api.md
@@ -100,6 +100,8 @@ and update the define version guards with the release version:
 + #endif  // NAPI_VERSION >= 10
 ```
 
+Remove any feature flags of the form `NODE_API_EXPERIMENTAL_HAS_<FEATURE>`.
+
 Also, update the Node-API version value of the `napi_get_version` test in
 `test/js-native-api/test_general/test.js` with the release version `x`:
 

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -93,6 +93,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_string_utf16(napi_env env,
                                                             size_t length,
                                                             napi_value* result);
 #ifdef NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_HAS_EXTERNAL_STRINGS
 NAPI_EXTERN napi_status NAPI_CDECL
 node_api_create_external_string_latin1(napi_env env,
                                        char* str,
@@ -518,6 +519,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_add_finalizer(napi_env env,
 #endif  // NAPI_VERSION >= 5
 
 #ifdef NAPI_EXPERIMENTAL
+#define NODE_API_EXPERIMENTAL_HAS_POST_FINALIZER
 
 NAPI_EXTERN napi_status NAPI_CDECL
 node_api_post_finalizer(napi_env env,


### PR DESCRIPTION
Add a flag for each experimental feature to indicate its presence. That way, if we compile with `NAPI_EXPERIMENTAL` turned on, we'll be able to distinguish between what `NAPI_EXPERIMENTAL` used to mean on an old version of the headers when compiling against such an old version, and what it means on a new version of Node.js.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
