### PR TITLE
lib: support keepOpen options in process.send for handle/socket/server

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1468,6 +1468,10 @@ subprocess.ref();
 <!-- YAML
 added: v0.5.9
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52061
+    description: support `keepOpen` options for TCP/UDP Socket
+                 and net Server.
   - version: v5.8.0
     pr-url: https://github.com/nodejs/node/pull/5283
     description: The `options` parameter, and the `keepOpen` option
@@ -1486,8 +1490,12 @@ changes:
   parameterize the sending of certain types of handles. `options` supports
   the following properties:
   * `keepOpen` {boolean} A value that can be used when passing instances of
-    `net.Socket`. When `true`, the socket is kept open in the sending process.
-    **Default:** `false`.
+    [`net.Server`][], [`net.Socket`][] and [`dgram.Socket`][].
+    When `true`, the socket is kept open in the sending process.
+    When `false`, the socket will be closed in the sending process when the
+    worker process receives it.
+    The default value of [`net.Server`][] and [`dgram.Socket`][] is `true`,
+    The default value of [`net.Socket`][] is `false`.
 * `callback` {Function}
 * Returns: {boolean}
 
@@ -1872,6 +1880,7 @@ or [`child_process.fork()`][].
 [`child_process.fork()`]: #child_processforkmodulepath-args-options
 [`child_process.spawn()`]: #child_processspawncommand-args-options
 [`child_process.spawnSync()`]: #child_processspawnsynccommand-args-options
+[`dgram.Socket`]: dgram.md#class-dgramsocket
 [`maxBuffer` and Unicode]: #maxbuffer-and-unicode
 [`net.Server`]: net.md#class-netserver
 [`net.Socket`]: net.md#class-netsocket

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -86,15 +86,37 @@ const kChannelHandle = Symbol('kChannelHandle');
 const kIsUsedAsStdio = Symbol('kIsUsedAsStdio');
 const kPendingMessages = Symbol('kPendingMessages');
 
+function postSend(message, handle, options, callback, target) {
+  // Store the handle after successfully sending it, so it can be closed
+  // when the NODE_HANDLE_ACK is received. If the handle could not be sent,
+  // just close it.
+  if (handle && !options.keepOpen) {
+    if (target) {
+      // There can only be one _pendingMessage as passing handles are
+      // processed one at a time: handles are stored in _handleQueue while
+      // waiting for the NODE_HANDLE_ACK of the current passing handle.
+      assert(!target._pendingMessage);
+      target._pendingMessage =
+          { callback, message, handle, options, retransmissions: 0 };
+    } else {
+      handle.close();
+    }
+  }
+}
+
 // This object contain function to convert TCP objects to native handle objects
 // and back again.
 const handleConversion = {
   'net.Native': {
     simultaneousAccepts: true,
 
+    keepOpen: true,
+
     send(message, handle, options) {
       return handle;
     },
+
+    postSend,
 
     got(message, handle, emit) {
       emit(handle);
@@ -104,9 +126,13 @@ const handleConversion = {
   'net.Server': {
     simultaneousAccepts: true,
 
+    keepOpen: true,
+
     send(message, server, options) {
       return server._handle;
     },
+
+    postSend,
 
     got(message, handle, emit) {
       const server = new net.Server();
@@ -117,6 +143,8 @@ const handleConversion = {
   },
 
   'net.Socket': {
+    keepOpen: false,
+
     send(message, socket, options) {
       if (!socket._handle)
         return;
@@ -165,23 +193,7 @@ const handleConversion = {
       return handle;
     },
 
-    postSend(message, handle, options, callback, target) {
-      // Store the handle after successfully sending it, so it can be closed
-      // when the NODE_HANDLE_ACK is received. If the handle could not be sent,
-      // just close it.
-      if (handle && !options.keepOpen) {
-        if (target) {
-          // There can only be one _pendingMessage as passing handles are
-          // processed one at a time: handles are stored in _handleQueue while
-          // waiting for the NODE_HANDLE_ACK of the current passing handle.
-          assert(!target._pendingMessage);
-          target._pendingMessage =
-              { callback, message, handle, options, retransmissions: 0 };
-        } else {
-          handle.close();
-        }
-      }
-    },
+    postSend,
 
     got(message, handle, emit) {
       const socket = new net.Socket({
@@ -207,9 +219,13 @@ const handleConversion = {
   'dgram.Native': {
     simultaneousAccepts: false,
 
+    keepOpen: true,
+
     send(message, handle, options) {
       return handle;
     },
+
+    postSend,
 
     got(message, handle, emit) {
       emit(handle);
@@ -219,11 +235,15 @@ const handleConversion = {
   'dgram.Socket': {
     simultaneousAccepts: false,
 
+    keepOpen: true,
+
     send(message, socket, options) {
       message.dgramType = socket.type;
 
       return socket[kStateSymbol].handle;
     },
+
+    postSend,
 
     got(message, handle, emit) {
       const socket = new dgram.Socket(message.dgramType);
@@ -851,6 +871,10 @@ function setupChannel(target, channel, serializationMode) {
 
     const err = writeChannelMessage(channel, req, message, handle);
     const wasAsyncWrite = streamBaseState[kLastWriteWasAsync];
+
+    if (obj && options.keepOpen === undefined) {
+      options.keepOpen = obj.keepOpen;
+    }
 
     if (err === 0) {
       if (handle) {

--- a/test/parallel/test-child-process-send-keep-open-with-net-server.js
+++ b/test/parallel/test-child-process-send-keep-open-with-net-server.js
@@ -1,0 +1,55 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const net = require('net');
+
+const count = 3;
+
+if (process.argv[2] !== 'child') {
+  const child = cp.fork(__filename, ['child']);
+  // The first step
+  const server1 = net.createServer(common.mustNotCall())
+    .listen(() => {
+      child.send(null, server1, { keepOpen: true }, common.mustSucceed());
+    });
+
+  const server2 = net.createServer(common.mustNotCall())
+    .listen(() => {
+      child.send(null, server2, { keepOpen: false }, common.mustSucceed());
+    });
+
+  const server3 = net.createServer(common.mustNotCall())
+    .listen(() => {
+      // The default value of `keepOpen` is true
+      child.send(null, server3, common.mustSucceed());
+    });
+
+  let i = 0;
+
+  // The third step
+  child.on('message', common.mustCall(() => {
+    if (++i === count) {
+      child.disconnect();
+    }
+  }, count));
+
+  // The fourth step
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+    // Test if the server is closed
+    assert.strictEqual(server1.address().port > 0, true);
+    assert.throws(() => server2.address(), Error);
+    assert.strictEqual(server3.address().port > 0, true);
+    server1.close();
+    server3.close();
+  }));
+} else {
+  // The second step
+  process.on('message', common.mustCall((_, server) => {
+    assert.strictEqual(server instanceof net.Server, true);
+    server.close(common.mustCall(() => {
+      process.send('done');
+    }));
+  }, count));
+}

--- a/test/parallel/test-child-process-send-keep-open-with-net-socket.js
+++ b/test/parallel/test-child-process-send-keep-open-with-net-socket.js
@@ -1,0 +1,83 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const net = require('net');
+const { internalBinding } = require('internal/test/binding');
+const { TCP } = internalBinding('tcp_wrap');
+
+const count = 6;
+
+if (process.argv[2] !== 'child') {
+  const child = cp.fork(__filename, ['child']);
+
+  let socket1, socket2, socket3, socket4, socket5, socket6;
+  function noop() {}
+  // The first step
+  const server = net.createServer(common.mustCall(noop, count))
+    .listen(() => {
+      const address = server.address();
+      socket1 = net.connect(address.port, address.address, common.mustCall(() => {
+        child.send('socket', socket1, { keepOpen: true }, common.mustSucceed());
+      }));
+      socket2 = net.connect(address.port, address.address, common.mustCall(() => {
+        child.send('socket', socket2, { keepOpen: false }, common.mustSucceed());
+      }));
+      socket3 = net.connect(address.port, address.address, common.mustCall(() => {
+        // The default value of `keepOpen` is false
+        child.send('socket', socket3, common.mustSucceed());
+      }));
+      socket4 = net.connect(address.port, address.address, common.mustCall(() => {
+        child.send('handle', socket4._handle, { keepOpen: true }, common.mustSucceed());
+      }));
+      socket5 = net.connect(address.port, address.address, common.mustCall(() => {
+        child.send('handle', socket5._handle, { keepOpen: false }, common.mustSucceed());
+      }));
+      socket6 = net.connect(address.port, address.address, common.mustCall(() => {
+        // The default value of `keepOpen` is true
+        child.send('handle', socket6._handle, common.mustSucceed());
+      }));
+    });
+
+  let i = 0;
+  // The third step
+  child.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'done');
+    if (++i === count) {
+      child.disconnect();
+    }
+  }, count));
+
+  // The fourth step
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+    // Test if the socket is closed
+    assert.strictEqual(!!socket1.localPort, true);
+    assert.strictEqual(!!socket2.localPort, false);
+    assert.strictEqual(!!socket3.localPort, false);
+    assert.strictEqual(!!socket4.localPort, true);
+    assert.strictEqual(!!socket5.localPort, false);
+    assert.strictEqual(!!socket6.localPort, true);
+    socket1.destroy();
+    socket4.destroy();
+    socket6.destroy();
+    server.close();
+  }));
+} else {
+  // The second step
+  process.on('message', common.mustCall((_, handle) => {
+    if (handle instanceof TCP) {
+      handle.close(common.mustCall(() => {
+        process.send('done');
+      }));
+    } else if (handle instanceof net.Socket) {
+      handle.destroy();
+      handle.on('close', common.mustCall(() => {
+        process.send('done');
+      }));
+    } else {
+      throw new Error('invalid type');
+    }
+  }, count));
+}

--- a/test/parallel/test-child-process-send-keep-open-with-udp-socket.js
+++ b/test/parallel/test-child-process-send-keep-open-with-udp-socket.js
@@ -1,0 +1,81 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const dgram = require('dgram');
+const { kStateSymbol } = require('internal/dgram');
+const { internalBinding } = require('internal/test/binding');
+const { UDP } = internalBinding('udp_wrap');
+
+const count = 6;
+
+if (process.argv[2] !== 'child') {
+  const child = cp.fork(__filename, ['child']);
+
+  // The first step
+  const socket1 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      child.send(null, socket1[kStateSymbol].handle, { keepOpen: true }, common.mustSucceed());
+    }));
+
+  const socket2 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      child.send(null, socket2[kStateSymbol].handle, { keepOpen: false }, common.mustSucceed());
+    }));
+
+  const socket3 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      // The default value of `keepOpen` is true
+      child.send(null, socket3[kStateSymbol].handle, common.mustSucceed());
+    }));
+
+  const socket4 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      child.send(null, socket4, { keepOpen: true }, common.mustSucceed());
+    }));
+
+  const socket5 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      child.send(null, socket5, { keepOpen: false }, common.mustSucceed());
+    }));
+
+  const socket6 = dgram.createSocket('udp4')
+    .bind(0, common.mustCall(() => {
+      // The default value of `keepOpen` is true
+      child.send(null, socket6, common.mustSucceed());
+    }));
+
+  let i = 0;
+
+  // The third step
+  child.on('message', common.mustCall((msg) => {
+    if (++i === count) {
+      child.disconnect();
+    }
+  }, count));
+
+  // The fourth step
+  child.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+    // Test if the socket is closed
+    assert.strictEqual(socket1.address().port > 0, true);
+    assert.throws(() => socket2.address(), Error);
+    assert.strictEqual(socket3.address().port > 0, true);
+    assert.strictEqual(socket4.address().port > 0, true);
+    assert.throws(() => socket5.address(), Error);
+    assert.strictEqual(socket6.address().port > 0, true);
+    socket1.close();
+    socket3.close();
+    socket4.close();
+    socket6.close();
+  }));
+} else {
+  // The second step
+  process.on('message', common.mustCall((_, handle) => {
+    assert.strictEqual(handle instanceof UDP || handle instanceof dgram.Socket, true);
+    handle.close(common.mustCall(() => {
+      process.send('done');
+    }));
+  }, count));
+}


### PR DESCRIPTION
Currently `keepOpen` is only used for `net.Socket`, I think we can support this option for all types of handle(such as native handle / Socket / net Server). The user can use it to control whether the socket needs to be closed.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
