### PR TITLE
[v20.x backport] src: disable uncaught exception abortion for ESM syntax detection

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1469,6 +1469,7 @@ void ContextifyContext::ContainsModuleSyntax(
       String::NewFromUtf8(isolate, "__dirname").ToLocalChecked()};
 
   TryCatchScope try_catch(env);
+  ShouldNotAbortOnUncaughtScope no_abort_scope(env);
 
   ContextifyContext::CompileFunctionAndCacheResult(env,
                                                    context,

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -235,3 +235,23 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     }
   });
 });
+
+// Validate temporarily disabling `--abort-on-uncaught-exception`
+// while running `containsModuleSyntax`.
+// Ref: https://github.com/nodejs/node/issues/50878
+describe('Wrapping a `require` of an ES module while using `--abort-on-uncaught-exception`', () => {
+  it('should work', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+      '--abort-on-uncaught-exception',
+      '--eval',
+      'assert.throws(() => require("./package-type-module/esm.js"), { code: "ERR_REQUIRE_ESM" })',
+    ], {
+      cwd: fixtures.path('es-modules'),
+    });
+
+    strictEqual(stderr, '');
+    strictEqual(stdout, '');
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+});


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/50987
Fixes: https://github.com/nodejs/node/issues/50878

I confirmed that **Wrapping a `require` of an ES module while using `--abort-on-uncaught-exception`** fails without the fix

PS. I read through [Backporting release lines](https://github.com/nodejs/node/blob/384fd1787634c13b3e5d2f225076d2175dc3b96b/doc/contributing/backporting-to-release-lines.md) and [Contributing](https://github.com/nodejs/node/blob/v20.x-staging/CONTRIBUTING.md) and I'm still not sure what should I do to get the fix backported. 

a) Is it still "baking", is the process automated so should I just wait a bit more?
b) Should I just add some label `backport-requested-vN.x` and because there are no conflicts it will be automatically backported? I guess it's not possible.
c) Was it decided that fix shouldn't land in LTS? 

Please let me know if I should close this PR and request it some other way. :)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
