### PR TITLE
watch: debounce restart in watch mode (#51954)

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -44,7 +44,7 @@ const args = ArrayPrototypeFilter(process.execArgv, (arg, i, arr) =>
   arg !== '--watch' && !StringPrototypeStartsWith(arg, '--watch=') && arg !== '--watch-preserve-output');
 ArrayPrototypePushApply(args, kCommand);
 
-const watcher = new FilesWatcher({ debounce: 200, mode: kShouldFilterModules ? 'filter' : 'all' });
+const watcher = new FilesWatcher({ mode: kShouldFilterModules ? 'filter' : 'all' });
 ArrayPrototypeForEach(kWatchedPaths, (p) => watcher.watchPath(p));
 
 let graceTimer;
@@ -110,16 +110,39 @@ async function restart() {
   start();
 }
 
+function debounce(fn, delay) {
+  let promise = Promise.resolve();
+
+  Object.defineProperty(debouncedFn, 'ended', { get: () => promise });
+
+  return debouncedFn;
+
+  function debouncedFn() {
+    const timer = new Promise(r => setTimeout(r, delay).unref());
+
+    promise = Promise.all([ promise, timer ]).then(() => {
+      if (promise === current) return fn();
+    });
+
+    const current = promise;
+    return current;
+  }
+}
+
 (async () => {
   emitExperimentalWarning('Watch mode');
 
   try {
     start();
 
+    const debouncedRestart = debounce(restart, 200);
+
     // eslint-disable-next-line no-unused-vars
     for await (const _ of on(watcher, 'changed')) {
-      await restart();
+      debouncedRestart();
     }
+
+    await debouncedRestart.ended;
   } catch (error) {
     triggerUncaughtException(error, true /* fromPromise */);
   }


### PR DESCRIPTION
In the current implementation, running in watch mode will **not** debounce the restart of the script when multiple files are updated simultaneously (e.g. after changing git branch, or triggering a build of a local dependency). See #51954.

This is an example of how this could be fixed.

I am not familiar with contributing to this project. Feel free to close.





<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
