### PR TITLE
build: fix warning in cares under GN build

### DIFF
--- a/deps/cares/unofficial.gni
+++ b/deps/cares/unofficial.gni
@@ -69,6 +69,8 @@ template("cares_gn_build") {
       cflags_c = [
         "-Wno-implicit-fallthrough",
         "-Wno-unreachable-code",
+        # Remove after https://github.com/c-ares/c-ares/pull/709 lands in Node.
+        "-Wno-unused-result",
       ]
     }
   }


### PR DESCRIPTION
This change can be removed after the upstream fix lands in Node:
https://github.com/c-ares/c-ares/pull/709
