### PR TITLE
test: fix test-child-process-fork-net

### DIFF
--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -154,7 +154,7 @@ if (process.argv[2] === 'child') {
       child1.kill();
       child2.kill();
       child3.kill();
-    } catch (e) {
+    } catch {
       debug('child process already terminated');
     }
   }));

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -19,6 +19,9 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// This tests that a socket sent to the forked process works.
+// See https://github.com/nodejs/node/commit/dceebbfa
+
 'use strict';
 const {
   mustCall,
@@ -65,7 +68,7 @@ if (process.argv[2] === 'child') {
     socket.on('finish', mustCall(() => {
       debug(`[${id}] socket finished ${m}`);
     }));
-  }));
+  }, 4));
 
   process.on('message', mustCall((m) => {
     if (m !== 'close') return;
@@ -74,7 +77,7 @@ if (process.argv[2] === 'child') {
       debug(`[${id}] ending ${i}/${needEnd.length}`);
       endMe.end('end');
     });
-  }));
+  }, 4));
 
   process.on('disconnect', mustCall(() => {
     debug(`[${id}] process disconnect, ending`);
@@ -146,9 +149,14 @@ if (process.argv[2] === 'child') {
   server.on('close', mustCall(function() {
     closeEmitted = true;
 
-    child1.kill();
-    child2.kill();
-    child3.kill();
+    // Clean up child processes.
+    try {
+      child1.kill();
+      child2.kill();
+      child3.kill();
+    } catch (e) {
+      debug('child process already terminated');
+    }
   }));
 
   server.listen(0, '127.0.0.1');

--- a/test/parallel/test-child-process-fork-net.js
+++ b/test/parallel/test-child-process-fork-net.js
@@ -152,7 +152,15 @@ if (process.argv[2] === 'child') {
     // Clean up child processes.
     try {
       child1.kill();
+    } catch {
+      debug('child process already terminated');
+    }
+    try {
       child2.kill();
+    } catch {
+      debug('child process already terminated');
+    }
+    try {
       child3.kill();
     } catch {
       debug('child process already terminated');


### PR DESCRIPTION
The child processes are supposed to get 4 messages (2 ends, 2 writes). Previously the mustCall() wrapping the message listener attempts to match exactly 1 invocation which is bound to fail but could be swallowed if the child happens to be killed before the exit event is fired for the mustCall() check to work. In the CI, on some machines the kill() could happen after the child process finishes with the mustCall() check, resulting in EPERM errors in kill().

This patch fixes the mustCall() checks (updating the expected invocation count to 4) and swallow the errors when kill() fails, which should be fine because they are only there for cleanup.

Refs: https://github.com/nodejs/node/issues/51813

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
