### PR TITLE
tools: only run `build-windows` workflow on source changes

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,10 +2,14 @@ name: Build Windows
 
 on:
   pull_request:
-    paths-ignore:
-      - README.md
-      - .github/**
-      - '!.github/workflows/build-windows.yml'
+    paths:
+      - lib/**/*.js
+      - Makefile
+      - src/**/*.cc
+      - src/**/*.h
+      - tools/gyp/**
+      - tools/test.py
+      - .github/workflows/build-windows.yml
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
@@ -13,10 +17,14 @@ on:
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
-    paths-ignore:
-      - README.md
-      - .github/**
-      - '!.github/workflows/build-windows.yml'
+    paths:
+      - lib/**/*.js
+      - Makefile
+      - src/**/*.cc
+      - src/**/*.h
+      - tools/gyp/**
+      - tools/test.py
+      - .github/workflows/build-windows.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -8,7 +8,6 @@ on:
       - src/**/*.cc
       - src/**/*.h
       - tools/gyp/**
-      - tools/test.py
       - .github/workflows/build-windows.yml
     types: [opened, synchronize, reopened, ready_for_review]
   push:
@@ -23,7 +22,6 @@ on:
       - src/**/*.cc
       - src/**/*.h
       - tools/gyp/**
-      - tools/test.py
       - .github/workflows/build-windows.yml
 
 concurrency:


### PR DESCRIPTION
Since this workflow does not run any tests, it doesn't really makes sense to have it run on doc-only changes, or test-only changes.
I took inspiration for the list of paths from https://github.com/nodejs/node/blob/084d761dfc1aa9ca0549e7c4d769e30b34347f69/.github/workflows/coverage-windows.yml#L6-L14

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
