### PR TITLE
process: wait promise resolve before print result

### DIFF
--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -119,7 +119,10 @@ function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
     });
     if (print) {
       const { log } = require('internal/console/global');
-      log(result);
+
+      process.on('exit', async () => {
+        log(await result);
+      });
     }
 
     if (origModule !== undefined)


### PR DESCRIPTION
Inspired by https://twitter.com/jarredsumner/status/1767795689575285214

Wait for Promise resolve when printing any code using `--print` or `--eval`.

```bash
$ ./out/Release/node --print 'fetch("https://api.github.com/repos/bigskysoftware/htmx").then(r => r.json())'
{
  id: 255378816,
  node_id: 'MDEwOlJlcG9zaXRvcnkyNTUzNzg4MTY=',
  name: 'htmx',
  full_name: 'bigskysoftware/htmx',
  private: false,
  owner: {
    login: 'bigskysoftware',
    id: 48798027,
    node_id: 'MDEyOk9yZ2FuaXphdGlvbjQ4Nzk4MDI3',
    avatar_url: 'https://avatars.githubusercontent.com/u/48798027?v=4',
    gravatar_id: '',
    url: 'https://api.github.com/users/bigskysoftware',
    html_url: 'https://github.com/bigskysoftware',
    followers_url: 'https://api.github.com/users/bigskysoftware/followers',
    following_url: 'https://api.github.com/users/bigskysoftware/following{/other_user}',
    gists_url: 'https://api.github.com/users/bigskysoftware/gists{/gist_id}',
    starred_url: 'https://api.github.com/users/bigskysoftware/starred{/owner}{/repo}',
    subscriptions_url: 'https://api.github.com/users/bigskysoftware/subscriptions',
    organizations_url: 'https://api.github.com/users/bigskysoftware/orgs',
    repos_url: 'https://api.github.com/users/bigskysoftware/repos',
    events_url: 'https://api.github.com/users/bigskysoftware/events{/privacy}',
    received_events_url: 'https://api.github.com/users/bigskysoftware/received_events',
    type: 'Organization',
    site_admin: false
  },
  html_url: 'https://github.com/bigskysoftware/htmx',
  description: '</> htmx - high power tools for HTML',
  fork: false,
...
```

When throwing an exception, the output is:

```js 
$ ./out/Release/node --print 'Promise.resolve().then(() => { throw new Error("123"); });'
[eval]:1
Promise.resolve().then(() => { throw new Error("123"); });
                                     ^

Error: 123
    at [eval]:1:38

Node.js v22.0.0-pre
```

Since I'm changing the output, this probably should be marked as major, right?