### PR TITLE
crypto: improve OpenSSL initialization

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1086,7 +1086,8 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
     OPENSSL_INIT_set_config_file_flags(settings,
                                        CONF_MFLAGS_IGNORE_MISSING_FILE);
 
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, settings);
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_ADD_ALL_DIGESTS,
+                        settings);
     OPENSSL_INIT_free(settings);
 
     if (ERR_peek_error() != 0) {


### PR DESCRIPTION
- Use OPENSSL_INIT_ADD_ALL_DIGESTS to speed up digest lookup.

It seems we are under-initializing OpenSSL. Doing this speeds up `createHash()` significantly locally for me on macOS + M2.  We may want to tweak other settings here as well. @nodejs/crypto 

```
                                                                                confidence improvement accuracy (*)   (**)   (***)
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=10 sync='createHash'           ***     10.11 %       ±3.74% ±5.16%  ±7.12%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=100 sync='createHash'          ***     11.42 %       ±2.50% ±3.40%  ±4.57%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=20 sync='createHash'           ***     13.72 %       ±3.52% ±4.88%  ±6.80%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=50 sync='createHash'             *      7.46 %       ±5.32% ±7.50% ±10.69%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=10 sync='createHash'         ***     10.61 %       ±4.84% ±6.75%  ±9.47%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=100 sync='createHash'        ***     11.10 %       ±2.03% ±2.75%  ±3.70%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=20 sync='createHash'         ***     11.85 %       ±2.19% ±2.97%  ±3.99%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=50 sync='createHash'         ***     10.08 %       ±2.09% ±2.91%  ±4.05%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=10 sync='createHash'         ***      9.92 %       ±2.36% ±3.24%  ±4.43%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=100 sync='createHash'        ***      9.39 %       ±1.84% ±2.50%  ±3.37%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=20 sync='createHash'         ***     11.08 %       ±1.45% ±1.99%  ±2.72%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=50 sync='createHash'         ***     10.58 %       ±2.63% ±3.57%  ±4.79%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=10 sync='createHash'         ***     13.68 %       ±6.86% ±9.58% ±13.48%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=100 sync='createHash'        ***      8.74 %       ±2.10% ±2.85%  ±3.84%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=20 sync='createHash'         ***      7.55 %       ±2.48% ±3.46%  ±4.85%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=50 sync='createHash'         ***     10.81 %       ±1.58% ±2.16%  ±2.93%
```

Refs: https://github.com/nodejs/performance/issues/136

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
