### PR TITLE
src: fix --disable-single-executable-application

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1403,13 +1403,16 @@ static ExitCode StartInternal(int argc, char** argv) {
   });
 
   uv_loop_configure(uv_default_loop(), UV_METRICS_IDLE_TIME);
-
   std::string sea_config = per_process::cli_options->experimental_sea_config;
   if (!sea_config.empty()) {
+#if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
     return sea::BuildSingleExecutableBlob(
         sea_config, result->args(), result->exec_args());
+#else
+    fprintf(stderr, "Single executable application is disabled.\n");
+    return ExitCode::kGenericUserError;
+#endif  // !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
   }
-
   // --build-snapshot indicates that we are in snapshot building mode.
   if (per_process::cli_options->per_isolate->build_snapshot) {
     if (per_process::cli_options->per_isolate->build_snapshot_config.empty() &&

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -27,8 +27,6 @@
 #include <tuple>
 #include <vector>
 
-#if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
-
 using node::ExitCode;
 using v8::ArrayBuffer;
 using v8::BackingStore;
@@ -189,6 +187,7 @@ SeaResource SeaDeserializer::Read() {
 }
 
 std::string_view FindSingleExecutableBlob() {
+#if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
   CHECK(IsSingleExecutable());
   static const std::string_view result = []() -> std::string_view {
     size_t size;
@@ -209,6 +208,9 @@ std::string_view FindSingleExecutableBlob() {
                      result.data(),
                      result.size());
   return result;
+#else
+  UNREACHABLE();
+#endif  // !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
 }
 
 }  // anonymous namespace
@@ -668,5 +670,3 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(sea, node::sea::Initialize)
 NODE_BINDING_EXTERNAL_REFERENCE(sea, node::sea::RegisterExternalReferences)
-
-#endif  // !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -3,8 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#if !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
-
 #include <cinttypes>
 #include <optional>
 #include <string>
@@ -51,8 +49,6 @@ node::ExitCode BuildSingleExecutableBlob(
     const std::vector<std::string>& exec_args);
 }  // namespace sea
 }  // namespace node
-
-#endif  // !defined(DISABLE_SINGLE_EXECUTABLE_APPLICATION)
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 


### PR DESCRIPTION
Previously it would not compile if the build is configured with
--disable-single-executable-application because we use directives
to exclude the definition of SEA-related code completely. This patch
changes them so that the SEA code are still compiled and internals
can still check whether the executable is an SEA. The executable would
not try to load the SEA blob at all if SEA is disabled. If future
modifications to the C++ code attempt to load the SEA blob when SEA
is disabled, UNREACHABLE() would be raised. If user attempt to
generate the SEA blob with --experimental-sea-config with an executable
that disables SEA, they would get an error.


Fixes: https://github.com/nodejs/node/issues/51730
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
