### PR TITLE
lib, src: add maxmem prop in os module

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -422,6 +422,19 @@ added: v0.3.3
 
 Returns the total amount of system memory in bytes as an integer.
 
+## `os.maxmem()`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+* Returns: {integer}
+
+Returns the total amount of memory available to the process (in bytes) based on
+limits imposed by the OS.
+If there is no such constraint, or the constraint is unknown, 0 is returned.
+
 ## `os.type()`
 
 <!-- YAML

--- a/lib/os.js
+++ b/lib/os.js
@@ -54,6 +54,7 @@ const {
   getPriority: _getPriority,
   getOSInformation: _getOSInformation,
   getTotalMem,
+  getConstrainedMem,
   getUserInfo,
   getUptime: _getUptime,
   isBigEndian,
@@ -109,6 +110,7 @@ getOSRelease[SymbolToPrimitive] = () => getOSRelease();
 getMachine[SymbolToPrimitive] = () => getMachine();
 getHomeDirectory[SymbolToPrimitive] = () => getHomeDirectory();
 getTotalMem[SymbolToPrimitive] = () => getTotalMem();
+getConstrainedMem[SymbolToPrimitive] = () => getConstrainedMem();
 getUptime[SymbolToPrimitive] = () => getUptime();
 
 const kEndianness = isBigEndian ? 'BE' : 'LE';
@@ -388,6 +390,7 @@ module.exports = {
   setPriority,
   tmpdir,
   totalmem: getTotalMem,
+  maxmem: getConstrainedMem,
   type: getOSType,
   userInfo,
   uptime: getUptime,

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -146,6 +146,10 @@ static void GetTotalMemory(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(amount);
 }
 
+static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
+  double amount = static_cast<double>(uv_get_constrained_memory());
+  args.GetReturnValue().Set(amount);
+}
 
 static void GetUptime(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -394,6 +398,7 @@ void Initialize(Local<Object> target,
   SetMethod(context, target, "getLoadAvg", GetLoadAvg);
   SetMethod(context, target, "getUptime", GetUptime);
   SetMethod(context, target, "getTotalMem", GetTotalMemory);
+  SetMethod(context, target, "getConstrainedMem", GetConstrainedMemory);
   SetMethod(context, target, "getFreeMem", GetFreeMemory);
   SetMethod(context, target, "getCPUs", GetCPUInfo);
   SetMethod(context, target, "getInterfaceAddresses", GetInterfaceAddresses);
@@ -416,6 +421,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(GetLoadAvg);
   registry->Register(GetUptime);
   registry->Register(GetTotalMemory);
+  registry->Register(GetConstrainedMemory);
   registry->Register(GetFreeMemory);
   registry->Register(GetCPUInfo);
   registry->Register(GetInterfaceAddresses);

--- a/typings/internalBinding/os.d.ts
+++ b/typings/internalBinding/os.d.ts
@@ -7,6 +7,7 @@ export interface OSBinding {
   getLoadAvg(array: Float64Array): void;
   getUptime(): number;
   getTotalMem(): number;
+  getConstrainedMem(): number;
   getFreeMem(): number;
   getCPUs(): Array<string | number>;
   getInterfaceAddresses(ctx: InternalOSBinding.OSContext): Array<string | number | boolean> | undefined;


### PR DESCRIPTION
Fixes #51095

add `maxmem` prop in os module

Eg: 
`require('os').maxmem()`

which will use the `uv_get_constrained_memory` for getting the memory limits

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
