### PR TITLE
util: add styleText API to text formatting

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1792,6 +1792,42 @@ console.log(util.stripVTControlCharacters('\u001B[4mvalue\u001B[0m'));
 // Prints "value"
 ```
 
+## `util.styleText(format, text)`
+
+> Stability: 1.1 - Active development
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `format` {string} A text format defined in `util.inspect.colors`.
+* `text` {string} The text to to be formatted.
+
+This function returns a formatted text considering the `format` passed.
+
+```mjs
+import { styleText } from 'node:util';
+const errorMessage = styleText('red', 'Error! Error!');
+console.log(errorMessage);
+```
+
+```cjs
+const { styleText } = require('node:util');
+const errorMessage = styleText('red', 'Error! Error!');
+console.log(errorMessage);
+```
+
+`util.inspect.colors` also provides text formats such as `italic`, and
+`underline` and you can combine both:
+
+```cjs
+console.log(
+  util.styleText('underline', util.styleText('italic', 'My italic underlined message')),
+);
+```
+
+The full list of formats can be found in [modifiers][].
+
 ## Class: `util.TextDecoder`
 
 <!-- YAML
@@ -3395,6 +3431,7 @@ util.log('Timestamped message.');
 [default sort]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 [global symbol registry]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for
 [list of deprecated APIS]: deprecations.md#list-of-deprecated-apis
+[modifiers]: #modifiers
 [realm]: https://tc39.es/ecma262/#realm
 [semantically incompatible]: https://github.com/nodejs/node/issues/4179
 [util.inspect.custom]: #utilinspectcustom

--- a/lib/util.js
+++ b/lib/util.js
@@ -68,6 +68,7 @@ const {
   validateFunction,
   validateNumber,
   validateString,
+  validateOneOf,
 } = require('internal/validators');
 const { isBuffer } = require('buffer').Buffer;
 const types = require('internal/util/types');
@@ -195,6 +196,20 @@ function isPrimitive(arg) {
  */
 function pad(n) {
   return StringPrototypePadStart(n.toString(), 2, '0');
+}
+
+/**
+ * @param {string} format
+ * @param {string} text
+ * @returns {string}
+ */
+function styleText(format, text) {
+  validateString(text, 'text');
+  const formatCodes = inspect.colors[format];
+  if (formatCodes == null) {
+    validateOneOf(format, 'format', ObjectKeys(inspect.colors));
+  }
+  return `\u001b[${formatCodes[0]}m${text}\u001b[${formatCodes[1]}m`;
 }
 
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep',
@@ -395,6 +410,7 @@ module.exports = {
   debuglog,
   deprecate,
   format,
+  styleText,
   formatWithOptions,
   getSystemErrorMap,
   getSystemErrorName,

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -1,0 +1,35 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+[
+  undefined,
+  null,
+  false,
+  5n,
+  5,
+  Symbol(),
+  () => {},
+  {},
+  [],
+].forEach((invalidOption) => {
+  assert.throws(() => {
+    util.styleText(invalidOption, 'test');
+  }, {
+    code: 'ERR_INVALID_ARG_VALUE',
+  });
+  assert.throws(() => {
+    util.styleText('red', invalidOption);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+});
+
+assert.throws(() => {
+  util.styleText('invalid', 'text');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+assert.strictEqual(util.styleText('red', 'test'), '\u001b[31mtest\u001b[39m');


### PR DESCRIPTION
A fresh new PR from https://github.com/nodejs/node/pull/43371. 

@hemanth I took the liberty to create a new fresh PR (including a few changes) as your PR is almost 2 years old. I have included you as Co-Author I hope you don't mind (I tried to search for your handle in the OpenJS Foundation Slack, but I couldn't find it).

The concerns raised in the original blocker can be discussed again if necessary, but I believe we should have this API on Node.js.

cc: @nodejs/tsc 

