### PR TITLE
console: colorize console error and warn

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -691,7 +691,7 @@ const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
 // Return styled text if all arguments are strings
 const colorizeText = (args, color) => {
-  if(!ArrayPrototypeEvery(args, (arg) => typeof arg === 'string')) return args;
+  if (!ArrayPrototypeEvery(args, (arg) => typeof arg === 'string')) return args;
 
   return ArrayPrototypeMap(args, (arg) => styleText(color, arg));
 };

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -387,12 +387,12 @@ const consoleMethods = {
 
 
   warn(...args) {
-    const color = shouldColorise(args, this._stdout.isTTY) && lazyUtilColors().yellow;
+    const color = shouldColorize(args) ? lazyUtilColors().yellow : '';
     this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
   },
 
   error(...args) {
-    const color = shouldColorise(args, this._stdout.isTTY) && lazyUtilColors().red;
+    const color = shouldColorize(args) ? lazyUtilColors().red : '';
     this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
   },
 
@@ -693,9 +693,8 @@ const iterKey = '(iteration index)';
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
 // Return true if all args are type string and isTTY
-const shouldColorise = (args, isTTY) => {
-  return isTTY && lazyUtilColors().hasColors &&
-    ArrayPrototypeEvery(args, (arg) => typeof arg === 'string');
+const shouldColorize = (args) => {
+  return ArrayPrototypeEvery(args, (arg) => typeof arg === 'string');
 };
 
 function noop() {}

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,7 +7,6 @@ const {
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
-  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSome,
   ArrayPrototypeUnshift,
@@ -276,7 +275,7 @@ ObjectDefineProperties(Console.prototype, {
   [kWriteToConsole]: {
     __proto__: null,
     ...consolePropAttributes,
-    value: function(streamSymbol, string) {
+    value: function(streamSymbol, string, color = '') {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = this[kGroupIndent];
 
@@ -291,6 +290,11 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
+
+      if (color) {
+        string = styleText(color, string);
+      }
+
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -381,16 +385,14 @@ const consoleMethods = {
   log(...args) {
     this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
   },
-
-
   warn(...args) {
-    args = colorizeText(args, 'yellow');
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
+    const color = (shouldColorize(args) && 'yellow') || '';
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
   },
 
   error(...args) {
-    args = colorizeText(args, 'red');
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
+    const color = (shouldColorize(args) && 'red') || '';
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
   },
 
   dir(object, options) {
@@ -690,11 +692,9 @@ const iterKey = '(iteration index)';
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
 // TODO: remove string type check once the styleText supports objects
-// Return styled text if all arguments are strings
-const colorizeText = (args, color) => {
-  if (ArrayPrototypeSome(args, (arg) => typeof arg !== 'string')) return args;
-
-  return ArrayPrototypeMap(args, (arg) => styleText(color, arg));
+// Return true if all args are type string
+const shouldColorize = (args) => {
+  return lazyUtilColors().hasColors && !ArrayPrototypeSome(args, (arg) => typeof arg !== 'string');
 };
 
 function noop() {}

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -8,6 +8,7 @@ const {
   ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypeEvery,
+  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeUnshift,
   Boolean,
@@ -68,6 +69,7 @@ const {
   CHAR_LOWERCASE_N: kTraceInstant,
   CHAR_UPPERCASE_C: kTraceCount,
 } = require('internal/constants');
+const { styleText } = require('util');
 const kCounts = Symbol('counts');
 
 const kTraceConsoleCategory = 'node,node.console';
@@ -274,7 +276,7 @@ ObjectDefineProperties(Console.prototype, {
   [kWriteToConsole]: {
     __proto__: null,
     ...consolePropAttributes,
-    value: function(streamSymbol, string, color) {
+    value: function(streamSymbol, string) {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = this[kGroupIndent];
 
@@ -289,11 +291,6 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
-
-      if (color) {
-        string = `${color}${string}${lazyUtilColors().clear}`;
-      }
-
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -387,13 +384,13 @@ const consoleMethods = {
 
 
   warn(...args) {
-    const color = shouldColorize(args) ? lazyUtilColors().yellow : '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
+    args = colorizeText(args, 'yellow');
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
   },
 
   error(...args) {
-    const color = shouldColorize(args) ? lazyUtilColors().red : '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
+    args = colorizeText(args, 'red');
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
   },
 
   dir(object, options) {
@@ -692,9 +689,11 @@ const iterKey = '(iteration index)';
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
-// Return true if all args are type string and isTTY
-const shouldColorize = (args) => {
-  return ArrayPrototypeEvery(args, (arg) => typeof arg === 'string');
+// Return styled text if all arguments are strings
+const colorizeText = (args, color) => {
+  if(!ArrayPrototypeEvery(args, (arg) => typeof arg === 'string')) return args;
+
+  return ArrayPrototypeMap(args, (arg) => styleText(color, arg));
 };
 
 function noop() {}

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,6 +7,7 @@ const {
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
+  ArrayPrototypeEvery,
   ArrayPrototypePush,
   ArrayPrototypeUnshift,
   Boolean,
@@ -273,7 +274,7 @@ ObjectDefineProperties(Console.prototype, {
   [kWriteToConsole]: {
     __proto__: null,
     ...consolePropAttributes,
-    value: function(streamSymbol, string) {
+    value: function(streamSymbol, string, color) {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = this[kGroupIndent];
 
@@ -288,6 +289,11 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
+
+      if (color) {
+        string = `${color}${string}${lazyUtilColors().clear}`;
+      }
+
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -381,9 +387,14 @@ const consoleMethods = {
 
 
   warn(...args) {
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
+    const color = shouldColorise(args, this._stdout.isTTY) && lazyUtilColors().yellow;
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
   },
 
+  error(...args) {
+    const color = shouldColorise(args, this._stdout.isTTY) && lazyUtilColors().red;
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
+  },
 
   dir(object, options) {
     this[kWriteToConsole](kUseStdout, inspect(object, {
@@ -681,6 +692,12 @@ const iterKey = '(iteration index)';
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
+// Return true if all args are type string and isTTY
+const shouldColorise = (args, isTTY) => {
+  return isTTY && lazyUtilColors().hasColors &&
+    ArrayPrototypeEvery(args, (arg) => typeof arg === 'string');
+};
+
 function noop() {}
 
 for (const method of ReflectOwnKeys(consoleMethods))
@@ -689,7 +706,6 @@ for (const method of ReflectOwnKeys(consoleMethods))
 Console.prototype.debug = Console.prototype.log;
 Console.prototype.info = Console.prototype.log;
 Console.prototype.dirxml = Console.prototype.log;
-Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 function initializeGlobalConsole(globalConsole) {

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -7,9 +7,9 @@ const {
   ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
-  ArrayPrototypeEvery,
   ArrayPrototypeMap,
   ArrayPrototypePush,
+  ArrayPrototypeSome,
   ArrayPrototypeUnshift,
   Boolean,
   ErrorCaptureStackTrace,
@@ -689,9 +689,10 @@ const iterKey = '(iteration index)';
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
+// TODO: remove string type check once the styleText supports objects
 // Return styled text if all arguments are strings
 const colorizeText = (args, color) => {
-  if (!ArrayPrototypeEvery(args, (arg) => typeof arg === 'string')) return args;
+  if (ArrayPrototypeSome(args, (arg) => typeof arg !== 'string')) return args;
 
   return ArrayPrototypeMap(args, (arg) => styleText(color, arg));
 };

--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -1,18 +1,27 @@
 'use strict';
 
+const {
+  ArrayPrototypeForEach,
+  ObjectKeys,
+} = primordials;
+
 let internalTTy;
 function lazyInternalTTY() {
   internalTTy ??= require('internal/tty');
   return internalTTy;
 }
 
+const colorsMap = {
+  blue: '\u001b[34m',
+  green: '\u001b[32m',
+  white: '\u001b[39m',
+  yellow: '\u001b[33m',
+  red: '\u001b[31m',
+  gray: '\u001b[90m',
+  clear: '\u001b[0m',
+};
+
 module.exports = {
-  blue: '',
-  green: '',
-  white: '',
-  red: '',
-  gray: '',
-  clear: '',
   hasColors: false,
   shouldColorize(stream) {
     if (process.env.FORCE_COLOR !== undefined) {
@@ -23,17 +32,13 @@ module.exports = {
         stream.getColorDepth() > 2 : true);
   },
   refresh() {
-    if (process.stderr.isTTY) {
-      const hasColors = module.exports.shouldColorize(process.stderr);
-      module.exports.blue = hasColors ? '\u001b[34m' : '';
-      module.exports.green = hasColors ? '\u001b[32m' : '';
-      module.exports.white = hasColors ? '\u001b[39m' : '';
-      module.exports.yellow = hasColors ? '\u001b[33m' : '';
-      module.exports.red = hasColors ? '\u001b[31m' : '';
-      module.exports.gray = hasColors ? '\u001b[90m' : '';
-      module.exports.clear = hasColors ? '\u001bc' : '';
-      module.exports.hasColors = hasColors;
-    }
+    const isTTY = process.stderr.isTTY;
+    const hasColors = isTTY && module.exports.shouldColorize(process.stderr);
+    ArrayPrototypeForEach(ObjectKeys(colorsMap), (key) => {
+      module.exports[key] = hasColors ? colorsMap[key] : '';
+    });
+
+    module.exports.hasColors = hasColors;
   },
 };
 

--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -1,27 +1,18 @@
 'use strict';
 
-const {
-  ArrayPrototypeForEach,
-  ObjectKeys,
-} = primordials;
-
 let internalTTy;
 function lazyInternalTTY() {
   internalTTy ??= require('internal/tty');
   return internalTTy;
 }
 
-const colorsMap = {
-  blue: '\u001b[34m',
-  green: '\u001b[32m',
-  white: '\u001b[39m',
-  yellow: '\u001b[33m',
-  red: '\u001b[31m',
-  gray: '\u001b[90m',
-  clear: '\u001b[0m',
-};
-
 module.exports = {
+  blue: '',
+  green: '',
+  white: '',
+  red: '',
+  gray: '',
+  clear: '',
   hasColors: false,
   shouldColorize(stream) {
     if (process.env.FORCE_COLOR !== undefined) {
@@ -32,13 +23,17 @@ module.exports = {
         stream.getColorDepth() > 2 : true);
   },
   refresh() {
-    const isTTY = process.stderr.isTTY;
-    const hasColors = isTTY && module.exports.shouldColorize(process.stderr);
-    ArrayPrototypeForEach(ObjectKeys(colorsMap), (key) => {
-      module.exports[key] = hasColors ? colorsMap[key] : '';
-    });
-
-    module.exports.hasColors = hasColors;
+    if (process.stderr.isTTY) {
+      const hasColors = module.exports.shouldColorize(process.stderr);
+      module.exports.blue = hasColors ? '\u001b[34m' : '';
+      module.exports.green = hasColors ? '\u001b[32m' : '';
+      module.exports.white = hasColors ? '\u001b[39m' : '';
+      module.exports.yellow = hasColors ? '\u001b[33m' : '';
+      module.exports.red = hasColors ? '\u001b[31m' : '';
+      module.exports.gray = hasColors ? '\u001b[90m' : '';
+      module.exports.clear = hasColors ? '\u001bc' : '';
+      module.exports.hasColors = hasColors;
+    }
   },
 };
 

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -770,6 +770,7 @@ const errorTests = [
       'Object [console] {',
       '  log: [Function: log],',
       '  warn: [Function: warn],',
+      '  error: [Function: error],',
       '  dir: [Function: dir],',
       '  time: [Function: time],',
       '  timeEnd: [Function: timeEnd],',
@@ -785,7 +786,6 @@ const errorTests = [
       / {2}debug: \[Function: (debug|log)],/,
       / {2}info: \[Function: (info|log)],/,
       / {2}dirxml: \[Function: (dirxml|log)],/,
-      / {2}error: \[Function: (error|warn)],/,
       / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
       / {2}Console: \[Function: Console],?/,
       ...process.features.inspector ? [

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
 [31m(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)[39m

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
-(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+[31m(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
-[31m(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)[39m
+*(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)*

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
 [31m(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)[39m

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
-[31m(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)[39m
+*(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)*

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
-(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+[31m(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
 [31m(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)[39m

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
-(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+[31m(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
-[31m(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)[39m
+*(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)*


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Related to : [40361](https://github.com/nodejs/node/issues/40361)

Colorise string type args of `console.error` and `console.warn`. We are skipping the non-string types.

Tasks:

- [ ] Run CITGM