### PR TITLE
stream: add `new` when constructing `ERR_MULTIPLE_CALLBACK`

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -876,7 +876,7 @@ function needFinish(state) {
 
 function onFinish(stream, state, err) {
   if ((state[kState] & kPrefinished) !== 0) {
-    errorOrDestroy(stream, err ?? ERR_MULTIPLE_CALLBACK());
+    errorOrDestroy(stream, err ?? new ERR_MULTIPLE_CALLBACK());
     return;
   }
   state.pendingcb--;

--- a/test/parallel/test-stream-err-multiple-callback-construction.js
+++ b/test/parallel/test-stream-err-multiple-callback-construction.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const stream = require('stream');
+const assert = require('assert');
+
+class TestWritable extends stream.Writable {
+  _write(_chunk, _encoding, callback) {
+    callback();
+  }
+
+  _final(callback) {
+    process.nextTick(callback);
+    process.nextTick(callback);
+  }
+}
+
+const writable = new TestWritable();
+
+writable.on('finish', common.mustCall());
+writable.on('error', common.mustCall((error) => {
+  assert.strictEqual(error.message, 'Callback called multiple times');
+}));
+
+writable.write('some data');
+writable.end();


### PR DESCRIPTION
commit c71e548b65d912a976b65ea10ad6ee7d66b6e997 changed NodeError from a function to a class, and missed a spot where `ERR_MULTIPLE_CALLBACK` was being instantiated. This commit fixes that by adding the new keyword to that instance.