### PR TITLE
lib: define FormData and fetch etc. in the built-in snapshot

### DIFF
--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -10,6 +10,7 @@
 
 const {
   globalThis,
+  ObjectDefineProperty,
 } = primordials;
 
 const {
@@ -55,3 +56,49 @@ defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 // https://w3c.github.io/FileAPI/#creating-revoking
 const { installObjectURLMethods } = require('internal/url');
 installObjectURLMethods();
+
+{
+  // https://fetch.spec.whatwg.org/#fetch-method
+  function set(value) {
+    ObjectDefineProperty(globalThis, 'fetch', {
+      __proto__: null,
+      writable: true,
+      value,
+    });
+  }
+  ObjectDefineProperty(globalThis, 'fetch', {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    set,
+  });
+  ObjectDefineProperty(globalThis, 'fetch', {
+    __proto__: null,
+    configurable: true,
+    enumerable: true,
+    get() {
+      function fetch(input, init = undefined) {
+        // Loading undici alone lead to promises which breaks lots of tests so we
+        // have to load it really lazily for now.
+        const { fetch: impl } = require('internal/deps/undici/undici');
+        return impl(input, init);
+      }
+      set(fetch);
+      return fetch;
+    }
+  });
+}
+
+// https://xhr.spec.whatwg.org/#interface-formdata
+// https://fetch.spec.whatwg.org/#headers-class
+// https://fetch.spec.whatwg.org/#request-class
+// https://fetch.spec.whatwg.org/#response-class
+exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', [
+  'FormData', 'Headers', 'Request', 'Response',
+]);
+
+// The WebAssembly Web API which relies on Response.
+// https:// webassembly.github.io/spec/web-api/#streaming-modules
+internalBinding('wasm_web_api').setImplementation((streamState, source) => {
+  require('internal/wasm_web_api').wasmStreamingCallback(streamState, source);
+});

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -71,11 +71,6 @@ installObjectURLMethods();
     configurable: true,
     enumerable: true,
     set,
-  });
-  ObjectDefineProperty(globalThis, 'fetch', {
-    __proto__: null,
-    configurable: true,
-    enumerable: true,
     get() {
       function fetch(input, init = undefined) {
         // Loading undici alone lead to promises which breaks lots of tests so we

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -85,7 +85,7 @@ installObjectURLMethods();
       }
       set(fetch);
       return fetch;
-    }
+    },
   });
 }
 

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -10,7 +10,6 @@ const {
   DatePrototypeGetMonth,
   DatePrototypeGetSeconds,
   NumberParseInt,
-  ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   SafeMap,
@@ -29,7 +28,6 @@ const {
 } = require('internal/options');
 const { reconnectZeroFillToggle } = require('internal/buffer');
 const {
-  defineOperation,
   exposeInterface,
   exposeLazyInterfaces,
   defineReplaceableLazyAttribute,
@@ -301,58 +299,16 @@ function setupWarningHandler() {
 // https://fetch.spec.whatwg.org/
 // https://websockets.spec.whatwg.org/
 function setupUndici() {
-  if (getEmbedderOptions().noBrowserGlobals) {
-    return;
+  if (getOptionValue('--no-experimental-fetch')) {
+    delete globalThis.fetch;
+    delete globalThis.FormData;
+    delete globalThis.Headers;
+    delete globalThis.Request;
+    delete globalThis.Response;
   }
 
-  let undici;
-  function lazyUndici() {
-    if (undici) {
-      return undici;
-    }
-
-    undici = require('internal/deps/undici/undici');
-    return undici;
-  }
-
-  function lazyInterface(name) {
-    return {
-      configurable: true,
-      enumerable: false,
-      get() {
-        return lazyUndici()[name];
-      },
-      set(value) {
-        exposeInterface(globalThis, name, value);
-      },
-    };
-  }
-
-  if (!getOptionValue('--no-experimental-fetch')) {
-    // Fetch is meant to return a Promise, but not be async.
-    function fetch(input, init = undefined) {
-      return lazyUndici().fetch(input, init);
-    }
-
-    defineOperation(globalThis, 'fetch', fetch);
-
-    ObjectDefineProperties(globalThis, {
-      FormData: lazyInterface('FormData'),
-      Headers: lazyInterface('Headers'),
-      Request: lazyInterface('Request'),
-      Response: lazyInterface('Response'),
-    });
-
-    // The WebAssembly Web API: https://webassembly.github.io/spec/web-api
-    internalBinding('wasm_web_api').setImplementation((streamState, source) => {
-      require('internal/wasm_web_api').wasmStreamingCallback(streamState, source);
-    });
-  }
-
-  if (getOptionValue('--experimental-websocket')) {
-    ObjectDefineProperties(globalThis, {
-      WebSocket: lazyInterface('WebSocket'),
-    });
+  if (!getEmbedderOptions().noBrowserGlobals && getOptionValue('--experimental-websocket')) {
+    exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', ['WebSocket']);
   }
 }
 

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -98,10 +98,10 @@ expected.beforePreExec = new Set([
   'NativeModule internal/modules/package_json_reader',
   'Internal Binding module_wrap',
   'NativeModule internal/modules/cjs/loader',
+  'Internal Binding wasm_web_api',
 ]);
 
 expected.atRunTime = new Set([
-  'Internal Binding wasm_web_api',
   'Internal Binding worker',
   'NativeModule internal/modules/run_main',
   'NativeModule internal/net',


### PR DESCRIPTION
Now that --experimental-fetch is true by default, define the dependent interfaces in the built-in snapshot and only delete them at run time when --no-experimental-fetch is set.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
