### PR TITLE
watch: fix infinite loop when passing --watch=true flag

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -41,7 +41,7 @@ const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
   !StringPrototypeStartsWith(arg, '--watch-path') &&
   (!arr[i - 1] || !StringPrototypeStartsWith(arr[i - 1], '--watch-path')) &&
-  arg !== '--watch' && arg !== '--watch-preserve-output');
+  arg !== '--watch' && !StringPrototypeStartsWith(arg, '--watch=') && arg !== '--watch-preserve-output');
 ArrayPrototypePushApply(args, kCommand);
 
 const watcher = new FilesWatcher({ debounce: 200, mode: kShouldFilterModules ? 'filter' : 'all' });


### PR DESCRIPTION
fix: #51159 

code: 

```js
console.log("hello world!");
```

run with cmd: `./node --watch=true index.mjs`

before: 
```bash
pulkitgupta@Pulkits-MacBook-Air node % ./node --watch=true index.mjs
(node:26067) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26068) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26069) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26070) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26071) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26072) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26073) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26074) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26075) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26076) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:26077) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
^C%   
```

now:

```bash
pulkitgupta@Pulkits-MacBook-Air node % ./node --watch=true index.mjs
(node:88235) ExperimentalWarning: Watch mode is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Hello world
Completed running 'index.mjs'
```


Note: watch-mode will be activated with `--watch=false` flag as well
