### PR TITLE
test_runner: format coverage report for tap reporter

### DIFF
--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -58,7 +58,7 @@ async function * tapReporter(source) {
         yield `${indent(data.nesting)}# ${tapEscape(data.message)}\n`;
         break;
       case 'test:coverage':
-        yield getCoverageReport(indent(data.nesting), data.summary, '# ', '');
+        yield getCoverageReport(indent(data.nesting), data.summary, '# ', '', true);
         break;
     }
   }

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -22,6 +22,7 @@ function findCoverageFileForPid(pid) {
 }
 
 function getTapCoverageFixtureReport() {
+  /* eslint-disable max-len */
   const report = [
     '# start of coverage report',
     '# -------------------------------------------------------------------------------------------------------------------',
@@ -35,6 +36,7 @@ function getTapCoverageFixtureReport() {
     '# -------------------------------------------------------------------------------------------------------------------',
     '# end of coverage report',
   ].join('\n');
+  /* eslint-enable max-len */
 
   if (common.isWindows) {
     return report.replaceAll('/', '\\');

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -24,12 +24,15 @@ function findCoverageFileForPid(pid) {
 function getTapCoverageFixtureReport() {
   const report = [
     '# start of coverage report',
-    '# file | line % | branch % | funcs % | uncovered lines',
-    '# test/fixtures/test-runner/coverage.js | 78.65 | 38.46 | 60.00 | 12, ' +
-    '13, 16, 17, 18, 19, 20, 21, 22, 27, 39, 43, 44, 61, 62, 66, 67, 71, 72',
-    '# test/fixtures/test-runner/invalid-tap.js | 100.00 | 100.00 | 100.00 | ',
-    '# test/fixtures/v8-coverage/throw.js | 71.43 | 50.00 | 100.00 | 5, 6',
-    '# all files | 78.35 | 43.75 | 60.00 |',
+    '# -------------------------------------------------------------------------------------------------------------------',
+    '# file                                     | line % | branch % | funcs % | uncovered lines',
+    '# -------------------------------------------------------------------------------------------------------------------',
+    '# test/fixtures/test-runner/coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
+    '# test/fixtures/test-runner/invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+    '# test/fixtures/v8-coverage/throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+    '# -------------------------------------------------------------------------------------------------------------------',
+    '# all files                                |  78.35 |    43.75 |   60.00 |',
+    '# -------------------------------------------------------------------------------------------------------------------',
     '# end of coverage report',
   ].join('\n');
 
@@ -88,7 +91,6 @@ test('test tap coverage reporter', skipIfNoInspector, async (t) => {
     const options = { env: { ...process.env, NODE_V8_COVERAGE: tmpdir.path } };
     const result = spawnSync(process.execPath, args, options);
     const report = getTapCoverageFixtureReport();
-
     assert(result.stdout.toString().includes(report));
     assert.strictEqual(result.stderr.toString(), '');
     assert.strictEqual(result.status, 0);
@@ -152,16 +154,16 @@ test('single process coverage is the same with --test', skipIfNoInspector, () =>
 test('coverage is combined for multiple processes', skipIfNoInspector, () => {
   let report = [
     '# start of coverage report',
-    '# file | line % | branch % | funcs % | uncovered lines',
-    '# common.js | 89.86 | ' +
-    '62.50 | 100.00 | 8, 13, 14, 18, 34, 35, 53',
-    '# first.test.js | 83.33 | ' +
-    '100.00 | 50.00 | 5, 6',
-    '# second.test.js | 100.00 ' +
-    '| 100.00 | 100.00 | ',
-    '# third.test.js | 100.00 | ' +
-    '100.00 | 100.00 | ',
-    '# all files | 92.11 | 72.73 | 88.89 |',
+    '# -------------------------------------------------------------------',
+    '# file           | line % | branch % | funcs % | uncovered lines',
+    '# -------------------------------------------------------------------',
+    '# common.js      |  89.86 |    62.50 |  100.00 | 8 13-14 18 34-35 53',
+    '# first.test.js  |  83.33 |   100.00 |   50.00 | 5-6',
+    '# second.test.js | 100.00 |   100.00 |  100.00 | ',
+    '# third.test.js  | 100.00 |   100.00 |  100.00 | ',
+    '# -------------------------------------------------------------------',
+    '# all files      |  92.11 |    72.73 |   88.89 |',
+    '# -------------------------------------------------------------------',
     '# end of coverage report',
   ].join('\n');
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

this PR enhances the tap coverage report output (similar to the spec reporter).

code: 
```js
import assert from "node:assert";
import { test } from "node:test";

test("some test", () => {
    assert.strictEqual(1,1)
})
```

before:
```bash
TAP version 13
# Subtest: some test
ok 1 - some test
  ---
  duration_ms: 1.008875
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 9.619875
# start of coverage report
# file | line % | branch % | funcs % | uncovered lines
# index.mjs | 100.00 | 100.00 | 100.00 | 
# all files | 100.00 | 100.00 | 100.00 |
# end of coverage report
```

now:

```bash
TAP version 13
# Subtest: some test
ok 1 - some test
  ---
  duration_ms: 1.41925
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 12.865292
# start of coverage report
# ----------------------------------------------------------
# file      | line % | branch % | funcs % | uncovered lines
# ----------------------------------------------------------
# index.mjs | 100.00 |   100.00 |  100.00 | 
# ----------------------------------------------------------
# all files | 100.00 |   100.00 |  100.00 |
# ----------------------------------------------------------
# end of coverage report
```
