### PR TITLE
test_runner: avoid overwriting root start time

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -608,7 +608,7 @@ class Test extends AsyncResource {
     if (this.parent !== null) {
       this.parent.activeSubtests++;
     }
-    this.startTime = hrtime();
+    this.startTime ??= hrtime();
 
     if (this[kShouldAbort]()) {
       this.postRun();

--- a/test/fixtures/test-runner/root-duration.mjs
+++ b/test/fixtures/test-runner/root-duration.mjs
@@ -1,0 +1,7 @@
+import { test, after } from 'node:test';
+
+after(() => {});
+
+test('a test with some delay', (t, done) => {
+  setTimeout(done, 50);
+});

--- a/test/parallel/test-runner-root-duration.js
+++ b/test/parallel/test-runner-root-duration.js
@@ -1,0 +1,25 @@
+'use strict';
+const { spawnPromisified } = require('../common');
+const fixtures = require('../common/fixtures');
+const { strictEqual } = require('node:assert');
+const { test } = require('node:test');
+
+test('root duration is longer than test duration', async () => {
+  const {
+    code,
+    stderr,
+    stdout,
+  } = await spawnPromisified(process.execPath, [
+    fixtures.path('test-runner/root-duration.mjs'),
+  ]);
+
+  strictEqual(code, 0);
+  strictEqual(stderr, '');
+  const durations = [...stdout.matchAll(/duration_ms:? ([.\d]+)/g)];
+  strictEqual(durations.length, 2);
+  const testDuration = Number.parseFloat(durations[0][1]);
+  const rootDuration = Number.parseFloat(durations[1][1]);
+  strictEqual(Number.isNaN(testDuration), false);
+  strictEqual(Number.isNaN(rootDuration), false);
+  strictEqual(rootDuration >= testDuration, true);
+});


### PR DESCRIPTION
This commit ensures the root test start time is not overwritten when top level `before()`/`after()` hooks are run.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
