### PR TITLE
string_decoder: throw an error when writing a too long buffer

### DIFF
--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -31,11 +31,11 @@ MaybeLocal<String> MakeString(Isolate* isolate,
   Local<Value> error;
   MaybeLocal<Value> ret;
   if (encoding == UTF8) {
-    MaybeLocal<String> utf8_string = String::NewFromUtf8(
-        isolate,
-        data,
-        v8::NewStringType::kNormal,
-        length);
+    MaybeLocal<String> utf8_string;
+    if (length <= static_cast<size_t>(v8::String::kMaxLength)) {
+      utf8_string = String::NewFromUtf8(
+          isolate, data, v8::NewStringType::kNormal, length);
+    }
     if (utf8_string.IsEmpty()) {
       isolate->ThrowException(node::ERR_STRING_TOO_LONG(isolate));
       return MaybeLocal<String>();

--- a/test/pummel/test-string-decoder-large-buffer.js
+++ b/test/pummel/test-string-decoder-large-buffer.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common');
+
+// Buffer with size > INT32_MAX
+common.skipIf32Bits();
+
+const assert = require('assert');
+const { StringDecoder } = require('node:string_decoder');
+const kStringMaxLength = require('buffer').constants.MAX_STRING_LENGTH;
+
+const size = 2 ** 31;
+
+const stringTooLongError = {
+  message: `Cannot create a string longer than 0x${kStringMaxLength.toString(16)}` +
+    ' characters',
+  code: 'ERR_STRING_TOO_LONG',
+  name: 'Error',
+};
+
+try {
+  const buf = Buffer.allocUnsafe(size);
+  const decoder = new StringDecoder('utf8');
+  assert.throws(() => decoder.write(buf), stringTooLongError);
+} catch (e) {
+  if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
+    throw e;
+  }
+  common.skip('insufficient space for Buffer.alloc');
+}


### PR DESCRIPTION
Fixes: #52214

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
