### PR TITLE
src: check empty before accessing string

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -116,11 +116,11 @@ void Dotenv::ParseContent(const std::string_view content) {
     value.erase(0, value.find_first_not_of(" \t"));
 
     // Remove trailing whitespaces
-    value.erase(value.find_last_not_of(" \t") + 1);
+    if (!value.empty()) {
+      value.erase(value.find_last_not_of(" \t") + 1);
+    }
 
-    const char maybeQuote = value.front();
-
-    if (maybeQuote == '"') {
+    if (!value.empty() && value.front() == '"') {
       value = std::regex_replace(value, std::regex("\\\\n"), "\n");
       value = std::regex_replace(value, std::regex("\\\\r"), "\r");
     }


### PR DESCRIPTION
Fix an assertion when running dotnev tests with GN build:
assertion !empty() failed: string::front(): string is empty

which was caused by calling value.front() without verifying the value is not empty.