### PR TITLE
fs: update jsdoc for `filehandle.createWriteStream` and `appendFile`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2379,6 +2379,7 @@ function writeFileSync(path, data, options) {
  *   encoding?: string | null;
  *   mode?: number;
  *   flag?: string;
+ *   flush?: boolean;
  *   } | string} [options]
  * @param {(err?: Error) => any} callback
  * @returns {void}

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -365,6 +365,7 @@ class FileHandle extends EventEmitter {
    *   autoClose?: boolean;
    *   emitClose?: boolean;
    *   start: number;
+   *   highWaterMark?: number;
    *   flush?: boolean;
    *   }} [options]
    * @returns {WriteStream}


### PR DESCRIPTION
I updated jsdoc due to inconsistency between documentation and jsdoc.

- filehandle.createWriteStream()
https://github.com/nodejs/node/blob/e133e5115a829aa7a445cfd8754df3a3dd586b0a/doc/api/fs.md?plain=1#L336-L344

- fs.appendFile()
https://github.com/nodejs/node/blob/e133e5115a829aa7a445cfd8754df3a3dd586b0a/doc/api/fs.md?plain=1#L2105-L2114


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
