### PR TITLE
crypto: runtime deprecate Hash constructor

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3563,12 +3563,15 @@ release lines. Please use [`dirent.parentPath`][] instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/51880
+    description: Runtime deprecation.
   - version: v21.5.0
     pr-url: https://github.com/nodejs/node/pull/51077
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `Hash` class directly with `Hash()` or `new Hash()` is
 deprecated due to being internals, not intended for public use.

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -229,7 +229,7 @@ module.exports = {
   DiffieHellman,
   DiffieHellmanGroup,
   ECDH,
-  Hash,
+  Hash: deprecate(Hash, 'crypto.Hash constructor is deprecated.', 'DEP0179'),
   Hmac,
   KeyObject,
   Sign,

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -276,3 +276,13 @@ assert.throws(
   assert.strictEqual(a.digest('hex'), b.digest('hex'));
   assert.strictEqual(c.digest('hex'), d.digest('hex'));
 }
+
+{
+  crypto.Hash('sha256');
+  common.expectWarning({
+    DeprecationWarning: [
+      ['crypto.Hash constructor is deprecated.',
+       'DEP0179'],
+    ]
+  });
+}


### PR DESCRIPTION
The idea is to deprecate constructor that were not supposed to be public so that we can refactor and transition to es6 classes
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
