### PR TITLE
src: remove comments from env file

### DIFF
--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -32,7 +32,8 @@ class Dotenv {
 
  private:
   std::map<std::string, std::string> store_;
-  std::string_view trim_quotes(std::string_view str);
+  std::string_view TrimQuotes(std::string_view str);
+  std::string RemoveComments(const std::string& str);
 };
 
 }  // namespace node

--- a/test/fixtures/dotenv/valid.env
+++ b/test/fixtures/dotenv/valid.env
@@ -24,6 +24,8 @@ EXPAND_NEWLINES="expand\nnew\nlines"
 DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
 DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
 # COMMENTS=work
+#BASIC=basic2
+#BASIC=basic3
 INLINE_COMMENTS=inline comments # work #very #well
 INLINE_COMMENTS_SINGLE_QUOTES='inline comments outside of #singlequotes' # work
 INLINE_COMMENTS_DOUBLE_QUOTES="inline comments outside of #doublequotes" # work
@@ -37,7 +39,7 @@ TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
 EMAIL=therealnerdybeast@example.tld
     SPACED_KEY = parsed
 EDGE_CASE_INLINE_COMMENTS="VALUE1" # or "VALUE2" or "VALUE3"
-
+export EXAMPLE = ignore export
 MULTI_DOUBLE_QUOTED="THIS
 IS
 A
@@ -58,4 +60,3 @@ STRING`
 MULTI_NOT_VALID_QUOTE="
 MULTI_NOT_VALID=THIS
 IS NOT MULTILINE
-export EXAMPLE = ignore export


### PR DESCRIPTION
Addressing this [issue](https://github.com/nodejs/node/issues/52084)
The regex wasn't dealing with multiple comment lines properly. I added a function to remove all comments first, then apply the regex to the cleaned-up content.