### PR TITLE
test: skip SEA tests when SEA generation fails

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1053,8 +1053,8 @@ in the current configuration.
 Copy `sourceExecutable` to `targetExecutable`, use postject to inject `seaBlob`
 into `targetExecutable` and sign it if necessary.
 
-If `verifyWorkflow` is false (default) and any of the steps fails, it skips the tests.
-Otherwise, an error is thrown.
+If `verifyWorkflow` is false (default) and any of the steps fails,
+it skips the tests. Otherwise, an error is thrown.
 
 ## tick Module
 

--- a/test/common/README.md
+++ b/test/common/README.md
@@ -1048,11 +1048,13 @@ Application functionality.
 Skip the rest of the tests if single executable applications are not supported
 in the current configuration.
 
-### `injectAndCodeSign(targetExecutable, resource)`
+### `generateSEA(targetExecutable, sourceExecutable, seaBlob, verifyWorkflow)`
 
-Uses Postect to inject the contents of the file at the path `resource` into
-the target executable file at the path `targetExecutable` and ultimately code
-sign the final binary.
+Copy `sourceExecutable` to `targetExecutable`, use postject to inject `seaBlob`
+into `targetExecutable` and sign it if necessary.
+
+If `verifyWorkflow` is false (default) and any of the steps fails, it skips the tests.
+Otherwise, an error is thrown.
 
 ## tick Module
 

--- a/test/common/sea.js
+++ b/test/common/sea.js
@@ -3,8 +3,9 @@
 const common = require('../common');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
+const { inspect } = require('util');
 
-const { readFileSync } = require('fs');
+const { readFileSync, copyFileSync } = require('fs');
 const {
   spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
@@ -54,47 +55,75 @@ function skipIfSingleExecutableIsNotSupported() {
   }
 }
 
-function injectAndCodeSign(targetExecutable, resource) {
+function generateSEA(targetExecutable, sourceExecutable, seaBlob, verifyWorkflow = false) {
+  try {
+    copyFileSync(sourceExecutable, targetExecutable);
+  } catch (e) {
+    const message = `Cannot copy ${sourceExecutable} to ${targetExecutable}: ${inspect(e)}`;
+    if (verifyWorkflow) {
+      throw new Error(message);
+    }
+    common.skip(message);
+  }
+  console.log(`Copied ${sourceExecutable} to ${targetExecutable}`);
+
   const postjectFile = fixtures.path('postject-copy', 'node_modules', 'postject', 'dist', 'cli.js');
-  spawnSyncAndExitWithoutError(process.execPath, [
-    postjectFile,
-    targetExecutable,
-    'NODE_SEA_BLOB',
-    resource,
-    '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
-    ...process.platform === 'darwin' ? [ '--macho-segment-name', 'NODE_SEA' ] : [],
-  ], {});
+  try {
+    spawnSyncAndExitWithoutError(process.execPath, [
+      postjectFile,
+      targetExecutable,
+      'NODE_SEA_BLOB',
+      seaBlob,
+      '--sentinel-fuse', 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+      ...process.platform === 'darwin' ? [ '--macho-segment-name', 'NODE_SEA' ] : [],
+    ]);
+  } catch (e) {
+    const message = `Cannot inject ${seaBlob} into ${targetExecutable}: ${inspect(e)}`;
+    if (verifyWorkflow) {
+      throw new Error(message);
+    }
+    common.skip(message);
+  }
+  console.log(`Injected ${seaBlob} into ${targetExecutable}`);
 
   if (process.platform === 'darwin') {
-    spawnSyncAndExitWithoutError('codesign', [ '--sign', '-', targetExecutable ], {});
-    spawnSyncAndExitWithoutError('codesign', [ '--verify', targetExecutable ], {});
+    try {
+      spawnSyncAndExitWithoutError('codesign', [ '--sign', '-', targetExecutable ], {});
+      spawnSyncAndExitWithoutError('codesign', [ '--verify', targetExecutable ], {});
+    } catch (e) {
+      const message = `Cannot sign ${targetExecutable}: ${inspect(e)}`;
+      if (verifyWorkflow) {
+        throw new Error(message);
+      }
+      common.skip(message);
+    }
+    console.log(`Signed ${targetExecutable}`);
   } else if (process.platform === 'win32') {
-    let signtoolFound = false;
     try {
       spawnSyncAndExitWithoutError('where', [ 'signtool' ], {});
-      signtoolFound = true;
-    } catch (err) {
-      console.log(err.message);
-    }
-    if (signtoolFound) {
-      let certificatesFound = false;
-      let stderr;
-      try {
-        ({ stderr } = spawnSyncAndExitWithoutError('signtool', [ 'sign', '/fd', 'SHA256', targetExecutable ], {}));
-        certificatesFound = true;
-      } catch (err) {
-        if (!/SignTool Error: No certificates were found that met all the given criteria/.test(stderr)) {
-          throw err;
-        }
+    } catch (e) {
+      const message = `Cannot find signtool: ${inspect(e)}`;
+      if (verifyWorkflow) {
+        throw new Error(message);
       }
-      if (certificatesFound) {
-        spawnSyncAndExitWithoutError('signtool', 'verify', '/pa', 'SHA256', targetExecutable, {});
-      }
+      common.skip(message);
     }
+    let stderr;
+    try {
+      ({ stderr } = spawnSyncAndExitWithoutError('signtool', [ 'sign', '/fd', 'SHA256', targetExecutable ], {}));
+      spawnSyncAndExitWithoutError('signtool', 'verify', '/pa', 'SHA256', targetExecutable, {});
+    } catch (e) {
+      const message = `Cannot sign ${targetExecutable}: ${inspect(e)}\n${stderr}`;
+      if (verifyWorkflow) {
+        throw new Error(message);
+      }
+      common.skip(message);
+    }
+    console.log(`Signed ${targetExecutable}`);
   }
 }
 
 module.exports = {
   skipIfSingleExecutableIsNotSupported,
-  injectAndCodeSign,
+  generateSEA,
 };

--- a/test/sequential/test-single-executable-application-assets-raw.js
+++ b/test/sequential/test-single-executable-application-assets-raw.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -56,8 +56,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
 
   assert(existsSync(seaPrepBlob));
 
-  copyFileSync(process.execPath, outputFile);
-  injectAndCodeSign(outputFile, seaPrepBlob);
+  generateSEA(outputFile, process.execPath, seaPrepBlob);
 
   spawnSyncAndExitWithoutError(
     outputFile,

--- a/test/sequential/test-single-executable-application-assets.js
+++ b/test/sequential/test-single-executable-application-assets.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -109,8 +109,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
 
   assert(existsSync(seaPrepBlob));
 
-  copyFileSync(process.execPath, outputFile);
-  injectAndCodeSign(outputFile, seaPrepBlob);
+  generateSEA(outputFile, process.execPath, seaPrepBlob);
 
   spawnSyncAndExitWithoutError(
     outputFile,

--- a/test/sequential/test-single-executable-application-disable-experimental-sea-warning.js
+++ b/test/sequential/test-single-executable-application-disable-experimental-sea-warning.js
@@ -3,7 +3,7 @@
 require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -51,8 +51,7 @@ spawnSyncAndExitWithoutError(
 
 assert(existsSync(seaPrepBlob));
 
-copyFileSync(process.execPath, outputFile);
-injectAndCodeSign(outputFile, seaPrepBlob);
+generateSEA(outputFile, process.execPath, seaPrepBlob);
 
 spawnSyncAndExitWithoutError(
   outputFile,

--- a/test/sequential/test-single-executable-application-empty.js
+++ b/test/sequential/test-single-executable-application-empty.js
@@ -1,9 +1,9 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -13,7 +13,7 @@ skipIfSingleExecutableIsNotSupported();
 // script.
 
 const tmpdir = require('../common/tmpdir');
-const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { writeFileSync, existsSync } = require('fs');
 const { spawnSyncAndExitWithoutError } = require('../common/child_process');
 const assert = require('assert');
 
@@ -38,8 +38,20 @@ spawnSyncAndExitWithoutError(
 
 assert(existsSync(seaPrepBlob));
 
-copyFileSync(process.execPath, outputFile);
-injectAndCodeSign(outputFile, seaPrepBlob);
+// Verify the workflow.
+try {
+  generateSEA(outputFile, process.execPath, seaPrepBlob, true);
+} catch (e) {
+  if (/Cannot copy/.test(e.message)) {
+    common.skip(e.message);
+  } else if (common.isWindows) {
+    if (/Cannot sign/.test(e.message) || /Cannot find signtool/.test(e.message)) {
+      common.skip(e.message);
+    }
+  }
+
+  throw e;
+}
 
 spawnSyncAndExitWithoutError(
   outputFile,

--- a/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
+++ b/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
@@ -3,7 +3,7 @@
 require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -12,7 +12,7 @@ skipIfSingleExecutableIsNotSupported();
 // This tests "useCodeCache" is ignored when "useSnapshot" is true.
 
 const tmpdir = require('../common/tmpdir');
-const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { writeFileSync, existsSync } = require('fs');
 const {
   spawnSyncAndExitWithoutError
 } = require('../common/child_process');
@@ -62,8 +62,7 @@ const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 
 
   assert(existsSync(seaPrepBlob));
 
-  copyFileSync(process.execPath, outputFile);
-  injectAndCodeSign(outputFile, seaPrepBlob);
+  generateSEA(outputFile, process.execPath, seaPrepBlob);
 
   spawnSyncAndExitWithoutError(
     outputFile,

--- a/test/sequential/test-single-executable-application-snapshot.js
+++ b/test/sequential/test-single-executable-application-snapshot.js
@@ -3,7 +3,7 @@
 require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -12,7 +12,7 @@ skipIfSingleExecutableIsNotSupported();
 // This tests the snapshot support in single executable applications.
 
 const tmpdir = require('../common/tmpdir');
-const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { writeFileSync, existsSync } = require('fs');
 const {
   spawnSyncAndExit,
   spawnSyncAndExitWithoutError
@@ -85,8 +85,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
 
   assert(existsSync(seaPrepBlob));
 
-  copyFileSync(process.execPath, outputFile);
-  injectAndCodeSign(outputFile, seaPrepBlob);
+  generateSEA(outputFile, process.execPath, seaPrepBlob);
 
   spawnSyncAndExitWithoutError(
     outputFile,

--- a/test/sequential/test-single-executable-application-use-code-cache.js
+++ b/test/sequential/test-single-executable-application-use-code-cache.js
@@ -3,7 +3,7 @@
 require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -56,8 +56,7 @@ spawnSyncAndExitWithoutError(
 
 assert(existsSync(seaPrepBlob));
 
-copyFileSync(process.execPath, outputFile);
-injectAndCodeSign(outputFile, seaPrepBlob);
+generateSEA(outputFile, process.execPath, seaPrepBlob);
 
 spawnSyncAndExitWithoutError(
   outputFile,

--- a/test/sequential/test-single-executable-application.js
+++ b/test/sequential/test-single-executable-application.js
@@ -3,7 +3,7 @@
 require('../common');
 
 const {
-  injectAndCodeSign,
+  generateSEA,
   skipIfSingleExecutableIsNotSupported,
 } = require('../common/sea');
 
@@ -50,8 +50,7 @@ spawnSyncAndExitWithoutError(
 
 assert(existsSync(seaPrepBlob));
 
-copyFileSync(process.execPath, outputFile);
-injectAndCodeSign(outputFile, seaPrepBlob);
+generateSEA(outputFile, process.execPath, seaPrepBlob);
 
 spawnSyncAndExitWithoutError(
   outputFile,


### PR DESCRIPTION
In the SEA tests, if any of these steps fail:

1. Copy the executable
2. Inject the SEA blob
3. Signing the SEA

We skip the test because the error likely comes from the system or postject and is not something the Node.js core can fix. We only leave an exception for a basic test that test injecting empty files as SEA to ensure the workflow is working (but we still skip if copying fails or signing fails on Windows).

Refs: https://github.com/nodejs/node/issues/49630

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
