### PR TITLE
deps: V8: cherry-pick efb1133eb894

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-script.h
+++ b/deps/v8/include/v8-script.h
@@ -394,6 +394,27 @@ class V8_EXPORT ScriptCompiler {
     CachedData(const uint8_t* data, int length,
                BufferPolicy buffer_policy = BufferNotOwned);
     ~CachedData();
+
+    enum CompatibilityCheckResult {
+      // Don't change order/existing values of this enum since it keys into the
+      // `code_cache_reject_reason` histogram. Append-only!
+      kSuccess = 0,
+      kMagicNumberMismatch = 1,
+      kVersionMismatch = 2,
+      kSourceMismatch = 3,
+      kFlagsMismatch = 5,
+      kChecksumMismatch = 6,
+      kInvalidHeader = 7,
+      kLengthMismatch = 8,
+      kReadOnlySnapshotChecksumMismatch = 9,
+
+      // This should always point at the last real enum value.
+      kLast = kReadOnlySnapshotChecksumMismatch
+    };
+
+    // Check if the CachedData can be loaded in the given isolate.
+    CompatibilityCheckResult CompatibilityCheck(Isolate* isolate);
+
     // TODO(marja): Async compilation; add constructors which take a callback
     // which will be called when V8 no longer needs the data.
     const uint8_t* data;

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -1951,6 +1951,18 @@ ScriptCompiler::CachedData::~CachedData() {
   }
 }
 
+ScriptCompiler::CachedData::CompatibilityCheckResult
+ScriptCompiler::CachedData::CompatibilityCheck(Isolate* isolate) {
+  i::AlignedCachedData aligned(data, length);
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(isolate);
+  i::SerializedCodeSanityCheckResult result;
+  i::SerializedCodeData scd =
+      i::SerializedCodeData::FromCachedDataWithoutSource(
+          i_isolate->AsLocalIsolate(), &aligned, &result);
+  return static_cast<ScriptCompiler::CachedData::CompatibilityCheckResult>(
+      result);
+}
+
 ScriptCompiler::StreamedSource::StreamedSource(
     std::unique_ptr<ExternalSourceStream> stream, Encoding encoding)
     : impl_(new i::ScriptStreamingData(std::move(stream), encoding)) {}

--- a/deps/v8/src/snapshot/code-serializer.h
+++ b/deps/v8/src/snapshot/code-serializer.h
@@ -49,22 +49,9 @@ class V8_EXPORT_PRIVATE AlignedCachedData {
   int length_;
 };
 
-enum class SerializedCodeSanityCheckResult {
-  // Don't change order/existing values of this enum since it keys into the
-  // `code_cache_reject_reason` histogram. Append-only!
-  kSuccess = 0,
-  kMagicNumberMismatch = 1,
-  kVersionMismatch = 2,
-  kSourceMismatch = 3,
-  kFlagsMismatch = 5,
-  kChecksumMismatch = 6,
-  kInvalidHeader = 7,
-  kLengthMismatch = 8,
-  kReadOnlySnapshotChecksumMismatch = 9,
+typedef v8::ScriptCompiler::CachedData::CompatibilityCheckResult
+    SerializedCodeSanityCheckResult;
 
-  // This should always point at the last real enum value.
-  kLast = kReadOnlySnapshotChecksumMismatch
-};
 // If this fails, update the static_assert AND the code_cache_reject_reason
 // histogram definition.
 static_assert(static_cast<int>(SerializedCodeSanityCheckResult::kLast) == 9);


### PR DESCRIPTION
Original commit message:

    [api] Add v8::ScriptCompiler::CachedData::CompatibilityCheck()

    This patch adds a new API v8::ScriptCompiler::CachedData::CompatibilityCheck()
    in order to allow embedders to check if the code cache can be used in
    the current isolate without looking up for the source code. It also returns more detailed reasons about why the code cache cannot be used
    when it's bound to be rejected. This makes it possible to enforce
    portability checks in case code code becomes CPU-dependent in the
    future.

    Refs: https://github.com/nodejs/node/issues/42566#issuecomment-1735862123

    Change-Id: Ia1d677b949050add961af6fbf62c44342c061312
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4905290
    Reviewed-by: Marja Hölttä <marja@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Commit-Queue: Joyee Cheung <joyee@igalia.com>
    Cr-Commit-Position: refs/heads/main@{#90833}

Refs: https://github.com/v8/v8/commit/efb1133eb894a283ff0341c4e44d43e913911b6c

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
