### PR TITLE
deps: update c-ares to 1.26.0 for Android

### DIFF
--- a/deps/cares/config/android/ares_config.h
+++ b/deps/cares/config/android/ares_config.h
@@ -1,38 +1,26 @@
-/* ares_config.h.  Generated from ares_config.h.in by configure.  */
-/* ares_config.h.in.  Generated from configure.ac by autoheader.  */
+/* Copyright (C) The c-ares project and its contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+/* Generated from ares_config.h.cmake */
 
 /* Define if building universal (internal helper macro) */
-/* #undef AC_APPLE_UNIVERSAL_BUILD */
-
-/* define this if ares is built for a big endian system */
-/* #undef ARES_BIG_ENDIAN */
-
-/* when building as static part of libcurl */
-/* #undef BUILDING_LIBCURL */
-
-/* Defined for build that exposes internal static functions for testing. */
-/* #undef CARES_EXPOSE_STATICS */
+#undef AC_APPLE_UNIVERSAL_BUILD
 
 /* Defined for build with symbol hiding. */
-#define CARES_SYMBOL_HIDING 1
-
-/* Definition to make a library symbol externally visible. */
-#define CARES_SYMBOL_SCOPE_EXTERN __attribute__ ((__visibility__ ("default")))
-
-/* the signed version of size_t */
-#define CARES_TYPEOF_ARES_SSIZE_T ssize_t
+/* #undef CARES_SYMBOL_HIDING */
 
 /* Use resolver library to configure cares */
 /* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
-/* #undef ETC_INET */
+#undef ETC_INET
 
 /* Define to the type of arg 2 for gethostname. */
 #define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
-#define GETNAMEINFO_QUAL_ARG1 const
+#define GETNAMEINFO_QUAL_ARG1 
 
 /* Define to the type of arg 1 for getnameinfo. */
 #define GETNAMEINFO_TYPE_ARG1 struct sockaddr *
@@ -47,34 +35,28 @@
 #define GETNAMEINFO_TYPE_ARG7 int
 
 /* Specifies the number of arguments to getservbyport_r */
-#define GETSERVBYPORT_R_ARGS 6
+#define GETSERVBYPORT_R_ARGS 
 
-/* Specifies the size of the buffer to pass to getservbyport_r */
-#define GETSERVBYPORT_R_BUFSIZE 4096
+/* Specifies the number of arguments to getservbyname_r */
+#define GETSERVBYNAME_R_ARGS 
 
 /* Define to 1 if you have AF_INET6. */
-#define HAVE_AF_INET6 1
+#define HAVE_AF_INET6
 
 /* Define to 1 if you have the <arpa/inet.h> header file. */
-#define HAVE_ARPA_INET_H 1
+#define HAVE_ARPA_INET_H
 
 /* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
-//#define HAVE_ARPA_NAMESER_COMPAT_H 1
+#define HAVE_ARPA_NAMESER_COMPAT_H
 
 /* Define to 1 if you have the <arpa/nameser.h> header file. */
-//#define HAVE_ARPA_NAMESER_H 1
+#define HAVE_ARPA_NAMESER_H
 
 /* Define to 1 if you have the <assert.h> header file. */
-#define HAVE_ASSERT_H 1
-
-/* Define to 1 if you have the `bitncmp' function. */
-/* #undef HAVE_BITNCMP */
-
-/* Define to 1 if bool is an available type. */
-#define HAVE_BOOL_T 1
+#define HAVE_ASSERT_H
 
 /* Define to 1 if you have the clock_gettime function and monotonic timer. */
-#define HAVE_CLOCK_GETTIME_MONOTONIC 1
+#define HAVE_CLOCK_GETTIME_MONOTONIC
 
 /* Define to 1 if you have the closesocket function. */
 /* #undef HAVE_CLOSESOCKET */
@@ -83,79 +65,100 @@
 /* #undef HAVE_CLOSESOCKET_CAMEL */
 
 /* Define to 1 if you have the connect function. */
-#define HAVE_CONNECT 1
+#define HAVE_CONNECT
 
 /* define if the compiler supports basic C++11 syntax */
-#define HAVE_CXX11 1
+/* #undef HAVE_CXX11 */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+#define HAVE_DLFCN_H
 
 /* Define to 1 if you have the <errno.h> header file. */
-#define HAVE_ERRNO_H 1
+#define HAVE_ERRNO_H
+
+/* Define to 1 if you have the <poll.h> header file. */
+#define HAVE_POLL_H
+
+/* Define to 1 if you have the poll function. */
+#define HAVE_POLL
+
+/* Define to 1 if you have the pipe function. */
+#define HAVE_PIPE
+
+/* Define to 1 if you have the pipe2 function. */
+/* #undef HAVE_PIPE2 */
+
+/* Define to 1 if you have the kqueue function. */
+/* #undef HAVE_KQUEUE */
+
+/* Define to 1 if you have the epoll{_create,ctl,wait} functions. */
+#define HAVE_EPOLL
 
 /* Define to 1 if you have the fcntl function. */
-#define HAVE_FCNTL 1
+#define HAVE_FCNTL
 
 /* Define to 1 if you have the <fcntl.h> header file. */
-#define HAVE_FCNTL_H 1
+#define HAVE_FCNTL_H
 
 /* Define to 1 if you have a working fcntl O_NONBLOCK function. */
-#define HAVE_FCNTL_O_NONBLOCK 1
+#define HAVE_FCNTL_O_NONBLOCK
 
 /* Define to 1 if you have the freeaddrinfo function. */
-#define HAVE_FREEADDRINFO 1
+#define HAVE_FREEADDRINFO
 
 /* Define to 1 if you have a working getaddrinfo function. */
-#define HAVE_GETADDRINFO 1
+#define HAVE_GETADDRINFO
 
 /* Define to 1 if the getaddrinfo function is threadsafe. */
-#define HAVE_GETADDRINFO_THREADSAFE 1
+/* #undef HAVE_GETADDRINFO_THREADSAFE */
 
 /* Define to 1 if you have the getenv function. */
-#define HAVE_GETENV 1
-
-/* Define to 1 if you have the gethostbyaddr function. */
-#define HAVE_GETHOSTBYADDR 1
-
-/* Define to 1 if you have the gethostbyname function. */
-#define HAVE_GETHOSTBYNAME 1
+#define HAVE_GETENV
 
 /* Define to 1 if you have the gethostname function. */
-#define HAVE_GETHOSTNAME 1
-
-/* Define to 1 if you have the getifaddrs function. */
-#define HAVE_GETIFADDRS 1
+#define HAVE_GETHOSTNAME
 
 /* Define to 1 if you have the getnameinfo function. */
-#define HAVE_GETNAMEINFO 1
+#define HAVE_GETNAMEINFO
+
+/* Define to 1 if you have the getrandom function. */
+#define HAVE_GETRANDOM
 
 /* Define to 1 if you have the getservbyport_r function. */
 /* #undef HAVE_GETSERVBYPORT_R */
 
-/* Define to 1 if you have the `gettimeofday' function. */
-#define HAVE_GETTIMEOFDAY 1
+/* Define to 1 if you have the getservbyname_r function. */
+/* #undef HAVE_GETSERVBYNAME_R */
 
-/* Define to 1 if you have the <ifaddrs.h> header file. */
-#define HAVE_IFADDRS_H 1
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY
 
 /* Define to 1 if you have the `if_indextoname' function. */
-#define HAVE_IF_INDEXTONAME 1
+#define HAVE_IF_INDEXTONAME
+
+/* Define to 1 if you have the `if_nametoindex' function. */
+#define HAVE_IF_NAMETOINDEX
+
+/* Define to 1 if you have the `ConvertInterfaceIndexToLuid' function. */
+/* #undef HAVE_CONVERTINTERFACEINDEXTOLUID */
+
+/* Define to 1 if you have the `ConvertInterfaceLuidToNameA' function. */
+/* #undef HAVE_CONVERTINTERFACELUIDTONAMEA */
 
 /* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
 /* #undef HAVE_INET_NET_PTON */
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
-#define HAVE_INET_NTOP 1
+#define HAVE_INET_NTOP
 
 /* Define to 1 if you have a IPv6 capable working inet_pton function. */
-#define HAVE_INET_PTON 1
+#define HAVE_INET_PTON
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-#define HAVE_INTTYPES_H 1
+#define HAVE_INTTYPES_H
 
 /* Define to 1 if you have the ioctl function. */
-#define HAVE_IOCTL 1
+/* #undef HAVE_IOCTL */
 
 /* Define to 1 if you have the ioctlsocket function. */
 /* #undef HAVE_IOCTLSOCKET */
@@ -171,109 +174,109 @@
 /* #undef HAVE_IOCTLSOCKET_FIONBIO */
 
 /* Define to 1 if you have a working ioctl FIONBIO function. */
-#define HAVE_IOCTL_FIONBIO 1
+/* #undef HAVE_IOCTL_FIONBIO */
 
 /* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
-#define HAVE_IOCTL_SIOCGIFADDR 1
+#define HAVE_IOCTL_SIOCGIFADDR
 
 /* Define to 1 if you have the `resolve' library (-lresolve). */
-/* #undef HAVE_LIBRESOLVE */
+/* #undef HAVE_LIBRESOLV */
+
+/* Define to 1 if you have iphlpapi.h */
+/* #undef HAVE_IPHLPAPI_H */
+
+/* Define to 1 if you have netioapi.h */
+/* #undef HAVE_NETIOAPI_H */
 
 /* Define to 1 if you have the <limits.h> header file. */
-#define HAVE_LIMITS_H 1
-
-/* if your compiler supports LL */
-#define HAVE_LL 1
+#define HAVE_LIMITS_H
 
 /* Define to 1 if the compiler supports the 'long long' data type. */
-#define HAVE_LONGLONG 1
+#define HAVE_LONGLONG
 
 /* Define to 1 if you have the malloc.h header file. */
-#define HAVE_MALLOC_H 1
+#define HAVE_MALLOC_H
 
 /* Define to 1 if you have the memory.h header file. */
-#define HAVE_MEMORY_H 1
+#define HAVE_MEMORY_H
+
+/* Define to 1 if you have the AvailabilityMacros.h header file. */
+/* #undef HAVE_AVAILABILITYMACROS_H */
 
 /* Define to 1 if you have the MSG_NOSIGNAL flag. */
-#define HAVE_MSG_NOSIGNAL 1
+#define HAVE_MSG_NOSIGNAL
 
 /* Define to 1 if you have the <netdb.h> header file. */
-#define HAVE_NETDB_H 1
+#define HAVE_NETDB_H
 
 /* Define to 1 if you have the <netinet/in.h> header file. */
-#define HAVE_NETINET_IN_H 1
+#define HAVE_NETINET_IN_H
 
 /* Define to 1 if you have the <netinet/tcp.h> header file. */
-#define HAVE_NETINET_TCP_H 1
+#define HAVE_NETINET_TCP_H
 
 /* Define to 1 if you have the <net/if.h> header file. */
-#define HAVE_NET_IF_H 1
+#define HAVE_NET_IF_H
 
 /* Define to 1 if you have PF_INET6. */
-#define HAVE_PF_INET6 1
+#define HAVE_PF_INET6
 
 /* Define to 1 if you have the recv function. */
-#define HAVE_RECV 1
+#define HAVE_RECV
 
 /* Define to 1 if you have the recvfrom function. */
-#define HAVE_RECVFROM 1
+#define HAVE_RECVFROM
 
 /* Define to 1 if you have the send function. */
-#define HAVE_SEND 1
+#define HAVE_SEND
 
 /* Define to 1 if you have the setsockopt function. */
-#define HAVE_SETSOCKOPT 1
+#define HAVE_SETSOCKOPT
 
 /* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
 /* #undef HAVE_SETSOCKOPT_SO_NONBLOCK */
 
 /* Define to 1 if you have the <signal.h> header file. */
-#define HAVE_SIGNAL_H 1
-
-/* Define to 1 if sig_atomic_t is an available typedef. */
-#define HAVE_SIG_ATOMIC_T 1
-
-/* Define to 1 if sig_atomic_t is already defined as volatile. */
-/* #undef HAVE_SIG_ATOMIC_T_VOLATILE */
+#define HAVE_SIGNAL_H
 
 /* Define to 1 if your struct sockaddr_in6 has sin6_scope_id. */
-#define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID 1
+#define HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID
 
 /* Define to 1 if you have the socket function. */
-#define HAVE_SOCKET 1
+#define HAVE_SOCKET
 
 /* Define to 1 if you have the <socket.h> header file. */
 /* #undef HAVE_SOCKET_H */
 
 /* Define to 1 if you have the <stdbool.h> header file. */
-#define HAVE_STDBOOL_H 1
+#define HAVE_STDBOOL_H
 
 /* Define to 1 if you have the <stdint.h> header file. */
-#define HAVE_STDINT_H 1
+#define HAVE_STDINT_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#define HAVE_STDLIB_H 1
+#define HAVE_STDLIB_H
 
 /* Define to 1 if you have the strcasecmp function. */
-#define HAVE_STRCASECMP 1
+#define HAVE_STRCASECMP
 
 /* Define to 1 if you have the strcmpi function. */
 /* #undef HAVE_STRCMPI */
 
 /* Define to 1 if you have the strdup function. */
-#define HAVE_STRDUP 1
+#define HAVE_STRDUP
 
 /* Define to 1 if you have the stricmp function. */
 /* #undef HAVE_STRICMP */
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+#define HAVE_STRINGS_H
 
 /* Define to 1 if you have the <string.h> header file. */
-#define HAVE_STRING_H 1
+#define HAVE_STRING_H
 
 /* Define to 1 if you have the strncasecmp function. */
-#define HAVE_STRNCASECMP 1
+#define HAVE_STRNCASECMP
 
 /* Define to 1 if you have the strncmpi function. */
 /* #undef HAVE_STRNCMPI */
@@ -282,52 +285,64 @@
 /* #undef HAVE_STRNICMP */
 
 /* Define to 1 if you have the <stropts.h> header file. */
-#define HAVE_STROPTS_H 1
+/* #undef HAVE_STROPTS_H */
 
 /* Define to 1 if you have struct addrinfo. */
-#define HAVE_STRUCT_ADDRINFO 1
+#define HAVE_STRUCT_ADDRINFO
 
 /* Define to 1 if you have struct in6_addr. */
-#define HAVE_STRUCT_IN6_ADDR 1
+#define HAVE_STRUCT_IN6_ADDR
 
 /* Define to 1 if you have struct sockaddr_in6. */
-#define HAVE_STRUCT_SOCKADDR_IN6 1
+#define HAVE_STRUCT_SOCKADDR_IN6
 
 /* if struct sockaddr_storage is defined */
-#define HAVE_STRUCT_SOCKADDR_STORAGE 1
+#define HAVE_STRUCT_SOCKADDR_STORAGE
 
 /* Define to 1 if you have the timeval struct. */
-#define HAVE_STRUCT_TIMEVAL 1
+#define HAVE_STRUCT_TIMEVAL
 
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
-#define HAVE_SYS_IOCTL_H 1
+#define HAVE_SYS_IOCTL_H
 
 /* Define to 1 if you have the <sys/param.h> header file. */
-#define HAVE_SYS_PARAM_H 1
+#define HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/random.h> header file. */
+#define HAVE_SYS_RANDOM_H
+
+/* Define to 1 if you have the <sys/event.h> header file. */
+/* #undef HAVE_SYS_EVENT_H */
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+#define HAVE_SYS_EPOLL_H
 
 /* Define to 1 if you have the <sys/select.h> header file. */
-#define HAVE_SYS_SELECT_H 1
+#define HAVE_SYS_SELECT_H
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
-#define HAVE_SYS_SOCKET_H 1
+#define HAVE_SYS_SOCKET_H
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#define HAVE_SYS_STAT_H 1
+#define HAVE_SYS_STAT_H
 
 /* Define to 1 if you have the <sys/time.h> header file. */
-#define HAVE_SYS_TIME_H 1
+#define HAVE_SYS_TIME_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#define HAVE_SYS_TYPES_H 1
+#define HAVE_SYS_TYPES_H
 
 /* Define to 1 if you have the <sys/uio.h> header file. */
-#define HAVE_SYS_UIO_H 1
+#define HAVE_SYS_UIO_H
 
 /* Define to 1 if you have the <time.h> header file. */
-#define HAVE_TIME_H 1
+#define HAVE_TIME_H
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
+#define HAVE_UNISTD_H
 
 /* Define to 1 if you have the windows.h header file. */
 /* #undef HAVE_WINDOWS_H */
@@ -338,14 +353,26 @@
 /* Define to 1 if you have the winsock.h header file. */
 /* #undef HAVE_WINSOCK_H */
 
+/* Define to 1 if you have the mswsock.h header file. */
+/* #undef HAVE_MSWSOCK_H */
+
+/* Define to 1 if you have the winternl.h header file. */
+/* #undef HAVE_WINTERNL_H */
+
+/* Define to 1 if you have the ntstatus.h header file. */
+/* #undef HAVE_NTSTATUS_H */
+
+/* Define to 1 if you have the ntdef.h header file. */
+/* #undef HAVE_NTDEF_H */
+
 /* Define to 1 if you have the writev function. */
-#define HAVE_WRITEV 1
+#define HAVE_WRITEV
 
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
 
-/* Define to the sub-directory where libtool stores uninstalled libraries. */
-#define LT_OBJDIR ".libs/"
+/* Define to 1 if you have the __system_property_get function */
+#define HAVE___SYSTEM_PROPERTY_GET
 
 /* Define to 1 if you need the malloc.h header file even with stdlib.h */
 /* #undef NEED_MALLOC_H */
@@ -353,50 +380,29 @@
 /* Define to 1 if you need the memory.h header file even with stdlib.h */
 /* #undef NEED_MEMORY_H */
 
-/* Define to 1 if _REENTRANT preprocessor symbol must be defined. */
-/* #undef NEED_REENTRANT */
+/* Define if have arc4random_buf() */
+#define HAVE_ARC4RANDOM_BUF
 
-/* Define to 1 if _THREAD_SAFE preprocessor symbol must be defined. */
-/* #undef NEED_THREAD_SAFE */
+/* Define if have getifaddrs() */
+#define HAVE_GETIFADDRS
 
-/* cpu-machine-OS */
-#define OS "i686-pc-linux-gnu"
-
-/* Name of package */
-#define PACKAGE "c-ares"
-
-/* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "c-ares mailing list: http://cool.haxx.se/mailman/listinfo/c-ares"
-
-/* Define to the full name of this package. */
-#define PACKAGE_NAME "c-ares"
-
-/* Define to the full name and version of this package. */
-#define PACKAGE_STRING "c-ares 1.13.0"
-
-/* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "c-ares"
-
-/* Define to the home page for this package. */
-#define PACKAGE_URL ""
-
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "1.13.0"
+/* Define if have stat() */
+#define HAVE_STAT
 
 /* a suitable file/device to read random data from */
 #define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
-#define RECVFROM_QUAL_ARG5
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
 
 /* Define to the type pointed by arg 2 for recvfrom. */
-#define RECVFROM_TYPE_ARG2 void
+#define RECVFROM_TYPE_ARG2 void *
 
 /* Define to 1 if the type pointed by arg 2 for recvfrom is void. */
-#define RECVFROM_TYPE_ARG2_IS_VOID 1
+#define RECVFROM_TYPE_ARG2_IS_VOID 0
 
 /* Define to the type of arg 3 for recvfrom. */
 #define RECVFROM_TYPE_ARG3 size_t
@@ -405,16 +411,16 @@
 #define RECVFROM_TYPE_ARG4 int
 
 /* Define to the type pointed by arg 5 for recvfrom. */
-#define RECVFROM_TYPE_ARG5 struct sockaddr
+#define RECVFROM_TYPE_ARG5 struct sockaddr *
 
 /* Define to 1 if the type pointed by arg 5 for recvfrom is void. */
-/* #undef RECVFROM_TYPE_ARG5_IS_VOID */
+#define RECVFROM_TYPE_ARG5_IS_VOID 0
 
 /* Define to the type pointed by arg 6 for recvfrom. */
-#define RECVFROM_TYPE_ARG6 socklen_t
+#define RECVFROM_TYPE_ARG6 socklen_t *
 
 /* Define to 1 if the type pointed by arg 6 for recvfrom is void. */
-/* #undef RECVFROM_TYPE_ARG6_IS_VOID */
+#define RECVFROM_TYPE_ARG6_IS_VOID 0
 
 /* Define to the function return type for recvfrom. */
 #define RECVFROM_TYPE_RETV ssize_t
@@ -434,11 +440,8 @@
 /* Define to the function return type for recv. */
 #define RECV_TYPE_RETV ssize_t
 
-/* Define as the return type of signal handlers (`int' or `void'). */
-#define RETSIGTYPE void
-
 /* Define to the type qualifier of arg 2 for send. */
-#define SEND_QUAL_ARG2 const
+#define SEND_QUAL_ARG2 
 
 /* Define to the type of arg 1 for send. */
 #define SEND_TYPE_ARG1 int
@@ -455,57 +458,22 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV ssize_t
 
-/* Define to 1 if you have the ANSI C header files. */
-#define STDC_HEADERS 1
-
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
-#define TIME_WITH_SYS_TIME 1
-
 /* Define to disable non-blocking sockets. */
-/* #undef USE_BLOCKING_SOCKETS */
-
-/* Version number of package */
-#define VERSION "1.13.0"
+#undef USE_BLOCKING_SOCKETS
 
 /* Define to avoid automatic inclusion of winsock.h */
-/* #undef WIN32_LEAN_AND_MEAN */
+#undef WIN32_LEAN_AND_MEAN
 
-/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
-   significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
-# if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
-# endif
-#else
-# ifndef WORDS_BIGENDIAN
-/* #  undef WORDS_BIGENDIAN */
-# endif
-#endif
+/* Define to 1 if you have the pthread.h header file. */
+#define HAVE_PTHREAD_H
 
-/* Define to 1 if OS is AIX. */
-#ifndef _ALL_SOURCE
-/* #  undef _ALL_SOURCE */
-#endif
+/* Define to 1 if you have the pthread_np.h header file. */
+/* #undef HAVE_PTHREAD_NP_H */
 
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
-#endif
+/* Define to 1 if threads are enabled */
+#define CARES_THREADS
 
-/* Number of bits in a file offset, on hosts where this is settable. */
-/* #undef _FILE_OFFSET_BITS */
+/* Define to 1 if pthread_init() exists */
+/* #undef HAVE_PTHREAD_INIT */
 
-/* Define for large files, on AIX-style hosts. */
-/* #undef _LARGE_FILES */
-
-/* Define to empty if `const' does not conform to ANSI C. */
-/* #undef const */
-
-/* Type to use in place of in_addr_t when system does not provide it. */
-/* #undef in_addr_t */
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-/* #undef size_t */
-
-/* the signed version of size_t */
-/* #undef ssize_t */
+    


### PR DESCRIPTION
Related PR: #51582

Update ares_config.h for Android with c-ares version 1.26.0.

NOTICE: This is only for arch arm64-v8a.

Built with `Android NDK 26.1.10909125`, c-ares `HEAD`.
