### PR TITLE
src: do not read string out of bounds

### DIFF
--- a/src/path.cc
+++ b/src/path.cc
@@ -24,15 +24,14 @@ std::string NormalizeString(const std::string_view path,
   int lastSegmentLength = 0;
   int lastSlash = -1;
   int dots = 0;
-  char code;
-  const auto pathLen = path.size();
-  for (uint8_t i = 0; i <= pathLen; ++i) {
-    if (i < pathLen) {
+  char code = 0;
+  for (size_t i = 0; i <= path.size(); ++i) {
+    if (i < path.size()) {
       code = path[i];
-    } else if (IsPathSeparator(path[i])) {
+    } else if (IsPathSeparator(code)) {
       break;
     } else {
-      code = node::kPathSeparator;
+      code = '/';
     }
 
     if (IsPathSeparator(code)) {


### PR DESCRIPTION
I'm seeing an assertion from libc++ when compiling Node with GN build:
```
../../third_party/gn/third_party/libc++/src/include/string_view:408: assertion __pos < size() failed: string_view[] index out of bounds
```

Which comes from the new C++ version of `NormalizeString` from #50758:

```c++
  const auto pathLen = path.size();
  for (uint8_t i = 0; i <= pathLen; ++i) {
    if (i < pathLen) {
      code = path[i];
    } else if (IsPathSeparator(path[i])) {
      break;
    } else {
      code = node::kPathSeparator;
    }
```

There seems to be a few errors:

1. `i` should a `size_t`, otherwise it can only parse strings at most 255 characters.
2. This code always ends up reading `path[path.size()]`, which reads out-of-bounds.

The origin js function was written in an unusual way which I don't quite understand, so I might be missing something here.

---

If I'm not missing anything, I suggest a fast track merge since it is a out-of-bounds read bug.