### PR TITLE
doc: added details about `statfs.type` and `statfs.bsize`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7532,7 +7532,7 @@ added:
 
 * {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size in bytes.
 
 #### `statfs.ffree`
 
@@ -7568,7 +7568,101 @@ added:
 
 * {number|bigint}
 
-Type of file system.
+Magic number of file system in decimal.
+
+The magic number of a file system is commonly referred to in hexadecimal.
+
+<details>
+<summary>Magic Numbers</summary>
+
+| Filesystem Type         | Hexadecimal  | Decimal      |
+| ----------------------- | ------------ | ------------ |
+| ADFS\_SUPER\_MAGIC      | `0xadf5`     | `44533`      |
+| AFFS\_SUPER\_MAGIC      | `0xadff`     | `44543`      |
+| AFS\_SUPER\_MAGIC       | `0x5346414f` | `1397113167` |
+| ANON\_INODE\_FS\_MAGIC  | `0x09041934` | `151263540`  |
+| AUTOFS\_SUPER\_MAGIC    | `0x0187`     | `391`        |
+| BDEVFS\_MAGIC           | `0x62646576` | `1650746742` |
+| BEFS\_SUPER\_MAGIC      | `0x42465331` | `1111905073` |
+| BFS\_MAGIC              | `0x1badface` | `464386766`  |
+| BINFMTFS\_MAGIC         | `0x42494e4d` | `1112100429` |
+| BPF\_FS\_MAGIC          | `0xcafe4a11` | `3405662737` |
+| BTRFS\_SUPER\_MAGIC     | `0x9123683e` | `2435016766` |
+| BTRFS\_TEST\_MAGIC      | `0x73727279` | `1936880249` |
+| CGROUP\_SUPER\_MAGIC    | `0x27e0eb`   | `2613483`    |
+| CGROUP2\_SUPER\_MAGIC   | `0x63677270` | `1667723888` |
+| CIFS\_MAGIC\_NUMBER     | `0xff534d42` | `4283649346` |
+| CODA\_SUPER\_MAGIC      | `0x73757245` | `1937076805` |
+| COH\_SUPER\_MAGIC       | `0x012ff7b7` | `19920823`   |
+| CRAMFS\_MAGIC           | `0x28cd3d45` | `684539205`  |
+| DEBUGFS\_MAGIC          | `0x64626720` | `1684170528` |
+| DEVFS\_SUPER\_MAGIC     | `0x1373`     | `4979`       |
+| DEVPTS\_SUPER\_MAGIC    | `0x1cd1`     | `7377`       |
+| ECRYPTFS\_SUPER\_MAGIC  | `0xf15f`     | `61791`      |
+| EFIVARFS\_MAGIC         | `0xde5e81e4` | `3730735588` |
+| EFS\_SUPER\_MAGIC       | `0x00414a53` | `4278867`    |
+| EXT\_SUPER\_MAGIC       | `0x137d`     | `4989`       |
+| EXT2\_OLD\_SUPER\_MAGIC | `0xef51`     | `61265`      |
+| EXT2\_SUPER\_MAGIC      | `0xef53`     | `61267`      |
+| EXT3\_SUPER\_MAGIC      | `0xef53`     | `61267`      |
+| EXT4\_SUPER\_MAGIC      | `0xef53`     | `61267`      |
+| F2FS\_SUPER\_MAGIC      | `0xf2f52010` | `4076150800` |
+| FUSE\_SUPER\_MAGIC      | `0x65735546` | `1702057286` |
+| FUTEXFS\_SUPER\_MAGIC   | `0xbad1dea`  | `195894762`  |
+| HFS\_SUPER\_MAGIC       | `0x4244`     | `16964`      |
+| HOSTFS\_SUPER\_MAGIC    | `0x00c0ffee` | `12648430`   |
+| HPFS\_SUPER\_MAGIC      | `0xf995e849` | `4187351113` |
+| HUGETLBFS\_MAGIC        | `0x958458f6` | `2508478710` |
+| ISOFS\_SUPER\_MAGIC     | `0x9660`     | `38496`      |
+| JFFS2\_SUPER\_MAGIC     | `0x72b6`     | `29366`      |
+| JFS\_SUPER\_MAGIC       | `0x3153464a` | `827541066`  |
+| MINIX\_SUPER\_MAGIC     | `0x137f`     | `4991`       |
+| MINIX\_SUPER\_MAGIC2    | `0x138f`     | `5007`       |
+| MINIX2\_SUPER\_MAGIC    | `0x2468`     | `9320`       |
+| MINIX2\_SUPER\_MAGIC2   | `0x2478`     | `9336`       |
+| MINIX3\_SUPER\_MAGIC    | `0x4d5a`     | `19802`      |
+| MQUEUE\_MAGIC           | `0x19800202` | `427819522`  |
+| MSDOS\_SUPER\_MAGIC     | `0x4d44`     | `19780`      |
+| MTD\_INODE\_FS\_MAGIC   | `0x11307854` | `288389204`  |
+| NCP\_SUPER\_MAGIC       | `0x564c`     | `22092`      |
+| NFS\_SUPER\_MAGIC       | `0x6969`     | `26985`      |
+| NILFS\_SUPER\_MAGIC     | `0x3434`     | `13364`      |
+| NSFS\_MAGIC             | `0x6e736673` | `1853056627` |
+| NTFS\_SB\_MAGIC         | `0x5346544e` | `1397118030` |
+| OCFS2\_SUPER\_MAGIC     | `0x7461636f` | `1952539503` |
+| OPENPROM\_SUPER\_MAGIC  | `0x9fa1`     | `40865`      |
+| OVERLAYFS\_SUPER\_MAGIC | `0x794c7630` | `2035054128` |
+| PIPEFS\_MAGIC           | `0x50495045` | `1346981957` |
+| PROC\_SUPER\_MAGIC      | `0x9fa0`     | `40864`      |
+| PSTOREFS\_MAGIC         | `0x6165676c` | `1634035564` |
+| QNX4\_SUPER\_MAGIC      | `0x002f`     | `47`         |
+| QNX6\_SUPER\_MAGIC      | `0x68191122` | `1746473250` |
+| RAMFS\_MAGIC            | `0x858458f6` | `2240043254` |
+| REISERFS\_SUPER\_MAGIC  | `0x52654973` | `1382369651` |
+| ROMFS\_MAGIC            | `0x7275`     | `29301`      |
+| SECURITYFS\_MAGIC       | `0x73636673` | `1935894131` |
+| SELINUX\_MAGIC          | `0xf97cff8c` | `4185718668` |
+| SMACK\_MAGIC            | `0x43415d53` | `1128357203` |
+| SMB\_SUPER\_MAGIC       | `0x517b`     | `20859`      |
+| SMB2\_MAGIC\_NUMBER     | `0xfe534d42` | `4266872130` |
+| SOCKFS\_MAGIC           | `0x534f434b` | `1397703499` |
+| SQUASHFS\_MAGIC         | `0x73717368` | `1936814952` |
+| SYSFS\_MAGIC            | `0x62656572` | `1650812274` |
+| SYSV2\_SUPER\_MAGIC     | `0x012ff7b6` | `19920822`   |
+| SYSV4\_SUPER\_MAGIC     | `0x012ff7b5` | `19920821`   |
+| TMPFS\_MAGIC            | `0x01021994` | `16914836`   |
+| TRACEFS\_MAGIC          | `0x74726163` | `1953653091` |
+| UDF\_SUPER\_MAGIC       | `0x15013346` | `352400198`  |
+| UFS\_MAGIC              | `0x00011954` | `72020`      |
+| USBDEVICE\_SUPER\_MAGIC | `0x9fa2`     | `40866`      |
+| V9FS\_MAGIC             | `0x01021997` | `16914839`   |
+| VXFS\_SUPER\_MAGIC      | `0xa501fcf5` | `2768370933` |
+| XENFS\_SUPER\_MAGIC     | `0xabba1974` | `2881100148` |
+| XENIX\_SUPER\_MAGIC     | `0x012ff7b4` | `19920820`   |
+| XFS\_SUPER\_MAGIC       | `0x58465342` | `1481003842` |
+| \_XIAFS\_SUPER\_MAGIC   | `0x012fd16d` | `19911021`   |
+
+</details>
 
 ### Class: `fs.WriteStream`
 


### PR DESCRIPTION
Added byte unit to `statfs.bsize` description. Added `statfs.type` list of potential values pulled from man page of statfs on Linux.

Fixes: https://github.com/nodejs/node/issues/50749

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
