### PR TITLE
meta: add .mailmap entry for lemire

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -125,6 +125,7 @@ Daniel Chcouri <333222@gmail.com>
 Daniel Clifford <danno@chromium.org>
 Daniel Gröber <darklord@darkboxed.org>
 Daniel Gröber <darklord@darkboxed.org> <dxld@darkboxed.org>
+Daniel Lemire <daniel@lemire.me> <lemire@gmail.com>
 Daniel Paulino <d_paulino@outlook.com>
 Daniel Pihlström <sciolist.se@gmail.com>
 Daniel Wang <wangyang0123@gmail.com>

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ For information about the governance of the Node.js project, see
 * [legendecas](https://github.com/legendecas) -
   **Chengzhong Wu** <<legendecas@gmail.com>> (he/him)
 * [lemire](https://github.com/lemire) -
-  **Daniel Lemire** <<lemire@gmail.com>>
+  **Daniel Lemire** <<daniel@lemire.me>>
 * [linkgoron](https://github.com/linkgoron) -
   **Nitzan Uziely** <<linkgoron@gmail.com>>
 * [LiviaMedeiros](https://github.com/LiviaMedeiros) -


### PR DESCRIPTION
Consolidate duplicate AUTHORS entries with a .mailmap entry. User @lemire has two email addresses on GitHub (lemire@gmail.com and daniel@lemire.me).

Should fix https://github.com/nodejs/node/pull/51588#issuecomment-1915288364