### PR TITLE
fix: make-colored dot reporter more readable

### DIFF
--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { MathMax } = primordials;
 
 module.exports = async function* dot(source) {
@@ -6,10 +7,12 @@ module.exports = async function* dot(source) {
   let columns = getLineLength();
   for await (const { type } of source) {
     if (type === 'test:pass') {
-      yield '.';
+      // Print green dot for pass
+      yield '\u001b[32m.\u001b[0m'; // \u001b[32m is ANSI escape code for green color
     }
     if (type === 'test:fail') {
-      yield 'X';
+      // Print red X for fail
+      yield '\u001b[31mX\u001b[0m'; // \u001b[31m is ANSI escape code for red color
     }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -19,7 +19,7 @@ module.exports = async function* dot(source) {
     }
 
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
-	  yield '\n';
+      yield '\n';
       // Getting the line length again in case the terminal was resized.
       columns = getLineLength();
       count = 0;

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -10,7 +10,7 @@ module.exports = async function* dot(source) {
   for await (const { type } of source) {
     if (type === 'test:pass') {
       // Made green dot for pass
-      yield green('.');
+      yield `${green}.`;
     }
 
     if (type === 'test:fail') {

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -6,20 +6,19 @@ const { MathMax } = primordials;
 module.exports = async function* dot(source) {
   let count = 0;
   let columns = getLineLength();
-
   for await (const { type } of source) {
     if (type === 'test:pass') {
       // Green dot for passing tests
       yield `${green}.${clear}`;
     }
-
     if (type === 'test:fail') {
       // Red dot for failing tests
       yield `${red}X${clear}`;
     }
-
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
-      // Getting the line length again in case the terminal was resized.
+      yield '\n';
+
+      // Getting again in case the terminal was resized.
       columns = getLineLength();
       count = 0;
     }

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Importing required modules
-const { MathMax } = primordials;
-const { green, red } = require('internal/util/colors');
+const {MathMax} = primordials;
+const {green, red} = require('internal/util/colors');
 
 // Exporting the dot reporter function as an asynchronous generator
 module.exports = async function* dot(source) {
@@ -11,7 +11,7 @@ module.exports = async function* dot(source) {
   let columns = getLineLength();
 
   // Iterating over the test events from the source
-  for await (const { type } of source) {
+  for await (const {type} of source) {
     // Check if the test passed
     if (type === 'test:pass') {
       // Print a green dot for pass
@@ -37,6 +37,7 @@ module.exports = async function* dot(source) {
   // Print a newline character at the end
   yield '\n';
 };
+
 
 // Function to get the line length for formatting
 function getLineLength() {

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -15,7 +15,7 @@ module.exports = async function* dot(source) {
 
     if (type === 'test:fail') {
       // Made red dot for fail
-      yield red('X');
+      yield `${red}X`;
     }
 
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -1,46 +1,33 @@
 'use strict';
 
-// Importing required modules
-const {MathMax} = primordials;
-const {green, red} = require('internal/util/colors');
+const { green, red } = require('internal/util/colors');
+const { MathMax } = primordials;
 
-// Exporting the dot reporter function as an asynchronous generator
 module.exports = async function* dot(source) {
-  // Initializing count and columns variables
   let count = 0;
   let columns = getLineLength();
 
-  // Iterating over the test events from the source
-  for await (const {type} of source) {
-    // Check if the test passed
+  for await (const { type } of source) {
     if (type === 'test:pass') {
-      // Print a green dot for pass
+      // Made green dot for pass
       yield green('.');
     }
 
-    // Check if the test failed
     if (type === 'test:fail') {
-      // Print a red X for fail
+      // Made red dot for fail
       yield red('X');
     }
 
-    // Check if it's time to move to a new line
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
-      // Print a newline character
-
       // Getting the line length again in case the terminal was resized.
       columns = getLineLength();
       count = 0;
     }
   }
 
-  // Print a newline character at the end
   yield '\n';
 };
 
-
-// Function to get the line length for formatting
 function getLineLength() {
-  // Use the greater of the terminal columns or a default of 20 columns
   return MathMax(process.stdout.columns ?? 20, 20);
 }

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -6,14 +6,15 @@ const { MathMax } = primordials;
 module.exports = async function* dot(source) {
   let count = 0;
   let columns = getLineLength();
+  const shouldColorize = process.stdout.isTTY || process.env.FORCE_COLOR !== undefined;
   for await (const { type } of source) {
     if (type === 'test:pass') {
       // Green dot for passing tests
-      yield `${green}.${clear}`;
+      yield shouldColorize ? `${green}.${clear}` : '.';
     }
     if (type === 'test:fail') {
       // Red dot for failing tests
-      yield `${red}X${clear}`;
+      yield shouldColorize ? `${red}X${clear}` : 'X';
     }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { green, red } = require('internal/util/colors');
+const { green, red, clear } = require('internal/util/colors');
 const { MathMax } = primordials;
 
 module.exports = async function* dot(source) {
@@ -9,17 +9,16 @@ module.exports = async function* dot(source) {
 
   for await (const { type } of source) {
     if (type === 'test:pass') {
-      // Made green dot for pass
-      yield `${green}.`;
+      // Green dot for passing tests
+      yield `${green}.${clear}`;
     }
 
     if (type === 'test:fail') {
-      // Made red dot for fail
-      yield `${red}X`;
+      // Red dot for failing tests
+      yield `${red}X${clear}`;
     }
 
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
-      yield '\n';
       // Getting the line length again in case the terminal was resized.
       columns = getLineLength();
       count = 0;

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -19,6 +19,7 @@ module.exports = async function* dot(source) {
     }
 
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
+	  yield '\n';
       // Getting the line length again in case the terminal was resized.
       columns = getLineLength();
       count = 0;

--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -1,30 +1,45 @@
 'use strict';
 
+// Importing required modules
 const { MathMax } = primordials;
+const { green, red } = require('internal/util/colors');
 
+// Exporting the dot reporter function as an asynchronous generator
 module.exports = async function* dot(source) {
+  // Initializing count and columns variables
   let count = 0;
   let columns = getLineLength();
-  for await (const { type } of source) {
-    if (type === 'test:pass') {
-      // Print green dot for pass
-      yield '\u001b[32m.\u001b[0m'; // \u001b[32m is ANSI escape code for green color
-    }
-    if (type === 'test:fail') {
-      // Print red X for fail
-      yield '\u001b[31mX\u001b[0m'; // \u001b[31m is ANSI escape code for red color
-    }
-    if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
-      yield '\n';
 
-      // Getting again in case the terminal was resized.
+  // Iterating over the test events from the source
+  for await (const { type } of source) {
+    // Check if the test passed
+    if (type === 'test:pass') {
+      // Print a green dot for pass
+      yield green('.');
+    }
+
+    // Check if the test failed
+    if (type === 'test:fail') {
+      // Print a red X for fail
+      yield red('X');
+    }
+
+    // Check if it's time to move to a new line
+    if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
+      // Print a newline character
+
+      // Getting the line length again in case the terminal was resized.
       columns = getLineLength();
       count = 0;
     }
   }
+
+  // Print a newline character at the end
   yield '\n';
 };
 
+// Function to get the line length for formatting
 function getLineLength() {
+  // Use the greater of the terminal columns or a default of 20 columns
   return MathMax(process.stdout.columns ?? 20, 20);
 }


### PR DESCRIPTION
fix(test_runner): improve colored dot reporter readability

In this commit, I've enhanced the colored dot reporter for the Node.js test runner. Now, passing test dots are displayed in bold and bright green, while failing test 'X's are in bold and bright red, making the output more visually distinct and readable.

Changes made:
- Updated the dot reporter to utilize ANSI escape codes for bold and bright colors.
- Improved the styling of dots and 'X' to enhance visibility.

Tested the changes locally with the provided test script to ensure the proper functioning of the updated dot reporter.

Closes #51770


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
