### PR TITLE
test_runner: check if timeout was cleared by own callback

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -622,8 +622,12 @@ class MockTimers {
       if (timer.runAt > this.#now) break;
       FunctionPrototypeApply(timer.callback, undefined, timer.args);
 
-      this.#executionQueue.shift();
-      timer.priorityQueuePosition = undefined;
+      // Check if the timeout was cleared by calling clearTimeout inside its own callback
+      const afterCallback = this.#executionQueue.peek();
+      if (afterCallback.id === timer.id) {
+        this.#executionQueue.shift();
+        timer.priorityQueuePosition = undefined;
+      }
 
       if (timer.interval !== undefined) {
         timer.runAt += timer.interval;

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -532,6 +532,22 @@ describe('Mock Timers Test Suite', () => {
           await nodeTimersPromises.setImmediate(); // let promises settle
           assert.strictEqual(f2.mock.callCount(), 1);
         });
+
+        it('should not affect other timers when clearing timeout inside own callback', (t) => {
+          t.mock.timers.enable({ apis: ['setTimeout'] });
+          const f = t.mock.fn();
+
+          const timer = nodeTimers.setTimeout(() => {
+            f();
+            // Clearing the already-expired timeout should do nothing
+            nodeTimers.clearTimeout(timer);
+          }, 50);
+          nodeTimers.setTimeout(f, 50);
+          nodeTimers.setTimeout(f, 50);
+
+          t.mock.timers.runAll();
+          assert.strictEqual(f.mock.callCount(), 3);
+        });
       });
 
       describe('setInterval Suite', () => {


### PR DESCRIPTION
Fixes calling `clearTimeout` in a mocked `setTimeout` callback resulting in two timeouts being removed from the execution queue (the current timeout and the next one in the queue). This happens because `clearTimeout` removes the timeout at execution queue position 1, followed by the call in `tick()` to `#executionQueue.shift()` removing the next item in the queue.

I fixed this by checking if the first item in the execution queue has the same ID as the one that is being executed before calling `#executionQueue.shift()`. If the IDs aren't the same, it means it was already removed by a call to `clearTimeout` in the callback.

```js
test('should not affect other timers when clearing timeout inside own callback', (t) => {
  t.mock.timers.enable({ apis: ['setTimeout'] });
  const f = t.mock.fn();

  const timer = setTimeout(() => {
    f();

    // Clearing the already-expired timeout should do nothing.
    // This call to clearTimeout removes the current timeout from the execution queue
    clearTimeout(timer);
  }, 50);

  // Once the above callback runs, the call to `#executionQueue.shift()` removes this timeout from the queue
  setTimeout(f, 50);
  setTimeout(f, 50);

  t.mock.timers.runAll();
  assert.strictEqual(f.mock.callCount(), 3); // AssertionError 2 !== 3
});
```