### PR TITLE
[v18.x backport] esm: use import attributes instead of import assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,10 +44,7 @@ module.exports = {
   parserOptions: {
     babelOptions: {
       plugins: [
-        [
-          Module._findPath('@babel/plugin-syntax-import-attributes'),
-          { deprecatedAssertSyntax: true },
-        ],
+        Module._findPath('@babel/plugin-syntax-import-attributes'),
       ],
     },
     requireConfigFile: false,

--- a/deps/v8/include/v8-script.h
+++ b/deps/v8/include/v8-script.h
@@ -128,10 +128,9 @@ class V8_EXPORT ModuleRequest : public Data {
    *
    * All assertions present in the module request will be supplied in this
    * list, regardless of whether they are supported by the host. Per
-   * https://tc39.es/proposal-import-assertions/#sec-hostgetsupportedimportassertions,
-   * hosts are expected to ignore assertions that they do not support (as
-   * opposed to, for example, triggering an error if an unsupported assertion is
-   * present).
+   * https://tc39.es/proposal-import-attributes/#sec-hostgetsupportedimportattributes,
+   * hosts are expected to throw for assertions that they do not support (as
+   * opposed to, for example, ignoring them).
    */
   Local<FixedArray> GetImportAssertions() const;
 

--- a/deps/v8/src/execution/isolate.cc
+++ b/deps/v8/src/execution/isolate.cc
@@ -4726,7 +4726,7 @@ MaybeHandle<FixedArray> Isolate::GetImportAssertionsFromArgument(
 
   // The parser shouldn't have allowed the second argument to import() if
   // the flag wasn't enabled.
-  DCHECK(FLAG_harmony_import_assertions);
+  DCHECK(FLAG_harmony_import_assertions || FLAG_harmony_import_attributes);
 
   if (!import_assertions_argument->IsJSReceiver()) {
     this->Throw(
@@ -4736,18 +4736,35 @@ MaybeHandle<FixedArray> Isolate::GetImportAssertionsFromArgument(
 
   Handle<JSReceiver> import_assertions_argument_receiver =
       Handle<JSReceiver>::cast(import_assertions_argument);
-  Handle<Name> key = factory()->assert_string();
 
   Handle<Object> import_assertions_object;
-  if (!JSReceiver::GetProperty(this, import_assertions_argument_receiver, key)
-           .ToHandle(&import_assertions_object)) {
-    // This can happen if the property has a getter function that throws
-    // an error.
-    return MaybeHandle<FixedArray>();
+
+  if (FLAG_harmony_import_attributes) {
+    Handle<Name> with_key = factory()->with_string();
+    if (!JSReceiver::GetProperty(this, import_assertions_argument_receiver,
+                                 with_key)
+             .ToHandle(&import_assertions_object)) {
+      // This can happen if the property has a getter function that throws
+      // an error.
+      return MaybeHandle<FixedArray>();
+    }
   }
 
-  // If there is no 'assert' option in the options bag, it's not an error. Just
-  // do the import() as if no assertions were provided.
+  if (FLAG_harmony_import_assertions &&
+      (!FLAG_harmony_import_attributes ||
+       import_assertions_object->IsUndefined())) {
+    Handle<Name> assert_key = factory()->assert_string();
+    if (!JSReceiver::GetProperty(this, import_assertions_argument_receiver,
+                                 assert_key)
+             .ToHandle(&import_assertions_object)) {
+      // This can happen if the property has a getter function that throws
+      // an error.
+      return MaybeHandle<FixedArray>();
+    }
+  }
+
+  // If there is no 'with' or 'assert' option in the options bag, it's not an
+  // error. Just do the import() as if no assertions were provided.
   if (import_assertions_object->IsUndefined()) return import_assertions_array;
 
   if (!import_assertions_object->IsJSReceiver()) {
@@ -4769,6 +4786,8 @@ MaybeHandle<FixedArray> Isolate::GetImportAssertionsFromArgument(
     return MaybeHandle<FixedArray>();
   }
 
+  bool has_non_string_attribute = false;
+
   // The assertions will be passed to the host in the form: [key1,
   // value1, key2, value2, ...].
   constexpr size_t kAssertionEntrySizeForDynamicImport = 2;
@@ -4786,15 +4805,19 @@ MaybeHandle<FixedArray> Isolate::GetImportAssertionsFromArgument(
     }
 
     if (!assertion_value->IsString()) {
-      this->Throw(*factory()->NewTypeError(
-          MessageTemplate::kNonStringImportAssertionValue));
-      return MaybeHandle<FixedArray>();
+      has_non_string_attribute = true;
     }
 
     import_assertions_array->set((i * kAssertionEntrySizeForDynamicImport),
                                  *assertion_key);
     import_assertions_array->set((i * kAssertionEntrySizeForDynamicImport) + 1,
                                  *assertion_value);
+  }
+
+  if (has_non_string_attribute) {
+    this->Throw(*factory()->NewTypeError(
+        MessageTemplate::kNonStringImportAssertionValue));
+    return MaybeHandle<FixedArray>();
   }
 
   return import_assertions_array;

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -300,6 +300,7 @@ DEFINE_BOOL(harmony_shipping, true, "enable all shipped harmony features")
 
 // Features that are still work in progress (behind individual flags).
 #define HARMONY_INPROGRESS_BASE(V)                                             \
+  V(harmony_import_attributes, "harmony import attributes")                    \
   V(harmony_weak_refs_with_cleanup_some,                                       \
     "harmony weak references with FinalizationRegistry.prototype.cleanupSome") \
   V(harmony_import_assertions, "harmony import assertions")                    \

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -4482,6 +4482,7 @@ void Genesis::InitializeConsole(Handle<JSObject> extras_binding) {
   void Genesis::InitializeGlobal_##id() {}
 
 EMPTY_INITIALIZE_GLOBAL_FOR_FEATURE(harmony_import_assertions)
+EMPTY_INITIALIZE_GLOBAL_FOR_FEATURE(harmony_import_attributes)
 EMPTY_INITIALIZE_GLOBAL_FOR_FEATURE(harmony_private_brand_checks)
 EMPTY_INITIALIZE_GLOBAL_FOR_FEATURE(harmony_class_static_blocks)
 EMPTY_INITIALIZE_GLOBAL_FOR_FEATURE(harmony_error_cause)

--- a/deps/v8/src/init/heap-symbols.h
+++ b/deps/v8/src/init/heap-symbols.h
@@ -432,6 +432,7 @@
   V(_, week_string, "week")                                           \
   V(_, weeks_string, "weeks")                                         \
   V(_, weekOfYear_string, "weekOfYear")                               \
+  V(_, with_string, "with")                                           \
   V(_, word_string, "word")                                           \
   V(_, writable_string, "writable")                                   \
   V(_, yearMonthFromFields_string, "yearMonthFromFields")             \

--- a/deps/v8/src/parsing/parser-base.h
+++ b/deps/v8/src/parsing/parser-base.h
@@ -3725,7 +3725,9 @@ ParserBase<Impl>::ParseImportExpressions() {
   AcceptINScope scope(this, true);
   ExpressionT specifier = ParseAssignmentExpressionCoverGrammar();
 
-  if (FLAG_harmony_import_assertions && Check(Token::COMMA)) {
+  if ((FLAG_harmony_import_assertions ||
+       FLAG_harmony_import_attributes) &&
+      Check(Token::COMMA)) {
     if (Check(Token::RPAREN)) {
       // A trailing comma allowed after the specifier.
       return factory()->NewImportCallExpression(specifier, pos);

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -1344,27 +1344,34 @@ ZonePtrList<const Parser::NamedImport>* Parser::ParseNamedImports(int pos) {
 }
 
 ImportAssertions* Parser::ParseImportAssertClause() {
+  // WithClause :
+  //    with '{' '}'
+  //    with '{' WithEntries ','? '}'
+
+  // WithEntries :
+  //    LiteralPropertyName
+  //    LiteralPropertyName ':' StringLiteral , WithEntries
+
+  // (DEPRECATED)
   // AssertClause :
   //    assert '{' '}'
-  //    assert '{' AssertEntries '}'
-
-  // AssertEntries :
-  //    IdentifierName: AssertionKey
-  //    IdentifierName: AssertionKey , AssertEntries
-
-  // AssertionKey :
-  //     IdentifierName
-  //     StringLiteral
+  //    assert '{' WithEntries ','? '}'
 
   auto import_assertions = zone()->New<ImportAssertions>(zone());
 
-  if (!FLAG_harmony_import_assertions) {
-    return import_assertions;
-  }
+  if (FLAG_harmony_import_attributes && Check(Token::WITH)) {
+    // 'with' keyword consumed
+  } else if (FLAG_harmony_import_assertions &&
+             !scanner()->HasLineTerminatorBeforeNext() &&
+             CheckContextualKeyword(ast_value_factory()->assert_string())) {
+    // The 'assert' contextual keyword is deprecated in favor of 'with', and we
+    // need to investigate feasibility of unshipping.
+    //
+    // TODO(v8:13856): Remove once decision is made to unship 'assert' or keep.
 
-  // Assert clause is optional, and cannot be preceded by a LineTerminator.
-  if (scanner()->HasLineTerminatorBeforeNext() ||
-      !CheckContextualKeyword(ast_value_factory()->assert_string())) {
+    // NOTE(Node.js): Commented out to avoid backporting this use counter to Node.js 18
+    // ++use_counts_[v8::Isolate::kImportAssertionDeprecatedSyntax];
+  } else {
     return import_assertions;
   }
 
@@ -1372,8 +1379,12 @@ ImportAssertions* Parser::ParseImportAssertClause() {
 
   while (peek() != Token::RBRACE) {
     const AstRawString* attribute_key = nullptr;
-    if (Check(Token::STRING)) {
+    if (Check(Token::STRING) || Check(Token::SMI)) {
       attribute_key = GetSymbol();
+    } else if (Check(Token::NUMBER)) {
+      attribute_key = GetNumberAsSymbol();
+    } else if (Check(Token::BIGINT)) {
+      attribute_key = GetBigIntAsSymbol();
     } else {
       attribute_key = ParsePropertyName();
     }

--- a/deps/v8/src/parsing/parser.cc
+++ b/deps/v8/src/parsing/parser.cc
@@ -1378,16 +1378,8 @@ ImportAssertions* Parser::ParseImportAssertClause() {
   Expect(Token::LBRACE);
 
   while (peek() != Token::RBRACE) {
-    const AstRawString* attribute_key = nullptr;
-    if (Check(Token::STRING) || Check(Token::SMI)) {
-      attribute_key = GetSymbol();
-    } else if (Check(Token::NUMBER)) {
-      attribute_key = GetNumberAsSymbol();
-    } else if (Check(Token::BIGINT)) {
-      attribute_key = GetBigIntAsSymbol();
-    } else {
-      attribute_key = ParsePropertyName();
-    }
+    const AstRawString* attribute_key =
+        Check(Token::STRING) ? GetSymbol() : ParsePropertyName();
 
     Scanner::Location location = scanner()->location();
 

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-1.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-1.mjs
@@ -1,0 +1,9 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-import-attributes
+
+import { life } from 'modules-skip-1.mjs' with { };
+
+assertEquals(42, life());

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-2.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-2.mjs
@@ -1,0 +1,9 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-import-attributes
+
+import json from 'modules-skip-1.json' with { type: 'json' };
+
+assertEquals(42, json.life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-3.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-3.mjs
@@ -1,0 +1,9 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-import-attributes
+
+import {life} from 'modules-skip-imports-json-1.mjs';
+
+assertEquals(42, life());

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-4.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-4.mjs
@@ -1,0 +1,9 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --harmony-import-attributes
+
+import json from 'modules-skip-1.json' with { type: 'json', notARealAssertion: 'value'};
+
+assertEquals(42, json.life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-1.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-1.mjs
@@ -1,0 +1,12 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.mjs', { }).then(namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-10.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-10.mjs
@@ -1,0 +1,19 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var result1;
+var result2;
+import('modules-skip-1.json', { get with() { throw 'bad \'with\' getter!'; } }).then(
+    () => assertUnreachable('Should have failed due to throwing getter'),
+    error => result1 = error);
+import('modules-skip-1.json', { with: { get assertionKey() { throw 'bad \'assertionKey\' getter!'; } } }).then(
+    () => assertUnreachable('Should have failed due to throwing getter'),
+    error => result2 = error);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals('bad \'with\' getter!', result1);
+assertEquals('bad \'assertionKey\' getter!', result2);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-11.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-11.mjs
@@ -1,0 +1,19 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes --harmony-top-level-await
+
+var life1;
+var life2;
+import('modules-skip-1.json', { with: { type: 'json' } }).then(
+    namespace => life1 = namespace.default.life);
+
+// Try loading the same module a second time.
+import('modules-skip-1.json', { with: { type: 'json' } }).then(
+    namespace => life2 = namespace.default.life);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life1);
+assertEquals(42, life2);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-12.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-12.mjs
@@ -1,0 +1,26 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+let result1;
+let result2;
+
+let badAssertProxy1 = new Proxy({}, { ownKeys() { throw "bad ownKeys!"; } });
+import('./modules-skip-1.mjs', { with: badAssertProxy1 }).then(
+    () => assertUnreachable('Should have failed due to throwing ownKeys'),
+    error => result1 = error);
+
+let badAssertProxy2 = new Proxy(
+    {foo: "bar"},
+    { getOwnPropertyDescriptor() { throw "bad getOwnPropertyDescriptor!"; } });
+import('./modules-skip-1.mjs', { with: badAssertProxy2 }).then(
+    () => assertUnreachable(
+        'Should have failed due to throwing getOwnPropertyDescriptor'),
+    error => result2 = error);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals('bad ownKeys!', result1);
+assertEquals('bad getOwnPropertyDescriptor!', result2);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-13.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-13.mjs
@@ -1,0 +1,26 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+let getters = 0;
+let result;
+
+import('./modules-skip-1.mjs', { with: {
+    get attr1() {
+        getters++;
+        return {};
+    },
+    get attr2() {
+        getters++;
+        return {};
+    },
+} }).then(
+    () => assertUnreachable('Should have failed due to invalid attributes values'),
+    error => result = error);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(2, getters);
+assertInstanceof(result, TypeError);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-2.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-2.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.mjs', { with: { } }).then(
+    namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-3.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-3.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.json', { with: { type: 'json' } }).then(
+    namespace => life = namespace.default.life);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-4.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-4.mjs
@@ -1,0 +1,14 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var result;
+import('modules-skip-1.json', { with: { type: 'notARealType' } }).then(
+    () => assertUnreachable('Should have failed due to bad module type'),
+    error => result = error.message);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals('Invalid module type was asserted', result);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-5.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-5.mjs
@@ -1,0 +1,12 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-imports-json-1.mjs',).then(namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-6.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-6.mjs
@@ -1,0 +1,18 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.json', { with: { type: 'json', notARealAssertion: 'value' } }).then(
+    namespace => life = namespace.default.life);
+
+var life2;
+import('modules-skip-1.json', { with: { 0: 'value', type: 'json' } }).then(
+    namespace => life2 = namespace.default.life);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);
+assertEquals(42, life2);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-7.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-7.mjs
@@ -1,0 +1,63 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var result1;
+var result2;
+var result3;
+var result4;
+var result5;
+var result6;
+var result7;
+var result8;
+var result9;
+var result10;
+import('modules-skip-1.json', null).then(
+    () => assertUnreachable('Should have failed due to non-object parameter'),
+    error => result1 = error.message);
+import('modules-skip-1.json', 7).then(
+    () => assertUnreachable('Should have failed due to non-object parameter'),
+    error => result2 = error.message);
+import('modules-skip-1.json', 'string').then(
+        () => assertUnreachable('Should have failed due to non-object parameter'),
+        error => result3 = error.message);
+import('modules-skip-1.json', { with: null}).then(
+    () => assertUnreachable('Should have failed due to bad with object'),
+    error => result4 = error.message);
+import('modules-skip-1.json', { with: 7}).then(
+    () => assertUnreachable('Should have failed due to bad with object'),
+    error => result5 = error.message);
+import('modules-skip-1.json', { with: 'string'}).then(
+    () => assertUnreachable('Should have failed due to bad with object'),
+    error => result6 = error.message);
+import('modules-skip-1.json', { with: { a: null }}).then(
+    () => assertUnreachable('Should have failed due to bad with object'),
+    error => result7 = error.message);
+import('modules-skip-1.json', { with: { a: undefined }}).then(
+    () => assertUnreachable('Should have failed due to bad assertion value'),
+    error => result8 = error.message);
+import('modules-skip-1.json', { with: { a: 7 }}).then(
+    () => assertUnreachable('Should have failed due to bad assertion value'),
+    error => result9 = error.message);
+    import('modules-skip-1.json', { with: { a: { } }}).then(
+        () => assertUnreachable('Should have failed due to bad assertion value'),
+        error => result10 = error.message);
+
+%PerformMicrotaskCheckpoint();
+
+const argumentNotObjectError = 'The second argument to import() must be an object';
+const assertOptionNotObjectError = 'The \'assert\' option must be an object';
+const assertionValueNotStringError = 'Import assertion value must be a string';
+
+assertEquals(argumentNotObjectError, result1);
+assertEquals(argumentNotObjectError, result2);
+assertEquals(argumentNotObjectError, result3);
+assertEquals(assertOptionNotObjectError, result4);
+assertEquals(assertOptionNotObjectError, result5);
+assertEquals(assertOptionNotObjectError, result6);
+assertEquals(assertionValueNotStringError, result7);
+assertEquals(assertionValueNotStringError, result8);
+assertEquals(assertionValueNotStringError, result9);
+assertEquals(assertionValueNotStringError, result10);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-8.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-8.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.mjs', undefined).then(
+    namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-9.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-9.mjs
@@ -1,0 +1,13 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes
+
+var life;
+import('modules-skip-1.mjs', { with: undefined }).then(
+    namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-assertions-fallback-1.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-assertions-fallback-1.mjs
@@ -1,0 +1,15 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes --harmony-import-assertions
+
+var life;
+import('modules-skip-1.mjs', {
+    with: {},
+    get assert() { throw 'Should not read assert'; }
+}).then(namespace => life = namespace.life());
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-assertions-fallback-2.mjs
+++ b/deps/v8/test/mjsunit/harmony/modules-import-attributes-dynamic-assertions-fallback-2.mjs
@@ -1,0 +1,15 @@
+// Copyright 2021 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --allow-natives-syntax --harmony-import-attributes --harmony-import-assertions
+
+var life;
+import('modules-skip-1.json', {
+    with: undefined,
+    assert: { type: 'json' }
+}).then(namespace => life = namespace.default.life);
+
+%PerformMicrotaskCheckpoint();
+
+assertEquals(42, life);

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -7,6 +7,9 @@
 <!-- YAML
 added: v8.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/50140
+    description: Add experimental support for import attributes.
   - version: v18.19.0
     pr-url: https://github.com/nodejs/node/pull/44710
     description: Module customization hooks are executed off the main thread.
@@ -202,7 +205,7 @@ added: v12.10.0
 
 ```js
 import 'data:text/javascript,console.log("hello!");';
-import _ from 'data:application/json,"world!"' assert { type: 'json' };
+import _ from 'data:application/json,"world!"' with { type: 'json' };
 ```
 
 `data:` URLs only resolve [bare specifiers][Terminology] for builtin modules
@@ -243,7 +246,7 @@ added:
   - v17.1.0
   - v16.14.0
 changes:
-  - version: v18.19.0
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/50140
     description: Switch from Import Assertions to Import Attributes.
 -->
@@ -251,18 +254,17 @@ changes:
 > Stability: 1.1 - Active development
 
 > This feature was previously named "Import assertions", and using the `assert`
-> keyword instead of `with`. Because the version of V8 on this release line does
-> not support the `with` keyword, you need to keep using `assert` to support
-> this version of Node.js.
+> keyword instead of `with`. Any uses in code of the prior `assert` keyword
+> should be updated to use `with` instead.
 
 The [Import Attributes proposal][] adds an inline syntax for module import
 statements to pass on more information alongside the module specifier.
 
 ```js
-import fooData from './foo.json' assert { type: 'json' };
+import fooData from './foo.json' with { type: 'json' };
 
 const { default: barData } =
-  await import('./bar.json', { assert: { type: 'json' } });
+  await import('./bar.json', { with: { type: 'json' } });
 ```
 
 Node.js supports the following `type` values, for which the attribute is
@@ -555,10 +557,10 @@ separate cache.
 JSON files can be referenced by `import`:
 
 ```js
-import packageConfig from './package.json' assert { type: 'json' };
+import packageConfig from './package.json' with { type: 'json' };
 ```
 
-The `assert { type: 'json' }` syntax is mandatory; see [Import Attributes][].
+The `with { type: 'json' }` syntax is mandatory; see [Import Attributes][].
 
 The imported JSON only exposes a `default` export. There is no support for named
 exports. A cache entry is created in the CommonJS cache to avoid duplication.

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -101,7 +101,7 @@ changes:
     using it in a production environment.
     * `specifier` {string} specifier passed to `import()`
     * `script` {vm.Script}
-    * `importAttributes` {Object} The `"assert"` value passed to the
+    * `importAttributes` {Object} The `"with"` value passed to the
       [`optionsExpression`][] optional parameter, or an empty object if no value
       was provided.
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
@@ -633,7 +633,7 @@ changes:
   * `extra` {Object}
     * `attributes` {Object} The data from the attribute:
       ```mjs
-      import foo from 'foo' assert { name: 'value' };
+      import foo from 'foo' with { name: 'value' };
       //                           ^^^^^^^^^^^^^^^^^ the attribute
       ```
       Per ECMA-262, hosts are expected to trigger an error if an
@@ -1025,7 +1025,7 @@ changes:
     considered stable.
     * `specifier` {string} specifier passed to `import()`
     * `function` {Function}
-    * `importAttributes` {Object} The `"assert"` value passed to the
+    * `importAttributes` {Object} The `"with"` value passed to the
       [`optionsExpression`][] optional parameter, or an empty object if no value
       was provided.
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
@@ -1249,7 +1249,7 @@ changes:
     using it in a production environment.
     * `specifier` {string} specifier passed to `import()`
     * `script` {vm.Script}
-    * `importAttributes` {Object} The `"assert"` value passed to the
+    * `importAttributes` {Object} The `"with"` value passed to the
       [`optionsExpression`][] optional parameter, or an empty object if no value
       was provided.
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
@@ -1348,7 +1348,7 @@ changes:
     using it in a production environment.
     * `specifier` {string} specifier passed to `import()`
     * `script` {vm.Script}
-    * `importAttributes` {Object} The `"assert"` value passed to the
+    * `importAttributes` {Object} The `"with"` value passed to the
       [`optionsExpression`][] optional parameter, or an empty object if no value
       was provided.
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is
@@ -1428,7 +1428,7 @@ changes:
     using it in a production environment.
     * `specifier` {string} specifier passed to `import()`
     * `script` {vm.Script}
-    * `importAttributes` {Object} The `"assert"` value passed to the
+    * `importAttributes` {Object} The `"with"` value passed to the
       [`optionsExpression`][] optional parameter, or an empty object if no value
       was provided.
     * Returns: {Module Namespace Object|vm.Module} Returning a `vm.Module` is

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -251,10 +251,14 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
 }
 
 static Local<Object> createImportAttributesContainer(
-    Environment* env, Isolate* isolate, Local<FixedArray> raw_attributes) {
+    Environment* env,
+    Isolate* isolate,
+    Local<FixedArray> raw_attributes,
+    const int elements_per_attribute) {
+  CHECK_EQ(raw_attributes->Length() % elements_per_attribute, 0);
   Local<Object> attributes =
       Object::New(isolate, v8::Null(env->isolate()), nullptr, nullptr, 0);
-  for (int i = 0; i < raw_attributes->Length(); i += 3) {
+  for (int i = 0; i < raw_attributes->Length(); i += elements_per_attribute) {
     attributes
         ->Set(env->context(),
               raw_attributes->Get(env->context(), i).As<String>(),
@@ -300,7 +304,7 @@ void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
 
     Local<FixedArray> raw_attributes = module_request->GetImportAssertions();
     Local<Object> attributes =
-        createImportAttributesContainer(env, isolate, raw_attributes);
+        createImportAttributesContainer(env, isolate, raw_attributes, 3);
 
     Local<Value> argv[] = {
         specifier,
@@ -603,7 +607,7 @@ static MaybeLocal<Promise> ImportModuleDynamically(
   }
 
   Local<Object> attributes =
-      createImportAttributesContainer(env, isolate, import_attributes);
+      createImportAttributesContainer(env, isolate, import_attributes, 2);
 
   Local<Value> import_args[] = {
     object,

--- a/src/node.cc
+++ b/src/node.cc
@@ -745,6 +745,13 @@ int ProcessGlobalArgs(std::vector<std::string>* args,
                 "--no-harmony-import-assertions") == v8_args.end()) {
     v8_args.emplace_back("--harmony-import-assertions");
   }
+  // TODO(aduh95): remove this when the harmony-import-attributes flag
+  // is removed in V8.
+  if (std::find(v8_args.begin(),
+                v8_args.end(),
+                "--no-harmony-import-attributes") == v8_args.end()) {
+    v8_args.emplace_back("--harmony-import-attributes");
+  }
 
   auto env_opts = per_process::cli_options->per_isolate->per_env;
   if (std::find(v8_args.begin(), v8_args.end(),

--- a/test/es-module/test-esm-assertionless-json-import.js
+++ b/test/es-module/test-esm-assertionless-json-import.js
@@ -9,7 +9,7 @@ async function test() {
       import('../fixtures/experimental.json'),
       import(
         '../fixtures/experimental.json',
-        { assert: { type: 'json' } }
+        { with: { type: 'json' } }
       ),
     ]);
 
@@ -24,7 +24,7 @@ async function test() {
       import('../fixtures/experimental.json?test'),
       import(
         '../fixtures/experimental.json?test',
-        { assert: { type: 'json' } }
+        { with: { type: 'json' } }
       ),
     ]);
 
@@ -39,7 +39,7 @@ async function test() {
       import('../fixtures/experimental.json#test'),
       import(
         '../fixtures/experimental.json#test',
-        { assert: { type: 'json' } }
+        { with: { type: 'json' } }
       ),
     ]);
 
@@ -54,7 +54,7 @@ async function test() {
       import('../fixtures/experimental.json?test2#test'),
       import(
         '../fixtures/experimental.json?test2#test',
-        { assert: { type: 'json' } }
+        { with: { type: 'json' } }
       ),
     ]);
 
@@ -69,7 +69,7 @@ async function test() {
       import('data:application/json,{"ofLife":42}'),
       import(
         'data:application/json,{"ofLife":42}',
-        { assert: { type: 'json' } }
+        { with: { type: 'json' } }
       ),
     ]);
 

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -60,21 +60,21 @@ function createBase64URL(mime, body) {
   }
   {
     const ns = await import('data:application/json;foo="test,"this"',
-      { assert: { type: 'json' } });
+      { with: { type: 'json' } });
     assert.deepStrictEqual(Object.keys(ns), ['default']);
     assert.strictEqual(ns.default, 'this');
   }
   {
     const ns = await import(`data:application/json;foo=${
       encodeURIComponent('test,')
-    },0`, { assert: { type: 'json' } });
+    },0`, { with: { type: 'json' } });
     assert.deepStrictEqual(Object.keys(ns), ['default']);
     assert.strictEqual(ns.default, 0);
   }
   {
     await assert.rejects(async () =>
       import('data:application/json;foo="test,",0',
-        { assert: { type: 'json' } }), {
+        { with: { type: 'json' } }), {
       name: 'SyntaxError',
       message: /Unexpected end of JSON input/
     });
@@ -82,14 +82,14 @@ function createBase64URL(mime, body) {
   {
     const body = '{"x": 1}';
     const plainESMURL = createURL('application/json', body);
-    const ns = await import(plainESMURL, { assert: { type: 'json' } });
+    const ns = await import(plainESMURL, { with: { type: 'json' } });
     assert.deepStrictEqual(Object.keys(ns), ['default']);
     assert.strictEqual(ns.default.x, 1);
   }
   {
     const body = '{"default": 2}';
     const plainESMURL = createURL('application/json', body);
-    const ns = await import(plainESMURL, { assert: { type: 'json' } });
+    const ns = await import(plainESMURL, { with: { type: 'json' } });
     assert.deepStrictEqual(Object.keys(ns), ['default']);
     assert.strictEqual(ns.default.default, 2);
   }

--- a/test/es-module/test-esm-dynamic-import-attribute.js
+++ b/test/es-module/test-esm-dynamic-import-attribute.js
@@ -5,7 +5,7 @@ const { strictEqual } = require('assert');
 async function test() {
   {
     const results = await Promise.allSettled([
-      import('../fixtures/empty.js', { assert: { type: 'json' } }),
+      import('../fixtures/empty.js', { with: { type: 'json' } }),
       import('../fixtures/empty.js'),
     ]);
 
@@ -16,7 +16,7 @@ async function test() {
   {
     const results = await Promise.allSettled([
       import('../fixtures/empty.js'),
-      import('../fixtures/empty.js', { assert: { type: 'json' } }),
+      import('../fixtures/empty.js', { with: { type: 'json' } }),
     ]);
 
     strictEqual(results[0].status, 'fulfilled');
@@ -25,7 +25,7 @@ async function test() {
 
   {
     const results = await Promise.allSettled([
-      import('../fixtures/empty.json', { assert: { type: 'json' } }),
+      import('../fixtures/empty.json', { with: { type: 'json' } }),
       import('../fixtures/empty.json'),
     ]);
 
@@ -36,7 +36,7 @@ async function test() {
   {
     const results = await Promise.allSettled([
       import('../fixtures/empty.json'),
-      import('../fixtures/empty.json', { assert: { type: 'json' } }),
+      import('../fixtures/empty.json', { with: { type: 'json' } }),
     ]);
 
     strictEqual(results[0].status, 'rejected');

--- a/test/es-module/test-esm-dynamic-import-attribute.mjs
+++ b/test/es-module/test-esm-dynamic-import-attribute.mjs
@@ -3,7 +3,7 @@ import { strictEqual } from 'assert';
 
 {
   const results = await Promise.allSettled([
-    import('../fixtures/empty.js', { assert: { type: 'json' } }),
+    import('../fixtures/empty.js', { with: { type: 'json' } }),
     import('../fixtures/empty.js'),
   ]);
 
@@ -14,7 +14,7 @@ import { strictEqual } from 'assert';
 {
   const results = await Promise.allSettled([
     import('../fixtures/empty.js'),
-    import('../fixtures/empty.js', { assert: { type: 'json' } }),
+    import('../fixtures/empty.js', { with: { type: 'json' } }),
   ]);
 
   strictEqual(results[0].status, 'fulfilled');
@@ -23,7 +23,7 @@ import { strictEqual } from 'assert';
 
 {
   const results = await Promise.allSettled([
-    import('../fixtures/empty.json', { assert: { type: 'json' } }),
+    import('../fixtures/empty.json', { with: { type: 'json' } }),
     import('../fixtures/empty.json'),
   ]);
 
@@ -34,7 +34,7 @@ import { strictEqual } from 'assert';
 {
   const results = await Promise.allSettled([
     import('../fixtures/empty.json'),
-    import('../fixtures/empty.json', { assert: { type: 'json' } }),
+    import('../fixtures/empty.json', { with: { type: 'json' } }),
   ]);
 
   strictEqual(results[0].status, 'rejected');

--- a/test/es-module/test-esm-import-attributes-1.mjs
+++ b/test/es-module/test-esm-import-attributes-1.mjs
@@ -1,6 +1,6 @@
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 
-import secret from '../fixtures/experimental.json' assert { type: 'json' };
+import secret from '../fixtures/experimental.json' with { type: 'json' };
 
 strictEqual(secret.ofLife, 42);

--- a/test/es-module/test-esm-import-attributes-2.mjs
+++ b/test/es-module/test-esm-import-attributes-2.mjs
@@ -1,9 +1,9 @@
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 
-import secret0 from '../fixtures/experimental.json' assert { type: 'json' };
+import secret0 from '../fixtures/experimental.json' with { type: 'json' };
 const secret1 = await import('../fixtures/experimental.json', {
-  assert: { type: 'json' },
+  with: { type: 'json' },
 });
 
 strictEqual(secret0.ofLife, 42);

--- a/test/es-module/test-esm-import-attributes-3.mjs
+++ b/test/es-module/test-esm-import-attributes-3.mjs
@@ -1,9 +1,9 @@
 import '../common/index.mjs';
 import { strictEqual } from 'assert';
 
-import secret0 from '../fixtures/experimental.json' assert { type: 'json' };
+import secret0 from '../fixtures/experimental.json' with { type: 'json' };
 const secret1 = await import('../fixtures/experimental.json',
-  { assert: { type: 'json' } });
+  { with: { type: 'json' } });
 
 strictEqual(secret0.ofLife, 42);
 strictEqual(secret1.default.ofLife, 42);

--- a/test/es-module/test-esm-import-attributes-errors.js
+++ b/test/es-module/test-esm-import-attributes-errors.js
@@ -27,6 +27,11 @@ async function test() {
   );
 
   await rejects(
+    import(jsModuleDataUrl, { with: { type: 'json', other: 'unsupported' } }),
+    { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
+  );
+
+  await rejects(
     import(jsModuleDataUrl, { with: { type: 'unsupported' } }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
   );

--- a/test/es-module/test-esm-import-attributes-errors.js
+++ b/test/es-module/test-esm-import-attributes-errors.js
@@ -7,27 +7,27 @@ const jsonModuleDataUrl = 'data:application/json,""';
 
 async function test() {
   await rejects(
-    import('data:text/css,', { assert: { type: 'css' } }),
+    import('data:text/css,', { with: { type: 'css' } }),
     { code: 'ERR_UNKNOWN_MODULE_FORMAT' }
   );
 
   await rejects(
-    import('data:text/css,', { assert: { unsupportedAttribute: 'value' } }),
+    import('data:text/css,', { with: { unsupportedAttribute: 'value' } }),
     { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
   );
 
   await rejects(
-    import(`data:text/javascript,import${JSON.stringify(jsModuleDataUrl)}assert{type:"json"}`),
+    import(`data:text/javascript,import${JSON.stringify(jsModuleDataUrl)}with{type:"json"}`),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
   );
 
   await rejects(
-    import(jsModuleDataUrl, { assert: { type: 'json' } }),
+    import(jsModuleDataUrl, { with: { type: 'json' } }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
   );
 
   await rejects(
-    import(jsModuleDataUrl, { assert: { type: 'unsupported' } }),
+    import(jsModuleDataUrl, { with: { type: 'unsupported' } }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
   );
 
@@ -37,17 +37,17 @@ async function test() {
   );
 
   await rejects(
-    import(jsonModuleDataUrl, { assert: {} }),
+    import(jsonModuleDataUrl, { with: {} }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING' }
   );
 
   await rejects(
-    import(jsonModuleDataUrl, { assert: { foo: 'bar' } }),
+    import(jsonModuleDataUrl, { with: { foo: 'bar' } }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING' }
   );
 
   await rejects(
-    import(jsonModuleDataUrl, { assert: { type: 'unsupported' } }),
+    import(jsonModuleDataUrl, { with: { type: 'unsupported' } }),
     { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
   );
 }

--- a/test/es-module/test-esm-import-attributes-errors.mjs
+++ b/test/es-module/test-esm-import-attributes-errors.mjs
@@ -22,6 +22,11 @@ await rejects(
 );
 
 await rejects(
+  import(jsModuleDataUrl, { with: { type: 'json', other: 'unsupported' } }),
+  { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
+);
+
+await rejects(
   import(import.meta.url, { with: { type: 'unsupported' } }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
 );

--- a/test/es-module/test-esm-import-attributes-errors.mjs
+++ b/test/es-module/test-esm-import-attributes-errors.mjs
@@ -7,22 +7,22 @@ const jsonModuleDataUrl = 'data:application/json,""';
 await rejects(
   // This rejects because of the unsupported MIME type, not because of the
   // unsupported assertion.
-  import('data:text/css,', { assert: { type: 'css' } }),
+  import('data:text/css,', { with: { type: 'css' } }),
   { code: 'ERR_UNKNOWN_MODULE_FORMAT' }
 );
 
 await rejects(
-  import(`data:text/javascript,import${JSON.stringify(jsModuleDataUrl)}assert{type:"json"}`),
+  import(`data:text/javascript,import${JSON.stringify(jsModuleDataUrl)}with{type:"json"}`),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
 );
 
 await rejects(
-  import(jsModuleDataUrl, { assert: { type: 'json' } }),
+  import(jsModuleDataUrl, { with: { type: 'json' } }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_FAILED' }
 );
 
 await rejects(
-  import(import.meta.url, { assert: { type: 'unsupported' } }),
+  import(import.meta.url, { with: { type: 'unsupported' } }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
 );
 
@@ -32,16 +32,16 @@ await rejects(
 );
 
 await rejects(
-  import(jsonModuleDataUrl, { assert: {} }),
+  import(jsonModuleDataUrl, { with: {} }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING' }
 );
 
 await rejects(
-  import(jsonModuleDataUrl, { assert: { foo: 'bar' } }),
+  import(jsonModuleDataUrl, { with: { foo: 'bar' } }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING' }
 );
 
 await rejects(
-  import(jsonModuleDataUrl, { assert: { type: 'unsupported' } }),
+  import(jsonModuleDataUrl, { with: { type: 'unsupported' } }),
   { code: 'ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED' }
 );

--- a/test/es-module/test-esm-json-cache.mjs
+++ b/test/es-module/test-esm-json-cache.mjs
@@ -6,7 +6,7 @@ import { createRequire } from 'module';
 
 import mod from '../fixtures/es-modules/json-cache/mod.cjs';
 import another from '../fixtures/es-modules/json-cache/another.cjs';
-import test from '../fixtures/es-modules/json-cache/test.json' assert
+import test from '../fixtures/es-modules/json-cache/test.json' with
   { type: 'json' };
 
 const require = createRequire(import.meta.url);

--- a/test/es-module/test-esm-json.mjs
+++ b/test/es-module/test-esm-json.mjs
@@ -7,7 +7,7 @@ import { describe, it, test } from 'node:test';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import * as tmpdir from '../common/tmpdir.js';
 
-import secret from '../fixtures/experimental.json' assert { type: 'json' };
+import secret from '../fixtures/experimental.json' with { type: 'json' };
 
 describe('ESM: importing JSON', () => {
   it('should load JSON', () => {
@@ -34,19 +34,19 @@ describe('ESM: importing JSON', () => {
         const url = new URL('./foo.json', root);
         await writeFile(url, JSON.stringify({ id: i++ }));
         const absoluteURL = await import(`${url}`, {
-          assert: { type: 'json' },
+          with: { type: 'json' },
         });
         await writeFile(url, JSON.stringify({ id: i++ }));
         const queryString = await import(`${url}?a=2`, {
-          assert: { type: 'json' },
+          with: { type: 'json' },
         });
         await writeFile(url, JSON.stringify({ id: i++ }));
         const hash = await import(`${url}#a=2`, {
-          assert: { type: 'json' },
+          with: { type: 'json' },
         });
         await writeFile(url, JSON.stringify({ id: i++ }));
         const queryStringAndHash = await import(`${url}?a=2#a=2`, {
-          assert: { type: 'json' },
+          with: { type: 'json' },
         });
 
         assert.notDeepStrictEqual(absoluteURL, queryString);

--- a/test/es-module/test-esm-virtual-json.mjs
+++ b/test/es-module/test-esm-virtual-json.mjs
@@ -25,6 +25,6 @@ function load(url, context, next) {
 register(`data:text/javascript,export ${encodeURIComponent(resolve)};export ${encodeURIComponent(load)}`);
 
 assert.notDeepStrictEqual(
-  await import(fixtures.fileURL('empty.json'), { assert: { type: 'json' } }),
-  await import(fixtures.fileURL('empty.json'), { assert: { type: 'json' } }),
+  await import(fixtures.fileURL('empty.json'), { with: { type: 'json' } }),
+  await import(fixtures.fileURL('empty.json'), { with: { type: 'json' } }),
 );

--- a/test/fixtures/es-modules/import-json-named-export.mjs
+++ b/test/fixtures/es-modules/import-json-named-export.mjs
@@ -1,1 +1,1 @@
-import { ofLife } from '../experimental.json' assert { type: 'json' };
+import { ofLife } from '../experimental.json' with { type: 'json' };

--- a/test/fixtures/es-modules/json-modules.mjs
+++ b/test/fixtures/es-modules/json-modules.mjs
@@ -1,1 +1,1 @@
-import secret from '../experimental.json' assert { type: 'json' };
+import secret from '../experimental.json' with { type: 'json' };

--- a/test/parallel/test-vm-module-dynamic-import.js
+++ b/test/parallel/test-vm-module-dynamic-import.js
@@ -58,7 +58,7 @@ async function test() {
   }
 
   {
-    const s = new Script('import("foo", { assert: { key: "value" } })', {
+    const s = new Script('import("foo", { with: { key: "value" } })', {
       importModuleDynamically: common.mustCall((specifier, wrap, attributes) => {
         assert.strictEqual(specifier, 'foo');
         assert.strictEqual(wrap, s);


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/50140, closes https://github.com/nodejs/node/issues/51118

That PR has already been fully backported to v20 (https://github.com/nodejs/node/pull/50183), but it was only partially backported to v18 (https://github.com/nodejs/node/pull/50329).

This PR backports syntax support from V8, that was only backported to v20. With this backport all maintained LTS versions support the new syntax, making it possible for libraries to actually migrate.

cc @aduh95