### PR TITLE
test: deflake test-http2-large-write-multiple-requests

### DIFF
--- a/test/parallel/test-http2-large-write-multiple-requests.js
+++ b/test/parallel/test-http2-large-write-multiple-requests.js
@@ -3,6 +3,10 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+// This tests that the http2 server sends data early when it accumulates
+// enough from ongoing requests to avoid DoS as mitigation for
+// CVE-2019-9517 and CVE-2019-9511.
+// Added by https://github.com/nodejs/node/commit/8a4a193
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const http2 = require('http2');
@@ -12,18 +16,21 @@ const content = fixtures.readSync('person-large.jpg');
 const server = http2.createServer({
   maxSessionMemory: 1000
 });
+let streamCount = 0;
 server.on('stream', (stream, headers) => {
   stream.respond({
     'content-type': 'image/jpeg',
     ':status': 200
   });
   stream.end(content);
+  console.log('server sends content', ++streamCount);
 });
 server.unref();
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}/`);
 
+  let endCount = 0;
   let finished = 0;
   for (let i = 0; i < 100; i++) {
     const req = client.request({ ':path': '/' }).end();
@@ -32,8 +39,16 @@ server.listen(0, common.mustCall(() => {
       chunks.push(chunk);
     });
     req.on('end', common.mustCall(() => {
+      console.log('client receives content', ++endCount);
       assert.deepStrictEqual(Buffer.concat(chunks), content);
-      if (++finished === 100) client.close();
+
+      if (++finished === 100) {
+        client.close();
+        server.close();
+      }
     }));
+    req.on('error', (e) => {
+      console.log('client error', e);
+    });
   }
 }));

--- a/test/parallel/test-http2-large-write-multiple-requests.js
+++ b/test/parallel/test-http2-large-write-multiple-requests.js
@@ -25,7 +25,6 @@ server.on('stream', (stream, headers) => {
   stream.end(content);
   console.log('server sends content', ++streamCount);
 });
-server.unref();
 
 server.listen(0, common.mustCall(() => {
   const client = http2.connect(`http://localhost:${server.address().port}/`);


### PR DESCRIPTION
If the server is not referenced, it might go away too soon and the client may not get enough ends for it to close itself, resulting a timeout.
This patch updates the test to simply close the server when enough requests have been processed, and keep the server referenced while the test is ongoing.

Drive-by: add more logs to facilitate debugging.
Refs: https://github.com/nodejs/reliability/issues/791

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
