### PR TITLE
doc: fix dns.lookup family `0` and `all` description

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -241,8 +241,8 @@ changes:
 
 Resolves a host name (e.g. `'nodejs.org'`) into the first found A (IPv4) or
 AAAA (IPv6) record. All `option` properties are optional. If `options` is an
-integer, then it must be `4` or `6` – if `options` is `0` or not provided, then
-IPv4 and IPv6 addresses are both returned if found.
+integer, then it must be `4` or `6` – if `options` is not provided, then
+either IPv4 or IPv6 addresses, or both, are returned if found.
 
 With the `all` option set to `true`, the arguments for `callback` change to
 `(err, addresses)`, with `addresses` being an array of objects with the
@@ -1015,8 +1015,8 @@ changes:
 
 Resolves a host name (e.g. `'nodejs.org'`) into the first found A (IPv4) or
 AAAA (IPv6) record. All `option` properties are optional. If `options` is an
-integer, then it must be `4` or `6` – if `options` is not provided, then IPv4
-and IPv6 addresses are both returned if found.
+integer, then it must be `4` or `6` – if `options` is not provided, then
+either IPv4 or IPv6 addresses, or both, are returned if found.
 
 With the `all` option set to `true`, the `Promise` is resolved with `addresses`
 being an array of objects with the properties `address` and `family`.

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -210,8 +210,9 @@ changes:
   * `family` {integer|string} The record family. Must be `4`, `6`, or `0`. For
     backward compatibility reasons,`'IPv4'` and `'IPv6'` are interpreted as `4`
     and `6` respectively. The value `0` indicates that either an IPv4 or IPv6
-    address is returned. If the value `0` is used with `{ all: true } (see below)`,
-    both IPv4 and IPv6 addresses are returned. **Default:** `0`.
+    address is returned. If the value `0` is used with `{ all: true }` (see below),
+    either one of or both IPv4 and IPv6 addresses are returned, depending on the
+    system's DNS resolver. **Default:** `0`.
   * `hints` {number} One or more [supported `getaddrinfo` flags][]. Multiple
     flags may be passed by bitwise `OR`ing their values.
   * `all` {boolean} When `true`, the callback returns all resolved addresses in
@@ -988,8 +989,9 @@ changes:
 * `options` {integer | Object}
   * `family` {integer} The record family. Must be `4`, `6`, or `0`. The value
     `0` indicates that either an IPv4 or IPv6 address is returned. If the
-    value `0` is used with `{ all: true }` (see below), both IPv4 and IPv6
-    addresses are returned. **Default:** `0`.
+    value `0` is used with `{ all: true }` (see below), either one of or both
+    IPv4 and IPv6 addresses are returned, depending on the system's DNS
+    resolver. **Default:** `0`.
   * `hints` {number} One or more [supported `getaddrinfo` flags][]. Multiple
     flags may be passed by bitwise `OR`ing their values.
   * `all` {boolean} When `true`, the `Promise` is resolved with all addresses in

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -210,9 +210,9 @@ changes:
   * `family` {integer|string} The record family. Must be `4`, `6`, or `0`. For
     backward compatibility reasons,`'IPv4'` and `'IPv6'` are interpreted as `4`
     and `6` respectively. The value `0` indicates that either an IPv4 or IPv6
-    address is returned. If the value `0` is used with `{ all: true }` (see below),
-    either one of or both IPv4 and IPv6 addresses are returned, depending on the
-    system's DNS resolver. **Default:** `0`.
+    address is returned. If the value `0` is used with `{ all: true }` (see
+    below), either one of or both IPv4 and IPv6 addresses are returned,
+    depending on the system's DNS resolver. **Default:** `0`.
   * `hints` {number} One or more [supported `getaddrinfo` flags][]. Multiple
     flags may be passed by bitwise `OR`ing their values.
   * `all` {boolean} When `true`, the callback returns all resolved addresses in


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51482

Also see #51483, #51517