### PR TITLE
test_runner: Convert file URLs to paths in test enqueue method

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -58,6 +58,7 @@ const {
 const { setTimeout } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
 const { availableParallelism } = require('os');
+const { fileURLToPath } = require('url');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';
@@ -359,7 +360,7 @@ class Test extends AsyncResource {
         file: loc[2] ? fileURLToPath(loc[2]) : undefined,
       };
     }
-  }    
+  }
 
   matchesTestNamePatterns() {
     return ArrayPrototypeSome(testNamePatterns, (re) => RegExpPrototypeExec(re, this.name) !== null) ||

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -58,7 +58,6 @@ const {
 const { setTimeout } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
 const { availableParallelism } = require('os');
-const { fileURLToPath } = require('internal/url');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';
@@ -357,8 +356,16 @@ class Test extends AsyncResource {
         __proto__: null,
         line: loc[0],
         column: loc[1],
-        file: loc[2] ? fileURLToPath(loc[2]) : undefined,
+        file: this.normalizeFilePath(loc[2]),
       };
+    }
+  }
+
+  normalizeFilePath(filePath) {
+    if (process.platform === 'win32') {
+      return 'file:///' + filePath.replace(/\\/g, '/');
+    } else {
+      return filePath;
     }
   }
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -58,7 +58,7 @@ const {
 const { setTimeout } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
 const { availableParallelism } = require('os');
-const { fileURLToPath } = require('url');
+const { fileURLToPath } = require('internal/url');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -364,9 +364,8 @@ class Test extends AsyncResource {
   normalizeFilePath(filePath) {
     if (process.platform === 'win32') {
       return 'file:///' + filePath.replace(/\\/g, '/');
-    } else {
-      return filePath;
     }
+    return filePath;
   }
 
   matchesTestNamePatterns() {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -356,10 +356,10 @@ class Test extends AsyncResource {
         __proto__: null,
         line: loc[0],
         column: loc[1],
-        file: loc[2],
+        file: loc[2] ? fileURLToPath(loc[2]) : undefined,
       };
     }
-  }
+  }    
 
   matchesTestNamePatterns() {
     return ArrayPrototypeSome(testNamePatterns, (re) => RegExpPrototypeExec(re, this.name) !== null) ||

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -79,7 +79,7 @@ class TestsStream extends Readable {
       file,
       ...loc,
     });
-}
+  }
 
   dequeue(nesting, loc, name) {
     this[kEmitMessage]('test:dequeue', {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -71,12 +71,10 @@ class TestsStream extends Readable {
   }
 
   enqueue(nesting, loc, name) {
-    const file = loc.file.startsWith('file://') ? loc.file.substring(7) : loc.file;
     this[kEmitMessage]('test:enqueue', {
       __proto__: null,
       nesting,
       name,
-      file,
       ...loc,
     });
   }

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -71,13 +71,15 @@ class TestsStream extends Readable {
   }
 
   enqueue(nesting, loc, name) {
+    const file = loc.file.startsWith('file://') ? loc.file.substring(7) : loc.file;
     this[kEmitMessage]('test:enqueue', {
       __proto__: null,
       nesting,
       name,
+      file,
       ...loc,
     });
-  }
+}
 
   dequeue(nesting, loc, name) {
     this[kEmitMessage]('test:dequeue', {

--- a/test/parallel/file-url-to-path-conversion.js
+++ b/test/parallel/file-url-to-path-conversion.js
@@ -1,3 +1,5 @@
+'use strict';
+require('../common');
 const { fileURLToPath } = require('url');
 const assert = require('assert');
 
@@ -11,10 +13,9 @@ const assert = require('assert');
     let parsedPath;
     try {
       parsedPath = fileURLToPath(url);
+      assert.ok(parsedPath !== null, `Failed to parse URL: ${url}`);
     } catch (error) {
-      parsedPath = null;
+      throw new Error(`Failed to parse URL: ${url}. Error: ${error}`);
     }
-
-    assert.ok(parsedPath !== null, `Failed to parse URL: ${url}`);
   });
 }

--- a/test/parallel/file-url-to-path-conversion.js
+++ b/test/parallel/file-url-to-path-conversion.js
@@ -1,0 +1,20 @@
+const { fileURLToPath } = require('url');
+const assert = require('assert');
+
+{
+  const testCases = [
+    'file:///path/to/file1.js',
+    'file:///C:/Users/Username/Documents/file2.js',
+  ];
+
+  testCases.forEach((url) => {
+    let parsedPath;
+    try {
+      parsedPath = fileURLToPath(url);
+    } catch (error) {
+      parsedPath = null;
+    }
+
+    assert.ok(parsedPath !== null, `Failed to parse URL: ${url}`);
+  });
+}


### PR DESCRIPTION
The enqueue method of the test runner now converts file URLs to file paths before emitting test events. This change ensures consistency in file representations and resolves parsing issues on platforms like Windows.

- Convert file URLs to paths in the enqueue method
- Emit file paths instead of file URLs in test events
- Improve platform compatibility and consistency in file handling

#51610