### PR TITLE
lib: .load .save add proper error message when no file passed

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -147,6 +147,7 @@ const {
     ERR_CANNOT_WATCH_SIGINT,
     ERR_INVALID_REPL_EVAL_CONFIG,
     ERR_INVALID_REPL_INPUT,
+    ERR_MISSING_ARGS,
     ERR_SCRIPT_EXECUTION_INTERRUPTED,
   },
   isErrorStackTraceLimitWritable,
@@ -1788,10 +1789,17 @@ function defineDefaultCommands(repl) {
     help: 'Save all evaluated commands in this REPL session to a file',
     action: function(file) {
       try {
+        if (file === '') {
+          throw new ERR_MISSING_ARGS('file');
+        }
         fs.writeFileSync(file, ArrayPrototypeJoin(this.lines, '\n'));
         this.output.write(`Session saved to: ${file}\n`);
-      } catch {
-        this.output.write(`Failed to save: ${file}\n`);
+      } catch (error) {
+        if (error instanceof ERR_MISSING_ARGS) {
+          this.output.write(`${error.message}\n`);
+        } else {
+          this.output.write(`Failed to save: ${file}\n`);
+        }
       }
       this.displayPrompt();
     },
@@ -1801,6 +1809,9 @@ function defineDefaultCommands(repl) {
     help: 'Load JS from a file into the REPL session',
     action: function(file) {
       try {
+        if (file === '') {
+          throw new ERR_MISSING_ARGS('file');
+        }
         const stats = fs.statSync(file);
         if (stats && stats.isFile()) {
           _turnOnEditorMode(this);
@@ -1815,8 +1826,12 @@ function defineDefaultCommands(repl) {
             `Failed to load: ${file} is not a valid file\n`,
           );
         }
-      } catch {
-        this.output.write(`Failed to load: ${file}\n`);
+      } catch (error) {
+        if (error instanceof ERR_MISSING_ARGS) {
+          this.output.write(`${error.message}\n`);
+        } else {
+          this.output.write(`Failed to load: ${file}\n`);
+        }
       }
       this.displayPrompt();
     },

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -144,7 +144,7 @@ putIn.run([`.save ${invalidFileName}`]);
 // Clear the REPL.
 putIn.run(['.clear']);
 
-// Error message when using save without a file 
+// Error message when using save without a file
 putIn.write = common.mustCall(function(data) {
   assert.strictEqual(data, 'The "file" argument must be specified\n');
   putIn.write = () => {};
@@ -156,7 +156,7 @@ putIn.run(['.save']);
 // Clear the REPL.
 putIn.run(['.clear']);
 
-// Error message when using load without a file 
+// Error message when using load without a file
 putIn.write = common.mustCall(function(data) {
   assert.strictEqual(data, 'The "file" argument must be specified\n');
   putIn.write = () => {};

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -24,7 +24,6 @@ const common = require('../common');
 const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const fs = require('fs');
-
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
@@ -139,3 +138,27 @@ putIn.run([`.save ${invalidFileName}`]);
   assert.strictEqual(fs.readFileSync(saveFileName, 'utf8'),
                      `${cmds.join('\n')}\n`);
 }
+
+// Check if the file is present when using save
+
+// Clear the REPL.
+putIn.run(['.clear']);
+
+// Error message when using save without a file 
+putIn.write = common.mustCall(function(data) {
+  assert.strictEqual(data, 'The "file" argument must be specified\n');
+  putIn.write = () => {};
+});
+putIn.run(['.save']);
+
+// Check if the file is present when using load
+
+// Clear the REPL.
+putIn.run(['.clear']);
+
+// Error message when using load without a file 
+putIn.write = common.mustCall(function(data) {
+  assert.strictEqual(data, 'The "file" argument must be specified\n');
+  putIn.write = () => {};
+});
+putIn.run(['.load']);


### PR DESCRIPTION
This commit adds a proper error message using ERR_MISSING_ARGS('file') when a .save or .load REPL command is runned. This commit also adds test for both of this cases.

Fixes: https://github.com/nodejs/node/issues/52218