### PR TITLE
assert: add deep equal check for more Error type

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -555,6 +555,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51805
+    description: Error cause and errors properties are now compared as well.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41020
     description: Regular expressions lastIndex property is now compared as well.
@@ -621,8 +624,8 @@ are also recursively evaluated by the following rules.
   both sides are `NaN`.
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * Only [enumerable "own" properties][] are considered.
-* [`Error`][] names and messages are always compared, even if these are not
-  enumerable properties.
+* [`Error`][] names, messages, causes, and errors are always compared,
+  even if these are not enumerable properties.
 * [Object wrappers][] are compared both as objects and unwrapped values.
 * `Object` properties are compared unordered.
 * [`Map`][] keys and [`Set`][] items are compared unordered.
@@ -736,6 +739,9 @@ parameter is an instance of an [`Error`][] then it will be thrown instead of the
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51805
+    description: Error cause and errors properties are now compared as well.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41020
     description: Regular expressions lastIndex property is now compared as well.
@@ -783,8 +789,9 @@ are recursively evaluated also by the following rules.
 * [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [`===` operator][].
 * Only [enumerable "own" properties][] are considered.
-* [`Error`][] names and messages are always compared, even if these are not
-  enumerable properties.
+* [`Error`][] names, messages, causes, and errors are always compared,
+  even if these are not enumerable properties.
+  `errors` is also compared.
 * Enumerable own [`Symbol`][] properties are compared as well.
 * [Object wrappers][] are compared both as objects and unwrapped values.
 * `Object` properties are compared unordered.

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -235,9 +235,23 @@ function innerDeepEqual(val1, val2, strict, memos) {
   } else if (isNativeError(val1) || val1 instanceof Error) {
     // Do not compare the stack as it might differ even though the error itself
     // is otherwise identical.
-    if ((!isNativeError(val2) && !(val2 instanceof Error)) ||
-        val1.message !== val2.message ||
-        val1.name !== val2.name) {
+    if (!isNativeError(val2) && !(val2 instanceof Error)) {
+      return false;
+    }
+
+    const message1Enumerable = ObjectPrototypePropertyIsEnumerable(val1, 'message');
+    const name1Enumerable = ObjectPrototypePropertyIsEnumerable(val1, 'name');
+    const cause1Enumerable = ObjectPrototypePropertyIsEnumerable(val1, 'cause');
+    const errors1Enumerable = ObjectPrototypePropertyIsEnumerable(val1, 'errors');
+
+    if ((message1Enumerable !== ObjectPrototypePropertyIsEnumerable(val2, 'message') ||
+          (!message1Enumerable && val1.message !== val2.message)) ||
+        (name1Enumerable !== ObjectPrototypePropertyIsEnumerable(val2, 'name') ||
+          (!name1Enumerable && val1.name !== val2.name)) ||
+        (cause1Enumerable !== ObjectPrototypePropertyIsEnumerable(val2, 'cause') ||
+          (!cause1Enumerable && !innerDeepEqual(val1.cause, val2.cause, strict, memos))) ||
+        (errors1Enumerable !== ObjectPrototypePropertyIsEnumerable(val2, 'errors') ||
+         (!errors1Enumerable && !innerDeepEqual(val1.errors, val2.errors, strict, memos)))) {
       return false;
     }
   } else if (isBoxedPrimitive(val1)) {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -1111,6 +1111,29 @@ assert.throws(
   assert.notDeepStrictEqual(err, err2);
 }
 
+// Check for Errors with cause property
+{
+  const e1 = new Error('err', { cause: new Error('cause e1') });
+  const e2 = new Error('err', { cause: new Error('cause e2') });
+  assertNotDeepOrStrict(e1, e2, AssertionError);
+  assertNotDeepOrStrict(e1, new Error('err'), AssertionError);
+  assertDeepAndStrictEqual(e1, new Error('err', { cause: new Error('cause e1') }));
+}
+
+// Check for AggregateError
+{
+  const e1 = new Error('e1');
+  const e1duplicate = new Error('e1');
+  const e2 = new Error('e2');
+
+  const e3 = new AggregateError([e1duplicate, e2], 'Aggregate Error');
+  const e3duplicate = new AggregateError([e1, e2], 'Aggregate Error');
+  const e4 = new AggregateError([e1], 'Aggregate Error');
+  assertNotDeepOrStrict(e1, e3, AssertionError);
+  assertNotDeepOrStrict(e3, e4, AssertionError);
+  assertDeepAndStrictEqual(e3, e3duplicate);
+}
+
 // Verify that `valueOf` is not called for boxed primitives.
 {
   const a = new Number(5);


### PR DESCRIPTION
add deep equal check for the cases below:
1. Error with `cause` property: `new Error('msg', { cause: xxx })`
2. AggregateError:  `new AggregateError([err1, err2, ...], 'msg')`

Fixes: https://github.com/nodejs/node/issues/51793

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
4. Update documentation if relevant.
5. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
