### PR TITLE
build: fix arm64 host cross-compilation in GN

### DIFF
--- a/deps/base64/unofficial.gni
+++ b/deps/base64/unofficial.gni
@@ -19,7 +19,7 @@ template("base64_gn_build") {
     } else {
       defines = []
     }
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       defines += [
         "HAVE_SSSE3=1",
         "HAVE_SSE41=1",
@@ -29,10 +29,10 @@ template("base64_gn_build") {
         "HAVE_AVX512=1",
       ]
     }
-    if (target_cpu == "arm") {
+    if (current_cpu == "arm") {
       defines += [ "HAVE_NEON32=1" ]
     }
-    if (target_cpu == "arm64") {
+    if (current_cpu == "arm64") {
       defines += [ "HAVE_NEON64=1" ]
     }
     if (is_clang || !is_win) {
@@ -69,7 +69,7 @@ template("base64_gn_build") {
   source_set("base64_ssse3") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/ssse3/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [ "-mssse3" ]
       }
@@ -79,7 +79,7 @@ template("base64_gn_build") {
   source_set("base64_sse41") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/sse41/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [ "-msse4.1" ]
       }
@@ -89,7 +89,7 @@ template("base64_gn_build") {
   source_set("base64_sse42") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/sse42/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [ "-msse4.2" ]
       }
@@ -99,7 +99,7 @@ template("base64_gn_build") {
   source_set("base64_avx") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/avx/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [ "-mavx" ]
       } else if (is_win) {
@@ -111,7 +111,7 @@ template("base64_gn_build") {
   source_set("base64_avx2") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/avx2/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [ "-mavx2" ]
       } else if (is_win) {
@@ -123,7 +123,7 @@ template("base64_gn_build") {
   source_set("base64_avx512") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/avx512/codec.c" ]
-    if (target_cpu == "x86" || target_cpu == "x64") {
+    if (current_cpu == "x86" || current_cpu == "x64") {
       if (is_clang || !is_win) {
         cflags_c = [
           "-mavx512vl",
@@ -138,7 +138,7 @@ template("base64_gn_build") {
   source_set("base64_neon32") {
     configs += [ ":base64_internal_config" ]
     sources = [ "base64/lib/arch/neon32/codec.c" ]
-    if (target_cpu == "arm") {
+    if (current_cpu == "arm") {
       if (is_clang || !is_win) {
         cflags_c = [ "-mfpu=neon" ]
       }

--- a/deps/openssl/unofficial.gni
+++ b/deps/openssl/unofficial.gni
@@ -95,29 +95,29 @@ template("openssl_gn_build") {
 
     config_path_name = ""
     if (is_win) {
-      if (target_cpu == "x86") {
+      if (current_cpu == "x86") {
         config_path_name = "VC-WIN32"
-      } else if (target_cpu == "x64") {
+      } else if (current_cpu == "x64") {
         config_path_name = "VC-WIN64A"
-      } else if (target_cpu == "arm64") {
+      } else if (current_cpu == "arm64") {
         config_path_name = "VC-WIN64-ARM"
       }
     } else if (is_linux) {
-      if (target_cpu == "x86") {
+      if (current_cpu == "x86") {
         config_path_name = "linux-elf"
-      } else if (target_cpu == "x64") {
+      } else if (current_cpu == "x64") {
         config_path_name = "linux-x86_64"
-      } else if (target_cpu == "arm") {
+      } else if (current_cpu == "arm") {
         config_path_name = "linux-armv4"
-      } else if (target_cpu == "arm64") {
+      } else if (current_cpu == "arm64") {
         config_path_name = "linux-aarch64"
       }
     } else if (is_apple) {
-      if (target_cpu == "x86") {
+      if (current_cpu == "x86") {
         config_path_name = "darwin-i386-cc"
-      } else if (target_cpu == "x64") {
+      } else if (current_cpu == "x64") {
         config_path_name = "darwin64-x86_64-cc"
-      } else if (target_cpu == "arm64") {
+      } else if (current_cpu == "arm64") {
         config_path_name = "darwin64-arm64-cc"
       }
     }
@@ -132,7 +132,7 @@ template("openssl_gn_build") {
       # TODO(zcbenz): Check gas_version and nasm_version.
       asm_name = "asm_avx2"
     }
-    if (is_win && target_cpu == "arm64") {
+    if (is_win && current_cpu == "arm64") {
       asm_name = "no-asm"
     }
     config_path = "config/archs/" + config_path_name + "/" + asm_name

--- a/node.gni
+++ b/node.gni
@@ -54,8 +54,10 @@ declare_args() {
   node_use_node_code_cache = host_os == target_os && host_cpu == target_cpu
 
   # Use snapshot to speed up startup.
-  # TODO(zcbenz): node_mksnapshot is not ready for cross-os compilation.
-  node_use_node_snapshot = host_os == target_os
+  # TODO(zcbenz): There are few broken things for now:
+  #   1. cross-os compilation is not supported.
+  #   2. node_mksnapshot crashes when cross-compiling for x64 from arm64.
+  node_use_node_snapshot = (host_os == target_os) && !(host_cpu == "arm64" && target_cpu == "x64")
 }
 
 assert(!node_enable_inspector || node_use_openssl,

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -82,10 +82,10 @@ template("node_gn_build") {
       "-Wno-unused-function",
     ]
 
-    if (target_cpu == "x86") {
+    if (current_cpu == "x86") {
       node_arch = "ia32"
     } else {
-      node_arch = target_cpu
+      node_arch = current_cpu
     }
     if (target_os == "win") {
       node_platform = "win32"


### PR DESCRIPTION
Should use `current_cpu` instead of `target_cpu` in GN build files, otherwise the host build may use wrong configs when doing cross-compilation.
