### PR TITLE
repl: fix `NO_COLORS` env var is ignored

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -302,7 +302,7 @@ function REPLServer(prompt,
 
   if (options.terminal && options.useColors === undefined) {
     // If possible, check if stdout supports colors or not.
-    options.useColors = shouldColorize(options.output) || process.env.NODE_DISABLE_COLORS === undefined;
+    options.useColors = shouldColorize(options.output);
   }
 
   // TODO(devsnek): Add a test case for custom eval functions.

--- a/test/parallel/test-repl-envvars.js
+++ b/test/parallel/test-repl-envvars.js
@@ -13,7 +13,7 @@ const { REPL_MODE_SLOPPY, REPL_MODE_STRICT } = require('repl');
 const tests = [
   {
     env: {},
-    expected: { terminal: true, useColors: true }
+    expected: { terminal: true, useColors: false }
   },
   {
     env: { NODE_DISABLE_COLORS: '1' },
@@ -29,7 +29,7 @@ const tests = [
   },
   {
     env: { TERM: 'dumb' },
-    expected: { terminal: true, useColors: true }
+    expected: { terminal: true, useColors: false }
   },
   {
     env: { TERM: 'dumb', FORCE_COLOR: '1' },
@@ -41,15 +41,15 @@ const tests = [
   },
   {
     env: { NODE_NO_READLINE: '0' },
-    expected: { terminal: true, useColors: true }
+    expected: { terminal: true, useColors: false }
   },
   {
     env: { NODE_REPL_MODE: 'sloppy' },
-    expected: { terminal: true, useColors: true, replMode: REPL_MODE_SLOPPY }
+    expected: { terminal: true, useColors: false, replMode: REPL_MODE_SLOPPY }
   },
   {
     env: { NODE_REPL_MODE: 'strict' },
-    expected: { terminal: true, useColors: true, replMode: REPL_MODE_STRICT }
+    expected: { terminal: true, useColors: false, replMode: REPL_MODE_STRICT }
   },
 ];
 

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -55,7 +55,7 @@ assert.strictEqual(r1.output, stream);
 assert.strictEqual(r1.input, r1.inputStream);
 assert.strictEqual(r1.output, r1.outputStream);
 assert.strictEqual(r1.terminal, true);
-assert.strictEqual(r1.useColors, r1.terminal);
+assert.strictEqual(r1.useColors, false);
 assert.strictEqual(r1.useGlobal, false);
 assert.strictEqual(r1.ignoreUndefined, false);
 assert.strictEqual(r1.replMode, repl.REPL_MODE_SLOPPY);


### PR DESCRIPTION
refs: https://github.com/nodejs/node/pull/48034#issuecomment-1904710409

the logic in `options.useColors = shouldColorize(options.output) || process.env.NODE_DISABLE_COLORS === undefined;` indroduced this bug since `shouldColorize` already checks `NODE_DISABLE_COLORS` among other env vars that disable colors: `NO_COLOR` and `TERM === 'dumb'`