### PR TITLE
doc: state that removing npm is a non-goal

### DIFF
--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -161,17 +161,16 @@ As TypeScript usage continues to grow and gains more prominence in the
 ecosystem, enhancing its support is essential for delivering an improved
 developer experience for newcomers and experienced users alike.
 
-## Non-goals
+## Package management
 
-The following are not considered technical priorities for the project:
+The ability to easily install and manage dependencies and development tools is a
+key part of the developer experience, and therefore Node.js must provide a
+package manager as part of its distribution. Node.js includes npm for this
+purpose. This is for historical reasons—when npm was added in 2011, it was the
+only JavaScript package manager—and because it is the reference implementation
+for the npm registry, which is the de facto primary source for most JavaScript
+software. In accordance with our [policy][distribution-policy] of not including
+multiple dependencies or tools that serve the same purpose, the Node.js project
+does not include any other package managers.
 
-* **Unbundling `npm`**. When `npm` was included in the Node.js distribution, it
-  was the only JavaScript package manager available, and it was provided as a
-  way to help developers easily install other JavaScript software. `npm` is also
-  the reference implementation for the npm registry, which is the de facto
-  primary source for most JavaScript software. Today, `npm` is one of many
-  high-quality options. However, the potential removal of `npm` would be a very
-  disruptive breaking change, even as a semver-major change, and therefore it is
-  not a goal of the Node.js project to work toward such a goal. The `npm`
-  library included with the Node.js distribution can be freely used as a
-  dependency of other parts of the Node.js distribution.
+[distribution-policy]: ./distribution.md

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -160,3 +160,18 @@ and integration with other systems.
 As TypeScript usage continues to grow and gains more prominence in the
 ecosystem, enhancing its support is essential for delivering an improved
 developer experience for newcomers and experienced users alike.
+
+## Non-goals
+
+The following are not considered technical priorities for the project:
+
+* **Unbundling `npm`**. When `npm` was included in the Node.js distribution, it
+  was the only JavaScript package manager available, and it was provided as a
+  way to help developers easily install other JavaScript software. `npm` is also
+  the reference implementation for the `npm` registry, which is the de facto
+  primary source for most JavaScript software. Today, `npm` is one of many
+  high-quality options. However, the potential removal of `npm` would be a very
+  disruptive breaking change, even as a semver-major change, and therefore it is
+  not a goal of the Node.js project to work toward such a goal. The `npm`
+  library included with the Node.js distribution can be freely used as a
+  dependency of other parts of the Node.js distribution.

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -166,8 +166,8 @@ developer experience for newcomers and experienced users alike.
 The ability to easily install and manage dependencies and development tools is a
 key part of the developer experience, and therefore Node.js must provide a
 package manager as part of its distribution. Node.js includes npm for this
-purpose. This is for historical reasons—when npm was added in 2011, it was the
-only JavaScript package manager—and because it is the reference implementation
+purpose. This is for historical reasons — when `npm` was added in 2011, it was the
+only JavaScript package manager — and because it is the reference implementation
 for the npm registry, which is the de facto primary source for most JavaScript
 software. In accordance with our [policy][distribution-policy] of not including
 multiple dependencies or tools that serve the same purpose, the Node.js project

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -171,6 +171,7 @@ the only JavaScript package manager — and because it is the reference
 implementation for the npm registry, which is the de facto primary source for
 most JavaScript software. In accordance with our [policy][distribution-policy]
 of not including multiple dependencies or tools that serve the same purpose, the
-Node.js project does not include any other package managers.
+Node.js project does not include any other package managers; though it may
+include other software to download other package managers.
 
 [distribution-policy]: ./distribution.md

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -168,7 +168,7 @@ The following are not considered technical priorities for the project:
 * **Unbundling `npm`**. When `npm` was included in the Node.js distribution, it
   was the only JavaScript package manager available, and it was provided as a
   way to help developers easily install other JavaScript software. `npm` is also
-  the reference implementation for the `npm` registry, which is the de facto
+  the reference implementation for the npm registry, which is the de facto
   primary source for most JavaScript software. Today, `npm` is one of many
   high-quality options. However, the potential removal of `npm` would be a very
   disruptive breaking change, even as a semver-major change, and therefore it is

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -164,7 +164,7 @@ developer experience for newcomers and experienced users alike.
 ## Package management
 
 The ability to easily install and manage dependencies and development tools is a
-key part of the developer experience, and therefore Node.js must provide a
+key part of the user experience, and for that reason Node.js must provide a
 package manager as part of its distribution. Node.js includes npm for this
 purpose. This is for historical reasons — when `npm` was added in 2011, it was the
 only JavaScript package manager — and because it is the reference implementation

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -165,7 +165,7 @@ developer experience for newcomers and experienced users alike.
 
 The ability to easily install and manage dependencies and development tools is a
 key part of the user experience, and for that reason Node.js must provide a
-package manager as part of its distribution. Node.js includes npm for this
+package manager as part of its distribution. Node.js includes `npm` for this
 purpose. This is for historical reasons — when `npm` was added in 2011, it was the
 only JavaScript package manager — and because it is the reference implementation
 for the npm registry, which is the de facto primary source for most JavaScript

--- a/doc/contributing/technical-priorities.md
+++ b/doc/contributing/technical-priorities.md
@@ -166,11 +166,11 @@ developer experience for newcomers and experienced users alike.
 The ability to easily install and manage dependencies and development tools is a
 key part of the user experience, and for that reason Node.js must provide a
 package manager as part of its distribution. Node.js includes `npm` for this
-purpose. This is for historical reasons — when `npm` was added in 2011, it was the
-only JavaScript package manager — and because it is the reference implementation
-for the npm registry, which is the de facto primary source for most JavaScript
-software. In accordance with our [policy][distribution-policy] of not including
-multiple dependencies or tools that serve the same purpose, the Node.js project
-does not include any other package managers.
+purpose. This is for historical reasons — when `npm` was added in 2011, it was
+the only JavaScript package manager — and because it is the reference
+implementation for the npm registry, which is the de facto primary source for
+most JavaScript software. In accordance with our [policy][distribution-policy]
+of not including multiple dependencies or tools that serve the same purpose, the
+Node.js project does not include any other package managers.
 
 [distribution-policy]: ./distribution.md


### PR DESCRIPTION
As part of resolving [the request of the members of the TSC who met on 2024-01-24](https://github.com/nodejs/node/issues/50963#issuecomment-1908582225), this PR aims to help clarify the goals of Corepack. In particular, this clarifies that it is a _non-goal_ of Node.js overall, and therefore Coreback by inclusion, to work toward removing `npm` from the Node.js distribution.

This also codifies what was written in https://github.com/nodejs/node/issues/50963#issuecomment-1963829377, which seems to be a consensus:

> 1. we solidify the “special relationship” with the `npm` client, clearly stating that it’s vendored because it is the _reference implementation_ for the npm registry, as well for historical reasons.

@nodejs/tsc @nodejs/npm @nodejs/package-maintenance @nodejs/corepack 