### PR TITLE
util: improve isInsideNodeModules

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -35,6 +35,7 @@ const {
   SafeSet,
   SafeWeakMap,
   SafeWeakRef,
+  StringPrototypeIncludes,
   StringPrototypeReplace,
   StringPrototypeToLowerCase,
   StringPrototypeToUpperCase,
@@ -476,7 +477,7 @@ function spliceOne(list, index) {
   list.pop();
 }
 
-const kNodeModulesRE = /^(.*)[\\/]node_modules[\\/]/;
+const kNodeModulesRE = /^(?:.*)[\\/]node_modules[\\/]/;
 
 let getStructuredStack;
 
@@ -506,8 +507,12 @@ function isInsideNodeModules() {
       const filename = frame.getFileName();
       // If a filename does not start with / or contain \,
       // it's likely from Node.js core.
-      if (RegExpPrototypeExec(/^\/|\\/, filename) === null)
+      if (
+        filename[0] !== '/' &&
+        StringPrototypeIncludes(filename, '\\') === false
+      ) {
         continue;
+      }
       return RegExpPrototypeExec(kNodeModulesRE, filename) !== null;
     }
   }


### PR DESCRIPTION
Improve isInsideNodeModules by avoiding a Regex
kNodeModulesRE is using a non-capturing group