### PR TITLE
fix(sec): upgrade certifi to 2023.7.22

### DIFF
--- a/deps/uv/docs/requirements.txt
+++ b/deps/uv/docs/requirements.txt
@@ -6,7 +6,7 @@ Sphinx==6.1.3
 alabaster==0.7.13
 Babel==2.11.0
 beautifulsoup4==4.12.2
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.0.1
 colorama==0.4.6
 docutils==0.19


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2023.7.22 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS