### PR TITLE
fs: remove `internalModuleReadJSON` binding

### DIFF
--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -260,7 +260,6 @@ export interface FsBinding {
   fsync: typeof InternalFSBinding.fsync;
   ftruncate: typeof InternalFSBinding.ftruncate;
   futimes: typeof InternalFSBinding.futimes;
-  internalModuleReadJSON: typeof InternalFSBinding.internalModuleReadJSON;
   internalModuleStat: typeof InternalFSBinding.internalModuleStat;
   lchown: typeof InternalFSBinding.lchown;
   link: typeof InternalFSBinding.link;


### PR DESCRIPTION
This function got removed in one of the previous pull requests and we forgot it to remove it from typings.

Refs: https://github.com/nodejs/node/commit/45e4f82912