### PR TITLE
doc: change `ExperimentalWarnings` to `ExperimentalWarning`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -545,7 +545,7 @@ For example, the following script will emit the
 [DEP0025 `require('node:sys')`][DEP0025 warning], but not any Experimental
 Warnings (such as
 [ExperimentalWarning: `vm.measureMemory` is an experimental feature][]
-in <=v21) when executed with `node --disable-warning=ExperimentalWarnings`:
+in <=v21) when executed with `node --disable-warning=ExperimentalWarning`:
 
 ```mjs
 import sys from 'node:sys';


### PR DESCRIPTION
## Change Summary

This PR changes `ExperimentalWarnings` to `ExperimentalWarning` in the documentation for the latest version of NodeJS as of this writing - `v21.6.1`.

## Why?

I am using the experimental [JSON Modules](https://nodejs.org/api/esm.html#json-modules) feature within my NodeJS project. Although the JSON Modules feature works, whenever I execute my ES Module based JavaScript file, I would receive the following warning:

```shell
(node:30484) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

After reading through the documentation under the section titled [`--disable-warning=code-or-type`](https://nodejs.org/api/cli.html#--disable-warningcode-or-type), I tried to suppress the `ExperimentalWarning` by changing the following `start` script within my `package.json` file:

```json
{
  ...
  "scripts": {
    "start": "node --disable-warning=ExperimentalWarnings src/index.js"
  },
  ...
}
```

But I still received the aforementioned `ExperimentalWarning` within my console.

After re-reading the documentation (and referring other documentations - like [this comment on issue #30810](https://github.com/nodejs/node/issues/30810#issuecomment-1446093458)), instead of the plural version (`ExperimentalWarnings`), I tried the singular version (`ExperimentalWarning`):

```diff
  {
    ...
    "scripts": {
-     "start": "node --disable-warning=ExperimentalWarnings src/index.js"
+     "start": "node --disable-warning=ExperimentalWarning src/index.js"
    },
    ...
  }
```

And it worked! The warning was suppressed.
Hence, this PR to address the confusion in the documentation.