### PR TITLE
deps: V8: fixed unable to find library -lrt

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1246,7 +1246,7 @@
               ['_toolset=="host" and host_os=="linux"', {
                 'libraries': [
                   '-ldl',
-                  '-lrt'
+                  '-lc'
                 ],
               }],
             ],


### PR DESCRIPTION
Fixed #50184.
To fix it I made the following changes to the file `tools/v8_gypfiles/v8.gyp` :
```diff
['is_android', {
          'sources': [
            '<(V8_ROOT)/src/base/platform/platform-posix.cc',
            '<(V8_ROOT)/src/base/platform/platform-posix.h',
            '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',
            '<(V8_ROOT)/src/base/platform/platform-posix-time.h',
          ],
          'link_settings': {
            'target_conditions': [
              ['_toolset=="host" and host_os=="linux"', {
                'libraries': [
-                  '-ldl',
+                  '-ldl',
+                  '-lc'
-                  '-lrt'
                ],
              }],
            ],
          },
          'target_conditions': [
            ['_toolset=="host"', {
              'sources': [
                '<(V8_ROOT)/src/base/debug/stack_trace_posix.cc',
                '<(V8_ROOT)/src/base/platform/platform-linux.cc',
              ],
            }, {
              'sources': [
                '<(V8_ROOT)/src/base/debug/stack_trace_android.cc',
                '<(V8_ROOT)/src/base/platform/platform-linux.cc',
              ],
            }],
          ],
        }],
``` 