### PR TITLE
crypto: fix `input` validation in `crypto.hash`

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3520,7 +3520,7 @@ added:
 > Stability: 1.2 - Release candidate
 
 * `algorithm` {string|undefined}
-* `data` {string|ArrayBuffer|Buffer|TypedArray|DataView} When `data` is a
+* `data` {string|Buffer|TypedArray|DataView} When `data` is a
   string, it will be encoded as UTF-8 before being hashed. If a different
   input encoding is desired for a string input, user could encode the string
   into a `TypedArray` using either `TextEncoder` or `Buffer.from()` and passing

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -52,7 +52,6 @@ const {
   validateEncoding,
   validateString,
   validateUint32,
-  validateBuffer,
 } = require('internal/validators');
 
 const {
@@ -196,8 +195,8 @@ async function asyncDigest(algorithm, data) {
 
 function hash(algorithm, input, outputEncoding = 'hex') {
   validateString(algorithm, 'algorithm');
-  if (typeof input !== 'string') {
-    validateBuffer(input, 'input');
+  if (typeof input !== 'string' && !isArrayBufferView(input)) {
+    throw new ERR_INVALID_ARG_TYPE('input', ['Buffer', 'TypedArray', 'DataView', 'string'], input);
   }
   let normalized = outputEncoding;
   // Fast case: if it's 'hex', we don't need to validate it further.


### PR DESCRIPTION
The documentation was wrong as it was mentioning `ArrayBuffer`, and the error message was wrong as it wasn't mentioning `string`.

Fixes: https://github.com/nodejs/node/pull/51044/files#r1522362983
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
