### PR TITLE
build: remove copyright header in node.gni

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -1,8 +1,3 @@
-# Copyright 2019 the V8 project authors. All rights reserved.
-# Copyright 2023 Microsoft Inc.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
 # This file is used by GN for building, which is NOT the build system used for
 # building official binaries.
 # Please take a look at node.gyp if you are making changes to build system.


### PR DESCRIPTION
This file was missed in https://github.com/nodejs/node/pull/50694.
