### PR TITLE
trace_events: use private fields instead of symbols for `Tracing`

### DIFF
--- a/lib/trace_events.js
+++ b/lib/trace_events.js
@@ -3,13 +3,9 @@
 const {
   ArrayPrototypeJoin,
   SafeSet,
-  Symbol,
 } = primordials;
 
 const { hasTracing } = internalBinding('config');
-const kHandle = Symbol('handle');
-const kEnabled = Symbol('enabled');
-const kCategories = Symbol('categories');
 
 const kMaxTracingCount = 10;
 
@@ -33,16 +29,19 @@ const {
 const enabledTracingObjects = new SafeSet();
 
 class Tracing {
+  #handle;
+  #categories;
+  #enabled = false;
+
   constructor(categories) {
-    this[kHandle] = new CategorySet(categories);
-    this[kCategories] = categories;
-    this[kEnabled] = false;
+    this.#handle = new CategorySet(categories);
+    this.#categories = categories;
   }
 
   enable() {
-    if (!this[kEnabled]) {
-      this[kEnabled] = true;
-      this[kHandle].enable();
+    if (!this.#enabled) {
+      this.#enabled = true;
+      this.#handle.enable();
       enabledTracingObjects.add(this);
       if (enabledTracingObjects.size > kMaxTracingCount) {
         process.emitWarning(
@@ -54,19 +53,19 @@ class Tracing {
   }
 
   disable() {
-    if (this[kEnabled]) {
-      this[kEnabled] = false;
-      this[kHandle].disable();
+    if (this.#enabled) {
+      this.#enabled = false;
+      this.#handle.disable();
       enabledTracingObjects.delete(this);
     }
   }
 
   get enabled() {
-    return this[kEnabled];
+    return this.#enabled;
   }
 
   get categories() {
-    return ArrayPrototypeJoin(this[kCategories], ',');
+    return ArrayPrototypeJoin(this.#categories, ',');
   }
 
   [customInspectSymbol](depth, opts) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2920,7 +2920,7 @@ assert.strictEqual(
   try {
     const trace = require('trace_events').createTracing({ categories: ['fo'] });
     const actualDepth0 = util.inspect({ trace }, { depth: 0 });
-    assert.strictEqual(actualDepth0, '{ trace: [Tracing] }');
+    assert.strictEqual(actualDepth0, '{ trace: Tracing {} }');
     const actualDepth1 = util.inspect({ trace }, { depth: 1 });
     assert.strictEqual(
       actualDepth1,


### PR DESCRIPTION
A small refactor to replace Symbols with private properties.

Refs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
