### PR TITLE
build: speed up compilation of some V8 files

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -261,6 +261,7 @@
       'type': 'static_library',
       'toolsets': ['host', 'target'],
       'dependencies': [
+        'generate_bytecode_builtins_list',
         'run_torque',
       ],
       'cflags!': ['-O3'],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -254,11 +254,31 @@
       ],
     },  # v8_init
     {
+      # This target is used to work around a GCC issue that causes the
+      # compilation to take several minutes when using -O2 or -O3.
+      # This is fixed in GCC 13.
+      'target_name': 'v8_initializers_slow',
+      'type': 'static_library',
+      'toolsets': ['host', 'target'],
+      'dependencies': [
+        'run_torque',
+      ],
+      'cflags!': ['-O3'],
+      'cflags': ['-O1'],
+      'sources': [
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/js-to-wasm-tq-csa.h',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/js-to-wasm-tq-csa.cc',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.h',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.cc',
+      ],
+    },  # v8_initializers_slow
+    {
       'target_name': 'v8_initializers',
       'type': 'static_library',
       'toolsets': ['host', 'target'],
       'dependencies': [
         'torque_generated_initializers',
+        'v8_initializers_slow',
         'v8_base_without_compiler',
         'v8_shared_internal_headers',
         'v8_pch',
@@ -266,6 +286,13 @@
       'include_dirs': [
         '<(SHARED_INTERMEDIATE_DIR)',
         '<(generate_bytecode_output_root)',
+      ],
+      # Compiled by v8_initializers_slow target.
+      'sources!': [
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/js-to-wasm-tq-csa.h',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/js-to-wasm-tq-csa.cc',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.h',
+        '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.cc',
       ],
       'sources': [
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_initializers.*?sources = ")',

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -272,6 +272,14 @@
         '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.h',
         '<(SHARED_INTERMEDIATE_DIR)/torque-generated/src/builtins/wasm-to-js-tq-csa.cc',
       ],
+      'conditions': [
+        ['v8_enable_i18n_support==1', {
+          'dependencies': [
+            '<(icu_gyp_path):icui18n',
+            '<(icu_gyp_path):icuuc',
+          ],
+        }],
+      ],
     },  # v8_initializers_slow
     {
       'target_name': 'v8_initializers',


### PR DESCRIPTION
This introduces a special target to compile some of the
'v8_initializers' files with "-O1" instead of "-O3" to avoid huge
compilation times with GCC versions <13.

Closes: https://github.com/nodejs/node/issues/52068
