### PR TITLE
test_runner: don't await the same promise for each test

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -225,7 +225,11 @@ function getGlobalRoot() {
 }
 
 async function startSubtest(subtest) {
-  await reportersSetup;
+  if (reportersSetup) {
+    // Only incur the overhead of awaiting the Promise once.
+    await reportersSetup;
+    reportersSetup = undefined;
+  }
 
   const root = getGlobalRoot();
   if (!root.harness.bootstrapComplete) {

--- a/test/fixtures/test-runner/output/default_output.js
+++ b/test/fixtures/test-runner/output/default_output.js
@@ -9,7 +9,9 @@ const test = require('node:test');
 test('should pass', () => {});
 test('should fail', () => { throw new Error('fail'); });
 test('should skip', { skip: true }, () => {});
-test('parent', () => {
-  test('should fail', () => { throw new Error('fail'); });
-  test('should pass but parent fail', () => {});
+test('parent', (t) => {
+  t.test('should fail', () => { throw new Error('fail'); });
+  t.test('should pass but parent fail', (t, done) => {
+    setImmediate(done);
+  });
 });

--- a/test/fixtures/test-runner/output/default_output.snapshot
+++ b/test/fixtures/test-runner/output/default_output.snapshot
@@ -18,6 +18,11 @@
     *[39m
     *[39m
     *[39m
+        *[39m
+    *[39m
+    *[39m
+    *[39m
+    *[39m
 
   [31m✖ should pass but parent fail [90m(*ms)[39m[39m
     [32m'test did not finish before its parent and was cancelled'[39m
@@ -49,6 +54,11 @@
 *
 [31m✖ should fail [90m(*ms)[39m[39m
   Error: fail
+      *[39m
+  *[39m
+  *[39m
+  *[39m
+  *[39m
       *[39m
   *[39m
   *[39m


### PR DESCRIPTION
##### test: fix incorrect test fixture

This commit updates a test runner fixture that includes a failing
child test. However, the nested test is created using the top
level `test()` function instead `t.test()`. This commit updates the
fixture to use `t.test()`, while preserving the expected failure.

Refs: https://github.com/nodejs/node/pull/47164

##### test_runner: don't await the same promise for each test

Prior to this commit, each top level test awaited the same
global promise for setting up test reporters. This commit
updates the logic to only await the promise the first time
it is encountered.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
