### PR TITLE
fs: runtime deprecate `dirent.path`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3551,6 +3551,9 @@ Please use `value instanceof WebAssembly.Module` instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51050
+    description: Runtime deprecation.
   - version:
     - v21.5.0
     - v20.12.0
@@ -3559,7 +3562,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`dirent.path`][] is deprecated due to its lack of consistency across
 release lines. Please use [`dirent.parentPath`][] instead.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6763,13 +6763,17 @@ deprecated:
   - v21.5.0
   - v20.12.0
   - v18.20.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51050
+    description: Accessing this property emits a warning. It is now read-only.
 -->
 
 > Stability: 0 - Deprecated: Use [`dirent.parentPath`][] instead.
 
 * {string}
 
-Alias for `dirent.parentPath`.
+Alias for `dirent.parentPath`. Read-only.
 
 ### Class: `fs.FSWatcher`
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -49,7 +49,6 @@ const {
   isUint8Array,
 } = require('internal/util/types');
 const {
-  deprecate,
   kEmptyObject,
   once,
   deprecate,

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -49,6 +49,7 @@ const {
   isUint8Array,
 } = require('internal/util/types');
 const {
+  deprecate,
   kEmptyObject,
   once,
   deprecate,
@@ -171,7 +172,6 @@ class Dirent {
   constructor(name, type, path) {
     this.name = name;
     this.parentPath = path;
-    this.path = path;
     this[kType] = type;
   }
 
@@ -219,6 +219,15 @@ for (const name of ReflectOwnKeys(Dirent.prototype)) {
     return this[kStats][name]();
   };
 }
+
+ObjectDefineProperty(Dirent.prototype, 'path', {
+  __proto__: null,
+  get: deprecate(function() {
+    return this.parentPath;
+  }, 'dirent.path is deprecated in favor of dirent.parentPath', 'DEP0178'),
+  configurable: true,
+  enumerable: false,
+});
 
 function copyObject(source) {
   const target = {};

--- a/test/parallel/test-fs-utils-get-dirents.js
+++ b/test/parallel/test-fs-utils-get-dirents.js
@@ -88,6 +88,11 @@ const filename = 'foo';
     common.mustCall((err, dirent) => {
       assert.strictEqual(err, null);
       assert.strictEqual(dirent.name, filenameBuffer);
+      common.expectWarning(
+        'DeprecationWarning',
+        'dirent.path is deprecated in favor of dirent.parentPath',
+        'DEP0178');
+      assert.deepStrictEqual(dirent.path, Buffer.from(tmpdir.resolve(`${filename}/`)));
     },
     ));
 }


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/51020
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
