### PR TITLE
util: improve performance of function areSimilarFloatArrays

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -21,6 +21,7 @@ const {
   StringPrototypeValueOf,
   SymbolPrototypeValueOf,
   TypedArrayPrototypeGetSymbolToStringTag,
+  TypedArrayPrototypeGetByteLength,
   Uint8Array,
 } = primordials;
 
@@ -71,7 +72,8 @@ function areSimilarFloatArrays(a, b) {
   if (a.byteLength !== b.byteLength) {
     return false;
   }
-  for (let offset = 0; offset < a.byteLength; offset++) {
+  const len = TypedArrayPrototypeGetByteLength(a);
+  for (let offset = 0; offset < len; offset++) {
     if (a[offset] !== b[offset]) {
       return false;
     }


### PR DESCRIPTION
Improve performance of `areSimilarFloatArrays` by using primordial.
- Platform: Linux
## How find the issue
When I test performance between node-16.x and node-22-pre, I found performance regression in `benchmark/assert/deepequal-typedarrays.js`. Old binary is `node-16.x` and the new is `node-22-pre`

### Original result of node-16.x and node-22-pre
```
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=500 type='Float32Array'            ***    -22.09 %       ±1.61% ±2.16% ±2.84%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=500 type='Float32Array'         ***    -13.65 %       ±2.85% ±3.83% ±5.04%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=500 type='Float32Array'           ***    -56.36 %       ±0.80% ±1.08% ±1.42%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=500 type='Float32Array'        ***    -67.89 %       ±4.42% ±6.04% ±8.20%
```

## How solved
I found the case  `benchmark/assert/deepequal-typedarrays.js` will finally call function `areSimilarFloatArrays(a, b)` in `lib/internal/util` when `strict=0 type='Float32Array'`. The problem is similar with https://github.com/nodejs/node/issues/50620. So I learned from the approach in https://github.com/nodejs/node/pull/50621.

## Results
### Comparison between node_16.x and node-22-pre
I modified the code in main branch (v22.0.0-pre), and compare with node_16.x
```
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=500 type='Float32Array'            ***    -11.67 %       ±1.81% ±2.44% ±3.23%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=500 type='Float32Array'         ***     -7.85 %       ±2.34% ±3.13% ±4.12%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=500 type='Float32Array'           ***     24.98 %       ±0.74% ±0.99% ±1.31%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=500 type='Float32Array'                -1.61 %       ±4.01% ±5.40% ±7.14%
```
### Performance improvement on main(node-22-pre)
### 
After the change, test on the latest main branch and get the results of performance comparison of node_22 before and after modifying the code.
```
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=500 type='Float32Array'            ***     11.33 %       ±1.89% ±2.53%  ±3.34%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=500 type='Float32Array'         ***      6.94 %       ±2.34% ±3.15%  ±4.18%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=500 type='Float32Array'           ***    183.33 %       ±2.96% ±4.01%  ±5.35%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=500 type='Float32Array'        ***    208.51 %       ±7.26% ±9.91% ±13.43%
```

Refs: https://github.com/nodejs/node/pull/50621
