### PR TITLE
build: enable `yarn` and `pnpm` Corepack binaries by default

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -30,18 +30,6 @@ This feature simplifies two core workflows:
 
 ## Workflows
 
-### Enabling the feature
-
-Due to its experimental status, Corepack currently needs to be explicitly
-enabled to have any effect. To do that, run [`corepack enable`][], which
-will set up the symlinks in your environment next to the `node` binary
-(and overwrite the existing symlinks if necessary).
-
-From this point forward, any call to the [supported binaries][] will work
-without further setup. Should you experience a problem, run
-[`corepack disable`][] to remove the proxies from your system (and consider
-opening an issue on the [Corepack repository][] to let us know).
-
 ### Configuring a package
 
 The Corepack proxies will find the closest [`package.json`][] file in your

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -118,13 +118,11 @@ install. To avoid this problem, consider one of the following options:
 [Corepack repository]: https://github.com/nodejs/corepack
 [Yarn]: https://yarnpkg.com
 [`"packageManager"`]: packages.md#packagemanager
-[`corepack disable`]: https://github.com/nodejs/corepack#corepack-disable--name
 [`corepack enable`]: https://github.com/nodejs/corepack#corepack-enable--name
 [`corepack install`]: https://github.com/nodejs/corepack#corepack-install--g--global---all--nameversion
 [`corepack pack`]: https://github.com/nodejs/corepack#corepack-pack---all--nameversion
 [`corepack use`]: https://github.com/nodejs/corepack#corepack-use-nameversion
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
 [pnpm]: https://pnpm.js.org
-[supported binaries]: #supported-package-managers
 [supported package manager]: #supported-package-managers
 [various flags]: https://github.com/nodejs/corepack#utility-commands

--- a/tools/install.py
+++ b/tools/install.py
@@ -116,11 +116,10 @@ def npm_files(options, action):
 def corepack_files(options, action):
   package_files(options, action, 'corepack', {
     'corepack': 'dist/corepack.js',
-#   Not the default just yet:
-#   'yarn': 'dist/yarn.js',
-#   'yarnpkg': 'dist/yarn.js',
-#   'pnpm': 'dist/pnpm.js',
-#   'pnpx': 'dist/pnpx.js',
+    'yarn': 'dist/yarn.js',
+    'yarnpkg': 'dist/yarn.js',
+    'pnpm': 'dist/pnpm.js',
+    'pnpx': 'dist/pnpx.js',
   })
 
   # On z/OS, we install node-gyp for convenience, as some vendors don't have

--- a/tools/msvs/msi/nodemsi/i18n/en-us.wxl
+++ b/tools/msvs/msi/nodemsi/i18n/en-us.wxl
@@ -20,10 +20,14 @@
     <String Id="NodeRuntime_Description" Value="Install the core [ProductName] runtime (node.exe)."/>
 
     <String Id="npm_Title" Value="npm package manager"/>
-    <String Id="npm_Description" Value="Install npm, the recommended package manager for [ProductName]."/>
+    <String Id="npm_Description" Value="Install npm, a package manager for [ProductName]."/>
 
-    <String Id="corepack_Title" Value="corepack manager"/>
+    <String Id="corepack_Title" Value="Corepack manager"/>
     <String Id="corepack_Description" Value="Install corepack, the universal package manager for [ProductName]."/>
+    <String Id="corepack_pnpm_Title" Value="pnpm package manager"/>
+    <String Id="corepack_pnpm_Description" Value="Install pnpm, a package manager for [ProductName], distributed by Corepack."/>
+    <String Id="corepack_yarn_Title" Value="Yarn package manager"/>
+    <String Id="corepack_yarn_Description" Value="Install Yarn, a package manager for [ProductName], distributed by Corepack."/>
 
     <String Id="DocumentationShortcuts_Title" Value="Online documentation shortcuts"/>
     <String Id="DocumentationShortcuts_Description" Value="Add start menu entries that link the online documentation for [ProductName] [FullVersion] and the [ProductName] website."/>

--- a/tools/msvs/msi/nodemsi/product.wxs
+++ b/tools/msvs/msi/nodemsi/product.wxs
@@ -82,6 +82,22 @@
       <ComponentGroupRef Id="CorepackSourceFiles"/>
     </Feature>
 
+    <Feature Id="corepack_pnpm"
+             Level="1"
+             Title="!(loc.corepack_pnpm_Title)"
+             Description="!(loc.corepack_pnpm_Description)">
+      <ComponentRef Id="CorepackpnpmCmdScript"/>
+      <ComponentRef Id="CorepackpnpmBashScript"/>
+    </Feature>
+
+    <Feature Id="corepack_yarn"
+             Level="1"
+             Title="!(loc.corepack_yarn_Title)"
+             Description="!(loc.corepack_yarn_Description)">
+      <ComponentRef Id="CorepackYarnCmdScript"/>
+      <ComponentRef Id="CorepackYarnBashScript"/>
+    </Feature>
+
     <Feature Id="npm"
              Level="1"
              Title="!(loc.npm_Title)"
@@ -214,6 +230,22 @@
 
       <Component Id="CorepackBashScript">
         <File Id="corepack.sh" KeyPath="yes" Source="$(var.CorepackSourceDir)\shims\nodewin\corepack"/>
+      </Component>
+
+      <Component Id="CorepackPnpmCmdScript">
+        <File Id="corepack.cmd" KeyPath="yes" Source="$(var.CorepackSourceDir)\shims\nodewin\pnpm.cmd"/>
+      </Component>
+
+      <Component Id="CorepackPnpmBashScript">
+        <File Id="corepack.sh" KeyPath="yes" Source="$(var.CorepackSourceDir)\shims\nodewin\pnpm"/>
+      </Component>
+
+      <Component Id="CorepackYarnCmdScript">
+        <File Id="corepack.cmd" KeyPath="yes" Source="$(var.CorepackSourceDir)\shims\nodewin\yarn.cmd"/>
+      </Component>
+
+      <Component Id="CorepackYarnBashScript">
+        <File Id="corepack.sh" KeyPath="yes" Source="$(var.CorepackSourceDir)\shims\nodewin\yarn"/>
       </Component>
 
       <Component Id="NpmCmdScript">


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/50963

Last version of Corepack has addressed (some of) the major concerns that was discussed in the TSC meeting last time:

- https://github.com/nodejs/corepack/pull/360
- https://github.com/nodejs/corepack/pull/364

IMO having Corepack enabled by default will overall be a clear win for Yarn and PNPM users (and won't affect npm users). Having it enabled by default does not stop those who don't like the "jumper binary" pattern to install Yarn and PNPM as they see fit.


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
