### PR TITLE
http2: close idle connections when allowHTTP1 is true

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -59,7 +59,7 @@ const {
   kIncomingMessage,
   _checkIsHttpToken: checkIsHttpToken,
 } = require('_http_common');
-const { kServerResponse } = require('_http_server');
+const { kServerResponse, Server: HttpServer, httpServerPreClose, setupConnectionsTracking } = require('_http_server');
 const JSStreamSocket = require('internal/js_stream_socket');
 
 const {
@@ -3180,6 +3180,11 @@ class Http2SecureServer extends TLSServer {
     this[kOptions] = options;
     this.timeout = 0;
     this.on('newListener', setupCompat);
+    if (options.allowHTTP1 === true) {
+      this.headersTimeout = 60_000; // Minimum between 60 seconds or requestTimeout
+      this.requestTimeout = 300_000; // 5 minutes
+      this.on('listening', setupConnectionsTracking);
+    }
     if (typeof requestListener === 'function')
       this.on('request', requestListener);
     this.on('tlsClientError', onErrorSecureServerSession);
@@ -3198,6 +3203,19 @@ class Http2SecureServer extends TLSServer {
     assertIsObject(settings, 'settings');
     validateSettings(settings);
     this[kOptions].settings = { ...this[kOptions].settings, ...settings };
+  }
+
+  close() {
+    if (this[kOptions].allowHTTP1 === true) {
+      httpServerPreClose(this);
+    }
+    ReflectApply(TLSServer.prototype.close, this, arguments);
+  }
+
+  closeIdleConnections() {
+    if (this[kOptions].allowHTTP1 === true) {
+      ReflectApply(HttpServer.prototype.closeIdleConnections, this, arguments);
+    }
   }
 }
 

--- a/test/parallel/test-http2-allow-http1.js
+++ b/test/parallel/test-http2-allow-http1.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const assert = require('assert');
+const https = require('https');
+const http2 = require('http2');
+
+(async function main() {
+  const server = http2.createSecureServer({
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem'),
+    allowHTTP1: true,
+  });
+
+  server.on(
+    'request',
+    common.mustCall((req, res) => {
+      res.writeHead(200);
+      res.end();
+    })
+  );
+
+  server.on(
+    'close',
+    common.mustCall()
+  );
+
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  await new Promise((resolve) =>
+    https.get(
+      `https://localhost:${server.address().port}`,
+      {
+        rejectUnauthorized: false,
+        headers: { connection: 'keep-alive' },
+      },
+      resolve
+    )
+  );
+
+  let serverClosed = false;
+  setImmediate(
+    common.mustCall(() => {
+      assert.ok(serverClosed, 'server should been closed immediately');
+    })
+  );
+  server.close(
+    common.mustSucceed(() => {
+      serverClosed = true;
+    })
+  );
+})().then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51493

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
