### PR TITLE
doc: correct tracingChannel.traceCallback()

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -887,7 +887,7 @@ the error as first arg convention typically used. This will always produce a
 function execution, and will produce a [`asyncStart` event][] and
 [`asyncEnd` event][] around the callback execution. It may also produce an
 [`error` event][] if the given function throws or the first argument passed to
-the calblack is set. This will run the given function using
+the callback is set. This will run the given function using
 [`channel.runStores(context, ...)`][] on the `start` channel which ensures all
 events should have any bound stores set to match this trace context.
 

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -862,7 +862,7 @@ channels.tracePromise(async () => {
 });
 ```
 
-#### `tracingChannel.traceCallback(fn[, position[, context[, thisArg[, ...args]]]])`
+#### `tracingChannel.traceCallback(fn, position, context, thisArg, ...args)`
 
 <!-- YAML
 added:
@@ -874,22 +874,22 @@ added:
 
 * `fn` {Function} callback using function to wrap a trace around
 * `position` {number} Zero-indexed argument position of expected callback
-* `context` {Object} Shared object to correlate trace events through
+  (defaults to last argument if `undefined` is passed)
+* `context` {Object} Shared object to correlate trace events through (defaults
+  to `{}` if `undefined` is passed)
 * `thisArg` {any} The receiver to be used for the function call
-* `...args` {any} Optional arguments to pass to the function
+* `...args` {any} arguments to pass to the function (must include the callback)
 * Returns: {any} The return value of the given function
 
-Trace a callback-receiving function call. This will always produce a
+Trace a callback-receiving function call. The callback is expected to follow
+the error as first arg convention typically used. This will always produce a
 [`start` event][] and [`end` event][] around the synchronous portion of the
 function execution, and will produce a [`asyncStart` event][] and
 [`asyncEnd` event][] around the callback execution. It may also produce an
-[`error` event][] if the given function throws an error or the returned
-promise rejects. This will run the given function using
+[`error` event][] if the given function throws or the first argument passed to
+the calblack is set. This will run the given function using
 [`channel.runStores(context, ...)`][] on the `start` channel which ensures all
 events should have any bound stores set to match this trace context.
-
-The `position` will be -1 by default to indicate the final argument should
-be used as the callback.
 
 ```mjs
 import diagnostics_channel from 'node:diagnostics_channel';

--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -371,9 +371,7 @@ class TracingChannel {
       // Using runStores here enables manual context failure recovery
       asyncStart.runStores(context, () => {
         try {
-          if (callback) {
-            return ReflectApply(callback, this, arguments);
-          }
+          return ReflectApply(callback, this, arguments);
         } finally {
           asyncEnd.publish(context);
         }


### PR DESCRIPTION
`tracingChannel.traceCallback()` requires a callback otherwise it throws and invalid argument error. As a result arguments are not optional.

Correct the documentation to reflect that arguments are not optional.

Besides that correct description regarding signaling of errors.

Remove an unneeded null check in `wrappedCallback()` which can't happen because it's validated that callback is of type function.

Fixes: #50996
