### PR TITLE
doc: optimize child process doc

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1222,8 +1222,8 @@ added: v0.5.9
 -->
 
 * `message` {Object} A parsed JSON object or primitive value.
-* `sendHandle` {Handle} A [`net.Socket`][] or [`net.Server`][] object, or
-  undefined.
+* `sendHandle` {Handle|undefined} `undefined` or a [`net.Socket`][],
+  [`net.Server`][], or [`dgram.Socket`][] object.
 
 The `'message'` event is triggered when a child process uses
 [`process.send()`][] to send messages.
@@ -1481,7 +1481,8 @@ changes:
 -->
 
 * `message` {Object}
-* `sendHandle` {Handle}
+* `sendHandle` {Handle|undefined} `undefined`, or a [`net.Socket`][],
+  [`net.Server`][], or [`dgram.Socket`][] object.
 * `options` {Object} The `options` argument, if present, is an object used to
   parameterize the sending of certain types of handles. `options` supports
   the following properties:
@@ -1539,7 +1540,8 @@ The optional `sendHandle` argument that may be passed to `subprocess.send()` is
 for passing a TCP server or socket object to the child process. The child will
 receive the object as the second argument passed to the callback function
 registered on the [`'message'`][] event. Any data that is received
-and buffered in the socket will not be sent to the child.
+and buffered in the socket will not be sent to the child. Sending IPC sockets is
+not supported on Windows.
 
 The optional `callback` is a function that is invoked after the message is
 sent but before the child may have received it. The function is called with a
@@ -1872,6 +1874,7 @@ or [`child_process.fork()`][].
 [`child_process.fork()`]: #child_processforkmodulepath-args-options
 [`child_process.spawn()`]: #child_processspawncommand-args-options
 [`child_process.spawnSync()`]: #child_processspawnsynccommand-args-options
+[`dgram.Socket`]: dgram.md#class-dgramsocket
 [`maxBuffer` and Unicode]: #maxbuffer-and-unicode
 [`net.Server`]: net.md#class-netserver
 [`net.Socket`]: net.md#class-netsocket


### PR DESCRIPTION
cc @bnoordhuis 

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
