### PR TITLE
test_runner: abort unfinished tests on async error

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -74,7 +74,7 @@ function createProcessEventHandler(eventName, rootTest) {
     }
 
     test.fail(new ERR_TEST_FAILURE(err, eventName));
-    test.postRun();
+    test.abortController.abort();
   };
 }
 

--- a/test/fixtures/test-runner/output/describe_it.snapshot
+++ b/test/fixtures/test-runner/output/describe_it.snapshot
@@ -494,10 +494,9 @@ not ok 50 - custom inspect symbol that throws fail
         *
         *
         *
-        *
-        *
-        *
         async Promise.all (index 0)
+        *
+        *
       ...
     1..2
 not ok 51 - subtest sync throw fails
@@ -627,7 +626,6 @@ not ok 54 - timeouts
       error: 'custom error'
       code: 'ERR_TEST_FAILURE'
       stack: |-
-        *
         *
       ...
     1..2

--- a/test/fixtures/test-runner/output/junit_reporter.snapshot
+++ b/test/fixtures/test-runner/output/junit_reporter.snapshot
@@ -372,8 +372,6 @@ Error [ERR_TEST_FAILURE]: thrown from subtest sync throw fails at second
       *
       *
       *
-      *
-      *
 }
 			</failure>
 		</testcase>

--- a/test/fixtures/test-runner/output/output.snapshot
+++ b/test/fixtures/test-runner/output/output.snapshot
@@ -552,8 +552,6 @@ not ok 51 - custom inspect symbol that throws fail
         *
         *
         *
-        *
-        *
       ...
     1..2
 not ok 52 - subtest sync throw fails

--- a/test/fixtures/test-runner/output/output_cli.snapshot
+++ b/test/fixtures/test-runner/output/output_cli.snapshot
@@ -552,8 +552,6 @@ not ok 51 - custom inspect symbol that throws fail
         *
         *
         *
-        *
-        *
       ...
     1..2
 not ok 52 - subtest sync throw fails

--- a/test/fixtures/test-runner/output/spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/spec_reporter.snapshot
@@ -229,8 +229,6 @@
         *
         *
         *
-        *
-        *
 
  subtest sync throw fails (*ms)
 
@@ -507,8 +505,6 @@
 *
  sync throw fails at second (*ms)
   Error: thrown from subtest sync throw fails at second
-      *
-      *
       *
       *
       *

--- a/test/fixtures/test-runner/output/spec_reporter_cli.snapshot
+++ b/test/fixtures/test-runner/output/spec_reporter_cli.snapshot
@@ -229,8 +229,6 @@
         *
         *
         *
-        *
-        *
 
  subtest sync throw fails (*ms)
 
@@ -507,8 +505,6 @@
 *
  sync throw fails at second (*ms)
   Error: thrown from subtest sync throw fails at second
-      *
-      *
       *
       *
       *

--- a/test/fixtures/test-runner/output/unfinished-suite-async-error.js
+++ b/test/fixtures/test-runner/output/unfinished-suite-async-error.js
@@ -1,0 +1,14 @@
+'use strict';
+const { describe, it } = require('node:test');
+
+describe('unfinished suite with asynchronous error', () => {
+  it('uses callback', (t, done) => {
+    setImmediate(() => {
+      throw new Error('callback test does not complete');
+    });
+  });
+
+  it('should pass 1');
+});
+
+it('should pass 2');

--- a/test/fixtures/test-runner/output/unfinished-suite-async-error.snapshot
+++ b/test/fixtures/test-runner/output/unfinished-suite-async-error.snapshot
@@ -1,0 +1,43 @@
+TAP version 13
+# Subtest: unfinished suite with asynchronous error
+    # Subtest: uses callback
+    not ok 1 - uses callback
+      ---
+      duration_ms: *
+      location: '/test/fixtures/test-runner/output/unfinished-suite-async-error.js:(LINE):3'
+      failureType: 'uncaughtException'
+      error: 'callback test does not complete'
+      code: 'ERR_TEST_FAILURE'
+      stack: |-
+        *
+        *
+      ...
+    # Subtest: should pass 1
+    ok 2 - should pass 1
+      ---
+      duration_ms: *
+      ...
+    1..2
+not ok 1 - unfinished suite with asynchronous error
+  ---
+  duration_ms: *
+  type: 'suite'
+  location: '/test/fixtures/test-runner/output/unfinished-suite-async-error.js:(LINE):1'
+  failureType: 'subtestsFailed'
+  error: '1 subtest failed'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: should pass 2
+ok 2 - should pass 2
+  ---
+  duration_ms: *
+  ...
+1..2
+# tests 3
+# suites 1
+# pass 2
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -111,6 +111,7 @@ const tests = [
   { name: 'test-runner/output/output_cli.js' },
   { name: 'test-runner/output/name_pattern.js' },
   { name: 'test-runner/output/name_pattern_with_only.js' },
+  { name: 'test-runner/output/unfinished-suite-async-error.js' },
   { name: 'test-runner/output/unresolved_promise.js' },
   { name: 'test-runner/output/default_output.js', transform: specTransform, tty: true },
   { name: 'test-runner/output/arbitrary-output.js' },


### PR DESCRIPTION
This commit updates the test runner's `uncaughtException` handler to abort tests instead of assuming they finished running.

Fixes: https://github.com/nodejs/node/issues/51381

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
