### PR TITLE
doc: mark isWebAssemblyCompiledModule as eol

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3527,6 +3527,9 @@ deprecated. Get them from `fs.constants` or `fs.promises.constants` instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/99999
+    description: End-of-Life.
   - version:
     - v21.3.0
     - v20.11.0
@@ -3539,8 +3542,8 @@ changes:
 
 Type: Documentation-only
 
-The [`util.types.isWebAssemblyCompiledModule`][] API is deprecated. Please use
-`value instanceof WebAssembly.Module` instead.
+The `util.types.isWebAssemblyCompiledModule` API has been removed.
+Please use `value instanceof WebAssembly.Module` instead.
 
 ### DEP0178: `dirent.path`
 
@@ -3715,7 +3718,6 @@ Please use the [`crypto.createHash()`][] method to create Hash instances.
 [`util.log()`]: util.md#utillogstring
 [`util.promisify`]: util.md#utilpromisifyoriginal
 [`util.toUSVString()`]: util.md#utiltousvstringstring
-[`util.types.isWebAssemblyCompiledModule`]: util.md#utiltypesiswebassemblycompiledmodulevalue
 [`util.types`]: util.md#utiltypes
 [`util`]: util.md
 [`worker.exitedAfterDisconnect`]: cluster.md#workerexitedafterdisconnect

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3528,7 +3528,7 @@ deprecated. Get them from `fs.constants` or `fs.promises.constants` instead.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/99999
+    pr-url: https://github.com/nodejs/node/pull/51442
     description: End-of-Life.
   - version:
     - v21.3.0

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3540,7 +3540,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: End-of-Life
 
 The `util.types.isWebAssemblyCompiledModule` API has been removed.
 Please use `value instanceof WebAssembly.Module` instead.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2838,25 +2838,6 @@ Returns `true` if the value is a built-in [`WeakSet`][] instance.
 util.types.isWeakSet(new WeakSet());  // Returns true
 ```
 
-### `util.types.isWebAssemblyCompiledModule(value)`
-
-<!-- YAML
-added: v10.0.0
-deprecated: v14.0.0
--->
-
-> Stability: 0 - Deprecated: Use `value instanceof WebAssembly.Module` instead.
-
-* `value` {any}
-* Returns: {boolean}
-
-Returns `true` if the value is a built-in [`WebAssembly.Module`][] instance.
-
-```js
-const module = new WebAssembly.Module(wasmBuffer);
-util.types.isWebAssemblyCompiledModule(module);  // Returns true
-```
-
 ## Deprecated APIs
 
 The following APIs are deprecated and should no longer be used. Existing
@@ -3362,7 +3343,6 @@ util.log('Timestamped message.');
 [`Uint8ClampedArray`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
 [`WeakMap`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
 [`WeakSet`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
-[`WebAssembly.Module`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module
 [`assert.deepStrictEqual()`]: assert.md#assertdeepstrictequalactual-expected-message
 [`console.error()`]: console.md#consoleerrordata-args
 [`mime.toString()`]: #mimetostring


### PR DESCRIPTION
The function `isWebAssemblyCompiledModule` has actually already been removed from the codebase with this [commit](https://github.com/nodejs/node/commit/a63db7fb5ebade4d82a16bfab426108b0cbc192e).
I just updated documentation and marked it as EOL since the code isn't there anymore and it could not be runtime deprecated.
Although eol deprecations are semver major, I would not mark it as such because its only a documentation update.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
