### PR TITLE
build: fix warnings from uv for gn build

### DIFF
--- a/deps/uv/unofficial.gni
+++ b/deps/uv/unofficial.gni
@@ -50,6 +50,7 @@ template("uv_gn_build") {
         "-Wno-shadow",
         "-Wno-unreachable-code",
         "-Wno-unreachable-code-return",
+        "-Wno-unused-but-set-parameter",
         "-Wno-unused-but-set-variable",
         "-Wno-unused-function",
         "-Wno-unused-result",


### PR DESCRIPTION
Fix build failure in GN build caused by upgrade of libuv in https://github.com/nodejs/node/pull/50650, a fast track merge would be appreciated so we can bring CI of GN build to green to continue monitoring the health of GN build .

```
../../node/deps/uv/src/idna.c:385:30: error: parameter 'w_target_len' set but not used [-Werror,-Wunused-but-set-parameter]
  385 |                       size_t w_target_len) {
      |                              ^
1 error generated.
```

Note that this parameter was intentionally used by libuv for safety check without being "used", so fixing it in libuv would be tricky as we need to tell the compiler the parameter is used. 
https://github.com/libuv/libuv/blob/5e302730cd29cfeb15d32369dd2edfd9d3c82c11/src/idna.c#L383-L404

I'll try to fix it (and some other compiler warnings) in libuv but it will be really helpful to merge this first.