### PR TITLE
test: skip test-http-correct-hostname on loong64

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -107,3 +107,7 @@ test-cluster-primary-error: PASS, FLAKY
 [$arch==s390x]
 # https://github.com/nodejs/node/issues/50222
 test-inspector-async-hook-setup-at-inspect-brk: PASS, FLAKY
+
+[$arch==loong64]
+# https://github.com/nodejs/node/issues/51662
+test-http-correct-hostname: SKIP


### PR DESCRIPTION
Hi,

log: https://ci.nodejs.org/job/node-test-commit-loongarch64/nodes=clfs23-64/75/console
issues: https://github.com/nodejs/node/issues/51662

In common user machines, the test case can pass normally. I guess it is the machine local area network problem of "node-test-commit-loongarch64/nodes=clfs23-64". It is recommended to skip this test item for the time being.

Best regards