### PR TITLE
Optimize Memory Usage by Hoisting Function in For Loop 💽

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -520,13 +520,12 @@ primordials.SafePromiseAllReturnArrayLike = (promises, mapFn) =>
     if (length === 0) resolve(returnVal);
 
     let pendingPromises = length;
-    const handlePromiseResult = (i) => (result) => {
-      returnVal[i] = result;
-      if (--pendingPromises === 0) resolve(returnVal);
-    };
     for (let i = 0; i < length; i++) {
       const promise = mapFn != null ? mapFn(promises[i], i) : promises[i];
-      PromisePrototypeThen(PromiseResolve(promise), handlePromiseResult(i), reject);
+      PromisePrototypeThen(PromiseResolve(promise), (result) => {
+        returnVal[i] = result;
+        if (--pendingPromises === 0) resolve(returnVal);
+      }, reject);
     }
   });
 

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -541,7 +541,7 @@ primordials.SafePromiseAllReturnVoid = (promises, mapFn) =>
   new Promise((resolve, reject) => {
     let pendingPromises = promises.length;
     if (pendingPromises === 0) resolve();
-    const onPromiseSettled = () => {
+    const onFulfilled = () => {
       if (--pendingPromises === 0) {
         resolve();
       }

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -520,12 +520,13 @@ primordials.SafePromiseAllReturnArrayLike = (promises, mapFn) =>
     if (length === 0) resolve(returnVal);
 
     let pendingPromises = length;
+    const handlePromiseResult = (i) => (result) => {
+      returnVal[i] = result;
+      if (--pendingPromises === 0) resolve(returnVal);
+    };
     for (let i = 0; i < length; i++) {
       const promise = mapFn != null ? mapFn(promises[i], i) : promises[i];
-      PromisePrototypeThen(PromiseResolve(promise), (result) => {
-        returnVal[i] = result;
-        if (--pendingPromises === 0) resolve(returnVal);
-      }, reject);
+      PromisePrototypeThen(PromiseResolve(promise), handlePromiseResult(i), reject);
     }
   });
 
@@ -541,11 +542,14 @@ primordials.SafePromiseAllReturnVoid = (promises, mapFn) =>
   new Promise((resolve, reject) => {
     let pendingPromises = promises.length;
     if (pendingPromises === 0) resolve();
+    const onPromiseSettled = () => {
+      if (--pendingPromises === 0) {
+        resolve();
+      }
+    };
     for (let i = 0; i < promises.length; i++) {
       const promise = mapFn != null ? mapFn(promises[i], i) : promises[i];
-      PromisePrototypeThen(PromiseResolve(promise), () => {
-        if (--pendingPromises === 0) resolve();
-      }, reject);
+      PromisePrototypeThen(PromiseResolve(promise), onPromiseSettled, reject);
     }
   });
 

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -548,7 +548,7 @@ primordials.SafePromiseAllReturnVoid = (promises, mapFn) =>
     };
     for (let i = 0; i < promises.length; i++) {
       const promise = mapFn != null ? mapFn(promises[i], i) : promises[i];
-      PromisePrototypeThen(PromiseResolve(promise), onPromiseSettled, reject);
+      PromisePrototypeThen(PromiseResolve(promise), onFulfilled, reject);
     }
   });
 


### PR DESCRIPTION
Hi, this pull request introduces a very minor improvement in memory usage by hoisting the function outside the for loop. This adjustment offers benefits such as reducing the overhead of redefining the function in each iteration, resulting in a more optimized and efficient code execution.

Extremely sorry, if I made any mistakes :)