### PR TITLE
run microtasks before ticks

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -863,6 +863,20 @@ Use this flag to generate a blob that can be injected into the Node.js
 binary to produce a [single executable application][]. See the documentation
 about [this configuration][`--experimental-sea-config`] for details.
 
+
+### `--experimental-task-ordering`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Enable experimental task ordering. Always drain micro task queue
+before running `process.nextTick` to avoid unintuitive behavior
+and unexpected logical deadlocks when mixing async callback and
+event API's with `Promise`, `async`/`await`` and `queueMicroTask`.
+
 ### `--experimental-shadow-realm`
 
 <!-- YAML

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -41,6 +41,7 @@ const {
 
 const { AsyncResource } = require('async_hooks');
 
+let experimentalTaskOrdering;
 // *Must* match Environment::TickInfo::Fields in src/env.h.
 const kHasTickScheduled = 0;
 
@@ -65,8 +66,16 @@ function runNextTicks() {
 }
 
 function processTicksAndRejections() {
+  if (experimentalTaskOrdering === undefined) {
+    const { getOptionValue } = require('internal/options');
+    experimentalTaskOrdering = getOptionValue('--experimental-task-ordering');
+  }
+
   let tock;
   do {
+    if (experimentalTaskOrdering) {
+      runMicrotasks();
+    }
     while ((tock = queue.shift()) !== null) {
       const asyncId = tock[async_id_symbol];
       emitBefore(asyncId, tock[trigger_async_id_symbol], tock);
@@ -92,7 +101,9 @@ function processTicksAndRejections() {
 
       emitAfter(asyncId);
     }
-    runMicrotasks();
+    if (!experimentalTaskOrdering) {
+      runMicrotasks();
+    }
   } while (!queue.isEmpty() || processPromiseRejections());
   setHasTickScheduled(false);
   setHasRejectionToWarn(false);


### PR DESCRIPTION
This resolve multiple timing issues related to promises and nextTick. As well as resolving zaldo in promise only code, i.e. our current best practice of using process.nextTick will always apply and work.

Enable experimental task ordering. Always drain micro task queue before running `process.nextTick` to avoid unintuitive behavior and unexpected logical deadlocks when mixing async callback and event API's with `Promise`, `async`/`await` and `queueMicroTask`.

Refs: https://github.com/nodejs/node/issues/51156
Refs: https://github.com/nodejs/node/issues/51156
Refs: https://github.com/nodejs/node/pull/51114#issuecomment-1868240741
Refs: https://github.com/nodejs/node/pull/51070
Refs: https://github.com/nodejs/node/issues/51156

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
