### PR TITLE
lib: fix listen with handle in cluster worker

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1994,7 +1994,7 @@ Server.prototype.listen = function(...args) {
   if (options instanceof TCP) {
     this._handle = options;
     this[async_id_symbol] = this._handle.getAsyncId();
-    listenInCluster(this, null, -1, -1, backlogFromArgs);
+    listenInCluster(this, null, -1, -1, backlogFromArgs, undefined, true);
     return this;
   }
   addServerAbortSignalOption(this, options);

--- a/test/parallel/test-net-listen-handle-in-cluster-1.js
+++ b/test/parallel/test-net-listen-handle-in-cluster-1.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const cluster = require('cluster');
+
+// Test if the worker can listen with handle successfully
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  const server = net.createServer();
+  worker.on('online', common.mustCall(() => {
+    server.listen(common.mustCall(() => {
+      // Send the server to worker
+      worker.send(null, server);
+    }));
+  }));
+  worker.on('exit', common.mustCall(() => {
+    server.close();
+  }));
+} else {
+  // The `got` function of net.Server will create a TCP server by listen(handle)
+  // See lib/internal/child_process.js
+  process.on('message', common.mustCall((_, server) => {
+    assert.strictEqual(server instanceof net.Server, true);
+    process.exit(0);
+  }));
+}

--- a/test/parallel/test-net-listen-handle-in-cluster-2.js
+++ b/test/parallel/test-net-listen-handle-in-cluster-2.js
@@ -1,0 +1,21 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const cluster = require('cluster');
+const { internalBinding } = require('internal/test/binding');
+const { TCP, constants: TCPConstants } = internalBinding('tcp_wrap');
+
+// Test if the worker can listen with handle successfully
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  const handle = new TCP(TCPConstants.SOCKET);
+  const errno = handle.bind('0.0.0.0', 0);
+  assert.strictEqual(errno, 0);
+  // Execute _listen2 instead of cluster._getServer in listenInCluster
+  net.createServer().listen(handle, common.mustCall(() => {
+    process.exit(0);
+  }));
+}


### PR DESCRIPTION
1. fork a process by `cluster.fork`.
2. call `net.createServer().listen(handle)` in worker.
3. the worker will pass some invalid parameters to main process by calling `cluster._getServer`.
4. throw an error in main process when try to create a handle or server.

the error is as follows.
```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'options' is invalid. Received {
  path: null,
  backlog: 0,
  readableAll: undefined,
  writableAll: undefined
}
    at new NodeError (node:internal/errors:405:5)
    at Server.listen (node:net:2016:9)
    at new RoundRobinHandle (node:internal/cluster/round_robin_handle:36:17)
    at queryServer (node:internal/cluster/primary:298:16)
    at Worker.onmessage (node:internal/cluster/primary:254:5)
    at ChildProcess.onInternalMessage (node:internal/cluster/utils:49:5)
    at ChildProcess.emit (node:events:523:35)
    at emit (node:internal/child_process:944:14)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21) 
```
I think it should not call `cluster._getServer` in this scenario(listen with handle).

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
