### PR TITLE
util: pass invalidSubtypeIndex instead of trimmedSubtype to error

### DIFF
--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -70,7 +70,7 @@ function parseTypeAndSubtype(str) {
   const invalidSubtypeIndex = SafeStringPrototypeSearch(trimmedSubtype,
                                                         NOT_HTTP_TOKEN_CODE_POINT);
   if (trimmedSubtype === '' || invalidSubtypeIndex !== -1) {
-    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, trimmedSubtype);
+    throw new ERR_INVALID_MIME_SYNTAX('subtype', str, invalidSubtypeIndex);
   }
   const subtype = toASCIILower(trimmedSubtype);
   return [


### PR DESCRIPTION
Followup from: #49711 

The error `ERR_INVALID_MIME_SYNTAX` expects the invalid index which wasn't being passed.