### PR TITLE
tools: allow local updates for llhttp

### DIFF
--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -12,9 +12,8 @@ DEPS_DIR="${BASE_DIR}/deps"
 # shellcheck disable=SC1091
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
-if test -e $LOCAL_COPY; then
+if [ -n "$LOCAL_COPY" ]; then
   NEW_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$LOCAL_COPY/package.json', 'utf-8')).version)")
-  echo $NEW_VERSION
 else
   NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
   const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest',
@@ -53,12 +52,12 @@ cd "$WORKSPACE"
 echo "Replacing existing llhttp (except GYP and GN build files)"
 mv "$DEPS_DIR/llhttp/"*.gn "$DEPS_DIR/llhttp/"*.gni "$WORKSPACE/"
 
-if test -n "$LOCAL_COPY"; then
+if [ -n "$LOCAL_COPY" ]; then
   echo "Copying llhttp release from $LOCAL_COPY ..."
   
   echo "Building llhttp ..."
-  cd $BASE_DIR
-  cd $LOCAL_COPY
+  cd "$BASE_DIR"
+  cd "$LOCAL_COPY"
   npm install
   RELEASE=$NEW_VERSION make release
 

--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -12,18 +12,23 @@ DEPS_DIR="${BASE_DIR}/deps"
 # shellcheck disable=SC1091
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
-NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
-const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest',
-  process.env.GITHUB_TOKEN && {
-    headers: {
-      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
-    },
-  });
-if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
-const { tag_name } = await res.json();
-console.log(tag_name.replace('release/v', ''));
+if test -e $LOCAL_COPY; then
+  NEW_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$LOCAL_COPY/package.json', 'utf-8')).version)")
+  echo $NEW_VERSION
+else
+  NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
+  const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest',
+    process.env.GITHUB_TOKEN && {
+      headers: {
+        "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+      },
+    });
+  if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
+  const { tag_name } = await res.json();
+  console.log(tag_name.replace('release/v', ''));
 EOF
 )"
+fi
 
 CURRENT_MAJOR_VERSION=$(grep "#define LLHTTP_VERSION_MAJOR" ./deps/llhttp/include/llhttp.h | sed -n "s/^.*MAJOR \(.*\)/\1/p")
 CURRENT_MINOR_VERSION=$(grep "#define LLHTTP_VERSION_MINOR" ./deps/llhttp/include/llhttp.h | sed -n "s/^.*MINOR \(.*\)/\1/p")
@@ -48,7 +53,19 @@ cd "$WORKSPACE"
 echo "Replacing existing llhttp (except GYP and GN build files)"
 mv "$DEPS_DIR/llhttp/"*.gn "$DEPS_DIR/llhttp/"*.gni "$WORKSPACE/"
 
-if echo "$NEW_VERSION" | grep -qs "/" ; then # Download a release
+if test -n "$LOCAL_COPY"; then
+  echo "Copying llhttp release from $LOCAL_COPY ..."
+  
+  echo "Building llhttp ..."
+  cd $BASE_DIR
+  cd $LOCAL_COPY
+  npm install
+  RELEASE=$NEW_VERSION make release
+
+  echo "Copying llhttp release ..."
+  rm -rf "$DEPS_DIR/llhttp"
+  cp -a release "$DEPS_DIR/llhttp"
+elif echo "$NEW_VERSION" | grep -qs "/" ; then # Download a release
   REPO="git@github.com:$NEW_VERSION.git"
   BRANCH=$2
   [ -z "$BRANCH" ] && BRANCH=main
@@ -61,7 +78,7 @@ if echo "$NEW_VERSION" | grep -qs "/" ; then # Download a release
 
   echo "Building llhttp ..."
   npm install
-  make release
+  RELEASE=$NEW_VERSION make release
 
   echo "Copying llhttp release ..."
   rm -rf "$DEPS_DIR/llhttp"

--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -120,6 +120,8 @@ main() {
     * )
       echo "unknown command: $1"
       help 1
+
+      # shellcheck disable=SC2317
       exit 1
     ;;
   esac


### PR DESCRIPTION
This PR allows to specify a local folder to update llhttp.

This is especially beneficial in security releases.