### PR TITLE
benchmark: fix api restriction for the permission category

### DIFF
--- a/benchmark/permission/permission-processhas-fs-read.js
+++ b/benchmark/permission/permission-processhas-fs-read.js
@@ -13,6 +13,7 @@ const options = {
   flags: [
     '--experimental-permission',
     `--allow-fs-read=${rootPath}`,
+    '--allow-child-process',
   ],
 };
 

--- a/benchmark/permission/permission-startup.js
+++ b/benchmark/permission/permission-startup.js
@@ -47,12 +47,14 @@ function spawnProcess(script, bench, state) {
 
 function main({ count, script, nFiles, prefixPath }) {
   script = path.resolve(__dirname, '../../', `${script}.js`);
-  const files = mockFiles(nFiles, prefixPath).join(',');
   const optionsWithScript = [
     '--experimental-permission',
-    `--allow-fs-read=${files},${script}`,
-    script,
+    `--allow-fs-read=${script}`,
   ];
+  for (const file of mockFiles(nFiles, prefixPath)) {
+    optionsWithScript.push('--allow-fs-read=' + file);
+  }
+  optionsWithScript.push(script);
   const warmup = 3;
   const state = { count, finished: -warmup };
   spawnProcess(optionsWithScript, bench, state);

--- a/benchmark/permission/permission-startup.js
+++ b/benchmark/permission/permission-startup.js
@@ -50,11 +50,9 @@ function main({ count, script, nFiles, prefixPath }) {
   const optionsWithScript = [
     '--experimental-permission',
     `--allow-fs-read=${script}`,
+    ...mockFiles(nFiles, prefixPath).map((file) => '--allow-fs-read=' + file),
+    script,
   ];
-  for (const file of mockFiles(nFiles, prefixPath)) {
-    optionsWithScript.push('--allow-fs-read=' + file);
-  }
-  optionsWithScript.push(script);
   const warmup = 3;
   const state = { count, finished: -warmup };
   spawnProcess(optionsWithScript, bench, state);


### PR DESCRIPTION
give appropriate permissions to the following scripts:

* permission-processhas-fs-read.js: 'ChildProcess' permission
* permission-startup.js: 'FileSystemRead' permission
  > Paths delimited by comma (,) are no longer allowed.

Refs: https://github.com/nodejs/node/blob/main/doc/api/cli.md#--allow-fs-read

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
