### PR TITLE
module: fix detect-module not retrying as ESM for code that errors only in CommonJS

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -799,7 +799,7 @@ CommonJS. This includes the following:
 * `export` statements.
 * `import.meta` references.
 * `await` at the top level of a module.
-* `const` declarations of the CommonJS wrapper variables (`require`, `module`,
+* Lexical redeclarations of the CommonJS wrapper variables (`require`, `module`,
   `exports`, `__dirname`, `__filename`).
 
 ### `--experimental-import-meta-resolve`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -777,7 +777,7 @@ added:
   - v20.10.0
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 Node.js will inspect the source code of ambiguous input to determine whether it
 contains ES module syntax; if such syntax is detected, the input will be treated
@@ -792,9 +792,15 @@ Ambiguous input is defined as:
   `--experimental-default-type` are specified.
 
 ES module syntax is defined as syntax that would throw when evaluated as
-CommonJS. This includes `import` and `export` statements and `import.meta`
-references. It does _not_ include `import()` expressions, which are valid in
-CommonJS.
+CommonJS. This includes the following:
+
+* `import` statements (but _not_ `import()` expressions, which are valid in
+  CommonJS).
+* `export` statements.
+* `import.meta` references.
+* `await` at the top level of a module.
+* `const` declarations of the CommonJS wrapper variables (`require`, `module`,
+  `exports`, `__dirname`, `__filename`).
 
 ### `--experimental-import-meta-resolve`
 

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1409,6 +1409,25 @@ constexpr std::array<std::string_view, 3> esm_syntax_error_messages = {
     "Unexpected token 'export'",                     // `export` statements
     "Cannot use 'import.meta' outside a module"};    // `import.meta` references
 
+// Another class of error messages that we need to check for are syntax errors
+// where the syntax throws when parsed as CommonJS but succeeds when parsed as
+// ESM. So far, the cases we've found are:
+// - CommonJS module variables (`module`, `exports`, `require`, `__filename`,
+//   `__dirname`): if the user writes code such as `const module =` in the top
+//   level of a CommonJS module, it will throw a syntax error; but the same
+//   code is valid in ESM.
+// - Top-level `await`: if the user writes `await` at the top level of a
+//   CommonJS module, it will throw a syntax error; but the same code is valid
+//   in ESM.
+constexpr std::array<std::string_view, 6> throws_only_in_cjs_error_messages = {
+    "Identifier 'module' has already been declared",
+    "Identifier 'exports' has already been declared",
+    "Identifier 'require' has already been declared",
+    "Identifier '__filename' has already been declared",
+    "Identifier '__dirname' has already been declared",
+    "await is only valid in async functions and "
+    "the top level bodies of modules"};
+
 void ContextifyContext::ContainsModuleSyntax(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1476,19 +1495,61 @@ void ContextifyContext::ContainsModuleSyntax(
                                                    id_symbol,
                                                    try_catch);
 
-  bool found_error_message_caused_by_module_syntax = false;
+  bool should_retry_as_esm = false;
   if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
     Utf8Value message_value(env->isolate(), try_catch.Message()->Get());
     auto message = message_value.ToStringView();
 
     for (const auto& error_message : esm_syntax_error_messages) {
       if (message.find(error_message) != std::string_view::npos) {
-        found_error_message_caused_by_module_syntax = true;
+        should_retry_as_esm = true;
+        break;
+      }
+    }
+
+    for (const auto& error_message : throws_only_in_cjs_error_messages) {
+      if (message.find(error_message) != std::string_view::npos) {
+        // Try parsing again where the user's code is wrapped within an async
+        // function. If the new parse succeeds, then the error was caused by
+        // either a top-level declaration of one of the CommonJS module
+        // variables, or a top-level `await`.
+        TryCatchScope second_parse_try_catch(env);
+        Local<String> wrapped_code =
+            String::Concat(isolate,
+                           String::NewFromUtf8(isolate, "(async function() {")
+                               .ToLocalChecked(),
+                           code);
+        wrapped_code = String::Concat(
+            isolate,
+            wrapped_code,
+            String::NewFromUtf8(isolate, "})();").ToLocalChecked());
+        ScriptCompiler::Source wrapped_source =
+            GetCommonJSSourceInstance(isolate,
+                                      wrapped_code,
+                                      filename,
+                                      0,
+                                      0,
+                                      host_defined_options,
+                                      nullptr);
+        ContextifyContext::CompileFunctionAndCacheResult(
+            env,
+            context,
+            &wrapped_source,
+            std::move(params),
+            std::vector<Local<Object>>(),
+            options,
+            true,
+            id_symbol,
+            second_parse_try_catch);
+        if (!second_parse_try_catch.HasCaught() &&
+            !second_parse_try_catch.HasTerminated()) {
+          should_retry_as_esm = true;
+        }
         break;
       }
     }
   }
-  args.GetReturnValue().Set(found_error_message_caused_by_module_syntax);
+  args.GetReturnValue().Set(should_retry_as_esm);
 }
 
 static void CompileFunctionForCJSLoader(

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1517,9 +1517,9 @@ void ContextifyContext::ContainsModuleSyntax(
           TryCatchScope second_parse_try_catch(env);
           Local<String> wrapped_code =
               String::Concat(isolate,
-                            String::NewFromUtf8(isolate, "(async function() {")
-                                .ToLocalChecked(),
-                            code);
+                             String::NewFromUtf8(isolate, "(async function() {")
+                                 .ToLocalChecked(),
+                             code);
           wrapped_code = String::Concat(
               isolate,
               wrapped_code,

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -250,6 +250,19 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
       strictEqual(signal, null);
     });
 
+    it('permits top-level `await` above import/export syntax', async () => {
+      const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--experimental-detect-module',
+        '--eval',
+        'await Promise.resolve(); import "node:os"; console.log("executed");',
+      ]);
+
+      strictEqual(stderr, '');
+      strictEqual(stdout, 'executed\n');
+      strictEqual(code, 0);
+      strictEqual(signal, null);
+    });
+
     it('still throws on `await` in an ordinary sync function', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--experimental-detect-module',

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -276,6 +276,19 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
       strictEqual(signal, null);
     });
 
+    it('throws on undefined `require` when top-level `await` triggers ESM parsing', async () => {
+      const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--experimental-detect-module',
+        '--eval',
+        'const fs = require("node:fs"); await Promise.resolve();',
+      ]);
+
+      match(stderr, /ReferenceError: require is not defined in ES module scope/);
+      strictEqual(stdout, '');
+      strictEqual(code, 1);
+      strictEqual(signal, null);
+    });
+
     it('permits declaration of CommonJS module variables', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--experimental-detect-module',

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -300,6 +300,19 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
       strictEqual(code, 0);
       strictEqual(signal, null);
     });
+
+    it('still throws on double `const` declaration not at the top level', async () => {
+      const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--experimental-detect-module',
+        '--eval',
+        'function fn() { const require = 1; const require = 2; } fn();',
+      ]);
+
+      match(stderr, /SyntaxError: Identifier 'require' has already been declared/);
+      strictEqual(stdout, '');
+      strictEqual(code, 1);
+      strictEqual(signal, null);
+    });
   });
 });
 

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -287,6 +287,19 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
       strictEqual(code, 0);
       strictEqual(signal, null);
     });
+
+    it('permits declaration of CommonJS module variables above import/export', async () => {
+      const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--experimental-detect-module',
+        '--eval',
+        'const module = 3; import "node:os"; console.log("executed");',
+      ]);
+
+      strictEqual(stderr, '');
+      strictEqual(stdout, 'executed\n');
+      strictEqual(code, 0);
+      strictEqual(signal, null);
+    });
   });
 });
 

--- a/test/fixtures/es-modules/package-without-type/commonjs-wrapper-variables.js
+++ b/test/fixtures/es-modules/package-without-type/commonjs-wrapper-variables.js
@@ -1,0 +1,6 @@
+const exports = "exports";
+const require = "require";
+const module = "module";
+const __filename = "__filename";
+const __dirname = "__dirname";
+console.log(exports, require, module, __filename, __dirname);


### PR DESCRIPTION
Fixes #50917, using the solution described in https://github.com/nodejs/node/issues/50917#issuecomment-1986412521.

The general algorithm for `--experimental-detect-module` is to try to parse as CommonJS, and if a syntax error is thrown that corresponds to ESM syntax (`import` or `export`, or `import.meta`), try again as ESM. The edge case pointed out by #50917 is when there’s syntax that throws in CommonJS but parses in ESM, and this syntax is _above_ the first ESM syntax (so top-level `await`, or a declaration of a variable with the same name as one of the CommonJS module wrapper variables such as `const require =`, on the first line or any line above the first `import` or `export`).

The tricky thing is that the errors thrown by top-level `await` or `const require` in CommonJS are the _same_ errors as thrown by typing `await` in any ordinary sync function, or by declaring `require` twice in user code (e.g. `const require = 1; const require = 2`). So we only want to retry parsing as ESM when these errors are because the `await` or problematic variable declaration _is at the top level,_ where it throws in CommonJS but parses in ESM.

To determine this, this PR creates a new error path where if the CommonJS parse returns a syntax error corresponding to either of these cases, we do a special second CommonJS parse of the code wrapped in an async function. This wrapper function creates a new scope, so `const require` is no longer a problematic redeclaration; and `await` no longer throws because it’s within an async function. This wrapper only affects the top level, so `await` in a sync function farther down or variable redeclarations farther down (or two `const` declarations at the top level) will still throw; but the code permitted in ESM parses successfully. If this second parse doesn’t throw any errors, we resume the detection algorithm and try parsing as ESM.

@nodejs/loaders @chjj @meyfa @joyeecheung 