### PR TITLE
src: assert size in js_native_api_v8.h

### DIFF
--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -315,6 +315,8 @@ inline napi_value JsValueFromV8LocalValue(v8::Local<v8::Value> local) {
 
 inline v8::Local<v8::Value> V8LocalValueFromJsValue(napi_value v) {
   v8::Local<v8::Value> local;
+  static_assert(sizeof(local) == sizeof(v),
+              "Cannot convert supposed napi_value v to v8::Local<v8::Value>");
   memcpy(static_cast<void*>(&local), &v, sizeof(v));
   return local;
 }


### PR DESCRIPTION
This prevents buffer overflows when napi_value is a greater size than the size of the destination variable V8 Local Value.

The reason is when someone wants to use the C++ JavaScript bindings of an npm package for a non NodeJS project, and are running the bindings their own way instead of relying on NodeJS's Buffer C++ struct.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
