### PR TITLE
fs: filehandle.read(buffer) can't read file when options are omitted

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -393,11 +393,14 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView} A buffer that will be filled with the
   file data read.
 * `offset` {integer} The location in the buffer at which to start filling.
-* `length` {integer} The number of bytes to read.
+  **Default:** `0`
+* `length` {integer} The number of bytes to read. **Default:**
+  `buffer.byteLength - offset`
 * `position` {integer|bigint|null} The location where to begin reading data
   from the file. If `null` or `-1`, data will be read from the current file
   position, and the position will be updated. If `position` is a non-negative
   integer, the current file position will remain unchanged.
+  **Default:**: `null`
 * Returns: {Promise} Fulfills upon success with an object with two properties:
   * `bytesRead` {integer} The number of bytes read
   * `buffer` {Buffer|TypedArray|DataView} A reference to the passed in `buffer`

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -670,7 +670,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validateInteger(offset, 'offset', 0);
   }
 
-  length |= 0;
+  length = length ?? buffer.byteLength - offset;
 
   if (length === 0)
     return { __proto__: null, bytesRead: length, buffer };

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -670,7 +670,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validateInteger(offset, 'offset', 0);
   }
 
-  length = length ?? buffer.byteLength - offset;
+  length ??= buffer.byteLength - offset;
 
   if (length === 0)
     return { __proto__: null, bytesRead: length, buffer };

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -109,7 +109,7 @@ async function validateReadWithNoOptions(byte) {
   response = await read(fileHandle, buf, 0, undefined, 0, { useConf: true });
   assert.strictEqual(response.bytesRead, byte);
   response = await read(fileHandle, buf, 0, null, 0, { useConf: true });
-  assert.strictEqual(response.bytesRead, 0);
+  assert.strictEqual(response.bytesRead, byte);
 }
 
 (async function() {

--- a/test/parallel/test-fs-promises-file-handle-read.js
+++ b/test/parallel/test-fs-promises-file-handle-read.js
@@ -14,7 +14,7 @@ const assert = require('assert');
 const tmpDir = tmpdir.path;
 
 async function read(fileHandle, buffer, offset, length, position, options) {
-  return options.useConf ?
+  return options?.useConf ?
     fileHandle.read({ buffer, offset, length, position }) :
     fileHandle.read(buffer, offset, length, position);
 }
@@ -96,6 +96,21 @@ async function validateReadLength(len) {
   assert.strictEqual(bytesRead, len);
 }
 
+async function validateReadWithNoOptions(byte) {
+  const buf = Buffer.alloc(byte);
+  const filePath = fixtures.path('x.txt');
+  const fileHandle = await open(filePath, 'r');
+  let response = await fileHandle.read(buf);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, undefined, 0);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, null, 0);
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, undefined, 0, { useConf: true });
+  assert.strictEqual(response.bytesRead, byte);
+  response = await read(fileHandle, buf, 0, null, 0, { useConf: true });
+  assert.strictEqual(response.bytesRead, 0);
+}
 
 (async function() {
   tmpdir.refresh();
@@ -109,4 +124,6 @@ async function validateReadLength(len) {
   await validateReadWithPositionZero();
   await validateReadLength(0);
   await validateReadLength(1);
+  await validateReadWithNoOptions(0);
+  await validateReadWithNoOptions(1);
 })().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

fix: #47183

- make length arg in fh.read(buffer, offset, position, length) default to `length ?? buffer.byteLength - offset`

**Code**

```js
import fs from "fs/promises";

async function test() {
  let path = './ex.txt';

  let buf = Buffer.alloc(4);
  let handle;
  try {
    handle = await fs.open(path);
    {
      let buf = Buffer.alloc(4);
      let { bytesRead, buffer } = await handle.read(buf);
      console.log(bytesRead);
      console.log(buffer);
      console.log(buf);
    }
  } finally {
    await handle?.close();
  }
}
test();
```


**before**

```bash
0
<Buffer 00 00 00 00>
<Buffer 00 00 00 00>
```

**now**
```bash
4
<Buffer 48 65 6c 6c>
<Buffer 48 65 6c 6c>
```


--- 

That's my second attempt at this issue 😅 