### PR TITLE
lib: parse the incoming http message url with the whatwg url class

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -94,6 +94,15 @@ function IncomingMessage(socket) {
   // read by the user, so there's no point continuing to handle it.
   this._dumped = false;
 }
+
+ObjectDefineProperty(IncomingMessage.prototype, 'fullUrl', {
+  __proto__: null,
+  get() {
+    const protocol = this.socket.encrypted ? 'https' : 'http';
+    return new URL(this.url, `${protocol}://${this.headers.host}`);
+  },
+});
+
 ObjectSetPrototypeOf(IncomingMessage.prototype, Readable.prototype);
 ObjectSetPrototypeOf(IncomingMessage, Readable);
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -445,6 +445,11 @@ function storeHTTPOptions(options) {
     validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
   this.maxHeaderSize = maxHeaderSize;
 
+  const parseIncomingUrlWithWhatWg = options.parseIncomingUrlWithWhatWg;
+  if (parseIncomingUrlWithWhatWg !== undefined)
+    validateBoolean(parseIncomingUrlWithWhatWg, 'options.parseIncomingUrlWithWhatWg');
+  this.parseIncomingUrlWithWhatWg = parseIncomingUrlWithWhatWg;
+
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined)
     validateBoolean(insecureHTTPParser, 'options.insecureHTTPParser');
@@ -1029,6 +1034,11 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
                   server.listenerCount('upgrade') > 0;
     if (req.upgrade)
       return 2;
+  }
+  if(server.parseIncomingUrlWithWhatWg) {
+    req.originalUrl = req.url;
+    const newUrl = new URL(req.url, 'http://localhost');
+    req.url = newUrl.pathname + newUrl.search;
   }
 
   state.incoming.push(req);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -445,11 +445,6 @@ function storeHTTPOptions(options) {
     validateInteger(maxHeaderSize, 'maxHeaderSize', 0);
   this.maxHeaderSize = maxHeaderSize;
 
-  const parseIncomingUrlWithWhatWg = options.parseIncomingUrlWithWhatWg;
-  if (parseIncomingUrlWithWhatWg !== undefined)
-    validateBoolean(parseIncomingUrlWithWhatWg, 'options.parseIncomingUrlWithWhatWg');
-  this.parseIncomingUrlWithWhatWg = parseIncomingUrlWithWhatWg;
-
   const insecureHTTPParser = options.insecureHTTPParser;
   if (insecureHTTPParser !== undefined)
     validateBoolean(insecureHTTPParser, 'options.insecureHTTPParser');
@@ -1034,11 +1029,6 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
                   server.listenerCount('upgrade') > 0;
     if (req.upgrade)
       return 2;
-  }
-  if(server.parseIncomingUrlWithWhatWg) {
-    req.originalUrl = req.url;
-    const newUrl = new URL(req.url, 'http://localhost');
-    req.url = newUrl.pathname + newUrl.search;
   }
 
   state.incoming.push(req);


### PR DESCRIPTION
Draft for https://github.com/nodejs/node/issues/51311
TODO:
 - add test
 - should the url object be added to the request object? (This would allow easy access to the search parameters)
 - should the property be named `originalUrl` or `rawUrl`