### PR TITLE
lib: fix handle.setSimultaneousAccepts

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -706,7 +706,9 @@ function setupChannel(target, channel, serializationMode) {
     const obj = handleConversion[message.type];
 
     // Update simultaneous accepts on Windows
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' &&
+        // Only available for TCP handle
+        typeof handle.setSimultaneousAccepts === 'function') {
       handle.setSimultaneousAccepts(false);
     }
 
@@ -831,7 +833,10 @@ function setupChannel(target, channel, serializationMode) {
         message = message.msg;
 
       // Update simultaneous accepts on Windows
-      if (obj.simultaneousAccepts && process.platform === 'win32') {
+      if (obj.simultaneousAccepts &&
+          process.platform === 'win32' &&
+          // Only available for TCP handle
+          typeof handle.setSimultaneousAccepts === 'function') {
         handle.setSimultaneousAccepts(true);
       }
     } else if (this._handleQueue &&

--- a/test/parallel/test-child-process-send-ipc-handle.js
+++ b/test/parallel/test-child-process-send-ipc-handle.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+
+// Make sure use shared handle
+process.env.NODE_CLUSTER_SCHED_POLICY = 'none';
+
+const net = require('net');
+const cluster = require('cluster');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  worker.on('exit', common.mustCall((code) => {
+    assert.ok(code === 0);
+  }));
+} else {
+  tmpdir.refresh();
+  const server = net.createServer();
+  server.listen(common.PIPE, common.mustCall(() => {
+    server.close(() => {
+      process.disconnect();
+    });
+  }));
+}


### PR DESCRIPTION
The error from CI is as follows. 
<img width="778" alt="image" src="https://github.com/nodejs/node/assets/21155906/c9e79bb3-a177-41c1-bfe0-eb321148b8b0">

`setSimultaneousAccepts ` is only defined for TCP handle on win32 plarform.

Refs: [link](https://ci.nodejs.org/job/node-test-binary-windows-js-suites/26558/RUN_SUBSET=2,nodes=win2022-COMPILED_BY-vs2022/console)

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)