### PR TITLE
[v18.x backport] Add test-child-process-pipe-dataflow skip

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -11,9 +11,6 @@ prefix parallel
 test-crypto-keygen: PASS,FLAKY
 # https://github.com/nodejs/node/issues/41201
 test-fs-rmdir-recursive: PASS, FLAKY
-# https://github.com/nodejs/node/issues/48300
-test-child-process-pipe-dataflow: PASS, FLAKY
-test-child-process-stdio-reuse-readable-stdio: PASS, FLAKY
 # https://github.com/nodejs/node/issues/49985
 test-runner-watch-mode: PASS, FLAKY
 # https://github.com/nodejs/node/issues/50295

--- a/test/parallel/test-child-process-pipe-dataflow.js
+++ b/test/parallel/test-child-process-pipe-dataflow.js
@@ -1,5 +1,11 @@
 'use strict';
 const common = require('../common');
+
+if (common.isWindows) {
+  // https://github.com/nodejs/node/issues/48300
+  common.skip('Does not work with cygwin quirks on Windows');
+}
+
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');

--- a/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
+++ b/test/parallel/test-child-process-stdio-reuse-readable-stdio.js
@@ -1,5 +1,11 @@
 'use strict';
 const common = require('../common');
+
+if (common.isWindows) {
+  // https://github.com/nodejs/node/issues/48300
+  common.skip('Does not work with cygwin quirks on Windows');
+}
+
 const assert = require('assert');
 const { spawn } = require('child_process');
 


### PR DESCRIPTION
Added skip to two tests (test-child-process-pipe-dataflow and test-child-process-stdio-reuse-readable-stdio) on Windows. We already had this on main, added it to v18 as well.

PR-URL: https://github.com/nodejs/node/pull/49621