### PR TITLE
benchmark: update iterations of benchmark/assert/deepequal-map.js

### DIFF
--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -5,7 +5,7 @@ const { deepEqual, deepStrictEqual, notDeepEqual, notDeepStrictEqual } =
   require('assert');
 
 const bench = common.createBenchmark(main, {
-  n: [5e2],
+  n: [5e3],
   len: [5e2],
   strict: [0, 1],
   method: [


### PR DESCRIPTION
Fixed: https://github.com/nodejs/node/issues/50571

Before applying this PR, the top functions are reading test JS file, instead of real logic code of "equal".
After increasing the iteration value, the test case behaved as expected to trigger equal.

Below is the benefit after changing the iteration value. Now it reflects the real performance but brought no much overhead on execution duration.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/lshi10/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/lshi10/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:0%;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


  |   |   | after PR | before PR | benefit
-- | -- | -- | -- | -- | --
assert/deepequal-map.js | method="deepEqual_primitiveOnly" | strict=0 | 59545.18483 | 34260.41796 | 174%
assert/deepequal-map.js | method="deepEqual_objectOnly" | strict=0 | 3638.474777 | 3392.21504 | 107%
assert/deepequal-map.js | method="deepEqual_mixed" | strict=0 | 6454.155549 | 5799.864942 | 111%
assert/deepequal-map.js | method="notDeepEqual_primitiveOnly" | strict=0 | 102229.4693 | 47497.09769 | 215%
assert/deepequal-map.js | method="notDeepEqual_objectOnly" | strict=0 | 6720.715593 | 6003.967109 | 112%
assert/deepequal-map.js | method="notDeepEqual_mixed" | strict=0 | 794615.0527 | 348783.2696 | 228%
assert/deepequal-map.js | method="deepEqual_primitiveOnly" | strict=1 | 56371.15599 | 34136.76485 | 165%
assert/deepequal-map.js | method="deepEqual_objectOnly" | strict=1 | 3605.96319 | 3395.947981 | 106%
assert/deepequal-map.js | method="deepEqual_mixed" | strict=1 | 7022.193813 | 6173.548626 | 114%
assert/deepequal-map.js | method="notDeepEqual_primitiveOnly" | strict=1 | 101741.2196 | 48439.2862 | 210%
assert/deepequal-map.js | method="notDeepEqual_objectOnly" | strict=1 | 6150.376161 | 5650.374937 | 109%
assert/deepequal-map.js | method="notDeepEqual_mixed" | strict=1 | 644760.3742 | 337935.3367 | 191%



</body>

</html>
