### PR TITLE
build: disable compiler warning when compiling cares using GN

### DIFF
--- a/deps/cares/unofficial.gni
+++ b/deps/cares/unofficial.gni
@@ -69,6 +69,7 @@ template("cares_gn_build") {
       cflags_c = [
         "-Wno-implicit-fallthrough",
         "-Wno-unreachable-code",
+        "-Wno-unused-result",
       ]
     }
   }


### PR DESCRIPTION
When compiling Node with V8 CI using GN, we get an error due to unused value in cares.
