### PR TITLE
test: add `spawnSyncAndAssert` util

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -70,11 +70,15 @@ gathering more information about test failures coming from child processes.
   * `stderr` [\<string>][<string>] The output from the child process to stderr.
   * `stdout` [\<string>][<string>] The output from the child process to stdout.
 
-### `spawnSyncAndExitWithoutError(command[, args][, spawnOptions], expectations)`
+### `spawnSyncAndExitWithoutError(command[, args][, spawnOptions])`
 
 Similar to `expectSyncExit()` with the `status` expected to be 0 and
-`signal` expected to be `null`. Any other optional options are passed
-into `expectSyncExit()`.
+`signal` expected to be `null`.
+
+### `spawnSyncAndAssert(command[, args][, spawnOptions], expectations)`
+
+Similar to `spawnSyncAndExitWithoutError()`, but with an additional
+`expectations` parameter.
 
 ## Common Module API
 

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -119,9 +119,15 @@ function spawnSyncAndExit(...args) {
 }
 
 function spawnSyncAndExitWithoutError(...args) {
-  const spawnArgs = args.slice(0, args.length);
-  const expectations = args[args.length - 1];
-  const child = spawnSync(...spawnArgs);
+  return expectSyncExit(spawnSync(...args), {
+    status: 0,
+    signal: null,
+  });
+}
+
+function spawnSyncAndAssert(...args) {
+  const expectations = args.pop();
+  const child = spawnSync(...args);
   return expectSyncExit(child, {
     status: 0,
     signal: null,
@@ -136,4 +142,5 @@ module.exports = {
   kExpiringParentTimer,
   spawnSyncAndExit,
   spawnSyncAndExitWithoutError,
+  spawnSyncAndAssert,
 };

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -140,7 +140,7 @@ module.exports = {
   logAfterTime,
   kExpiringChildRunTime,
   kExpiringParentTimer,
+  spawnSyncAndAssert,
   spawnSyncAndExit,
   spawnSyncAndExitWithoutError,
-  spawnSyncAndAssert,
 };

--- a/test/common/sea.js
+++ b/test/common/sea.js
@@ -92,8 +92,8 @@ function generateSEA(targetExecutable, sourceExecutable, seaBlob, verifyWorkflow
 
   if (process.platform === 'darwin') {
     try {
-      spawnSyncAndExitWithoutError('codesign', [ '--sign', '-', targetExecutable ], {});
-      spawnSyncAndExitWithoutError('codesign', [ '--verify', targetExecutable ], {});
+      spawnSyncAndExitWithoutError('codesign', [ '--sign', '-', targetExecutable ]);
+      spawnSyncAndExitWithoutError('codesign', [ '--verify', targetExecutable ]);
     } catch (e) {
       const message = `Cannot sign ${targetExecutable}: ${inspect(e)}`;
       if (verifyWorkflow) {
@@ -104,7 +104,7 @@ function generateSEA(targetExecutable, sourceExecutable, seaBlob, verifyWorkflow
     console.log(`Signed ${targetExecutable}`);
   } else if (process.platform === 'win32') {
     try {
-      spawnSyncAndExitWithoutError('where', [ 'signtool' ], {});
+      spawnSyncAndExitWithoutError('where', [ 'signtool' ]);
     } catch (e) {
       const message = `Cannot find signtool: ${inspect(e)}`;
       if (verifyWorkflow) {
@@ -114,8 +114,8 @@ function generateSEA(targetExecutable, sourceExecutable, seaBlob, verifyWorkflow
     }
     let stderr;
     try {
-      ({ stderr } = spawnSyncAndExitWithoutError('signtool', [ 'sign', '/fd', 'SHA256', targetExecutable ], {}));
-      spawnSyncAndExitWithoutError('signtool', 'verify', '/pa', 'SHA256', targetExecutable, {});
+      ({ stderr } = spawnSyncAndExitWithoutError('signtool', [ 'sign', '/fd', 'SHA256', targetExecutable ]));
+      spawnSyncAndExitWithoutError('signtool', ['verify', '/pa', 'SHA256', targetExecutable]);
     } catch (e) {
       const message = `Cannot sign ${targetExecutable}: ${inspect(e)}\n${stderr}`;
       if (verifyWorkflow) {

--- a/test/common/wasi.js
+++ b/test/common/wasi.js
@@ -1,7 +1,7 @@
 // Test version set to preview1
 'use strict';
 
-const { spawnSyncAndExitWithoutError } = require('./child_process');
+const { spawnSyncAndAssert } = require('./child_process');
 const fixtures = require('./fixtures');
 const childPath = fixtures.path('wasi-preview-1.js');
 
@@ -15,7 +15,7 @@ function testWasiPreview1(args, spawnArgs = {}, expectations = {}) {
   spawnArgs.env = newEnv;
 
   console.log('Testing with --turbo-fast-api-calls:', ...args);
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     process.execPath, [
       '--turbo-fast-api-calls',
       childPath,
@@ -26,7 +26,7 @@ function testWasiPreview1(args, spawnArgs = {}, expectations = {}) {
   );
 
   console.log('Testing with --no-turbo-fast-api-calls:', ...args);
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     process.execPath,
     [
       '--no-turbo-fast-api-calls',

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -4,6 +4,7 @@ const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const {
+  spawnSyncAndAssert,
   spawnSyncAndExit,
   spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
@@ -23,7 +24,7 @@ function resolveBuiltBinary(binary) {
 
 const binary = resolveBuiltBinary('embedtest');
 
-spawnSyncAndExitWithoutError(
+spawnSyncAndAssert(
   binary,
   ['console.log(42)'],
   {
@@ -31,7 +32,7 @@ spawnSyncAndExitWithoutError(
     stdout: '42',
   });
 
-spawnSyncAndExitWithoutError(
+spawnSyncAndAssert(
   binary,
   ['console.log(embedVars.nön_ascıı)'],
   {
@@ -111,9 +112,8 @@ for (const extraSnapshotArgs of [
   spawnSyncAndExitWithoutError(
     binary,
     [ '--', ...buildSnapshotArgs ],
-    { cwd: tmpdir.path },
-    {});
-  spawnSyncAndExitWithoutError(
+    { cwd: tmpdir.path });
+  spawnSyncAndAssert(
     binary,
     [ '--', ...runSnapshotArgs ],
     { cwd: tmpdir.path },
@@ -145,11 +145,9 @@ for (const extraSnapshotArgs of [
   spawnSyncAndExitWithoutError(
     binary,
     [ '--', ...buildSnapshotArgs ],
-    { cwd: tmpdir.path },
-    {});
+    { cwd: tmpdir.path });
   spawnSyncAndExitWithoutError(
     binary,
     [ '--', ...runEmbeddedArgs ],
-    { cwd: tmpdir.path },
-    {});
+    { cwd: tmpdir.path });
 }

--- a/test/parallel/test-error-prepare-stack-trace.js
+++ b/test/parallel/test-error-prepare-stack-trace.js
@@ -26,6 +26,5 @@ if (process.argv[2] !== 'child') {
   // enabled.
   spawnSyncAndExitWithoutError(
     process.execPath,
-    ['--enable-source-maps', __filename, 'child'],
-    {});
+    ['--enable-source-maps', __filename, 'child']);
 }

--- a/test/parallel/test-snapshot-api.js
+++ b/test/parallel/test-snapshot-api.js
@@ -6,7 +6,7 @@ require('../common');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
 const fs = require('fs');
 
 const v8 = require('v8');
@@ -41,7 +41,7 @@ const entry = fixtures.path('snapshot', 'v8-startup-snapshot-api.js');
 }
 
 {
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     'book1',

--- a/test/parallel/test-snapshot-basic.js
+++ b/test/parallel/test-snapshot-basic.js
@@ -8,8 +8,9 @@ const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const {
-  spawnSyncAndExitWithoutError,
+  spawnSyncAndAssert,
   spawnSyncAndExit,
+  spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
 const fs = require('fs');
 
@@ -65,7 +66,7 @@ const blobPath = tmpdir.resolve('my-snapshot.blob');
 
 {
   // Check --help.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--help',
@@ -78,7 +79,7 @@ const blobPath = tmpdir.resolve('my-snapshot.blob');
 
 {
   // Check -c.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '-c',

--- a/test/parallel/test-snapshot-child-process-sync.js
+++ b/test/parallel/test-snapshot-child-process-sync.js
@@ -4,7 +4,7 @@
 // restoring state from a snapshot
 
 require('../common');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert } = require('../common/child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
@@ -20,7 +20,7 @@ const expected = [
 
 {
   // Create the snapshot.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -37,7 +37,7 @@ const expected = [
 }
 
 {
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     file,

--- a/test/parallel/test-snapshot-config.js
+++ b/test/parallel/test-snapshot-config.js
@@ -5,8 +5,9 @@
 require('../common');
 const assert = require('assert');
 const {
-  spawnSyncAndExitWithoutError,
+  spawnSyncAndAssert,
   spawnSyncAndExit,
+  spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
@@ -84,7 +85,7 @@ let sizeWithCache;
     configPath,
   ], {
     cwd: tmpdir.path
-  }, {});
+  });
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
   sizeWithCache = stats.size;
@@ -115,14 +116,14 @@ let sizeWithoutCache;
       NODE_DEBUG_NATIVE: 'CODE_CACHE'
     },
     cwd: tmpdir.path
-  }, {});
+  });
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
   sizeWithoutCache = stats.size;
   assert(sizeWithoutCache < sizeWithCache,
          `sizeWithoutCache = ${sizeWithoutCache} >= sizeWithCache ${sizeWithCache}`);
   // Check the snapshot.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     checkFile,

--- a/test/parallel/test-snapshot-cwd.js
+++ b/test/parallel/test-snapshot-cwd.js
@@ -4,7 +4,7 @@
 // restoring state from a snapshot
 
 require('../common');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert } = require('../common/child_process');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
 const fs = require('fs');
@@ -18,7 +18,7 @@ fs.mkdirSync(subdir);
 
 {
   // Create the snapshot.
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -32,7 +32,7 @@ fs.mkdirSync(subdir);
 }
 
 {
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     file,

--- a/test/parallel/test-snapshot-warning.js
+++ b/test/parallel/test-snapshot-warning.js
@@ -9,7 +9,7 @@ require('../common');
 const assert = require('assert');
 const tmpdir = require('../common/tmpdir');
 const fixtures = require('../common/fixtures');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
 const fs = require('fs');
 
 const warningScript = fixtures.path('snapshot', 'warning.js');
@@ -30,7 +30,7 @@ tmpdir.refresh();
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
 
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     warningScript,
@@ -49,7 +49,7 @@ tmpdir.refresh();
 {
   console.log('\n# Check snapshot scripts that emit ' +
               'warnings and --trace-warnings hint.');
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--build-snapshot',
@@ -68,7 +68,7 @@ tmpdir.refresh();
   const stats = fs.statSync(blobPath);
   assert(stats.isFile());
 
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     warningScript,
@@ -92,7 +92,7 @@ tmpdir.refresh();
   const warningFile1 = tmpdir.resolve('warnings.txt');
   const warningFile2 = tmpdir.resolve('warnings2.txt');
 
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--redirect-warnings',
@@ -120,7 +120,7 @@ tmpdir.refresh();
     maxRetries: 3, recursive: false, force: true
   });
 
-  spawnSyncAndExitWithoutError(process.execPath, [
+  spawnSyncAndAssert(process.execPath, [
     '--snapshot-blob',
     blobPath,
     '--redirect-warnings',

--- a/test/sequential/test-single-executable-application-assets-raw.js
+++ b/test/sequential/test-single-executable-application-assets-raw.js
@@ -51,8 +51,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
         ...process.env,
       },
       cwd: tmpdir.path
-    },
-    {});
+    });
 
   assert(existsSync(seaPrepBlob));
 
@@ -67,6 +66,5 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
         __TEST_PERSON_JPG: fixtures.path('person.jpg'),
       }
     },
-    { }
   );
 }

--- a/test/sequential/test-single-executable-application-assets.js
+++ b/test/sequential/test-single-executable-application-assets.js
@@ -14,6 +14,7 @@ const tmpdir = require('../common/tmpdir');
 
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
 const {
+  spawnSyncAndAssert,
   spawnSyncAndExit,
   spawnSyncAndExitWithoutError,
 } = require('../common/child_process');
@@ -104,14 +105,13 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
         ...process.env,
       },
       cwd: tmpdir.path
-    },
-    {});
+    });
 
   assert(existsSync(seaPrepBlob));
 
   generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     outputFile,
     {
       env: {

--- a/test/sequential/test-single-executable-application-disable-experimental-sea-warning.js
+++ b/test/sequential/test-single-executable-application-disable-experimental-sea-warning.js
@@ -15,7 +15,7 @@ skipIfSingleExecutableIsNotSupported();
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
 const { join } = require('path');
 const assert = require('assert');
 
@@ -46,14 +46,13 @@ copyFileSync(inputFile, tmpdir.resolve('sea.js'));
 spawnSyncAndExitWithoutError(
   process.execPath,
   ['--experimental-sea-config', 'sea-config.json'],
-  { cwd: tmpdir.path },
-  {});
+  { cwd: tmpdir.path });
 
 assert(existsSync(seaPrepBlob));
 
 generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-spawnSyncAndExitWithoutError(
+spawnSyncAndAssert(
   outputFile,
   [ '-a', '--b=c', 'd' ],
   {

--- a/test/sequential/test-single-executable-application-empty.js
+++ b/test/sequential/test-single-executable-application-empty.js
@@ -60,5 +60,4 @@ spawnSyncAndExitWithoutError(
       NODE_DEBUG_NATIVE: 'SEA',
       ...process.env,
     }
-  },
-  {});
+  });

--- a/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
+++ b/test/sequential/test-single-executable-application-snapshot-and-code-cache.js
@@ -14,7 +14,7 @@ skipIfSingleExecutableIsNotSupported();
 const tmpdir = require('../common/tmpdir');
 const { writeFileSync, existsSync } = require('fs');
 const {
-  spawnSyncAndExitWithoutError
+  spawnSyncAndAssert,
 } = require('../common/child_process');
 const { join } = require('path');
 const assert = require('assert');
@@ -45,7 +45,7 @@ const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 
   }
   `);
 
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     process.execPath,
     ['--experimental-sea-config', 'sea-config.json'],
     {
@@ -64,7 +64,7 @@ const outputFile = join(tmpdir.path, process.platform === 'win32' ? 'sea.exe' : 
 
   generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     outputFile,
     {
       env: {

--- a/test/sequential/test-single-executable-application-snapshot.js
+++ b/test/sequential/test-single-executable-application-snapshot.js
@@ -14,8 +14,8 @@ skipIfSingleExecutableIsNotSupported();
 const tmpdir = require('../common/tmpdir');
 const { writeFileSync, existsSync } = require('fs');
 const {
+  spawnSyncAndAssert,
   spawnSyncAndExit,
-  spawnSyncAndExitWithoutError
 } = require('../common/child_process');
 const assert = require('assert');
 
@@ -69,7 +69,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
   }
   `);
 
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     process.execPath,
     ['--experimental-sea-config', 'sea-config.json'],
     {
@@ -87,7 +87,7 @@ const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'se
 
   generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     outputFile,
     {
       env: {

--- a/test/sequential/test-single-executable-application-use-code-cache.js
+++ b/test/sequential/test-single-executable-application-use-code-cache.js
@@ -15,7 +15,7 @@ skipIfSingleExecutableIsNotSupported();
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
 const { join } = require('path');
 const assert = require('assert');
 
@@ -58,7 +58,7 @@ assert(existsSync(seaPrepBlob));
 
 generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-spawnSyncAndExitWithoutError(
+spawnSyncAndAssert(
   outputFile,
   [ '-a', '--b=c', 'd' ],
   {

--- a/test/sequential/test-single-executable-application.js
+++ b/test/sequential/test-single-executable-application.js
@@ -14,7 +14,7 @@ skipIfSingleExecutableIsNotSupported();
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const { copyFileSync, writeFileSync, existsSync } = require('fs');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
 const { join } = require('path');
 const assert = require('assert');
 
@@ -45,14 +45,13 @@ copyFileSync(inputFile, tmpdir.resolve('sea.js'));
 spawnSyncAndExitWithoutError(
   process.execPath,
   ['--experimental-sea-config', 'sea-config.json'],
-  { cwd: tmpdir.path },
-  {});
+  { cwd: tmpdir.path });
 
 assert(existsSync(seaPrepBlob));
 
 generateSEA(outputFile, process.execPath, seaPrepBlob);
 
-spawnSyncAndExitWithoutError(
+spawnSyncAndAssert(
   outputFile,
   [ '-a', '--b=c', 'd' ],
   {

--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const tmpdir = require('../common/tmpdir');
 const fs = require('fs');
 const assert = require('assert');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert } = require('../common/child_process');
 
 // Test that --prof also tracks Worker threads.
 // Refs: https://github.com/nodejs/node/issues/24016
@@ -50,7 +50,7 @@ if (process.argv[2] === 'child') {
 
   const workerProfRegexp = /worker prof file: (.+\.log)/;
   const parentProfRegexp = /parent prof file: (.+\.log)/;
-  const { stdout } = spawnSyncAndExitWithoutError(
+  const { stdout } = spawnSyncAndAssert(
     process.execPath, ['--prof', __filename, 'child'],
     { cwd: tmpdir.path, encoding: 'utf8' }, {
       stdout(output) {


### PR DESCRIPTION
`spawnSyncAndExitWithoutError` will use the last argument as a bag of expectations, but will also pass it to `spawnSync`. That sometimes causes problems if the expectations are incompatible with the bag of options `spawnSync` expects. With this PR, all arguments but the last one is passed to `spawnSync`, making for a more comprehensible API.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
