### PR TITLE
build: remove `librt` library dependency for Android compatibility

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1245,8 +1245,7 @@
             'target_conditions': [
               ['_toolset=="host" and host_os=="linux"', {
                 'libraries': [
-                  '-ldl',
-                  '-lrt'
+                  '-ldl'
                 ],
               }],
             ],


### PR DESCRIPTION
> On Android, unlike Linux, there are no separate libpthread or librt libraries. That functionality is included directly in libc, which does not need to be explicitly linked against. ([Native APIs | Android NDK](https://developer.android.com/ndk/guides/stable_apis#core_cc))

Fix: #50184

Remove `librt` library dependency when building Node.js for Android, as it does not exist on Android.

Related to PR #51646, as part of a series of build fixes for Android.