### PR TITLE
lib,src: remove detachArrayBuffer from buffer binding

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -4,6 +4,7 @@ const {
   ArrayBuffer,
   ArrayBufferPrototypeGetByteLength,
   ArrayBufferPrototypeSlice,
+  ArrayBufferPrototypeTransfer,
   ArrayPrototypePush,
   ArrayPrototypeShift,
   DataView,
@@ -105,7 +106,6 @@ const {
   isBrandCheck,
   resetQueue,
   setPromiseHandled,
-  transferArrayBuffer,
   nonOpCancel,
   nonOpPull,
   nonOpStart,
@@ -1960,7 +1960,7 @@ function readableByteStreamControllerConvertPullIntoDescriptor(desc) {
   if (bytesFilled > byteLength)
     throw new ERR_INVALID_STATE.RangeError('The buffer size is invalid');
   assert(!(bytesFilled % elementSize));
-  const transferredBuffer = transferArrayBuffer(buffer);
+  const transferredBuffer = ArrayBufferPrototypeTransfer(buffer);
 
   if (ctor === Buffer) {
     return Buffer.from(transferredBuffer, byteOffset, bytesFilled / elementSize);
@@ -2622,7 +2622,7 @@ function readableByteStreamControllerPullInto(
 
   let transferredBuffer;
   try {
-    transferredBuffer = transferArrayBuffer(buffer);
+    transferredBuffer = ArrayBufferPrototypeTransfer(buffer);
   } catch (error) {
     readIntoRequest[kError](error);
     return;
@@ -2714,7 +2714,7 @@ function readableByteStreamControllerRespond(controller, bytesWritten) {
       throw new ERR_INVALID_ARG_VALUE.RangeError('bytesWritten', bytesWritten);
   }
 
-  desc.buffer = transferArrayBuffer(desc.buffer);
+  desc.buffer = ArrayBufferPrototypeTransfer(desc.buffer);
 
   readableByteStreamControllerRespondInternal(controller, bytesWritten);
 }
@@ -2764,7 +2764,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
   if (closeRequested || stream[kState].state !== 'readable')
     return;
 
-  const transferredBuffer = transferArrayBuffer(buffer);
+  const transferredBuffer = ArrayBufferPrototypeTransfer(buffer);
 
   if (pendingPullIntos.length) {
     const firstPendingPullInto = pendingPullIntos[0];
@@ -2777,7 +2777,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
 
     readableByteStreamControllerInvalidateBYOBRequest(controller);
 
-    firstPendingPullInto.buffer = transferArrayBuffer(
+    firstPendingPullInto.buffer = ArrayBufferPrototypeTransfer(
       firstPendingPullInto.buffer,
     );
 
@@ -3074,7 +3074,7 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   if (bufferByteLength !== viewBufferByteLength)
     throw new ERR_INVALID_ARG_VALUE.RangeError('view', view);
 
-  desc.buffer = transferArrayBuffer(viewBuffer);
+  desc.buffer = ArrayBufferPrototypeTransfer(viewBuffer);
 
   readableByteStreamControllerRespondInternal(controller, viewByteLength);
 }

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -19,14 +19,12 @@ const {
 const {
   codes: {
     ERR_INVALID_ARG_VALUE,
-    ERR_OPERATION_FAILED,
     ERR_INVALID_STATE,
   },
 } = require('internal/errors');
 
 const {
   copyArrayBuffer,
-  detachArrayBuffer,
 } = internalBinding('buffer');
 
 const {
@@ -115,15 +113,6 @@ function isBrandCheck(brand) {
            value[kState] !== undefined &&
            value[kType] === brand;
   };
-}
-
-function transferArrayBuffer(buffer) {
-  const res = detachArrayBuffer(buffer);
-  if (res === undefined) {
-    throw new ERR_OPERATION_FAILED.TypeError(
-      'The ArrayBuffer could not be transferred');
-  }
-  return res;
 }
 
 function isViewedArrayBufferDetached(view) {
@@ -285,7 +274,6 @@ module.exports = {
   peekQueueValue,
   resetQueue,
   setPromiseHandled,
-  transferArrayBuffer,
   nonOpCancel,
   nonOpFlush,
   nonOpPull,

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1193,18 +1193,6 @@ void GetZeroFillToggle(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(Uint32Array::New(ab, 0, 1));
 }
 
-void DetachArrayBuffer(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  if (args[0]->IsArrayBuffer()) {
-    Local<ArrayBuffer> buf = args[0].As<ArrayBuffer>();
-    if (buf->IsDetachable()) {
-      std::shared_ptr<BackingStore> store = buf->GetBackingStore();
-      buf->Detach(Local<Value>()).Check();
-      args.GetReturnValue().Set(ArrayBuffer::New(env->isolate(), store));
-    }
-  }
-}
-
 namespace {
 
 std::pair<void*, size_t> DecomposeBufferToParts(Local<Value> buffer) {
@@ -1283,7 +1271,6 @@ void Initialize(Local<Object> target,
   SetMethodNoSideEffect(context, target, "indexOfNumber", IndexOfNumber);
   SetMethodNoSideEffect(context, target, "indexOfString", IndexOfString);
 
-  SetMethod(context, target, "detachArrayBuffer", DetachArrayBuffer);
   SetMethod(context, target, "copyArrayBuffer", CopyArrayBuffer);
 
   SetMethod(context, target, "swap16", Swap16);
@@ -1366,7 +1353,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(StringWrite<UTF8>);
   registry->Register(GetZeroFillToggle);
 
-  registry->Register(DetachArrayBuffer);
   registry->Register(CopyArrayBuffer);
 }
 


### PR DESCRIPTION
Now that `ArrayBuffer.prototype.transfer` is available, there's no need for the `DetachArrayBuffer` utility
