### PR TITLE
doc, test: clarify the behavior of todo tests

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -162,6 +162,37 @@ test('skip() method with message', (t) => {
 });
 ```
 
+## TODO tests
+
+Individual tests can be marked as flaky or incomplete by passing the `todo`
+option to the test, or by calling the test context's `todo()` method, as shown
+in the following example. These tests represent a pending implementation or bug
+that needs to be fixed. TODO tests are executed, but are not treated as test
+failures, and therefore do not affect the process exit code. If a test is marked
+as both TODO and skipped, the TODO option is ignored.
+
+```js
+// The todo option is used, but no message is provided.
+test('todo option', { todo: true }, (t) => {
+  // This code is executed, but not treated as a failure.
+  throw new Error('this does not fail the test');
+});
+
+// The todo option is used, and a message is provided.
+test('todo option with message', { todo: 'this is a todo test' }, (t) => {
+  // This code is executed.
+});
+
+test('todo() method', (t) => {
+  t.todo();
+});
+
+test('todo() method with message', (t) => {
+  t.todo('this is a todo test and is not treated as a failure');
+  throw new Error('this does not fail the test');
+});
+```
+
 ## `describe()` and `it()` aliases
 
 Suites and tests can also be written using the `describe()` and `it()`

--- a/test/parallel/test-runner-todo-skip-tests.js
+++ b/test/parallel/test-runner-todo-skip-tests.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+const { strictEqual } = require('node:assert');
+const { run, suite, test } = require('node:test');
+
+if (!process.env.NODE_TEST_CONTEXT) {
+  const stream = run({ files: [__filename] });
+
+  stream.on('test:fail', common.mustNotCall());
+  stream.on('test:pass', common.mustCall((event) => {
+    strictEqual(event.skip, true);
+    strictEqual(event.todo, undefined);
+  }, 4));
+} else {
+  test('test options only', { skip: true, todo: true }, common.mustNotCall());
+
+  test('test context calls only', common.mustCall((t) => {
+    t.todo();
+    t.skip();
+  }));
+
+  test('todo test with context skip', { todo: true }, common.mustCall((t) => {
+    t.skip();
+  }));
+
+  // Note - there is no test for the skip option and t.todo() because the skip
+  // option prevents the test from running at all. This is verified by other
+  // tests.
+
+  // Suites don't have the context methods, so only test the options combination.
+  suite('suite options only', { skip: true, todo: true }, common.mustNotCall());
+}


### PR DESCRIPTION
##### test: add test for skip+todo combinations

This commit adds a regression test for the edge case where a
test runner test is marked as both todo and skip.

Refs: https://github.com/nodejs/node/issues/49013

##### doc: add section explaining todo tests

This commit adds a section to the test runner docs explaining
what a TODO test is.

Refs: https://github.com/nodejs/node/issues/49013

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
