### PR TITLE
doc: add ESM and CommonJS examples in `fs` documentation

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -898,6 +898,21 @@ try {
 }
 ```
 
+```cjs
+const { access, constants } =  require('node:fs/promises');
+
+async function checkAccess () {
+  try {
+    await access('/etc/passwd', constants.R_OK | constants.W_OK);
+    console.log('can access');
+  } catch {
+    console.error('cannot access');
+  }
+}
+
+checkAccess()
+```
+
 Using `fsPromises.access()` to check for the accessibility of a file before
 calling `fsPromises.open()` is not recommended. Doing so introduces a race
 condition, since other processes may change the file's state between the two

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -994,7 +994,7 @@ import { chmod } from 'node:fs/promises';
 try {
   await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'));
 } catch {
-  console.log('The permissions for file "my_file.txt" failed to change!');
+  console.error('The permissions for file "my_file.txt" failed to change!');
 }
 ```
 
@@ -1005,7 +1005,7 @@ async function changeFilePermissions() {
   try {
     await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'));
   } catch {
-    console.log('The permissions for file "my_file.txt" failed to change!');
+    console.error('The permissions for file "my_file.txt" failed to change!');
   }
 }
 
@@ -1035,7 +1035,7 @@ const gid = getgid();
 try {
   await chown('my_file.txt', uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`));
 } catch {
-  console.log('Failed to chown my_file.txt!');
+  console.error('Failed to chown my_file.txt!');
 }
 ```
 
@@ -1050,7 +1050,7 @@ async function chownMyFile() {
   try {
     await chown('my_file.txt', uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`));
   } catch {
-    console.log('Failed to chown my_file.txt!');
+    console.error('Failed to chown my_file.txt!');
   }
 }
 
@@ -2436,7 +2436,7 @@ const uid = getuid();
 const gid = getgid();
 
 chown('my_file.txt', uid, gid, (err) => {
-  if (err) throw new Error('Could not chown my_file.txt');
+  if (err) throw err;
 
   console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`);
 });
@@ -2450,7 +2450,7 @@ const uid = getuid();
 const gid = getgid();
 
 chown('my_file.txt', uid, gid, (err) => {
-  if (err) throw new Error('Could not chown my_file.txt');
+  if (err) throw err  ;
 
   console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`);
 });

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -899,9 +899,9 @@ try {
 ```
 
 ```cjs
-const { access, constants } =  require('node:fs/promises');
+const { access, constants } = require('node:fs/promises');
 
-async function checkAccess () {
+async function checkAccess() {
   try {
     await access('/etc/passwd', constants.R_OK | constants.W_OK);
     console.log('can access');
@@ -910,7 +910,7 @@ async function checkAccess () {
   }
 }
 
-checkAccess()
+checkAccess();
 ```
 
 Using `fsPromises.access()` to check for the accessibility of a file before
@@ -956,24 +956,24 @@ for appending (using `fsPromises.open()`).
 import { appendFile } from 'node:fs/promises';
 
 try {
-	await appendFile('message.txt', 'data to append');
+  await appendFile('message.txt', 'data to append');
 } catch {
-	console.error('The file could not be appended!');
+  console.error('The file could not be appended!');
 }
 ```
 
 ```cjs
 const { appendFile } = require('node:fs/promises');
 
-async function appendMessagesFile () {
-	try {
-		await appendFile('message.txt', 'data to append');
-	} catch {
-		console.error('The file could not be appended!');
-	}
+async function appendMessagesFile() {
+  try {
+    await appendFile('message.txt', 'data to append');
+  } catch {
+    console.error('The file could not be appended!');
+  }
 }
 
-appendMessagesFile()
+appendMessagesFile();
 ```
 
 ### `fsPromises.chmod(path, mode)`
@@ -992,7 +992,7 @@ Changes the permissions of a file.
 import { chmod } from 'node:fs/promises';
 
 try {
-  await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'))
+  await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'));
 } catch {
   console.log('The permissions for file "my_file.txt" failed to change!');
 }
@@ -1001,15 +1001,15 @@ try {
 ```cjs
 const { chmod } = require('node:fs/promises');
 
-async function changeFilePermissions () {
+async function changeFilePermissions() {
   try {
-    await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'))
+    await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'));
   } catch {
     console.log('The permissions for file "my_file.txt" failed to change!');
   }
 }
 
-changeFilePermissions()
+changeFilePermissions();
 ```
 
 ### `fsPromises.chown(path, uid, gid)`
@@ -1026,35 +1026,35 @@ added: v10.0.0
 Changes the ownership of a file.
 
 ```mjs
-import { chown } from 'node:fs/promises'
-import { getuid, getgid } from 'node:process'
+import { chown } from 'node:fs/promises';
+import { getuid, getgid } from 'node:process';
 
-const uid = getuid()
-const gid = getgid()
+const uid = getuid();
+const gid = getgid();
 
 try {
-	await chown("my_file.txt", uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`))
+  await chown('my_file.txt', uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`));
 } catch {
-	console.log("Failed to chown my_file.txt!")
+  console.log('Failed to chown my_file.txt!');
 }
 ```
 
 ```cjs
-const { chown } = require('node:fs/promises')
-const { getuid, getgid } = require('node:process')
+const { chown } = require('node:fs/promises');
+const { getuid, getgid } = require('node:process');
 
-async function chownMyFile () {
-	const uid = getuid()
-	const gid = getgid()
-	
-	try {
-		await chown("my_file.txt", uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`))
-	} catch {
-		console.log("Failed to chown my_file.txt!")
-	}
+async function chownMyFile() {
+  const uid = getuid();
+  const gid = getgid();
+
+  try {
+    await chown('my_file.txt', uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`));
+  } catch {
+    console.log('Failed to chown my_file.txt!');
+  }
 }
 
-chownMyFile()
+chownMyFile();
 ```
 
 ### `fsPromises.copyFile(src, dest[, mode])`
@@ -2429,31 +2429,31 @@ possible exception are given to the completion callback.
 See the POSIX chown(2) documentation for more detail.
 
 ```mjs
-import { chown } from 'node:fs'
-import { getuid, getgid } from 'node:process'
+import { chown } from 'node:fs';
+import { getuid, getgid } from 'node:process';
 
-const uid = getuid()
-const gid = getgid()
+const uid = getuid();
+const gid = getgid();
 
 chown('my_file.txt', uid, gid, (err) => {
-  if (err) throw "Coudln't chown my_file.txt"
+  if (err) throw new Error('Could not chown my_file.txt');
 
-  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`)
-})
+  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`);
+});
 ```
 
 ```cjs
-const { chown } = require('node:fs')
-const { getuid, getgid } = require('node:process')
+const { chown } = require('node:fs');
+const { getuid, getgid } = require('node:process');
 
-const uid = getuid()
-const gid = getgid()
+const uid = getuid();
+const gid = getgid();
 
 chown('my_file.txt', uid, gid, (err) => {
-  if (err) throw "Coudln't chown my_file.txt"
+  if (err) throw new Error('Could not chown my_file.txt');
 
-  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`)
-})
+  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`);
+});
 ```
 
 ### `fs.close(fd[, callback])`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -952,6 +952,30 @@ for more details.
 The `path` may be specified as a {FileHandle} that has been opened
 for appending (using `fsPromises.open()`).
 
+```mjs
+import { appendFile } from 'node:fs/promises';
+
+try {
+	await appendFile('message.txt', 'data to append');
+} catch {
+	console.error('The file could not be appended!');
+}
+```
+
+```cjs
+const { appendFile } = require('node:fs/promises');
+
+async function appendMessagesFile () {
+	try {
+		await appendFile('message.txt', 'data to append');
+	} catch {
+		console.error('The file could not be appended!');
+	}
+}
+
+appendMessagesFile()
+```
+
 ### `fsPromises.chmod(path, mode)`
 
 <!-- YAML
@@ -963,6 +987,30 @@ added: v10.0.0
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Changes the permissions of a file.
+
+```mjs
+import { chmod } from 'node:fs/promises';
+
+try {
+  await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'))
+} catch {
+  console.log('The permissions for file "my_file.txt" failed to change!');
+}
+```
+
+```cjs
+const { chmod } = require('node:fs/promises');
+
+async function changeFilePermissions () {
+  try {
+    await chmod('my_file.txt', 0o775).then(console.log('The permissions for file "my_file.txt" have been changed!'))
+  } catch {
+    console.log('The permissions for file "my_file.txt" failed to change!');
+  }
+}
+
+changeFilePermissions()
+```
 
 ### `fsPromises.chown(path, uid, gid)`
 
@@ -976,6 +1024,38 @@ added: v10.0.0
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Changes the ownership of a file.
+
+```mjs
+import { chown } from 'node:fs/promises'
+import { getuid, getgid } from 'node:process'
+
+const uid = getuid()
+const gid = getgid()
+
+try {
+	await chown("my_file.txt", uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`))
+} catch {
+	console.log("Failed to chown my_file.txt!")
+}
+```
+
+```cjs
+const { chown } = require('node:fs/promises')
+const { getuid, getgid } = require('node:process')
+
+async function chownMyFile () {
+	const uid = getuid()
+	const gid = getgid()
+	
+	try {
+		await chown("my_file.txt", uid, gid).then(console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`))
+	} catch {
+		console.log("Failed to chown my_file.txt!")
+	}
+}
+
+chownMyFile()
+```
 
 ### `fsPromises.copyFile(src, dest[, mode])`
 
@@ -2254,6 +2334,15 @@ chmod('my_file.txt', 0o775, (err) => {
 });
 ```
 
+```cjs
+const { chmod } = require('node:fs');
+
+chmod('my_file.txt', 0o775, (err) => {
+  if (err) throw err;
+  console.log('The permissions for file "my_file.txt" have been changed!');
+});
+```
+
 #### File modes
 
 The `mode` argument used in both the `fs.chmod()` and `fs.chmodSync()`
@@ -2338,6 +2427,34 @@ Asynchronously changes owner and group of a file. No arguments other than a
 possible exception are given to the completion callback.
 
 See the POSIX chown(2) documentation for more detail.
+
+```mjs
+import { chown } from 'node:fs'
+import { getuid, getgid } from 'node:process'
+
+const uid = getuid()
+const gid = getgid()
+
+chown('my_file.txt', uid, gid, (err) => {
+  if (err) throw "Coudln't chown my_file.txt"
+
+  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`)
+})
+```
+
+```cjs
+const { chown } = require('node:fs')
+const { getuid, getgid } = require('node:process')
+
+const uid = getuid()
+const gid = getgid()
+
+chown('my_file.txt', uid, gid, (err) => {
+  if (err) throw "Coudln't chown my_file.txt"
+
+  console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`)
+})
+```
 
 ### `fs.close(fd[, callback])`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2450,7 +2450,7 @@ const uid = getuid();
 const gid = getgid();
 
 chown('my_file.txt', uid, gid, (err) => {
-  if (err) throw err  ;
+  if (err) throw err;
 
   console.log(`Successfully ran chown on my_file.txt to UID ${uid} and GID ${gid}!`);
 });


### PR DESCRIPTION
This PR adds a handful of code examples to `fs` methods where code examples were either entirely omitted or were only available for ESM. This includes code examples for both `fsPromises` and `fs`, trying to keep them in lockstep.

This includes a code example for a method, `fs.chown`, that was added in Node.js v0.1.97 and seemingly has never had a code example. I've added ESM and CommonJS examples for both the normal `fs` and `fsPromises` versions of this method.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
