### PR TITLE
src: return a number from process.constrainedMemory() constantly

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1114,15 +1114,19 @@ over the IPC channel using `process.send()`.
 added:
   - v19.6.0
   - v18.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52039
+    description: Aligned return value with `uv_get_constrained_memory`.
 -->
 
 > Stability: 1 - Experimental
 
-* {number|undefined}
+* {number}
 
 Gets the amount of memory available to the process (in bytes) based on
 limits imposed by the OS. If there is no such constraint, or the constraint
-is unknown, `undefined` is returned.
+is unknown, `0` is returned.
 
 See [`uv_get_constrained_memory`][uv_get_constrained_memory] for more
 information.

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -211,9 +211,7 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
 
 static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
   uint64_t value = uv_get_constrained_memory();
-  if (value != 0) {
-    args.GetReturnValue().Set(static_cast<double>(value));
-  }
+  args.GetReturnValue().Set(static_cast<double>(value));
 }
 
 void RawDebug(const FunctionCallbackInfo<Value>& args) {

--- a/test/parallel/test-process-constrained-memory.js
+++ b/test/parallel/test-process-constrained-memory.js
@@ -1,12 +1,6 @@
 'use strict';
 require('../common');
 const assert = require('assert');
-const { Worker } = require('worker_threads');
+
 const constrainedMemory = process.constrainedMemory();
-if (constrainedMemory !== undefined) {
-  assert(constrainedMemory > 0);
-}
-if (!process.env.isWorker) {
-  process.env.isWorker = true;
-  new Worker(__filename);
-}
+assert.strictEqual(typeof constrainedMemory, 'number');


### PR DESCRIPTION
`0` is already a special value returned from
`uv_get_constrained_memory` representing unknown or no constraint.
Make `process.constrainedMemory()` constantly return a number instead
to avoid polymorphic return type.

Also, `test/parallel/test-process-constrained-memory.js` is evaluated with `tools/run-worker.js`, it is not necessary to run the test in a worker context manually.