### PR TITLE
src: implement v8 array iteration using the new callback-based API

### DIFF
--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -196,8 +196,8 @@ void Blob::New(const FunctionCallbackInfo<Value>& args) {
     Local<Value> entry = sources[i].Get(isolate);
 
     const auto entryFromArrayBuffer = [isolate](v8::Local<v8::ArrayBuffer> buf,
-                                            size_t byte_length,
-                                            size_t byte_offset = 0) {
+                                                size_t byte_length,
+                                                size_t byte_offset = 0) {
       if (buf->IsDetachable()) {
         std::shared_ptr<BackingStore> store = buf->GetBackingStore();
         USE(buf->Detach(Local<Value>()));

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -41,7 +41,10 @@ namespace {
 // Concatenate multiple ArrayBufferView/ArrayBuffers into a single ArrayBuffer.
 // This method treats all ArrayBufferView types the same.
 void Concat(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+
   CHECK(args[0]->IsArray());
   Local<Array> array = args[0].As<Array>();
 
@@ -54,9 +57,14 @@ void Concat(const FunctionCallbackInfo<Value>& args) {
   std::vector<View> views;
   size_t total = 0;
 
-  for (uint32_t n = 0; n < array->Length(); n++) {
-    Local<Value> val;
-    if (!array->Get(env->context(), n).ToLocal(&val)) return;
+  std::vector<v8::Global<Value>> buffers;
+  if (FromV8Array(context, array, &buffers).IsNothing()) {
+    return;
+  }
+
+  size_t count = buffers.size();
+  for (uint32_t i = 0; i < count; i++) {
+    Local<Value> val = buffers[i].Get(isolate);
     if (val->IsArrayBuffer()) {
       auto ab = val.As<ArrayBuffer>();
       views.push_back(View{ab->GetBackingStore(), ab->ByteLength(), 0});
@@ -169,19 +177,25 @@ BaseObjectPtr<Blob> Blob::Create(Environment* env,
 }
 
 void Blob::New(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+
   CHECK(args[0]->IsArray());  // sources
 
   Local<Array> array = args[0].As<Array>();
   std::vector<std::unique_ptr<DataQueue::Entry>> entries(array->Length());
 
-  for (size_t i = 0; i < array->Length(); i++) {
-    Local<Value> entry;
-    if (!array->Get(env->context(), i).ToLocal(&entry)) {
-      return;
-    }
+  std::vector<v8::Global<Value>> sources;
+  if (FromV8Array(context, array, &sources).IsNothing()) {
+    return;
+  }
 
-    const auto entryFromArrayBuffer = [env](v8::Local<v8::ArrayBuffer> buf,
+  size_t count = sources.size();
+  for (size_t i = 0; i < count; i++) {
+    Local<Value> entry = sources[i].Get(isolate);
+
+    const auto entryFromArrayBuffer = [isolate](v8::Local<v8::ArrayBuffer> buf,
                                             size_t byte_length,
                                             size_t byte_offset = 0) {
       if (buf->IsDetachable()) {
@@ -193,7 +207,7 @@ void Blob::New(const FunctionCallbackInfo<Value>& args) {
 
       // If the ArrayBuffer is not detachable, we will copy from it instead.
       std::shared_ptr<BackingStore> store =
-          ArrayBuffer::NewBackingStore(env->isolate(), byte_length);
+          ArrayBuffer::NewBackingStore(isolate, byte_length);
       uint8_t* ptr = static_cast<uint8_t*>(buf->Data()) + byte_offset;
       std::copy(ptr, ptr + byte_length, static_cast<uint8_t*>(store->Data()));
       return DataQueue::CreateInMemoryEntryFromBackingStore(

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -401,6 +401,27 @@ inline char* UncheckedCalloc(size_t n) { return UncheckedCalloc<char>(n); }
 // headers than we really need to.
 void ThrowErrStringTooLong(v8::Isolate* isolate);
 
+struct ArrayIterationData {
+  std::vector<v8::Global<v8::Value>>* out;
+  v8::Isolate* isolate = nullptr;
+};
+
+inline v8::Array::CallbackResult PushItemToVector(uint32_t index, v8::Local<v8::Value> element, void* data) {
+  auto vec = static_cast<ArrayIterationData*>(data)->out;
+  auto isolate = static_cast<ArrayIterationData*>(data)->isolate;
+  vec->push_back(v8::Global<v8::Value>(isolate, element));
+  return v8::Array::CallbackResult::kContinue;
+}
+
+v8::Maybe<void> FromV8Array(
+    v8::Local<v8::Context> context, v8::Local<v8::Array> js_array,
+    std::vector<v8::Global<v8::Value>>* out) {
+  uint32_t count = js_array->Length();
+  out->reserve(count);
+  ArrayIterationData data { out, context->GetIsolate() };
+  return js_array->Iterate(context, PushItemToVector, &data);
+}
+
 v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
                                     std::string_view str,
                                     v8::Isolate* isolate) {

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -406,19 +406,21 @@ struct ArrayIterationData {
   v8::Isolate* isolate = nullptr;
 };
 
-inline v8::Array::CallbackResult PushItemToVector(uint32_t index, v8::Local<v8::Value> element, void* data) {
+inline v8::Array::CallbackResult PushItemToVector(uint32_t index,
+                                                  v8::Local<v8::Value> element,
+                                                  void* data) {
   auto vec = static_cast<ArrayIterationData*>(data)->out;
   auto isolate = static_cast<ArrayIterationData*>(data)->isolate;
   vec->push_back(v8::Global<v8::Value>(isolate, element));
   return v8::Array::CallbackResult::kContinue;
 }
 
-v8::Maybe<void> FromV8Array(
-    v8::Local<v8::Context> context, v8::Local<v8::Array> js_array,
-    std::vector<v8::Global<v8::Value>>* out) {
+v8::Maybe<void> FromV8Array(v8::Local<v8::Context> context,
+                            v8::Local<v8::Array> js_array,
+                            std::vector<v8::Global<v8::Value>>* out) {
   uint32_t count = js_array->Length();
   out->reserve(count);
-  ArrayIterationData data { out, context->GetIsolate() };
+  ArrayIterationData data{out, context->GetIsolate()};
   return js_array->Iterate(context, PushItemToVector, &data);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -697,16 +697,16 @@ struct FunctionDeleter {
 template <typename T, void (*function)(T*)>
 using DeleteFnPtr = typename FunctionDeleter<T, function>::Pointer;
 
-// Covert a v8::Array into an std::vector using the callback-based API.
+// Convert a v8::Array into an std::vector using the callback-based API.
 // This can be faster than calling Array::Get() repeatedly when the array
 // has more than 2 entries.
 // Note that iterating over an array in C++ and performing operations on each
 // element in a C++ loop is still slower than iterating over the array in JS
 // and calling into native in the JS loop repeatedly on each element,
 // as of V8 11.9.
-inline v8::Maybe<void> FromV8Array(
-    v8::Local<v8::Context> context, v8::Local<v8::Array> js_array,
-    std::vector<v8::Global<v8::Value>>* out);
+inline v8::Maybe<void> FromV8Array(v8::Local<v8::Context> context,
+                                   v8::Local<v8::Array> js_array,
+                                   std::vector<v8::Global<v8::Value>>* out);
 std::vector<std::string_view> SplitString(const std::string_view in,
                                           const std::string_view delim);
 

--- a/src/util.h
+++ b/src/util.h
@@ -697,6 +697,16 @@ struct FunctionDeleter {
 template <typename T, void (*function)(T*)>
 using DeleteFnPtr = typename FunctionDeleter<T, function>::Pointer;
 
+// Covert a v8::Array into an std::vector using the callback-based API.
+// This can be faster than calling Array::Get() repeatedly when the array
+// has more than 2 entries.
+// Note that iterating over an array in C++ and performing operations on each
+// element in a C++ loop is still slower than iterating over the array in JS
+// and calling into native in the JS loop repeatedly on each element,
+// as of V8 11.9.
+inline v8::Maybe<void> FromV8Array(
+    v8::Local<v8::Context> context, v8::Local<v8::Array> js_array,
+    std::vector<v8::Global<v8::Value>>* out);
 std::vector<std::string_view> SplitString(const std::string_view in,
                                           const std::string_view delim);
 


### PR DESCRIPTION
### src: implement v8 array iteration using the new callback-based API

Using this to iterate over an array can be faster than calling
Array::Get repeatedly. Local experiment shows that this is faster
once the array size is bigger than 2.

### src: use callback-based array iteration in Blob

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
