### PR TITLE
module: eliminate performance cost of ESM syntax detection for CommonJS entry points

### DIFF
--- a/benchmark/misc/startup-core.js
+++ b/benchmark/misc/startup-core.js
@@ -9,6 +9,7 @@ const bench = common.createBenchmark(main, {
   script: [
     'benchmark/fixtures/require-builtins',
     'test/fixtures/semicolon',
+    'test/fixtures/snapshot/typescript',
   ],
   mode: ['process', 'worker'],
   count: [30],

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,18 +70,10 @@ const cjsSourceCache = new SafeWeakMap();
  */
 const cjsExportsCache = new SafeWeakMap();
 
-/**
- * Map of CJS modules where the initial attempt to parse as CommonJS failed;
- * we want to retry as ESM but avoid reading the module from disk again.
- * @type {SafeMap<string, string>} filename: contents
- */
-const cjsRetryAsESMCache = new SafeMap();
-
 // Set first due to cycle with ESM loader functions.
 module.exports = {
   cjsExportsCache,
   cjsSourceCache,
-  cjsRetryAsESMCache,
   initializeCJS,
   Module,
   wrapSafe,
@@ -1347,7 +1339,7 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     if (process.mainModule === cjsModuleInstance) {
       if (getOptionValue('--experimental-detect-module')) {
         // For the main entry point, cache the source to potentially retry as ESM.
-        cjsRetryAsESMCache.set(filename, content);
+        process.mainModule._retryAsESMSource = content;
       } else {
         // We only enrich the error (print a warning) if we're sure we're going to for-sure throw it; so if we're
         // retrying as ESM, wait until we know whether we're going to retry before calling `enrichCJSError`.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,14 +70,12 @@ const cjsSourceCache = new SafeWeakMap();
  */
 const cjsExportsCache = new SafeWeakMap();
 
-const kEntryPointSource = Symbol('kEntryPointSource');
-
 // Set first due to cycle with ESM loader functions.
 module.exports = {
   cjsExportsCache,
   cjsSourceCache,
   initializeCJS,
-  kEntryPointSource,
+  entryPointSource: undefined, // Set below.
   Module,
   wrapSafe,
 };
@@ -1342,7 +1340,7 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     if (process.mainModule === cjsModuleInstance) {
       if (getOptionValue('--experimental-detect-module')) {
         // For the main entry point, cache the source to potentially retry as ESM.
-        process.mainModule[kEntryPointSource] = content;
+        module.exports.entryPointSource = content;
       } else {
         // We only enrich the error (print a warning) if we're sure we're going to for-sure throw it; so if we're
         // retrying as ESM, wait until we know whether we're going to retry before calling `enrichCJSError`.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1348,10 +1348,12 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
       if (getOptionValue('--experimental-detect-module')) {
         // For the main entry point, cache the source to potentially retry as ESM.
         cjsRetryAsESMCache.set(filename, content);
+      } else {
+        // We only enrich the error (print a warning) if we're sure we're going to for-sure throw it; so if we're
+        // retrying as ESM, wait until we know whether we're going to retry before calling `enrichCJSError`.
+        const { enrichCJSError } = require('internal/modules/esm/translators');
+        enrichCJSError(err, content, filename);
       }
-
-      const { enrichCJSError } = require('internal/modules/esm/translators');
-      enrichCJSError(err, content, filename);
     }
     throw err;
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,11 +70,14 @@ const cjsSourceCache = new SafeWeakMap();
  */
 const cjsExportsCache = new SafeWeakMap();
 
+const kEntryPointSource = Symbol('kEntryPointSource');
+
 // Set first due to cycle with ESM loader functions.
 module.exports = {
   cjsExportsCache,
   cjsSourceCache,
   initializeCJS,
+  kEntryPointSource,
   Module,
   wrapSafe,
 };
@@ -1339,7 +1342,7 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     if (process.mainModule === cjsModuleInstance) {
       if (getOptionValue('--experimental-detect-module')) {
         // For the main entry point, cache the source to potentially retry as ESM.
-        process.mainModule._retryAsESMSource = content;
+        process.mainModule[kEntryPointSource] = content;
       } else {
         // We only enrich the error (print a warning) if we're sure we're going to for-sure throw it; so if we're
         // retrying as ESM, wait until we know whether we're going to retry before calling `enrichCJSError`.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,10 +70,18 @@ const cjsSourceCache = new SafeWeakMap();
  */
 const cjsExportsCache = new SafeWeakMap();
 
+/**
+ * Map of CJS modules where the initial attempt to parse as CommonJS failed;
+ * we want to retry as ESM but avoid reading the module from disk again.
+ * @type {SafeMap<string, string>} filename: contents
+ */
+const cjsRetryAsESMCache = new SafeMap();
+
 // Set first due to cycle with ESM loader functions.
 module.exports = {
   cjsExportsCache,
   cjsSourceCache,
+  cjsRetryAsESMCache,
   initializeCJS,
   Module,
   wrapSafe,
@@ -1337,6 +1345,11 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     return result;
   } catch (err) {
     if (process.mainModule === cjsModuleInstance) {
+      if (getOptionValue('--experimental-detect-module')) {
+        // For the main entry point, cache the source to potentially retry as ESM.
+        cjsRetryAsESMCache.set(filename, content);
+      }
+
       const { enrichCJSError } = require('internal/modules/esm/translators');
       enrichCJSError(err, content, filename);
     }

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -320,6 +320,37 @@ function normalizeReferrerURL(referrerName) {
 }
 
 
+const esmSyntaxErrorMessages = new SafeSet([
+  'Cannot use import statement outside a module', // `import` statements
+  "Unexpected token 'export'",                    // `export` statements
+  "Cannot use 'import.meta' outside a module",    // `import.meta` references
+]);
+const throwsOnlyInCommonJSErrorMessages = new SafeSet([
+  "Identifier 'module' has already been declared",
+  "Identifier 'exports' has already been declared",
+  "Identifier 'require' has already been declared",
+  "Identifier '__filename' has already been declared",
+  "Identifier '__dirname' has already been declared",
+  'await is only valid in async functions and the top level bodies of modules', // Top-level `await`
+]);
+/**
+ * After an attempt to parse a module as CommonJS throws an error, should we try again as ESM?
+ * @param {string} errorMessage The string message thrown by V8 when attempting to parse as CommonJS
+ * @param {string} source Module contents
+ */
+function shouldRetryAsESM(errorMessage, source) {
+  if (esmSyntaxErrorMessages.has(errorMessage)) {
+    return true;
+  }
+
+  if (throwsOnlyInCommonJSErrorMessages.has(errorMessage)) {
+    return /** @type {boolean} */(internalBinding('contextify').shouldRetryAsESM(source));
+  }
+
+  return false;
+}
+
+
 // Whether we have started executing any user-provided CJS code.
 // This is set right before we call the wrapped CJS code (not after,
 // in case we are half-way in the execution when internals check this).
@@ -339,6 +370,7 @@ module.exports = {
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,
+  shouldRetryAsESM,
   stripBOM,
   toRealPath,
   hasStartedUserCJSExecution() {

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -19,6 +19,15 @@ const {
 } = require('internal/errors').codes;
 const { BuiltinModule } = require('internal/bootstrap/realm');
 
+const {
+  shouldRetryAsESM: contextifyShouldRetryAsESM,
+  constants: {
+    syntaxDetectionErrors: {
+      esmSyntaxErrorMessages,
+      throwsOnlyInCommonJSErrorMessages,
+    },
+  },
+} = internalBinding('contextify');
 const { validateString } = require('internal/validators');
 const fs = require('fs'); // Import all of `fs` so that it can be monkey-patched.
 const internalFS = require('internal/fs/utils');
@@ -320,31 +329,22 @@ function normalizeReferrerURL(referrerName) {
 }
 
 
-const esmSyntaxErrorMessages = new SafeSet([
-  'Cannot use import statement outside a module', // `import` statements
-  "Unexpected token 'export'",                    // `export` statements
-  "Cannot use 'import.meta' outside a module",    // `import.meta` references
-]);
-const throwsOnlyInCommonJSErrorMessages = new SafeSet([
-  "Identifier 'module' has already been declared",
-  "Identifier 'exports' has already been declared",
-  "Identifier 'require' has already been declared",
-  "Identifier '__filename' has already been declared",
-  "Identifier '__dirname' has already been declared",
-  'await is only valid in async functions and the top level bodies of modules', // Top-level `await`
-]);
+let esmSyntaxErrorMessagesSet; // Declared lazily in shouldRetryAsESM
+let throwsOnlyInCommonJSErrorMessagesSet; // Declared lazily in shouldRetryAsESM
 /**
  * After an attempt to parse a module as CommonJS throws an error, should we try again as ESM?
  * @param {string} errorMessage The string message thrown by V8 when attempting to parse as CommonJS
  * @param {string} source Module contents
  */
 function shouldRetryAsESM(errorMessage, source) {
-  if (esmSyntaxErrorMessages.has(errorMessage)) {
+  esmSyntaxErrorMessagesSet ??= new SafeSet(esmSyntaxErrorMessages);
+  if (esmSyntaxErrorMessagesSet.has(errorMessage)) {
     return true;
   }
 
-  if (throwsOnlyInCommonJSErrorMessages.has(errorMessage)) {
-    return /** @type {boolean} */(internalBinding('contextify').shouldRetryAsESM(source));
+  throwsOnlyInCommonJSErrorMessagesSet ??= new SafeSet(throwsOnlyInCommonJSErrorMessages);
+  if (throwsOnlyInCommonJSErrorMessagesSet.has(errorMessage)) {
+    return /** @type {boolean} */(contextifyShouldRetryAsESM(source));
   }
 
   return false;

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -333,6 +333,9 @@ let esmSyntaxErrorMessagesSet; // Declared lazily in shouldRetryAsESM
 let throwsOnlyInCommonJSErrorMessagesSet; // Declared lazily in shouldRetryAsESM
 /**
  * After an attempt to parse a module as CommonJS throws an error, should we try again as ESM?
+ * We only want to try again as ESM if the error is due to syntax that is only valid in ESM; and if the CommonJS parse
+ * throws on an error that would not have been a syntax error in ESM (like via top-level `await` or a lexical
+ * redeclaration of one of the CommonJS variables) then we need to parse again to see if it would have thrown in ESM.
  * @param {string} errorMessage The string message thrown by V8 when attempting to parse as CommonJS
  * @param {string} source Module contents
  */

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -164,10 +164,10 @@ function executeUserEntryPoint(main = process.argv[1]) {
   if (!useESMLoader) {
     // Module._load is the monkey-patchable CJS module loader.
     const { Module } = require('internal/modules/cjs/loader');
-    try {
-      Module._load(main, null, true);
-    } catch (error) {
-      if (getOptionValue('--experimental-detect-module')) {
+    if (getOptionValue('--experimental-detect-module')) {
+      try {
+        Module._load(main, null, true);
+      } catch (error) {
         const { cjsRetryAsESMCache } = require('internal/modules/cjs/loader');
         const source = cjsRetryAsESMCache.get(resolvedMain);
         cjsRetryAsESMCache.delete(resolvedMain);
@@ -176,11 +176,11 @@ function executeUserEntryPoint(main = process.argv[1]) {
         if (!retryAsESM) {
           const { enrichCJSError } = require('internal/modules/esm/translators');
           enrichCJSError(error, source, resolvedMain);
+          throw error;
         }
       }
-      if (!retryAsESM) {
-        throw error;
-      }
+    } else {
+      Module._load(main, null, true);
     }
   }
 

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -173,6 +173,10 @@ function executeUserEntryPoint(main = process.argv[1]) {
         cjsRetryAsESMCache.delete(resolvedMain);
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
+        if (!retryAsESM) {
+          const { enrichCJSError } = require('internal/modules/esm/translators');
+          enrichCJSError(error, source, resolvedMain);
+        }
       }
       if (!retryAsESM) {
         throw error;

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -168,9 +168,9 @@ function executeUserEntryPoint(main = process.argv[1]) {
       try {
         Module._load(main, null, true);
       } catch (error) {
-        const { cjsRetryAsESMCache } = require('internal/modules/cjs/loader');
-        const source = cjsRetryAsESMCache.get(resolvedMain);
-        cjsRetryAsESMCache.delete(resolvedMain);
+        const source = process.mainModule._retryAsESMSource;
+        // In case the entry point is a large file, such as a bundle, release it from memory since we're done with it.
+        process.mainModule._retryAsESMSource = undefined; // No need to `delete` since we don't care if the key exists.
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
         if (!retryAsESM) {

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -5,7 +5,6 @@ const {
   globalThis,
 } = primordials;
 
-const { containsModuleSyntax } = internalBinding('contextify');
 const { getNearestParentPackageJSONType } = internalBinding('modules');
 const { getOptionValue } = require('internal/options');
 const { checkPackageJSONIntegrity } = require('internal/modules/package_json_reader');
@@ -87,10 +86,6 @@ function shouldUseESMLoader(mainPath) {
 
   // No package.json or no `type` field.
   if (response === undefined || response[0] === 'none') {
-    if (getOptionValue('--experimental-detect-module')) {
-      // If the first argument of `containsModuleSyntax` is undefined, it will read `mainPath` from the file system.
-      return containsModuleSyntax(undefined, mainPath);
-    }
     return false;
   }
 
@@ -162,7 +157,30 @@ function runEntryPointWithESMLoader(callback) {
 function executeUserEntryPoint(main = process.argv[1]) {
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
-  if (useESMLoader) {
+
+  // We might retry as ESM if the CommonJS loader throws because the file is ESM, so
+  // try the CommonJS loader first unless we know it's supposed to be parsed as ESM.
+  let retryAsESM = false;
+  if (!useESMLoader) {
+    // Module._load is the monkey-patchable CJS module loader.
+    const { Module } = require('internal/modules/cjs/loader');
+    try {
+      Module._load(main, null, true);
+    } catch (error) {
+      if (getOptionValue('--experimental-detect-module')) {
+        const { cjsRetryAsESMCache } = require('internal/modules/cjs/loader');
+        const source = cjsRetryAsESMCache.get(resolvedMain);
+        cjsRetryAsESMCache.delete(resolvedMain);
+        const { shouldRetryAsESM } = require('internal/modules/helpers');
+        retryAsESM = shouldRetryAsESM(error.message, source);
+      }
+      if (!retryAsESM) {
+        throw error;
+      }
+    }
+  }
+
+  if (useESMLoader || retryAsESM) {
     const mainPath = resolvedMain || main;
     const mainURL = pathToFileURL(mainPath).href;
 
@@ -171,10 +189,6 @@ function executeUserEntryPoint(main = process.argv[1]) {
       // even after the event loop stops running.
       return cascadedLoader.import(mainURL, undefined, { __proto__: null }, true);
     });
-  } else {
-    // Module._load is the monkey-patchable CJS module loader.
-    const { Module } = require('internal/modules/cjs/loader');
-    Module._load(main, null, true);
   }
 }
 

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -174,7 +174,8 @@ function executeUserEntryPoint(main = process.argv[1]) {
         const source = cjsLoader.entryPointSource;
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
-        // In case the entry point is a large file, such as a bundle, release it from memory since we're done with it.
+        // In case the entry point is a large file, such as a bundle,
+        // ensure no further references can prevent it being garbage-collected.
         cjsLoader.entryPointSource = undefined;
         if (!retryAsESM) {
           const { enrichCJSError } = require('internal/modules/esm/translators');

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -164,18 +164,18 @@ function executeUserEntryPoint(main = process.argv[1]) {
   // try to run the entry point via the CommonJS loader; and if that fails under certain conditions, retry as ESM.
   let retryAsESM = false;
   if (!useESMLoader) {
-    // Module._load is the monkey-patchable CJS module loader.
-    const { Module } = require('internal/modules/cjs/loader');
+    const cjsLoader = require('internal/modules/cjs/loader');
+    const { Module } = cjsLoader;
     if (getOptionValue('--experimental-detect-module')) {
       try {
+        // Module._load is the monkey-patchable CJS module loader.
         Module._load(main, null, true);
       } catch (error) {
-        const { kEntryPointSource } = require('internal/modules/cjs/loader');
-        const source = process.mainModule[kEntryPointSource];
-        // In case the entry point is a large file, such as a bundle, release it from memory since we're done with it.
-        process.mainModule[kEntryPointSource] = undefined;
+        const source = cjsLoader.entryPointSource;
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
+        // In case the entry point is a large file, such as a bundle, release it from memory since we're done with it.
+        cjsLoader.entryPointSource = undefined;
         if (!retryAsESM) {
           const { enrichCJSError } = require('internal/modules/esm/translators');
           enrichCJSError(error, source, resolvedMain);

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -152,14 +152,16 @@ function runEntryPointWithESMLoader(callback) {
  * by `require('module')`) even when the entry point is ESM.
  * This monkey-patchable code is bypassed under `--experimental-default-type=module`.
  * Because of backwards compatibility, this function is exposed publicly via `import { runMain } from 'node:module'`.
+ * When `--experimental-detect-module` is passed, this function will attempt to run ambiguous (no explicit extension, no
+ * `package.json` type field) entry points as CommonJS first; under certain conditions, it will retry running as ESM.
  * @param {string} main - First positional CLI argument, such as `'entry.js'` from `node entry.js`
  */
 function executeUserEntryPoint(main = process.argv[1]) {
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
 
-  // We might retry as ESM if the CommonJS loader throws because the file is ESM, so
-  // try the CommonJS loader first unless we know it's supposed to be parsed as ESM.
+  // Unless we know we should use the ESM loader to handle the entry point per the checks in `shouldUseESMLoader`, first
+  // try to run the entry point via the CommonJS loader; and if that fails under certain conditions, retry as ESM.
   let retryAsESM = false;
   if (!useESMLoader) {
     // Module._load is the monkey-patchable CJS module loader.
@@ -168,9 +170,10 @@ function executeUserEntryPoint(main = process.argv[1]) {
       try {
         Module._load(main, null, true);
       } catch (error) {
-        const source = process.mainModule._retryAsESMSource;
+        const { kEntryPointSource } = require('internal/modules/cjs/loader');
+        const source = process.mainModule[kEntryPointSource];
         // In case the entry point is a large file, such as a bundle, release it from memory since we're done with it.
-        process.mainModule._retryAsESMSource = undefined; // No need to `delete` since we don't care if the key exists.
+        process.mainModule[kEntryPointSource] = undefined;
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
         if (!retryAsESM) {
@@ -179,7 +182,7 @@ function executeUserEntryPoint(main = process.argv[1]) {
           throw error;
         }
       }
-    } else {
+    } else { // `--experimental-detect-module` is not passed
       Module._load(main, null, true);
     }
   }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1728,6 +1728,7 @@ static void CreatePerContextProperties(Local<Object> target,
   Local<Object> constants = Object::New(env->isolate());
   Local<Object> measure_memory = Object::New(env->isolate());
   Local<Object> memory_execution = Object::New(env->isolate());
+  Local<Object> syntax_detection_errors = Object::New(env->isolate());
 
   {
     Local<Object> memory_mode = Object::New(env->isolate());
@@ -1747,6 +1748,40 @@ static void CreatePerContextProperties(Local<Object> target,
   }
 
   READONLY_PROPERTY(constants, "measureMemory", measure_memory);
+
+  {
+    Local<Array> esm_syntax_error_messages_array =
+        Array::New(env->isolate(), esm_syntax_error_messages.size());
+    for (size_t i = 0; i < esm_syntax_error_messages.size(); i++) {
+      const char* message = esm_syntax_error_messages[i].data();
+      (void)esm_syntax_error_messages_array->Set(
+          context,
+          static_cast<uint32_t>(i),
+          String::NewFromUtf8(env->isolate(), message)
+              .ToLocalChecked());
+    }
+    READONLY_PROPERTY(syntax_detection_errors, "esmSyntaxErrorMessages",
+                      esm_syntax_error_messages_array);
+  }
+
+  {
+    Local<Array> throws_only_in_cjs_error_messages_array =
+        Array::New(env->isolate(), throws_only_in_cjs_error_messages.size());
+    for (size_t i = 0; i < throws_only_in_cjs_error_messages.size(); i++) {
+      const char* message = throws_only_in_cjs_error_messages[i].data();
+      (void)throws_only_in_cjs_error_messages_array->Set(
+          context,
+          static_cast<uint32_t>(i),
+          String::NewFromUtf8(env->isolate(), message)
+              .ToLocalChecked());
+    }
+    READONLY_PROPERTY(syntax_detection_errors,
+                      "throwsOnlyInCommonJSErrorMessages",
+                      throws_only_in_cjs_error_messages_array);
+  }
+
+  READONLY_PROPERTY(constants, "syntaxDetectionErrors",
+                    syntax_detection_errors);
 
   target->Set(context, env->constants_string(), constants).Check();
 }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1509,8 +1509,8 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
                                                  Local<String> code) {
   Isolate* isolate = env->isolate();
 
-  Local<String> script_id = FIXED_ONE_BYTE_STRING(isolate,
-                                                  "[retry_as_esm_check]");
+  Local<String> script_id =
+      FIXED_ONE_BYTE_STRING(isolate, "[retry_as_esm_check]");
   Local<Symbol> id_symbol = Symbol::New(isolate, script_id);
 
   Local<PrimitiveArray> host_defined_options =
@@ -1526,11 +1526,8 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
   // module was caused by either a top-level declaration of one of the CommonJS
   // module variables, or a top-level `await`.
   code = String::Concat(
-      isolate,
-      FIXED_ONE_BYTE_STRING(isolate, "(async function() {"),
-      code);
-  code = String::Concat(
-      isolate, code, FIXED_ONE_BYTE_STRING(isolate, "})();"));
+      isolate, FIXED_ONE_BYTE_STRING(isolate, "(async function() {"), code);
+  code = String::Concat(isolate, code, FIXED_ONE_BYTE_STRING(isolate, "})();"));
 
   ScriptCompiler::Source wrapped_source = GetCommonJSSourceInstance(
       isolate, code, script_id, 0, 0, host_defined_options, nullptr);
@@ -1757,10 +1754,10 @@ static void CreatePerContextProperties(Local<Object> target,
       USE(esm_syntax_error_messages_array->Set(
           context,
           static_cast<uint32_t>(i),
-          String::NewFromUtf8(env->isolate(), message)
-              .ToLocalChecked()));
+          String::NewFromUtf8(env->isolate(), message).ToLocalChecked()));
     }
-    READONLY_PROPERTY(syntax_detection_errors, "esmSyntaxErrorMessages",
+    READONLY_PROPERTY(syntax_detection_errors,
+                      "esmSyntaxErrorMessages",
                       esm_syntax_error_messages_array);
   }
 
@@ -1772,16 +1769,15 @@ static void CreatePerContextProperties(Local<Object> target,
       USE(throws_only_in_cjs_error_messages_array->Set(
           context,
           static_cast<uint32_t>(i),
-          String::NewFromUtf8(env->isolate(), message)
-              .ToLocalChecked()));
+          String::NewFromUtf8(env->isolate(), message).ToLocalChecked()));
     }
     READONLY_PROPERTY(syntax_detection_errors,
                       "throwsOnlyInCommonJSErrorMessages",
                       throws_only_in_cjs_error_messages_array);
   }
 
-  READONLY_PROPERTY(constants, "syntaxDetectionErrors",
-                    syntax_detection_errors);
+  READONLY_PROPERTY(
+      constants, "syntaxDetectionErrors", syntax_detection_errors);
 
   target->Set(context, env->constants_string(), constants).Check();
 }

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1517,7 +1517,6 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
       GetHostDefinedOptions(isolate, id_symbol);
   ScriptCompiler::Source source = GetCommonJSSourceInstance(
       isolate, code, script_id, 0, 0, host_defined_options, nullptr);
-  ScriptCompiler::CompileOptions options = GetCompileOptions(source);
 
   TryCatchScope try_catch(env);
   ShouldNotAbortOnUncaughtScope no_abort_scope(env);
@@ -1545,7 +1544,7 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
       params.data(),
       0,
       nullptr,
-      options,
+      ScriptCompiler::kNoCompileOptions,
       v8::ScriptCompiler::NoCacheReason::kNoCacheNoReason);
 
   if (!try_catch.HasTerminated()) {

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1537,7 +1537,7 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
 
   Local<Context> context = env->context();
   std::vector<Local<String>> params = GetCJSParameters(env->isolate_data());
-  std::ignore = ScriptCompiler::CompileFunction(
+  USE(ScriptCompiler::CompileFunction(
       context,
       &wrapped_source,
       params.size(),
@@ -1545,7 +1545,7 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
       0,
       nullptr,
       ScriptCompiler::kNoCompileOptions,
-      v8::ScriptCompiler::NoCacheReason::kNoCacheNoReason);
+      v8::ScriptCompiler::NoCacheReason::kNoCacheNoReason));
 
   if (!try_catch.HasTerminated()) {
     if (try_catch.HasCaught()) {
@@ -1754,11 +1754,11 @@ static void CreatePerContextProperties(Local<Object> target,
         Array::New(env->isolate(), esm_syntax_error_messages.size());
     for (size_t i = 0; i < esm_syntax_error_messages.size(); i++) {
       const char* message = esm_syntax_error_messages[i].data();
-      (void)esm_syntax_error_messages_array->Set(
+      USE(esm_syntax_error_messages_array->Set(
           context,
           static_cast<uint32_t>(i),
           String::NewFromUtf8(env->isolate(), message)
-              .ToLocalChecked());
+              .ToLocalChecked()));
     }
     READONLY_PROPERTY(syntax_detection_errors, "esmSyntaxErrorMessages",
                       esm_syntax_error_messages_array);
@@ -1769,11 +1769,11 @@ static void CreatePerContextProperties(Local<Object> target,
         Array::New(env->isolate(), throws_only_in_cjs_error_messages.size());
     for (size_t i = 0; i < throws_only_in_cjs_error_messages.size(); i++) {
       const char* message = throws_only_in_cjs_error_messages[i].data();
-      (void)throws_only_in_cjs_error_messages_array->Set(
+      USE(throws_only_in_cjs_error_messages_array->Set(
           context,
           static_cast<uint32_t>(i),
           String::NewFromUtf8(env->isolate(), message)
-              .ToLocalChecked());
+              .ToLocalChecked()));
     }
     READONLY_PROPERTY(syntax_detection_errors,
                       "throwsOnlyInCommonJSErrorMessages",

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1406,7 +1406,7 @@ Local<Object> ContextifyContext::CompileFunctionAndCacheResult(
 // While top-level `await` is not permitted in CommonJS, it returns the same
 // error message as when `await` is used in a sync function, so we don't use it
 // as a disambiguation.
-constexpr std::array<std::string_view, 3> esm_syntax_error_messages = {
+static std::vector<std::string_view> esm_syntax_error_messages = {
     "Cannot use import statement outside a module",  // `import` statements
     "Unexpected token 'export'",                     // `export` statements
     "Cannot use 'import.meta' outside a module"};    // `import.meta` references
@@ -1421,7 +1421,7 @@ constexpr std::array<std::string_view, 3> esm_syntax_error_messages = {
 // - Top-level `await`: if the user writes `await` at the top level of a
 //   CommonJS module, it will throw a syntax error; but the same code is valid
 //   in ESM.
-constexpr std::array<std::string_view, 6> throws_only_in_cjs_error_messages = {
+static std::vector<std::string_view> throws_only_in_cjs_error_messages = {
     "Identifier 'module' has already been declared",
     "Identifier 'exports' has already been declared",
     "Identifier 'require' has already been declared",
@@ -1752,30 +1752,16 @@ static void CreatePerContextProperties(Local<Object> target,
   READONLY_PROPERTY(constants, "measureMemory", measure_memory);
 
   {
-    Local<Array> esm_syntax_error_messages_array =
-        Array::New(env->isolate(), esm_syntax_error_messages.size());
-    for (size_t i = 0; i < esm_syntax_error_messages.size(); i++) {
-      const char* message = esm_syntax_error_messages[i].data();
-      USE(esm_syntax_error_messages_array->Set(
-          context,
-          static_cast<uint32_t>(i),
-          String::NewFromUtf8(env->isolate(), message).ToLocalChecked()));
-    }
+    Local<Value> esm_syntax_error_messages_array =
+        ToV8Value(context, esm_syntax_error_messages).ToLocalChecked();
     READONLY_PROPERTY(syntax_detection_errors,
                       "esmSyntaxErrorMessages",
                       esm_syntax_error_messages_array);
   }
 
   {
-    Local<Array> throws_only_in_cjs_error_messages_array =
-        Array::New(env->isolate(), throws_only_in_cjs_error_messages.size());
-    for (size_t i = 0; i < throws_only_in_cjs_error_messages.size(); i++) {
-      const char* message = throws_only_in_cjs_error_messages[i].data();
-      USE(throws_only_in_cjs_error_messages_array->Set(
-          context,
-          static_cast<uint32_t>(i),
-          String::NewFromUtf8(env->isolate(), message).ToLocalChecked()));
-    }
+    Local<Value> throws_only_in_cjs_error_messages_array =
+        ToV8Value(context, throws_only_in_cjs_error_messages).ToLocalChecked();
     READONLY_PROPERTY(syntax_detection_errors,
                       "throwsOnlyInCommonJSErrorMessages",
                       throws_only_in_cjs_error_messages_array);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1509,7 +1509,8 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
                                                  Local<String> code) {
   Isolate* isolate = env->isolate();
 
-  Local<String> script_id = FIXED_ONE_BYTE_STRING(isolate, "throwaway");
+  Local<String> script_id = FIXED_ONE_BYTE_STRING(isolate,
+                                                  "[retry_as_esm_check]");
   Local<Symbol> id_symbol = Symbol::New(isolate, script_id);
 
   Local<PrimitiveArray> host_defined_options =
@@ -1527,10 +1528,10 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
   // module variables, or a top-level `await`.
   code = String::Concat(
       isolate,
-      String::NewFromUtf8(isolate, "(async function() {").ToLocalChecked(),
+      FIXED_ONE_BYTE_STRING(isolate, "(async function() {"),
       code);
   code = String::Concat(
-      isolate, code, String::NewFromUtf8(isolate, "})();").ToLocalChecked());
+      isolate, code, FIXED_ONE_BYTE_STRING(isolate, "})();"));
 
   ScriptCompiler::Source wrapped_source = GetCommonJSSourceInstance(
       isolate, code, script_id, 0, 0, host_defined_options, nullptr);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1521,7 +1521,7 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
                                 0,          // line offset
                                 0,          // column offset
                                 host_defined_options,
-                                nullptr);   // cached_data
+                                nullptr);  // cached_data
 
   TryCatchScope try_catch(env);
   ShouldNotAbortOnUncaughtScope no_abort_scope(env);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1442,9 +1442,8 @@ void ContextifyContext::ContainsModuleSyntax(
   }
 
   // Argument 1: source code
-  Local<String> code;
   CHECK(args[0]->IsString());
-  code = args[0].As<String>();
+  auto code = args[0].As<String>();
 
   // Argument 2: filename; if undefined, use empty string
   Local<String> filename = String::Empty(isolate);
@@ -1492,7 +1491,7 @@ void ContextifyContext::ShouldRetryAsESM(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
-  CHECK_EQ(args.Length(), 1);
+  CHECK_EQ(args.Length(), 1);  // code
 
   // Argument 1: source code
   Local<String> code;
@@ -1515,8 +1514,14 @@ bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
 
   Local<PrimitiveArray> host_defined_options =
       GetHostDefinedOptions(isolate, id_symbol);
-  ScriptCompiler::Source source = GetCommonJSSourceInstance(
-      isolate, code, script_id, 0, 0, host_defined_options, nullptr);
+  ScriptCompiler::Source source =
+      GetCommonJSSourceInstance(isolate,
+                                code,
+                                script_id,  // filename
+                                0,          // line offset
+                                0,          // column offset
+                                host_defined_options,
+                                nullptr);   // cached_data
 
   TryCatchScope try_catch(env);
   ShouldNotAbortOnUncaughtScope no_abort_scope(env);

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -107,6 +107,8 @@ class ContextifyContext : public BaseObject {
   static void ContainsModuleSyntax(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ShouldRetryAsESM(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static bool ShouldRetryAsESMInternal(Environment* env,
+                                       v8::Local<v8::String> code);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -106,6 +106,7 @@ class ContextifyContext : public BaseObject {
       const v8::ScriptCompiler::Source& source);
   static void ContainsModuleSyntax(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void ShouldRetryAsESM(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -8,6 +8,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
   describe('string input', { concurrency: true }, () => {
     it('permits ESM syntax in --eval input without requiring --input-type=module', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'import { version } from "node:process"; console.log(version);',
@@ -23,6 +24,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits ESM syntax in STDIN input without requiring --input-type=module', async () => {
       const child = spawn(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
       ]);
       child.stdin.end('console.log(typeof import.meta.resolve)');
@@ -32,6 +34,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('should be overridden by --input-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--input-type=commonjs',
         '--eval',
@@ -46,6 +49,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('should be overridden by --experimental-default-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--experimental-default-type=commonjs',
         '--eval',
@@ -60,6 +64,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('does not trigger detection via source code `eval()`', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'eval("import \'nonexistent\';");',
@@ -101,6 +106,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -142,6 +148,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -156,6 +163,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     it('should not hint wrong format in resolve hook', async () => {
       let writeSync;
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--no-warnings',
         '--loader',
@@ -194,6 +202,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -223,6 +232,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -239,6 +249,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
   describe('syntax that errors in CommonJS but works in ESM', { concurrency: true }, () => {
     it('permits top-level `await`', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); console.log("executed");',
@@ -252,6 +263,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits top-level `await` above import/export syntax', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); import "node:os"; console.log("executed");',
@@ -265,6 +277,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('still throws on `await` in an ordinary sync function', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'function fn() { await Promise.resolve(); } fn();',
@@ -278,6 +291,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('throws on undefined `require` when top-level `await` triggers ESM parsing', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'const fs = require("node:fs"); await Promise.resolve();',
@@ -291,6 +305,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits declaration of CommonJS module variables', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         fixtures.path('es-modules/package-without-type/commonjs-wrapper-variables.js'),
       ]);
@@ -303,6 +318,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits declaration of CommonJS module variables above import/export', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'const module = 3; import "node:os"; console.log("executed");',
@@ -316,6 +332,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('still throws on double `const` declaration not at the top level', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'function fn() { const require = 1; const require = 2; } fn();',

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -8,7 +8,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
   describe('string input', { concurrency: true }, () => {
     it('permits ESM syntax in --eval input without requiring --input-type=module', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'import { version } from "node:process"; console.log(version);',
@@ -24,7 +23,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits ESM syntax in STDIN input without requiring --input-type=module', async () => {
       const child = spawn(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
       ]);
       child.stdin.end('console.log(typeof import.meta.resolve)');
@@ -34,7 +32,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('should be overridden by --input-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--input-type=commonjs',
         '--eval',
@@ -49,7 +46,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('should be overridden by --experimental-default-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--experimental-default-type=commonjs',
         '--eval',
@@ -64,7 +60,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('does not trigger detection via source code `eval()`', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'eval("import \'nonexistent\';");',
@@ -106,7 +101,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -148,7 +142,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -163,7 +156,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     it('should not hint wrong format in resolve hook', async () => {
       let writeSync;
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--no-warnings',
         '--loader',
@@ -202,7 +194,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -232,7 +223,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--no-warnings',
           '--experimental-detect-module',
           entryPath,
         ]);
@@ -249,7 +239,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
   describe('syntax that errors in CommonJS but works in ESM', { concurrency: true }, () => {
     it('permits top-level `await`', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); console.log("executed");',
@@ -263,7 +252,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits top-level `await` above import/export syntax', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); import "node:os"; console.log("executed");',
@@ -277,7 +265,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('still throws on `await` in an ordinary sync function', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'function fn() { await Promise.resolve(); } fn();',
@@ -291,7 +278,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('throws on undefined `require` when top-level `await` triggers ESM parsing', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'const fs = require("node:fs"); await Promise.resolve();',
@@ -305,7 +291,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits declaration of CommonJS module variables', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         fixtures.path('es-modules/package-without-type/commonjs-wrapper-variables.js'),
       ]);
@@ -318,7 +303,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('permits declaration of CommonJS module variables above import/export', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'const module = 3; import "node:os"; console.log("executed");',
@@ -332,7 +316,6 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
 
     it('still throws on double `const` declaration not at the top level', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--no-warnings',
         '--experimental-detect-module',
         '--eval',
         'function fn() { const require = 1; const require = 2; } fn();',


### PR DESCRIPTION
This PR eliminates the performance penalty incurred by `--experimental-detect-module` for the common use case of CommonJS entry points:

```
hyperfine --warmup 10 --runs 30 \
  './node ./test/fixtures/snapshot/typescript.js' \
  './node --experimental-detect-module ./test/fixtures/snapshot/typescript.js'

Benchmark 1: ./node ./test/fixtures/snapshot/typescript.js
  Time (mean ± σ):     135.0 ms ±   3.3 ms    [User: 117.5 ms, System: 13.9 ms]
  Range (min … max):   129.0 ms … 143.5 ms    30 runs

Benchmark 2: ./node --experimental-detect-module ./test/fixtures/snapshot/typescript.js
  Time (mean ± σ):     135.3 ms ±   2.8 ms    [User: 117.3 ms, System: 13.9 ms]
  Range (min … max):   130.0 ms … 143.1 ms    30 runs

Summary
  ./node ./test/fixtures/snapshot/typescript.js ran
    1.00 ± 0.03 times faster than ./node --experimental-detect-module ./test/fixtures/snapshot/typescript.js
```

It does this by changing the startup flow for “ambiguous” entry points (where there’s no explicit file extension or `package.json` `"type"` field). On current `main`, there’s an initial file load and CommonJS parse to determine whether or not the such ambiguous entry points should be handled by the CommonJS or the ESM loader; and then the chosen loader reloads and reparses the entry point. In this PR, ambiguous files are always sent into the CommonJS loader, and _only if it throws an error_ do we check if we should retry the entry point as ESM via the ESM loader. Because nothing “extra” happens for the common case of CommonJS entry points that parse successfully as CommonJS, there is no performance penalty for incurred for CommonJS entry points by having `--experimental-detect-module` enabled by default.

I haven’t gone further to investigate if additional optimizations are possible within the ESM loader; there probably are. But this was significant enough that I thought it could probably land on its own.

<details>
<summary>Additional benchmarks</summary>

```
./node benchmark/compare.js --new ./out/Release/node --old ./node-main --filter startup misc | Rscript benchmark/compare.R
[00:22:32|% 100| 2/2 files | 60/60 runs | 4/4 configs]: Done
                                                                                           confidence improvement accuracy (*)   (**)  (***)
misc/startup-cli-version.js count=30 cli='deps/corepack/dist/corepack.js'                                 0.80 %       ±1.15% ±1.53% ±1.99%
misc/startup-cli-version.js count=30 cli='deps/npm/bin/npm-cli.js'                                        0.72 %       ±1.17% ±1.56% ±2.03%
misc/startup-cli-version.js count=30 cli='deps/npm/bin/npx-cli.js'                                        0.60 %       ±1.32% ±1.76% ±2.29%
misc/startup-cli-version.js count=30 cli='tools/node_modules/eslint/bin/eslint.js'                       -0.24 %       ±1.50% ±1.99% ±2.60%
misc/startup-core.js count=30 mode='process' script='benchmark/fixtures/require-builtins'                 0.40 %       ±1.15% ±1.53% ±2.00%
misc/startup-core.js count=30 mode='process' script='test/fixtures/semicolon'                             0.84 %       ±1.14% ±1.52% ±1.97%
misc/startup-core.js count=30 mode='worker' script='benchmark/fixtures/require-builtins'                  1.55 %       ±2.40% ±3.19% ±4.15%
misc/startup-core.js count=30 mode='worker' script='test/fixtures/semicolon'                             -0.23 %       ±2.56% ±3.40% ±4.43%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 8 comparisons, you can thus
expect the following amount of false-positive results:
  0.40 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.08 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

</details>

@nodejs/loaders @nodejs/performance 