### PR TITLE
doc: clarify after and afterEach hooks execution

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1480,6 +1480,12 @@ added:
 This function is used to create a hook running
 after each subtest of the current test.
 
+**Note:** The `afterEach` hook is executed after each individual test
+in a test suite, regardless of whether the test passed or failed.
+This hook is commonly used for cleaning up resources or resetting state
+between tests. It's important to note that the `afterEach` hook
+is guaranteed to run after every test, even if any of the tests fail.
+
 ```js
 describe('tests', async () => {
   afterEach(() => console.log('finished running a test'));

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1420,11 +1420,7 @@ describe('tests', async () => {
 });
 ```
 
-**Note:** The `after` hook is executed once after all the tests
-in a test suite have completed, regardless of whether the tests
-passed or failed. This hook is useful for performing cleanup tasks
-or actions that should occur after the entire test suite has been run.
-The `after` hook is guaranteed to run, even if tests within the suite fail.
+**Note:** The `after` hook is guaranteed to run, even if tests within the suite fail.
 
 ## `beforeEach([fn][, options])`
 
@@ -1479,10 +1475,7 @@ added:
 This function is used to create a hook running
 after each subtest of the current test.
 
-**Note:** The `afterEach` hook is executed after each individual test
-in a test suite, regardless of whether the test passed or failed.
-This hook is commonly used for cleaning up resources or resetting state
-between tests. The `afterEach` hook is guaranteed to run after every test,
+**Note:** The `afterEach` hook is guaranteed to run after every test,
 even if any of the tests fail.
 
 ```js

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1420,6 +1420,13 @@ describe('tests', async () => {
 });
 ```
 
+**Note:** The `after` hook is executed once after all the tests
+in a test suite have completed, regardless of whether the tests
+passed or failed. This hook is useful for performing cleanup tasks
+or actions that should occur after the entire test suite has been run.
+It's important to note that the `after` hook is guaranteed to run,
+even if tests within the suite fail.
+
 ## `beforeEach([fn][, options])`
 
 <!-- YAML

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1420,7 +1420,8 @@ describe('tests', async () => {
 });
 ```
 
-**Note:** The `after` hook is guaranteed to run, even if tests within the suite fail.
+**Note:** The `after` hook is guaranteed to run,
+even if tests within the suite fail.
 
 ## `beforeEach([fn][, options])`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1424,8 +1424,7 @@ describe('tests', async () => {
 in a test suite have completed, regardless of whether the tests
 passed or failed. This hook is useful for performing cleanup tasks
 or actions that should occur after the entire test suite has been run.
-It's important to note that the `after` hook is guaranteed to run,
-even if tests within the suite fail.
+The `after` hook is guaranteed to run, even if tests within the suite fail.
 
 ## `beforeEach([fn][, options])`
 
@@ -1483,8 +1482,8 @@ after each subtest of the current test.
 **Note:** The `afterEach` hook is executed after each individual test
 in a test suite, regardless of whether the test passed or failed.
 This hook is commonly used for cleaning up resources or resetting state
-between tests. It's important to note that the `afterEach` hook
-is guaranteed to run after every test, even if any of the tests fail.
+between tests. The `afterEach` hook is guaranteed to run after every test,
+even if any of the tests fail.
 
 ```js
 describe('tests', async () => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

### Summary

This pull request addresses Issue #50901 , which highlights a documentation clarification regarding the execution of the `after` and `afterEach` hooks in the test runner.

### Changes Made

`after` Hook Documentation:

* Clarified that the `after` hook is executed once after all tests in a suite, irrespective of test success or failure.
* Replaced instances of "note that" with more direct language for enhanced clarity.

`afterEach` Hook Documentation:

* updated the documentation to explicitly state that the `afterEach` hook is executed after each individual test, regardless of test outcomes.
* Improved clarity by replacing occurrences of "note that" with more straightforward language.

### Additional Notes

The changes adhere to the Node.js documentation style guide.
Linting warnings related to the phrase "note that" have been addressed for improved documentation clarity.

### Related Issues
Fixes: Issue #50901 