### PR TITLE
test_runner: do not invoke after hook when test is empty

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -587,7 +587,7 @@ class Test extends AsyncResource {
 
     const { args, ctx } = this.getRunArgs();
     const after = async () => {
-      if (this.hooks.after.length > 0) {
+      if (this.parent?.hooks.after.length > 0) {
         await this.runHook('after', { __proto__: null, args, ctx });
       }
     };

--- a/test/parallel/test-runner-skip-after-hook.js
+++ b/test/parallel/test-runner-skip-after-hook.js
@@ -1,0 +1,10 @@
+'use strict';
+// Refs: https://github.com/nodejs/node/issues/51371
+const common = require('../common');
+const { test } = require('node:test');
+
+test('test', async (t) => {
+  t.after(common.mustNotCall(() => {
+    t.fail('should not run');
+  }));
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51371