### PR TITLE
Revert "build: workaround for node-core-utils"

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -10,9 +10,8 @@ on:
 
 concurrency: ${{ github.workflow }}
 
-# todo (node-fetch not working on 18, waiting for node-core-utils to fix)
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: lts/*
 
 permissions:
   contents: read


### PR DESCRIPTION
This reverts commit b2a60839808b3778c2a3424d9098a7acc4b77f5d.

The [auto-start-ci](https://github.com/nodejs/node/blob/main/.github/workflows/auto-start-ci.yml) workflow is currently broken by the latest node-core-utils. e.g.
https://github.com/nodejs/node/actions/runs/8158770866/job/22301449831#step:6:17 (note the workflow passed but failed to start any CIs)
```console
/opt/hostedtoolcache/node/16.20.2/x64/lib/node_modules/@node-core/utils/node_modules/undici/lib/web/fetch/response.js:507
  ReadableStream
  ^

ReferenceError: ReadableStream is not defined
    at Object.<anonymous> (/opt/hostedtoolcache/node/16.20.2/x64/lib/node_modules/@node-core/utils/node_modules/undici/lib/web/fetch/response.js:507:3)
    at Module._compile (node:internal/modules/cjs/loader:1198:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1252:10)
    at Module.load (node:internal/modules/cjs/loader:1076:32)
    at Function.Module._load (node:internal/modules/cjs/loader:911:12)
    at Module.require (node:internal/modules/cjs/loader:1100:19)
    at require (node:internal/modules/cjs/helpers:119:[18](https://github.com/nodejs/node/actions/runs/8158770866/job/22301449831#step:6:19))
    at Object.<anonymous> (/opt/hostedtoolcache/node/16.20.2/x64/lib/node_modules/@node-core/utils/node_modules/undici/lib/web/fetch/index.js:11:5)
    at Module._compile (node:internal/modules/cjs/loader:1[19](https://github.com/nodejs/node/actions/runs/8158770866/job/22301449831#step:6:20)8:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1[25](https://github.com/nodejs/node/actions/runs/8158770866/job/22301449831#step:6:26)2:10)
```

From @targos in [Slack](https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1709653768309839):

> The workflow should be updated, Node.js 16 support was removed in https://github.com/nodejs/node-core-utils/releases/tag/v4.0.0
> Also node-fetch was removed by https://github.com/nodejs/node-core-utils/pull/666/files
> 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
