### PR TITLE
lib: add assertion for user ESM execution

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -76,7 +76,6 @@ module.exports = {
   initializeCJS,
   Module,
   wrapSafe,
-  get hasLoadedAnyUserCJSModule() { return hasLoadedAnyUserCJSModule; },
 };
 
 const { BuiltinModule } = require('internal/bootstrap/realm');
@@ -113,6 +112,7 @@ const {
   initializeCjsConditions,
   loadBuiltinModule,
   makeRequireFunction,
+  setHasStartedUserCJSExecution,
   stripBOM,
   toRealPath,
 } = require('internal/modules/helpers');
@@ -127,9 +127,6 @@ const permission = require('internal/process/permission');
 const {
   vm_dynamic_import_default_internal,
 } = internalBinding('symbols');
-// Whether any user-provided CJS modules had been loaded (executed).
-// Used for internal assertions.
-let hasLoadedAnyUserCJSModule = false;
 
 const {
   codes: {
@@ -1363,6 +1360,7 @@ Module.prototype._compile = function(content, filename) {
   const thisValue = exports;
   const module = this;
   if (requireDepth === 0) { statCache = new SafeMap(); }
+  setHasStartedUserCJSExecution();
   if (inspectorWrapper) {
     result = inspectorWrapper(compiledWrapper, thisValue, exports,
                               require, module, filename, dirname);
@@ -1370,7 +1368,6 @@ Module.prototype._compile = function(content, filename) {
     result = ReflectApply(compiledWrapper, thisValue,
                           [exports, require, module, filename, dirname]);
   }
-  hasLoadedAnyUserCJSModule = true;
   if (requireDepth === 0) { statCache = null; }
   return result;
 };

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -27,7 +27,9 @@ const {
 } = require('internal/source_map/source_map_cache');
 const assert = require('internal/assert');
 const resolvedPromise = PromiseResolve();
-
+const {
+  setHasStartedUserESMExecution,
+} = require('internal/modules/helpers');
 const noop = FunctionPrototype;
 
 let hasPausedEntry = false;
@@ -206,6 +208,7 @@ class ModuleJob {
     this.instantiated = PromiseResolve();
     const timeout = -1;
     const breakOnSigint = false;
+    setHasStartedUserESMExecution();
     this.module.evaluate(timeout, breakOnSigint);
     return { __proto__: null, module: this.module };
   }
@@ -214,6 +217,7 @@ class ModuleJob {
     await this.instantiate();
     const timeout = -1;
     const breakOnSigint = false;
+    setHasStartedUserESMExecution();
     try {
       await this.module.evaluate(timeout, breakOnSigint);
     } catch (e) {

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -319,6 +319,19 @@ function normalizeReferrerURL(referrerName) {
   assert.fail('Unreachable code reached by ' + inspect(referrerName));
 }
 
+
+// Whether we have started executing any user-provided CJS code.
+// This is set right before we call the wrapped CJS code (not after,
+// in case we are half-way in the execution when internals check this).
+// Used for internal assertions.
+let _hasStartedUserCJSExecution = false;
+// Similar to _hasStartedUserCJSExecution but for ESM. This is set
+// right before ESM evaluation in the default ESM loader. We do not
+// update this during vm SourceTextModule execution because at that point
+// some user code must already have been run to execute code via vm
+// there is little value checking whether any user JS code is run anyway.
+let _hasStartedUserESMExecution = false;
+
 module.exports = {
   addBuiltinLibsToObject,
   getCjsConditions,
@@ -328,4 +341,16 @@ module.exports = {
   normalizeReferrerURL,
   stripBOM,
   toRealPath,
+  hasStartedUserCJSExecution() {
+    return _hasStartedUserCJSExecution;
+  },
+  setHasStartedUserCJSExecution() {
+    _hasStartedUserCJSExecution = true;
+  },
+  hasStartedUserESMExecution() {
+    return _hasStartedUserESMExecution;
+  },
+  setHasStartedUserESMExecution() {
+    _hasStartedUserESMExecution = true;
+  },
 };

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -190,8 +190,12 @@ function setupSymbolDisposePolyfill() {
 function setupUserModules(forceDefaultLoader = false) {
   initializeCJSLoader();
   initializeESMLoader(forceDefaultLoader);
-  const CJSLoader = require('internal/modules/cjs/loader');
-  assert(!CJSLoader.hasLoadedAnyUserCJSModule);
+  const {
+    hasStartedUserCJSExecution,
+    hasStartedUserESMExecution,
+  } = require('internal/modules/helpers');
+  assert(!hasStartedUserCJSExecution());
+  assert(!hasStartedUserESMExecution());
   // Do not enable preload modules if custom loaders are disabled.
   // For example, loader workers are responsible for doing this themselves.
   // And preload modules are not supported in ShadowRealm as well.


### PR DESCRIPTION
Previously we only had an internal assertion to ensure certain code is executed before any user-provided CJS is run. This patch adds another assertion for ESM.

Note that this internal state is not updated during source text module execution via vm because to run any code via vm, some user JS code must have already been executed anyway.

In addition this patch moves the states into internal/modules/helpers to avoid circular dependencies. Also moves toggling the states to true *right before* user code execution instead of after in case we are half-way in the execution when internals try to check them.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
