### PR TITLE
stream: fix eventNames() to not return not defined events

### DIFF
--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -3,6 +3,7 @@
 const {
   ArrayIsArray,
   ObjectSetPrototypeOf,
+  ReflectOwnKeys,
 } = primordials;
 
 const EE = require('events');
@@ -91,6 +92,16 @@ Stream.prototype.pipe = function(dest, options) {
 
   // Allow for unix-like usage: A.pipe(B).pipe(C)
   return dest;
+};
+
+Stream.prototype.eventNames = function eventNames() {
+  const names = [];
+  for (const key of ReflectOwnKeys(this._events)) {
+    if (typeof this._events[key] === 'function' || (ArrayIsArray(this._events[key]) && this._events[key].length > 0)) {
+      names.push(key);
+    }
+  }
+  return names;
 };
 
 function prependListener(emitter, event, fn) {

--- a/test/parallel/test-stream-event-names.js
+++ b/test/parallel/test-stream-event-names.js
@@ -1,0 +1,42 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { Readable, Writable, Duplex } = require('stream');
+
+{
+  const stream = new Readable();
+  assert.strictEqual(stream.eventNames().length, 0);
+}
+
+{
+  const stream = new Readable();
+  stream.on('foo', () => {});
+  stream.on('data', () => {});
+  stream.on('error', () => {});
+  assert.deepStrictEqual(stream.eventNames(), ['error', 'data', 'foo']);
+}
+
+{
+  const stream = new Writable();
+  assert.strictEqual(stream.eventNames().length, 0);
+}
+
+{
+  const stream = new Writable();
+  stream.on('foo', () => {});
+  stream.on('drain', () => {});
+  stream.on('prefinish', () => {});
+  assert.deepStrictEqual(stream.eventNames(), ['prefinish', 'drain', 'foo']);
+}
+{
+  const stream = new Duplex();
+  assert.strictEqual(stream.eventNames().length, 0);
+}
+
+{
+  const stream = new Duplex();
+  stream.on('foo', () => {});
+  stream.on('finish', () => {});
+  assert.deepStrictEqual(stream.eventNames(), ['finish', 'foo']);
+}


### PR DESCRIPTION
Fix issue https://github.com/nodejs/node/issues/51302
As explained by @Qard, the root cause is that by default, we pre-allocate events here [here](https://github.com/nodejs/node/pull/50428/files)

1. Since those events are initially set to undefined, we should check the value of the listener before returning eventNames().
2. I also believe that we are protected because we are not allowed to set a null or undefined listener.

I did different tests like:
```
const readableStream = createReadable();
readableStream.on('a', () => {});
readableStream.on('error', () => {});
console.log(readableStream.eventNames()); // ['a', 'error']
```
```
const readableStream = createReadable();
readableStream.on('a', () => {});
console.log(readableStream.eventNames()); // ['a']
```

I will add tests as soon as I can