### PR TITLE
node-api: make tsfn accept napi_finalize once more

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1319,12 +1319,10 @@ napi_create_threadsafe_function(napi_env env,
                                 size_t max_queue_size,
                                 size_t initial_thread_count,
                                 void* thread_finalize_data,
-                                node_api_nogc_finalize nogc_thread_finalize_cb,
+                                napi_finalize thread_finalize_cb,
                                 void* context,
                                 napi_threadsafe_function_call_js call_js_cb,
                                 napi_threadsafe_function* result) {
-  napi_finalize thread_finalize_cb =
-      reinterpret_cast<napi_finalize>(nogc_thread_finalize_cb);
   CHECK_ENV_NOT_IN_GC(env);
   CHECK_ARG(env, async_resource_name);
   RETURN_STATUS_IF_FALSE(env, initial_thread_count > 0, napi_invalid_arg);

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -209,7 +209,7 @@ napi_create_threadsafe_function(napi_env env,
                                 size_t max_queue_size,
                                 size_t initial_thread_count,
                                 void* thread_finalize_data,
-                                node_api_nogc_finalize thread_finalize_cb,
+                                napi_finalize thread_finalize_cb,
                                 void* context,
                                 napi_threadsafe_function_call_js call_js_cb,
                                 napi_threadsafe_function* result);

--- a/test/node-api/test_threadsafe_function/test_uncaught_exception.c
+++ b/test/node-api/test_threadsafe_function/test_uncaught_exception.c
@@ -16,18 +16,6 @@ static void ThreadSafeFunctionFinalize(napi_env env,
   NODE_API_CALL_RETURN_VOID(env, napi_delete_reference(env, js_func_ref));
 }
 
-static void ThreadSafeFunctionNogcFinalize(node_api_nogc_env env,
-                                           void* data,
-                                           void* hint) {
-#ifdef NAPI_EXPERIMENTAL
-  NODE_API_NOGC_CALL_RETURN_VOID(
-      env,
-      node_api_post_finalizer(env, ThreadSafeFunctionFinalize, data, hint));
-#else
-  ThreadSafeFunctionFinalize(env, data, hint);
-#endif
-}
-
 // Testing calling into JavaScript
 static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
   size_t argc = 4;
@@ -46,7 +34,7 @@ static napi_value CallIntoModule(napi_env env, napi_callback_info info) {
                                                 0,
                                                 1,
                                                 finalize_func,
-                                                ThreadSafeFunctionNogcFinalize,
+                                                ThreadSafeFunctionFinalize,
                                                 NULL,
                                                 NULL,
                                                 &tsfn));


### PR DESCRIPTION
The thread-safe function's finalizer is not called in conjunction with the garbage collection of a JS value. In fact, it keeps a strong reference to the JS function it is expected to call. Thus, it is safe to make calls that affect GC state from its body.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
