### PR TITLE
lib: make sure clear the old timer in http server

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -515,6 +515,9 @@ function setupConnectionsTracking() {
     this[kConnections] = new ConnectionsList();
   }
 
+  if (this[kConnectionsCheckingInterval]) {
+    clearInterval(this[kConnectionsCheckingInterval]);
+  }
   // This checker is started without checking whether any headersTimeout or requestTimeout is non zero
   // otherwise it would not be started if such timeouts are modified after createServer.
   this[kConnectionsCheckingInterval] =

--- a/test/parallel/test-http-server-clear-timer.js
+++ b/test/parallel/test-http-server-clear-timer.js
@@ -1,0 +1,24 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+const { kConnectionsCheckingInterval } = require('_http_server');
+
+let i = 0;
+let timer;
+const server = http.createServer();
+server.on('listening', common.mustCall(() => {
+  // If there was a timer, it must be destroyed
+  if (timer) {
+    assert.ok(timer._destroyed);
+  }
+  // Save the last timer
+  timer = server[kConnectionsCheckingInterval];
+  if (++i === 2) {
+    server.close(() => {
+      assert.ok(timer._destroyed);
+    });
+  }
+}, 2));
+server.emit('listening');
+server.emit('listening');


### PR DESCRIPTION
Currently we can call `listen` twice with same server in cluster worker and the server will emit `listening` event twice.
The http server will call `setInterval` in`listening` event handler, but the second call do not clear the old timer which will make the memory leak.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
