### PR TITLE
lib: fix recursive watch on Linux

### DIFF
--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const {
-  ArrayPrototypePush,
-  SafePromiseAllReturnVoid,
   Promise,
-  PromisePrototypeThen,
   SafeMap,
   SafeSet,
   StringPrototypeStartsWith,
@@ -42,31 +39,8 @@ function lazyLoadFsSync() {
   internalSync ??= require('fs');
   return internalSync;
 }
+
 let kResistStopPropagation;
-
-async function traverse(dir, files = new SafeMap(), symbolicLinks = new SafeSet()) {
-  const { opendir } = lazyLoadFsPromises();
-
-  const filenames = await opendir(dir);
-  const subdirectories = [];
-
-  for await (const file of filenames) {
-    const f = pathJoin(dir, file.name);
-
-    files.set(f, file);
-
-    // Do not follow symbolic links
-    if (file.isSymbolicLink()) {
-      symbolicLinks.add(f);
-    } else if (file.isDirectory()) {
-      ArrayPrototypePush(subdirectories, traverse(f, files));
-    }
-  }
-
-  await SafePromiseAllReturnVoid(subdirectories);
-
-  return files;
-}
 
 class FSWatcher extends EventEmitter {
   #options = null;
@@ -219,15 +193,8 @@ class FSWatcher extends EventEmitter {
 
       if (file.isDirectory()) {
         this.#files.set(filename, file);
-
-        PromisePrototypeThen(
-          traverse(filename, this.#files, this.#symbolicFiles),
-          () => {
-            for (const f of this.#files.keys()) {
-              this.#watchFile(f);
-            }
-          },
-        );
+        this.#watchFile(filename);
+        this.#watchFolder(filename);
       } else {
         this.#watchFile(filename);
       }

--- a/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -50,7 +49,6 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(childrenAbsolutePath, 'world');
 
   process.once('exit', function() {

--- a/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -46,9 +45,7 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.mkdirSync(filePath);
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(childrenAbsolutePath, 'world');
 
   process.once('exit', function() {

--- a/test/parallel/test-fs-watch-recursive-add-file-with-url.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-with-url.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -43,7 +42,6 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(filePath, 'world');
 
   process.on('exit', function() {

--- a/test/parallel/test-fs-watch-recursive-add-file.js
+++ b/test/parallel/test-fs-watch-recursive-add-file.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -41,7 +40,6 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(testFile, 'world');
 
   process.once('exit', function() {

--- a/test/parallel/test-fs-watch-recursive-add-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-folder.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -41,7 +40,6 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.mkdirSync(testFile);
 
   process.once('exit', function() {

--- a/test/parallel/test-fs-watch-recursive-assert-leaks.js
+++ b/test/parallel/test-fs-watch-recursive-assert-leaks.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -31,18 +30,15 @@ tmpdir.refresh();
   let watcherClosed = false;
   const watcher = fs.watch(testDirectory, { recursive: true });
   watcher.on('change', common.mustCallAtLeast(async (event, filename) => {
-    await setTimeout(common.platformTimeout(100));
     if (filename === path.basename(filePath)) {
       watcher.close();
       watcherClosed = true;
     }
-    await setTimeout(common.platformTimeout(100));
     assert(!process._getActiveHandles().some((handle) => handle.constructor.name === 'StatWatcher'));
   }));
 
   process.on('exit', function() {
     assert(watcherClosed, 'watcher Object was not closed');
   });
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(filePath, 'content');
 })().then(common.mustCall());

--- a/test/parallel/test-fs-watch-recursive-symlink.js
+++ b/test/parallel/test-fs-watch-recursive-symlink.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const { setTimeout } = require('timers/promises');
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -48,7 +47,6 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(filePath, 'world');
 
   process.once('exit', function() {
@@ -89,9 +87,7 @@ tmpdir.refresh();
     }
   });
 
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(forbiddenFile, 'world');
-  await setTimeout(common.platformTimeout(100));
   fs.writeFileSync(acceptableFile, 'acceptable');
 
   process.once('exit', function() {


### PR DESCRIPTION
Fixes: #48437

Any changes that happen before the `watch` is set up are lost because the `traverse` call is asynchronous. I get the tests to pass changing the `traverse` call by `this.#watchFile` to watch the folder before any changes and then calling `this.#watchFolder` to traverse the folder's content and watch it.

Also noticed the [timeout calls in the tests](https://github.com/nodejs/node/blob/main/test/parallel/test-fs-watch-recursive-add-file.js#L44). I removed them because I think they're highlighting the issue.