### PR TITLE
util: detecting terminal capabilities in styleText

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1803,7 +1803,10 @@ added: REPLACEME
 * `format` {string} A text format defined in `util.inspect.colors`.
 * `text` {string} The text to to be formatted.
 
-This function returns a formatted text considering the `format` passed.
+This function returns a formatted text considering the `format` passed
+for printing in a terminal, it is aware of the terminal's capabilities
+and act according to the configuration set via `NO_COLORS`,
+`NODE_DISABLE_COLORS` and `FORCE_COLOR` environment variables.
 
 ```mjs
 import { styleText } from 'node:util';

--- a/lib/util.js
+++ b/lib/util.js
@@ -204,6 +204,12 @@ function pad(n) {
  * @returns {string}
  */
 function styleText(format, text) {
+  const env = process.env;
+  if (!process.stdout.isTTY ||
+    (!env.FORCE_COLOR && (env.NO_COLOR || env.NODE_DISABLE_COLORS))) {
+    return text;
+  }
+
   validateString(text, 'text');
   const formatCodes = inspect.colors[format];
   if (formatCodes == null) {

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -2,6 +2,11 @@
 require('../common');
 const assert = require('assert');
 const util = require('util');
+const { execSync } = require('child_process');
+const { EOL } = require('os');
+const styled = '\u001b[31mtest\u001b[39m';
+const noChange = 'test';
+
 
 [
   undefined,
@@ -32,4 +37,27 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
-assert.strictEqual(util.styleText('red', 'test'), '\u001b[31mtest\u001b[39m');
+assert.strictEqual(util.styleText('red', 'test'), styled);
+
+function checkCase(isTTY, env, expected) {
+  process.stdout.isTTY = isTTY;
+  const code = `
+    process.stdout.isTTY = ${isTTY}; console.log(util.styleText('red', 'test'));
+  `;
+  const output = execSync(`${process.execPath} -e "${code}"`, { env }).toString();
+  assert.strictEqual(output, expected + EOL);
+}
+
+
+[
+  { isTTY: true, env: {}, expected: styled },
+  { isTTY: false, env: {}, expected: noChange },
+  { isTTY: true, env: { NODE_DISABLE_COLORS: 1 }, expected: noChange },
+  { isTTY: true, env: { NO_COLOR: 1 }, expected: noChange },
+  { isTTY: true, env: { FORCE_COLOR: 1 }, expected: styled },
+  { isTTY: true, env: { FORCE_COLOR: 1, NODE_DISABLE_COLORS: 1 }, expected: styled },
+  { isTTY: false, env: { FORCE_COLOR: 1, NO_COLOR: 1, NODE_DISABLE_COLORS: 1 }, expected: noChange },
+  { isTTY: true, env: { FORCE_COLOR: 1, NO_COLOR: 1, NODE_DISABLE_COLORS: 1 }, expected: styled },
+].forEach((testCase) => {
+  checkCase(testCase.isTTY, testCase.env, testCase.expected);
+});


### PR DESCRIPTION
This PR adds some detection of the process configuration for printing colors when using `util.styleText` 