### PR TITLE
fs: improve mkdtemp performance for buffer prefix

### DIFF
--- a/benchmark/fs/bench-mkdtempSync.js
+++ b/benchmark/fs/bench-mkdtempSync.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+const tmpdir = require('../../test/common/tmpdir');
+
+const bench = common.createBenchmark(main, {
+  type: ['valid-string', 'valid-buffer', 'invalid'],
+  n: [1e4],
+});
+
+function main({ n, type }) {
+  tmpdir.refresh();
+  const options = { encoding: 'utf8' };
+  let prefix;
+  let out = true;
+
+  switch (type) {
+    case 'valid-string':
+      prefix = tmpdir.resolve(`${Date.now()}`);
+      break;
+    case 'valid-buffer':
+      prefix = Buffer.from(tmpdir.resolve(`${Date.now()}`));
+      break;
+    case 'invalid':
+      prefix = tmpdir.resolve('non-existent', 'foo', 'bar');
+      break;
+    default:
+      new Error('Invalid type');
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    try {
+      out = fs.mkdtempSync(prefix, options);
+    } catch {
+      // do nothing
+    }
+  }
+  bench.end(n);
+  assert.ok(out);
+}

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2948,16 +2948,9 @@ function mkdtemp(prefix, options, callback) {
   prefix = getValidatedPath(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
 
-  let path;
-  if (typeof prefix === 'string') {
-    path = `${prefix}XXXXXX`;
-  } else {
-    path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
-  }
-
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.mkdtemp(path, options.encoding, req);
+  binding.mkdtemp(prefix, options.encoding, req);
 }
 
 /**
@@ -2971,15 +2964,7 @@ function mkdtempSync(prefix, options) {
 
   prefix = getValidatedPath(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
-
-  let path;
-  if (typeof prefix === 'string') {
-    path = `${prefix}XXXXXX`;
-  } else {
-    path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
-  }
-
-  return binding.mkdtemp(path, options.encoding);
+  return binding.mkdtemp(prefix, options.encoding);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2737,6 +2737,11 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue tmpl(isolate, args[0]);
+  static constexpr const char* const suffix = "XXXXXX";
+  const auto length = tmpl.length();
+  tmpl.AllocateSufficientStorage(length + strlen(suffix));
+  snprintf(tmpl.out() + length, tmpl.length(), "%s", suffix);
+
   CHECK_NOT_NULL(*tmpl);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());


### PR DESCRIPTION
This small PR improves the `mkdtempSync` performance for buffer inputs by 5%. Basically, we achieve this performance boost because `Buffer.concat()` is costly, and doing it in C++ is beneficial for performance.


## Local benchmarks

```
❯ node benchmark/compare.js --old ./node-main --new out/Release/node --filter mkdtempSync fs > fs.csv && node-benchmark-compare fs.csv
[00:00:25|% 100| 1/1 files | 60/60 runs | 3/3 configs]: Done
                                                    confidence improvement accuracy (*)   (**)   (***)
fs/bench-mkdtempSync.js n=1000 type='invalid'                      1.64 %       ±6.96% ±9.28% ±12.11%
fs/bench-mkdtempSync.js n=1000 type='valid-buffer'        ***      5.52 %       ±2.97% ±3.95%  ±5.14%
fs/bench-mkdtempSync.js n=1000 type='valid-string'                -1.40 %       ±3.73% ±4.96%  ±6.46%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

## Benchmark CI

https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1483/

```
                                                   confidence improvement accuracy (*)   (**)  (***)
fs/bench-mkdtempSync.js n=1000 type='invalid'                     -2.32 %       ±2.97% ±3.97% ±5.19%
fs/bench-mkdtempSync.js n=1000 type='valid-buffer'        ***     21.88 %       ±2.87% ±3.84% ±5.02%
fs/bench-mkdtempSync.js n=1000 type='valid-string'                -1.53 %       ±4.60% ±6.13% ±8.00%
```