### PR TITLE
test: fix tests for coverage generation

### DIFF
--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -161,6 +161,11 @@ if (process.features.inspector) {
   expected.beforePreExec.add('Internal Binding inspector');
   expected.beforePreExec.add('NativeModule internal/util/inspector');
   expected.atRunTime.add('NativeModule internal/inspector_async_hook');
+
+  // This is loaded if the test is run with NODE_V8_COVERAGE.
+  if (process.env.NODE_V8_COVERAGE) {
+    expected.atRunTime.add('Internal Binding profiler');
+  }
 }
 
 const difference = (setA, setB) => {

--- a/test/parallel/test-debugger-profile.js
+++ b/test/parallel/test-debugger-profile.js
@@ -14,7 +14,14 @@ function delay(ms) {
 
 // Profiles.
 {
-  const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')]);
+  const cli = startCLI(['--port=0', fixtures.path('debugger/empty.js')], [], {
+    env: {
+      ...process.env,
+      // When this test is run with NODE_V8_COVERAGE, it clobbers the inspector
+      // output, so override to disable coverage for the child process.
+      NODE_V8_COVERAGE: undefined,
+    }
+  });
 
   function onFatal(error) {
     cli.quit();


### PR DESCRIPTION
#### test: fix test-bootstrap-modules for coverage generation

The internal binding profiler is loaded if the test is run with
NODE_V8_COVERAGE.

#### test: fix test-debugger-profile for coverage generation

The child process should not inherit NODE_V8_COVERAGE because
that clobbers the inspector output the test is checking.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
