### PR TITLE
test: handle relative https redirect

### DIFF
--- a/test/internet/test-inspector-help-page.js
+++ b/test/internet/test-inspector-help-page.js
@@ -18,7 +18,7 @@ function check(url, cb) {
     assert(res.statusCode >= 200 && res.statusCode < 400);
 
     if (res.statusCode >= 300)
-      return check(res.headers.location, cb);
+      return check(new URL(res.headers.location, url), cb);
 
     let result = '';
 


### PR DESCRIPTION
Fix `internet/test-inspector-help-page` to handle the relative redirect of `https://nodejs.org/en/docs/inspector` to `/en/docs/guides/debugging-getting-started`. Previously this URL redirected to an absolute URL.

---

The [`internet/test-inspector-help-page`](https://github.com/nodejs/node/blob/6e90fed8c3da4faae9adedd6f1b58cf951382d72/test/internet/test-inspector-help-page.js) test has been failing for about a week:
- On [node-daily-master](https://ci.nodejs.org/view/Node.js%20Daily/job/node-daily-master/) in Jenkins since 6 December 2023, e.g. 
  - https://ci.nodejs.org/view/Node.js%20Daily/job/node-daily-master/3253/
    - https://ci.nodejs.org/job/node-test-commit-custom-suites-freestyle/33912/testReport/junit/(root)/test/internet_test_inspector_help_page/
- On [GitHub Actions](https://github.com/nodejs/node/actions/workflows/test-internet.yml), e.g.
  - https://github.com/nodejs/node/actions/runs/7108379296/job/19351546344
```console
=== release test-inspector-help-page ===
Path: internet/test-inspector-help-page
node:internal/url:787
    this.#updateContext(bindingUrl.parse(input, base));
                                   ^

TypeError: Invalid URL
    at new URL (node:internal/url:787:36)
    at request (node:https:366:32)
    at Object.get (node:https:414:15)
    at check (/home/runner/work/node/node/test/internet/test-inspector-help-page.js:17:9)
    at ClientRequest.<anonymous> (/home/runner/work/node/node/test/internet/test-inspector-help-page.js:21:14)
    at ClientRequest.<anonymous> (/home/runner/work/node/node/test/common/index.js:476:15)
    at Object.onceWrapper (node:events:634:26)
    at ClientRequest.emit (node:events:519:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:6[93](https://github.com/nodejs/node/actions/runs/7108379296/job/19351546344#step:6:94):27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17) {
  code: 'ERR_INVALID_URL',
  input: '/en/docs/guides/debugging-getting-started'
}

Node.js v22.0.0-pre
Command: out/Release/node /home/runner/work/node/node/test/internet/test-inspector-help-page.js
```

The test attempts to connect to https://nodejs.org/en/docs/inspector (output from [`node --inspect -e ""`](https://github.com/nodejs/node/blob/6e90fed8c3da4faae9adedd6f1b58cf951382d72/test/internet/test-inspector-help-page.js#L12)), and then to `res.headers.location` which comes back as `/en/docs/guides/debugging-getting-started`.

Presumably something changed around then on the website so that the redirect is now to a relative URL rather than an absolute one. The test itself hasn't changed in over a year.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
