### PR TITLE
tools: disable automated libuv updates

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -27,7 +27,7 @@ on:
           - googletest
           - histogram
           - icu
-          - libuv
+          # - libuv
           - lint-md-dependencies
           - llhttp
           - minimatch
@@ -174,14 +174,17 @@ jobs:
               cat temp-output
               tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
               rm temp-output
-          - id: libuv
-            subsystem: deps
-            label: dependencies
-            run: |
-              ./tools/dep_updaters/update-libuv.sh > temp-output
-              cat temp-output
-              tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
-              rm temp-output
+          # libuv update was disabled because of Feb 14, 2024 security releas
+          # modified the bundled version of libuv, we cannot automatically update
+          # libuv without potentially undoing those changes.
+          # - id: libuv
+          #   subsystem: deps
+          #   label: dependencies
+          #   run: |
+          #     ./tools/dep_updaters/update-libuv.sh > temp-output
+          #     cat temp-output
+          #     tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+          #     rm temp-output
           - id: lint-md-dependencies
             subsystem: tools
             label: tools


### PR DESCRIPTION
Because the previous security release modified the bundled version of libuv, we cannot automatically update libuv without potentially undoing those changes.

cc: @nodejs/security-wg 