### PR TITLE
lib: create global console properties at snapshot build time

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -694,8 +694,6 @@ Console.prototype.groupCollapsed = Console.prototype.group;
 
 function initializeGlobalConsole(globalConsole) {
   globalConsole[kBindStreamsLazy](process);
-  globalConsole[kBindProperties](true, 'auto');
-
   const {
     namespace: {
       addSerializeCallback,

--- a/lib/internal/console/global.js
+++ b/lib/internal/console/global.js
@@ -21,6 +21,7 @@ const {
 
 const {
   Console,
+  kBindProperties,
 } = require('internal/console/constructor');
 
 const globalConsole = { __proto__: {} };
@@ -40,6 +41,8 @@ for (const prop of ReflectOwnKeys(Console.prototype)) {
   }
   ReflectDefineProperty(globalConsole, prop, desc);
 }
+
+globalConsole[kBindProperties](true, 'auto');
 
 // This is a legacy feature - the Console constructor is exposed on
 // the global console instance.


### PR DESCRIPTION
It is safe to create the console properties for the global console at snapshot build time. Streams must still be created lazily however because they need special synchronization for the handles.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
