### PR TITLE
Remove Redundant Path Resolution in Internal File System Utilities

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -743,31 +743,10 @@ const validatePath = hideStackFrames((path, propName = 'path') => {
   );
 });
 
-// TODO(rafaelgss): implement the path.resolve on C++ side
-// See: https://github.com/nodejs/node/pull/44004#discussion_r930958420
-// The permission model needs the absolute path for the fs_permission
-const resolvePath = pathModule.resolve;
-const { isBuffer: BufferIsBuffer, from: BufferFrom } = Buffer;
-const BufferToString = uncurryThis(Buffer.prototype.toString);
-function possiblyTransformPath(path) {
-  if (permission.isEnabled()) {
-    if (typeof path === 'string') {
-      return resolvePath(path);
-    }
-    assert(isUint8Array(path));
-    if (!BufferIsBuffer(path)) path = BufferFrom(path);
-    // Avoid Buffer.from() and use a C++ binding instead to encode the result
-    // of path.resolve() in order to prevent path traversal attacks that
-    // monkey-patch Buffer internals.
-    return encodeUtf8String(resolvePath(BufferToString(path)));
-  }
-  return path;
-}
-
 const getValidatedPath = hideStackFrames((fileURLOrPath, propName = 'path') => {
   const path = toPathIfFileURL(fileURLOrPath);
   validatePath(path, propName);
-  return possiblyTransformPath(path);
+  return path;
 });
 
 const getValidatedFd = hideStackFrames((fd, propName = 'fd') => {
@@ -1002,7 +981,6 @@ module.exports = {
   getValidatedPath,
   getValidMode,
   handleErrorFromBinding,
-  possiblyTransformPath,
   preprocessSymlinkDestination,
   realpathCacheKey: Symbol('realpathCacheKey'),
   getStatFsFromBinding,


### PR DESCRIPTION
### Summary
This pull request eliminates redundant path resolution within the internal file system (`fs`) utilities. Previously, this resolution was implemented to prevent path traversal via relative paths. However, with the mitigation of this threat, the code responsible for converting absolute paths has become unnecessary.

### Proof of Concept
```javascript
process.cwd = () => '../'; // Sets CWD to relative
fs.readFileSync('unsafe/file.txt')
```
Executing this code with `--experimental-permission --allow-fs-read=safe` will result in `Error: Access to this API has been restricted`, even though `path.resolve` returns a relative path. Therefore, the conversion of absolute paths is no longer essential.

### Related Issues
> "Due to the PrefixRadixTree (fs_permission) lookup, relative paths are not supported. For this reason, the possiblyTransformPath was needed. I do have plans to create a pretty similar path.resolve on the C++ side so the possiblyTransformPath won't be needed, but I'll do it in a second iteration."

- #44004 introduced this functionality initially when relative paths posed a threat. However, with the current landscape, they are no longer necessary.
> A discussion [here](https://github.com/nodejs/node/pull/44004#discussion_r930958420) mentioned this change, but did not end up implementing it. While this code is redundant, I can't locate the original pull-request that made it so.

> [!NOTE]
> I am a JS dev, but not a C one. While I know that this all works from the JS side, I am no expert in identifying the C code that makes this redundant, and the commit that added it.