### PR TITLE
build: fix arm64 cross-compilation

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1273,9 +1273,7 @@ def configure_node(o):
 
   o['variables']['want_separate_host_toolset'] = int(cross_compiling)
 
-  # Enable branch protection for arm64
   if target_arch == 'arm64':
-    o['cflags']+=['-msign-return-address=all']
     o['variables']['arm_fpu'] = options.arm_fpu or 'neon'
 
   if options.node_snapshot_main is not None:

--- a/node.gyp
+++ b/node.gyp
@@ -470,6 +470,9 @@
     },
 
     'conditions': [
+      ['target_arch=="arm64"', {
+        'cflags': ['-mbranch-protection=standard'],  # Pointer authentication.
+      }],
       ['OS in "aix os400"', {
         'ldflags': [
           '-Wl,-bnoerrmsg',


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/45756 (@bnoordhuis)

Commit 938212f added -msign-return-address=all to _all_ cflags but that
is wrong when cross-compiling, it should only be added to the target's
cflags.

The flag being deprecated, it is also changed to
`-mbranch-protection=standard`.

Fixes: https://github.com/nodejs/node/issues/42888
Fixes: https://github.com/nodejs/build/issues/3319