### PR TITLE
test: reduce flakiness of `test-runner-output`

### DIFF
--- a/test/fixtures/test-runner/output/describe_it.js
+++ b/test/fixtures/test-runner/output/describe_it.js
@@ -302,12 +302,18 @@ describe('describe async throw fails', async () => {
 describe('timeouts', () => {
   it('timed out async test', { timeout: 5 }, async () => {
     return new Promise((resolve) => {
-      setTimeout(resolve, 100);
+      setTimeout(() => {
+        // empty timers so the process doesn't end before the timeout triggers.
+      }, 5);
+      setTimeout(resolve, 30_000_000).unref();
     });
   });
 
   it('timed out callback test', { timeout: 5 }, (t, done) => {
-    setTimeout(done, 100);
+    setTimeout(() => {
+      // empty timers so the process doesn't end before the timeout triggers.
+    }, 5);
+    setTimeout(done, 30_000_000).unref();
   });
 
 

--- a/test/fixtures/test-runner/output/describe_it.js
+++ b/test/fixtures/test-runner/output/describe_it.js
@@ -303,7 +303,7 @@ describe('timeouts', () => {
   it('timed out async test', { timeout: 5 }, async () => {
     return new Promise((resolve) => {
       setTimeout(() => {
-        // empty timers so the process doesn't end before the timeout triggers.
+        // Empty timer so the process doesn't exit before the timeout triggers.
       }, 5);
       setTimeout(resolve, 30_000_000).unref();
     });
@@ -311,7 +311,7 @@ describe('timeouts', () => {
 
   it('timed out callback test', { timeout: 5 }, (t, done) => {
     setTimeout(() => {
-      // empty timers so the process doesn't end before the timeout triggers.
+        // Empty timer so the process doesn't exit before the timeout triggers.
     }, 5);
     setTimeout(done, 30_000_000).unref();
   });


### PR DESCRIPTION
It was failing 1% of the times on my local machine. With that patch, I got no failures on 1000 runs.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
