### PR TITLE
meta: add .temp and .lock tags to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /perf.data
 /perf.data.old
 /tags
+/tags.*
 /doc/api.xml
 /node
 /node_g


### PR DESCRIPTION
This happens frequently when using vim in different panels. While adding to a local git exclude would work, I don't think I'm the only one facing that.