### PR TITLE
async_hooks,inspector: inspector keeps async context untouched

### DIFF
--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -102,17 +102,9 @@ namespace node {
 #define NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 #endif  // HAVE_OPENSSL
 
-#if HAVE_INSPECTOR
-#define NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)                                \
-  V(INSPECTORJSBINDING)
-#else
-#define NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)
-#endif  // HAVE_INSPECTOR
-
-#define NODE_ASYNC_PROVIDER_TYPES(V)                                          \
-  NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                                     \
-  NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)                                         \
-  NODE_ASYNC_INSPECTOR_PROVIDER_TYPES(V)
+#define NODE_ASYNC_PROVIDER_TYPES(V)                                           \
+  NODE_ASYNC_NON_CRYPTO_PROVIDER_TYPES(V)                                      \
+  NODE_ASYNC_CRYPTO_PROVIDER_TYPES(V)
 
 class Environment;
 class DestroyParam;

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,4 +1,3 @@
-#include "async_wrap-inl.h"
 #include "base_object-inl.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"
@@ -61,7 +60,7 @@ struct MainThreadConnection {
 };
 
 template <typename ConnectionType>
-class JSBindingsConnection : public AsyncWrap {
+class JSBindingsConnection : public BaseObject {
  public:
   class JSBindingsSessionDelegate : public InspectorSessionDelegate {
    public:
@@ -91,15 +90,16 @@ class JSBindingsConnection : public AsyncWrap {
   JSBindingsConnection(Environment* env,
                        Local<Object> wrap,
                        Local<Function> callback)
-                       : AsyncWrap(env, wrap, PROVIDER_INSPECTORJSBINDING),
-                         callback_(env->isolate(), callback) {
+      : BaseObject(env, wrap), callback_(env->isolate(), callback) {
     Agent* inspector = env->inspector_agent();
     session_ = ConnectionType::Connect(
         inspector, std::make_unique<JSBindingsSessionDelegate>(env, this));
   }
 
   void OnMessage(Local<Value> value) {
-    MakeCallback(callback_.Get(env()->isolate()), 1, &value);
+    auto result = callback_.Get(env()->isolate())
+                      ->Call(env()->context(), object(), 1, &value);
+    (void)result;
   }
 
   static void Bind(Environment* env, Local<Object> target) {
@@ -108,7 +108,6 @@ class JSBindingsConnection : public AsyncWrap {
         NewFunctionTemplate(isolate, JSBindingsConnection::New);
     tmpl->InstanceTemplate()->SetInternalFieldCount(
         JSBindingsConnection::kInternalFieldCount);
-    tmpl->Inherit(AsyncWrap::GetConstructorTemplate(env));
     SetProtoMethod(isolate, tmpl, "dispatch", JSBindingsConnection::Dispatch);
     SetProtoMethod(
         isolate, tmpl, "disconnect", JSBindingsConnection::Disconnect);

--- a/test/parallel/test-inspector-async-context-brk.js
+++ b/test/parallel/test-inspector-async-context-brk.js
@@ -1,0 +1,68 @@
+'use strict';
+const common = require('../common');
+const { AsyncLocalStorage } = require('async_hooks');
+const als = new AsyncLocalStorage();
+
+function getStore() {
+  return als.getStore();
+}
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { Session } = require('inspector');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+let valueInFunction = 0;
+let valueInBreakpoint = 0;
+
+function debugged() {
+  valueInFunction = getStore();
+  console.log('in code => ', getStore());
+  return 42;
+}
+
+async function test() {
+  const session = new Session();
+
+  session.connect();
+  console.log('Connected');
+
+  session.post('Debugger.enable');
+  console.log('Debugger was enabled');
+
+  session.on('Debugger.paused', () => {
+    valueInBreakpoint = getStore();
+    console.log('on Debugger.paused callback => ', getStore());
+  });
+
+  await new Promise((resolve, reject) => {
+    session.post('Debugger.setBreakpointByUrl', {
+      'lineNumber': 22,
+      'url': pathToFileURL(path.resolve(__dirname, __filename)).toString(),
+      'columnNumber': 0,
+      'condition': ''
+    }, (error, result) => {
+      return error ? reject(error) : resolve(result);
+    });
+  });
+  console.log('Breakpoint was set');
+
+  als.run(1, debugged);
+  assert.strictEqual(valueInFunction, valueInBreakpoint);
+  assert.strictEqual(valueInFunction, 1);
+  assert.notStrictEqual(valueInFunction, 0);
+  assert.notStrictEqual(valueInBreakpoint, 0);
+
+  console.log('Breakpoint was hit');
+
+  session.disconnect();
+  console.log('Session disconnected');
+}
+
+const interval = setInterval(() => {}, 1000);
+test().then(common.mustCall(() => {
+  clearInterval(interval);
+  console.log('Done!');
+}));

--- a/test/parallel/test-inspector-async-context-brk.js
+++ b/test/parallel/test-inspector-async-context-brk.js
@@ -19,7 +19,6 @@ let valueInBreakpoint = 0;
 
 function debugged() {
   valueInFunction = getStore();
-  console.log('in code => ', getStore());
   return 42;
 }
 
@@ -27,14 +26,10 @@ async function test() {
   const session = new Session();
 
   session.connect();
-  console.log('Connected');
-
   session.post('Debugger.enable');
-  console.log('Debugger was enabled');
 
   session.on('Debugger.paused', () => {
     valueInBreakpoint = getStore();
-    console.log('on Debugger.paused callback => ', getStore());
   });
 
   await new Promise((resolve, reject) => {
@@ -47,22 +42,15 @@ async function test() {
       return error ? reject(error) : resolve(result);
     });
   });
-  console.log('Breakpoint was set');
 
   als.run(1, debugged);
   assert.strictEqual(valueInFunction, valueInBreakpoint);
   assert.strictEqual(valueInFunction, 1);
-  assert.notStrictEqual(valueInFunction, 0);
-  assert.notStrictEqual(valueInBreakpoint, 0);
-
-  console.log('Breakpoint was hit');
 
   session.disconnect();
-  console.log('Session disconnected');
 }
 
 const interval = setInterval(() => {}, 1000);
 test().then(common.mustCall(() => {
   clearInterval(interval);
-  console.log('Done!');
 }));

--- a/test/parallel/test-inspector-multisession-js.js
+++ b/test/parallel/test-inspector-multisession-js.js
@@ -1,4 +1,3 @@
-// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -47,8 +47,6 @@ const { getSystemErrorName } = require('util');
     delete providers.WORKER;
     // TODO(danbev): Test for these
     delete providers.JSUDPWRAP;
-    if (!common.isMainThread)
-      delete providers.INSPECTORJSBINDING;
     delete providers.KEYPAIRGENREQUEST;
     delete providers.KEYGENREQUEST;
     delete providers.KEYEXPORTREQUEST;
@@ -314,13 +312,6 @@ if (common.hasCrypto) { // eslint-disable-line node-core/crypto-check
   req.oncomplete = () => handle.close();
   handle.send(req, [Buffer.alloc(1)], 1, req.port, req.address, true);
   testInitialized(req, 'SendWrap');
-}
-
-if (process.features.inspector && common.isMainThread) {
-  const binding = internalBinding('inspector');
-  const handle = new binding.Connection(() => {});
-  testInitialized(handle, 'Connection');
-  handle.disconnect();
 }
 
 // PROVIDER_HEAPDUMP

--- a/typings/internalBinding/async_wrap.d.ts
+++ b/typings/internalBinding/async_wrap.d.ts
@@ -68,7 +68,6 @@ declare namespace InternalAsyncWrapBinding {
     SIGNREQUEST: 54;
     TLSWRAP: 55;
     VERIFYREQUEST: 56;
-    INSPECTORJSBINDING: 57;
   }
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This started as an observation that the async context is modified from the function where the breakpoint is defined to the Debugger.paused callback function. The debugger breakpoint handler function should be able to access the async context of the involved function. 

I decided for a PR instead of an issue because it allows to make a code proposal to start the discussion. Is there anything that can cause issues with this change?

The testcase with this PR (`test-inspector-async-context-brk.js`) fails without the change because the `Debugger.paused` callback runs in the context available at callback creation (in this example `undefined`). With this modification, the inspector is not considered an async resource and it does not create an own async context and the test passes.
