### PR TITLE
doc: mention native addons are restricted in pm

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -482,7 +482,7 @@ flag.
 
 When starting Node.js with `--experimental-permission`,
 the ability to access the file system through the `fs` module, spawn processes,
-use `node:worker_threads` and enable the runtime inspector
+use `node:worker_threads`, native addons and enable the runtime inspector
 will be restricted.
 
 ```console

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -482,7 +482,7 @@ flag.
 
 When starting Node.js with `--experimental-permission`,
 the ability to access the file system through the `fs` module, spawn processes,
-use `node:worker_threads`, native addons and enable the runtime inspector
+use `node:worker_threads`, native addons, and enable the runtime inspector
 will be restricted.
 
 ```console


### PR DESCRIPTION
Clarifying native addons are restricted by default when using the permission model.