### PR TITLE
events: remove the abort listener on iterator completion

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1169,7 +1169,7 @@ function on(emitter, event, options = kEmptyObject) {
   }
   if (signal) {
     kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-    eventTargetAgnosticAddListener(
+    addEventListener(
       signal,
       'abort',
       abortListener,

--- a/lib/events.js
+++ b/lib/events.js
@@ -1167,14 +1167,8 @@ function on(emitter, event, options = kEmptyObject) {
       addEventListener(emitter, closeEvents[i], closeHandler);
     }
   }
-  if (signal) {
-    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-    addEventListener(
-      signal,
-      'abort',
-      abortListener,
-      { __proto__: null, once: true, [kResistStopPropagation]: true });
-  }
+
+  const abortListenerDisposable = signal ? addAbortListener(signal, abortListener) : null;
 
   return iterator;
 
@@ -1201,6 +1195,7 @@ function on(emitter, event, options = kEmptyObject) {
   }
 
   function closeHandler() {
+    abortListenerDisposable?.[SymbolDispose]();
     removeAll();
     finished = true;
     const doneResult = createIterResult(undefined, true);

--- a/test/parallel/test-events-on-async-iterator.js
+++ b/test/parallel/test-events-on-async-iterator.js
@@ -379,17 +379,25 @@ async function abortListenerRemovedAfterComplete() {
 
   const i = setInterval(() => ee.emit('foo', 'foo'), 1);
   try {
+    // Below: either the kEvents map is empty or the 'abort' listener list is empty
+
     // Return case
     const endedIterator = on(ee, 'foo', { signal: ac.signal });
-    assert.ok(ac.signal[kEvents].size > 0);
+    assert.ok(ac.signal[kEvents].get('abort').size > 0);
     endedIterator.return();
-    assert.strictEqual(ac.signal[kEvents].size, 0);
+    assert.strictEqual(ac.signal[kEvents].get('abort')?.size ?? ac.signal[kEvents].size, 0);
 
     // Throw case
     const throwIterator = on(ee, 'foo', { signal: ac.signal });
-    assert.ok(ac.signal[kEvents].size > 0);
+    assert.ok(ac.signal[kEvents].get('abort').size > 0);
     throwIterator.throw(new Error());
-    assert.strictEqual(ac.signal[kEvents].size, 0);
+    assert.strictEqual(ac.signal[kEvents].get('abort')?.size ?? ac.signal[kEvents].size, 0);
+
+    // Abort case
+    on(ee, 'foo', { signal: ac.signal });
+    assert.ok(ac.signal[kEvents].get('abort').size > 0);
+    ac.abort(new Error());
+    assert.strictEqual(ac.signal[kEvents].get('abort')?.size ?? ac.signal[kEvents].size, 0);
   } finally {
     clearInterval(i);
   }


### PR DESCRIPTION
events: remove abort listener from signal in `on`
    
the `abortHandler` function is declared within the scope of
the `events.on` function so cannot be removed by the caller
which can lead to a memory leak
adding the abort listener using the `addAbortListener` helper
returns a disposable that can be used to clean up the listener
when the iterator is exited
    
Fixes: https://github.com/nodejs/node/issues/51010

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
