### PR TITLE
fs: runtime deprecate fs.Stats constructor

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3579,11 +3579,14 @@ Please use the [`crypto.createHash()`][] method to create Hash instances.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52067
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/51879
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `fs.Stats` class directly with `Stats()` or `new Stats()` is
 deprecated due to being internals, not intended for public use.

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -51,6 +51,7 @@ const {
 const {
   kEmptyObject,
   once,
+  deprecate,
 } = require('internal/util');
 const { toPathIfFileURL } = require('internal/url');
 const {
@@ -1009,7 +1010,7 @@ module.exports = {
   getStatsFromBinding,
   stringToFlags,
   stringToSymlinkType,
-  Stats,
+  Stats: deprecate(Stats, 'fs.Stats constructor is deprecated.', 'DEP0180'),
   toUnixTimestamp,
   validateBufferArray,
   validateCpOptions,

--- a/test/parallel/test-fs-stat.js
+++ b/test/parallel/test-fs-stat.js
@@ -154,3 +154,28 @@ fs.open(__filename, 'r', undefined, common.mustCall((err, fd) => {
 
 // Should not throw an error
 fs.lstat(__filename, undefined, common.mustCall());
+
+{
+  fs.Stats(
+    0,                                        // dev
+    0,                                        // mode
+    0,                                        // nlink
+    0,                                        // uid
+    0,                                        // gid
+    0,                                        // rdev
+    0,                                        // blksize
+    0,                                        // ino
+    0,                                        // size
+    0,                                        // blocks
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
+    Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
+    Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
+  );
+  common.expectWarning({
+    DeprecationWarning: [
+      ['fs.Stats constructor is deprecated.',
+       'DEP0180'],
+    ]
+  });
+}


### PR DESCRIPTION
moved to runtime deprecated on next semver major, due to being a internal and not supposed to be public. This will help with future refactoring
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
