### PR TITLE
test: add test for using `--print` with promises

### DIFF
--- a/test/parallel/test-cli-print-promise.mjs
+++ b/test/parallel/test-cli-print-promise.mjs
@@ -1,0 +1,93 @@
+import { spawnPromisified } from '../common/index.mjs';
+import assert from 'node:assert';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+
+describe('--print with a promise', { concurrency: true }, () => {
+  it('should handle directly-fulfilled promises', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'Promise.resolve(42)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { 42 }\n',
+    });
+  });
+
+  it('should handle promises fulfilled after one tick', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'Promise.resolve().then(()=>42)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should handle promise that never settles', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'new Promise(()=>{})',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should output something if process exits before promise settles', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--print',
+      'setTimeout(process.exit,100, 0);timers.promises.setTimeout(200)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+
+  it('should handle rejected promises', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      'Promise.reject(1)',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <rejected> 1 }\n',
+    });
+  });
+
+  it('should handle promises that reject after one tick', async () => {
+    const result = await spawnPromisified(execPath, [
+      '--unhandled-rejections=none',
+      '--print',
+      'Promise.resolve().then(()=>Promise.reject(1))',
+    ]);
+
+    assert.deepStrictEqual(result, {
+      code: 0,
+      signal: null,
+      stderr: '',
+      stdout: 'Promise { <pending> }\n',
+    });
+  });
+});


### PR DESCRIPTION
Just a handful of tests that validate the current behavior of `node`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
