### PR TITLE
doc: add tips about vcpkg cause build faild on windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -578,6 +578,16 @@ to run it again before invoking `make -j4`.
 
 ### Windows
 
+#### Tips
+You may need disable vcpkg integration if you got link error about symbol redefine related to zlib.lib(zlib1.dll), even you never install it by hand, as vcpkg is part of CLion and Visual Studio now.
+
+```bat
+REM find your vcpkg
+vcpkg integration remove
+```
+
+Refs: #24448, https://github.com/microsoft/vcpkg/issues/37518, [vcpkg](https://github.com/microsoft/vcpkg/)
+
 #### Prerequisites
 
 ##### Option 1: Manual install

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -589,7 +589,7 @@ as vcpkg is part of CLion and Visual Studio now.
 # double check vcpkg install the related file
 vcpkg owns zlib.lib
 vcpkg owns zlib1.dll
-vcpkg integration remove
+vcpkg integrate remove
 ```
 
 Refs: #24448, <https://github.com/microsoft/vcpkg/issues/37518>, [vcpkg](https://github.com/microsoft/vcpkg/)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -579,14 +579,20 @@ to run it again before invoking `make -j4`.
 ### Windows
 
 #### Tips
-You may need disable vcpkg integration if you got link error about symbol redefine related to zlib.lib(zlib1.dll), even you never install it by hand, as vcpkg is part of CLion and Visual Studio now.
 
-```bat
-REM find your vcpkg
+You may need disable vcpkg integration if you got link error about symbol
+redefine related to zlib.lib(zlib1.dll), even you never install it by hand,
+as vcpkg is part of CLion and Visual Studio now.
+
+```powershell
+# find your vcpkg
+# double check vcpkg install the related file
+vcpkg owns zlib.lib
+vcpkg owns zlib1.dll
 vcpkg integration remove
 ```
 
-Refs: #24448, https://github.com/microsoft/vcpkg/issues/37518, [vcpkg](https://github.com/microsoft/vcpkg/)
+Refs: #24448, <https://github.com/microsoft/vcpkg/issues/37518>, [vcpkg](https://github.com/microsoft/vcpkg/)
 
 #### Prerequisites
 


### PR DESCRIPTION

vcpkg may cause nodejs build on windows to fail,  **symbol already defined in zlib.lib(zlib1.dll)**.

vcpkg uses some magic to hook into the vc++ project, add its include to include search dir and auto copy the dll to output dir if **vcpkg integrate install** is done.

some talk happens on the internet and none of them point to vcpkg, but one thing is sure, once you run **vcpkg integrate remove**, [vcbuild.bat](https://github.com/nodejs/node/blob/main/vcbuild.bat) will succ!

vcpkg is popular and included in CLion and Visual Studio, so our folks should know this may be a trouble!

Refs: 
1. https://github.com/nodejs/help/issues/1656
2. https://github.com/nodejs/node/issues/24448