### PR TITLE
test: ensure delay in recursive fs watch tests

### DIFF
--- a/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
@@ -48,7 +48,10 @@ watcher.on('change', function(event, filename) {
   }
 });
 
-fs.writeFileSync(childrenAbsolutePath, 'world');
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  fs.writeFileSync(childrenAbsolutePath, 'world');
+}, common.platformTimeout(200));
 
 process.once('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');

--- a/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
@@ -44,8 +44,11 @@ watcher.on('change', function(event, filename) {
   }
 });
 
-fs.mkdirSync(filePath);
-fs.writeFileSync(childrenAbsolutePath, 'world');
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  fs.mkdirSync(filePath);
+  fs.writeFileSync(childrenAbsolutePath, 'world');
+}, common.platformTimeout(200));
 
 process.once('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');

--- a/test/parallel/test-fs-watch-recursive-add-file.js
+++ b/test/parallel/test-fs-watch-recursive-add-file.js
@@ -39,7 +39,10 @@ watcher.on('change', function(event, filename) {
   }
 });
 
-fs.writeFileSync(testFile, 'world');
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  fs.writeFileSync(testFile, 'world');
+}, common.platformTimeout(200));
 
 process.once('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');

--- a/test/parallel/test-fs-watch-recursive-assert-leaks.js
+++ b/test/parallel/test-fs-watch-recursive-assert-leaks.js
@@ -42,4 +42,9 @@ watcher.on('change', common.mustCallAtLeast(async (event, filename) => {
 process.on('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');
 });
-fs.writeFileSync(filePath, 'content');
+
+// Do the write with a delay to ensure that the OS is ready to notify us.
+(async () => {
+  await setTimeout(200);
+  fs.writeFileSync(filePath, 'content');
+})().then(common.mustCall());

--- a/test/parallel/test-fs-watch-recursive-sync-write.js
+++ b/test/parallel/test-fs-watch-recursive-sync-write.js
@@ -35,4 +35,4 @@ const watcher = watch(tmpDir, { recursive: true }, common.mustCall((eventType, _
 // Do the write with a delay to ensure that the OS is ready to notify us.
 setTimeout(() => {
   writeFileSync(filename, 'foobar2');
-});
+}, common.platformTimeout(200));

--- a/test/parallel/test-fs-watch-recursive-sync-write.js
+++ b/test/parallel/test-fs-watch-recursive-sync-write.js
@@ -32,4 +32,7 @@ const watcher = watch(tmpDir, { recursive: true }, common.mustCall((eventType, _
   assert.strictEqual(join(tmpDir, _filename), filename);
 }));
 
-writeFileSync(filename, 'foobar2');
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  writeFileSync(filename, 'foobar2');
+});

--- a/test/parallel/test-fs-watch-recursive-update-file.js
+++ b/test/parallel/test-fs-watch-recursive-update-file.js
@@ -39,4 +39,7 @@ watcher.on('change', common.mustCallAtLeast(function(event, filename) {
   }
 }));
 
-fs.writeFileSync(testFile, 'hello');
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  fs.writeFileSync(testFile, 'hello');
+}, common.platformTimeout(200));


### PR DESCRIPTION
The recursive fs watch tests that mutate the watched folder immediately after fs.watch() returns are all flaking in the CI while the others that mutate the folder with a bit of delay aren't flaking. So this patch adds a bit of delay for the rest of the tests to deflake them.

Refs: https://github.com/nodejs/reliability/issues/790

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
