### PR TITLE
fs: fix edge case in readFileSync utf8 fast path

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2402,7 +2402,7 @@ static void ReadFileUtf8(const FunctionCallbackInfo<Value>& args) {
     if (CheckOpenPermissions(env, path, flags).IsNothing()) return;
 
     FS_SYNC_TRACE_BEGIN(open);
-    file = uv_fs_open(nullptr, &req, *path, flags, O_RDONLY, nullptr);
+    file = uv_fs_open(nullptr, &req, *path, flags, 0666, nullptr);
     FS_SYNC_TRACE_END(open);
     if (req.result < 0) {
       uv_fs_req_cleanup(&req);

--- a/test/parallel/test-fs-read-file-sync.js
+++ b/test/parallel/test-fs-read-file-sync.js
@@ -24,11 +24,37 @@ require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
 
 const fn = fixtures.path('elipses.txt');
+tmpdir.refresh();
 
 const s = fs.readFileSync(fn, 'utf8');
 for (let i = 0; i < s.length; i++) {
   assert.strictEqual(s[i], '\u2026');
 }
 assert.strictEqual(s.length, 10000);
+
+// Test file permissions set for readFileSync() in append mode.
+{
+  const expectedMode = 0o666 & ~process.umask();
+
+  for (const test of [
+    { },
+    { encoding: 'ascii' },
+    { encoding: 'base64' },
+    { encoding: 'hex' },
+    { encoding: 'latin1' },
+    { encoding: 'uTf8' }, // case variation
+    { encoding: 'utf16le' },
+    { encoding: 'utf8' },
+  ]) {
+    const opts = { ...test, flag: 'a+' };
+    const file = tmpdir.resolve(`testReadFileSyncAppend${opts.encoding ?? ''}.txt`);
+    const variant = `for '${file}'`;
+
+    const content = fs.readFileSync(file, opts);
+    assert.strictEqual(opts.encoding ? content : content.toString(), '', `file contents ${variant}`);
+    assert.strictEqual(fs.statSync(file).mode & 0o777, expectedMode, `file permissions ${variant}`);
+  }
+}


### PR DESCRIPTION
Fix a file permissions regression when `fs.readFileSync()` is called in append mode on a file that does not already exist introduced by the fast path for utf8 encoding.

Fixes: https://github.com/nodejs/node/issues/52079
Refs: https://github.com/nodejs/node/pull/49691

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
