### PR TITLE
build: use clang over g++ for ubsan

### DIFF
--- a/.github/workflows/test-ubsan.yml
+++ b/.github/workflows/test-ubsan.yml
@@ -40,9 +40,9 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     env:
-      CC: gcc
-      CXX: g++
-      LINK: g++
+      CC: clang
+      CXX: clang++
+      LINK: clang++
       CONFIG_FLAGS: --enable-ubsan
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1


### PR DESCRIPTION
Use `clang` instead of `g++` as we do for `test-asan` since it appears to use less memory, and probably should build faster too, refs: https://github.com/nodejs/node/pull/32776
