### PR TITLE
doc,crypto: further clarify RSA_PKCS1_PADDING support

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -4392,8 +4392,9 @@ changes:
       - v21.6.2
       - v20.11.1
       - v18.19.1
-    pr-url: https://github.com/nodejs-private/node-private/pull/525
-    description: The `RSA_PKCS1_PADDING` padding was disabled.
+    pr-url: https://github.com/nodejs-private/node-private/pull/515
+    description: The `RSA_PKCS1_PADDING` padding was disabled unless the
+                 OpenSSL build supports implicit rejection.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: Added string, ArrayBuffer, and CryptoKey as allowable key
@@ -4435,8 +4436,10 @@ If `privateKey` is not a [`KeyObject`][], this function behaves as if
 object, the `padding` property can be passed. Otherwise, this function uses
 `RSA_PKCS1_OAEP_PADDING`.
 
-The `crypto.constants.RSA_PKCS1_PADDING` padding is disabled in
-[`crypto.privateDecrypt()`][] since the February 2024 security releases. <span class="deprecated-inline"></span>
+Using `crypto.constants.RSA_PKCS1_PADDING` in [`crypto.privateDecrypt()`][]
+requires OpenSSL to support implicit rejection (`rsa_pkcs1_implicit_rejection`).
+If the version of OpenSSL used by Node.js does not support this feature,
+attempting to use `RSA_PKCS1_PADDING` will fail.
 
 ### `crypto.privateEncrypt(privateKey, buffer)`
 


### PR DESCRIPTION
It's not apparent from the commit message, but the recent security release did not really deprecate `RSA_PKCS1_PADDING` in `privateDecrypt()`. On some distros, OpenSSL already supports implicit rejection, and future versions of Node.js will almost certainly bundle versions of OpenSSL that do. In these cases, `RSA_PKCS1_PADDING` works just fine.