### PR TITLE
watch: debounce restart in watch mode

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -6,6 +6,7 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,
+  PromiseResolve,
   StringPrototypeStartsWith,
 } = primordials;
 
@@ -110,16 +111,62 @@ async function restart() {
   start();
 }
 
+function debounce(fn, delay) {
+  let state = 'idle';
+  let timer;
+  let promise = PromiseResolve();
+
+  const afterDelay = () => {
+    state = 'running';
+    promise = promise
+      .then(() => fn())
+      .catch((error) => {
+        triggerUncaughtException(error, true /* fromPromise */);
+      })
+      .finally(() => {
+        if (state === 'running') {
+          state = 'idle';
+        } else if (state === 'pending') {
+          state = 'debouncing';
+          timer = setTimeout(afterDelay, delay);
+        }
+      });
+  };
+
+  return debouncedFn;
+
+  function debouncedFn(destroy = false) {
+    if (destroy) {
+      clearTimeout(timer);
+      state = 'destroyed';
+    } else if (state === 'idle') {
+      state = 'debouncing';
+      timer = setTimeout(afterDelay, delay);
+    } else if (state === 'debouncing') {
+      clearTimeout(timer);
+      timer = setTimeout(afterDelay, delay);
+    } else if (state === 'running') {
+      state = 'pending';
+    }
+
+    return promise;
+  }
+}
+
 (async () => {
   emitExperimentalWarning('Watch mode');
 
   try {
     start();
 
+    const debouncedRestart = debounce(restart, 200);
+
     // eslint-disable-next-line no-unused-vars
     for await (const _ of on(watcher, 'changed')) {
-      await restart();
+      debouncedRestart();
     }
+
+    await debouncedRestart(true);
   } catch (error) {
     triggerUncaughtException(error, true /* fromPromise */);
   }


### PR DESCRIPTION
This implementation ignores any `changed` event triggered by the file watcher  that might occur before an application restart. This will significatively reduce the number of restarts of the app in watch mode.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
