### PR TITLE
assert: add assert.unreachable

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1437,6 +1437,90 @@ suppressFrame();
 //     ...
 ```
 
+## `assert.unreachable(actual, [message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `actual` {any}
+* `message` {string|Error} **Default:** `'Expected this assertion not to be reached'`
+
+Asserts that a code path does not execute. This is like `assert.fail` but it
+takes a value, usually used in a branch condition, that caused this branch to
+execute.
+
+This is useful for writing exhaustive checks, when you want to indicate to
+readers that you think you've covered all cases, and error at runtime which
+value caused this branch to execute.
+
+```mjs
+import assert from 'node:assert/strict';
+
+/**
+ * @param {'a' | 'b'} type
+ */
+function fn(type) {
+  if (type === 'a' || type === 'b') {
+    // Do something with a or b
+  } else {
+    // Will throw on an unexpected type
+    assert.unreachable(type, 'Unexpected type');
+  }
+}
+```
+
+```cjs
+const assert = require('node:assert/strict');
+
+/**
+ * @param {'a' | 'b'} type
+ */
+function fn(type) {
+  if (type === 'a' || type === 'b') {
+    // Do something with a or b
+  } else {
+    // Will throw on an unexpected type
+    assert.unreachable(type, 'Unexpected type');
+  }
+}
+```
+
+With a type checker that can follow types thru conditional branches, like
+TypeScript, uncovered branches can be detected without running your code.
+
+```mjs
+import assert from 'node:assert/strict';
+
+/**
+ * @param {'a' | 'b' | 'c'} type
+ */
+function fn(type) {
+  if (type === 'a' || type === 'b') {
+    // Do something with a or b
+  } else {
+    assert.unreachable(type, 'Unexpected type');
+    //                  ^? Argument of type 'c' does not satisfy never
+  }
+}
+```
+
+```cjs
+const assert = require('node:assert/strict');
+
+/**
+ * @param {'a' | 'b' | 'c'} type
+ */
+function fn(type) {
+  if (type === 'a' || type === 'b') {
+    // Do something with a or b
+  } else {
+    assert.unreachable(type, 'Unexpected type');
+    //                  ^? Argument of type 'c' does not satisfy never
+  }
+}
+```
+
 ## `assert.ifError(value)`
 
 <!-- YAML

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -1001,6 +1001,38 @@ assert.ifError = function ifError(err) {
   }
 };
 
+/**
+ * @param {never} actual
+ * @param {string | Error} [message]
+ */
+assert.unreachable = function unreachable(actual, message) {
+  const argsLen = arguments.length;
+  if (argsLen < 1) {
+    throw new ERR_MISSING_ARGS('actual');
+  }
+
+  let internalMessage = false;
+  if (argsLen === 1) {
+    message = 'Expected this assertion to be unreachable';
+    internalMessage = true;
+  }
+
+  if (message instanceof Error) throw message;
+
+  const err = new AssertionError({
+    actual,
+    operator: 'unreachable',
+    message,
+    stackStartFn: unreachable,
+  });
+
+  if (internalMessage) {
+    err.generatedMessage = true;
+  }
+
+  throw err;
+};
+
 function internalMatch(string, regexp, message, fn) {
   if (!isRegExp(regexp)) {
     throw new ERR_INVALID_ARG_TYPE(

--- a/test/parallel/test-assert-unreachable.js
+++ b/test/parallel/test-assert-unreachable.js
@@ -1,0 +1,51 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Unreachable should error for any value truthy or falsy
+[ true, false, null, undefined, '', 'type' ].forEach((exampleValue) => {
+  assert.throws(
+    () => { assert.unreachable(exampleValue); },
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError',
+      message: 'Expected this assertion to be unreachable',
+      operator: 'unreachable',
+      actual: exampleValue,
+      expected: undefined,
+      generatedMessage: true,
+      stack: /to be unreachable/
+    }
+  );
+});
+
+// Message can be changed
+assert.throws(
+  () => { assert.unreachable(null, 'whoops'); },
+  {
+    code: 'ERR_ASSERTION',
+    name: 'AssertionError',
+    message: 'whoops',
+    operator: 'unreachable',
+    actual: null,
+    expected: undefined,
+    generatedMessage: false,
+    stack: /whoops/
+  }
+);
+
+// Or the whole error can be replaced
+const err = new Error();
+assert.throws(
+  () => { assert.unreachable(null, err); },
+  err,
+);
+
+// The `actual` argument is required
+assert.throws(
+  () => { assert.unreachable(); },
+  {
+    code: 'ERR_MISSING_ARGS',
+  }
+);


### PR DESCRIPTION
Like `assert.fail` but takes a value, which should be some value used previously in a conditional that caused this assertion to execute.

Useful with TypeScript or another type checker that can tell when all expected values are handled in other branches and the type is narrowed to `never`. Then when `actual` is not `never` the type checker can error.

I'm not sure if yall will accept this contribution because the value add without TypeScript is minimal. One might argue that `unreachable` is more readable and gives more context than `fail`. However, the real value is having TypeScript error when `actual` is not `never`.

I define a helper like this in every project I work on. While I haven't used it there is [#aikoven/assert-never](https://github.com/aikoven/assert-never) with 1.4m weekly downloads across 117 direct dependencies on npm. Other inspiration comes from rusts [unreachable!](https://doc.rust-lang.org/std/macro.unreachable.html) macro.   

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
