### PR TITLE
deps: V8: backports for gcc 12

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1664,6 +1664,10 @@ config("toolchain") {
       # of `this` in capture-by-value lambdas and preventing a build roll which
       # enables C++20 (see https://crbug.com/1374227).
       "-Wno-deprecated",
+
+      # Fix build with older versions of GCC
+      # Ported from v8 bazel: https://crrev.com/c/3368869
+      "-Wno-stringop-overflow",
     ]
   }
 

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1668,6 +1668,20 @@ config("toolchain") {
       # Fix build with older versions of GCC
       # Ported from v8 bazel: https://crrev.com/c/3368869
       "-Wno-stringop-overflow",
+
+      # Fix a number of bogus errors with gcc12
+      # TODO(miladfarca): re-evaluate for future gcc upgrades
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111499
+      "-Wno-stringop-overread",
+
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104336
+      "-Wno-restrict",
+
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+      "-Wno-array-bounds",
+
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108517
+      "-Wno-nonnull",
     ]
   }
 

--- a/deps/v8/src/d8/d8.cc
+++ b/deps/v8/src/d8/d8.cc
@@ -4022,7 +4022,9 @@ V8_NOINLINE void FuzzerMonitor::UseAfterFree() {
   // Use-after-free caught by ASAN.
   std::vector<bool>* storage = new std::vector<bool>(3);
   delete storage;
+#if defined(__clang__)
   USE(storage->at(1));
+#endif
 }
 
 V8_NOINLINE void FuzzerMonitor::UseOfUninitializedValue() {

--- a/deps/v8/src/wasm/function-compiler.cc
+++ b/deps/v8/src/wasm/function-compiler.cc
@@ -110,7 +110,7 @@ WasmCompilationResult WasmCompilationUnit::ExecuteFunctionCompilation(
     case ExecutionTier::kNone:
       UNREACHABLE();
 
-    case ExecutionTier::kLiftoff:
+    case ExecutionTier::kLiftoff: {
       // The --wasm-tier-mask-for-testing flag can force functions to be
       // compiled with TurboFan, and the --wasm-debug-mask-for-testing can force
       // them to be compiled for debugging, see documentation.
@@ -144,8 +144,8 @@ WasmCompilationResult WasmCompilationUnit::ExecuteFunctionCompilation(
       // TODO(wasm): We could actually stop or remove the tiering unit for this
       // function to avoid compiling it twice with TurboFan.
       V8_FALLTHROUGH;
-
-    case ExecutionTier::kTurbofan:
+    }
+    case ExecutionTier::kTurbofan: {
       compiler::WasmCompilationData data(func_body);
       data.func_index = func_index_;
       data.wire_bytes_storage = wire_bytes_storage;
@@ -165,6 +165,9 @@ WasmCompilationResult WasmCompilationUnit::ExecuteFunctionCompilation(
                                                         detected);
       result.for_debugging = for_debugging_;
       break;
+    }
+    default:
+      UNREACHABLE();
   }
 
   DCHECK(result.succeeded());

--- a/deps/v8/third_party/inspector_protocol/crdtp/dispatch_test.cc
+++ b/deps/v8/third_party/inspector_protocol/crdtp/dispatch_test.cc
@@ -169,10 +169,11 @@ TEST(DispatchableTest, MessageWithUnknownProperty) {
 }
 
 TEST(DispatchableTest, DuplicateMapKey) {
-  for (const std::string& json :
-       {"{\"id\":42,\"id\":42}", "{\"params\":null,\"params\":null}",
-        "{\"method\":\"foo\",\"method\":\"foo\"}",
-        "{\"sessionId\":\"42\",\"sessionId\":\"42\"}"}) {
+  const std::array<std::string, 4> jsons = {
+      {"{\"id\":42,\"id\":42}", "{\"params\":null,\"params\":null}",
+       "{\"method\":\"foo\",\"method\":\"foo\"}",
+       "{\"sessionId\":\"42\",\"sessionId\":\"42\"}"}};
+  for (const std::string& json : jsons) {
     SCOPED_TRACE("json = " + json);
     std::vector<uint8_t> cbor;
     ASSERT_TRUE(json::ConvertJSONToCBOR(SpanFrom(json), &cbor).ok());
@@ -185,11 +186,12 @@ TEST(DispatchableTest, DuplicateMapKey) {
 }
 
 TEST(DispatchableTest, ValidMessageParsesOK_NoParams) {
-  for (const std::string& json :
-       {"{\"id\":42,\"method\":\"Foo.executeBar\",\"sessionId\":"
-        "\"f421ssvaz4\"}",
-        "{\"id\":42,\"method\":\"Foo.executeBar\",\"sessionId\":\"f421ssvaz4\","
-        "\"params\":null}"}) {
+  const std::array<std::string, 2> jsons = {
+      {"{\"id\":42,\"method\":\"Foo.executeBar\",\"sessionId\":"
+       "\"f421ssvaz4\"}",
+       "{\"id\":42,\"method\":\"Foo.executeBar\",\"sessionId\":\"f421ssvaz4\","
+       "\"params\":null}"}};
+  for (const std::string& json : jsons) {
     SCOPED_TRACE("json = " + json);
     std::vector<uint8_t> cbor;
     ASSERT_TRUE(json::ConvertJSONToCBOR(SpanFrom(json), &cbor).ok());

--- a/deps/v8/third_party/inspector_protocol/crdtp/json_test.cc
+++ b/deps/v8/third_party/inspector_protocol/crdtp/json_test.cc
@@ -704,15 +704,16 @@ using ContainerTestTypes = ::testing::Types<std::vector<uint8_t>, std::string>;
 TYPED_TEST_SUITE(ConvertJSONToCBORTest, ContainerTestTypes);
 
 TYPED_TEST(ConvertJSONToCBORTest, RoundTripValidJson) {
-  for (const std::string& json_in : {
-           "{\"msg\":\"Hello, world.\",\"lst\":[1,2,3]}",
-           "3.1415",
-           "false",
-           "true",
-           "\"Hello, world.\"",
-           "[1,2,3]",
-           "[]",
-       }) {
+  const std::array<std::string, 7> jsons = {{
+      "{\"msg\":\"Hello, world.\",\"lst\":[1,2,3]}",
+      "3.1415",
+      "false",
+      "true",
+      "\"Hello, world.\"",
+      "[1,2,3]",
+      "[]",
+  }};
+  for (const std::string& json_in : jsons) {
     SCOPED_TRACE(json_in);
     TypeParam json(json_in.begin(), json_in.end());
     std::vector<uint8_t> cbor;


### PR DESCRIPTION
Original commit message:

    Fix build with older versions of GCC.

    This ports the change from bazel on v8:
    https://crrev.com/c/3368869

    Compilation errors started showing after this CL:
    https://crrev.com/c/5199515

    Change-Id: I8c161a0d9ad5c04d452c444ef4feafae2ef4f6db
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5280535
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Commit-Queue: Milad Farazmand <mfarazma@redhat.com>
    Cr-Commit-Position: refs/heads/main@{#92252}

Refs: https://github.com/v8/v8/commit/f8d5e576b814c92c39ec0cea80c21e4162270e12

Original commit message:

    Fix build with gcc12

    - A number of erroneous flags have been added to BUILD.gn
    - wasm-init-expr.cc is creating an 8 byte buffer witch may be
      much smaller than max size_t output. We also need to make room
      for the `f` character and the terminating null character
    - inspector_protocol currently generates the following error
       ```
       error: loop variable ‘json_in’ of type ‘const std::string&’ {aka
       ‘const std::__cxx11::basic_string<char>&’} binds to a temporary
       constructed from type ‘const char* const’
       ```

    Change-Id: I1139899b2664e47d01ebc44f2e972fc4c0ec212d
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5331756
    Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
    Commit-Queue: Milad Farazmand <mfarazma@redhat.com>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#92615}

Refs: https://github.com/v8/v8/commit/c4be0a97f981ce08bad854684c941e4c98647025

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
