### PR TITLE
[v18.x backport] fs: introduce `dirent.parentPath`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3322,10 +3322,15 @@ In a future version of Node.js, [`message.headers`][],
 [`message.trailersDistinct`][] will be read-only.
 
 <!-- md-lint skip-deprecation DEP0172 -->
+
 <!-- md-lint skip-deprecation DEP0173 -->
+
 <!-- md-lint skip-deprecation DEP0174 -->
+
 <!-- md-lint skip-deprecation DEP0175 -->
+
 <!-- md-lint skip-deprecation DEP0176 -->
+
 <!-- md-lint skip-deprecation DEP0177 -->
 
 ### DEP0178: `dirent.path`

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3321,6 +3321,27 @@ In a future version of Node.js, [`message.headers`][],
 [`message.headersDistinct`][], [`message.trailers`][], and
 [`message.trailersDistinct`][] will be read-only.
 
+<!-- md-lint skip-deprecation DEP0172 -->
+<!-- md-lint skip-deprecation DEP0173 -->
+<!-- md-lint skip-deprecation DEP0174 -->
+<!-- md-lint skip-deprecation DEP0175 -->
+<!-- md-lint skip-deprecation DEP0176 -->
+<!-- md-lint skip-deprecation DEP0177 -->
+
+### DEP0178: `dirent.path`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51020
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The [`dirent.path`][] is deprecated due to its lack of consistency across
+release lines. Please use [`dirent.parentPath`][] instead.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4
@@ -3366,6 +3387,8 @@ In a future version of Node.js, [`message.headers`][],
 [`decipher.setAuthTag()`]: crypto.md#deciphersetauthtagbuffer-encoding
 [`diagnostics_channel.subscribe(name, onMessage)`]: diagnostics_channel.md#diagnostics_channelsubscribename-onmessage
 [`diagnostics_channel.unsubscribe(name, onMessage)`]: diagnostics_channel.md#diagnostics_channelunsubscribename-onmessage
+[`dirent.parentPath`]: fs.md#direntparentpath
+[`dirent.path`]: fs.md#direntpath
 [`dns.lookup()`]: dns.md#dnslookuphostname-options-callback
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
 [`domain`]: domain.md

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6437,6 +6437,19 @@ The file name that this {fs.Dirent} object refers to. The type of this
 value is determined by the `options.encoding` passed to [`fs.readdir()`][] or
 [`fs.readdirSync()`][].
 
+#### `dirent.parentPath`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1 – Experimental
+
+* {string}
+
+The path to the parent directory of the file this {fs.Dirent} object refers to.
+
 #### `dirent.path`
 
 <!-- YAML

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6454,7 +6454,10 @@ The path to the parent directory of the file this {fs.Dirent} object refers to.
 
 <!-- YAML
 added: v18.17.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated: Use [`dirent.parentPath`][] instead.
 
 * {string}
 
@@ -7995,6 +7998,7 @@ the file contents.
 [`Number.MAX_SAFE_INTEGER`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
 [`ReadDirectoryChangesW`]: https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-readdirectorychangesw
 [`UV_THREADPOOL_SIZE`]: cli.md#uv_threadpool_sizesize
+[`dirent.parentPath`]: #direntparentpath
 [`event ports`]: https://illumos.org/man/port_create
 [`filehandle.createReadStream()`]: #filehandlecreatereadstreamoptions
 [`filehandle.createWriteStream()`]: #filehandlecreatewritestreamoptions

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1431,7 +1431,7 @@ function readdirSyncRecursive(basePath, options) {
         const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
         if (dirent.isDirectory()) {
-          ArrayPrototypePush(pathsQueue, pathModule.join(dirent.path, dirent.name));
+          ArrayPrototypePush(pathsQueue, pathModule.join(dirent.parentPath, dirent.name));
         }
       }
     } else {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1431,7 +1431,7 @@ function readdirSyncRecursive(basePath, options) {
         const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
         if (dirent.isDirectory()) {
-          ArrayPrototypePush(pathsQueue, pathModule.join(dirent.parentPath, dirent.name));
+          ArrayPrototypePush(pathsQueue, pathModule.join(dirent.path, dirent.name));
         }
       }
     } else {

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -152,7 +152,7 @@ class Dir {
       ArrayPrototypePush(
         this[kDirBufferedEntries],
         getDirent(
-          pathModule.join(path, result[i]),
+          path,
           result[i],
           result[i + 1],
         ),

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -155,6 +155,7 @@ class Dir {
           path,
           result[i],
           result[i + 1],
+          true, // Quirk to not introduce a breaking change.
         ),
       );
     }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -164,7 +164,7 @@ class Dirent {
   constructor(name, type, path) {
     this.name = name;
     this.parentPath = path;
-    this.path = path;
+    this.path = pathModule.join(path, name);
     this[kType] = type;
   }
 
@@ -234,7 +234,7 @@ function join(path, name) {
   }
 
   if (typeof path === 'string' && typeof name === 'string') {
-    return pathModule.basename(path) === name ? path : pathModule.join(path, name);
+    return pathModule.join(path, name);
   }
 
   if (isUint8Array(path) && isUint8Array(name)) {

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -163,6 +163,7 @@ function assertEncoding(encoding) {
 class Dirent {
   constructor(name, type, path) {
     this.name = name;
+    this.parentPath = path;
     this.path = path;
     this[kType] = type;
   }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -234,7 +234,7 @@ function join(path, name) {
   }
 
   if (typeof path === 'string' && typeof name === 'string') {
-    return pathModule.basename(path) === name ? path : pathModule.join(path, name);
+    return pathModule.join(path, name);
   }
 
   if (isUint8Array(path) && isUint8Array(name)) {
@@ -313,9 +313,13 @@ function getDirent(path, name, type, callback) {
   } else if (type === UV_DIRENT_UNKNOWN) {
     const filepath = join(path, name);
     const stats = lazyLoadFs().lstatSync(filepath);
-    return new DirentFromStats(name, stats, path, filepath);
-  } else {
+    // callback === true: Quirk to not introduce a breaking change.
+    return new DirentFromStats(name, stats, path, callback === true ? filepath : path);
+  } else if (callback === true) {
+    // callback === true: Quirk to not introduce a breaking change.
     return new Dirent(name, type, path);
+  } else {
+    return new Dirent(name, type, path, path);
   }
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -161,10 +161,10 @@ function assertEncoding(encoding) {
 }
 
 class Dirent {
-  constructor(name, type, path) {
+  constructor(name, type, path, filepath = path && join(path, name)) {
     this.name = name;
     this.parentPath = path;
-    this.path = pathModule.join(path, name);
+    this.path = filepath;
     this[kType] = type;
   }
 
@@ -198,8 +198,8 @@ class Dirent {
 }
 
 class DirentFromStats extends Dirent {
-  constructor(name, stats, path) {
-    super(name, null, path);
+  constructor(name, stats, path, filepath) {
+    super(name, null, path, filepath);
     this[kStats] = stats;
   }
 }
@@ -234,7 +234,7 @@ function join(path, name) {
   }
 
   if (typeof path === 'string' && typeof name === 'string') {
-    return pathModule.join(path, name);
+    return pathModule.basename(path) === name ? path : pathModule.join(path, name);
   }
 
   if (isUint8Array(path) && isUint8Array(name)) {
@@ -269,7 +269,7 @@ function getDirents(path, { 0: names, 1: types }, callback) {
             callback(err);
             return;
           }
-          names[idx] = new DirentFromStats(name, stats, path);
+          names[idx] = new DirentFromStats(name, stats, path, filepath);
           if (--toFinish === 0) {
             callback(null, names);
           }
@@ -305,7 +305,7 @@ function getDirent(path, name, type, callback) {
           callback(err);
           return;
         }
-        callback(null, new DirentFromStats(name, stats, filepath));
+        callback(null, new DirentFromStats(name, stats, path, filepath));
       });
     } else {
       callback(null, new Dirent(name, type, path));
@@ -313,7 +313,7 @@ function getDirent(path, name, type, callback) {
   } else if (type === UV_DIRENT_UNKNOWN) {
     const filepath = join(path, name);
     const stats = lazyLoadFs().lstatSync(filepath);
-    return new DirentFromStats(name, stats, path);
+    return new DirentFromStats(name, stats, path, filepath);
   } else {
     return new Dirent(name, type, path);
   }

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -48,9 +48,11 @@ const invalidCallbackObj = {
   const entries = files.map(() => {
     const dirent = dir.readSync();
     assertDirent(dirent);
-    return dirent.name;
-  });
-  assert.deepStrictEqual(files, entries.sort());
+    return { name: dirent.name, path: dirent.path, parentPath: dirent.parentPath, toString() { return dirent.name; } };
+  }).sort();
+  assert.deepStrictEqual(entries.map((d) => d.name), files);
+  assert.deepStrictEqual(entries.map((d) => d.path), files.map((name) => path.join(testDir, name)));
+  assert.deepStrictEqual(entries.map((d) => d.parentPath), Array(entries.length).fill(testDir));
 
   // dir.read should return null when no more entries exist
   assert.strictEqual(dir.readSync(), null);


### PR DESCRIPTION
The goal is to replace `dirent.path` using a name that's less likely to create confusion.
`dirent.path` value has not been stable, moving it to a different property name should avoid breaking some upgrading user expectations.

PR-URL: https://github.com/nodejs/node/pull/50976
Reviewed-By: Ethan Arrowood <ethan@arrowood.dev>
Reviewed-By: LiviaMedeiros <livia@cirno.name>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
