### PR TITLE
src: fix double free reported by coverity

### DIFF
--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -194,8 +194,9 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
     ret = New(env, src, len_in_bytes);
     // new always takes ownership of src
     buf->Release();
-  } else if (!buf->IsInvalidated())
+  } else if (!buf->IsInvalidated()) {
     ret = Copy(env, src, len_in_bytes);
+  }
 
   return ret;
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -190,16 +190,12 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
   char* src = reinterpret_cast<char*>(buf->out());
   const size_t len_in_bytes = buf->length() * sizeof(buf->out()[0]);
 
-  if (buf->IsAllocated())
+  if (buf->IsAllocated()) {
     ret = New(env, src, len_in_bytes);
-  else if (!buf->IsInvalidated())
-    ret = Copy(env, src, len_in_bytes);
-
-  if (ret.IsEmpty())
-    return ret;
-
-  if (buf->IsAllocated())
+    // new always takes ownership of src
     buf->Release();
+  } else if (!buf->IsInvalidated())
+    ret = Copy(env, src, len_in_bytes);
 
   return ret;
 }


### PR DESCRIPTION
Fix double free reported by coverity. ToBufferEndian() in node_i18n.cc was the only caller of Buffer::New() passing in a MaybeStackBuffer. Coverity reported a double free because there were paths in which the src buffer would be deleted by both the destruction of the MaybeStackBuffer and by the Buffer which was done even in failure cases for Buffer::New().

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
