### PR TITLE
test: fix inconsistency write size in `test-fs-readfile-tostring-fail`

### DIFF
--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 const fs = require('fs');
 const cp = require('child_process');
 const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
-const size = kStringMaxLength / 200;
+const size = Math.floor(kStringMaxLength / 200);
 
 if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');

--- a/test/pummel/test-fs-readfile-tostring-fail.js
+++ b/test/pummel/test-fs-readfile-tostring-fail.js
@@ -9,13 +9,15 @@ const assert = require('assert');
 const fs = require('fs');
 const cp = require('child_process');
 const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
+const size = kStringMaxLength / 200;
+
 if (common.isAIX && (Number(cp.execSync('ulimit -f')) * 512) < kStringMaxLength)
   common.skip('intensive toString tests due to file size confinements');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-if (!tmpdir.hasEnoughSpace(kStringMaxLength)) {
+if (!tmpdir.hasEnoughSpace(kStringMaxLength + size)) {
   common.skip(`Not enough space in ${tmpdir.path}`);
 }
 
@@ -26,7 +28,6 @@ const stream = fs.createWriteStream(file, {
 
 stream.on('error', (err) => { throw err; });
 
-const size = kStringMaxLength / 200;
 const a = Buffer.alloc(size, 'a');
 let expectedSize = 0;
 


### PR DESCRIPTION
In this test, more space is being used than the space being checked.
It's actually using more capacity in `stream.write()` than is written to `kStringMaxLength`.
There are `201` buffers used in the for loop.

Even if this code is fixed, I'm not sure if the unstable tests are resolved.
https://github.com/nodejs/node/blob/1b60054fffc0c67a711cdf3efbcc8f44afab0ce2/test/pummel/test-fs-readfile-tostring-fail.js#L18-L20
https://github.com/nodejs/node/blob/1b60054fffc0c67a711cdf3efbcc8f44afab0ce2/test/pummel/test-fs-readfile-tostring-fail.js#L29-L36

Refs: #51133 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
