### PR TITLE
src: avoid shadowed string in fs_permission

### DIFF
--- a/src/permission/fs_permission.h
+++ b/src/permission/fs_permission.h
@@ -32,24 +32,26 @@ class FSPermission final : public PermissionBase {
 
       Node() : wildcard_child(nullptr), is_leaf(false) {}
 
-      Node* CreateChild(const std::string& prefix) {
-        if (prefix.empty() && !is_leaf) {
+      Node* CreateChild(const std::string& path_prefix) {
+        if (path_prefix.empty() && !is_leaf) {
           is_leaf = true;
           return this;
         }
-        char label = prefix[0];
+
+        CHECK(!path_prefix.empty());
+        char label = path_prefix[0];
 
         Node* child = children[label];
         if (child == nullptr) {
-          children[label] = new Node(prefix);
+          children[label] = new Node(path_prefix);
           return children[label];
         }
 
         // swap prefix
         size_t i = 0;
-        size_t prefix_len = prefix.length();
+        size_t prefix_len = path_prefix.length();
         for (; i < child->prefix.length(); ++i) {
-          if (i > prefix_len || prefix[i] != child->prefix[i]) {
+          if (i > prefix_len || path_prefix[i] != child->prefix[i]) {
             std::string parent_prefix = child->prefix.substr(0, i);
             std::string child_prefix = child->prefix.substr(i);
 
@@ -58,11 +60,11 @@ class FSPermission final : public PermissionBase {
             split_child->children[child_prefix[0]] = child;
             children[parent_prefix[0]] = split_child;
 
-            return split_child->CreateChild(prefix.substr(i));
+            return split_child->CreateChild(path_prefix.substr(i));
           }
         }
         child->is_leaf = true;
-        return child->CreateChild(prefix.substr(i));
+        return child->CreateChild(path_prefix.substr(i));
       }
 
       Node* CreateWildcardChild() {


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/44004

Addresses the following shadowing issue in `fs_permission`:

```
../../third_party/electron_node/src/permission/fs_permission.h:34:37: error: declaration shadows a field of 'node::permission::FSPermission::RadixTree::Node' [-Werror,-Wshadow]
   34 |       Node* CreateChild(std::string prefix) {
      |                                     ^
../../third_party/electron_node/src/permission/fs_permission.h:24:19: note: previous declaration is here
   24 |       std::string prefix;
      |                   ^
1 error generated.
```

Allows Electron to remove a [patch](https://github.com/electron/electron/blob/main/patches/node/src_avoid_copying_string_in_fs_permission.patch).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
