### PR TITLE
build: add `-flax-vector-conversions` to V8 build

### DIFF
--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -138,7 +138,11 @@
         'cflags': [ '-Werror', '-Wno-unknown-pragmas' ],
       },{
         'cflags!': [ '-Wall', '-Wextra' ],
-        'cflags': [ '-Wno-return-type' ],
+        'cflags': [
+          '-Wno-return-type',
+          # On by default in Clang and V8 requires it at least for arm64.
+          '-flax-vector-conversions',
+        ],
       }],
       ['clang or OS!="win"', {
         'cflags': [ '-Wno-invalid-offsetof' ],


### PR DESCRIPTION
The flag is on by default in Clang and V8 recently made a change that makes it
necessary with GCC.

Refs: https://github.com/v8/v8/commit/7fbbf93ea879863c1b92ef1a829190b3a31e544c
Refs: https://github.com/llvm/llvm-project/blob/54067c5fbe9fc13ab195cdddb8f17e18d72b5fe4/clang/include/clang/Basic/LangOptions.def#L133-L134
Refs: https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#index-flax-vector-conversions

Failing canary build before the change: https://ci.nodejs.org/job/node-test-commit-arm-debug/11011/nodes=ubuntu2004_debug-arm64/console
Successful canary build with the change: https://ci.nodejs.org/job/node-test-commit-arm-debug/11012/nodes=ubuntu2004_debug-arm64/console
