### PR TITLE
test: do not set concurrency on parallelized runs

### DIFF
--- a/test/es-module/test-cjs-esm-warn.js
+++ b/test/es-module/test-cjs-esm-warn.js
@@ -15,7 +15,7 @@ const pjson = path.resolve(
 );
 
 
-describe('CJS ↔︎ ESM interop warnings', { concurrency: true }, () => {
+describe('CJS ↔︎ ESM interop warnings', { concurrency: !process.env.TEST_PARALLEL }, () => {
 
   it(async () => {
     const required = path.resolve(

--- a/test/es-module/test-esm-cjs-exports.js
+++ b/test/es-module/test-esm-cjs-exports.js
@@ -7,7 +7,7 @@ const { execPath } = require('node:process');
 const { describe, it } = require('node:test');
 
 
-describe('ESM: importing CJS', { concurrency: true }, () => {
+describe('ESM: importing CJS', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should support valid CJS exports', async () => {
     const validEntry = fixtures.path('/es-modules/cjs-exports.mjs');
     const { code, signal, stdout } = await spawnPromisified(execPath, [validEntry]);

--- a/test/es-module/test-esm-cjs-load-error-note.mjs
+++ b/test/es-module/test-esm-cjs-load-error-note.mjs
@@ -19,7 +19,7 @@ const mustNotIncludeMessage = {
   includeNote: false,
 };
 
-describe('ESM: Errors for unexpected exports', { concurrency: true }, () => {
+describe('ESM: Errors for unexpected exports', { concurrency: !process.env.TEST_PARALLEL }, () => {
   for (
     const { errorNeedle, filePath, getMessage, includeNote }
     of [

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -4,8 +4,8 @@ import { spawn } from 'node:child_process';
 import { describe, it } from 'node:test';
 import { strictEqual, match } from 'node:assert';
 
-describe('--experimental-detect-module', { concurrency: true }, () => {
-  describe('string input', { concurrency: true }, () => {
+describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  describe('string input', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('permits ESM syntax in --eval input without requiring --input-type=module', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--experimental-detect-module',
@@ -72,7 +72,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     });
   });
 
-  describe('.js file input in a typeless package', { concurrency: true }, () => {
+  describe('.js file input in a typeless package', { concurrency: !process.env.TEST_PARALLEL }, () => {
     for (const { testName, entryPath } of [
       {
         testName: 'permits CommonJS syntax in a .js entry point',
@@ -113,7 +113,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     }
   });
 
-  describe('extensionless file input in a typeless package', { concurrency: true }, () => {
+  describe('extensionless file input in a typeless package', { concurrency: !process.env.TEST_PARALLEL }, () => {
     for (const { testName, entryPath } of [
       {
         testName: 'permits CommonJS syntax in an extensionless entry point',
@@ -177,7 +177,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     });
   });
 
-  describe('file input in a "type": "commonjs" package', { concurrency: true }, () => {
+  describe('file input in a "type": "commonjs" package', { concurrency: !process.env.TEST_PARALLEL }, () => {
     for (const { testName, entryPath } of [
       {
         testName: 'disallows ESM syntax in a .js entry point',
@@ -206,7 +206,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
     }
   });
 
-  describe('file input in a "type": "module" package', { concurrency: true }, () => {
+  describe('file input in a "type": "module" package', { concurrency: !process.env.TEST_PARALLEL }, () => {
     for (const { testName, entryPath } of [
       {
         testName: 'disallows CommonJS syntax in a .js entry point',
@@ -236,7 +236,7 @@ describe('--experimental-detect-module', { concurrency: true }, () => {
   });
 
   // https://github.com/nodejs/node/issues/50917
-  describe('syntax that errors in CommonJS but works in ESM', { concurrency: true }, () => {
+  describe('syntax that errors in CommonJS but works in ESM', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('permits top-level `await`', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--experimental-detect-module',

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: warn for obsolete hooks provided', { concurrency: true }, () => {
+describe('ESM: warn for obsolete hooks provided', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should not print warnings when no experimental features are enabled or used', async () => {
     const { code, signal, stderr } = await spawnPromisified(execPath, [
       '--input-type=module',

--- a/test/es-module/test-esm-export-not-found.mjs
+++ b/test/es-module/test-esm-export-not-found.mjs
@@ -12,7 +12,7 @@ const importStatementMultiline = `import {
 } from './module-named-exports.mjs';
 `;
 
-describe('ESM: nonexistent exports', { concurrency: true }, () => {
+describe('ESM: nonexistent exports', { concurrency: !process.env.TEST_PARALLEL }, () => {
   for (
     const { name, input }
     of [

--- a/test/es-module/test-esm-extension-lookup-deprecation.mjs
+++ b/test/es-module/test-esm-extension-lookup-deprecation.mjs
@@ -7,7 +7,7 @@ import * as path from 'node:path';
 import { execPath } from 'node:process';
 import { describe, it, before } from 'node:test';
 
-describe('ESM in main field', { concurrency: true }, () => {
+describe('ESM in main field', { concurrency: !process.env.TEST_PARALLEL }, () => {
   before(() => tmpdir.refresh());
 
   it('should handle fully-specified relative path without any warning', async () => {

--- a/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
+++ b/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
@@ -4,7 +4,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
 import { match, ok, strictEqual } from 'node:assert';
 
-describe('extensionless ES modules within a "type": "module" package scope', { concurrency: true }, () => {
+describe('extensionless ES modules within a "type": "module" package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should run as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       fixtures.path('es-modules/package-type-module/noext-esm'),
@@ -29,7 +29,7 @@ describe('extensionless ES modules within a "type": "module" package scope', { c
     strictEqual(defaultExport, 'module');
   });
 });
-describe('extensionless Wasm modules within a "type": "module" package scope', { concurrency: true }, () => {
+describe('extensionless Wasm modules within a "type": "module" package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should run as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-wasm-modules',
@@ -55,7 +55,7 @@ describe('extensionless Wasm modules within a "type": "module" package scope', {
   });
 });
 
-describe('extensionless ES modules within no package scope', { concurrency: true }, () => {
+describe('extensionless ES modules within no package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
   // This succeeds with `--experimental-default-type=module`
   it('should error as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
@@ -79,7 +79,7 @@ describe('extensionless ES modules within no package scope', { concurrency: true
   });
 });
 
-describe('extensionless Wasm within no package scope', { concurrency: true }, () => {
+describe('extensionless Wasm within no package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
   // This succeeds with `--experimental-default-type=module`
   it('should error as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
+++ b/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
@@ -4,7 +4,9 @@ import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
 import { match, ok, strictEqual } from 'node:assert';
 
-describe('extensionless ES modules within a "type": "module" package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('extensionless ES modules within a "type": "module" package scope', {
+  concurrency: !process.env.TEST_PARALLEL,
+}, () => {
   it('should run as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       fixtures.path('es-modules/package-type-module/noext-esm'),
@@ -29,7 +31,9 @@ describe('extensionless ES modules within a "type": "module" package scope', { c
     strictEqual(defaultExport, 'module');
   });
 });
-describe('extensionless Wasm modules within a "type": "module" package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('extensionless Wasm modules within a "type": "module" package scope', {
+  concurrency: !process.env.TEST_PARALLEL,
+}, () => {
   it('should run as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-wasm-modules',

--- a/test/es-module/test-esm-import-flag.mjs
+++ b/test/es-module/test-esm-import-flag.mjs
@@ -10,7 +10,7 @@ const mjsEntry = fixtures.path('es-modules', 'mjs-file.mjs');
 const mjsImport = fixtures.fileURL('es-modules', 'mjs-file.mjs');
 
 
-describe('import modules using --import', { concurrency: true }, () => {
+describe('import modules using --import', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should import when using --eval', async () => {
     const { code, signal, stderr, stdout } = await spawnPromisified(
       execPath,

--- a/test/es-module/test-esm-import-json-named-export.mjs
+++ b/test/es-module/test-esm-import-json-named-export.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: named JSON exports', { concurrency: true }, () => {
+describe('ESM: named JSON exports', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should throw, citing named import', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       fixtures.path('es-modules', 'import-json-named-export.mjs'),

--- a/test/es-module/test-esm-initialization.mjs
+++ b/test/es-module/test-esm-initialization.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: ensure initialization happens only once', { concurrency: true }, () => {
+describe('ESM: ensure initialization happens only once', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it(async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--experimental-import-meta-resolve',

--- a/test/es-module/test-esm-invalid-pjson.js
+++ b/test/es-module/test-esm-invalid-pjson.js
@@ -7,7 +7,7 @@ const { execPath } = require('node:process');
 const { describe, it } = require('node:test');
 
 
-describe('ESM: Package.json', { concurrency: true }, () => {
+describe('ESM: Package.json', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should throw on invalid pson', async () => {
     const entry = fixtures.path('/es-modules/import-invalid-pjson.mjs');
     const invalidJson = fixtures.path('/node_modules/invalid-pjson/package.json');

--- a/test/es-module/test-esm-loader-chaining.mjs
+++ b/test/es-module/test-esm-loader-chaining.mjs
@@ -15,7 +15,7 @@ const commonArgs = [
   commonInput,
 ];
 
-describe('ESM: loader chaining', { concurrency: true }, () => {
+describe('ESM: loader chaining', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should load unadulterated source when there are no loaders', async () => {
     const { code, stderr, stdout } = await spawnPromisified(
       execPath,

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-describe('Loader hooks', { concurrency: true }, () => {
+describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('are called with all expected arguments', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
@@ -50,7 +50,7 @@ describe('Loader hooks', { concurrency: true }, () => {
     assert.strictEqual(lines.length, 5);
   });
 
-  describe('should handle never-settling hooks in ESM files', { concurrency: true }, () => {
+  describe('should handle never-settling hooks in ESM files', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('top-level await of a never-settling resolve without warning', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',
@@ -134,7 +134,7 @@ describe('Loader hooks', { concurrency: true }, () => {
     });
   });
 
-  describe('should handle never-settling hooks in CJS files', { concurrency: true }, () => {
+  describe('should handle never-settling hooks in CJS files', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('never-settling resolve', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',

--- a/test/es-module/test-esm-loader-http-imports.mjs
+++ b/test/es-module/test-esm-loader-http-imports.mjs
@@ -46,7 +46,7 @@ const {
   port,
 } = server.address();
 
-describe('ESM: http import via loader', { concurrency: true }, () => {
+describe('ESM: http import via loader', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should load using --import flag', async () => {
     // ! MUST NOT use spawnSync to avoid blocking the event loop
     const { code, signal, stderr, stdout } = await spawnPromisified(

--- a/test/es-module/test-esm-loader-programmatically.mjs
+++ b/test/es-module/test-esm-loader-programmatically.mjs
@@ -20,7 +20,7 @@ const commonEvals = {
   staticImport: (module) => `import ${JSON.stringify(`data:text/javascript,${encodeURIComponent(module)}`)};`,
 };
 
-describe('ESM: programmatically register loaders', { concurrency: true }, () => {
+describe('ESM: programmatically register loaders', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('works with only a dummy CLI argument', async () => {
     const parentURL = fixtures.fileURL('es-module-loaders', 'loader-resolve-passthru.mjs');
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
@@ -49,7 +49,7 @@ describe('ESM: programmatically register loaders', { concurrency: true }, () => 
     assert.strictEqual(lines[5], '');
   });
 
-  describe('registering via --import', { concurrency: true }, () => {
+  describe('registering via --import', { concurrency: !process.env.TEST_PARALLEL }, () => {
     for (const moduleType of ['mjs', 'cjs']) {
       it(`should programmatically register a loader from a ${moduleType.toUpperCase()} file`, async () => {
         const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [

--- a/test/es-module/test-esm-loader-spawn-promisified.mjs
+++ b/test/es-module/test-esm-loader-spawn-promisified.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-describe('Loader hooks throwing errors', { concurrency: true }, () => {
+describe('Loader hooks throwing errors', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('throws on nonexistent modules', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
@@ -161,7 +161,7 @@ describe('Loader hooks throwing errors', { concurrency: true }, () => {
   });
 });
 
-describe('Loader hooks parsing modules', { concurrency: true }, () => {
+describe('Loader hooks parsing modules', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('can parse .js files as ESM', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',

--- a/test/es-module/test-esm-loader-thenable.mjs
+++ b/test/es-module/test-esm-loader-thenable.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: thenable loader hooks', { concurrency: true }, () => {
+describe('ESM: thenable loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should behave as a normal promise resolution', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',

--- a/test/es-module/test-esm-loader-with-syntax-error.mjs
+++ b/test/es-module/test-esm-loader-with-syntax-error.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: loader with syntax error', { concurrency: true }, () => {
+describe('ESM: loader with syntax error', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should crash the node process', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',

--- a/test/es-module/test-esm-module-not-found-commonjs-hint.mjs
+++ b/test/es-module/test-esm-module-not-found-commonjs-hint.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: module not found hint', { concurrency: true }, () => {
+describe('ESM: module not found hint', { concurrency: !process.env.TEST_PARALLEL }, () => {
   for (
     const { input, expected, cwd = fixturesDir }
     of [

--- a/test/es-module/test-esm-non-js.mjs
+++ b/test/es-module/test-esm-non-js.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: non-js extensions fail', { concurrency: true }, () => {
+describe('ESM: non-js extensions fail', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it(async () => {
     const { code, stderr, signal } = await spawnPromisified(execPath, [
       '--input-type=module',

--- a/test/es-module/test-esm-nowarn-exports.mjs
+++ b/test/es-module/test-esm-nowarn-exports.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: experiemental warning for import.meta.resolve', { concurrency: true }, () => {
+describe('ESM: experiemental warning for import.meta.resolve', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should not warn when caught', async () => {
     const { code, signal, stderr } = await spawnPromisified(execPath, [
       '--experimental-import-meta-resolve',

--- a/test/es-module/test-esm-preserve-symlinks-main.js
+++ b/test/es-module/test-esm-preserve-symlinks-main.js
@@ -41,7 +41,7 @@ try {
   skip('insufficient privileges for symlinks');
 }
 
-describe('Invoke the main file via a symlink.', { concurrency: true }, () => {
+describe('Invoke the main file via a symlink.', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should resolve relative imports in the main file', async () => {
     const { code } = await spawnPromisified(execPath, [
       '--preserve-symlinks',

--- a/test/es-module/test-esm-repl-imports.js
+++ b/test/es-module/test-esm-repl-imports.js
@@ -8,7 +8,7 @@ const { execPath } = require('node:process');
 const { describe, it } = require('node:test');
 
 
-describe('ESM: REPL runs', { concurrency: true }, () => {
+describe('ESM: REPL runs', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it((t, done) => {
     const child = spawn(execPath, [
       '--interactive',

--- a/test/es-module/test-esm-source-map.mjs
+++ b/test/es-module/test-esm-source-map.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-describe('esm source-map', { concurrency: true }, () => {
+describe('esm source-map', { concurrency: !process.env.TEST_PARALLEL }, () => {
   // Issue: https://github.com/nodejs/node/issues/51522
 
   [

--- a/test/es-module/test-esm-syntax-error.mjs
+++ b/test/es-module/test-esm-syntax-error.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: importing a module with syntax error(s)', { concurrency: true }, () => {
+describe('ESM: importing a module with syntax error(s)', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should throw', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       path('es-module-loaders', 'syntax-error.mjs'),

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -10,7 +10,7 @@ const commonArgs = [
   '--eval',
 ];
 
-describe('ESM: unsettled and rejected promises', { concurrency: true }, () => {
+describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should exit for an unsettled TLA promise via --eval with a warning', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       ...commonArgs,

--- a/test/es-module/test-esm-type-flag-cli-entry.mjs
+++ b/test/es-module/test-esm-type-flag-cli-entry.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
 import { match, strictEqual } from 'node:assert';
 
-describe('--experimental-default-type=module should not support extension searching', { concurrency: true }, () => {
+describe('--experimental-default-type=module should not support extension searching', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should support extension searching under --experimental-default-type=commonjs', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=commonjs',
@@ -33,7 +33,7 @@ describe('--experimental-default-type=module should not support extension search
   });
 });
 
-describe('--experimental-default-type=module should not parse paths as URLs', { concurrency: true }, () => {
+describe('--experimental-default-type=module should not parse paths as URLs', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should not parse a `?` in a filename as starting a query string', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-cli-entry.mjs
+++ b/test/es-module/test-esm-type-flag-cli-entry.mjs
@@ -3,7 +3,9 @@ import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
 import { match, strictEqual } from 'node:assert';
 
-describe('--experimental-default-type=module should not support extension searching', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('--experimental-default-type=module should not support extension searching', {
+  concurrency: !process.env.TEST_PARALLEL,
+}, () => {
   it('should support extension searching under --experimental-default-type=commonjs', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=commonjs',
@@ -33,7 +35,9 @@ describe('--experimental-default-type=module should not support extension search
   });
 });
 
-describe('--experimental-default-type=module should not parse paths as URLs', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('--experimental-default-type=module should not parse paths as URLs', {
+  concurrency: !process.env.TEST_PARALLEL,
+}, () => {
   it('should not parse a `?` in a filename as starting a query string', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-errors.mjs
+++ b/test/es-module/test-esm-type-flag-errors.mjs
@@ -4,7 +4,9 @@ import { describe, it } from 'node:test';
 import { deepStrictEqual, match, strictEqual } from 'node:assert';
 
 describe('--experimental-default-type=module', { concurrency: !process.env.TEST_PARALLEL }, () => {
-  describe('should not affect the interpretation of files with unknown extensions', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  describe('should not affect the interpretation of files with unknown extensions', {
+    concurrency: !process.env.TEST_PARALLEL,
+  }, () => {
     it('should error on an entry point with an unknown extension', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
         '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-errors.mjs
+++ b/test/es-module/test-esm-type-flag-errors.mjs
@@ -3,8 +3,8 @@ import * as fixtures from '../common/fixtures.mjs';
 import { describe, it } from 'node:test';
 import { deepStrictEqual, match, strictEqual } from 'node:assert';
 
-describe('--experimental-default-type=module', { concurrency: true }, () => {
-  describe('should not affect the interpretation of files with unknown extensions', { concurrency: true }, () => {
+describe('--experimental-default-type=module', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  describe('should not affect the interpretation of files with unknown extensions', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('should error on an entry point with an unknown extension', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
         '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-loose-files.mjs
+++ b/test/es-module/test-esm-type-flag-loose-files.mjs
@@ -5,7 +5,7 @@ import { describe, it } from 'node:test';
 import { strictEqual } from 'node:assert';
 
 describe('the type flag should change the interpretation of certain files outside of any package scope',
-         { concurrency: true }, () => {
+         { concurrency: !process.env.TEST_PARALLEL }, () => {
            it('should run as ESM a .js file that is outside of any package scope', async () => {
              const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
                '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-package-scopes.mjs
+++ b/test/es-module/test-esm-type-flag-package-scopes.mjs
@@ -5,7 +5,7 @@ import { describe, it } from 'node:test';
 import { strictEqual } from 'node:assert';
 
 describe('the type flag should change the interpretation of certain files within a "type": "module" package scope',
-         { concurrency: true }, () => {
+         { concurrency: !process.env.TEST_PARALLEL }, () => {
            it('should run as ESM an extensionless JavaScript file within a "type": "module" scope', async () => {
              const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
                '--experimental-default-type=module',
@@ -60,7 +60,7 @@ describe('the type flag should change the interpretation of certain files within
          });
 
 describe(`the type flag should change the interpretation of certain files within a package scope that lacks a
-"type" field and is not under node_modules`, { concurrency: true }, () => {
+"type" field and is not under node_modules`, { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should run as ESM a .js file within package scope that has no defined "type" and is not under node_modules',
      async () => {
        const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
@@ -122,7 +122,7 @@ under node_modules`, async () => {
 });
 
 describe(`the type flag should NOT change the interpretation of certain files within a package scope that lacks a
-"type" field and is under node_modules`, { concurrency: true }, () => {
+"type" field and is under node_modules`, { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should run as CommonJS a .js file within package scope that has no defined "type" and is under node_modules',
      async () => {
        const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-esm-type-flag-string-input.mjs
+++ b/test/es-module/test-esm-type-flag-string-input.mjs
@@ -3,7 +3,7 @@ import { spawn } from 'node:child_process';
 import { describe, it } from 'node:test';
 import { strictEqual, match } from 'node:assert';
 
-describe('the type flag should change the interpretation of string input', { concurrency: true }, () => {
+describe('the type flag should change the interpretation of string input', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should run as ESM input passed via --eval', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',

--- a/test/es-module/test-esm-type-flag-string-input.mjs
+++ b/test/es-module/test-esm-type-flag-string-input.mjs
@@ -3,7 +3,9 @@ import { spawn } from 'node:child_process';
 import { describe, it } from 'node:test';
 import { strictEqual, match } from 'node:assert';
 
-describe('the type flag should change the interpretation of string input', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('the type flag should change the interpretation of string input', {
+  concurrency: !process.env.TEST_PARALLEL,
+}, () => {
   it('should run as ESM input passed via --eval', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       '--experimental-default-type=module',

--- a/test/es-module/test-esm-unknown-extension.js
+++ b/test/es-module/test-esm-unknown-extension.js
@@ -9,7 +9,7 @@ const { describe, it } = require('node:test');
 
 // In a "type": "module" package scope, files with unknown extensions should throw;
 // both when used as a main entry point and also when referenced via `import`.
-describe('ESM: unknown specifiers', { concurrency: true }, () => {
+describe('ESM: unknown specifiers', { concurrency: !process.env.TEST_PARALLEL }, () => {
   for (
     const fixturePath of [
       '/es-modules/package-type-module/extension.unknown',

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: WASM modules', { concurrency: true }, () => {
+describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should load exports', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',

--- a/test/es-module/test-http-imports-cli.mjs
+++ b/test/es-module/test-http-imports-cli.mjs
@@ -5,7 +5,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('ESM: http import via CLI', { concurrency: true }, () => {
+describe('ESM: http import via CLI', { concurrency: !process.env.TEST_PARALLEL }, () => {
   const disallowedSpecifier = 'http://example.com';
 
   it('should throw disallowed error for insecure protocol', async () => {

--- a/test/es-module/test-loaders-workers-spawned.mjs
+++ b/test/es-module/test-loaders-workers-spawned.mjs
@@ -4,7 +4,7 @@ import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
-describe('Worker threads do not spawn infinitely', { concurrency: true }, () => {
+describe('Worker threads do not spawn infinitely', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should not trigger an infinite loop when using a loader exports no recognized hooks', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',

--- a/test/parallel/test-abortsignal-any.mjs
+++ b/test/parallel/test-abortsignal-any.mjs
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { once } from 'node:events';
 import assert from 'node:assert';
 
-describe('AbortSignal.any()', { concurrency: true }, () => {
+describe('AbortSignal.any()', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should throw when not receiving an array', () => {
     const expectedError = { code: 'ERR_INVALID_ARG_TYPE' };
     assert.throws(() => AbortSignal.any(), expectedError);

--- a/test/parallel/test-assert-calltracker-getCalls.js
+++ b/test/parallel/test-assert-calltracker-getCalls.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const { describe, it } = require('node:test');
 
 
-describe('assert.CallTracker.getCalls()', { concurrency: true }, () => {
+describe('assert.CallTracker.getCalls()', { concurrency: !process.env.TEST_PARALLEL }, () => {
   const tracker = new assert.CallTracker();
 
   it('should return empty list when no calls', () => {

--- a/test/parallel/test-cli-print-promise.mjs
+++ b/test/parallel/test-cli-print-promise.mjs
@@ -4,7 +4,7 @@ import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
 
 
-describe('--print with a promise', { concurrency: true }, () => {
+describe('--print with a promise', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should handle directly-fulfilled promises', async () => {
     const result = await spawnPromisified(execPath, [
       '--print',

--- a/test/parallel/test-fs-write-stream-eagain.mjs
+++ b/test/parallel/test-fs-write-stream-eagain.mjs
@@ -11,7 +11,7 @@ const errorWithEAGAIN = (fd, buffer, offset, length, position, callback) => {
   callback(Object.assign(new Error(), { code: 'EAGAIN' }), 0, buffer);
 };
 
-describe('WriteStream EAGAIN', { concurrency: true }, () => {
+describe('WriteStream EAGAIN', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('_write', async () => {
     const mockWrite = mock.fn(fs.write);
     mockWrite.mock.mockImplementationOnce(errorWithEAGAIN);

--- a/test/parallel/test-node-output-console.mjs
+++ b/test/parallel/test-node-output-console.mjs
@@ -11,7 +11,7 @@ function replaceStackTrace(str) {
   return snapshot.replaceStackTrace(str, '$1at *$7\n');
 }
 
-describe('console output', { concurrency: true }, () => {
+describe('console output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('/', '*').replaceAll(process.version, '*').replaceAll(/\d+/g, '*');
   }

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -20,7 +20,7 @@ function replaceForceColorsStackTrace(str) {
   return str.replaceAll(/(\[90m\W+)at .*node:.*/g, '$1at *[39m');
 }
 
-describe('errors output', { concurrency: true }, () => {
+describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
       .replaceAll(pathToFileURL(process.cwd()).pathname, '')

--- a/test/parallel/test-node-output-sourcemaps.mjs
+++ b/test/parallel/test-node-output-sourcemaps.mjs
@@ -4,7 +4,7 @@ import * as snapshot from '../common/assertSnapshot.js';
 import * as path from 'node:path';
 import { describe, it } from 'node:test';
 
-describe('sourcemaps output', { concurrency: true }, () => {
+describe('sourcemaps output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     const result = str
     .replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')

--- a/test/parallel/test-node-output-v8-warning.mjs
+++ b/test/parallel/test-node-output-v8-warning.mjs
@@ -7,7 +7,7 @@ function replaceNodeVersion(str) {
   return str.replaceAll(process.version, '*');
 }
 
-describe('v8 output', { concurrency: true }, () => {
+describe('v8 output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
     .replaceAll(/:\d+/g, ':*')

--- a/test/parallel/test-node-output-vm.mjs
+++ b/test/parallel/test-node-output-vm.mjs
@@ -7,7 +7,7 @@ function replaceNodeVersion(str) {
   return str.replaceAll(process.version, '*');
 }
 
-describe('vm output', { concurrency: true }, () => {
+describe('vm output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('//', '*').replaceAll(/\/(\w)/g, '*$1').replaceAll('*test*', '*').replaceAll(/node:vm:\d+:\d+/g, 'node:vm:*');
   }

--- a/test/parallel/test-process-warnings.mjs
+++ b/test/parallel/test-process-warnings.mjs
@@ -9,7 +9,7 @@ const dep1Message = /\(node:\d+\) \[DEP1\] DeprecationWarning/;
 const dep2Message = /\(node:\d+\) \[DEP2\] DeprecationWarning/;
 const experimentalWarningMessage = /\(node:\d+\) ExperimentalWarning/;
 
-describe('process warnings', { concurrency: true }, () => {
+describe('process warnings', { concurrency: !process.env.TEST_PARALLEL }, () => {
 
   it('should emit all warnings by default', async () => {
     const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
@@ -24,7 +24,7 @@ describe('process warnings', { concurrency: true }, () => {
     assert.strictEqual(signal, null);
   });
 
-  describe('--no-warnings', { concurrency: true }, () => {
+  describe('--no-warnings', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('should silence all warnings by default', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--no-warnings',
@@ -40,7 +40,7 @@ describe('process warnings', { concurrency: true }, () => {
     });
   });
 
-  describe('--no-deprecation', { concurrency: true }, () => {
+  describe('--no-deprecation', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('should silence all deprecation warnings', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--no-deprecation',
@@ -56,7 +56,7 @@ describe('process warnings', { concurrency: true }, () => {
     });
   });
 
-  describe('--disable-warning', { concurrency: true }, () => {
+  describe('--disable-warning', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('should silence deprecation warning DEP1', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--disable-warning=DEP1',

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -87,7 +87,7 @@ async function failWriteSucceed({ file, watchedFile }) {
 
 tmpdir.refresh();
 
-describe('watch mode', { concurrency: true, timeout: 60_000 }, () => {
+describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_000 }, () => {
   it('should watch changes to a file', async () => {
     const file = createTmpFile();
     const { stderr, stdout } = await runWriteSucceed({ file, watchedFile: file, watchFlag: '--watch=true', options: {


### PR DESCRIPTION
Our CI already run test files in parallel, having `node:test` spawns child processes concurrently could lead to oversubscribing the CI machine. This commit sets the `concurrency` depending on the presence of `TEST_PARALLEL` in the env, so running the test file individually still spawns child processes concurrently, and running the whole test suite does not oversubscribe the machine.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
