### PR TITLE
lib: introduce 'unhandledErrorEvent' event in 'uncaughtException' handler

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1810,7 +1810,7 @@ E('ERR_UNHANDLED_ERROR',
     const msg = 'Unhandled error.';
     if (err === undefined) return msg;
     return `${msg} (${err})`;
-  }, Error);
+  }, TypeError);
 E('ERR_UNKNOWN_BUILTIN_MODULE', 'No such built-in module: %s', Error);
 E('ERR_UNKNOWN_CREDENTIAL', '%s identifier does not exist: %s', Error);
 E('ERR_UNKNOWN_ENCODING', 'Unknown encoding: %s', TypeError);

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -4,6 +4,7 @@ const {
   Symbol,
   RegExpPrototypeExec,
   globalThis,
+  TypeError,
 } = primordials;
 
 const path = require('path');
@@ -171,7 +172,10 @@ function createOnGlobalUncaughtException() {
     // call that threw and was never cleared. So clear it now.
     clearDefaultTriggerAsyncId();
 
-    const type = fromPromise ? 'unhandledRejection' : 'uncaughtException';
+    let type = fromPromise ? 'unhandledRejection' : 'uncaughtException';
+    // Redefine the type only when it's an UnhandledErrorEvent.
+    // Refs: https://github.com/nodejs/node/issues/51202
+    if (er instanceof TypeError) type = 'unhandledErrorEvent';
     process.emit('uncaughtExceptionMonitor', er, type);
     if (exceptionHandlerState.captureFn !== null) {
       exceptionHandlerState.captureFn(er);

--- a/test/parallel/test-event-emitter-errors.js
+++ b/test/parallel/test-event-emitter-errors.js
@@ -10,7 +10,7 @@ assert.throws(
   () => EE.emit('error', 'Accepts a string'),
   {
     code: 'ERR_UNHANDLED_ERROR',
-    name: 'Error',
+    name: 'TypeError',
     message: "Unhandled error. ('Accepts a string')",
   }
 );
@@ -19,7 +19,7 @@ assert.throws(
   () => EE.emit('error', { message: 'Error!' }),
   {
     code: 'ERR_UNHANDLED_ERROR',
-    name: 'Error',
+    name: 'TypeError',
     message: "Unhandled error. ({ message: 'Error!' })",
   }
 );
@@ -31,7 +31,7 @@ assert.throws(
   }),
   {
     code: 'ERR_UNHANDLED_ERROR',
-    name: 'Error',
+    name: 'TypeError',
     message: 'Unhandled error. ([object Object])',
   }
 );

--- a/test/parallel/test-process-uncaught-exception-monitor.js
+++ b/test/parallel/test-process-uncaught-exception-monitor.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const common = require('../common');
-const assert = require('assert');
-const { execFile } = require('child_process');
 const fixtures = require('../common/fixtures');
+const assert = require('node:assert');
+const { execFile } = require('node:child_process');
+const { EventEmitter } = require('node:events');
 
 {
   // Verify exit behavior is unchanged
@@ -43,6 +44,20 @@ const fixtures = require('../common/fixtures');
 }
 
 const theErr = new Error('MyError');
+
+// Test the unhandled error events
+// Refs: https://github.com/nodejs/node/issues/51202
+{
+  process.on('uncaughtException', common.mustCall((err, origin) => {
+    assert.strictEqual(origin, 'unhandledErrorEvent');
+  }));
+
+  const ee = new EventEmitter();
+  // Handles generic error events
+  ee.emit('error', 'meow');
+  // Handles "Error" typed events
+  ee.emit('error', theErr);
+}
 
 process.on(
   'uncaughtExceptionMonitor',


### PR DESCRIPTION
This patch introduces a new type of error type for the 'uncaughtExceptionMonitor' triggered in case an 'error' event has not associated handlers.

E.g:

```
process.on('uncaughtException', (err, origin) => {
  // origin value will be 'unhandledErrorEvent'
});

ee.emit('error', 'meow');
ee.emit('error', new Error('Boom'));
```

Fixes: https://github.com/nodejs/node/issues/51202

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
