### PR TITLE
test: fix broken env fuzzer by initializing process 

### DIFF
--- a/test/fuzzers/fuzz_env.cc
+++ b/test/fuzzers/fuzz_env.cc
@@ -44,6 +44,7 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv) {
   platform.reset(
     new node::NodePlatform(kV8ThreadPoolSize, tracing_controller));
   v8::V8::InitializePlatform(platform.get());
+  cppgc::InitializeProcess(platform->GetPageAllocator());
   v8::V8::Initialize();
   return 0;
 }


### PR DESCRIPTION
Fixes a broken fuzzer. 

It looks like the fuzzer is leaking memory, but it is so slow that it is hard to tell. Once the fuzzer starts running on OSS-Fuzz again, we should get good feedback. If it has a leak, then I plan to fix it over the next couple of weeks; If anyone can spot a possible leak without running it, it would be a great help.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
