### PR TITLE
tools: do not pass invalid flag to C compiler

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1989,6 +1989,12 @@
           ]
         }],
       ],
+      # -Wno-invalid-offsetof flag is not valid for C.
+      # The flag is initially set in `toolchain.gypi` for all targets.
+      'cflags!': [ '-Wno-invalid-offsetof' ],
+      'xcode_settings': {
+        'WARNING_CFLAGS!': ['-Wno-invalid-offsetof']
+      },
       'direct_dependent_settings': {
         'include_dirs': [
           '<(V8_ROOT)/third_party/zlib',


### PR DESCRIPTION
`-Wno-invalid-offsetof` is only valid for C++ and GCC warns about its
usage for C.
