### PR TITLE
lib: enable WebSocket by default

### DIFF
--- a/benchmark/websocket/simple.js
+++ b/benchmark/websocket/simple.js
@@ -3,7 +3,6 @@
 const common = require('../common.js');
 const crypto = require('crypto');
 const http = require('http');
-const { WebSocket } = require('../../deps/undici/undici');
 
 const GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -949,16 +949,6 @@ added: v12.3.0
 
 Enable experimental WebAssembly module support.
 
-### `--experimental-websocket`
-
-<!-- YAML
-added:
-  - v21.0.0
-  - v20.10.0
--->
-
-Enable experimental [`WebSocket`][] support.
-
 ### `--force-context-aware`
 
 <!-- YAML
@@ -1376,6 +1366,14 @@ added: v16.6.0
 -->
 
 Use this flag to disable top-level await in REPL.
+
+### `--no-experimental-websocket`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Use this flag to disable experimental [`WebSocket`][] support.
 
 ### `--no-extra-info-on-fatal-exception`
 
@@ -2511,7 +2509,6 @@ Node.js options that are allowed are:
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`
 * `--experimental-wasm-modules`
-* `--experimental-websocket`
 * `--force-context-aware`
 * `--force-fips`
 * `--force-node-api-uncaught-exceptions-policy`
@@ -2536,6 +2533,7 @@ Node.js options that are allowed are:
 * `--no-experimental-global-navigator`
 * `--no-experimental-global-webcrypto`
 * `--no-experimental-repl-await`
+* `--no-experimental-websocket`
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`
 * `--no-global-search-paths`

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1097,12 +1097,16 @@ The object that acts as the namespace for all W3C
 added:
   - v21.0.0
   - v20.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51594
+    description: No longer behind `--experimental-websocket` CLI flag.
 -->
 
 > Stability: 1 - Experimental.
 
-A browser-compatible implementation of [`WebSocket`][]. Enable this API
-with the [`--experimental-websocket`][] CLI flag.
+A browser-compatible implementation of [`WebSocket`][]. Disable this API
+with the [`--no-experimental-websocket`][] CLI flag.
 
 ## Class: `WritableStream`
 
@@ -1139,10 +1143,10 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [Navigator API]: https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
 [RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.txt
 [Web Crypto API]: webcrypto.md
-[`--experimental-websocket`]: cli.md#--experimental-websocket
 [`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
 [`--no-experimental-global-navigator`]: cli.md#--no-experimental-global-navigator
 [`--no-experimental-global-webcrypto`]: cli.md#--no-experimental-global-webcrypto
+[`--no-experimental-websocket`]: cli.md#--no-experimental-websocket
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [`ByteLengthQueuingStrategy`]: webstreams.md#class-bytelengthqueuingstrategy
 [`CompressionStream`]: webstreams.md#class-compressionstream

--- a/doc/node.1
+++ b/doc/node.1
@@ -186,11 +186,11 @@ Use this flag to enable ShadowRealm support.
 .It Fl -experimental-test-coverage
 Enable code coverage in the test runner.
 .
-.It Fl -experimental-websocket
-Enable experimental support for the WebSocket API.
-.
 .It Fl -no-experimental-fetch
 Disable experimental support for the Fetch API.
+.
+.It Fl -no-experimental-websocket
+Disable experimental support for the WebSocket API.
 .
 .It Fl -no-experimental-global-customevent
 Disable exposition of the CustomEvent on the global scope.

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -92,6 +92,9 @@ exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', [
   'FormData', 'Headers', 'Request', 'Response',
 ]);
 
+// https://websockets.spec.whatwg.org/
+exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', ['WebSocket']);
+
 // The WebAssembly Web API which relies on Response.
 // https:// webassembly.github.io/spec/web-api/#streaming-modules
 internalBinding('wasm_web_api').setImplementation((streamState, source) => {

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -315,8 +315,8 @@ function setupUndici() {
     delete globalThis.Response;
   }
 
-  if (!getEmbedderOptions().noBrowserGlobals && getOptionValue('--experimental-websocket')) {
-    exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', ['WebSocket']);
+  if (getOptionValue('--no-experimental-websocket')) {
+    delete globalThis.WebSocket;
   }
 }
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -108,7 +108,7 @@ class EnvironmentOptions : public Options {
   std::string dns_result_order;
   bool enable_source_maps = false;
   bool experimental_fetch = true;
-  bool experimental_websocket = false;
+  bool experimental_websocket = true;
   bool experimental_global_customevent = true;
   bool experimental_global_navigator = true;
   bool experimental_global_web_crypto = true;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -369,9 +369,6 @@ if (global.ReadableStream) {
     global.DecompressionStream,
   );
 }
-if (global.WebSocket) {
-  knownGlobals.push(WebSocket);
-}
 
 function allowGlobals(...allowlist) {
   knownGlobals = knownGlobals.concat(allowlist);

--- a/test/parallel/test-websocket-disabled.js
+++ b/test/parallel/test-websocket-disabled.js
@@ -1,0 +1,7 @@
+// Flags: --no-experimental-websocket
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.strictEqual(typeof WebSocket, 'undefined');

--- a/test/parallel/test-websocket.js
+++ b/test/parallel/test-websocket.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-websocket
 'use strict';
 
 require('../common');


### PR DESCRIPTION
For node 22 we enable WebSocket by default.

Is the target correct?

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
