### PR TITLE
test: add missing cctest/test_path.cc

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -398,6 +398,7 @@
       'test/cctest/test_environment.cc',
       'test/cctest/test_linked_binding.cc',
       'test/cctest/test_node_api.cc',
+      'test/cctest/test_path.cc',
       'test/cctest/test_per_process.cc',
       'test/cctest/test_platform.cc',
       'test/cctest/test_report.cc',

--- a/src/path.cc
+++ b/src/path.cc
@@ -101,7 +101,7 @@ std::string PathResolve(Environment* env,
   const size_t numArgs = paths.size();
   auto cwd = env->GetCwd(env->exec_path());
 
-  for (int i = numArgs - 1; i >= -1 && !resolvedAbsolute; i--) {
+  for (int i = numArgs - 1; i >= -1; i--) {
     std::string path;
     if (i >= 0) {
       path = std::string(paths[i]);


### PR DESCRIPTION
We weren't running and testing test_path.cc. This change ensures that `make cctest` runs the test file.

cc @RafaelGSS @nodejs/path 