### PR TITLE
fs: fix fs.promises.realpath for long paths on Windows

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1160,7 +1160,7 @@ async function realpath(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path);
   return await PromisePrototypeThen(
-    binding.realpath(path, options.encoding, kUsePromises),
+    binding.realpath(pathModule.toNamespacedPath(path), options.encoding, kUsePromises),
     undefined,
     handleErrorFromBinding,
   );

--- a/test/parallel/test-fs-long-path.js
+++ b/test/parallel/test-fs-long-path.js
@@ -46,4 +46,7 @@ fs.writeFile(fullPath, 'ok', common.mustSucceed(() => {
 
   // Tests https://github.com/nodejs/node/issues/39721
   fs.realpath.native(fullPath, common.mustSucceed());
+
+  // Tests https://github.com/nodejs/node/issues/51031
+  fs.promises.realpath(fullPath).then(common.mustCall(), common.mustNotCall());
 }));


### PR DESCRIPTION
This PR is almost the same with #44536 but for `fs.promises.realpath`.

Fixes: #51031

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
