### PR TITLE
src: fix vm bug for configurable globalThis

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -609,11 +609,14 @@ void ContextifyContext::PropertyDefinerCallback(
   bool read_only =
       static_cast<int>(attributes) &
           static_cast<int>(PropertyAttribute::ReadOnly);
+  bool dont_delete = static_cast<int>(attributes) &
+                     static_cast<int>(PropertyAttribute::DontDelete);
 
-  // If the property is set on the global as read_only, don't change it on
-  // the global or sandbox.
-  if (is_declared && read_only)
+  // If the property is set on the global as neither writable nor
+  // configurable, don't change it on the global or sandbox.
+  if (is_declared && read_only && dont_delete) {
     return;
+  }
 
   Local<Object> sandbox = ctx->sandbox();
 

--- a/test/parallel/test-vm-global-configurable-properties.js
+++ b/test/parallel/test-vm-global-configurable-properties.js
@@ -1,0 +1,15 @@
+'use strict';
+// https://github.com/nodejs/node/issues/47799
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const ctx = vm.createContext();
+
+const window = vm.runInContext('this', ctx);
+
+Object.defineProperty(window, 'x', { value: '1', configurable: true });
+assert.strictEqual(window.x, '1');
+Object.defineProperty(window, 'x', { value: '2', configurable: true });
+assert.strictEqual(window.x, '2');


### PR DESCRIPTION
Object.defineProperty allows to change the value for non-writable properties if they are configurable. We missed that case in the vm module when checking if a property is read-only.

Fixes: https://github.com/nodejs/node/issues/47799

cc @domenic 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
