### PR TITLE
inspector: add NodeRuntime.waitingForDebugger event

### DIFF
--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -100,6 +100,12 @@ experimental domain NodeWorker
 
 # Support for inspecting node process state.
 experimental domain NodeRuntime
+  # Enable the NodeRuntime events except by `NodeRuntime.waitingForDisconnect`.
+  command enable
+
+  # Disable NodeRuntime events
+  command disable
+
   # Enable the `NodeRuntime.waitingForDisconnect`.
   command notifyWhenWaitingForDisconnect
     parameters
@@ -110,3 +116,7 @@ experimental domain NodeRuntime
   # It is fired when the Node process finished all code execution and is
   # waiting for all frontends to disconnect.
   event waitingForDisconnect
+
+  # This event is fired when the runtime is waiting for the debugger. For
+  # example, when inspector.waitingForDebugger is called
+  event waitingForDebugger

--- a/src/inspector/runtime_agent.cc
+++ b/src/inspector/runtime_agent.cc
@@ -8,7 +8,9 @@ namespace inspector {
 namespace protocol {
 
 RuntimeAgent::RuntimeAgent()
-  : notify_when_waiting_for_disconnect_(false) {}
+    : notify_when_waiting_for_disconnect_(false),
+      enabled_(false),
+      is_waiting_for_debugger_(false) {}
 
 void RuntimeAgent::Wire(UberDispatcher* dispatcher) {
   frontend_ = std::make_unique<NodeRuntime::Frontend>(dispatcher->channel());
@@ -18,6 +20,30 @@ void RuntimeAgent::Wire(UberDispatcher* dispatcher) {
 DispatchResponse RuntimeAgent::notifyWhenWaitingForDisconnect(bool enabled) {
   notify_when_waiting_for_disconnect_ = enabled;
   return DispatchResponse::OK();
+}
+
+DispatchResponse RuntimeAgent::enable() {
+  enabled_ = true;
+  if (is_waiting_for_debugger_) {
+    frontend_->waitingForDebugger();
+  }
+  return DispatchResponse::OK();
+}
+
+DispatchResponse RuntimeAgent::disable() {
+  enabled_ = false;
+  return DispatchResponse::OK();
+}
+
+void RuntimeAgent::setWaitingForDebugger() {
+  is_waiting_for_debugger_ = true;
+  if (enabled_) {
+    frontend_->waitingForDebugger();
+  }
+}
+
+void RuntimeAgent::unsetWaitingForDebugger() {
+  is_waiting_for_debugger_ = false;
 }
 
 bool RuntimeAgent::notifyWaitingForDisconnect() {

--- a/src/inspector/runtime_agent.h
+++ b/src/inspector/runtime_agent.h
@@ -18,11 +18,21 @@ class RuntimeAgent : public NodeRuntime::Backend {
 
   DispatchResponse notifyWhenWaitingForDisconnect(bool enabled) override;
 
+  DispatchResponse enable() override;
+
+  DispatchResponse disable() override;
+
   bool notifyWaitingForDisconnect();
+
+  void setWaitingForDebugger();
+
+  void unsetWaitingForDebugger();
 
  private:
   std::shared_ptr<NodeRuntime::Frontend> frontend_;
   bool notify_when_waiting_for_disconnect_;
+  bool enabled_;
+  bool is_waiting_for_debugger_;
 };
 }  // namespace protocol
 }  // namespace inspector

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -303,6 +303,9 @@ class InspectorSession {
     console.log('[test]', 'Verify node waits for the frontend to disconnect');
     await this.send({ 'method': 'Debugger.resume' });
     await this.waitForNotification((notification) => {
+      if (notification.method === 'Debugger.paused') {
+        this.send({ 'method': 'Debugger.resume' });
+      }
       return notification.method === 'Runtime.executionContextDestroyed' &&
         notification.params.executionContextId === 1;
     });

--- a/test/parallel/test-inspect-async-hook-setup-at-inspect.js
+++ b/test/parallel/test-inspect-async-hook-setup-at-inspect.js
@@ -54,7 +54,6 @@ async function runTests() {
       'params': { 'maxDepth': 10 } },
     { 'method': 'Debugger.setBlackboxPatterns',
       'params': { 'patterns': [] } },
-    { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
 
   await waitForInitialSetup(session);

--- a/test/parallel/test-inspector-async-hook-setup-at-inspect-brk.js
+++ b/test/parallel/test-inspector-async-hook-setup-at-inspect-brk.js
@@ -30,6 +30,8 @@ async function checkAsyncStackTrace(session) {
 async function runTests() {
   const instance = new NodeInstance(undefined, script);
   const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { 'method': 'Runtime.enable' },
     { 'method': 'Debugger.enable' },
@@ -39,6 +41,7 @@ async function runTests() {
       'params': { 'patterns': [] } },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
+  await session.send({ method: 'NodeRuntime.disable' });
   await skipBreakpointAtStart(session);
   await checkAsyncStackTrace(session);
 

--- a/test/parallel/test-inspector-async-hook-setup-at-signal.js
+++ b/test/parallel/test-inspector-async-hook-setup-at-signal.js
@@ -69,7 +69,6 @@ async function runTests() {
       'params': { 'maxDepth': 10 } },
     { 'method': 'Debugger.setBlackboxPatterns',
       'params': { 'patterns': [] } },
-    { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
 
   await waitForInitialSetup(session);

--- a/test/parallel/test-inspector-async-stack-traces-promise-then.js
+++ b/test/parallel/test-inspector-async-stack-traces-promise-then.js
@@ -20,6 +20,8 @@ function runTest() {
 async function runTests() {
   const instance = new NodeInstance(undefined, script);
   const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { 'method': 'Runtime.enable' },
     { 'method': 'Debugger.enable' },
@@ -29,6 +31,7 @@ async function runTests() {
       'params': { 'patterns': [] } },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
+  session.send({ method: 'NodeRuntime.disable' });
 
   await session.waitForBreakOnLine(0, '[eval]');
   await session.send({ 'method': 'Debugger.resume' });

--- a/test/parallel/test-inspector-async-stack-traces-set-interval.js
+++ b/test/parallel/test-inspector-async-stack-traces-set-interval.js
@@ -26,6 +26,8 @@ async function checkAsyncStackTrace(session) {
 async function runTests() {
   const instance = new NodeInstance(undefined, script);
   const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { 'method': 'Runtime.enable' },
     { 'method': 'Debugger.enable' },
@@ -35,6 +37,7 @@ async function runTests() {
       'params': { 'patterns': [] } },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
+  await session.send({ method: 'NodeRuntime.disable' });
 
   await skipFirstBreakpoint(session);
   await checkAsyncStackTrace(session);

--- a/test/parallel/test-inspector-break-e.js
+++ b/test/parallel/test-inspector-break-e.js
@@ -8,11 +8,14 @@ const { NodeInstance } = require('../common/inspector-helper.js');
 async function runTests() {
   const instance = new NodeInstance(undefined, 'console.log(10)');
   const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { 'method': 'Runtime.enable' },
     { 'method': 'Debugger.enable' },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ]);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForBreakOnLine(0, '[eval]');
   await session.runToCompletion();
   assert.strictEqual((await instance.expectShutdown()).exitCode, 0);

--- a/test/parallel/test-inspector-break-when-eval.js
+++ b/test/parallel/test-inspector-break-when-eval.js
@@ -20,7 +20,10 @@ async function setupDebugger(session) {
       'params': { 'maxDepth': 0 } },
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
-  session.send(commands);
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
 
   await session.waitForNotification('Debugger.paused', 'Initial pause');
 

--- a/test/parallel/test-inspector-console.js
+++ b/test/parallel/test-inspector-console.js
@@ -20,7 +20,10 @@ async function runTest() {
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
 
-  session.send(commands);
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
 
   const msg = await session.waitForNotification('Runtime.consoleAPICalled');
 

--- a/test/parallel/test-inspector-debug-brk-flag.js
+++ b/test/parallel/test-inspector-debug-brk-flag.js
@@ -22,7 +22,10 @@ async function testBreakpointOnStart(session) {
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
 
-  session.send(commands);
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForBreakOnLine(0, session.scriptURL());
 }
 

--- a/test/parallel/test-inspector-debug-end.js
+++ b/test/parallel/test-inspector-debug-end.js
@@ -30,6 +30,8 @@ async function testSessionNoCrash() {
 
   const instance = new NodeInstance('--inspect-brk=0', script);
   const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send({ 'method': 'Runtime.runIfWaitingForDebugger' });
   await session.waitForServerDisconnect();
   strictEqual((await instance.expectShutdown()).exitCode, 42);

--- a/test/parallel/test-inspector-esm.js
+++ b/test/parallel/test-inspector-esm.js
@@ -36,7 +36,10 @@ async function testBreakpointOnStart(session) {
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
 
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForBreakOnLine(
     0, UrlResolve(session.scriptURL().toString(), 'message.mjs'));
 }

--- a/test/parallel/test-inspector-exception.js
+++ b/test/parallel/test-inspector-exception.js
@@ -28,7 +28,10 @@ async function testBreakpointOnStart(session) {
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
 
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForBreakOnLine(21, pathToFileURL(script).toString());
 }
 

--- a/test/parallel/test-inspector-inspect-brk-node.js
+++ b/test/parallel/test-inspector-inspect-brk-node.js
@@ -10,9 +10,12 @@ const { NodeInstance } = require('../common/inspector-helper.js');
 async function runTest() {
   const child = new NodeInstance(['--inspect-brk-node=0', '-p', '42']);
   const session = await child.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send({ method: 'Runtime.enable' });
   await session.send({ method: 'Debugger.enable' });
   await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForNotification((notification) => {
     // The main assertion here is that we do hit the loader script first.
     return notification.method === 'Debugger.scriptParsed' &&

--- a/test/parallel/test-inspector-scriptparsed-context.js
+++ b/test/parallel/test-inspector-scriptparsed-context.js
@@ -46,10 +46,13 @@ async function runTests() {
   const instance = new NodeInstance(['--inspect-brk=0', '--expose-internals'],
                                     script);
   const session = await instance.connectInspectorSession();
-  await session.send([
-    { 'method': 'Debugger.enable' },
-    { 'method': 'Runtime.runIfWaitingForDebugger' },
-  ]);
+
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send({ 'method': 'Debugger.enable' });
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.disable' });
+
   await session.waitForBreakOnLine(2, '[eval]');
 
   await session.send({ 'method': 'Runtime.enable' });

--- a/test/parallel/test-inspector-wait-for-connection.js
+++ b/test/parallel/test-inspector-wait-for-connection.js
@@ -24,7 +24,11 @@ async function runTests() {
     }
   });
   assert.ok(value.startsWith('ws://'));
-  session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.enable' });
+  child.write('first');
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.disable' });
   // Check that messages after first and before second waitForDebugger are
   // received
   await session.waitForConsoleOutput('log', 'after wait for debugger');
@@ -33,7 +37,11 @@ async function runTests() {
                     .some((n) => n.method === 'Runtime.consoleAPICalled'));
   const secondSession = await child.connectInspectorSession();
   // Check that inspector.waitForDebugger can be resumed from another session
-  secondSession.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.enable' });
+  child.write('second');
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForConsoleOutput('log', 'after second wait for debugger');
   assert.ok(!session.unprocessedNotifications()
                     .some((n) => n.method === 'Runtime.consoleAPICalled'));
@@ -45,11 +53,20 @@ async function runTests() {
     inspector.open(0, undefined, false);
     process._ws = inspector.url();
     console.log('before wait for debugger');
-    inspector.waitForDebugger();
-    console.log('after wait for debugger');
-    console.log('before second wait for debugger');
-    inspector.waitForDebugger();
-    console.log('after second wait for debugger');
+    process.stdin.once('data', (data) => {
+      if (data.toString() === 'first') {
+        inspector.waitForDebugger();
+        console.log('after wait for debugger');
+        console.log('before second wait for debugger');
+        process.stdin.once('data', (data) => {
+          if (data.toString() === 'second') {
+            inspector.waitForDebugger();
+            console.log('after second wait for debugger');
+            process.exit();
+          }
+        });
+      }
+    });
   }
 
   // Check that inspector.waitForDebugger throws if there is no active

--- a/test/parallel/test-inspector-waiting-for-disconnect.js
+++ b/test/parallel/test-inspector-waiting-for-disconnect.js
@@ -17,11 +17,14 @@ async function runTest() {
   const oldStyleSession = await child.connectInspectorSession();
   await oldStyleSession.send([
     { method: 'Runtime.enable' }]);
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { method: 'Runtime.enable' },
     { method: 'NodeRuntime.notifyWhenWaitingForDisconnect',
       params: { enabled: true } },
     { method: 'Runtime.runIfWaitingForDebugger' }]);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForNotification((notification) => {
     return notification.method === 'NodeRuntime.waitingForDisconnect';
   });

--- a/test/parallel/test-inspector.js
+++ b/test/parallel/test-inspector.js
@@ -75,7 +75,10 @@ async function testBreakpointOnStart(session) {
     { 'method': 'Runtime.runIfWaitingForDebugger' },
   ];
 
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send(commands);
+  await session.send({ method: 'NodeRuntime.disable' });
   await session.waitForBreakOnLine(0, session.scriptURL());
 }
 

--- a/test/parallel/test-runner-inspect.mjs
+++ b/test/parallel/test-runner-inspect.mjs
@@ -24,9 +24,12 @@ tmpdir.refresh();
 
   const session = await child.connectInspectorSession();
 
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
   await session.send([
     { method: 'Runtime.enable' },
     { method: 'Runtime.runIfWaitingForDebugger' }]);
+  await session.send({ method: 'NodeRuntime.disable' });
 
   session.disconnect();
   assert.match(stderr,


### PR DESCRIPTION
`NodeRuntime.waitingForDebugger` is a new Inspector Protocol event that will fire when the process being inspected is waiting for the debugger (for example, when `inspector.waitForDebugger()` is called). This allows inspecting processes to know when the inspected process is waiting for a `Runtime.runIfWaitingForDebugger` message to resume execution. It allows tooling to resume execution of the inspected process as soon as it deems necessary, without having to guess if the inspected process is waiting or not, making the workflow more deterministic. With a more deterministic workflow, it is possible to update Node.js core tests to avoid race conditions that can cause flakiness. Therefore, tests were also changed as following:

  * Remove no-op Runtime.runIfWaitingForDebugger from tests that don't need it
  * Use NodeRuntime.waitingForDebugger in all tests that need Runtime.runIfWaitingForDebugger, to ensure order of operations is predictable and correct
  * Simplify test-inspector-multisession-ws

There might be value in adding `NodeWorker.waitingForDebugger` in a future patch, but as of right now, no Node.js core inspector tests using worker threads are failing due to race conditions.

Fixes: https://github.com/nodejs/node/issues/34730

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
