### PR TITLE
lib: fix --preserve-symlinks-main

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -477,10 +477,7 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
 function tryFile(requestPath, isMain) {
   const rc = _stat(requestPath);
   if (rc !== 0) { return; }
-  if (getOptionValue('--preserve-symlinks') && !isMain) {
-    return path.resolve(requestPath);
-  }
-  if (getOptionValue('--preserve-symlinks-main') && isMain) {
+  if (getOptionValue(isMain ? '--preserve-symlinks-main' : '--preserve-symlinks')) {
     return path.resolve(requestPath);
   }
   return toRealPath(requestPath);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -469,8 +469,8 @@ function tryPackage(requestPath, exts, isMain, originalPath) {
 }
 
 /**
- * Check if the file exists and is not a directory if using `--preserve-symlinks` and `isMain` is false, keep symlinks
- * intact, otherwise resolve to the absolute realpath.
+ * Check if the file exists and is not a directory if using `--preserve-symlinks` and `isMain` is false or
+ * `--preserve-symlinks-main` and `isMain` is true , keep symlinks intact, otherwise resolve to the absolute realpath.
  * @param {string} requestPath The path to the file to load.
  * @param {boolean} isMain Whether the file is the main module.
  */
@@ -478,6 +478,9 @@ function tryFile(requestPath, isMain) {
   const rc = _stat(requestPath);
   if (rc !== 0) { return; }
   if (getOptionValue('--preserve-symlinks') && !isMain) {
+    return path.resolve(requestPath);
+  }
+  if (getOptionValue('--preserve-symlinks-main') && isMain) {
     return path.resolve(requestPath);
   }
   return toRealPath(requestPath);

--- a/test/es-module/test-esm-preserve-symlinks-main.js
+++ b/test/es-module/test-esm-preserve-symlinks-main.js
@@ -1,12 +1,19 @@
 'use strict';
 
-const common = require('../common');
-const { spawn } = require('child_process');
-const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
-
+const { spawnPromisified, skip } = require('../common');
 const tmpdir = require('../common/tmpdir');
+
+// Invoke the main file via a symlink.  In this case --preserve-symlinks-main
+// dictates that it'll resolve relative imports in the main file relative to
+// the symlink, and not relative to the symlink target; the file structure set
+// up below requires this to not crash when loading ./submodule_link.js
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execPath } = require('node:process');
+const { describe, it } = require('node:test');
+
 tmpdir.refresh();
 const tmpDir = tmpdir.path;
 
@@ -14,7 +21,7 @@ fs.mkdirSync(path.join(tmpDir, 'nested'));
 fs.mkdirSync(path.join(tmpDir, 'nested2'));
 
 const entry = path.join(tmpDir, 'nested', 'entry.js');
-const entry_link_absolute_path = path.join(tmpDir, 'link.js');
+const entry_link_absolute_path = path.join(tmpDir, 'index.js');
 const submodule = path.join(tmpDir, 'nested2', 'submodule.js');
 const submodule_link_absolute_path = path.join(tmpDir, 'submodule_link.js');
 
@@ -31,27 +38,39 @@ try {
   fs.symlinkSync(submodule, submodule_link_absolute_path);
 } catch (err) {
   if (err.code !== 'EPERM') throw err;
-  common.skip('insufficient privileges for symlinks');
+  skip('insufficient privileges for symlinks');
 }
 
-function doTest(flags, done) {
-  // Invoke the main file via a symlink.  In this case --preserve-symlinks-main
-  // dictates that it'll resolve relative imports in the main file relative to
-  // the symlink, and not relative to the symlink target; the file structure set
-  // up above requires this to not crash when loading ./submodule_link.js
-  spawn(process.execPath, [
-    '--preserve-symlinks',
-    '--preserve-symlinks-main',
-    entry_link_absolute_path,
-  ], { stdio: 'inherit' })
-    .on('exit', (code) => {
-      assert.strictEqual(code, 0);
-      done();
-    });
-}
+describe('Invoke the main file via a symlink.', { concurrency: true }, () => {
+  it('should resolve relative imports in the main file', async () => {
+    const { code } = await spawnPromisified(execPath, [
+      '--preserve-symlinks',
+      '--preserve-symlinks-main',
+      entry_link_absolute_path,
+    ]);
 
-// First test the commonjs module loader
-doTest([], () => {
-  // Now test the new loader
-  doTest([], () => {});
+    assert.strictEqual(code, 0);
+  });
+
+  it('should resolve relative imports in the main file when file extension is omitted', async () => {
+    const entry_link_absolute_path_without_ext = path.join(tmpDir, 'index');
+
+    const { code } = await spawnPromisified(execPath, [
+      '--preserve-symlinks',
+      '--preserve-symlinks-main',
+      entry_link_absolute_path_without_ext,
+    ]);
+
+    assert.strictEqual(code, 0);
+  });
+
+  it('should resolve relative imports in the main file when filename(index.js) is omitted', async () => {
+    const { code } = await spawnPromisified(execPath, [
+      '--preserve-symlinks',
+      '--preserve-symlinks-main',
+      tmpDir,
+    ]);
+
+    assert.strictEqual(code, 0);
+  });
 });


### PR DESCRIPTION
lib: fix --preserve-symlinks-main

When the `--preserve-symlinks-main` flag is used when running a node, the main file path is resolved to the target path instead of the symlink path. This cause issues with relative imports. This problem occurs when the called symlink does not contain a file extension(i.e. `node package`, `node package/file`). 

In the `loader.js` file, there is a function called `tryExtensions` which in turn calls `tryFile`. The `tryFile` function originally only had a check for the `--preserve-symlinks` flag, so I have added a check for `--preserve-symlinks-main` as well.


Fixes: https://github.com/nodejs/node/issues/41000

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
