### PR TITLE
feat: add -w option as an alias to --watch

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2286,7 +2286,7 @@ added: v0.1.3
 
 Print node's version.
 
-### `--watch`
+### `-w`, `--watch`
 
 <!-- YAML
 added:

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2298,6 +2298,10 @@ changes:
       - v18.13.0
     pr-url: https://github.com/nodejs/node/pull/45214
     description: Test runner now supports running in watch mode.
+  - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51696
+    description: With this pull request, node -w also will be activate watch mode alongside node --watch.
 -->
 
 > Stability: 1 - Experimental

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2597,7 +2597,7 @@ Node.js options that are allowed are:
 * `--v8-pool-size`
 * `--watch-path`
 * `--watch-preserve-output`
-* `--watch`
+* `--watch`, `-w`
 * `--zero-fill-buffers`
 
 <!-- node-options-node end -->

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -706,6 +706,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "run in watch mode",
             &EnvironmentOptions::watch_mode,
             kAllowedInEnvvar);
+  AddAlias("-w", "--watch");
   AddOption("--watch-path",
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,


### PR DESCRIPTION
With this pull request, `node -w` also will be activate watch mode alongside `node --watch`.