### PR TITLE
test_runner: simplify test time tracking

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -526,7 +526,7 @@ class Test extends AsyncResource {
   };
 
   #cancel(error) {
-    if (this.endTime !== null) {
+    if (this.endTime !== null || this.error !== null) {
       return;
     }
 
@@ -564,17 +564,15 @@ class Test extends AsyncResource {
       return;
     }
 
-    this.endTime = hrtime();
     this.passed = false;
     this.error = err;
   }
 
   pass() {
-    if (this.endTime !== null) {
+    if (this.error !== null) {
       return;
     }
 
-    this.endTime = hrtime();
     this.passed = true;
   }
 
@@ -707,15 +705,8 @@ class Test extends AsyncResource {
       }
 
       this.pass();
-      try {
-        await afterEach();
-        await after();
-      } catch (err) {
-        // If one of the after hooks has thrown unset endTime so that the
-        // catch below can do its cancel/fail logic.
-        this.endTime = null;
-        throw err;
-      }
+      await afterEach();
+      await after();
     } catch (err) {
       if (isTestFailureError(err)) {
         if (err.failureType === kTestTimeoutFailure) {
@@ -761,13 +752,10 @@ class Test extends AsyncResource {
   }
 
   postRun(pendingSubtestsError) {
-    this.startTime ??= hrtime();
-
-    // If the test was failed before it even started, then the end time will
-    // be earlier than the start time. Correct that here.
-    if (this.endTime < this.startTime) {
-      this.endTime = hrtime();
-    }
+    // If the test was cancelled before it started, then the start and end
+    // times need to be corrected.
+    this.endTime ??= hrtime();
+    this.startTime ??= this.endTime;
 
     // The test has run, so recursively cancel any outstanding subtests and
     // mark this test as failed if any subtests failed.
@@ -974,6 +962,7 @@ class TestHook extends Test {
         error.failureType = kHookFailure;
       }
 
+      this.endTime ??= hrtime();
       parent.reporter.fail(0, loc, parent.subtests.length + 1, loc.file, {
         __proto__: null,
         duration_ms: this.duration(),

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -507,7 +507,6 @@ class Test extends AsyncResource {
     }
 
     if (preventAddingSubtests) {
-      test.startTime = test.startTime || hrtime();
       test.fail(
         new ERR_TEST_FAILURE(
           'test could not be started because its parent finished',
@@ -537,7 +536,6 @@ class Test extends AsyncResource {
         kCancelledByParent,
       ),
     );
-    this.startTime = this.startTime || this.endTime; // If a test was canceled before it was started, e.g inside a hook
     this.cancelled = true;
     this.abortController.abort();
   }
@@ -763,12 +761,13 @@ class Test extends AsyncResource {
   }
 
   postRun(pendingSubtestsError) {
+    this.startTime ??= hrtime();
+
     // If the test was failed before it even started, then the end time will
     // be earlier than the start time. Correct that here.
     if (this.endTime < this.startTime) {
       this.endTime = hrtime();
     }
-    this.startTime ??= this.endTime;
 
     // The test has run, so recursively cancel any outstanding subtests and
     // mark this test as failed if any subtests failed.

--- a/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
@@ -11,10 +11,10 @@
 
  describe hooks - no subtests (*ms)
  before throws
-   1
+   1 (*ms)
     'test did not finish before its parent and was cancelled'
 
-   2
+   2 (*ms)
     'test did not finish before its parent and was cancelled'
 
  before throws (*ms)
@@ -390,7 +390,7 @@
 
  - after() called
  run after when before throws
-   1
+   1 (*ms)
     'test did not finish before its parent and was cancelled'
 
  run after when before throws (*ms)
@@ -422,11 +422,11 @@
  failing tests:
 
 *
- 1
+ 1 (*ms)
   'test did not finish before its parent and was cancelled'
 
 *
- 2
+ 2 (*ms)
   'test did not finish before its parent and was cancelled'
 
 *
@@ -772,7 +772,7 @@
       *
 
 *
- 1
+ 1 (*ms)
   'test did not finish before its parent and was cancelled'
 
 *

--- a/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
@@ -11,10 +11,10 @@
 
  describe hooks - no subtests (*ms)
  before throws
-   1 (*ms)
+   1
     'test did not finish before its parent and was cancelled'
 
-   2 (*ms)
+   2
     'test did not finish before its parent and was cancelled'
 
  before throws (*ms)
@@ -390,7 +390,7 @@
 
  - after() called
  run after when before throws
-   1 (*ms)
+   1
     'test did not finish before its parent and was cancelled'
 
  run after when before throws (*ms)
@@ -422,11 +422,11 @@
  failing tests:
 
 *
- 1 (*ms)
+ 1
   'test did not finish before its parent and was cancelled'
 
 *
- 2 (*ms)
+ 2
   'test did not finish before its parent and was cancelled'
 
 *
@@ -772,7 +772,7 @@
       *
 
 *
- 1 (*ms)
+ 1
   'test did not finish before its parent and was cancelled'
 
 *


### PR DESCRIPTION
This PR simplifies some of the logic that has accumulated over time for tracking test durations.

##### test_runner: simplify test start time tracking

This commit simplifies the logic for tracking test start time.
The start time is now set only when a test/suite begins running.
If the test/suite never runs, a fallback is provided in postRun().

##### test_runner: simplify test end time tracking

This commit simplifies the logic for tracking test end time.
The end time is now only set in postRun(), which every test
runs when it ends.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
