### PR TITLE
wip: crypto: use cppgc to manage Hash

### DIFF
--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -1,6 +1,8 @@
 #include "crypto/crypto_hash.h"
 #include "async_wrap-inl.h"
 #include "base_object-inl.h"
+#include "cppgc/allocation.h"
+#include "cppgc_helpers-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "string_bytes.h"
@@ -31,14 +33,23 @@ using v8::Object;
 using v8::Uint32;
 using v8::Value;
 
+#ifdef ASSIGN_OR_RETURN_UNWRAP
+#undef ASSIGN_OR_RETURN_UNWRAP
+#endif
+
+#define ASSIGN_OR_RETURN_UNWRAP ASSIGN_OR_RETURN_UNWRAP_CPPGC
 namespace crypto {
-Hash::Hash(Environment* env, Local<Object> wrap) : BaseObject(env, wrap) {
-  MakeWeak();
+Hash::Hash(Environment* env, Local<Object> wrap) {
+  CppgcMixin::Wrap(this, env, wrap);
+}
+
+void Hash::Trace(cppgc::Visitor* visitor) const {
+  CppgcMixin::Trace(visitor);
 }
 
 void Hash::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackFieldWithSize("mdctx", mdctx_ ? kSizeOf_EVP_MD_CTX : 0);
-  tracker->TrackFieldWithSize("md", digest_ ? md_len_ : 0);
+  tracker->TrackFieldWithSize("mdctx", mdctx_ ? kSizeOf_EVP_MD_CTX : 0, "EVP_MD_CTX");
+  tracker->TrackFieldWithSize("md", digest_ ? md_len_ : 0, "ByteSource");
 }
 
 #if OPENSSL_VERSION_MAJOR >= 3
@@ -358,7 +369,8 @@ void Hash::New(const FunctionCallbackInfo<Value>& args) {
     xof_md_len = Just<unsigned int>(args[1].As<Uint32>()->Value());
   }
 
-  Hash* hash = new Hash(env, args.This());
+  Hash* hash = cppgc::MakeGarbageCollected<Hash>(
+      env->isolate()->GetCppHeap()->GetAllocationHandle(), env, args.This());
   if (md == nullptr || !hash->HashInit(md, xof_md_len)) {
     return ThrowCryptoError(env, ERR_get_error(),
                             "Digest method not supported");

--- a/src/crypto/crypto_hash.h
+++ b/src/crypto/crypto_hash.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "base_object.h"
+#include "cppgc_helpers.h"
 #include "crypto/crypto_keys.h"
 #include "crypto/crypto_util.h"
 #include "env.h"
@@ -12,14 +12,15 @@
 
 namespace node {
 namespace crypto {
-class Hash final : public BaseObject {
+
+class Hash final : CPPGC_MIXIN(Hash) {
  public:
+  SET_CPPGC_NAME(Hash)
+  void Trace(cppgc::Visitor* visitor) const final;
+  void MemoryInfo(MemoryTracker* tracker) const override;
+
   static void Initialize(Environment* env, v8::Local<v8::Object> target);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
-
-  void MemoryInfo(MemoryTracker* tracker) const override;
-  SET_MEMORY_INFO_NAME(Hash)
-  SET_SELF_SIZE(Hash)
 
   bool HashInit(const EVP_MD* md, v8::Maybe<unsigned int> xof_md_len);
   bool HashUpdate(const char* data, size_t len);
@@ -28,12 +29,12 @@ class Hash final : public BaseObject {
   static void GetCachedAliases(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void OneShotDigest(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  Hash(Environment* env, v8::Local<v8::Object> wrap);
+
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HashUpdate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void HashDigest(const v8::FunctionCallbackInfo<v8::Value>& args);
-
-  Hash(Environment* env, v8::Local<v8::Object> wrap);
 
  private:
   ncrypto::EVPMDCtxPointer mdctx_{};

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "async_wrap.h"
+#include "cppgc_helpers.h"
 #include "env.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
@@ -57,7 +58,12 @@ void Decode(const v8::FunctionCallbackInfo<v8::Value>& args,
             void (*callback)(T*, const v8::FunctionCallbackInfo<v8::Value>&,
                              const char*, size_t)) {
   T* ctx;
-  ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
+  if constexpr (std::is_base_of_v<BaseObject, T>) {
+    ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
+  } else {
+    ctx = CppgcMixin::Unwrap<T>(args.This());
+    if (ctx == nullptr) return;
+  }
 
   if (args[0]->IsString()) {
     StringBytes::InlineDecoder decoder;

--- a/test/pummel/test-heapdump-hash.js
+++ b/test/pummel/test-heapdump-hash.js
@@ -1,0 +1,33 @@
+'use strict';
+require('../common');
+const { validateByRetainingPath } = require('../common/heap');
+const { createHash } = require('crypto');
+const assert = require('assert');
+
+// In case the bootstrap process creates any Hash objects, capture a snapshot first
+// and save the initial length.
+const originalNodes = validateByRetainingPath('Node / Hash', [
+  { edge_name: 'mdctx' },
+], true);
+
+const count = 5;
+const arr = [];
+for (let i = 0; i < count; ++i) {
+  arr.push(createHash('sha1'));
+}
+
+const nodesWithCtx = validateByRetainingPath('Node / Hash', [
+  { edge_name: 'mdctx', node_name: 'Node / EVP_MD_CTX' },
+]);
+
+assert.strictEqual(nodesWithCtx.length - originalNodes.length, count);
+
+for (let i = 0; i < count; ++i) {
+  arr[i].update('test').digest('hex');
+}
+
+const nodesWithDigest = validateByRetainingPath('Node / Hash', [
+  { edge_name: 'md', node_name: 'Node / ByteSource' },
+]);
+
+assert.strictEqual(nodesWithDigest.length - originalNodes.length, count);


### PR DESCRIPTION
While working on https://github.com/nodejs/node/issues/40786 I happened to notice that the current BaseObject management comes with a significant overhead from global handle creation and incidentally migrating these objects to Oilpan gives us faster creation of objects (in my local testing, creating a cppgc-managed object is about 2.5x faster than creating a weak BaseObject).

This is only a WIP and not yet ready for review. It's mostly open as a reference for https://github.com/nodejs/performance/issues/136 and for running benchmark CI. The primary blocker is that I'll need to figure out how to support embedder object book-keeping in the heap snapshot with cppgc (right now it doesn't work and embedder objects become missing in the heap snapshots) - EDIT: this is currently being worked on in https://chromium-review.googlesource.com/c/v8/v8/+/5630497

Refs: https://github.com/nodejs/performance/issues/136
Refs: https://github.com/nodejs/node/issues/40786


On macOS + M2 where OpenSSL 3 performs much better

```
                               confidence improvement accuracy (*)   (**)  (***)
crypto/create-hash.js n=100000        ***     16.29 %       ±1.83% ±2.44% ±3.18%
```

```
                                                                              confidence improvement accuracy (*)   (**)  (***)
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=10 sync='createHash'         ***      9.52 %       ±1.41% ±1.88% ±2.46%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=100 sync='createHash'        ***      9.96 %       ±1.71% ±2.27% ±2.97%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=20 sync='createHash'         ***      9.85 %       ±1.08% ±1.44% ±1.87%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=50 sync='createHash'         ***      9.80 %       ±1.91% ±2.55% ±3.35%
```

On Ubuntu + Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz, where OpenSSL 3 does not perform as well and becomes the bottleneck in digest computation:

```
                               confidence improvement accuracy (*)   (**)  (***)
crypto/create-hash.js n=100000        ***     17.17 %       ±1.53% ±2.03% ±2.65%
```

```
                                                                              confidence improvement accuracy (*)   (**)  (***)
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=10 sync='createHash'                  0.43 %       ±0.91% ±1.21% ±1.57%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=100 sync='createHash'                 0.55 %       ±0.98% ±1.31% ±1.70%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=20 sync='createHash'                  0.18 %       ±1.07% ±1.42% ±1.86%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=50 sync='createHash'                  1.19 %       ±1.71% ±2.28% ±2.98%
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
