### PR TITLE
fs: add missing jsdoc parameters to `readSync`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -703,6 +703,8 @@ ObjectDefineProperty(read, kCustomPromisifyArgsSymbol,
  *   length?: number;
  *   position?: number | bigint | null;
  *   }} [offsetOrOptions]
+ * @param {number} [length]
+ * @param {number} [position]
  * @returns {number}
  */
 function readSync(fd, buffer, offsetOrOptions, length, position) {


### PR DESCRIPTION
Adds missing optional JSDoc parameters to `fs.readFile`