### PR TITLE
module: fix crash when built-in module export a `default` key

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -350,7 +350,8 @@ class BuiltinModule {
     const url = `node:${this.id}`;
     const builtin = this;
     const exportsKeys = ArrayPrototypeSlice(this.exportKeys);
-    ArrayPrototypePush(exportsKeys, 'default');
+    if (!ArrayPrototypeIncludes(exportsKeys, 'default'))
+      ArrayPrototypePush(exportsKeys, 'default');
     this.module = new ModuleWrap(
       url, undefined, exportsKeys,
       function() {

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -350,8 +350,9 @@ class BuiltinModule {
     const url = `node:${this.id}`;
     const builtin = this;
     const exportsKeys = ArrayPrototypeSlice(this.exportKeys);
-    if (!ArrayPrototypeIncludes(exportsKeys, 'default'))
+    if (!ArrayPrototypeIncludes(exportsKeys, 'default')) {
       ArrayPrototypePush(exportsKeys, 'default');
+    }
     this.module = new ModuleWrap(
       url, undefined, exportsKeys,
       function() {

--- a/test/parallel/test-process-default.js
+++ b/test/parallel/test-process-default.js
@@ -1,0 +1,8 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+
+process.default = 1;
+import('node:process').then(common.mustCall((processModule) => {
+  assert.strictEqual(processModule.default.default, 1);
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51480
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
