### PR TITLE
fs: keep fs.promises.readFile read until EOF is reached

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -538,6 +538,7 @@ async function readFileHandle(filehandle, options) {
     throw new ERR_FS_FILE_TOO_LARGE(size);
 
   let totalRead = 0;
+  const noSize = size === 0;
   let buffer = Buffer.allocUnsafeSlow(length);
   let result = '';
   let offset = 0;
@@ -560,7 +561,7 @@ async function readFileHandle(filehandle, options) {
 
     if (bytesRead === 0 ||
         totalRead === size ||
-        (bytesRead !== buffer.length && !chunkedRead)) {
+        (bytesRead !== buffer.length && !chunkedRead && !noSize)) {
       const singleRead = bytesRead === totalRead;
 
       const bytesToCheck = chunkedRead ? totalRead : bytesRead;
@@ -570,7 +571,7 @@ async function readFileHandle(filehandle, options) {
       }
 
       if (!encoding) {
-        if (size === 0 && !singleRead) {
+        if (noSize && !singleRead) {
           ArrayPrototypePush(buffers, buffer);
           return Buffer.concat(buffers, totalRead);
         }
@@ -583,15 +584,17 @@ async function readFileHandle(filehandle, options) {
       result += decoder.end(buffer);
       return result;
     }
-
+    const readBuffer = bytesRead !== buffer.length ?
+      buffer.subarray(0, bytesRead) :
+      buffer;
     if (encoding) {
-      result += decoder.write(buffer);
+      result += decoder.write(readBuffer);
     } else if (size !== 0) {
       offset = totalRead;
     } else {
       buffers ??= [];
       // Unknown file size requires chunks.
-      ArrayPrototypePush(buffers, buffer);
+      ArrayPrototypePush(buffers, readBuffer);
       buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
     }
   }

--- a/test/parallel/test-fs-readfile-eof.js
+++ b/test/parallel/test-fs-readfile-eof.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+
+if (common.isWindows || common.isAIX || common.isIBMi)
+  common.skip(`No /dev/stdin on ${process.platform}.`);
+
+const assert = require('assert');
+const fs = require('fs/promises');
+const childType = ['child-encoding', 'child-non-encoding'];
+
+if (process.argv[2] === childType[0]) {
+  fs.readFile('/dev/stdin', 'utf8').then((data) => {
+    process.stdout.write(data);
+  });
+  return;
+} else if (process.argv[2] === childType[1]) {
+  fs.readFile('/dev/stdin').then((data) => {
+    process.stdout.write(data);
+  });
+  return;
+}
+
+const data1 = 'Hello';
+const data2 = 'World';
+const expected = `${data1}\n${data2}\n`;
+
+const exec = require('child_process').exec;
+const f = JSON.stringify(__filename);
+const node = JSON.stringify(process.execPath);
+
+function test(child) {
+  const cmd = `(echo ${data1}; sleep 0.5; echo ${data2}) | ${node} ${f} ${child}`;
+  exec(cmd, common.mustSucceed((stdout, stderr) => {
+    assert.strictEqual(
+      stdout,
+      expected,
+      `expected to read(${child === childType[0] ? 'with' : 'without'} encoding): '${expected}' but got: '${stdout}'`);
+    assert.strictEqual(
+      stderr,
+      '',
+      `expected not to read anything from stderr but got: '${stderr}'`);
+  }));
+}
+
+test(childType[0]);
+test(childType[1]);


### PR DESCRIPTION
+ For cases where the size==0 of the file to read, ensure it ends upon reaching EOF.

Fixes: #52155
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
