### PR TITLE
test_runner: added coverage support with watch mode

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -179,6 +179,7 @@ function setup(root) {
     __proto__: null,
     bootstrapComplete: false,
     coverage: FunctionPrototypeBind(collectCoverage, null, root, coverage),
+    watchMode: globalOptions.watch,
     counters: {
       __proto__: null,
       all: 0,

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -65,6 +65,7 @@ const {
   kTestTimeoutFailure,
   Test,
 } = require('internal/test_runner/test');
+let addAbortListener;
 
 const {
   convertStringToRegExp,
@@ -79,14 +80,12 @@ const {
   exitCodes: { kGenericUserError },
 } = internalBinding('errors');
 
-const kFilterArgs = ['--test', '--experimental-test-coverage', '--watch'];
+const kFilterArgs = new SafeSet(['--test', '--experimental-test-coverage', '--watch']);
 const kFilterArgValues = ['--test-reporter', '--test-reporter-destination'];
 const kDiagnosticsFilterArgs = ['tests', 'suites', 'pass', 'fail', 'cancelled', 'skipped', 'todo', 'duration_ms'];
 
 const kCanceledTests = new SafeSet()
   .add(kCancelledByParent).add(kAborted).add(kTestTimeoutFailure);
-
-let kResistStopPropagation;
 
 function createTestFileList() {
   const cwd = process.cwd();
@@ -108,7 +107,7 @@ function createTestFileList() {
 }
 
 function filterExecArgv(arg, i, arr) {
-  return !ArrayPrototypeIncludes(kFilterArgs, arg) &&
+  return !kFilterArgs.has(arg) &&
   !ArrayPrototypeSome(kFilterArgValues, (p) => arg === p || (i > 0 && arr[i - 1] === p) || StringPrototypeStartsWith(arg, `${p}=`));
 }
 
@@ -425,12 +424,12 @@ function watchFiles(testFiles, opts) {
     }));
   });
   if (opts.signal) {
-    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-    opts.signal.addEventListener(
-      'abort',
-      () => opts.root.postRun(),
-      { __proto__: null, once: true, [kResistStopPropagation]: true },
-    );
+    addAbortListener ??= require('events').addAbortListener;
+    addAbortListener(opts.signal, () => {
+      opts.root.postRun();
+      opts.root.reporter.end();
+    });
+
   }
 
   return filesWatcher;
@@ -503,8 +502,12 @@ function run(options = kEmptyObject) {
   let filesWatcher;
   const opts = { __proto__: null, root, signal, inspectPort, testNamePatterns, only };
   if (watch) {
+    root.harness.watchMode = true;
     filesWatcher = watchFiles(testFiles, opts);
-    postRun = undefined;
+    postRun = () => {
+      kFilterArgs.delete('--experimental-test-coverage');
+      root.postRun();
+    };
   }
   const runFiles = () => {
     root.harness.bootstrapComplete = true;

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -758,7 +758,9 @@ class Test extends AsyncResource {
         reporter.coverage(nesting, loc, coverage);
       }
 
-      reporter.end();
+      if (harness.watchMode === false) {
+        reporter.end();
+      }
     }
   }
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -193,6 +193,7 @@ function parseCommandLine() {
 
   const isTestRunner = getOptionValue('--test');
   const coverage = getOptionValue('--experimental-test-coverage');
+  const watch = getOptionValue('--watch');
   const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
   const isChildProcessV8 = process.env.NODE_TEST_CONTEXT === 'child-v8';
   let destinations;
@@ -244,6 +245,7 @@ function parseCommandLine() {
     __proto__: null,
     isTestRunner,
     coverage,
+    watch,
     testOnlyFlag,
     testNamePatterns,
     reporters,

--- a/test/parallel/test-runner-watch-coverage.mjs
+++ b/test/parallel/test-runner-watch-coverage.mjs
@@ -1,0 +1,89 @@
+// Flags: --expose-internals
+import * as common from '../common/index.mjs';
+import { test } from 'node:test';
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import util from 'internal/util';
+import tmpdir from '../common/tmpdir.js';
+import assert from 'node:assert';
+
+const skipIfNoInspector = {
+  skip: !process.features.inspector ? 'inspector disabled' : false
+};
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+function getCoverageFixtureReport() {
+  const report = [
+    '# start of coverage report',
+    '# ---------------------------------------------------------------',
+    '# file           | line % | branch % | funcs % | uncovered lines',
+    '# ---------------------------------------------------------------',
+    '# dependency.js  | 100.00 |   100.00 |  100.00 | ',
+    '# dependency.mjs | 100.00 |   100.00 |  100.00 | ',
+    '# test.js        | 100.00 |   100.00 |  100.00 | ',
+    '# ---------------------------------------------------------------',
+    '# all files      | 100.00 |   100.00 |  100.00 |',
+    '# ---------------------------------------------------------------',
+    '# end of coverage report',
+  ].join('\n');
+
+  if (common.isWindows) {
+    return report.replaceAll('/', '\\');
+  }
+
+  return report;
+}
+
+const fixtureContent = {
+  'dependency.js': 'module.exports = {};',
+  'dependency.mjs': 'export const a = 1;',
+  'test.js': `
+const test = require('node:test');
+require('./dependency.js');
+import('./dependency.mjs');
+import('data:text/javascript,');
+test('test has ran');`,
+};
+
+tmpdir.refresh();
+
+const fixturePaths = Object.keys(fixtureContent)
+  .reduce((acc, file) => ({ ...acc, [file]: tmpdir.resolve(file) }), {});
+Object.entries(fixtureContent)
+  .forEach(([file, content]) => writeFileSync(fixturePaths[file], content));
+
+async function testWatch({ fileToUpdate, file }) {
+  const ran1 = util.createDeferredPromise();
+  const ran2 = util.createDeferredPromise();
+  const args = [ '--test', '--watch', '--experimental-test-coverage',
+                 '--test-reporter', 'tap', file ? fixturePaths[file] : undefined];
+  const child = spawn(process.execPath,
+                      args.filter(Boolean),
+                      { encoding: 'utf8', stdio: 'pipe', cwd: tmpdir.path });
+  let stdout = '';
+
+  child.stdout.on('data', (data) => {
+    stdout += data.toString();
+    const testRuns = stdout.match(/ - test has ran/g);
+    if (testRuns?.length >= 1) ran1.resolve();
+    if (testRuns?.length >= 2) ran2.resolve();
+  });
+
+  await ran1.promise;
+  const content = fixtureContent[fileToUpdate];
+  const path = fixturePaths[fileToUpdate];
+  const interval = setInterval(() => writeFileSync(path, content), common.platformTimeout(1000));
+  await ran2.promise;
+  clearInterval(interval);
+  child.kill();
+
+  return stdout;
+}
+
+test('should report coverage report with watch mode', skipIfNoInspector, async () => {
+  const stdout = await testWatch({ file: 'test.js', fileToUpdate: 'test.js' });
+  const expectedCoverageReport = getCoverageFixtureReport();
+  assert(stdout.includes(expectedCoverageReport));
+});


### PR DESCRIPTION
fix #51253 

**code:**

with following test files
```js
// test1.test.mjs
import { test } from 'node:test';

test('test1', () => {})

```
```js
// test2.test.mjs
import { test } from 'node:test';

test('test2', () => {})

```

run `node --test --experimental-test-coverage --watch`

**output:**

```bash
✔ test1 (1.952625ms)
✔ test2 (2.08075ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 228.890917
ℹ start of coverage report
ℹ ---------------------------------------------------------------
ℹ file           | line % | branch % | funcs % | uncovered lines
ℹ ---------------------------------------------------------------
ℹ test1.test.mjs | 100.00 |   100.00 |  100.00 | 
ℹ test2.test.mjs | 100.00 |   100.00 |  100.00 | 
ℹ ---------------------------------------------------------------
ℹ all files      | 100.00 |   100.00 |  100.00 |
ℹ ---------------------------------------------------------------
ℹ end of coverage report
```

- when i update `test2.test.mjs`
```bash
✔ test1 (1.952625ms)
✔ test2 (2.08075ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 228.890917
ℹ start of coverage report
ℹ ---------------------------------------------------------------
ℹ file           | line % | branch % | funcs % | uncovered lines
ℹ ---------------------------------------------------------------
ℹ test1.test.mjs | 100.00 |   100.00 |  100.00 | 
ℹ test2.test.mjs | 100.00 |   100.00 |  100.00 | 
ℹ ---------------------------------------------------------------
ℹ all files      | 100.00 |   100.00 |  100.00 |
ℹ ---------------------------------------------------------------
ℹ end of coverage report
✔ test2 (3.161208ms)
ℹ start of coverage report
ℹ ---------------------------------------------------------------
ℹ file           | line % | branch % | funcs % | uncovered lines
ℹ ---------------------------------------------------------------
ℹ test2.test.mjs | 100.00 |   100.00 |  100.00 | 
ℹ ---------------------------------------------------------------
ℹ all files      | 100.00 |   100.00 |  100.00 |
ℹ ---------------------------------------------------------------
ℹ end of coverage report
```