### PR TITLE
stream: fix deadlock when cloning webstreams

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -589,18 +589,24 @@ class ReadableStream {
         'DataCloneError');
     }
 
+    const { port1, port2 } = this[kState].transfer;
+
+    this[kState].transfer.port2 = undefined;
+
+    const transfer = lazyTransfer();
     const {
       writable,
+      source,
       promise,
-    } = lazyTransfer().newCrossRealmWritableSink(
-      this,
-      this[kState].transfer.port1);
+    } = transfer.newCrossRealmWritableSink(this, port1);
+
+    transfer.closeRegistry().register(port2, source);
 
     this[kState].transfer.writable = writable;
     this[kState].transfer.promise = promise;
 
     return {
-      data: { port: this[kState].transfer.port2 },
+      data: { port: port2 },
       deserializeInfo:
         'internal/webstreams/readablestream:TransferredReadableStream',
     };

--- a/lib/internal/webstreams/transfer.js
+++ b/lib/internal/webstreams/transfer.js
@@ -4,6 +4,7 @@ const {
   ObjectDefineProperties,
   PromiseResolve,
   ReflectConstruct,
+  SafeFinalizationRegistry,
 } = primordials;
 
 const {
@@ -261,10 +262,18 @@ class CrossRealmTransformWritableSink {
   }
 }
 
+let finalizer = null;
+
+function closeRegistry() {
+  return (finalizer ??= new SafeFinalizationRegistry((source) => {
+    source[kState].port.close();
+  }));
+}
+
 function newCrossRealmReadableStream(writable, port) {
-  const readable =
-    new ReadableStream(
-      new CrossRealmTransformReadableSource(port));
+  const source = new CrossRealmTransformReadableSource(port);
+
+  const readable = new ReadableStream(source);
 
   const promise =
     readableStreamPipeTo(readable, writable, false, false, false);
@@ -273,19 +282,21 @@ function newCrossRealmReadableStream(writable, port) {
 
   return {
     readable,
+    source,
     promise,
   };
 }
 
 function newCrossRealmWritableSink(readable, port) {
-  const writable =
-    new WritableStream(
-      new CrossRealmTransformWritableSink(port));
+  const source = new CrossRealmTransformWritableSink(port);
+
+  const writable = new WritableStream(source);
 
   const promise = readableStreamPipeTo(readable, writable, false, false, false);
   setPromiseHandled(promise);
   return {
     writable,
+    source,
     promise,
   };
 }
@@ -297,4 +308,5 @@ module.exports = {
   CrossRealmTransformReadableSource,
   CloneableDOMException,
   InternalCloneableDOMException,
+  closeRegistry,
 };

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -282,20 +282,27 @@ class WritableStream {
         'DataCloneError');
     }
 
+    const { port1, port2 } = this[kState].transfer;
+
+    this[kState].transfer.port2 = undefined;
+
+    const transfer = lazyTransfer();
     const {
       readable,
+      source,
       promise,
-    } = lazyTransfer().newCrossRealmReadableStream(
+    } = transfer.newCrossRealmReadableStream(
       this,
-      this[kState].transfer.port1);
+      port1);
+
+    transfer.closeRegistry().register(port2, source);
 
     this[kState].transfer.readable = readable;
     this[kState].transfer.promise = promise;
 
-    setPromiseHandled(this[kState].transfer.promise);
 
     return {
-      data: { port: this[kState].transfer.port2 },
+      data: { port: port2 },
       deserializeInfo:
         'internal/webstreams/writablestream:TransferredWritableStream',
     };

--- a/test/parallel/test-webstreams-using-structuredclone-exit-process.js
+++ b/test/parallel/test-webstreams-using-structuredclone-exit-process.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common');
+const { Worker } = require('worker_threads');
+const { once } = require('node:events');
+
+const worker = new Worker(
+  `
+  const { ReadableStream } = require('stream/web');
+  const rs = new ReadableStream();
+  const cloned = structuredClone(rs, { transfer: [rs] });
+  `,
+  { eval: true },
+);
+
+const worker2 = new Worker(
+  `
+  const { WritableStream } = require('stream/web');
+  const ws = new WritableStream();
+  const cloned = structuredClone(ws, { transfer: [ws] });
+  `,
+  { eval: true },
+);
+
+(async () => {
+  // A timer is used here to detect the end of a process.
+  const timer = setTimeout(common.mustNotCall(), common.platformTimeout(10000));
+
+  await Promise.all([once(worker, 'exit'), once(worker2, 'exit')]);
+
+  clearTimeout(timer);
+})().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #44985.
Fixed a problem where the process would not terminate if structuredClone was used for webstream and body was not consumed.