### PR TITLE
test_runner: parse escape sequences in spec reporter

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -16,7 +16,7 @@ const Transform = require('internal/streams/transform');
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const colors = require('internal/util/colors');
 const { kSubtestsFailed } = require('internal/test_runner/test');
-const { tapEscape, getCoverageReport } = require('internal/test_runner/utils');
+const { parseEscapeSequence, getCoverageReport } = require('internal/test_runner/utils');
 const { relative } = require('path');
 
 const symbols = {
@@ -73,12 +73,12 @@ class SpecReporter extends Transform {
     let symbol = symbols[type] ?? ' ';
     const { skip, todo } = data;
     const duration_ms = data.details?.duration_ms ? ` ${colors.gray}(${data.details.duration_ms}ms)${colors.white}` : '';
-    let title = tapEscape(`${data.name}${duration_ms}`);
+    let title = parseEscapeSequence(`${data.name}${duration_ms}`);
 
     if (skip !== undefined) {
-      title += ` # ${typeof skip === 'string' && skip.length ? tapEscape(skip) : 'SKIP'}`;
+      title += ` # ${typeof skip === 'string' && skip.length ? parseEscapeSequence(skip) : 'SKIP'}`;
     } else if (todo !== undefined) {
-      title += ` # ${typeof todo === 'string' && todo.length ? tapEscape(todo) : 'TODO'}`;
+      title += ` # ${typeof todo === 'string' && todo.length ? parseEscapeSequence(todo) : 'TODO'}`;
     }
     const error = this.#formatError(data.details?.error, indent);
     if (hasChildren) {

--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -16,7 +16,7 @@ const Transform = require('internal/streams/transform');
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const colors = require('internal/util/colors');
 const { kSubtestsFailed } = require('internal/test_runner/test');
-const { getCoverageReport } = require('internal/test_runner/utils');
+const { getCoverageReport, tapEscape } = require('internal/test_runner/utils');
 const { relative } = require('path');
 
 const symbols = {
@@ -73,12 +73,12 @@ class SpecReporter extends Transform {
     let symbol = symbols[type] ?? ' ';
     const { skip, todo } = data;
     const duration_ms = data.details?.duration_ms ? ` ${colors.gray}(${data.details.duration_ms}ms)${colors.white}` : '';
-    let title = `${data.name}${duration_ms}`;
+    let title = tapEscape(`${data.name}${duration_ms}`);
 
     if (skip !== undefined) {
-      title += ` # ${typeof skip === 'string' && skip.length ? skip : 'SKIP'}`;
+      title += ` # ${typeof skip === 'string' && skip.length ? tapEscape(skip) : 'SKIP'}`;
     } else if (todo !== undefined) {
-      title += ` # ${typeof todo === 'string' && todo.length ? todo : 'TODO'}`;
+      title += ` # ${typeof todo === 'string' && todo.length ? tapEscape(todo) : 'TODO'}`;
     }
     const error = this.#formatError(data.details?.error, indent);
     if (hasChildren) {

--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -16,7 +16,7 @@ const Transform = require('internal/streams/transform');
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const colors = require('internal/util/colors');
 const { kSubtestsFailed } = require('internal/test_runner/test');
-const { getCoverageReport, tapEscape } = require('internal/test_runner/utils');
+const { tapEscape, getCoverageReport } = require('internal/test_runner/utils');
 const { relative } = require('path');
 
 const symbols = {

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -12,7 +12,7 @@ const {
 } = primordials;
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const { isError, kEmptyObject } = require('internal/util');
-const { tapEscape, getCoverageReport } = require('internal/test_runner/utils');
+const { parseEscapeSequence, getCoverageReport } = require('internal/test_runner/utils');
 const kDefaultIndent = '    '; // 4 spaces
 const kFrameStartRegExp = /^ {4}at /;
 const kLineBreakRegExp = /\n|\r\n/;
@@ -43,18 +43,18 @@ async function * tapReporter(source) {
         yield `${indent(data.nesting)}1..${data.count}\n`;
         break;
       case 'test:start':
-        yield `${indent(data.nesting)}# Subtest: ${tapEscape(data.name)}\n`;
+        yield `${indent(data.nesting)}# Subtest: ${parseEscapeSequence(data.name)}\n`;
         break;
       case 'test:stderr':
       case 'test:stdout': {
         const lines = RegExpPrototypeSymbolSplit(kLineBreakRegExp, data.message);
         for (let i = 0; i < lines.length; i++) {
           if (lines[i].length === 0) continue;
-          yield `# ${tapEscape(lines[i])}\n`;
+          yield `# ${parseEscapeSequence(lines[i])}\n`;
         }
         break;
       } case 'test:diagnostic':
-        yield `${indent(data.nesting)}# ${tapEscape(data.message)}\n`;
+        yield `${indent(data.nesting)}# ${parseEscapeSequence(data.message)}\n`;
         break;
       case 'test:coverage':
         yield getCoverageReport(indent(data.nesting), data.summary, '# ', '');
@@ -67,13 +67,13 @@ function reportTest(nesting, testNumber, status, name, skip, todo) {
   let line = `${indent(nesting)}${status} ${testNumber}`;
 
   if (name) {
-    line += ` ${tapEscape(`- ${name}`)}`;
+    line += ` ${parseEscapeSequence(`- ${name}`)}`;
   }
 
   if (skip !== undefined) {
-    line += ` # SKIP${typeof skip === 'string' && skip.length ? ` ${tapEscape(skip)}` : ''}`;
+    line += ` # SKIP${typeof skip === 'string' && skip.length ? ` ${parseEscapeSequence(skip)}` : ''}`;
   } else if (todo !== undefined) {
-    line += ` # TODO${typeof todo === 'string' && todo.length ? ` ${tapEscape(todo)}` : ''}`;
+    line += ` # TODO${typeof todo === 'string' && todo.length ? ` ${parseEscapeSequence(todo)}` : ''}`;
   }
 
   line += '\n';

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -8,12 +8,11 @@ const {
   RegExpPrototypeSymbolSplit,
   SafeMap,
   SafeSet,
-  StringPrototypeReplaceAll,
   StringPrototypeRepeat,
 } = primordials;
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const { isError, kEmptyObject } = require('internal/util');
-const { getCoverageReport } = require('internal/test_runner/utils');
+const { getCoverageReport, tapEscape } = require('internal/test_runner/utils');
 const kDefaultIndent = '    '; // 4 spaces
 const kFrameStartRegExp = /^ {4}at /;
 const kLineBreakRegExp = /\n|\r\n/;
@@ -108,20 +107,6 @@ function indent(nesting) {
   }
 
   return value;
-}
-
-
-// In certain places, # and \ need to be escaped as \# and \\.
-function tapEscape(input) {
-  let result = StringPrototypeReplaceAll(input, '\b', '\\b');
-  result = StringPrototypeReplaceAll(result, '\f', '\\f');
-  result = StringPrototypeReplaceAll(result, '\t', '\\t');
-  result = StringPrototypeReplaceAll(result, '\n', '\\n');
-  result = StringPrototypeReplaceAll(result, '\r', '\\r');
-  result = StringPrototypeReplaceAll(result, '\v', '\\v');
-  result = StringPrototypeReplaceAll(result, '\\', '\\\\');
-  result = StringPrototypeReplaceAll(result, '#', '\\#');
-  return result;
 }
 
 function jsToYaml(indent, name, value, seen) {

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -12,7 +12,7 @@ const {
 } = primordials;
 const { inspectWithNoCustomRetry } = require('internal/errors');
 const { isError, kEmptyObject } = require('internal/util');
-const { getCoverageReport, tapEscape } = require('internal/test_runner/utils');
+const { tapEscape, getCoverageReport } = require('internal/test_runner/utils');
 const kDefaultIndent = '    '; // 4 spaces
 const kFrameStartRegExp = /^ {4}at /;
 const kLineBreakRegExp = /\n|\r\n/;

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -433,8 +433,8 @@ module.exports = {
   isTestFailureError,
   kDefaultPattern,
   parseCommandLine,
+  parseEscapeSequence,
   reporterScope,
   setupTestReporters,
-  parseEscapeSequence,
   getCoverageReport,
 };

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -414,7 +414,7 @@ function getCoverageReport(pad, summary, symbol, color, table) {
 }
 
 // In certain places, # and \ need to be escaped as \# and \\.
-function tapEscape(input) {
+function parseEscapeSequence(input) {
   let result = StringPrototypeReplaceAll(input, '\b', '\\b');
   result = StringPrototypeReplaceAll(result, '\f', '\\f');
   result = StringPrototypeReplaceAll(result, '\t', '\\t');
@@ -435,6 +435,6 @@ module.exports = {
   parseCommandLine,
   reporterScope,
   setupTestReporters,
-  tapEscape,
+  parseEscapeSequence,
   getCoverageReport,
 };

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -17,6 +17,7 @@ const {
   StringPrototypePadStart,
   StringPrototypePadEnd,
   StringPrototypeRepeat,
+  StringPrototypeReplaceAll,
   StringPrototypeSlice,
 } = primordials;
 
@@ -412,6 +413,19 @@ function getCoverageReport(pad, summary, symbol, color, table) {
   return report;
 }
 
+// In certain places, # and \ need to be escaped as \# and \\.
+function tapEscape(input) {
+  let result = StringPrototypeReplaceAll(input, '\b', '\\b');
+  result = StringPrototypeReplaceAll(result, '\f', '\\f');
+  result = StringPrototypeReplaceAll(result, '\t', '\\t');
+  result = StringPrototypeReplaceAll(result, '\n', '\\n');
+  result = StringPrototypeReplaceAll(result, '\r', '\\r');
+  result = StringPrototypeReplaceAll(result, '\v', '\\v');
+  result = StringPrototypeReplaceAll(result, '\\', '\\\\');
+  result = StringPrototypeReplaceAll(result, '#', '\\#');
+  return result;
+}
+
 module.exports = {
   convertStringToRegExp,
   countCompletedTest,
@@ -421,5 +435,6 @@ module.exports = {
   parseCommandLine,
   reporterScope,
   setupTestReporters,
+  tapEscape,
   getCoverageReport,
 };

--- a/test/fixtures/test-runner/output/spec_tap_escape.js
+++ b/test/fixtures/test-runner/output/spec_tap_escape.js
@@ -1,0 +1,11 @@
+'use strict';
+require('../../../common');
+const fixtures = require('../../../common/fixtures');
+const spawn = require('node:child_process').spawn;
+
+const child = spawn(process.execPath,
+                    ['--no-warnings','--test-reporter', 'spec', fixtures.path('test-runner/output/tap_escape.js')],
+                    { stdio: 'pipe' });
+// eslint-disable-next-line no-control-regex
+child.stdout.on('data', (d) => process.stdout.write(d.toString()));
+child.stderr.pipe(process.stderr);

--- a/test/fixtures/test-runner/output/spec_tap_escape.snapshot
+++ b/test/fixtures/test-runner/output/spec_tap_escape.snapshot
@@ -1,0 +1,13 @@
+✔ escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r (*ms)
+﹣ escaped skip message (*ms) # \#skip
+✔ escaped todo message (*ms) # \#todo
+✔ escaped diagnostic (*ms)
+ℹ #diagnostic
+ℹ tests 4
+ℹ suites 0
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 1
+ℹ todo 1
+ℹ duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -127,6 +127,10 @@ const tests = [
       replaceTestDuration,
     ),
   },
+  {
+    name: 'test-runner/output/spec_tap_escape.js',
+    transform: specTransform,
+  },
   process.features.inspector ? { name: 'test-runner/output/coverage_failure.js' } : false,
 ]
 .filter(Boolean)


### PR DESCRIPTION
Code: 
```js
import test from "node:test"

test('escaped description \\ # \\#\\ \n \t \f \v \b \r');
```

before:

```bash
✔ escaped description \ # \#\ 
         
          
 (0.865459ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7.378084
```

now:

```bash
✔ escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r (1.436458ms)
ℹ tests 1
ℹ suites 0
ℹ pass 1
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 9.951791
```