### PR TITLE
deps: compile c-ares with C11 support

### DIFF
--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -181,7 +181,7 @@
         }],
         [ 'OS not in "win android"', {
           'cflags': [
-            '--std=gnu89'
+            '--std=gnu11'
           ],
         }],
         [ 'OS=="linux"', {


### PR DESCRIPTION
This should get rid of the following GCC warning:
ISO C90 does not support ‘long long’ [-Wlong-long]
