### PR TITLE
src,stream: Improve WriteString

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -91,7 +91,7 @@ StreamWriteResult StreamBase::Write(uv_buf_t* bufs,
   for (size_t i = 0; i < count; ++i) total_bytes += bufs[i].len;
   bytes_written_ += total_bytes;
 
-  if (send_handle == nullptr && !skip_try_write) {
+  if (send_handle == nullptr && HasDoTryWrite() && !skip_try_write) {
     err = DoTryWrite(&bufs, &count);
     if (err != 0 || count == 0) {
       return StreamWriteResult{false, err, nullptr, total_bytes, {}};
@@ -365,7 +365,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
   size_t synchronously_written = 0;
   uv_buf_t buf;
 
-  bool try_write = storage_size <= sizeof(stack_storage) &&
+  bool try_write = HasDoTryWrite() && storage_size <= sizeof(stack_storage) &&
                    (!IsIPCPipe() || send_handle_obj.IsEmpty());
   if (try_write) {
     data_size = StringBytes::Write(isolate,

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -244,6 +244,7 @@ class StreamResource {
   // `*bufs` and `*count` accordingly. This is a no-op by default.
   // Return 0 for success and a libuv error code for failures.
   virtual int DoTryWrite(uv_buf_t** bufs, size_t* count);
+  // Indicates whether this subclass override the DoTryWrite
   virtual inline bool HasDoTryWrite() const { return false; }
   // Initiate a write of data.
   // Upon an immediate failure, a libuv error code is returned,

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -244,6 +244,7 @@ class StreamResource {
   // `*bufs` and `*count` accordingly. This is a no-op by default.
   // Return 0 for success and a libuv error code for failures.
   virtual int DoTryWrite(uv_buf_t** bufs, size_t* count);
+  virtual inline bool HasDoTryWrite() const { return false; }
   // Initiate a write of data.
   // Upon an immediate failure, a libuv error code is returned,
   // w->Done() will never be called and caller should free `bufs`.

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -244,7 +244,7 @@ class StreamResource {
   // `*bufs` and `*count` accordingly. This is a no-op by default.
   // Return 0 for success and a libuv error code for failures.
   virtual int DoTryWrite(uv_buf_t** bufs, size_t* count);
-  // Indicates whether this subclass override the DoTryWrite
+  // Indicates whether this subclass overrides the DoTryWrite
   virtual inline bool HasDoTryWrite() const { return false; }
   // Initiate a write of data.
   // Upon an immediate failure, a libuv error code is returned,

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -52,6 +52,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   // Resource implementation
   int DoShutdown(ShutdownWrap* req_wrap) override;
   int DoTryWrite(uv_buf_t** bufs, size_t* count) override;
+  inline bool HasDoTryWrite() const override { return true; };
   int DoWrite(WriteWrap* w,
               uv_buf_t* bufs,
               size_t count,

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -52,7 +52,7 @@ class LibuvStreamWrap : public HandleWrap, public StreamBase {
   // Resource implementation
   int DoShutdown(ShutdownWrap* req_wrap) override;
   int DoTryWrite(uv_buf_t** bufs, size_t* count) override;
-  inline bool HasDoTryWrite() const override { return true; };
+  inline bool HasDoTryWrite() const override { return true; }
   int DoWrite(WriteWrap* w,
               uv_buf_t* bufs,
               size_t count,


### PR DESCRIPTION
Introduce HasDoTryWrite in order to eliminate the unnecessary memory copy in WriteString for StreamBase not overriding DoTryWrite, e.g. TLSWrap, HTTP2Session

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
