### PR TITLE
vm: implement isContext() directly in JS land with private symbol

### DIFF
--- a/lib/internal/vm.js
+++ b/lib/internal/vm.js
@@ -8,7 +8,6 @@ const {
 const {
   ContextifyScript,
   compileFunction,
-  isContext: _isContext,
 } = internalBinding('contextify');
 const {
   runInContext,
@@ -21,18 +20,19 @@ const {
 } = internalBinding('symbols');
 const {
   validateFunction,
-  validateObject,
-  kValidateObjectAllowArray,
 } = require('internal/validators');
 
 const {
   getOptionValue,
 } = require('internal/options');
+const {
+  privateSymbols: {
+    contextify_context_private_symbol,
+  },
+} = internalBinding('util');
 
 function isContext(object) {
-  validateObject(object, 'object', kValidateObjectAllowArray);
-
-  return _isContext(object);
+  return object[contextify_context_private_symbol] !== undefined;
 }
 
 function getHostDefinedOptionId(importModuleDynamically, hint) {

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -17,7 +17,6 @@ const {
   TypeError,
 } = primordials;
 
-const { isContext } = internalBinding('contextify');
 const {
   isModuleNamespaceObject,
 } = require('internal/util/types');
@@ -74,6 +73,8 @@ const kWrap = Symbol('kWrap');
 const kContext = Symbol('kContext');
 const kPerContextModuleId = Symbol('kPerContextModuleId');
 const kLink = Symbol('kLink');
+
+const { isContext } = require('internal/vm');
 
 class Module {
   constructor(options) {

--- a/lib/vm.js
+++ b/lib/vm.js
@@ -49,6 +49,7 @@ const {
   validateString,
   validateStringArray,
   validateUint32,
+  kValidateObjectAllowArray,
   kValidateObjectAllowNullable,
 } = require('internal/validators');
 const {
@@ -59,13 +60,25 @@ const {
 const {
   getHostDefinedOptionId,
   internalCompileFunction,
-  isContext,
+  isContext: _isContext,
   registerImportModuleDynamically,
 } = require('internal/vm');
 const {
   vm_dynamic_import_main_context_default,
 } = internalBinding('symbols');
 const kParsingContext = Symbol('script parsing context');
+
+/**
+ * Check if object is a context object created by vm.createContext().
+ * @throws {TypeError} If object is not an object in the first place, throws TypeError.
+ * @param {object} object Object to check.
+ * @returns {boolean}
+ */
+function isContext(object) {
+  validateObject(object, 'object', kValidateObjectAllowArray);
+
+  return _isContext(object);
+}
 
 class Script extends ContextifyScript {
   constructor(code, options = kEmptyObject) {

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -342,7 +342,6 @@ void ContextifyContext::CreatePerIsolateProperties(
     IsolateData* isolate_data, Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
   SetMethod(isolate, target, "makeContext", MakeContext);
-  SetMethod(isolate, target, "isContext", IsContext);
   SetMethod(isolate, target, "compileFunction", CompileFunction);
   SetMethod(isolate, target, "containsModuleSyntax", ContainsModuleSyntax);
 }
@@ -350,7 +349,6 @@ void ContextifyContext::CreatePerIsolateProperties(
 void ContextifyContext::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(MakeContext);
-  registry->Register(IsContext);
   registry->Register(CompileFunction);
   registry->Register(ContainsModuleSyntax);
   registry->Register(PropertyGetterCallback);
@@ -414,20 +412,6 @@ void ContextifyContext::MakeContext(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 }
-
-
-void ContextifyContext::IsContext(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  CHECK(args[0]->IsObject());
-  Local<Object> sandbox = args[0].As<Object>();
-
-  Maybe<bool> result =
-      sandbox->HasPrivate(env->context(),
-                          env->contextify_context_private_symbol());
-  args.GetReturnValue().Set(result.FromJust());
-}
-
 
 void ContextifyContext::WeakCallback(
     const WeakCallbackInfo<ContextifyContext>& data) {


### PR DESCRIPTION
We are now directly checking the existence of a private symbol in the object to determine if an object is a ContextifyContext anyway, so there is no need to implement it in C++ anymore.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
