### PR TITLE
lib: do not access process.noDeprecation at build time

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -907,8 +907,12 @@ const validateRmOptionsSync = hideStackFrames((path, options, expectDir) => {
   return options;
 });
 
-let recursiveRmdirWarned = process.noDeprecation;
+let recursiveRmdirWarned;
 function emitRecursiveRmdirWarning() {
+  if (recursiveRmdirWarned === undefined) {
+    // TODO(joyeecheung): use getOptionValue('--no-deprecation') instead.
+    recursiveRmdirWarned = process.noDeprecation;
+  }
   if (!recursiveRmdirWarned) {
     process.emitWarning(
       'In future versions of Node.js, fs.rmdir(path, { recursive: true }) ' +

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -142,10 +142,6 @@ function pendingDeprecate(fn, msg, code) {
 // Returns a modified function which warns once by default.
 // If --no-deprecation is set, then it is a no-op.
 function deprecate(fn, msg, code, useEmitSync) {
-  if (process.noDeprecation === true) {
-    return fn;
-  }
-
   // Lazy-load to avoid a circular dependency.
   if (validateString === undefined)
     ({ validateString } = require('internal/validators'));
@@ -158,7 +154,10 @@ function deprecate(fn, msg, code, useEmitSync) {
   );
 
   function deprecated(...args) {
-    emitDeprecationWarning();
+    // TODO(joyeecheung): use getOptionValue('--no-deprecation') instead.
+    if (!process.noDeprecation) {
+      emitDeprecationWarning();
+    }
     if (new.target) {
       return ReflectConstruct(fn, args, new.target);
     }


### PR DESCRIPTION
Delay access at run time otherwise the value is captured at build time and always false.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
