### PR TITLE
test_runner: add ref methods to mocked timers

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -67,6 +67,32 @@ const TIMERS_DEFAULT_INTERVAL = {
   setImmediate: -1,
 };
 
+class Timeout {
+  constructor(opts) {
+    this.id = opts.id;
+    this.callback = opts.callback;
+    this.runAt = opts.runAt;
+    this.interval = opts.interval;
+    this.args = opts.args;
+  }
+
+  hasRef() {
+    return true;
+  }
+
+  ref() {
+    return this;
+  }
+
+  unref() {
+    return this;
+  }
+
+  refresh() {
+    return this;
+  }
+}
+
 class MockTimers {
   #realSetTimeout;
   #realClearTimeout;
@@ -260,7 +286,7 @@ class MockTimers {
 
   #createTimer(isInterval, callback, delay, ...args) {
     const timerId = this.#currentTimer++;
-    const timer = {
+    const opts = {
       __proto__: null,
       id: timerId,
       callback,
@@ -268,6 +294,8 @@ class MockTimers {
       interval: isInterval ? delay : undefined,
       args,
     };
+
+    const timer = new Timeout(opts);
     this.#executionQueue.insert(timer);
     return timer;
   }

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -844,4 +844,38 @@ describe('Mock Timers Test Suite', () => {
       clearTimeout(id);
     });
   });
+
+  describe('Api should have same public properties as original', () => {
+    it('should have hasRef', (t) => {
+      t.mock.timers.enable();
+      const timer = setTimeout();
+      assert.strictEqual(typeof timer.hasRef, 'function');
+      assert.strictEqual(timer.hasRef(), true);
+      clearTimeout(timer);
+    });
+
+    it('should have ref', (t) => {
+      t.mock.timers.enable();
+      const timer = setTimeout();
+      assert.ok(typeof timer.ref === 'function');
+      assert.deepStrictEqual(timer.ref(), timer);
+      clearTimeout(timer);
+    });
+
+    it('should have unref', (t) => {
+      t.mock.timers.enable();
+      const timer = setTimeout();
+      assert.ok(typeof timer.unref === 'function');
+      assert.deepStrictEqual(timer.unref(), timer);
+      clearTimeout(timer);
+    });
+
+    it('should have refresh', (t) => {
+      t.mock.timers.enable();
+      const timer = setTimeout();
+      assert.ok(typeof timer.refresh === 'function');
+      assert.deepStrictEqual(timer.refresh(), timer);
+      clearTimeout(timer);
+    });
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51701
It adds properties `ref`, `unref`, `refresh`, `hasRef` to mock timers for compatibility.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
