### PR TITLE
test_runner: ignore todo flag when running suites

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -988,7 +988,7 @@ class Suite extends Test {
   constructor(options) {
     super(options);
 
-    if (testNamePatterns !== null && !options.skip && !options.todo) {
+    if (testNamePatterns !== null && !options.skip) {
       this.fn = options.fn || this.fn;
       this.skipped = false;
     }

--- a/test/fixtures/test-runner/output/name_pattern.js
+++ b/test/fixtures/test-runner/output/name_pattern.js
@@ -66,6 +66,16 @@ describe('no', function() {
   });
 });
 
+describe('no with todo', { todo: true }, () => {
+  it('no', () => {});
+  it('yes', () => {});
+
+  describe('maybe', function() {
+    it('no', () => {});
+    it('yes', () => {});
+  });
+});
+
 describe('DescribeForMatchWithAncestors', () => {
   it('NestedTest', () => common.mustNotCall());
 

--- a/test/fixtures/test-runner/output/name_pattern.snapshot
+++ b/test/fixtures/test-runner/output/name_pattern.snapshot
@@ -171,6 +171,40 @@ ok 15 - no
   duration_ms: *
   type: 'suite'
   ...
+# Subtest: no with todo
+    # Subtest: no
+    ok 1 - no # SKIP test name does not match pattern
+      ---
+      duration_ms: *
+      ...
+    # Subtest: yes
+    ok 2 - yes
+      ---
+      duration_ms: *
+      ...
+    # Subtest: maybe
+        # Subtest: no
+        ok 1 - no # SKIP test name does not match pattern
+          ---
+          duration_ms: *
+          ...
+        # Subtest: yes
+        ok 2 - yes
+          ---
+          duration_ms: *
+          ...
+        1..2
+    ok 3 - maybe
+      ---
+      duration_ms: *
+      type: 'suite'
+      ...
+    1..3
+ok 16 - no with todo # TODO test name does not match pattern
+  ---
+  duration_ms: *
+  type: 'suite'
+  ...
 # Subtest: DescribeForMatchWithAncestors
     # Subtest: NestedTest
     ok 1 - NestedTest # SKIP test name does not match pattern
@@ -190,7 +224,7 @@ ok 15 - no
       type: 'suite'
       ...
     1..2
-ok 16 - DescribeForMatchWithAncestors
+ok 17 - DescribeForMatchWithAncestors
   ---
   duration_ms: *
   type: 'suite'
@@ -202,17 +236,17 @@ ok 16 - DescribeForMatchWithAncestors
       duration_ms: *
       ...
     1..1
-ok 17 - DescribeForMatchWithAncestors
+ok 18 - DescribeForMatchWithAncestors
   ---
   duration_ms: *
   type: 'suite'
   ...
-1..17
-# tests 24
-# suites 13
-# pass 14
+1..18
+# tests 28
+# suites 15
+# pass 16
 # fail 0
 # cancelled 0
-# skipped 10
+# skipped 12
 # todo 0
 # duration_ms *


### PR DESCRIPTION
This commit removes a check for the todo flag when determining if a suite should run. In general, the todo flag should have no impact on whether or not a test/suite runs. Instead, it should only impact how the result of the test/suite is handled.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
