### PR TITLE
src: use v8 fast api on `runMicroTasks()`

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -13,6 +13,7 @@ namespace node {
 using CFunctionCallbackWithOneByteString =
     uint32_t (*)(v8::Local<v8::Value>, const v8::FastOneByteString&);
 using CFunctionCallback = void (*)(v8::Local<v8::Value> receiver);
+using CFunctionCallbackReturnVoid = void (*)(v8::Local<v8::Object> receiver);
 using CFunctionCallbackReturnDouble =
     double (*)(v8::Local<v8::Object> receiver);
 using CFunctionCallbackValueReturnDouble =
@@ -39,6 +40,7 @@ class ExternalReferenceRegistry {
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
   V(CFunctionCallback)                                                         \
   V(CFunctionCallbackWithOneByteString)                                        \
+  V(CFunctionCallbackReturnVoid)                                               \
   V(CFunctionCallbackReturnDouble)                                             \
   V(CFunctionCallbackValueReturnDouble)                                        \
   V(CFunctionCallbackWithInt64)                                                \


### PR DESCRIPTION
I'm having crashes due to `GetCreationContextChecked()`. Any suggestions? @joyeecheung @legendecas 

Example crash:

```
=== release test-file-write-stream4 ===
Path: parallel/test-file-write-stream4
FATAL ERROR: v8::Object::GetCreationContextChecked No creation context available
----- Native stack trace -----

 1: 0x1045df464 node::OnFatalError(char const*, char const*) [/Users/yagiz/coding/node/out/Release/node]
 2: 0x1047c0ec8 v8::Object::GetCreationContextChecked() [/Users/yagiz/coding/node/out/Release/node]
 3: 0x1046900fc node::task_queue::FastRunMicrotasks(v8::Local<v8::Object>) [/Users/yagiz/coding/node/out/Release/node]
 4: 0x10a364c70
 5: 0x1050a28ac Builtins_JSEntryTrampoline [/Users/yagiz/coding/node/out/Release/node]
 6: 0x1050a2594 Builtins_JSEntry [/Users/yagiz/coding/node/out/Release/node]
 7: 0x10491fdbc v8::internal::(anonymous namespace)::Invoke(v8::internal::Isolate*, v8::internal::(anonymous namespace)::InvokeParams const&) [/Users/yagiz/coding/node/out/Release/node]
 8: 0x10491f6dc v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*) [/Users/yagiz/coding/node/out/Release/node]
 9: 0x1047c20e0 v8::Function::Call(v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*) [/Users/yagiz/coding/node/out/Release/node]
10: 0x1044ff138 node::InternalCallbackScope::Close() [/Users/yagiz/coding/node/out/Release/node]
11: 0x1044ff390 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [/Users/yagiz/coding/node/out/Release/node]
12: 0x104513784 node::AsyncWrap::MakeCallback(v8::Local<v8::Function>, int, v8::Local<v8::Value>*) [/Users/yagiz/coding/node/out/Release/node]
13: 0x1045e5158 node::fs::FSReqCallback::Resolve(v8::Local<v8::Value>) [/Users/yagiz/coding/node/out/Release/node]
14: 0x1045e5e44 node::fs::AfterInteger(uv_fs_s*) [/Users/yagiz/coding/node/out/Release/node]
15: 0x1045d9acc node::MakeLibuvRequestCallback<uv_fs_s, void (*)(uv_fs_s*)>::Wrapper(uv_fs_s*) [/Users/yagiz/coding/node/out/Release/node]
16: 0x105080a70 uv__work_done [/Users/yagiz/coding/node/out/Release/node]
17: 0x1050844b8 uv__async_io [/Users/yagiz/coding/node/out/Release/node]
18: 0x10509751c uv__io_poll [/Users/yagiz/coding/node/out/Release/node]
19: 0x105084a50 uv_run [/Users/yagiz/coding/node/out/Release/node]
20: 0x1044ffbd0 node::SpinEventLoopInternal(node::Environment*) [/Users/yagiz/coding/node/out/Release/node]
21: 0x1046225c4 node::NodeMainInstance::Run(node::ExitCode*, node::Environment*) [/Users/yagiz/coding/node/out/Release/node]
22: 0x104622370 node::NodeMainInstance::Run() [/Users/yagiz/coding/node/out/Release/node]
23: 0x1045a43d8 node::Start(int, char**) [/Users/yagiz/coding/node/out/Release/node]
24: 0x18121d0e0 start [/usr/lib/dyld]
Command: out/Release/node /Users/yagiz/coding/node/test/parallel/test-file-write-stream4.js
--- CRASHED (Signal: 6) ---
```