### PR TITLE
src: do not coerce dotenv paths

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -869,11 +869,9 @@ static ExitCode InitializeNodeWithArgsInternal(
 
   if (!file_paths.empty()) {
     CHECK(!per_process::v8_initialized);
-    auto cwd = Environment::GetCwd(Environment::GetExecPath(*argv));
 
     for (const auto& file_path : file_paths) {
-      std::string path = cwd + kPathSeparator + file_path;
-      auto path_exists = per_process::dotenv_file.ParsePath(path);
+      bool path_exists = per_process::dotenv_file.ParsePath(file_path);
 
       if (!path_exists) errors->push_back(file_path + ": not found");
     }

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -2,6 +2,7 @@
 
 const common = require('../common');
 const assert = require('node:assert');
+const path = require('node:path');
 const { describe, it } = require('node:test');
 
 const validEnvFilePath = '../fixtures/dotenv/valid.env';
@@ -20,6 +21,18 @@ describe('.env supports edge cases', () => {
       process.execPath,
       [ `--env-file=${nodeOptionsEnvFilePath}`, `--env-file=${validEnvFilePath}`, '--eval', code ],
       { cwd: __dirname },
+    );
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
+  it('supports absolute paths', async () => {
+    const code = `
+      require('assert').strictEqual(process.env.BASIC, 'basic');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ `--env-file=${path.resolve(__dirname, validEnvFilePath)}`, '--eval', code ],
     );
     assert.strictEqual(child.stderr, '');
     assert.strictEqual(child.code, 0);


### PR DESCRIPTION
Vastly simpler alternative to https://github.com/nodejs/node/pull/49232 that doesn't require `std::filesystem` or C++20.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
