### PR TITLE
streams: fix cloned webstreams not being unref'd

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -609,6 +609,8 @@ class ReadableStream {
 
   [kTransferList]() {
     const { port1, port2 } = new MessageChannel();
+    port1.unref();
+    port2.unref();
     this[kState].transfer.port1 = port1;
     this[kState].transfer.port2 = port2;
     return [ port2 ];

--- a/lib/internal/webstreams/transfer.js
+++ b/lib/internal/webstreams/transfer.js
@@ -143,6 +143,8 @@ class CrossRealmTransformReadableSource {
         error);
       port.close();
     };
+
+    port.unref();
   }
 
   start(controller) {
@@ -210,7 +212,7 @@ class CrossRealmTransformWritableSink {
         error);
       port.close();
     };
-
+    port.unref();
   }
 
   start(controller) {

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -304,6 +304,8 @@ class WritableStream {
 
   [kTransferList]() {
     const { port1, port2 } = new MessageChannel();
+    port1.unref();
+    port2.unref();
     this[kState].transfer.port1 = port1;
     this[kState].transfer.port2 = port2;
     return [ port2 ];

--- a/test/parallel/test-webstreams-clone-unref.js
+++ b/test/parallel/test-webstreams-clone-unref.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('../common');
+const { ok } = require('node:assert');
+
+// This test verifies that cloned ReadableStream and WritableStream instances
+// do not keep the process alive. The test fails if it timesout (it should just
+// exit immediately)
+
+const rs1 = new ReadableStream();
+const ws1 = new WritableStream();
+
+const [rs2, ws2] = structuredClone([rs1, ws1], { transfer: [rs1, ws1] });
+
+ok(rs2 instanceof ReadableStream);
+ok(ws2 instanceof WritableStream);

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -465,7 +465,13 @@ const theData = 'hello';
     });
 
     // We create an interval to keep the event loop alive while
-    // we wait for the stream read to complete.
+    // we wait for the stream read to complete. The reason this is needed is because there's
+    // otherwise nothing to keep the worker thread event loop alive long enough to actually
+    // complete the read from the stream. Under the covers the ReadableStream uses an
+    // unref'd MessagePort to communicate with the main thread. Because the MessagePort
+    // is unref'd, it's existence would not keep the thread alive on its own. There was previously
+    // a bug where this MessagePort was ref'd which would block the thread and main thread
+    // from terminating at all unless the stream was consumed/closed.
     const i = setInterval(() => {}, 1000);
 
     parentPort.onmessage = tracker.calls(({ data }) => {

--- a/test/parallel/test-whatwg-webstreams-transfer.js
+++ b/test/parallel/test-whatwg-webstreams-transfer.js
@@ -464,12 +464,17 @@ const theData = 'hello';
       tracker.verify();
     });
 
+    // We create an interval to keep the event loop alive while
+    // we wait for the stream read to complete.
+    const i = setInterval(() => {}, 1000);
+
     parentPort.onmessage = tracker.calls(({ data }) => {
       assert(isReadableStream(data));
       const reader = data.getReader();
       reader.read().then(tracker.calls((result) => {
         assert(!result.done);
         assert(result.value instanceof Uint8Array);
+        clearInterval(i);
       }));
       parentPort.close();
     });


### PR DESCRIPTION
When cloning a `ReadableStream` and `WritableStream`, both use an internal `MessageChannel` to communicate with the original stream. Those, however, previously were not unref'd which would lead to the process not exiting if the stream was not fully consumed.

Alternative for: https://github.com/nodejs/node/pull/51131

Fixes: https://github.com/nodejs/node/issues/44985

Semver-major because this can change whether a worker thread stays alive solely because of the existence of the cloned streams vs. needing something else to keep it alive (see the modified test in this PR for instance).
