### PR TITLE
meta: mark security-wg codeowner for deps folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,6 +174,7 @@
 /.github/workflows/tools.yml @nodejs/security-wg
 /.github/workflows/update-openssl.yml @nodejs/security-wg
 /.github/workflows/update-v8.yml @nodejs/security-wg @nodejs/v8-update
+/deps @nodejs/security-wg
 /tools/dep_updaters/* @nodejs/security-wg
 
 # Web Standards


### PR DESCRIPTION
In the last @nodejs/security-wg meeting we discussed about having visibility on dependencies update.
With this  [commit](https://github.com/nodejs/node/commit/f9d4e07fafdc0e1fae32af039415a44c829d79e8) we lost vibility on dependencies update (because that file of which we are codeowners does not get updated), so we would like to keep receiving the notification by adding security-wg as codeowner of deps.
