### PR TITLE
src: add `process.loadEnvFile` and `util.parseEnv`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2260,6 +2260,29 @@ process.kill(process.pid, 'SIGHUP');
 When `SIGUSR1` is received by a Node.js process, Node.js will start the
 debugger. See [Signal Events][].
 
+## `process.loadEnvFile(path)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.1 - Active development
+
+* `path` {string | URL | Buffer | undefined}. **Default:** `'./.env'`
+
+Loads the `.env` file into `process.env`. Usage of `NODE_OPTIONS`
+in the `.env` file will not have any effect on Node.js.
+
+```cjs
+const { loadEnvFile } = require('node:process');
+loadEnvFile();
+```
+
+```mjs
+import { loadEnvFile } from 'node:process';
+loadEnvFile();
+```
+
 ## `process.mainModule`
 
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1593,6 +1593,36 @@ $ node negate.js --no-logfile --logfile=test.log --color --no-color
 { logfile: 'test.log', color: false }
 ```
 
+## `util.parseEnv(content)`
+
+> Stability: 1.1 - Active development
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `content` {string}
+
+The raw contents of a `.env` file.
+
+* Returns: {Object}
+
+Given an example `.env` file:
+
+```cjs
+const { parseEnv } = require('node:util');
+
+parseEnv('HELLO=world\nHELLO=oh my\n');
+// Returns: { HELLO: 'oh my' }
+```
+
+```mjs
+import { parseEnv } from 'node:util';
+
+parseEnv('HELLO=world\nHELLO=oh my\n');
+// Returns: { HELLO: 'oh my' }
+```
+
 ## `util.promisify(original)`
 
 <!-- YAML

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -172,6 +172,7 @@ const rawMethods = internalBinding('process_methods');
   process._kill = rawMethods._kill;
 
   const wrapped = perThreadSetup.wrapProcessMethods(rawMethods);
+  process.loadEnvFile = wrapped.loadEnvFile;
   process._rawDebug = wrapped._rawDebug;
   process.cpuUsage = wrapped.cpuUsage;
   process.resourceUsage = wrapped.resourceUsage;

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -46,6 +46,8 @@ const {
   validateNumber,
   validateObject,
 } = require('internal/validators');
+const { getValidatedPath } = require('internal/fs/utils');
+const { toNamespacedPath } = require('path');
 const constants = internalBinding('constants').os.signals;
 
 const kInternal = Symbol('internal properties');
@@ -100,6 +102,7 @@ function wrapProcessMethods(binding) {
     memoryUsage: _memoryUsage,
     rss,
     resourceUsage: _resourceUsage,
+    loadEnvFile: _loadEnvFile,
   } = binding;
 
   function _rawDebug(...args) {
@@ -250,6 +253,19 @@ function wrapProcessMethods(binding) {
     };
   }
 
+  /**
+   * Loads the `.env` file to process.env.
+   * @param {string | URL | Buffer | undefined} path
+   */
+  function loadEnvFile(path = undefined) { // Provide optional value so that `loadEnvFile.length` returns 0
+    if (path != null) {
+      path = getValidatedPath(path);
+      _loadEnvFile(toNamespacedPath(path));
+    } else {
+      _loadEnvFile();
+    }
+  }
+
 
   return {
     _rawDebug,
@@ -258,6 +274,7 @@ function wrapProcessMethods(binding) {
     memoryUsage,
     kill,
     exit,
+    loadEnvFile,
   };
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -67,9 +67,11 @@ const { debuglog } = require('internal/util/debuglog');
 const {
   validateFunction,
   validateNumber,
+  validateString,
 } = require('internal/validators');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
+const binding = internalBinding('util');
 
 const {
   deprecate,
@@ -371,6 +373,16 @@ function _exceptionWithHostPort(...args) {
   return new ExceptionWithHostPort(...args);
 }
 
+/**
+ * Parses the content of a `.env` file.
+ * @param {string} content
+ * @returns {Record<string, string>}
+ */
+function parseEnv(content) {
+  validateString(content, 'content');
+  return binding.parseEnv(content);
+}
+
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = {
   _errnoException,
@@ -465,6 +477,7 @@ module.exports = {
     return lazyAbortController().aborted;
   },
   types,
+  parseEnv,
 };
 
 defineLazyProperties(

--- a/src/node.cc
+++ b/src/node.cc
@@ -871,9 +871,18 @@ static ExitCode InitializeNodeWithArgsInternal(
     CHECK(!per_process::v8_initialized);
 
     for (const auto& file_path : file_paths) {
-      bool path_exists = per_process::dotenv_file.ParsePath(file_path);
-
-      if (!path_exists) errors->push_back(file_path + ": not found");
+      switch (per_process::dotenv_file.ParsePath(file_path)) {
+        case Dotenv::ParseResult::Valid:
+          break;
+        case Dotenv::ParseResult::InvalidContent:
+          errors->push_back(file_path + ": invalid format");
+          break;
+        case Dotenv::ParseResult::FileError:
+          errors->push_back(file_path + ": not found");
+          break;
+        default:
+          UNREACHABLE();
+      }
     }
 
     per_process::dotenv_file.AssignNodeOptionsIfAvailable(&node_options);

--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "util-inl.h"
+#include "v8.h"
 
 #include <map>
 
@@ -11,6 +12,8 @@ namespace node {
 
 class Dotenv {
  public:
+  enum ParseResult { Valid, FileError, InvalidContent };
+
   Dotenv() = default;
   Dotenv(const Dotenv& d) = default;
   Dotenv(Dotenv&& d) noexcept = default;
@@ -18,9 +21,11 @@ class Dotenv {
   Dotenv& operator=(const Dotenv& d) = default;
   ~Dotenv() = default;
 
-  bool ParsePath(const std::string_view path);
+  void ParseContent(const std::string_view content);
+  ParseResult ParsePath(const std::string_view path);
   void AssignNodeOptionsIfAvailable(std::string* node_options);
   void SetEnvironment(Environment* env);
+  v8::Local<v8::Object> ToObject(Environment* env);
 
   static std::vector<std::string> GetPathFromArgs(
       const std::vector<std::string>& args);

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -84,6 +84,8 @@ class BindingData : public SnapshotableObject {
 
   static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static void LoadEnvFile(const v8::FunctionCallbackInfo<v8::Value>& args);
+
  private:
   // Buffer length in uint32.
   static constexpr size_t kHrTimeBufferLength = 3;

--- a/test/fixtures/dotenv/.env
+++ b/test/fixtures/dotenv/.env
@@ -1,0 +1,1 @@
+BASIC=basic

--- a/test/fixtures/dotenv/basic-valid.env
+++ b/test/fixtures/dotenv/basic-valid.env
@@ -1,0 +1,1 @@
+BASIC=overriden

--- a/test/parallel/test-process-load-env-file.js
+++ b/test/parallel/test-process-load-env-file.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../../test/common/fixtures');
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+const basicValidEnvFilePath = fixtures.path('dotenv/basic-valid.env');
+const validEnvFilePath = fixtures.path('dotenv/valid.env');
+const missingEnvFile = fixtures.path('dotenv/non-existent-file.env');
+
+describe('process.loadEnvFile()', () => {
+
+  it('supports passing path', async () => {
+    const code = `
+      process.loadEnvFile(${JSON.stringify(validEnvFilePath)});
+      const assert = require('assert');
+      assert.strictEqual(process.env.BASIC, 'basic');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--eval', code ],
+      { cwd: __dirname },
+    );
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
+  it('supports not-passing a path', async () => {
+    // Uses `../fixtures/dotenv/.env` file.
+    const code = `
+      process.loadEnvFile();
+      const assert = require('assert');
+      assert.strictEqual(process.env.BASIC, 'basic');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--eval', code ],
+      { cwd: fixtures.path('dotenv/') },
+    );
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
+  it('should throw when file does not exist', async () => {
+    assert.throws(() => {
+      process.loadEnvFile(missingEnvFile);
+    }, { code: 'ENOENT' });
+  });
+
+  it('should throw when `.env` does not exist', async () => {
+    assert.throws(() => {
+      process.loadEnvFile();
+    }, { code: 'ENOENT' });
+  });
+
+  it('should check for permissions', async () => {
+    const code = `
+      process.loadEnvFile(${JSON.stringify(missingEnvFile)});
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--eval', code, '--experimental-permission' ],
+      { cwd: __dirname },
+    );
+    assert.match(child.stderr, /Error: Access to this API has been restricted/);
+    assert.match(child.stderr, /code: 'ERR_ACCESS_DENIED'/);
+    assert.match(child.stderr, /permission: 'FileSystemRead'/);
+    if (!common.isWindows) {
+      assert(child.stderr.includes(`resource: '${JSON.stringify(missingEnvFile).replaceAll('"', '')}'`));
+    }
+    assert.strictEqual(child.code, 1);
+  });
+
+  it('loadEnvFile does not mutate --env-file output', async () => {
+    const code = `
+      process.loadEnvFile(${JSON.stringify(basicValidEnvFilePath)});
+      require('assert')(process.env.BASIC === 'basic');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ `--env-file=${validEnvFilePath}`, '--eval', code ],
+      { cwd: __dirname },
+    );
+    assert.strictEqual(child.stdout, '');
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+});

--- a/test/parallel/util-parse-env.js
+++ b/test/parallel/util-parse-env.js
@@ -1,0 +1,59 @@
+'use strict';
+
+require('../common');
+const fixtures = require('../../test/common/fixtures');
+const assert = require('node:assert');
+const util = require('node:util');
+const fs = require('node:fs');
+
+{
+  const validEnvFilePath = fixtures.path('dotenv/valid.env');
+  const validContent = fs.readFileSync(validEnvFilePath, 'utf8');
+
+  assert.deepStrictEqual(util.parseEnv(validContent), {
+    AFTER_LINE: 'after_line',
+    BACKTICKS: 'backticks',
+    BACKTICKS_INSIDE_DOUBLE: '`backticks` work inside double quotes',
+    BACKTICKS_INSIDE_SINGLE: '`backticks` work inside single quotes',
+    BACKTICKS_SPACED: '    backticks    ',
+    BASIC: 'basic',
+    DOUBLE_AND_SINGLE_QUOTES_INSIDE_BACKTICKS: 'double "quotes" and single \'quotes\' work inside backticks',
+    DOUBLE_QUOTES: 'double_quotes',
+    DOUBLE_QUOTES_INSIDE_BACKTICKS: 'double "quotes" work inside backticks',
+    DOUBLE_QUOTES_INSIDE_SINGLE: 'double "quotes" work inside single quotes',
+    DOUBLE_QUOTES_SPACED: '    double quotes    ',
+    DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET: '{ port: $MONGOLAB_PORT}',
+    EMAIL: 'therealnerdybeast@example.tld',
+    EMPTY: '',
+    EMPTY_BACKTICKS: '',
+    EMPTY_DOUBLE_QUOTES: '',
+    EMPTY_SINGLE_QUOTES: '',
+    EQUAL_SIGNS: 'equals==',
+    INLINE_COMMENTS: 'inline comments',
+    INLINE_COMMENTS_BACKTICKS: 'inline comments outside of #backticks',
+    INLINE_COMMENTS_DOUBLE_QUOTES: 'inline comments outside of #doublequotes',
+    INLINE_COMMENTS_SINGLE_QUOTES: 'inline comments outside of #singlequotes',
+    INLINE_COMMENTS_SPACE: 'inline comments start with a',
+    RETAIN_INNER_QUOTES: '{"foo": "bar"}',
+    RETAIN_INNER_QUOTES_AS_BACKTICKS: '{"foo": "bar\'s"}',
+    RETAIN_INNER_QUOTES_AS_STRING: '{"foo": "bar"}',
+    SINGLE_QUOTES: 'single_quotes',
+    SINGLE_QUOTES_INSIDE_BACKTICKS: "single 'quotes' work inside backticks",
+    SINGLE_QUOTES_INSIDE_DOUBLE: "single 'quotes' work inside double quotes",
+    SINGLE_QUOTES_SPACED: '    single quotes    ',
+    SPACED_KEY: 'parsed',
+    TRIM_SPACE_FROM_UNQUOTED: 'some spaced out string'
+  });
+}
+
+assert.deepStrictEqual(util.parseEnv(''), {});
+assert.deepStrictEqual(util.parseEnv('FOO=bar\nFOO=baz\n'), { FOO: 'baz' });
+
+// Test for invalid input.
+assert.throws(() => {
+  for (const value of [null, undefined, {}, []]) {
+    util.parseEnv(value);
+  }
+}, {
+  code: 'ERR_INVALID_ARG_TYPE',
+});

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -43,4 +43,5 @@ export interface UtilBinding {
   shouldAbortOnUncaughtToggle: [shouldAbort: 0 | 1];
   WeakReference: typeof InternalUtilBinding.WeakReference;
   guessHandleType(fd: number): 'TCP' | 'TTY' | 'UDP' | 'FILE' | 'PIPE' | 'UNKNOWN';
+  parseEnv(content: string): Record<string, string>;
 }


### PR DESCRIPTION
Introduces 2 new functions to use the default `.env` parser. 

## `process.loadEnvFile(path)`

- In order to load the `.env` file in the current directory:

```js
process.loadEnvFile()
```

- Load a specific path:

```js
process.loadEnvFile('./development.env')
```

## `util.parseEnv(content)`

- In order to parse an existing string:

```js
assert.deepStrictEqual(require('node:util').parseEnv('HELLO=world'), { HELLO: 'world' });
```

Fixes https://github.com/nodejs/node/issues/51413
Ref https://github.com/nodejs/node/issues/49148


------

Thank you [Sentry](https://sentry.io) for sponsoring this work!