### PR TITLE
module: move the CJS exports cache to internal/modules/cjs/loader

### DIFF
--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -291,10 +291,11 @@ rawMethods.resetStdioForTesting = function() {
 require('fs');
 require('util');
 require('url'); // eslint-disable-line no-restricted-modules
-
+internalBinding('module_wrap');
 require('internal/modules/cjs/loader');
 require('internal/modules/esm/utils');
 require('internal/vm/module');
+
 // Needed to refresh the time origin.
 require('internal/perf/utils');
 // Needed to register the async hooks.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -65,12 +65,19 @@ const {
 
 // Map used to store CJS parsing data.
 const cjsParseCache = new SafeWeakMap();
+/**
+ * Map of already-loaded CJS modules to use.
+ */
+const cjsExportsCache = new SafeWeakMap();
 
 // Set first due to cycle with ESM loader functions.
 module.exports = {
-  wrapSafe, Module, cjsParseCache,
-  get hasLoadedAnyUserCJSModule() { return hasLoadedAnyUserCJSModule; },
+  cjsExportsCache,
+  cjsParseCache,
   initializeCJS,
+  Module,
+  wrapSafe,
+  get hasLoadedAnyUserCJSModule() { return hasLoadedAnyUserCJSModule; },
 };
 
 const { BuiltinModule } = require('internal/bootstrap/realm');
@@ -150,7 +157,6 @@ const {
   isProxy,
 } = require('internal/util/types');
 
-const { kEvaluated } = internalBinding('module_wrap');
 const isWindows = process.platform === 'win32';
 
 const relativeResolveCache = { __proto__: null };
@@ -1206,14 +1212,11 @@ Module.prototype.load = function(filename) {
   Module._extensions[extension](this, filename);
   this.loaded = true;
 
-  const cascadedLoader = getCascadedLoader();
   // Create module entry at load time to snapshot exports correctly
   const exports = this.exports;
-  // Preemptively cache
-  if ((module?.module === undefined ||
-       module.module.getStatus() < kEvaluated) &&
-      !cascadedLoader.cjsCache.has(this)) {
-    cascadedLoader.cjsCache.set(this, exports);
+  // Preemptively cache for ESM loader.
+  if (!cjsExportsCache.has(this)) {
+    cjsExportsCache.set(this, exports);
   }
 };
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -11,7 +11,6 @@ const {
   JSONStringify,
   ObjectSetPrototypeOf,
   RegExpPrototypeSymbolReplace,
-  SafeWeakMap,
   encodeURIComponent,
   hardenRegExp,
 } = primordials;
@@ -85,11 +84,6 @@ class ModuleLoader {
    * The conditions for resolving packages if `--conditions` is not used.
    */
   #defaultConditions = getDefaultConditions();
-
-  /**
-   * Map of already-loaded CJS modules to use
-   */
-  cjsCache = new SafeWeakMap();
 
   /**
    * The index for assigning unique URLs to anonymous module evaluation

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -42,6 +42,7 @@ const {
 const {
   Module: CJSModule,
   cjsParseCache,
+  cjsExportsCache,
 } = require('internal/modules/cjs/loader');
 const { fileURLToPath, pathToFileURL, URL } = require('internal/url');
 let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
@@ -308,9 +309,9 @@ function createCJSModuleWrap(url, source, isMain, loadCJS = loadCJSModule) {
     }
 
     let exports;
-    if (asyncESM.esmLoader.cjsCache.has(module)) {
-      exports = asyncESM.esmLoader.cjsCache.get(module);
-      asyncESM.esmLoader.cjsCache.delete(module);
+    if (cjsExportsCache.has(module)) {
+      exports = cjsExportsCache.get(module);
+      cjsExportsCache.delete(module);
     } else {
       ({ exports } = module);
     }


### PR DESCRIPTION
This puts it together with the cjsParseCache and reduces the circular dependency on the singleton loader, which is the only place where this cache is stored.

Drive-by: remove always-false module status check because there's no longer a local module variable after
https://github.com/nodejs/node/pull/34605 which is now invalid leftover code at this point and only doesn't throw because we happen to have a top-level variable called module.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
