### PR TITLE
test: add error only reporter for node:test

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -105,4 +105,4 @@ jobs:
       - name: Test
         run: |
           cd $TAR_DIR
-          make run-ci -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=spec' --measure-flakiness 9"
+          make run-ci -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9"

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -68,7 +68,7 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=spec' --measure-flakiness 9" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage
         env:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -68,7 +68,7 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=spec' --measure-flakiness 9" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage
         env:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -40,4 +40,4 @@ jobs:
           name: docs
           path: out/doc
       - name: Test
-        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Build
         run: make build-ci -j4 V=1
       - name: Test
-        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -53,4 +53,4 @@ jobs:
       - name: Build
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
-        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -84,4 +84,4 @@ jobs:
       - name: Free Space After Build
         run: df -h
       - name: Test
-        run: make run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"

--- a/.github/workflows/test-ubsan.yml
+++ b/.github/workflows/test-ubsan.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"

--- a/test/common/test-error-reporter.js
+++ b/test/common/test-error-reporter.js
@@ -1,0 +1,35 @@
+'use strict';
+const { relative } = require('node:path');
+const { inspect } = require('node:util');
+const cwd = process.cwd();
+
+module.exports = async function* errorReporter(source) {
+  for await (const event of source) {
+    if (event.type === 'test:fail') {
+      const { name, details, line, column, file } = event.data;
+      let { error } = details;
+
+      if (error?.failureType === 'subtestsFailed') {
+        // In the interest of keeping things concise, skip failures that are
+        // only due to nested failures.
+        continue;
+      }
+
+      if (error?.code === 'ERR_TEST_FAILURE') {
+        error = error.cause;
+      }
+
+      const output = [
+        `Test failure: '${name}'`,
+      ];
+
+      if (file) {
+        output.push(`Location: ${relative(cwd, file)}:${line}:${column}`);
+      }
+
+      output.push(inspect(error));
+      output.push('\n');
+      yield output.join('\n');
+    }
+  }
+};

--- a/test/parallel/test-runner-cli-concurrency.js
+++ b/test/parallel/test-runner-cli-concurrency.js
@@ -23,6 +23,7 @@ test('concurrency of two', async () => {
   const args = ['--test', '--test-concurrency=2'];
   const cp = spawnSync(process.execPath, args, { cwd, env });
   assert.match(cp.stderr.toString(), /concurrency: 2,/);
+  throw new Error('bye');
 });
 
 test('isolation=none uses a concurrency of one', async () => {


### PR DESCRIPTION
Opening as a draft to determine if this is a desirable change.

This commit introduces a node:test reporter to the common utils. This reporter can be used to silence output other than errors from node:test. This is useful because in Node's own test suite, the output of node:test is included in the output of the Python test runner.

Refs: https://github.com/nodejs/node/issues/49120

A comparison of output before and after this change is shown below. The TAP reporter is shown for the current output. The output is generated by `./tools/test.py test/parallel/test-runner-cli-concurrency.js` with an artificial error introduced.

**Before**:
```
=== release test-runner-cli-concurrency ===                   
Path: parallel/test-runner-cli-concurrency
TAP version 13
# Subtest: default concurrency
ok 1 - default concurrency
  ---
  duration_ms: 74.002459
  ...
# Subtest: concurrency of one
ok 2 - concurrency of one
  ---
  duration_ms: 190.883208
  ...
# Subtest: concurrency of two
not ok 3 - concurrency of two
  ---
  duration_ms: 125.033667
  location: '/redacted/test/parallel/test-runner-cli-concurrency.js:23:1'
  failureType: 'testCodeFailure'
  error: 'bye'
  code: 'ERR_TEST_FAILURE'
  stack: |-
    TestContext.<anonymous> (/redacted/test/parallel/test-runner-cli-concurrency.js:27:9)
    Test.runInAsyncScope (node:async_hooks:206:9)
    Test.run (node:internal/test_runner/test:702:25)
    Test.processPendingSubtests (node:internal/test_runner/test:439:18)
    Test.postRun (node:internal/test_runner/test:807:19)
    Test.run (node:internal/test_runner/test:751:12)
    async Test.processPendingSubtests (node:internal/test_runner/test:439:7)
  ...
1..3
# tests 3
# suites 0
# pass 2
# fail 1
# cancelled 0
# skipped 0
# todo 0
# duration_ms 396.478041
```

**After**:
```
=== release test-runner-cli-concurrency ===                   
Path: parallel/test-runner-cli-concurrency
Test failure: 'concurrency of two'
Location: test/parallel/test-runner-cli-concurrency.js:23:1
Error: bye
    at TestContext.<anonymous> (/redacted/test/parallel/test-runner-cli-concurrency.js:27:9)
    at Test.runInAsyncScope (node:async_hooks:206:9)
    at Test.run (node:internal/test_runner/test:702:25)
    at Test.processPendingSubtests (node:internal/test_runner/test:439:18)
    at Test.postRun (node:internal/test_runner/test:807:19)
    at Test.run (node:internal/test_runner/test:751:12)
    at async Test.processPendingSubtests (node:internal/test_runner/test:439:7)
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
