### PR TITLE
fs: load rimraf lazily in fs/promises

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -43,7 +43,7 @@ const {
   aggregateTwoErrors,
 } = require('internal/errors');
 const { isArrayBufferView } = require('internal/util/types');
-const { rimrafPromises } = require('internal/fs/rimraf');
+
 const {
   constants: {
     kIoMaxLength,
@@ -93,6 +93,7 @@ const {
   kEmptyObject,
   lazyDOMException,
   promisify,
+  getLazy,
 } = require('internal/util');
 const EventEmitter = require('events');
 const { StringDecoder } = require('string_decoder');
@@ -135,6 +136,8 @@ let fsStreams;
 function lazyFsStreams() {
   return fsStreams ??= require('internal/fs/streams');
 }
+
+const lazyRimRaf = getLazy(() => require('internal/fs/rimraf').rimrafPromises);
 
 // By the time the C++ land creates an error for a promise rejection (likely from a
 // libuv callback), there is already no JS frames on the stack. So we need to
@@ -803,7 +806,7 @@ async function ftruncate(handle, len = 0) {
 async function rm(path, options) {
   path = pathModule.toNamespacedPath(getValidatedPath(path));
   options = await validateRmOptionsPromise(path, options, false);
-  return rimrafPromises(path, options);
+  return lazyRimRaf()(path, options);
 }
 
 async function rmdir(path, options) {
@@ -814,7 +817,7 @@ async function rmdir(path, options) {
     emitRecursiveRmdirWarning();
     const stats = await stat(path);
     if (stats.isDirectory()) {
-      return rimrafPromises(path, options);
+      return lazyRimRaf()(path, options);
     }
   }
 


### PR DESCRIPTION
Avoid the potential circular dependency and make fs/promises load faster when rimraf is not used.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
