### PR TITLE
lib: reduce overhead of `SafePromiseAllSettledReturnVoid` calls

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -570,9 +570,17 @@ primordials.SafePromiseAllSettled = (promises, mapFn) =>
  * @param {(v: T|PromiseLike<T>, k: number) => U|PromiseLike<U>} [mapFn]
  * @returns {Promise<void>}
  */
-primordials.SafePromiseAllSettledReturnVoid = async (promises, mapFn) => {
-  await primordials.SafePromiseAllSettled(promises, mapFn);
-};
+primordials.SafePromiseAllSettledReturnVoid = (promises, mapFn) => new Promise((resolve) => {
+  let pendingPromises = promises.length;
+  if (pendingPromises === 0) resolve();
+  const onSettle = () => {
+    if (--pendingPromises === 0) resolve();
+  };
+  for (let i = 0; i < promises.length; i++) {
+    const promise = mapFn != null ? mapFn(promises[i], i) : promises[i];
+    PromisePrototypeThen(PromiseResolve(promise), onSettle, onSettle);
+  }
+});
 
 /**
  * @template T,U


### PR DESCRIPTION
It was simply calling `SafePromiseAllSettled`, which itself calls `arrayToSafePromiseIterable` which wraps all promises into new `SafePromise` object and wraps it into a `SafeArrayIterator`. Since we don't care about the return value, we can take some shortcuts.

https://github.com/nodejs/node/blob/fd21429ef5f6c2c06ce9e108a8548a1703577714/lib/internal/per_context/primordials.js#L483-L490

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
