### PR TITLE
lib: add EventSource

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -346,6 +346,7 @@ module.exports = {
     Crypto: 'readable',
     CryptoKey: 'readable',
     DecompressionStream: 'readable',
+    EventSource: 'readable',
     fetch: 'readable',
     FormData: 'readable',
     navigator: 'readable',

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -853,6 +853,14 @@ CommonJS. This includes the following:
 * Lexical redeclarations of the CommonJS wrapper variables (`require`, `module`,
   `exports`, `__dirname`, `__filename`).
 
+### `--experimental-eventsource`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Enable exposition of [EventSource Web API][] on the global scope.
+
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -2648,6 +2656,7 @@ one is included in the list below.
 * `--experimental-abortcontroller`
 * `--experimental-default-type`
 * `--experimental-detect-module`
+* `--experimental-eventsource`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`
@@ -3153,6 +3162,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [CommonJS module]: modules.md
 [DEP0025 warning]: deprecations.md#dep0025-requirenodesys
 [ECMAScript module]: esm.md#modules-ecmascript-modules
+[EventSource Web API]: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
 [ExperimentalWarning: `vm.measureMemory` is an experimental feature]: vm.md#vmmeasurememoryoptions
 [File System Permissions]: permissions.md#file-system-permissions
 [Loading ECMAScript modules using `require()`]: modules.md#loading-ecmascript-modules-using-require

--- a/doc/node.1
+++ b/doc/node.1
@@ -185,6 +185,9 @@ Use this flag to enable ShadowRealm support.
 .It Fl -experimental-test-coverage
 Enable code coverage in the test runner.
 .
+.It Fl -experimental-eventsource
+Enable experimental support for the EventSource Web API.
+.
 .It Fl -no-experimental-websocket
 Disable experimental support for the WebSocket API.
 .

--- a/lib/.eslintrc.yaml
+++ b/lib/.eslintrc.yaml
@@ -154,6 +154,8 @@ rules:
       message: Use `const { Crypto } = require('internal/crypto/webcrypto');` instead of the global.
     - name: CryptoKey
       message: Use `const { CryptoKey } = require('internal/crypto/webcrypto');` instead of the global.
+    - name: EventSource
+      message: Use `const { EventSource } = require('internal/deps/undici/undici');` instead of the global.
     - name: fetch
       message: Use `const { fetch } = require('internal/deps/undici/undici');` instead of the global.
     - name: global

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -87,8 +87,9 @@ exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', [
   'FormData', 'Headers', 'Request', 'Response', 'MessageEvent',
 ]);
 
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events.org/
 // https://websockets.spec.whatwg.org/
-exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', ['WebSocket']);
+exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', ['EventSource', 'WebSocket']);
 
 // The WebAssembly Web API which relies on Response.
 // https:// webassembly.github.io/spec/web-api/#streaming-modules

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -101,6 +101,7 @@ function prepareExecution(options) {
   setupNavigator();
   setupWarningHandler();
   setupWebsocket();
+  setupEventsource();
   setupCodeCoverage();
   setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
@@ -303,6 +304,13 @@ function setupWarningHandler() {
 function setupWebsocket() {
   if (getOptionValue('--no-experimental-websocket')) {
     delete globalThis.WebSocket;
+  }
+}
+
+// https://html.spec.whatwg.org/multipage/server-sent-events.html
+function setupEventsource() {
+  if (!getOptionValue('--experimental-eventsource')) {
+    delete globalThis.EventSource;
   }
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -398,6 +398,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::enable_source_maps,
             kAllowedInEnvvar);
   AddOption("--experimental-abortcontroller", "", NoOp{}, kAllowedInEnvvar);
+  AddOption("--experimental-eventsource",
+            "experimental EventSource API",
+            &EnvironmentOptions::experimental_eventsource,
+            kAllowedInEnvvar,
+            false);
   AddOption("--experimental-fetch", "", NoOp{}, kAllowedInEnvvar);
   AddOption("--experimental-websocket",
             "experimental WebSocket API",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -115,6 +115,7 @@ class EnvironmentOptions : public Options {
   bool require_module = false;
   std::string dns_result_order;
   bool enable_source_maps = false;
+  bool experimental_eventsource = false;
   bool experimental_fetch = true;
   bool experimental_websocket = true;
   bool experimental_global_navigator = true;

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -126,6 +126,7 @@ const webIdlExposedWindow = new Set([
   'Request',
   'Response',
   'WebSocket',
+  'EventSource',
 ]);
 
 const nodeGlobals = new Set([

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -333,6 +333,10 @@ if (global.structuredClone) {
   knownGlobals.push(global.structuredClone);
 }
 
+if (global.EventSource) {
+  knownGlobals.push(EventSource);
+}
+
 if (global.fetch) {
   knownGlobals.push(fetch);
 }

--- a/test/parallel/test-eventsource-disabled.js
+++ b/test/parallel/test-eventsource-disabled.js
@@ -1,0 +1,6 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(typeof EventSource, 'undefined');

--- a/test/parallel/test-eventsource.js
+++ b/test/parallel/test-eventsource.js
@@ -1,0 +1,7 @@
+// Flags: --experimental-eventsource
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(typeof EventSource, 'function');


### PR DESCRIPTION
Proposal for Release Notes:

EventSource

EventSource is a W3C compliant Client for [Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events). The  new flag `--experimental-eventsource` can be used to expose a global `EventSource`-constructor. 