### PR TITLE
doc && http: fix agent default value for `keepAlive`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -142,7 +142,7 @@ changes:
     header is always sent when using an agent except when the `Connection`
     header is explicitly specified or when the `keepAlive` and `maxSockets`
     options are respectively set to `false` and `Infinity`, in which case
-    `Connection: close` will be used. **Default:** `false`.
+    `Connection: close` will be used. **Default:** `true`.
   * `keepAliveMsecs` {number} When using the `keepAlive` option, specifies
     the [initial delay][]
     for TCP Keep-Alive packets. Ignored when the

--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -108,7 +108,7 @@ function Agent(options) {
   this.sockets = { __proto__: null };
   this.freeSockets = { __proto__: null };
   this.keepAliveMsecs = this.options.keepAliveMsecs || 1000;
-  this.keepAlive = this.options.keepAlive || false;
+  this.keepAlive = this.options.keepAlive || true;
   this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
   this.maxFreeSockets = this.options.maxFreeSockets || 256;
   this.scheduling = this.options.scheduling || 'lifo';


### PR DESCRIPTION
Since node 19, option keepAlive is true by default.
