### PR TITLE
test_runner: ref test timeout timers

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -89,7 +89,6 @@ function stopTest(timeout, signal) {
     disposeFunction = abortListener[SymbolDispose];
   } else {
     timer = setTimeout(() => deferred.resolve(), timeout);
-    timer.unref();
 
     ObjectDefineProperty(deferred, 'promise', {
       __proto__: null,

--- a/test/fixtures/test-runner/output/timeout_ref.js
+++ b/test/fixtures/test-runner/output/timeout_ref.js
@@ -1,0 +1,7 @@
+'use strict';
+const { test } = require('node:test');
+
+test('callback test that times out', { timeout: 1 }, (t, done) => {});
+test('promise test that times out', { timeout: 1 }, () => {
+  return new Promise(() => {});
+});

--- a/test/fixtures/test-runner/output/timeout_ref.snapshot
+++ b/test/fixtures/test-runner/output/timeout_ref.snapshot
@@ -1,0 +1,28 @@
+TAP version 13
+# Subtest: callback test that times out
+not ok 1 - callback test that times out
+  ---
+  duration_ms: *
+  location: '/test/fixtures/test-runner/output/timeout_ref.js:(LINE):1'
+  failureType: 'testTimeoutFailure'
+  error: 'test timed out after 1ms'
+  code: 'ERR_TEST_FAILURE'
+  ...
+# Subtest: promise test that times out
+not ok 2 - promise test that times out
+  ---
+  duration_ms: *
+  location: '/test/fixtures/test-runner/output/timeout_ref.js:(LINE):1'
+  failureType: 'testTimeoutFailure'
+  error: 'test timed out after 1ms'
+  code: 'ERR_TEST_FAILURE'
+  ...
+1..2
+# tests 2
+# suites 0
+# pass 0
+# fail 0
+# cancelled 2
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -94,6 +94,7 @@ const tests = [
   { name: 'test-runner/output/hooks.js' },
   { name: 'test-runner/output/hooks_spec_reporter.js', transform: specTransform },
   { name: 'test-runner/output/timeout_in_before_each_should_not_affect_further_tests.js' },
+  { name: 'test-runner/output/timeout_ref.js' },
   { name: 'test-runner/output/hooks-with-no-global-test.js' },
   { name: 'test-runner/output/global-hooks-with-no-tests.js' },
   { name: 'test-runner/output/before-and-after-each-too-many-listeners.js' },


### PR DESCRIPTION
Timeouts associated with tests should keep the process alive for cases like this:

```js
const { test } = require('node:test');

test({ timeout: 3000 }, (t, done) => {
  // done() is not called but there are no ref()'ed handles
  // so the process exits immediately.
});
```

Refs: https://github.com/nodejs/node/issues/51381

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
