### PR TITLE
lib: make sure close the net server

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1770,6 +1770,7 @@ function Server(options, connectionListener) {
   this._usingWorkers = false;
   this._workers = [];
   this._unref = false;
+  this._listeningId = 1;
 
   this.allowHalfOpen = options.allowHalfOpen || false;
   this.pauseOnConnect = !!options.pauseOnConnect;
@@ -1951,10 +1952,14 @@ function listenInCluster(server, address, port, addressType,
     backlog,
     ...options,
   };
+  const listeningId = server._listeningId;
   // Get the primary's server handle, and listen on it
   cluster._getServer(server, serverQuery, listenOnPrimaryHandle);
-
   function listenOnPrimaryHandle(err, handle) {
+    if (listeningId !== server._listeningId) {
+      handle.close();
+      return;
+    }
     err = checkBindError(err, port, handle);
 
     if (err) {
@@ -2086,9 +2091,14 @@ Server.prototype.listen = function(...args) {
   throw new ERR_INVALID_ARG_VALUE('options', options);
 };
 
-function lookupAndListen(self, port, address, backlog, exclusive, flags) {
+function lookupAndListen(self, port, address, backlog,
+                         exclusive, flags) {
   if (dns === undefined) dns = require('dns');
+  const listeningId = self._listeningId;
   dns.lookup(address, function doListen(err, ip, addressType) {
+    if (listeningId !== self._listeningId) {
+      return;
+    }
     if (err) {
       self.emit('error', err);
     } else {
@@ -2234,6 +2244,7 @@ Server.prototype.getConnections = function(cb) {
 
 
 Server.prototype.close = function(cb) {
+  this._listeningId++;
   if (typeof cb === 'function') {
     if (!this._handle) {
       this.once('close', function close() {

--- a/test/parallel/test-net-server-close-before-calling-lookup-callback.js
+++ b/test/parallel/test-net-server-close-before-calling-lookup-callback.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+// Process should exit because it does not create a real TCP server.
+// Paas localhost to ensure create TCP handle asynchronously because It causes DNS resolution.
+net.createServer().listen(0, 'localhost', common.mustNotCall()).close();

--- a/test/parallel/test-net-server-close-before-ipc-response.js
+++ b/test/parallel/test-net-server-close-before-ipc-response.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common');
+const net = require('net');
+const cluster = require('cluster');
+
+// Process should exit
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  const send = process.send;
+  process.send = function(message) {
+    // listenOnPrimaryHandle in net.js should call handle.close()
+    if (message.act === 'close') {
+      setImmediate(() => {
+        process.disconnect();
+      });
+    }
+    return send.apply(this, arguments);
+  };
+  net.createServer().listen(0, common.mustNotCall()).close();
+}


### PR DESCRIPTION
If perform asynchronous operations in the `listen` function of `net.js` (execute `dns.lookup` or ask the main process to create a server), the server will not close properly. 

The example is as follows.
```js
// The "closed" TCP server will keep the process because 
// after calling close function, a TCP handle is created in the callback of `dns.lookup`.
const net = require('net');
net.createServer().listen(9999, 'localhost').close();
```
See https://github.com/nodejs/node/blob/c08b7975735aaa633e2573da692a05aa3f13d700/lib/net.js#L2092.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
