### PR TITLE
build: use macOS m1 machines for testing

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   test-macOS:
     if: github.event.pull_request.draft == false
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:


### PR DESCRIPTION
macOS-14 now uses M1 machines. Let's see if the build speed and duration is worth the change.

Ref: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

cc @nodejs/build


------

macOS-14: 27m
macOS-latest: 1h 18m