### PR TITLE
inspect: fix console.log(%s, { [Symbol.toPrimitive]: () => hello })

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -87,6 +87,7 @@ const {
   SymbolIterator,
   SymbolPrototypeToString,
   SymbolPrototypeValueOf,
+  SymbolToPrimitive,
   SymbolToStringTag,
   TypedArrayPrototypeGetLength,
   TypedArrayPrototypeGetSymbolToStringTag,
@@ -2101,6 +2102,11 @@ function hasBuiltInToString(value) {
       return true;
     }
     value = proxyTarget;
+  }
+
+  // Check if value has a custom Symbol.toPrimitive transformation.
+  if (typeof value[SymbolToPrimitive] === 'function') {
+    return false;
   }
 
   // Count objects that have no `toString` function as built-in.

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -269,6 +269,27 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   );
 }
 
+// Symbol.toPrimitive handling for string format specifier
+{
+  const objectWithToPrimitive = {
+    [Symbol.toPrimitive](hint) {
+      switch (hint) {
+        case 'number':
+          return 42;
+        case 'string':
+          return 'string representation';
+        case 'default':
+        default:
+          return 'default context';
+      }
+    }
+  };
+
+  assert.strictEqual(util.format('%s', +objectWithToPrimitive), '42');
+  assert.strictEqual(util.format('%s', objectWithToPrimitive), 'string representation');
+  assert.strictEqual(util.format('%s', objectWithToPrimitive + ''), 'default context');
+}
+
 // JSON format specifier
 assert.strictEqual(util.format('%j'), '%j');
 assert.strictEqual(util.format('%j', 42), '42');


### PR DESCRIPTION
`console.log("%s", o)` invokes the `inspect `method to retrieve the object. This results in `console.log("%s", { [Symbol.toPrimitive]: () => "hello" })` displaying the object itself, rather than 'hello'.

Fixes: #50909