### PR TITLE
benchmark: move non-present deps down the list

### DIFF
--- a/benchmark/misc/startup-cli-version.js
+++ b/benchmark/misc/startup-cli-version.js
@@ -9,13 +9,15 @@ const path = require('path');
 // tends to be minimal and fewer operations are done to generate
 // these so that the startup cost is still dominated by a more
 // indispensible part of the CLI.
+// NOTE: not all tools are present in tarball hence need to filter
+const availableCli = [
+  'tools/node_modules/eslint/bin/eslint.js',
+  'deps/npm/bin/npx-cli.js',
+  'deps/npm/bin/npm-cli.js',
+  'deps/corepack/dist/corepack.js',
+].filter((cli) => existsSync(path.resolve(__dirname, '../../', cli)));
 const bench = common.createBenchmark(main, {
-  cli: [
-    'tools/node_modules/eslint/bin/eslint.js',
-    'deps/npm/bin/npx-cli.js',
-    'deps/npm/bin/npm-cli.js',
-    'deps/corepack/dist/corepack.js',
-  ],
+  cli: availableCli,
   count: [30],
 });
 
@@ -47,10 +49,6 @@ function spawnProcess(cli, bench, state) {
 
 function main({ count, cli }) {
   cli = path.resolve(__dirname, '../../', cli);
-  if (!existsSync(cli)) {
-    return;
-  }
-
   const warmup = 3;
   const state = { count, finished: -warmup };
   spawnProcess(cli, bench, state);


### PR DESCRIPTION
In previous version of this fix, I've simply added a check if the tested tool is available or not. Unfortuntelly, this fails when only the first tool is to be run as part of the test-benchmark-misc, and it doesn't exist.

```
benchmark/test-benchmark-misc
...
AssertionError [ERR_ASSERTION]: benchmark file not running exactly one configuration in test:
...
misc/startup-cli-version.js
...
```
The solution is to move the tool that is not present in a tarball down the list.

Fixes: https://github.com/nodejs/node/pull/51146
Refs: https://github.com/nodejs/node/pull/50684

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
