### PR TITLE
test: resolve flakiness in worker*.test-free-called

### DIFF
--- a/test/addons/worker-buffer-callback/test-free-called.js
+++ b/test/addons/worker-buffer-callback/test-free-called.js
@@ -6,12 +6,14 @@ const { Worker } = require('worker_threads');
 const binding = path.resolve(__dirname, `./build/${common.buildType}/binding`);
 const { getFreeCallCount } = require(binding);
 
+// getFreeCallCount initial value is 0
+assert.strictEqual(getFreeCallCount(), 0);
+
 // Test that buffers allocated with a free callback through our APIs are
 // released when a Worker owning it exits.
 
 const w = new Worker(`require(${JSON.stringify(binding)})`, { eval: true });
 
-assert.strictEqual(getFreeCallCount(), 0);
 w.on('exit', common.mustCall(() => {
   assert.strictEqual(getFreeCallCount(), 1);
 }));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51003

The issue arises from the `getFreeCallCount()` function yielding the initial value of 0. Upon instantiation of the `Worker` object, it increments to 1. In the case of this flaky test, if the creation of the `Worker` object is faster, the subsequent `getFreeCallCount()` call always returns 1 instead of the expected 0.