### PR TITLE
http: split set-cookie when using setHeaders

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -732,7 +732,7 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
   // the getter to retrieve the value,
   // unless iterating over the headers directly.
   // We also cannot safely split by comma.
-  // To avoid setHeader owerwriting the previous value we push
+  // To avoid setHeader overwriting the previous value we push
   // set-cookie values in array and set them all at once.
   const cookies = [];
 

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -728,8 +728,27 @@ OutgoingMessage.prototype.setHeaders = function setHeaders(headers) {
     throw new ERR_INVALID_ARG_TYPE('headers', ['Headers', 'Map'], headers);
   }
 
-  for (const key of headers.keys()) {
-    this.setHeader(key, headers.get(key));
+  // Headers object joins multiple cookies with a comma when using
+  // the getter to retrieve the value,
+  // unless iterating over the headers directly.
+  // We also cannot safely split by comma.
+  // To avoid setHeader owerwriting the previous value we push
+  // set-cookie values in array and set them all at once.
+  const cookies = [];
+
+  for (const { 0: key, 1: value } of headers) {
+    if (key === 'set-cookie') {
+      if (ArrayIsArray(value)) {
+        cookies.push(...value);
+      } else {
+        cookies.push(value);
+      }
+      continue;
+    }
+    this.setHeader(key, value);
+  }
+  if (cookies.length) {
+    this.setHeader('set-cookie', cookies);
   }
 
   return this;

--- a/test/parallel/test-http-response-setheaders.js
+++ b/test/parallel/test-http-response-setheaders.js
@@ -129,3 +129,46 @@ const assert = require('assert');
     });
   }));
 }
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Headers();
+    headers.append('Set-Cookie', 'a=b');
+    headers.append('Set-Cookie', 'c=d');
+    res.setHeaders(headers);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert(Array.isArray(res.headers['set-cookie']));
+      assert.strictEqual(res.headers['set-cookie'].length, 2);
+      assert.strictEqual(res.headers['set-cookie'][0], 'a=b');
+      assert.strictEqual(res.headers['set-cookie'][1], 'c=d');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}
+
+{
+  const server = http.createServer({ requireHostHeader: false }, common.mustCall((req, res) => {
+    const headers = new Map();
+    headers.set('Set-Cookie', ['a=b', 'c=d']);
+    res.setHeaders(headers);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, (res) => {
+      assert(Array.isArray(res.headers['set-cookie']));
+      assert.strictEqual(res.headers['set-cookie'].length, 2);
+      assert.strictEqual(res.headers['set-cookie'][0], 'a=b');
+      assert.strictEqual(res.headers['set-cookie'][1], 'c=d');
+      res.resume().on('end', common.mustCall(() => {
+        server.close();
+      }));
+    });
+  }));
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51599
This allows `set-cookie` header to work correctly with `setHeaders`
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
