### PR TITLE
fs: expose `BigIntStats`, `StatFs`, `FSWatcher`, `StatWatcher` classes

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3242,6 +3242,18 @@ defineLazyProperties(
   ['Dir', 'opendir', 'opendirSync'],
 );
 
+defineLazyProperties(
+  fs,
+  'internal/fs/utils',
+  ['BigIntStats', 'StatFs'],
+);
+
+defineLazyProperties(
+  fs,
+  'internal/fs/watchers',
+  ['FSWatcher', 'StatWatcher'],
+);
+
 ObjectDefineProperties(fs, {
   F_OK: { __proto__: null, enumerable: true, value: F_OK || 0 },
   R_OK: { __proto__: null, enumerable: true, value: R_OK || 0 },

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -1000,6 +1000,7 @@ module.exports = {
   getStatsFromBinding,
   stringToFlags,
   stringToSymlinkType,
+  StatFs,
   Stats,
   toUnixTimestamp,
   validateBufferArray,

--- a/test/parallel/test-fs-classes-exist.mjs
+++ b/test/parallel/test-fs-classes-exist.mjs
@@ -1,0 +1,25 @@
+import '../common/index.mjs';
+import { equal } from 'node:assert/strict';
+import {
+  BigIntStats,
+  Dir,
+  Dirent,
+  FSWatcher,
+  StatWatcher,
+  ReadStream,
+  Stats,
+  StatFs,
+  WriteStream,
+} from 'node:fs';
+
+// Test classes listed in https://nodejs.org/api/fs.html#common-objects
+
+equal(typeof BigIntStats, 'function');
+equal(typeof Dir, 'function');
+equal(typeof Dirent, 'function');
+equal(typeof FSWatcher, 'function');
+equal(typeof StatWatcher, 'function');
+equal(typeof ReadStream, 'function');
+equal(typeof Stats, 'function');
+equal(typeof StatFs, 'function');
+equal(typeof WriteStream, 'function');


### PR DESCRIPTION
These classes are documented in https://nodejs.org/api/fs.html#common-objects as a part of public API.

Alternatively, we can add common `fs.classes` object and define these properties on it (similar to `fs.constants`) and maybe deprecate `fs.Stats`, `fs.Dir`, `fs.Dirent`, `fs.ReadStream`, `fs.Stats`, and `fs.WriteStream`.

Fixes: https://github.com/nodejs/node/issues/51674