### PR TITLE
fs,test: add URL to string to fs.watch

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -108,7 +108,6 @@ const {
   getValidatedPath,
   getValidMode,
   handleErrorFromBinding,
-  possiblyTransformPath,
   preprocessSymlinkDestination,
   Stats,
   getStatFsFromBinding,
@@ -2451,7 +2450,7 @@ function watch(filename, options, listener) {
 
   let watcher;
   const watchers = require('internal/fs/watchers');
-  const path = possiblyTransformPath(filename);
+  const path = getValidatedPath(filename);
   // TODO(anonrig): Remove non-native watcher when/if libuv supports recursive.
   // As of November 2022, libuv does not support recursive file watch on all platforms,
   // e.g. Linux due to the limitations of inotify.

--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -265,6 +265,13 @@ const regularFile = __filename;
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
+  assert.throws(() => {
+    fs.watch(blockedFileURL, () => {});
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
 
   // doesNotThrow
   fs.readdir(allowedFolder, (err) => {


### PR DESCRIPTION
I don't know if the URL is expected to be supported through `fs.watch`.

@nodejs/fs 