### PR TITLE
src: stop the profiler and the inspector before snapshot serialization

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -881,6 +881,9 @@ class Environment : public MemoryRetainer {
   inline inspector::Agent* inspector_agent() const {
     return inspector_agent_.get();
   }
+  inline void StopInspector() {
+    inspector_agent_.reset();
+  }
 
   inline bool is_in_inspector_console_call() const;
   inline void set_is_in_inspector_console_call(bool value);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1156,6 +1156,14 @@ ExitCode SnapshotBuilder::CreateSnapshot(SnapshotData* out,
         fprintf(stderr, "Environment = %p\n", env);
       }
 
+      // Clean up the states left by the inspector because V8 cannot serialize
+      // them. They don't need to be persisted and can be created from scratch
+      // after snapshot deserialization.
+      RunAtExit(env);
+#if HAVE_INSPECTOR
+      env->StopInspector();
+#endif
+
       // Serialize the native states
       out->isolate_data_info = setup->isolate_data()->Serialize(creator);
       out->env_info = env->Serialize(creator);

--- a/test/parallel/test-snapshot-coverage.js
+++ b/test/parallel/test-snapshot-coverage.js
@@ -2,7 +2,9 @@
 
 // This tests that the snapshot works with built-in coverage collection.
 
-require('../common');
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
 const { spawnSyncAndExitWithoutError } = require('../common/child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
@@ -18,7 +20,7 @@ function filterCoverageFiles(name) {
 }
 {
   // Create the snapshot.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  const { child } = spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -28,16 +30,18 @@ function filterCoverageFiles(name) {
     env: {
       ...process.env,
       NODE_V8_COVERAGE: tmpdir.path,
+      NODE_DEBUG_NATIVE: 'inspector_profiler',
     }
   });
   const files = fs.readdirSync(tmpdir.path);
   console.log('Files in tmpdir.path', files);  // Log for debugging the test.
   const coverage = files.filter(filterCoverageFiles);
+  console.log(child.stderr.toString());
   assert.strictEqual(coverage.length, 1);
 }
 
 {
-  spawnSyncAndExitWithoutError(process.execPath, [
+  const { child } = spawnSyncAndExitWithoutError(process.execPath, [
     '--snapshot-blob',
     blobPath,
     file,
@@ -46,10 +50,12 @@ function filterCoverageFiles(name) {
     env: {
       ...process.env,
       NODE_V8_COVERAGE: tmpdir.path,
+      NODE_DEBUG_NATIVE: 'inspector_profiler',
     },
   });
   const files = fs.readdirSync(tmpdir.path);
   console.log('Files in tmpdir.path', files);  // Log for debugging the test.
   const coverage = files.filter(filterCoverageFiles);
+  console.log(child.stderr.toString());
   assert.strictEqual(coverage.length, 2);
 }

--- a/test/parallel/test-snapshot-coverage.js
+++ b/test/parallel/test-snapshot-coverage.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// This tests that the snapshot works with built-in coverage collection.
+
+require('../common');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const fs = require('fs');
+const assert = require('assert');
+
+tmpdir.refresh();
+const blobPath = tmpdir.resolve('snapshot.blob');
+const file = fixtures.path('empty.js');
+
+function filterCoverageFiles(name) {
+  return name.startsWith('coverage') && name.endsWith('.json');
+}
+{
+  // Create the snapshot.
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    file,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+      NODE_V8_COVERAGE: tmpdir.path,
+    }
+  });
+  const files = fs.readdirSync(tmpdir.path);
+  console.log('Files in tmpdir.path', files);  // Log for debugging the test.
+  const coverage = files.filter(filterCoverageFiles);
+  assert.strictEqual(coverage.length, 1);
+}
+
+{
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    file,
+  ], {
+    cwd: tmpdir.path,
+    env: {
+      ...process.env,
+      NODE_V8_COVERAGE: tmpdir.path,
+    },
+  });
+  const files = fs.readdirSync(tmpdir.path);
+  console.log('Files in tmpdir.path', files);  // Log for debugging the test.
+  const coverage = files.filter(filterCoverageFiles);
+  assert.strictEqual(coverage.length, 2);
+}


### PR DESCRIPTION
Otherwise NODE_V8_COVERAGE would crash in snapshot tests because V8 cannot serialize the leftover debug infos. This ensures that we clean them all up before serialization.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
