### PR TITLE
Add appendHeader to HTTP/2 compat API and fix issues with duplicate headers in H2 writeHead

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2991,12 +2991,12 @@ added:
 * `value` {string|string\[]} Header value
 * Returns: {this}
 
-Append a single header value for the header object.
+Append a single header value to the header object.
 
-If the value is an array, this is equivalent of calling this method multiple
+If the value is an array, this is equivalent to calling this method multiple
 times.
 
-If there were no previous value for the header, this is equivalent of calling
+If there were no previous values for the header, this is equivalent to calling
 [`outgoingMessage.setHeader(name, value)`][].
 
 Depending of the value of `options.uniqueHeaders` when the client request or the

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3646,6 +3646,36 @@ message) to the response.
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+#### `response.appendHeader(name, value)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string}
+* `value` {string|string\[]}
+
+Append a single header value to the header object.
+
+If the value is an array, this is equivalent to calling this method multiple
+times.
+
+If there were no previous values for the header, this is equivalent to calling
+[`response.setHeader()`][].
+
+Attempting to set a header field name or value that contains invalid characters
+will result in a [`TypeError`][] being thrown.
+
+```js
+// Returns headers including "set-cookie: a" and "set-cookie: b"
+const server = http2.createServer((req, res) => {
+  res.setHeader('set-cookie', 'a');
+  res.appendHeader('set-cookie', 'b');
+  res.writeHead(200);
+  res.end('ok');
+});
+```
+
 #### `response.connection`
 
 <!-- YAML

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -76,6 +76,7 @@ const kRawHeaders = Symbol('rawHeaders');
 const kTrailers = Symbol('trailers');
 const kRawTrailers = Symbol('rawTrailers');
 const kSetHeader = Symbol('setHeader');
+const kAppendHeader = Symbol('appendHeader');
 const kAborted = Symbol('aborted');
 
 let statusMessageWarned = false;
@@ -650,6 +651,47 @@ class Http2ServerResponse extends Stream {
       this.destroy(new ERR_INVALID_HTTP_TOKEN('Header name', name));
 
     this[kHeaders][name] = value;
+  }
+
+  appendHeader(name, value) {
+    validateString(name, 'name');
+    if (this[kStream].headersSent)
+      throw new ERR_HTTP2_HEADERS_SENT();
+
+    this[kAppendHeader](name, value);
+  }
+
+  [kAppendHeader](name, value) {
+    name = StringPrototypeToLowerCase(StringPrototypeTrim(name));
+    assertValidHeader(name, value);
+
+    if (!isConnectionHeaderAllowed(name, value)) {
+      return;
+    }
+
+    if (name[0] === ':')
+      assertValidPseudoHeader(name);
+    else if (!checkIsHttpToken(name))
+      this.destroy(new ERR_INVALID_HTTP_TOKEN('Header name', name));
+
+    // Handle various possible cases the same as OutgoingMessage.appendHeader:
+    const headers = this[kHeaders];
+    if (headers === null || !headers[name]) {
+      return this.setHeader(name, value);
+    }
+
+    if (!ArrayIsArray(headers[name])) {
+      headers[name] = [headers[name]];
+    }
+
+    const existingValues = headers[name];
+    if (ArrayIsArray(value)) {
+      for (let i = 0, length = value.length; i < length; i++) {
+        existingValues.push(value[i]);
+      }
+    } else {
+      existingValues.push(value);
+    }
   }
 
   get statusMessage() {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -726,10 +726,33 @@ class Http2ServerResponse extends Stream {
 
     let i;
     if (ArrayIsArray(headers)) {
+      if (this[kHeaders]) {
+        // Headers in obj should override previous headers but still
+        // allow explicit duplicates. To do so, we first remove any
+        // existing conflicts, then use appendHeader. This is the
+        // slow path, which only applies when you use setHeader and
+        // then pass headers in writeHead too.
+
+        // We need to handle both the tuple and flat array formats, just
+        // like the logic further below.
+        if (headers.length && ArrayIsArray(headers[0])) {
+          for (let n = 0; n < headers.length; n += 1) {
+            const key = headers[n + 0][0];
+            this.removeHeader(key);
+          }
+        } else {
+          for (let n = 0; n < headers.length; n += 2) {
+            const key = headers[n + 0];
+            this.removeHeader(key);
+          }
+        }
+      }
+
+      // Append all the headers provided in the array:
       if (headers.length && ArrayIsArray(headers[0])) {
         for (i = 0; i < headers.length; i++) {
           const header = headers[i];
-          this[kSetHeader](header[0], header[1]);
+          this[kAppendHeader](header[0], header[1]);
         }
       } else {
         if (headers.length % 2 !== 0) {
@@ -737,7 +760,7 @@ class Http2ServerResponse extends Stream {
         }
 
         for (i = 0; i < headers.length; i += 2) {
-          this[kSetHeader](headers[i], headers[i + 1]);
+          this[kAppendHeader](headers[i], headers[i + 1]);
         }
       }
     } else if (typeof headers === 'object') {

--- a/test/parallel/test-http2-compat-serverresponse-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-headers.js
@@ -38,8 +38,18 @@ server.listen(0, common.mustCall(function() {
     response.setHeader(denormalised, expectedValue);
     assert.strictEqual(response.getHeader(denormalised), expectedValue);
     assert.strictEqual(response.hasHeader(denormalised), true);
+    assert.strictEqual(response.hasHeader(real), true);
+
+    response.appendHeader(real, expectedValue);
+    assert.deepStrictEqual(response.getHeader(real), [
+      expectedValue,
+      expectedValue,
+    ]);
+    assert.strictEqual(response.hasHeader(real), true);
+
     response.removeHeader(denormalised);
     assert.strictEqual(response.hasHeader(denormalised), false);
+    assert.strictEqual(response.hasHeader(real), false);
 
     ['hasHeader', 'getHeader', 'removeHeader'].forEach((fnName) => {
       assert.throws(

--- a/test/parallel/test-http2-compat-serverresponse-writehead-array.js
+++ b/test/parallel/test-http2-compat-serverresponse-writehead-array.js
@@ -16,6 +16,7 @@ const http2 = require('http2');
     server.once('request', common.mustCall((request, response) => {
       const returnVal = response.writeHead(200, [
         ['foo', 'bar'],
+        ['foo', 'baz'],
         ['ABC', 123],
       ]);
       assert.strictEqual(returnVal, response);
@@ -26,7 +27,7 @@ const http2 = require('http2');
       const request = client.request();
 
       request.on('response', common.mustCall((headers) => {
-        assert.strictEqual(headers.foo, 'bar');
+        assert.strictEqual(headers.foo, 'bar, baz');
         assert.strictEqual(headers.abc, '123');
         assert.strictEqual(headers[':status'], 200);
       }, 1));
@@ -45,7 +46,7 @@ const http2 = require('http2');
     const port = server.address().port;
 
     server.once('request', common.mustCall((request, response) => {
-      const returnVal = response.writeHead(200, ['foo', 'bar', 'ABC', 123]);
+      const returnVal = response.writeHead(200, ['foo', 'bar', 'foo', 'baz', 'ABC', 123]);
       assert.strictEqual(returnVal, response);
       response.end(common.mustCall(() => { server.close(); }));
     }));
@@ -54,7 +55,7 @@ const http2 = require('http2');
       const request = client.request();
 
       request.on('response', common.mustCall((headers) => {
-        assert.strictEqual(headers.foo, 'bar');
+        assert.strictEqual(headers.foo, 'bar, baz');
         assert.strictEqual(headers.abc, '123');
         assert.strictEqual(headers[':status'], 200);
       }, 1));


### PR DESCRIPTION
This PR

* Adds the `appendHeader` method from the HTTP/1 API to the HTTP/2 compat API.
* Fixes #51402, by using this appendHeader method to ensure that array header elements passed to `writeHead` don't overwrite each other. This follows the same logic as the semi-related recent fix for #50387 in HTTP/1 (so this fixes this issue, and ensures that any resulting conflicts between `writeHead` and `setHeader` are handled in the same way as HTTP/1 too).

In both cases, the specific code is drawn almost directly from the existing HTTP/1 equivalent (I've mildly tweaked the phrasing in the H1 appendHeader docs en route, as the grammar was a bit off).

There will be some performance impact to this for some uses of the H2 compat API, but I think this should be relevant only in the case where you call `setHeader` on a response and then also pass a separate list of headers to `writeHead` for that response. Performance-sensitive code should not do this, and should just pass all headers directly to `writeHead` in one go instead. The same concerns already apply to HTTP/1.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
