### PR TITLE
src: add `node.h` include to `module_wrap.h`

### DIFF
--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -3,10 +3,11 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "base_object.h"
+#include "node.h"
 
 namespace node {
 


### PR DESCRIPTION
All other classes using `NODE_EXTERN` include `node.h`, and not including it causes the following compilation errors in Electron:

<details><summary>Build Failure</summary>
<p>

```
In file included from ../../third_party/electron_node/src/module_wrap.cc:1:
../../third_party/electron_node/src/module_wrap.h:34:1: error: unknown type name 'NODE_EXTERN'
   34 | NODE_EXTERN v8::MaybeLocal<v8::Promise> ImportModuleDynamically(
      | ^
../../third_party/electron_node/src/module_wrap.h:34:17: error: template specialization requires 'template<>'
   34 | NODE_EXTERN v8::MaybeLocal<v8::Promise> ImportModuleDynamically(
      |                 ^         ~~~~~~~~~~~~~
      | template<>
../../third_party/electron_node/src/module_wrap.h:34:17: error: no variable template matches specialization
../../third_party/electron_node/src/module_wrap.h:34:40: error: expected ';' after top level declarator
   34 | NODE_EXTERN v8::MaybeLocal<v8::Promise> ImportModuleDynamically(
      |                                        ^
      |                                        ;
../../third_party/electron_node/src/module_wrap.h:41:19: error: variable has incomplete type 'class NODE_EXTERN'
   41 | class NODE_EXTERN ModuleWrap : public BaseObject {
      |                   ^
../../third_party/electron_node/src/module_wrap.h:41:7: note: forward declaration of 'node::loader::NODE_EXTERN'
   41 | class NODE_EXTERN ModuleWrap : public BaseObject {
      |       ^
../../third_party/electron_node/src/module_wrap.h:41:30: error: expected ';' after top level declarator
   41 | class NODE_EXTERN ModuleWrap : public BaseObject {
      |                              ^
      |                              ;
../../third_party/electron_node/src/module_wrap.h:41:32: error: expected unqualified-id
   41 | class NODE_EXTERN ModuleWrap : public BaseObject {
      |                                ^
../../third_party/electron_node/src/module_wrap.cc:53:1: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
   53 | ModuleWrap::ModuleWrap(Realm* realm,
      | ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:53:1: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
   53 | ModuleWrap::ModuleWrap(Realm* realm,
      | ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:76:1: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
   76 | ModuleWrap::~ModuleWrap() {
      | ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:86:16: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
   86 | Local<Context> ModuleWrap::context() const {
      |                ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:94:13: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
   94 | ModuleWrap* ModuleWrap::GetFromModule(Environment* env,
      |             ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:107:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  107 | void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:275:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  275 | void ModuleWrap::Link(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:339:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  339 | void ModuleWrap::Instantiate(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:364:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  364 | void ModuleWrap::Evaluate(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:440:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  440 | void ModuleWrap::GetNamespace(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:466:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  466 | void ModuleWrap::GetStatus(const FunctionCallbackInfo<Value>& args) {
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
../../third_party/electron_node/src/module_wrap.cc:476:6: error: incomplete type 'node::loader::ModuleWrap' named in nested name specifier
  476 | void ModuleWrap::GetStaticDependencySpecifiers(
      |      ^~~~~~~~~~~~
../../third_party/electron_node/src/env.h:104:7: note: forward declaration of 'node::loader::ModuleWrap'
  104 | class ModuleWrap;
      |       ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

</p>
</details>

This allows Electron to remove a [patch](https://github.com/electron/electron/blob/646870564436e07e5e4cb48962f0fc7e50c84884/patches/node/fix_missing_include_for_node_extern.patch)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
