### PR TITLE
deps: provide NoDefaultCurrentDirectoryInExePath env var on Windows 

### DIFF
--- a/deps/uv/src/win/process.c
+++ b/deps/uv/src/win/process.c
@@ -389,11 +389,13 @@ static WCHAR* search_path(const WCHAR *file,
   } else {
     dir_end = path;
 
-    /* The file is really only a name; look in cwd first, then scan path */
-    result = path_search_walk_ext(L"", 0,
-                                  file, file_len,
-                                  cwd, cwd_len,
-                                  name_has_ext);
+    if (NeedCurrentDirectoryForExePathW(L"")) {
+      /* The file is really only a name; look in cwd first, then scan path */
+      result = path_search_walk_ext(L"", 0,
+                                    file, file_len,
+                                    cwd, cwd_len,
+                                    name_has_ext);
+    }
 
     while (result == NULL) {
       if (*dir_end == L'\0') {


### PR DESCRIPTION
Regarding the issue of https://github.com/nodejs/node/issues/46264, libuv has been updated with `NoDefaultCurrentDirectoryInExePath` for the validation path in Windows. In this proposal, I suggest updating the dependencies to match libuv's changes.