### PR TITLE
[v21.x] Revert "fs: remove workaround for `esm` package"

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -500,6 +500,10 @@ function Stats(dev, mode, nlink, uid, gid, rdev, blksize,
 ObjectSetPrototypeOf(Stats.prototype, StatsBase.prototype);
 ObjectSetPrototypeOf(Stats, StatsBase);
 
+// HACK: Workaround for https://github.com/standard-things/esm/issues/821.
+// TODO(ronag): Remove this as soon as `esm` publishes a fixed version.
+Stats.prototype.isFile = StatsBase.prototype.isFile;
+
 Stats.prototype._checkModeProperty = function(property) {
   if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
     property === S_IFSOCK)) {


### PR DESCRIPTION
Fixes: #51081
