### PR TITLE
doc,crypto: add changelog and note about disabled RSA_PKCS1_PADDING

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4388,6 +4388,12 @@ An array of supported digest functions can be retrieved using
 <!-- YAML
 added: v0.11.14
 changes:
+  - version:
+      - v21.6.2
+      - v20.11.1
+      - v18.19.1
+    pr-url: https://github.com/nodejs-private/node-private/pull/525
+    description: The `RSA_PKCS1_PADDING` padding was disabled.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: Added string, ArrayBuffer, and CryptoKey as allowable key
@@ -4428,6 +4434,9 @@ If `privateKey` is not a [`KeyObject`][], this function behaves as if
 `privateKey` had been passed to [`crypto.createPrivateKey()`][]. If it is an
 object, the `padding` property can be passed. Otherwise, this function uses
 `RSA_PKCS1_OAEP_PADDING`.
+
+The `crypto.constants.RSA_PKCS1_PADDING` padding is disabled in
+[`crypto.privateDecrypt()`][] since the February 2024 security releases. <span class="deprecated-inline"></span>
 
 ### `crypto.privateEncrypt(privateKey, buffer)`
 


### PR DESCRIPTION
Adds a changelog and a note for the [disabled RSA_PKCS1_PADDING](https://nodejs.org/en/blog/vulnerability/february-2024-security-releases/#nodejs-is-vulnerable-to-the-marvin-attack-timing-variant-of-the-bleichenbacher-attack-against-pkcs1-v15-padding-cve-2023-46809---medium)

![image](https://github.com/nodejs/node/assets/241506/eebd18f0-87fd-423d-b95b-54df38b1a76d)