### PR TITLE
test, crypto: use correct object on assert

### DIFF
--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -169,16 +169,16 @@ const privateDsa = fixtures.readKey('dsa_private_encrypted_1025.pem',
   assert.strictEqual(derivedPublicKey.symmetricKeySize, undefined);
 
   const publicKeyFromJwk = createPublicKey({ key: publicJwk, format: 'jwk' });
-  assert.strictEqual(publicKey.type, 'public');
-  assert.strictEqual(publicKey.toString(), '[object KeyObject]');
-  assert.strictEqual(publicKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(publicKey.symmetricKeySize, undefined);
+  assert.strictEqual(publicKeyFromJwk.type, 'public');
+  assert.strictEqual(publicKeyFromJwk.toString(), '[object KeyObject]');
+  assert.strictEqual(publicKeyFromJwk.asymmetricKeyType, 'rsa');
+  assert.strictEqual(publicKeyFromJwk.symmetricKeySize, undefined);
 
   const privateKeyFromJwk = createPrivateKey({ key: jwk, format: 'jwk' });
-  assert.strictEqual(privateKey.type, 'private');
-  assert.strictEqual(privateKey.toString(), '[object KeyObject]');
-  assert.strictEqual(privateKey.asymmetricKeyType, 'rsa');
-  assert.strictEqual(privateKey.symmetricKeySize, undefined);
+  assert.strictEqual(privateKeyFromJwk.type, 'private');
+  assert.strictEqual(privateKeyFromJwk.toString(), '[object KeyObject]');
+  assert.strictEqual(privateKeyFromJwk.asymmetricKeyType, 'rsa');
+  assert.strictEqual(privateKeyFromJwk.symmetricKeySize, undefined);
 
   // It should also be possible to import an encrypted private key as a public
   // key.


### PR DESCRIPTION
The test case for KeyObject does not really test the creation of asymmetric cryptographic keys using jwk because of a misspelling of the variable.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
