### PR TITLE
test: fix unreliable assumption in js-native-api/test_cannot_run_js

### DIFF
--- a/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c
+++ b/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c
@@ -21,12 +21,14 @@ static void Finalize(napi_env env, void* data, void* hint) {
   // or during environment shutdown (where napi_cannot_run_js or
   // napi_pending_exception is returned). This is not deterministic from
   // the point of view of the addon.
-  NODE_API_NOGC_ASSERT_RETURN_VOID(
+
 #ifdef NAPI_EXPERIMENTAL
+  NODE_API_NOGC_ASSERT_RETURN_VOID(
       result == napi_cannot_run_js || result == napi_ok,
       "getting named property from global in finalizer should succeed "
       "or return napi_cannot_run_js");
 #else
+  NODE_API_NOGC_ASSERT_RETURN_VOID(
       result == napi_pending_exception || result == napi_ok,
       "getting named property from global in finalizer should succeed "
       "or return napi_pending_exception");

--- a/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c
+++ b/test/js-native-api/test_cannot_run_js/test_cannot_run_js.c
@@ -6,17 +6,31 @@
 static void Finalize(napi_env env, void* data, void* hint) {
   napi_value global, set_timeout;
   napi_ref* ref = data;
-#ifdef NAPI_EXPERIMENTAL
-  napi_status expected_status = napi_cannot_run_js;
-#else
-  napi_status expected_status = napi_pending_exception;
-#endif  // NAPI_EXPERIMENTAL
 
-  if (napi_delete_reference(env, *ref) != napi_ok) abort();
-  if (napi_get_global(env, &global) != napi_ok) abort();
-  if (napi_get_named_property(env, global, "setTimeout", &set_timeout) !=
-      expected_status)
-    abort();
+  NODE_API_NOGC_ASSERT_RETURN_VOID(
+      napi_delete_reference(env, *ref) == napi_ok,
+      "deleting reference in finalizer should succeed");
+  NODE_API_NOGC_ASSERT_RETURN_VOID(
+      napi_get_global(env, &global) == napi_ok,
+      "getting global reference in finalizer should succeed");
+  napi_status result =
+      napi_get_named_property(env, global, "setTimeout", &set_timeout);
+
+  // The finalizer could be invoked either from check callbacks (as native
+  // immediates) if the event loop is still running (where napi_ok is returned)
+  // or during environment shutdown (where napi_cannot_run_js or
+  // napi_pending_exception is returned). This is not deterministic from
+  // the point of view of the addon.
+  NODE_API_NOGC_ASSERT_RETURN_VOID(
+#ifdef NAPI_EXPERIMENTAL
+      result == napi_cannot_run_js || result == napi_ok,
+      "getting named property from global in finalizer should succeed "
+      "or return napi_cannot_run_js");
+#else
+      result == napi_pending_exception || result == napi_ok,
+      "getting named property from global in finalizer should succeed "
+      "or return napi_pending_exception");
+#endif  // NAPI_EXPERIMENTAL
   free(ref);
 }
 

--- a/test/root.status
+++ b/test/root.status
@@ -1,5 +1,4 @@
 [true]
-js-native-api/test_cannot_run_js/test: PASS,FLAKY
 
 [$mode==debug]
 async-hooks/test-callback-error: SLOW


### PR DESCRIPTION
Previously the test assumes that when the queued finalizer is run, it must be run at a point where env->can_call_into_js() is false (typically, during Environment shutdown), which is not certain. If GC kicks in early and the second pass finalizer is queued before the event loop runs the check callbacks, the finalizer would then be called in check callbacks (via native immediates), where the finalizer can still call into JS. Essentially, addons can't make assumptions about where the queued finalizer would be called. This patch updates the assertions in the test to account for that.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
