### PR TITLE
lib: return directly if udp socket close before lookup

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -328,6 +328,9 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
 
   // Resolve address first
   state.handle.lookup(address, (err, ip) => {
+    if (!state.handle)
+      return; // Handle has been closed in the mean time
+
     if (err) {
       state.bindState = BIND_STATE_UNBOUND;
       this.emit('error', err);
@@ -356,9 +359,6 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
         this.emit('error', ex);
       });
     } else {
-      if (!state.handle)
-        return; // Handle has been closed in the mean time
-
       const err = state.handle.bind(ip, port || 0, flags);
       if (err) {
         const ex = new ExceptionWithHostPort(err, 'bind', ip, port);

--- a/test/parallel/test-dgram-bind-socket-close-before-lookup.js
+++ b/test/parallel/test-dgram-bind-socket-close-before-lookup.js
@@ -1,0 +1,19 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+
+// Do not emit error event in callback which is called by lookup when socket is closed
+const socket = dgram.createSocket({
+  type: 'udp4',
+  lookup: (...args) => {
+    // Call lookup callback after 1s
+    setTimeout(() => {
+      args.at(-1)(new Error('an error'));
+    }, 1000);
+  }
+});
+
+socket.on('error', common.mustNotCall());
+socket.bind(12345, 'localhost');
+// Close the socket before calling DNS lookup callback
+socket.close();


### PR DESCRIPTION
return directly in callback which is called by lookup when udp socket is closed.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
