### PR TITLE
crypto: implement crypto.hash()

### DIFF
--- a/benchmark/crypto/oneshot-hash.js
+++ b/benchmark/crypto/oneshot-hash.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common.js');
+const { createHash, hash } = require('crypto');
+const path = require('path');
+const filepath = path.resolve(__dirname, '../../test/fixtures/snapshot/typescript.js');
+const fs = require('fs');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  length: [1000, 100_000],
+  method: ['md5', 'sha1', 'sha256'],
+  type: ['string', 'buffer'],
+  n: [100_000, 1000],
+}, {
+  combinationFilter: ({ length, n }) => {
+    return length * n <= 100_000 * 1000;
+  },
+});
+
+function main({ length, type, method, n }) {
+  let data = fs.readFileSync(filepath);
+  if (type === 'string') {
+    data = data.toString().slice(0, length);
+  } else {
+    data = Uint8Array.prototype.slice.call(data, 0, length);
+  }
+
+  const oneshotHash = hash ?
+    (method, input) => hash(method, input, 'hex') :
+    (method, input) => createHash(method).update(input).digest('hex');
+  const array = [];
+  for (let i = 0; i < n; i++) {
+    array.push(null);
+  }
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    array[i] = oneshotHash(method, data);
+  }
+  bench.end(n);
+  assert.strictEqual(typeof array[n - 1], 'string');
+}

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3510,6 +3510,67 @@ Computes the Diffie-Hellman secret based on a `privateKey` and a `publicKey`.
 Both keys must have the same `asymmetricKeyType`, which must be one of `'dh'`
 (for Diffie-Hellman), `'ec'` (for ECDH), `'x448'`, or `'x25519'` (for ECDH-ES).
 
+### `crypto.hash(algorith, data[, outputEncoding])`
+
+<!-- YAML
+added:
+ - REPLACEME
+-->
+
+* `algorithm` {string|undefined}
+* `data` {string|ArrayBuffer|Buffer|TypedArray|DataView} When `data` is a
+  string, it will be encoded as UTF-8 before being hashed. If a different
+  input encoding is desired for a string input, user could encode the string
+  into a TypedArray using either `TextEncoder` or `Buffer.from()` and passing
+  the encoded TypedArray into this API instead.
+* `outputEncoding` {string|undefined}  [Encoding][encoding] used to encode the
+  returned digest. **Default:** `'hex'`.
+* Returns: {string|Buffer}
+
+A utility for creating one-shot hash digests of data. It can be faster than
+the object-based `crypto.createHash()` when hashing a smaller amount of data
+(<= 5MB) that's readily available. If the data can be big or if it is streamed,
+it's still recommended to use `crypto.createHash()` instead.
+
+The `algorithm` is dependent on the available algorithms supported by the
+version of OpenSSL on the platform. Examples are `'sha256'`, `'sha512'`, etc.
+On recent releases of OpenSSL, `openssl list -digest-algorithms` will
+display the available digest algorithms.
+
+Example:
+
+```cjs
+const crypto = require('node:crypto');
+const { Buffer } = require('node:buffer');
+
+// Hashing a string and return the result as a hex-encoded string.
+const string = 'Node.js';
+// 10b3493287f831e81a438811a1ffba01f8cec4b7
+console.log(crypto.hash('sha1', string));
+
+// Encode a base64-encoded string into a Buffer, hash it and return
+// the result as a buffer.
+const base64 = 'Tm9kZS5qcw==';
+// <Buffer 10 b3 49 32 87 f8 31 e8 1a 43 88 11 a1 ff ba 01 f8 ce c4 b7>
+console.log(crypto.hash('sha1', Buffer.from(base64, 'base64'), 'buffer'));
+```
+
+```mjs
+import crypto from 'node:crypto';
+import { Buffer } from 'node:buffer';
+
+// Hashing a string and return the result as a hex-encoded string.
+const string = 'Node.js';
+// 10b3493287f831e81a438811a1ffba01f8cec4b7
+console.log(crypto.hash('sha1', string));
+
+// Encode a base64-encoded string into a Buffer, hash it and return
+// the result as a buffer.
+const base64 = 'Tm9kZS5qcw==';
+// <Buffer 10 b3 49 32 87 f8 31 e8 1a 43 88 11 a1 ff ba 01 f8 ce c4 b7>
+console.log(crypto.hash('sha1', Buffer.from(base64, 'base64'), 'buffer'));
+```
+
 ### `crypto.generateKey(type, options, callback)`
 
 <!-- YAML

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3521,8 +3521,8 @@ added:
 * `data` {string|ArrayBuffer|Buffer|TypedArray|DataView} When `data` is a
   string, it will be encoded as UTF-8 before being hashed. If a different
   input encoding is desired for a string input, user could encode the string
-  into a TypedArray using either `TextEncoder` or `Buffer.from()` and passing
-  the encoded TypedArray into this API instead.
+  into a `TypedArray` using either `TextEncoder` or `Buffer.from()` and passing
+  the encoded `TypedArray` into this API instead.
 * `outputEncoding` {string|undefined}  [Encoding][encoding] used to encode the
   returned digest. **Default:** `'hex'`.
 * Returns: {string|Buffer}

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -85,6 +85,7 @@ const {
   normalizeEncoding,
   kIsEncodingSymbol,
   defineLazyProperties,
+  encodingsMap,
 } = require('internal/util');
 const {
   isAnyArrayBuffer,
@@ -95,7 +96,6 @@ const {
 const {
   inspect: utilInspect,
 } = require('internal/util/inspect');
-const { encodings } = internalBinding('string_decoder');
 
 const {
   codes: {
@@ -148,10 +148,6 @@ const constants = ObjectDefineProperties({}, {
 
 Buffer.poolSize = 8 * 1024;
 let poolSize, poolOffset, allocPool;
-
-const encodingsMap = { __proto__: null };
-for (let i = 0; i < encodings.length; ++i)
-  encodingsMap[encodings[i]] = i;
 
 function createPool() {
   poolSize = Buffer.poolSize;

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -107,6 +107,7 @@ const {
 const {
   Hash,
   Hmac,
+  hash,
 } = require('internal/crypto/hash');
 const {
   X509Certificate,
@@ -219,6 +220,7 @@ module.exports = {
   getFips,
   setFips,
   verify: verifyOneShot,
+  hash,
 
   // Classes
   Certificate,

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -3,6 +3,7 @@
 const {
   ObjectSetPrototypeOf,
   ReflectApply,
+  StringPrototypeToLowerCase,
   Symbol,
 } = primordials;
 
@@ -11,6 +12,7 @@ const {
   HashJob,
   Hmac: _Hmac,
   kCryptoJobAsync,
+  oneShotDigest,
 } = internalBinding('crypto');
 
 const {
@@ -29,6 +31,8 @@ const {
 
 const {
   lazyDOMException,
+  normalizeEncoding,
+  encodingsMap,
 } = require('internal/util');
 
 const {
@@ -40,6 +44,7 @@ const {
     ERR_CRYPTO_HASH_FINALIZED,
     ERR_CRYPTO_HASH_UPDATE_FAILED,
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
   },
 } = require('internal/errors');
 
@@ -47,6 +52,7 @@ const {
   validateEncoding,
   validateString,
   validateUint32,
+  validateBuffer,
 } = require('internal/validators');
 
 const {
@@ -188,8 +194,33 @@ async function asyncDigest(algorithm, data) {
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
 
+function hash(algorithm, input, outputEncoding = 'hex') {
+  validateString(algorithm, 'algorithm');
+  if (typeof input !== 'string') {
+    validateBuffer(input, 'input');
+  }
+  let normalized = outputEncoding;
+  // Fast case: if it's 'hex', we don't need to validate it further.
+  if (outputEncoding !== 'hex') {
+    validateString(outputEncoding, 'outputEncoding');
+    normalized = normalizeEncoding(outputEncoding);
+    // If the encoding is invalid, normalizeEncoding() returns undefined.
+    if (normalized === undefined) {
+      // normalizeEncoding() doesn't handle 'buffer'.
+      if (StringPrototypeToLowerCase(outputEncoding) === 'buffer') {
+        normalized = 'buffer';
+      } else {
+        throw new ERR_INVALID_ARG_VALUE('outputEncoding', outputEncoding);
+      }
+    }
+  }
+  return oneShotDigest(algorithm, getCachedHashId(algorithm), getHashCache(),
+                       input, normalized, encodingsMap[normalized]);
+}
+
 module.exports = {
   Hash,
   Hmac,
   asyncDigest,
+  hash,
 };

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -65,6 +65,7 @@ const {
 } = internalBinding('util');
 const { isNativeError, isPromise } = internalBinding('types');
 const { getOptionValue } = require('internal/options');
+const { encodings } = internalBinding('string_decoder');
 
 const noCrypto = !process.versions.openssl;
 
@@ -859,6 +860,10 @@ class WeakReference {
   }
 }
 
+const encodingsMap = { __proto__: null };
+for (let i = 0; i < encodings.length; ++i)
+  encodingsMap[encodings[i]] = i;
+
 module.exports = {
   getLazy,
   assertCrypto,
@@ -872,6 +877,7 @@ module.exports = {
   defineReplaceableLazyAttribute,
   deprecate,
   emitExperimentalWarning,
+  encodingsMap,
   exposeInterface,
   exposeLazyInterfaces,
   exposeNamespace,

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -38,15 +38,18 @@ const {
   kSize,
   decode,
   flush,
-  encodings,
 } = internalBinding('string_decoder');
-const internalUtil = require('internal/util');
+const {
+  kIsEncodingSymbol,
+  encodingsMap,
+  normalizeEncoding: _normalizeEncoding,
+} = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_THIS,
   ERR_UNKNOWN_ENCODING,
 } = require('internal/errors').codes;
-const isEncoding = Buffer[internalUtil.kIsEncodingSymbol];
+const isEncoding = Buffer[kIsEncodingSymbol];
 
 const kNativeDecoder = Symbol('kNativeDecoder');
 
@@ -60,7 +63,7 @@ const kNativeDecoder = Symbol('kNativeDecoder');
  * @throws {TypeError} Throws an error when encoding is invalid
  */
 function normalizeEncoding(enc) {
-  const nenc = internalUtil.normalizeEncoding(enc);
+  const nenc = _normalizeEncoding(enc);
   if (nenc === undefined) {
     if (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc))
       throw new ERR_UNKNOWN_ENCODING(enc);
@@ -68,10 +71,6 @@ function normalizeEncoding(enc) {
   }
   return nenc;
 }
-
-const encodingsMap = {};
-for (let i = 0; i < encodings.length; ++i)
-  encodingsMap[encodings[i]] = i;
 
 /**
  * StringDecoder provides an interface for efficiently splitting a series of

--- a/src/api/encoding.cc
+++ b/src/api/encoding.cc
@@ -109,6 +109,16 @@ enum encoding ParseEncoding(const char* encoding,
   return default_encoding;
 }
 
+enum encoding ParseEncoding(Isolate* isolate,
+                            Local<Value> encoding_v,
+                            Local<Value> encoding_id,
+                            enum encoding default_encoding) {
+  if (encoding_id->IsUint32()) {
+    return static_cast<enum encoding>(encoding_id.As<v8::Uint32>()->Value());
+  }
+
+  return ParseEncoding(isolate, encoding_v, default_encoding);
+}
 
 enum encoding ParseEncoding(Isolate* isolate,
                             Local<Value> encoding_v,

--- a/src/crypto/crypto_hash.h
+++ b/src/crypto/crypto_hash.h
@@ -26,6 +26,7 @@ class Hash final : public BaseObject {
 
   static void GetHashes(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetCachedAliases(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void OneShotDigest(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  protected:
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -446,6 +446,10 @@ v8::HeapProfiler::HeapSnapshotOptions GetHeapSnapshotOptions(
     v8::Local<v8::Value> options);
 }  // namespace heap
 
+enum encoding ParseEncoding(v8::Isolate* isolate,
+                            v8::Local<v8::Value> encoding_v,
+                            v8::Local<v8::Value> encoding_id,
+                            enum encoding default_encoding);
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/test/parallel/test-crypto-oneshot-hash.js
+++ b/test/parallel/test-crypto-oneshot-hash.js
@@ -1,0 +1,43 @@
+'use strict';
+// This tests crypto.hash() works.
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+
+// Test errors for invalid arguments.
+[undefined, null, true, 1, () => {}, {}].forEach((invalid) => {
+  assert.throws(() => { crypto.hash(invalid, 'test'); }, { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+[undefined, null, true, 1, () => {}, {}].forEach((invalid) => {
+  assert.throws(() => { crypto.hash('sha1', invalid); }, { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+[null, true, 1, () => {}, {}].forEach((invalid) => {
+  assert.throws(() => { crypto.hash('sha1', 'test', invalid); }, { code: 'ERR_INVALID_ARG_TYPE' });
+});
+
+assert.throws(() => { crypto.hash('sha1', 'test', 'not an encoding'); }, { code: 'ERR_INVALID_ARG_VALUE' });
+
+// Test that the output of crypto.hash() is the same as crypto.createHash().
+const methods = crypto.getHashes();
+
+const input = fs.readFileSync(fixtures.path('utf8_test_text.txt'));
+
+for (const method of methods) {
+  for (const outputEncoding of ['buffer', 'hex', 'base64', undefined]) {
+    const oldDigest = crypto.createHash(method).update(input).digest(outputEncoding || 'hex');
+    const digestFromBuffer = crypto.hash(method, input, outputEncoding);
+    assert.deepStrictEqual(digestFromBuffer, oldDigest,
+                           `different result from ${method} with encoding ${outputEncoding}`);
+    const digestFromString = crypto.hash(method, input.toString(), outputEncoding);
+    assert.deepStrictEqual(digestFromString, oldDigest,
+                           `different result from ${method} with encoding ${outputEncoding}`);
+  }
+}


### PR DESCRIPTION
### crypto: implement crypto.hash()

This patch introduces a helper crypto.hash() that computes
a digest from the input at one shot. This can be 1.2-2x faster
than the object-based createHash() for smaller inputs (<= 5MB)
that are readily available (not streamed) and incur less memory
overhead since no intermediate objects will be created.

Refs: https://github.com/nodejs/performance/issues/136

From the benchmark CI https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1493/console

```
22:46:22                                                                           confidence improvement accuracy (*)    (**)   (***)
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='md5' length=1000             ***     76.69 %      ±11.25% ±15.02% ±19.65%
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='md5' length=100000            **     12.44 %       ±8.53% ±11.36% ±14.78%
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='sha1' length=1000            ***     72.44 %      ±11.25% ±15.01% ±19.61%
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='sha1' length=100000                  -1.19 %       ±6.72%  ±8.94% ±11.65%
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='sha256' length=1000          ***     65.75 %      ±11.03% ±14.71% ±19.22%
22:46:22 crypto/oneshot-hash.js n=1000 type='buffer' method='sha256' length=100000                -1.41 %       ±2.99%  ±3.99%  ±5.22%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='md5' length=1000             ***     98.77 %      ±15.43% ±20.67% ±27.18%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='md5' length=100000                    1.43 %       ±3.17%  ±4.21%  ±5.48%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='sha1' length=1000            ***    111.56 %      ±17.04% ±22.85% ±30.09%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='sha1' length=100000                   1.67 %       ±3.73%  ±4.96%  ±6.46%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='sha256' length=1000          ***     88.15 %      ±13.62% ±18.19% ±23.83%
22:46:22 crypto/oneshot-hash.js n=1000 type='string' method='sha256' length=100000                 2.00 %       ±2.05%  ±2.73%  ±3.56%
22:46:22 crypto/oneshot-hash.js n=100000 type='buffer' method='md5' length=1000           ***     39.52 %       ±6.05%  ±8.11% ±10.67%
22:46:22 crypto/oneshot-hash.js n=100000 type='buffer' method='sha1' length=1000          ***     41.96 %       ±7.36%  ±9.86% ±12.95%
22:46:22 crypto/oneshot-hash.js n=100000 type='buffer' method='sha256' length=1000        ***     23.13 %       ±3.97%  ±5.31%  ±6.96%
22:46:22 crypto/oneshot-hash.js n=100000 type='string' method='md5' length=1000           ***     23.50 %       ±3.04%  ±4.06%  ±5.30%
22:46:22 crypto/oneshot-hash.js n=100000 type='string' method='sha1' length=1000          ***     30.30 %       ±3.67%  ±4.89%  ±6.39%
22:46:22 crypto/oneshot-hash.js n=100000 type='string' method='sha256' length=1000        ***     18.63 %       ±3.12%  ±4.16%  ±5.43%
```