### PR TITLE
meta: pass Codecov upload token to codecov action

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -71,3 +71,4 @@ jobs:
         uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab  # v4.1.0
         with:
           directory: ./coverage
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -71,3 +71,4 @@ jobs:
         uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab  # v4.1.0
         with:
           directory: ./coverage
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -70,3 +70,4 @@ jobs:
         uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab  # v4.1.0
         with:
           directory: ./coverage
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This is required since version 4 of the action (except for pull requests opened from forks).

Refs: https://github.com/codecov/codecov-action/blob/e7748388508dfb57a188b1593a92c9ca8d865365/README.md#v4-release
