### PR TITLE
benchmark: update iterations of assert/deepequal-typedarrays.js

### DIFF
--- a/benchmark/assert/deepequal-typedarrays.js
+++ b/benchmark/assert/deepequal-typedarrays.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
     'Float32Array',
     'Uint32Array',
   ],
-  n: [5e2],
+  n: [25000],
   strict: [0, 1],
   method: [
     'deepEqual',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50571

Before applying this PR, the top functions are reading test JS file, instead of real logic code of "equal".
After increasing the iteration value, the test case behaved as expected to trigger "equal" code.

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/lshi10/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/lshi10/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:0%;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


  |   |   |   | after PR | before PR | benefit
-- | -- | -- | -- | -- | -- | --
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Int8Array": | 824746.3493 | 243048.5679 | 339%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Int8Array": | 779766.1781 | 233794.6413 | 334%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Int8Array": | 1136986.291 | 294974.9832 | 385%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Int8Array": | 1106649.347 | 295092.668 | 375%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Int8Array": | 847645.5458 | 247216.344 | 343%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Int8Array": | 799122.474 | 242063.4652 | 330%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Int8Array": | 1133671.938 | 308798.0899 | 367%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Int8Array": | 1081829.263 | 297812.4484 | 363%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Uint8Array": | 826865.9462 | 247329.0931 | 334%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Uint8Array": | 783388.5037 | 235249.7246 | 333%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Uint8Array": | 1146704.619 | 295838.7324 | 388%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Uint8Array": | 1107188.907 | 291751.2016 | 379%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Uint8Array": | 835204.4976 | 245779.354 | 340%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Uint8Array": | 792970.5005 | 241826.6229 | 328%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Uint8Array": | 1100274.29 | 303353.1443 | 363%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Uint8Array": | 1070294.228 | 306121.5743 | 350%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Float32Array": | 134114.6596 | 78330.42153 | 171%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Float32Array": | 3133.745148 | 3054.98716 | 103%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Float32Array": | 779201.6493 | 156644.0577 | 497%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Float32Array": | 31156.45764 | 25603.25755 | 122%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Float32Array": | 841584.2251 | 248456.0938 | 339%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Float32Array": | 575310.3581 | 215447.8709 | 267%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Float32Array": | 1112535.008 | 303634.2592 | 366%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Float32Array": | 932094.9793 | 282013.6224 | 331%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Uint32Array": | 824229.3357 | 240765.2096 | 342%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=0 | type="Uint32Array": | 558549.0558 | 210350.9495 | 266%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Uint32Array": | 1114482.346 | 291626.9811 | 382%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=0 | type="Uint32Array": | 976467.5614 | 287154.8184 | 340%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Uint32Array": | 844915.4341 | 252636.5147 | 334%
assert/deepequal-typedarrays.js | method="deepEqual" | strict=1 | type="Uint32Array": | 579043.6774 | 213440.3381 | 271%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Uint32Array": | 1113688.235 | 307862.6268 | 362%
assert/deepequal-typedarrays.js | method="notDeepEqual" | strict=1 | type="Uint32Array": | 941621.1107 | 288160.3555 | 327%



</body>

</html>

