### PR TITLE
doc: add policy for distribution

### DIFF
--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -5,13 +5,20 @@ Node.js distribution.
 
 ## Inclusion
 
-Node.js includes many dependencies, such as V8, Undici and others; and comes
-bundled with standalone tools such as `npm`. It is not a goal of the Node.js
-project to provide a level playing field for all dependencies or bundled tools.
-With limited resources, the Node.js project does not intend to bundle or
-officially support multiple dependencies or tools that serve the same purpose.
+Node.js includes some external projects that the Node.js team does not maintain.
+The fact of a project's inclusion should not imply anything about the project
+relative to its competitors; in some cases, a project was added when it had no
+competitors. While the Node.js team supports and encourages competition in the
+JavaScript ecosystem, as a policy, the Node.js project does not include multiple
+dependencies or tools that serve the same purpose.
 
-## Package managers
+The following user-accessible external projects are the ones chosen for their
+particular purposes:
 
-The Node.js distribution includes `npm`, and does not include any other
-package managers.
+* JavaScript engine: V8
+* Package manager: `npm`
+
+Being user-accessible, removal or replacement of these projects could happen
+only as a semver-major change. In addition, Node.js includes external projects
+as internal dependencies. These may be replaced or removed at any time, provided
+that doing so is not a breaking change.

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -21,6 +21,7 @@ for their particular purposes:
 * Package manager version manager: Corepack
 
 Being user-accessible, removal or replacement of these projects could happen
-only as a semver-major change. In addition, Node.js includes external projects
-as internal dependencies. These may be replaced or removed at any time, provided
+only as a semver-major change, unless the related feature or project is
+documented as experimental. In addition, Node.js includes external projects as
+internal dependencies. These may be replaced or removed at any time, provided
 that doing so is not a breaking change.

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -17,6 +17,7 @@ particular purposes:
 
 * JavaScript engine: V8
 * Package manager: `npm`
+* Package manager version manager: Corepack
 
 Being user-accessible, removal or replacement of these projects could happen
 only as a semver-major change. In addition, Node.js includes external projects

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -13,5 +13,5 @@ officially support multiple dependencies or tools that serve the same purpose.
 
 ## Package managers
 
-The Node.js distribution will include `npm`, and will not include any other
+The Node.js distribution includes `npm`, and does not include any other
 package managers.

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -8,7 +8,7 @@ Node.js distribution.
 Node.js includes some external projects that the Node.js team does not maintain.
 The fact of a project's inclusion should not imply anything about the project
 relative to its competitors; in some cases, a project was added when it had no
-competitors. While the Node.js team supports and encourages competition in the
+competitors. While the Node.js project supports and encourages competition in the
 JavaScript ecosystem, as a policy, the Node.js project does not include multiple
 dependencies or tools that serve the same purpose.
 

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -5,7 +5,7 @@ Node.js distribution.
 
 ## Inclusion
 
-Node.js includes some external projects that the Node.js team does not maintain.
+The Node.js distribution includes some external projects that the Node.js project does not maintain.
 The fact of a project's inclusion should not imply anything about the project
 relative to its competitors; in some cases, a project was added when it had no
 competitors. While the Node.js project supports and encourages competition in the

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -1,0 +1,17 @@
+# Node.js Distribution Policy
+
+This document describes some policies around what is and is not included in the
+Node.js distribution.
+
+## Inclusion
+
+Node.js includes many dependencies, such as V8, Undici and others; and comes
+bundled with standalone tools such as `npm`. It is not a goal of the Node.js
+project to provide a level playing field for all dependencies or bundled tools.
+With limited resources, the Node.js project does not intend to bundle or
+officially support multiple dependencies or tools that serve the same purpose.
+
+## Package managers
+
+The Node.js distribution will include `npm`, and will not include any other
+package managers.

--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -5,15 +5,16 @@ Node.js distribution.
 
 ## Inclusion
 
-The Node.js distribution includes some external projects that the Node.js project does not maintain.
-The fact of a project's inclusion should not imply anything about the project
-relative to its competitors; in some cases, a project was added when it had no
-competitors. While the Node.js project supports and encourages competition in the
-JavaScript ecosystem, as a policy, the Node.js project does not include multiple
-dependencies or tools that serve the same purpose.
+The Node.js distribution includes some external software that the Node.js
+project does not maintain. The choice to include a particular piece of software
+should not imply anything about that software relative to its competitors; in
+some cases, software was added when it had no competitors. While the Node.js
+project supports and encourages competition in the JavaScript ecosystem, as a
+policy, the Node.js project does not include multiple dependencies or tools that
+serve the same purpose.
 
-The following user-accessible external projects are the ones chosen for their
-particular purposes:
+The following user-accessible external tools or libraries are the ones chosen
+for their particular purposes:
 
 * JavaScript engine: V8
 * Package manager: `npm`


### PR DESCRIPTION
This is my attempt at writing down what seems to be a rough consensus emerging in the various Corepack-related threads such as #50963. The purpose of this PR is to confirm that what’s written here _is_ a consensus or majority opinion (if it comes to a vote) to help focus the decision-making around Corepack. This file can always change (or be removed) in the future; all it takes is another PR.

@nodejs/tsc @nodejs/corepack @nodejs/package-maintenance 