### PR TITLE
net: fix connect crash when call destroy in lookup handler

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1435,7 +1435,10 @@ function lookupAndConnectMultiple(
         const address = addresses[i];
         const { address: ip, family: addressType } = address;
         self.emit('lookup', err, ip, addressType, host);
-
+        // It's possible we were destroyed while looking this up.
+        if (!self.connecting) {
+          return;
+        }
         if (isIP(ip) && (addressType === 4 || addressType === 6)) {
           if (!destinations) {
             destinations = addressType === 6 ? { 6: 0, 4: 1 } : { 4: 0, 6: 1 };

--- a/test/parallel/test-destroy-socket-in-lookup.js
+++ b/test/parallel/test-destroy-socket-in-lookup.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('../common');
+const net = require('net');
+
+// Test that the process does not crash.
+const socket = net.connect({
+  port: 12345,
+  host: 'localhost',
+  // Make sure autoSelectFamily is true
+  // so that lookupAndConnectMultiple is called.
+  autoSelectFamily: true,
+});
+// DNS resolution fails or succeeds
+socket.on('lookup', common.mustCall(() => {
+  socket.destroy();
+}));


### PR DESCRIPTION
fix: https://github.com/nodejs/node/issues/50841

cc @ShogunPanda

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
