### PR TITLE
lib: account for cwd access from snapshot serialization cb

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1021,6 +1021,8 @@ get serialized into a snapshot and exit. This can be used to release
 resources that should not or cannot be serialized or to convert user data
 into a form more suitable for serialization.
 
+Callbacks are run in the order in which they are added.
+
 ### `v8.startupSnapshot.addDeserializeCallback(callback[, data])`
 
 <!-- YAML
@@ -1039,6 +1041,8 @@ from a snapshot. The `callback` and the `data` (if provided) will be
 serialized into the snapshot, they can be used to re-initialize the state
 of the application or to re-acquire resources that the application needs
 when the application is restarted from the snapshot.
+
+Callbacks are run in the order in which they are added.
 
 ### `v8.startupSnapshot.setDeserializeMainFunction(callback[, data])`
 

--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -4,6 +4,7 @@ const credentials = internalBinding('credentials');
 const rawMethods = internalBinding('process_methods');
 const {
   namespace: {
+    addDeserializeCallback,
     addSerializeCallback,
     isBuildingSnapshot,
   },
@@ -114,8 +115,13 @@ function wrapPosixCredentialSetters(credentials) {
 let cachedCwd = '';
 
 if (isBuildingSnapshot()) {
+  // Reset the cwd on both serialization and deserialization so it's fine
+  // for process.cwd() to be accessed inside of serialization callbacks.
   addSerializeCallback(() => {
     cachedCwd = '';
+    addDeserializeCallback(() => {
+      cachedCwd = '';
+    });
   });
 }
 

--- a/test/fixtures/snapshot/cwd.js
+++ b/test/fixtures/snapshot/cwd.js
@@ -1,9 +1,15 @@
 const {
+  addSerializeCallback,
   setDeserializeMainFunction,
 } = require('v8').startupSnapshot;
 
 // To make sure the cwd is present in the cache
 process.cwd();
+
+// Also access it from a serialization callback once
+addSerializeCallback(() => {
+  process.cwd();
+});
 
 setDeserializeMainFunction(() => {
   console.log(process.cwd());


### PR DESCRIPTION
Functions registered with `addSerializeCallback()` can access and call `process.cwd()`. b7d836e2c7f57 accounted for the fact that it is necessary to reset the cwd cache after the snapshot builder script has run, but did not account for possible accesses from serialization callbacks. To properly account for these, add a deserialization callback as well.

As a related drive-by fix, also mention the execution order of callbacks in the documentation.

Refs: https://github.com/nodejs/node/pull/49684

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
