### PR TITLE
src: make start of signal_wrap reenterable

### DIFF
--- a/test/parallel/test-signal-reuse.js
+++ b/test/parallel/test-signal-reuse.js
@@ -1,0 +1,21 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+const { internalBinding } = require('internal/test/binding');
+const { signals } = internalBinding('constants').os;
+const Signal = internalBinding('signal_wrap').Signal;
+
+common.skipIfWorker();
+
+const signal = new Signal();
+signal.start(signals.SIGUSR2);
+signal.onsignal = common.mustCall(() => {
+  process.nextTick(common.mustCall(() => {
+    signal.start(signals.SIGINT);
+    signal.onsignal = common.mustCall(() => {
+      signal.close();
+    });
+    process.kill(0, signals.SIGINT);
+  }));
+});
+process.kill(0, signals.SIGUSR2);


### PR DESCRIPTION
make start of signal_wrap reenterable.
```js
const Signal = internalBinding('signal_wrap').Signal;
const { signals } = internalBinding('constants').os;

const signal = new Signal();
signal.start(signals.SIGUSR2);
signal.start(signals.SIGINT);
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
