### PR TITLE
tools: fix missing [[fallthrough]] in js2c

### DIFF
--- a/tools/js2c.cc
+++ b/tools/js2c.cc
@@ -603,6 +603,7 @@ bool Simplify(const std::vector<char>& code,
           simplified_count++;
           break;
         }
+        [[fallthrough]];
       }
       default: {
         simplified->push_back(code[i]);


### PR DESCRIPTION
The latest clang warns about this.