### PR TITLE
module: warn on detection in typeless package

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -5,6 +5,7 @@ const {
   ObjectPrototypeHasOwnProperty,
   PromisePrototypeThen,
   PromiseResolve,
+  SafeSet,
   StringPrototypeIncludes,
   StringPrototypeCharCodeAt,
   StringPrototypeSlice,
@@ -19,7 +20,7 @@ const {
 const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
 const { containsModuleSyntax } = internalBinding('contextify');
-const { getPackageType } = require('internal/modules/package_json_reader');
+const { getPackageScopeConfig, getPackageType } = require('internal/modules/package_json_reader');
 const { fileURLToPath } = require('internal/url');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
@@ -81,6 +82,7 @@ function underNodeModules(url) {
   return StringPrototypeIncludes(url.pathname, '/node_modules/');
 }
 
+let typelessPackageJsonFilesWarnedAbout;
 /**
  * @param {URL} url
  * @param {{parentURL: string; source?: Buffer}} context
@@ -92,7 +94,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
   const ext = extname(url);
 
   if (ext === '.js') {
-    const packageType = getPackageType(url);
+    const { type: packageType, pjsonPath } = getPackageScopeConfig(url);
     if (packageType !== 'none') {
       return packageType;
     }
@@ -111,9 +113,23 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
         // `source` is undefined when this is called from `defaultResolve`;
         // but this gets called again from `defaultLoad`/`defaultLoadSync`.
         if (getOptionValue('--experimental-detect-module')) {
-          return source ?
+          const format = source ?
             (containsModuleSyntax(`${source}`, fileURLToPath(url)) ? 'module' : 'commonjs') :
             null;
+          if (format === 'module') {
+            // This module has a .js extension, a package.json with no `type` field, and ESM syntax.
+            // Warn about the missing `type` field so that the user can avoid the performance penalty of detection.
+            typelessPackageJsonFilesWarnedAbout ??= new SafeSet();
+            if (!typelessPackageJsonFilesWarnedAbout.has(pjsonPath)) {
+              const warning = `${url} parsed as an ES module because module syntax was detected;` +
+              ` to avoid the performance penalty of syntax detection, add "type": "module" to ${pjsonPath}`;
+              process.emitWarning(warning, {
+                code: 'MODULE_TYPELESS_PACKAGE_JSON',
+              });
+              typelessPackageJsonFilesWarnedAbout.add(pjsonPath);
+            }
+          }
+          return format;
         }
         return 'commonjs';
       }

--- a/test/fixtures/es-modules/package-without-type/detected-as-esm.js
+++ b/test/fixtures/es-modules/package-without-type/detected-as-esm.js
@@ -1,0 +1,2 @@
+import './module.js';
+console.log('executed');


### PR DESCRIPTION
Following up on https://github.com/nodejs/node/pull/52093#issuecomment-1999095048, this PR prints a warning when a `.js` file runs as ESM due to detection, if that file is within the scope of a `package.json` file that lacks a `type` field. In discussion with @joyeecheung we decided to warn once per applicable `package.json` file, so that the warning corresponds with a straightforward remediation.