### PR TITLE
esm: drop support for import assertions

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -796,12 +796,6 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
     return ExitCode::kInvalidCommandLineArgument2;
   }
 
-  // TODO(aduh95): remove this when the harmony-import-assertions flag
-  // is removed in V8.
-  if (std::find(v8_args.begin(), v8_args.end(),
-                "--no-harmony-import-assertions") == v8_args.end()) {
-    v8_args.emplace_back("--harmony-import-assertions");
-  }
   // TODO(aduh95): remove this when the harmony-import-attributes flag
   // is removed in V8.
   if (std::find(v8_args.begin(),
@@ -809,6 +803,9 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
                 "--no-harmony-import-attributes") == v8_args.end()) {
     v8_args.emplace_back("--harmony-import-attributes");
   }
+  // TODO(nicolo-ribaudo): remove this once V8 doesn't enable it by default
+  // anymore.
+  v8_args.emplace_back("--no-harmony-import-assertions");
 
   auto env_opts = per_process::cli_options->per_isolate->per_env;
   if (std::find(v8_args.begin(), v8_args.end(),

--- a/test/es-module/test-esm-import-attributes-errors.js
+++ b/test/es-module/test-esm-import-attributes-errors.js
@@ -55,6 +55,16 @@ async function test() {
     import(jsonModuleDataUrl, { with: { type: 'unsupported' } }),
     { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
   );
+
+  await rejects(
+    import(jsonModuleDataUrl, { assert: { type: 'json' } }),
+    { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' }
+  );
+
+  await rejects(
+    import(`data:text/javascript,import${JSON.stringify(jsonModuleDataUrl)}assert{type:"json"}`),
+    SyntaxError
+  );
 }
 
 test().then(common.mustCall());

--- a/test/es-module/test-esm-import-attributes-errors.mjs
+++ b/test/es-module/test-esm-import-attributes-errors.mjs
@@ -50,3 +50,13 @@ await rejects(
   import(jsonModuleDataUrl, { with: { type: 'unsupported' } }),
   { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
 );
+
+await rejects(
+  import(jsonModuleDataUrl, { assert: { type: 'json' } }),
+  { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' }
+);
+
+await rejects(
+  import(`data:text/javascript,import${JSON.stringify(jsonModuleDataUrl)}assert{type:"json"}`),
+  SyntaxError
+);


### PR DESCRIPTION
This patch removes support for the `assert` keyword for import attributes. It was an old variant of the proposal that was only shipped in V8 and no other
engine, and that has then been replaced by the `with` keyword.

Chrome is planning to remove support for `assert`
in version 126, which will be released in June.

Node.js already supports the `with` keyword for
import attributes, and this patch does not change that.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #51622