### PR TITLE
lib: fix type error for _refreshLine

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -685,7 +685,7 @@ class Interface extends InterfaceConstructor {
                                        this.cursor,
                                        this.line.length);
       this.cursor = this.cursor - completeOn.length + prefix.length;
-      this._refreshLine();
+      this[kRefreshLine]();
       return;
     }
 


### PR DESCRIPTION
When press `tab`, but don't hit any completions, the interface throws type error.
```
node:internal/readline/interface:687
      this._refreshLine();
           ^

TypeError: this._refreshLine is not a function
    at [_tabCompleter] (node:internal/readline/interface:687:12)
    at [_tabComplete] (node:internal/readline/interface:660:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.11.1
```

The reproduce steps:

1. The code:
```js
import readline from "readline/promises";

const completions = '.set_a .set_b .help'.split(' ');
const rl = readline.createInterface({
    input: process.stdin,
    output: process.stdout,
    completer: (line) => {
        const hits = completions.filter((c) => c.startsWith(line));
        // Show all completions if none found
        return [hits.length ? hits : completions, line];
    }
});

const answer = await rl.question('What is your query: > ');
```
2. Run it with node. Type in `hh`, then press tab.
3. Gets type error.