### PR TITLE
fs: validate file mode from cpp

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -108,7 +108,6 @@ const {
   getOptions,
   getValidatedFd,
   getValidatedPath,
-  getValidMode,
   handleErrorFromBinding,
   preprocessSymlinkDestination,
   Stats,
@@ -233,7 +232,6 @@ function access(path, mode, callback) {
   }
 
   path = getValidatedPath(path);
-  mode = getValidMode(mode, 'access');
   callback = makeCallback(callback);
 
   const req = new FSReqCallback();
@@ -250,8 +248,6 @@ function access(path, mode, callback) {
  */
 function accessSync(path, mode) {
   path = getValidatedPath(path);
-  mode = getValidMode(mode, 'access');
-
   binding.access(pathModule.toNamespacedPath(path), mode);
 }
 
@@ -2984,7 +2980,6 @@ function copyFile(src, dest, mode, callback) {
 
   src = pathModule.toNamespacedPath(src);
   dest = pathModule.toNamespacedPath(dest);
-  mode = getValidMode(mode, 'copyFile');
   callback = makeCallback(callback);
 
   const req = new FSReqCallback();
@@ -3007,7 +3002,7 @@ function copyFileSync(src, dest, mode) {
   binding.copyFile(
     pathModule.toNamespacedPath(src),
     pathModule.toNamespacedPath(dest),
-    getValidMode(mode, 'copyFile'),
+    mode,
   );
 }
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -59,7 +59,6 @@ const {
   getStatFsFromBinding,
   getStatsFromBinding,
   getValidatedPath,
-  getValidMode,
   preprocessSymlinkDestination,
   stringToFlags,
   stringToSymlinkType,
@@ -600,7 +599,6 @@ async function readFileHandle(filehandle, options) {
 async function access(path, mode = F_OK) {
   path = getValidatedPath(path);
 
-  mode = getValidMode(mode, 'access');
   return await PromisePrototypeThen(
     binding.access(pathModule.toNamespacedPath(path), mode, kUsePromises),
     undefined,
@@ -618,7 +616,6 @@ async function cp(src, dest, options) {
 async function copyFile(src, dest, mode) {
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
-  mode = getValidMode(mode, 'copyFile');
   return await PromisePrototypeThen(
     binding.copyFile(pathModule.toNamespacedPath(src),
                      pathModule.toNamespacedPath(dest),

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -1000,7 +1000,6 @@ module.exports = {
   getOptions,
   getValidatedFd,
   getValidatedPath,
-  getValidMode,
   handleErrorFromBinding,
   possiblyTransformPath,
   preprocessSymlinkDestination,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -38,6 +38,7 @@
 #include "req_wrap-inl.h"
 #include "stream_base-inl.h"
 #include "string_bytes.h"
+#include "uv.h"
 
 #if defined(__MINGW32__) || defined(_MSC_VER)
 # include <io.h>
@@ -950,10 +951,12 @@ void Access(const FunctionCallbackInfo<Value>& args) {
   HandleScope scope(isolate);
 
   const int argc = args.Length();
-  CHECK_GE(argc, 2);
+  CHECK_GE(argc, 2);  // path, mode
 
-  CHECK(args[1]->IsInt32());
-  int mode = args[1].As<Int32>()->Value();
+  int mode;
+  if (!GetValidFileMode(env, args[1], UV_FS_ACCESS).To(&mode)) {
+    return;
+  }
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
@@ -1982,7 +1985,12 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
 
   const int argc = args.Length();
-  CHECK_GE(argc, 3);
+  CHECK_GE(argc, 3);  // src, dest, flags
+
+  int flags;
+  if (!GetValidFileMode(env, args[2], UV_FS_COPYFILE).To(&flags)) {
+    return;
+  }
 
   BufferValue src(isolate, args[0]);
   CHECK_NOT_NULL(*src);
@@ -1993,9 +2001,6 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(*dest);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
-
-  CHECK(args[2]->IsInt32());
-  const int flags = args[2].As<Int32>()->Value();
 
   if (argc > 3) {  // copyFile(src, dest, flags, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);

--- a/src/util.h
+++ b/src/util.h
@@ -24,6 +24,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "uv.h"
 #include "v8.h"
 
 #include "node.h"
@@ -1027,6 +1028,9 @@ std::string DetermineSpecificErrorType(Environment* env,
                                        v8::Local<v8::Value> input);
 
 v8::Maybe<int32_t> GetValidatedFd(Environment* env, v8::Local<v8::Value> input);
+v8::Maybe<int> GetValidFileMode(Environment* env,
+                                v8::Local<v8::Value> input,
+                                uv_fs_type type);
 
 }  // namespace node
 


### PR DESCRIPTION
This is somewhat similar to https://github.com/nodejs/node/pull/49970, with major modifications to input validation to avoid making this a breaking change due to the input validation on `Infinity` and `NaN` on the original PR. Credit to [@andremralves](https://github.com/andremralves) for the initial push.

The original PR was blocked due to @tniessen's following comment:

> Unless I'm missing something, some functions now don't throw synchronously anymore but instead report the validation error to the callback, which seems unusual for argument validation. I am not sure if that's desirable (or if we treat these things as semver-major).

This does not apply because we throw the error synchronously from the C++ side. A similar work was done on `getValidatedFd` couple of months ago. (Ref: https://github.com/nodejs/node/pull/51027)

In promisified calls the error was thrown inside an `async function`, and it is thrown the similar way. For non promisified calls, right now the error is thrown still synchronously but inside the C++ file before any callback execution is done. 

The only difference is the order of errors. For example, previously for a callback version of `access` we were checking the validity of `mode` and later the validity of `callback`, right now `mode` is checked later. According to the documentation, and if I'm not mistaken, this is not a breaking change.

cc @nodejs/fs @tniessen @nodejs/performance @nodejs/cpp-reviewers 

---

And most importantly, I'm back.

