### PR TITLE
net: deferred self.destroy calls in internalConnect(Multiple) to next…

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1052,7 +1052,7 @@ function internalConnect(
     err = checkBindError(err, localPort, self._handle);
     if (err) {
       const ex = new ExceptionWithHostPort(err, 'bind', localAddress, localPort);
-      self.destroy(ex);
+      process.nextTick(internalConnectErrorNT, self, ex);
       return;
     }
   }
@@ -1088,10 +1088,14 @@ function internalConnect(
     }
 
     const ex = new ExceptionWithHostPort(err, 'connect', address, port, details);
-    self.destroy(ex);
+    process.nextTick(internalConnectErrorNT, self, ex);
   } else if ((addressType === 6 || addressType === 4) && hasObserver('net')) {
     startPerf(self, kPerfHooksNetConnectContext, { type: 'net', name: 'connect', detail: { host: address, port } });
   }
+}
+
+function internalConnectErrorNT(self, ex) {
+  self.destroy(ex);
 }
 
 
@@ -1107,11 +1111,11 @@ function internalConnectMultiple(context, canceled) {
   // All connections have been tried without success, destroy with error
   if (canceled || context.current === context.addresses.length) {
     if (context.errors.length === 0) {
-      self.destroy(new ERR_SOCKET_CONNECTION_TIMEOUT());
+      process.nextTick(internalConnectMultipleErrorNT, self, new ERR_SOCKET_CONNECTION_TIMEOUT());
       return;
     }
 
-    self.destroy(new NodeAggregateError(context.errors));
+    process.nextTick(internalConnectMultipleErrorNT, self, new NodeAggregateError(context.errors));
     return;
   }
 
@@ -1184,6 +1188,10 @@ function internalConnectMultiple(context, canceled) {
     // If the attempt has not returned an error, start the connection timer
     context[kTimeout] = setTimeout(internalConnectMultipleTimeout, context.timeout, context, req, self._handle);
   }
+}
+
+function internalConnectMultipleErrorNT(self, ex) {
+  self.destroy(ex);
 }
 
 Socket.prototype.connect = function(...args) {


### PR DESCRIPTION
… tick

self.destroy calls in the internalConnect adn internalConnectMultiple functions have a narrow case where they can throw before an error handler has been established. This change defers them to the next tick to allow time for the error handler to be set.

Fixes: https://github.com/nodejs/node/issues/48771

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
