### PR TITLE
src: add uv_get_available_memory to report and process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1127,6 +1127,22 @@ is unknown, `undefined` is returned.
 See [`uv_get_constrained_memory`][uv_get_constrained_memory] for more
 information.
 
+## `process.availableMemory()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* {number}
+
+Gets the amount of free memory that is still available to the process
+(in bytes).
+
+See [`uv_get_available_memory`][uv_get_available_memory] for more
+information.
+
 ## `process.cpuUsage([previousValue])`
 
 <!-- YAML
@@ -4026,6 +4042,7 @@ cases:
 [process_warning]: #event-warning
 [report documentation]: report.md
 [terminal raw mode]: tty.md#readstreamsetrawmodemode
+[uv_get_available_memory]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_available_memory
 [uv_get_constrained_memory]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory
 [uv_rusage_t]: https://docs.libuv.org/en/v1.x/misc.html#c.uv_rusage_t
 [wikipedia_major_fault]: https://en.wikipedia.org/wiki/Page_fault#Major

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -178,6 +178,7 @@ const rawMethods = internalBinding('process_methods');
   process.resourceUsage = wrapped.resourceUsage;
   process.memoryUsage = wrapped.memoryUsage;
   process.constrainedMemory = rawMethods.constrainedMemory;
+  process.availableMemory = rawMethods.availableMemory;
   process.kill = wrapped.kill;
   process.exit = wrapped.exit;
 

--- a/src/env.cc
+++ b/src/env.cc
@@ -1843,25 +1843,6 @@ void Environment::DeserializeProperties(const EnvSerializeInfo* info) {
   should_abort_on_uncaught_toggle_.Deserialize(ctx);
 }
 
-uint64_t GuessMemoryAvailableToTheProcess() {
-  uint64_t free_in_system = uv_get_free_memory();
-  size_t allowed = uv_get_constrained_memory();
-  if (allowed == 0) {
-    return free_in_system;
-  }
-  size_t rss;
-  int err = uv_resident_set_memory(&rss);
-  if (err) {
-    return free_in_system;
-  }
-  if (allowed < rss) {
-    // Something is probably wrong. Fallback to the free memory.
-    return free_in_system;
-  }
-  // There may still be room for swap, but we will just leave it here.
-  return allowed - rss;
-}
-
 void Environment::BuildEmbedderGraph(Isolate* isolate,
                                      EmbedderGraph* graph,
                                      void* data) {
@@ -1966,7 +1947,7 @@ size_t Environment::NearHeapLimitCallback(void* data,
         static_cast<uint64_t>(old_gen_size),
         static_cast<uint64_t>(young_gen_size + old_gen_size));
 
-  uint64_t available = GuessMemoryAvailableToTheProcess();
+  uint64_t available = uv_get_available_memory();
   // TODO(joyeecheung): get a better estimate about the native memory
   // usage into the overhead, e.g. based on the count of objects.
   uint64_t estimated_overhead = max_young_gen_size;

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -216,6 +216,11 @@ static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static void GetAvailableMemory(const FunctionCallbackInfo<Value>& args) {
+  uint64_t value = uv_get_available_memory();
+  args.GetReturnValue().Set(static_cast<double>(value));
+}
+
 void RawDebug(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.Length() == 1 && args[0]->IsString() &&
         "must be called with a single string");
@@ -633,6 +638,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "umask", Umask);
   SetMethod(isolate, target, "memoryUsage", MemoryUsage);
   SetMethod(isolate, target, "constrainedMemory", GetConstrainedMemory);
+  SetMethod(isolate, target, "availableMemory", GetAvailableMemory);
   SetMethod(isolate, target, "rss", Rss);
   SetMethod(isolate, target, "cpuUsage", CPUUsage);
   SetMethod(isolate, target, "resourceUsage", ResourceUsage);
@@ -674,6 +680,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(RawDebug);
   registry->Register(MemoryUsage);
   registry->Register(GetConstrainedMemory);
+  registry->Register(GetAvailableMemory);
   registry->Register(Rss);
   registry->Register(CPUUsage);
   registry->Register(ResourceUsage);

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -638,13 +638,8 @@ static void PrintResourceUsage(JSONWriter* writer) {
     writer->json_keyvalue("constrained_memory", constrained_memory);
   }
 
-  // See GuessMemoryAvailableToTheProcess
-  if (!err && constrained_memory && constrained_memory >= rss) {
-    uint64_t available_memory = constrained_memory - rss;
-    writer->json_keyvalue("available_memory", available_memory);
-  } else {
-    writer->json_keyvalue("available_memory", free_memory);
-  }
+  uint64_t available_memory = uv_get_available_memory();
+  writer->json_keyvalue("available_memory", available_memory);
 
   if (uv_getrusage(&rusage) == 0) {
     double user_cpu =

--- a/test/parallel/test-process-available-memory.js
+++ b/test/parallel/test-process-available-memory.js
@@ -1,0 +1,5 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const availableMemory = process.availableMemory();
+assert(typeof availableMemory, 'number');


### PR DESCRIPTION
Add `uv_get_available_memory` to `Diagnostic Report` and `process`.
cc @joyeecheung @bnoordhuis
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
