### PR TITLE
fs: validate remaining fd calls from cpp

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -522,7 +522,7 @@ function close(fd, callback = defaultCloseCallback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.close(getValidatedFd(fd), req);
+  binding.close(fd, req);
 }
 
 /**
@@ -531,7 +531,7 @@ function close(fd, callback = defaultCloseCallback) {
  * @returns {void}
  */
 function closeSync(fd) {
-  binding.close(getValidatedFd(fd));
+  binding.close(fd);
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2034,7 +2034,7 @@ function fchown(fd, uid, gid, callback) {
 
   const req = new FSReqCallback();
   req.oncomplete = callback;
-  binding.fchown(getValidatedFd(fd), uid, gid, req);
+  binding.fchown(fd, uid, gid, req);
 }
 
 /**
@@ -2048,7 +2048,7 @@ function fchownSync(fd, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
 
-  binding.fchown(getValidatedFd(fd), uid, gid);
+  binding.fchown(fd, uid, gid);
 }
 
 /**

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -981,8 +981,10 @@ void Close(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 1);
 
-  CHECK(args[0]->IsInt32());
-  int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
   env->RemoveUnmanagedFd(fd);
 
   if (argc > 1) {  // close(fd, req)

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2593,8 +2593,10 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 3);
 
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   CHECK(IsSafeJsInt(args[1]));
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());


### PR DESCRIPTION
Moves 2 remaining calls for `getValidatedFd` to C++.

cc @nodejs/fs @nodejs/cpp-reviewers 