### PR TITLE
tools: fix installing node with shared mode

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -176,7 +176,7 @@ def files(options, action):
       try_symlink(options, so_name, link_path)
     else:
       output_lib = 'libnode.' + options.variables.get('shlib_suffix')
-      action(options, [os.path.join(output_prefix, output_lib)],
+      action(options, [os.path.join(options.build_dir, output_lib)],
              os.path.join(options.variables.get('libdir'), output_lib))
 
   action(options, [os.path.join(options.v8_dir, 'tools/gdbinit')], 'share/doc/node/')


### PR DESCRIPTION
Fix a bug caused by https://github.com/nodejs/node/pull/50737 that, make install fails for `--shared` mode.

This was reported by https://github.com/nodejs/node/pull/50737#issuecomment-1968696720.