### PR TITLE
build: ignore `v8_enable|disble_object_print` CLI option handling

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -803,7 +803,7 @@ parser.add_argument('--v8-lite-mode',
 parser.add_argument('--v8-enable-object-print',
     action='store_true',
     dest='v8_enable_object_print',
-    default=True,
+    default=False,
     help='compile V8 with auxiliary functions for native debuggers')
 
 parser.add_argument('--v8-disable-object-print',


### PR DESCRIPTION
This patch will avoid collisions in the `v8_enable_object_print` build
definition.

This are the results of the V8 build after this patch:

```sh
$ ./configure --verbose | \
  grep v8_enable_object_print
    'v8_enable_object_print': 1,

$ ./configure --v8-enable-object-print --verbose | \
  grep v8_enable_object_print
    'v8_enable_object_print': 1,

$ ./configure --v8-disable-object-print --verbose | \
  grep v8_enable_object_print
    'v8_enable_object_print': 0,

$ ./configure --v8-enable-object-print --v8-disable-object-print
    Exception: Only one of the --v8-enable-object-print or ...
```
