### PR TITLE
[v20.x] backport libuv wtf-8 decoding fix

### DIFF
--- a/deps/uv/src/win/fs.c
+++ b/deps/uv/src/win/fs.c
@@ -176,9 +176,11 @@ static int32_t fs__decode_wtf8_char(const char** input) {
   if ((b4 & 0xC0) != 0x80)
     return -1; /* invalid: not a continuation byte */
   code_point = (code_point << 6) | (b4 & 0x3F);
-  if (b1 <= 0xF4)
+  if (b1 <= 0xF4) {
+    code_point &= 0x1FFFFF;
     if (code_point <= 0x10FFFF)
       return code_point; /* four-byte character */
+  }
 
   /* code point too large */
   return -1;

--- a/test/parallel/test-fs-operations-with-surrogate-pairs.js
+++ b/test/parallel/test-fs-operations-with-surrogate-pairs.js
@@ -1,0 +1,31 @@
+'use strict';
+
+require('../common');
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+describe('File operations with filenames containing surrogate pairs', () => {
+  it('should write, read, and delete a file with surrogate pairs in the filename', () => {
+    // Create a temporary directory
+    const tempdir = fs.mkdtempSync(tmpdir.resolve('emoji-fruit-🍇 🍈 🍉 🍊 🍋'));
+    assert.strictEqual(fs.existsSync(tempdir), true);
+
+    const filename = '🚀🔥🛸.txt';
+    const content = 'Test content';
+
+    // Write content to a file
+    fs.writeFileSync(path.join(tempdir, filename), content);
+
+    // Read content from the file
+    const readContent = fs.readFileSync(path.join(tempdir, filename), 'utf8');
+
+    // Check if the content matches
+    assert.strictEqual(readContent, content);
+
+  });
+});


### PR DESCRIPTION
This backports https://github.com/libuv/libuv/commit/d09441c to Node.js 20 to fix a long standing regression in the way filenames are handled on Windows. On Node.js 21 this was fixed by the update to libuv 1.47.0, but that version cannot be backported to Node.js 20 because [libuv have dropped support for macOS <11](https://github.com/libuv/libuv/issues/4204) and we [target macOS 10.15 for Node.js 20](https://github.com/nodejs/node/blob/4036ffd9096968c27cb098c4640c91b5e2a89b5c/common.gypi#L571).

Refs: https://github.com/nodejs/node/issues/48673

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
