### PR TITLE
crypto: use new.target instead of instaceof to detect construct calls

### DIFF
--- a/benchmark/crypto/create-hash.js
+++ b/benchmark/crypto/create-hash.js
@@ -18,5 +18,5 @@ function main({ n }) {
     array[i] = createHash('sha1');
   }
   bench.end(n);
-  assert.strictEqual(typeof array[n - 1], 'object')
+  assert.strictEqual(typeof array[n - 1], 'object');
 }

--- a/benchmark/crypto/create-hash.js
+++ b/benchmark/crypto/create-hash.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common.js');
+const { createHash } = require('crypto');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+});
+
+function main({ n }) {
+  const array = [];
+  for (let i = 0; i < n; ++i) {
+    array.push(null);
+  }
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    array[i] = createHash('sha1');
+  }
+  bench.end(n);
+  assert.strictEqual(typeof array[n - 1], 'object')
+}

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -57,7 +57,7 @@ const kState = Symbol('kState');
 const kFinalized = Symbol('kFinalized');
 
 function Hash(algorithm, options) {
-  if (!(this instanceof Hash))
+  if (!new.target)
     return new Hash(algorithm, options);
   if (!(algorithm instanceof _Hash))
     validateString(algorithm, 'algorithm');


### PR DESCRIPTION
The former is much more performant.

Refs: https://github.com/nodejs/performance/issues/136

On macOS + M2:

```
                                                                                confidence improvement accuracy (*)   (**)  (***)
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=10 sync='createHash'           ***      4.19 %       ±1.05% ±1.40% ±1.84%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=100 sync='createHash'          ***      4.83 %       ±0.64% ±0.85% ±1.10%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=20 sync='createHash'            **      3.77 %       ±2.59% ±3.49% ±4.62%
crypto/webcrypto-digest.js n=100000 method='SHA-1' data=50 sync='createHash'           ***      5.10 %       ±0.56% ±0.75% ±0.98%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=10 sync='createHash'         ***      5.82 %       ±2.27% ±3.05% ±4.04%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=100 sync='createHash'        ***      5.86 %       ±2.46% ±3.31% ±4.37%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=20 sync='createHash'         ***      5.92 %       ±2.24% ±3.02% ±4.00%
crypto/webcrypto-digest.js n=100000 method='SHA-256' data=50 sync='createHash'         ***      5.67 %       ±0.50% ±0.66% ±0.87%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=10 sync='createHash'         ***      4.68 %       ±0.72% ±0.96% ±1.25%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=100 sync='createHash'        ***      5.83 %       ±2.52% ±3.39% ±4.49%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=20 sync='createHash'           *      2.91 %       ±2.73% ±3.68% ±4.88%
crypto/webcrypto-digest.js n=100000 method='SHA-384' data=50 sync='createHash'         ***      4.19 %       ±0.79% ±1.06% ±1.39%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=10 sync='createHash'          **      3.51 %       ±2.28% ±3.07% ±4.06%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=100 sync='createHash'        ***      5.01 %       ±0.54% ±0.71% ±0.93%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=20 sync='createHash'          **      4.38 %       ±2.64% ±3.53% ±4.64%
crypto/webcrypto-digest.js n=100000 method='SHA-512' data=50 sync='createHash'          **      4.01 %       ±2.40% ±3.22% ±4.26%
```

```
crypto/create-hash.js n=100000        ***      6.77 %       ±3.00% ±3.99% ±5.20%
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
