### PR TITLE
test: remove common.expectsError calls for asserts

### DIFF
--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -33,11 +33,11 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
   });
   assert.throws(() => {
     fs.writeFile(blockedFileURL, 'example', () => {});
-  }, common.expectsError({
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
-  }));
+  });
   assert.throws(() => {
     fs.writeFile(relativeProtectedFile, 'example', () => {});
   }, {
@@ -101,11 +101,11 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
   });
   assert.throws(() => {
     fs.utimes(blockedFileURL, new Date(), new Date(), () => {});
-  }, common.expectsError({
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
-  }));
+  });
   assert.throws(() => {
     fs.utimes(relativeProtectedFile, new Date(), new Date(), () => {});
   }, {
@@ -134,11 +134,11 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
   });
   assert.throws(() => {
     fs.lutimes(blockedFileURL, new Date(), new Date(), () => {});
-  }, common.expectsError({
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
-  }));
+  });
 }
 
 // fs.mkdir
@@ -195,11 +195,11 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
     fs.rename(blockedFileURL, path.join(blockedFile, 'renamed'), (err) => {
       assert.ifError(err);
     });
-  }, common.expectsError({
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
-  }));
+  });
   assert.throws(() => {
     fs.rename(relativeProtectedFile, path.join(relativeProtectedFile, 'renamed'), (err) => {
       assert.ifError(err);


### PR DESCRIPTION
An object can be passed as the second param to `assert.throws`. this change removes `common.expectsError` calls as it is no longer needed.

cc: @RafaelGSS 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
