### PR TITLE
tools: limit parallelism with ninja in V8 builds

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -9,6 +9,11 @@ cd deps/v8 || exit
 find . -type d -name .git -print0 | xargs -0 rm -rf
 ../../tools/v8/fetch_deps.py .
 
+JOBS_ARG=
+if [ "${JOBS}" ]; then
+  JOBS_ARG="-j ${JOBS}"
+fi
+
 ARCH=$(arch)
 if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   TARGET_ARCH=$ARCH
@@ -46,10 +51,10 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   gcc --version
   export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config
   gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true $CC_WRAPPER"
-  ninja -v -C "out.gn/$BUILD_ARCH_TYPE" d8 cctest inspector-test
+  ninja -v -C "out.gn/$BUILD_ARCH_TYPE" "${JOBS_ARG}" d8 cctest inspector-test
 else
   DEPOT_TOOLS_DIR="$(cd _depot_tools && pwd)"
   # shellcheck disable=SC2086
   PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
-  PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" d8 cctest inspector-test
+  PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" "${JOBS_ARG}" d8 cctest inspector-test
 fi


### PR DESCRIPTION
If `JOBS` has been set in the environment to limit build parallelism, pass that onto `ninja` when building V8.

Refs: https://github.com/nodejs/node/pull/51362#issuecomment-1892526404

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
