### PR TITLE
doc: remove reference to resolved child_process v8 issue

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -873,10 +873,6 @@ child registers an event handler for the [`'disconnect'`][] event
 or the [`'message'`][] event. This allows the child to exit
 normally without the process being held open by the open IPC channel._
 
-On Unix-like operating systems, the [`child_process.spawn()`][] method
-performs memory operations synchronously before decoupling the event loop
-from the child.
-
 See also: [`child_process.exec()`][] and [`child_process.fork()`][].
 
 ## Synchronous process creation

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -875,9 +875,7 @@ normally without the process being held open by the open IPC channel._
 
 On Unix-like operating systems, the [`child_process.spawn()`][] method
 performs memory operations synchronously before decoupling the event loop
-from the child. Applications with a large memory footprint may find frequent
-[`child_process.spawn()`][] calls to be a bottleneck. For more information,
-see [V8 issue 7381](https://bugs.chromium.org/p/v8/issues/detail?id=7381).
+from the child.
 
 See also: [`child_process.exec()`][] and [`child_process.fork()`][].
 


### PR DESCRIPTION
The linked v8 issue is closed. The NodeJS half of that issue has also been resolved. While there still may be issues related to child_process spawn performance, they are not related to this v8 issue.

Refs: https://bugs.chromium.org/p/v8/issues/detail?id=7381
Refs: https://github.com/nodejs/node/pull/48523
Refs: https://github.com/nodejs/performance/issues/138

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
