### PR TITLE
fix embedding.md

### DIFF
--- a/doc/api/embedding.md
+++ b/doc/api/embedding.md
@@ -147,9 +147,9 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
     MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
         env,
         "const publicRequire ="
-        "  require('node:module').createRequire(process.cwd() + '/');"
+        "  require('module').createRequire(process.cwd() + '/');"
         "globalThis.require = publicRequire;"
-        "require('node:vm').runInThisContext(process.argv[1]);");
+        "require('vm').runInThisContext(process.argv[1]);");
 
     if (loadenv_ret.IsEmpty())  // There has been a JS exception.
       return 1;


### PR DESCRIPTION
the embedding API document is out of date and doesn't work, as import node module doesn't need node: prefix

after checking the embedtest.cc, the minor fix works

ref:
https://github.com/nodejs/node/blob/main/test/embedding/embedtest.cc

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
