### PR TITLE
fix(sec): upgrade urllib3 to 

### DIFF
--- a/deps/uv/docs/requirements.txt
+++ b/deps/uv/docs/requirements.txt
@@ -32,5 +32,5 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib.applehelp==1.0.3
 tornado==6.3.2
-urllib3==1.26.14
+urllib3==2.0.7
 zipp==3.11.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.26.14
- [CVE-2023-43804](https://www.oscs1024.com/hd/CVE-2023-43804)


### What did I do？
Upgrade urllib3 from 1.26.14 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS