### PR TITLE
tools: fix version parsing in brotli update script

### DIFF
--- a/tools/dep_updaters/update-brotli.sh
+++ b/tools/dep_updaters/update-brotli.sh
@@ -24,12 +24,10 @@ console.log(tag_name.replace('v', ''));
 EOF
 )"
 
-VERSION_HEX=$(grep "#define BROTLI_VERSION" ./deps/brotli/c/common/version.h | sed 's/.* //')
-
-major=$(( ($VERSION_HEX >> 24) & 0xff ))
-minor=$(( ($VERSION_HEX >> 12) & 0xfff ))
-patch=$(( $VERSION_HEX & 0xfff ))
-CURRENT_VERSION="${major}.${minor}.${patch}"
+CURRENT_MAJOR_VERSION=$(grep "#define BROTLI_VERSION_MAJOR" ./deps/brotli/c/common/version.h | sed -n "s/^.*MAJOR \(.*\)/\1/p")
+CURRENT_MINOR_VERSION=$(grep "#define BROTLI_VERSION_MINOR" ./deps/brotli/c/common/version.h | sed -n "s/^.*MINOR \(.*\)/\1/p")
+CURRENT_PATCH_VERSION=$(grep "#define BROTLI_VERSION_PATCH" ./deps/brotli/c/common/version.h | sed -n "s/^.*PATCH \(.*\)/\1/p")
+CURRENT_VERSION="$CURRENT_MAJOR_VERSION.$CURRENT_MINOR_VERSION.$CURRENT_PATCH_VERSION"
 
 # This function exit with 0 if new version and current version are the same
 compare_dependency_version "brotli" "$NEW_VERSION" "$CURRENT_VERSION"


### PR DESCRIPTION
Update `tools/dep_updaters/update-brotli.sh` to parse the current version of brotli from the newer macros `BROTLI_VERSION_MAJOR`, `BROTLI_VERSION_MINOR` and `BROTLI_VERSION_PATCH`.

Refs: https://github.com/nodejs/node/pull/50804
Refs: https://github.com/nodejs/security-wg/issues/1181

---

e.g. Failing in https://github.com/nodejs/node/actions/runs/7367214596/job/20050242756
```console
./tools/dep_updaters/update-brotli.sh: 29: arithmetic expression: expecting ')': " (1
1
0
\ >> 24) & 0xff "
Error: Process completed with exit code 2.
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
