### PR TITLE
doc: remove ableist language from crypto

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5809,7 +5809,7 @@ See the [list of SSL OP Flags][] for details.
   </tr>
   <tr>
     <td><code>SSL_OP_CISCO_ANYCONNECT</code></td>
-    <td>Instructs OpenSSL to use Cisco's "speshul" version of DTLS_BAD_VER.</td>
+    <td>Instructs OpenSSL to use Cisco's version identifier of DTLS_BAD_VER.</td>
   </tr>
   <tr>
     <td><code>SSL_OP_COOKIE_EXCHANGE</code></td>


### PR DESCRIPTION
I noticed some ableist language in the description for `SSL_OP_CISCO_ANYCONNECT`. It uses the word "speshul" in a way that is not very inclusive. I've suggested a change to make it more neutral & respectful, aligning with OpenSSL's [current description](https://github.com/openssl/openssl/blob/b317583f4ad8a8e742781381fa10db5bcd072585/include/openssl/ssl.h.in#L362-L366) of `SSL_OP_CISCO_ANYCONNECT`

related: DefinitelyTyped/DefinitelyTyped#68969