### PR TITLE
test_runner: skip each hooks for skipped tests

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -666,7 +666,7 @@ class Test extends AsyncResource {
       }
     };
     const afterEach = runOnce(async () => {
-      if (this.parent?.hooks.afterEach.length > 0) {
+      if (this.parent?.hooks.afterEach.length > 0 && !this.skipped) {
         await this.parent.runHook('afterEach', hookArgs);
       }
     });
@@ -678,7 +678,7 @@ class Test extends AsyncResource {
         // This hook usually runs immediately, we need to wait for it to finish
         await this.parent.runHook('before', this.parent.getRunArgs());
       }
-      if (this.parent?.hooks.beforeEach.length > 0) {
+      if (this.parent?.hooks.beforeEach.length > 0 && !this.skipped) {
         await this.parent.runHook('beforeEach', hookArgs);
       }
       stopPromise = stopTest(this.timeout, this.signal);

--- a/test/fixtures/test-runner/output/skip-each-hooks.js
+++ b/test/fixtures/test-runner/output/skip-each-hooks.js
@@ -1,0 +1,21 @@
+// Flags: --test-reporter=spec
+'use strict';
+const { after, afterEach, before, beforeEach, test } = require('node:test');
+
+before(() => {
+  console.log('BEFORE');
+});
+
+beforeEach(() => {
+  console.log('BEFORE EACH');
+});
+
+after(() => {
+  console.log('AFTER');
+});
+
+afterEach(() => {
+  console.log('AFTER EACH');
+});
+
+test('skipped test', { skip: true });

--- a/test/fixtures/test-runner/output/skip-each-hooks.snapshot
+++ b/test/fixtures/test-runner/output/skip-each-hooks.snapshot
@@ -1,0 +1,11 @@
+BEFORE
+AFTER
+﹣ skipped test (*ms) # SKIP
+ℹ tests 1
+ℹ suites 0
+ℹ pass 0
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 1
+ℹ todo 0
+ℹ duration_ms *

--- a/test/fixtures/test-runner/output/suite-skip-hooks.js
+++ b/test/fixtures/test-runner/output/suite-skip-hooks.js
@@ -9,22 +9,6 @@ const {
   it,
 } = require('node:test');
 
-// before(() => {
-//   console.log('BEFORE');
-// });
-
-// beforeEach(() => {
-//   console.log('BEFORE EACH');
-// });
-
-// after(() => {
-//   console.log('AFTER');
-// });
-
-// afterEach(() => {
-//   console.log('AFTER EACH');
-// });
-
 describe('skip all hooks in this suite', { skip: true }, () => {
   before(() => {
     console.log('BEFORE 1');

--- a/test/fixtures/test-runner/output/suite-skip-hooks.js
+++ b/test/fixtures/test-runner/output/suite-skip-hooks.js
@@ -1,0 +1,76 @@
+// Flags: --test-reporter=spec
+'use strict';
+const {
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  describe,
+  it,
+} = require('node:test');
+
+// before(() => {
+//   console.log('BEFORE');
+// });
+
+// beforeEach(() => {
+//   console.log('BEFORE EACH');
+// });
+
+// after(() => {
+//   console.log('AFTER');
+// });
+
+// afterEach(() => {
+//   console.log('AFTER EACH');
+// });
+
+describe('skip all hooks in this suite', { skip: true }, () => {
+  before(() => {
+    console.log('BEFORE 1');
+  });
+
+  beforeEach(() => {
+    console.log('BEFORE EACH 1');
+  });
+
+  after(() => {
+    console.log('AFTER 1');
+  });
+
+  afterEach(() => {
+    console.log('AFTER EACH 1');
+  });
+
+  it('should not run');
+});
+
+describe('suite runs with mixture of skipped tests', () => {
+  before(() => {
+    console.log('BEFORE 2');
+  });
+
+  beforeEach(() => {
+    console.log('BEFORE EACH 2');
+  });
+
+  after(() => {
+    console.log('AFTER 2');
+  });
+
+  afterEach(() => {
+    console.log('AFTER EACH 2');
+  });
+
+  it('should not run', { skip: true });
+
+  it('should run 1', () => {
+    console.log('should run 1');
+  });
+
+  it('should not run', { skip: true });
+
+  it('should run 2', () => {
+    console.log('should run 2');
+  });
+});

--- a/test/fixtures/test-runner/output/suite-skip-hooks.snapshot
+++ b/test/fixtures/test-runner/output/suite-skip-hooks.snapshot
@@ -1,0 +1,24 @@
+BEFORE 2
+BEFORE EACH 2
+should run 1
+AFTER EACH 2
+BEFORE EACH 2
+should run 2
+AFTER EACH 2
+AFTER 2
+﹣ skip all hooks in this suite (*ms) # SKIP
+▶ suite runs with mixture of skipped tests
+  ﹣ should not run (*ms) # SKIP
+  ✔ should run 1 (*ms)
+  ﹣ should not run (*ms) # SKIP
+  ✔ should run 2 (*ms)
+▶ suite runs with mixture of skipped tests (*ms)
+
+ℹ tests 4
+ℹ suites 2
+ℹ pass 2
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 2
+ℹ todo 0
+ℹ duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -96,6 +96,7 @@ const tests = [
   { name: 'test-runner/output/eval_tap.js' },
   { name: 'test-runner/output/hooks.js' },
   { name: 'test-runner/output/hooks_spec_reporter.js', transform: specTransform },
+  { name: 'test-runner/output/skip-each-hooks.js', transform: specTransform },
   { name: 'test-runner/output/timeout_in_before_each_should_not_affect_further_tests.js' },
   { name: 'test-runner/output/hooks-with-no-global-test.js' },
   { name: 'test-runner/output/global-hooks-with-no-tests.js' },

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -97,6 +97,7 @@ const tests = [
   { name: 'test-runner/output/hooks.js' },
   { name: 'test-runner/output/hooks_spec_reporter.js', transform: specTransform },
   { name: 'test-runner/output/skip-each-hooks.js', transform: specTransform },
+  { name: 'test-runner/output/suite-skip-hooks.js', transform: specTransform },
   { name: 'test-runner/output/timeout_in_before_each_should_not_affect_further_tests.js' },
   { name: 'test-runner/output/hooks-with-no-global-test.js' },
   { name: 'test-runner/output/global-hooks-with-no-tests.js' },


### PR DESCRIPTION
When a test is skipped, the corresponding beforeEach and afterEach hooks should also be skipped.

Fixes: https://github.com/nodejs/node/issues/52112

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
