### PR TITLE
lib: remove unnecessary refreshHrtimeBuffer()

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -57,21 +57,13 @@ const { exitCodes: { kNoFailure } } = internalBinding('errors');
 
 const binding = internalBinding('process_methods');
 
-let hrValues;
-let hrBigintValues;
-
-function refreshHrtimeBuffer() {
-  // The 3 entries filled in by the original process.hrtime contains
-  // the upper/lower 32 bits of the second part of the value,
-  // and the remaining nanoseconds of the value.
-  hrValues = binding.hrtimeBuffer;
-  // Use a BigUint64Array in the closure because this is actually a bit
-  // faster than simply returning a BigInt from C++ in V8 7.1.
-  hrBigintValues = new BigUint64Array(binding.hrtimeBuffer.buffer, 0, 1);
-}
-
-// Create the buffers.
-refreshHrtimeBuffer();
+// The 3 entries filled in by the original process.hrtime contains
+// the upper/lower 32 bits of the second part of the value,
+// and the remaining nanoseconds of the value.
+const hrValues = binding.hrtimeBuffer;
+// Use a BigUint64Array because this is actually a bit
+// faster than simply returning a BigInt from C++ in V8 7.1.
+const hrBigintValues = new BigUint64Array(binding.hrtimeBuffer.buffer, 0, 1);
 
 function hrtime(time) {
   binding.hrtime();
@@ -425,5 +417,4 @@ module.exports = {
   wrapProcessMethods,
   hrtime,
   hrtimeBigInt,
-  refreshHrtimeBuffer,
 };

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -211,8 +211,6 @@ function patchProcessObject(expandArgv1) {
   const binding = internalBinding('process_methods');
   binding.patchProcessObject(process);
 
-  require('internal/process/per_thread').refreshHrtimeBuffer();
-
   // Since we replace process.argv[0] below, preserve the original value in case the user needs it.
   ObjectDefineProperty(process, 'argv0', {
     __proto__: null,


### PR DESCRIPTION
We now serialize/deseialize the hrtime buffers properly instead of throwing them away at serialization and creating new ones at pre-execution, so there is no need to reset the variables to the binding property at pre-execution time.

Refs: https://github.com/nodejs/node/pull/48655
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
