### PR TITLE
src: fix empty string access in dotenv

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -118,9 +118,7 @@ void Dotenv::ParseContent(const std::string_view content) {
     // Remove trailing whitespaces
     value.erase(value.find_last_not_of(" \t") + 1);
 
-    const char maybeQuote = value.front();
-
-    if (maybeQuote == '"') {
+    if (!value.empty() && value.front() == '"') {
       value = std::regex_replace(value, std::regex("\\\\n"), "\n");
       value = std::regex_replace(value, std::regex("\\\\r"), "\r");
     }


### PR DESCRIPTION
The value string added in (https://github.com/nodejs/node/pull/51289) can sometimes be empty. We check for it before accessing it.