### PR TITLE
 buffer: make `buflen` in integer range

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -198,6 +198,13 @@ MaybeLocal<Value> ExternTwoByteString::NewSimpleFromCopy(Isolate* isolate,
 
 }  // anonymous namespace
 
+static size_t keep_buflen_in_range(size_t len) {
+  if (len > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    return static_cast<size_t>(std::numeric_limits<int>::max());
+  }
+  return len;
+}
+
 size_t StringBytes::WriteUCS2(
     Isolate* isolate, char* buf, size_t buflen, Local<String> str, int flags) {
   uint16_t* const dst = reinterpret_cast<uint16_t*>(buf);
@@ -243,7 +250,7 @@ size_t StringBytes::Write(Isolate* isolate,
                           enum encoding encoding) {
   HandleScope scope(isolate);
   size_t nbytes;
-
+  buflen = keep_buflen_in_range(buflen);
   CHECK(val->IsString() == true);
   Local<String> str = val.As<String>();
   String::ValueView input_view(isolate, str);
@@ -516,6 +523,7 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
       }
 
     case ASCII:
+      buflen = keep_buflen_in_range(buflen);
       if (simdutf::validate_ascii_with_errors(buf, buflen).error) {
         // The input contains non-ASCII bytes.
         char* out = node::UncheckedMalloc(buflen);
@@ -529,23 +537,23 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
         return ExternOneByteString::NewFromCopy(isolate, buf, buflen, error);
       }
 
-    case UTF8:
-      {
-        val = String::NewFromUtf8(isolate,
-                                  buf,
-                                  v8::NewStringType::kNormal,
-                                  buflen);
-        Local<String> str;
-        if (!val.ToLocal(&str)) {
-          *error = node::ERR_STRING_TOO_LONG(isolate);
-        }
-        return str;
+    case UTF8: {
+      buflen = keep_buflen_in_range(buflen);
+      val =
+          String::NewFromUtf8(isolate, buf, v8::NewStringType::kNormal, buflen);
+      Local<String> str;
+      if (!val.ToLocal(&str)) {
+        *error = node::ERR_STRING_TOO_LONG(isolate);
       }
+      return str;
+    }
 
     case LATIN1:
+      buflen = keep_buflen_in_range(buflen);
       return ExternOneByteString::NewFromCopy(isolate, buf, buflen, error);
 
     case BASE64: {
+      buflen = keep_buflen_in_range(buflen);
       size_t dlen = simdutf::base64_length_from_binary(buflen);
       char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
@@ -560,6 +568,7 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
     }
 
     case BASE64URL: {
+      buflen = keep_buflen_in_range(buflen);
       size_t dlen =
           simdutf::base64_length_from_binary(buflen, simdutf::base64_url);
       char* dst = node::UncheckedMalloc(dlen);
@@ -576,6 +585,7 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
     }
 
     case HEX: {
+      buflen = keep_buflen_in_range(buflen);
       size_t dlen = buflen * 2;
       char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
@@ -589,6 +599,7 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
     }
 
     case UCS2: {
+      buflen = keep_buflen_in_range(buflen);
       size_t str_len = buflen / 2;
       if constexpr (IsBigEndian()) {
         uint16_t* dst = node::UncheckedMalloc<uint16_t>(str_len);

--- a/test/pummel/test-buffer-large-size.js
+++ b/test/pummel/test-buffer-large-size.js
@@ -1,0 +1,51 @@
+'use strict';
+const common = require('../common');
+
+// Buffer with size > INT32_MAX
+common.skipIf32Bits();
+
+// Test Buffer size larger than integer range
+const { test } = require('node:test');
+const assert = require('assert');
+const {
+  SlowBuffer,
+} = require('buffer');
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
+
+const stringTooLongError = {
+  message: `Cannot create a string longer than 0x${kStringMaxLength.toString(16)}` +
+    ' characters',
+  code: 'ERR_STRING_TOO_LONG',
+  name: 'Error',
+};
+
+const size = 2 ** 31;
+
+// Test Buffer.toString
+test('Buffer.toString with too long size', () => {
+  try {
+    assert.throws(() => SlowBuffer(size).toString('utf8'), stringTooLongError);
+    assert.throws(() => Buffer.alloc(size).toString('utf8'), stringTooLongError);
+    assert.throws(() => Buffer.allocUnsafe(size).toString('utf8'), stringTooLongError);
+    assert.throws(() => Buffer.allocUnsafeSlow(size).toString('utf8'), stringTooLongError);
+  } catch (e) {
+    if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
+      throw e;
+    }
+    common.skip('insufficient space for Buffer.alloc');
+  }
+});
+
+// Test Buffer.write
+test('Buffer.write with too long size', () => {
+  try {
+    const buf = Buffer.alloc(size);
+    assert.strictEqual(buf.write('a', 2, kStringMaxLength), 1);
+    assert.strictEqual(buf.write('a', 2, size), 1);
+  } catch (e) {
+    if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
+      throw e;
+    }
+    common.skip('insufficient space for Buffer.alloc');
+  }
+});


### PR DESCRIPTION
make `buflen`  within the integer range when `buffer.toString()` and writing a string to buffer(for example `buffer.write(str)`)

Fixes: https://github.com/nodejs/node/issues/51817

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
