### PR TITLE
module: improve detection try catch

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1338,10 +1338,8 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
     return result;
   } catch (err) {
     if (process.mainModule === cjsModuleInstance) {
-      if (getOptionValue('--experimental-detect-module')) {
-        // For the main entry point, cache the source to potentially retry as ESM.
-        module.exports.entryPointSource = content;
-      }
+      // For the main entry point, cache the source to potentially retry as ESM; or to decorate the error.
+      module.exports.entryPointSource = content;
     }
     throw err;
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1341,12 +1341,9 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
       if (getOptionValue('--experimental-detect-module')) {
         // For the main entry point, cache the source to potentially retry as ESM.
         module.exports.entryPointSource = content;
-      } else {
-        // We only enrich the error (print a warning) if we're sure we're going to for-sure throw it; so if we're
-        // retrying as ESM, wait until we know whether we're going to retry before calling `enrichCJSError`.
-        const { enrichCJSError } = require('internal/modules/esm/translators');
-        enrichCJSError(err, content, filename);
       }
+      const { enrichCJSError } = require('internal/modules/esm/translators');
+      enrichCJSError(err, content, filename);
     }
     throw err;
   }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1342,8 +1342,6 @@ function wrapSafe(filename, content, cjsModuleInstance, codeCache) {
         // For the main entry point, cache the source to potentially retry as ESM.
         module.exports.entryPointSource = content;
       }
-      const { enrichCJSError } = require('internal/modules/esm/translators');
-      enrichCJSError(err, content, filename);
     }
     throw err;
   }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -182,8 +182,6 @@ function executeUserEntryPoint(main = process.argv[1]) {
         // ensure no further references can prevent it being garbage-collected.
         cjsLoader.entryPointSource = undefined;
         if (!retryAsESM) {
-          const { enrichCJSError } = require('internal/modules/esm/translators');
-          enrichCJSError(error, source, resolvedMain);
           return true; // Rethrow original exception.
         }
       });

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -167,11 +167,12 @@ function executeUserEntryPoint(main = process.argv[1]) {
   if (!useESMLoader) {
     const cjsLoader = require('internal/modules/cjs/loader');
     const { Module } = cjsLoader;
-    if (getOptionValue('--experimental-detect-module')) {
-      tryCatchRethrow(() => {
-        // Module._load is the monkey-patchable CJS module loader.
-        Module._load(main, null, true);
-      }, (error) => {
+
+    tryCatchRethrow(() => {
+      // Module._load is the monkey-patchable CJS module loader.
+      Module._load(main, null, true);
+    }, (error) => {
+      if (getOptionValue('--experimental-detect-module')) {
         const source = cjsLoader.entryPointSource;
         if (!source) {
           return true; // Rethrow original exception.
@@ -181,13 +182,12 @@ function executeUserEntryPoint(main = process.argv[1]) {
         // In case the entry point is a large file, such as a bundle,
         // ensure no further references can prevent it being garbage-collected.
         cjsLoader.entryPointSource = undefined;
-        if (!retryAsESM) {
-          return true; // Rethrow original exception.
-        }
-      });
-    } else { // `--experimental-detect-module` is not passed
-      Module._load(main, null, true);
-    }
+      }
+
+      if (!retryAsESM) {
+        return true; // Rethrow original exception.
+      }
+    });
   }
 
   if (useESMLoader || retryAsESM) {

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -15,6 +15,7 @@ const {
   hasUncaughtExceptionCaptureCallback,
 } = require('internal/process/execution');
 const {
+  tryCatchRethrow,
   triggerUncaughtException,
 } = internalBinding('errors');
 const {
@@ -167,11 +168,14 @@ function executeUserEntryPoint(main = process.argv[1]) {
     const cjsLoader = require('internal/modules/cjs/loader');
     const { Module } = cjsLoader;
     if (getOptionValue('--experimental-detect-module')) {
-      try {
+      tryCatchRethrow(() => {
         // Module._load is the monkey-patchable CJS module loader.
         Module._load(main, null, true);
-      } catch (error) {
+      }, (error) => {
         const source = cjsLoader.entryPointSource;
+        if (!source) {
+          return true; // Rethrow original exception.
+        }
         const { shouldRetryAsESM } = require('internal/modules/helpers');
         retryAsESM = shouldRetryAsESM(error.message, source);
         // In case the entry point is a large file, such as a bundle,
@@ -180,9 +184,9 @@ function executeUserEntryPoint(main = process.argv[1]) {
         if (!retryAsESM) {
           const { enrichCJSError } = require('internal/modules/esm/translators');
           enrichCJSError(error, source, resolvedMain);
-          throw error;
+          return true; // Rethrow original exception.
         }
-      }
+      });
     } else { // `--experimental-detect-module` is not passed
       Module._load(main, null, true);
     }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -185,6 +185,10 @@ function executeUserEntryPoint(main = process.argv[1]) {
       }
 
       if (!retryAsESM) {
+        if (Module === process.mainModule) {
+          const { enrichCJSError } = require('internal/modules/esm/translators');
+          enrichCJSError(error, source, resolvedMain);
+        }
         return true; // Rethrow original exception.
       }
     });

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -172,8 +172,8 @@ function executeUserEntryPoint(main = process.argv[1]) {
       // Module._load is the monkey-patchable CJS module loader.
       Module._load(main, null, true);
     }, (error) => {
+      const source = cjsLoader.entryPointSource;
       if (getOptionValue('--experimental-detect-module')) {
-        const source = cjsLoader.entryPointSource;
         if (!source) {
           return true; // Rethrow original exception.
         }
@@ -185,7 +185,7 @@ function executeUserEntryPoint(main = process.argv[1]) {
       }
 
       if (!retryAsESM) {
-        if (Module === process.mainModule) {
+        if (source) {
           const { enrichCJSError } = require('internal/modules/esm/translators');
           enrichCJSError(error, source, resolvedMain);
         }

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -41,7 +41,7 @@ using v8::Value;
 // If the second one returns true, rethrow the original exception.
 // This is to keep the location of the original throw in JS.
 static void TryCatchRethrow(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args.Length() == 2);
+  CHECK_EQ(args.Length(), 2);
   CHECK(args[0]->IsFunction());
   CHECK(args[1]->IsFunction());
 

--- a/test/es-module/test-esm-cjs-load-error-note.mjs
+++ b/test/es-module/test-esm-cjs-load-error-note.mjs
@@ -79,7 +79,7 @@ describe('ESM: Errors for unexpected exports', { concurrency: true }, () => {
       },
     ]
   ) {
-    it(`should ${includeNote ? '' : 'NOT'} include note`, async () => {
+    it(`should${includeNote ? '' : ' NOT'} include note`, async () => {
       const { code, stderr } = await spawnPromisified(execPath, [filePath]);
 
       assert.strictEqual(code, 1);

--- a/test/fixtures/console/console.snapshot
+++ b/test/fixtures/console/console.snapshot
@@ -6,3 +6,4 @@ Trace: foo
     at *
     at *
     at *
+    at *

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -10,5 +10,6 @@ Error: Should include grayed stack trace
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
+[90m    at *[39m
 
 Node.js *

--- a/test/fixtures/errors/promise_always_throw_unhandled.snapshot
+++ b/test/fixtures/errors/promise_always_throw_unhandled.snapshot
@@ -12,5 +12,6 @@ Error: One
     at *
     at *
     at *
+    at *
 
 Node.js *

--- a/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
+++ b/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
@@ -6,5 +6,6 @@
     at *
     at *
     at *
+    at *
 (Use `node --trace-warnings ...` to show where the warning was created)
 (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
+++ b/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
@@ -9,7 +9,9 @@
     at *
     at *
     at *
+    at *
 (node:*) Error: This was rejected
+    at *
     at *
     at *
     at *

--- a/test/fixtures/test-runner/output/abort.snapshot
+++ b/test/fixtures/test-runner/output/abort.snapshot
@@ -135,6 +135,7 @@ not ok 2 - promise abort signal
     *
     *
     *
+    *
   ...
 # Subtest: callback timeout signal
     # Subtest: ok 1
@@ -263,6 +264,7 @@ not ok 4 - callback abort signal
   code: 20
   name: 'AbortError'
   stack: |-
+    *
     *
     *
     *

--- a/test/fixtures/test-runner/output/abort_suite.snapshot
+++ b/test/fixtures/test-runner/output/abort_suite.snapshot
@@ -137,6 +137,7 @@ not ok 2 - describe abort signal
     *
     *
     *
+    *
   ...
 1..2
 # tests 9

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -15,6 +15,7 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
     at *
     at *
     at *
+    at *
     at * {
   generatedMessage: true,
   code: 'ERR_ASSERTION',

--- a/test/message/internal_assert.out
+++ b/test/message/internal_assert.out
@@ -12,6 +12,7 @@ Please open an issue with this stack trace at https://github.com/nodejs/node/iss
     at *
     at *
     at *
+    at *
     at * {
   code: 'ERR_INTERNAL_ASSERTION'
 }

--- a/test/message/internal_assert_fail.out
+++ b/test/message/internal_assert_fail.out
@@ -13,6 +13,7 @@ Please open an issue with this stack trace at https://github.com/nodejs/node/iss
     at *
     at *
     at *
+    at *
     at * {
   code: 'ERR_INTERNAL_ASSERTION'
 }

--- a/test/message/util-inspect-error-cause.out
+++ b/test/message/util-inspect-error-cause.out
@@ -5,10 +5,12 @@ Error: Number error cause
     at *
     at *
     at *
+    at *
     at * {
   [cause]: 42
 }
 Error: Object cause
+    at *
     at *
     at *
     at *
@@ -30,10 +32,12 @@ Error: undefined cause
     at *
     at *
     at *
+    at *
     at * {
   [cause]: undefined
 }
 Error: cause that throws
+    at *
     at *
     at *
     at *
@@ -49,12 +53,13 @@ RangeError: New Stack Frames
   [cause]: FoobarError: Individual message
       at *
   *[90m    at *[39m
-  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    ... 5 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     status: *[32m'Feeling good'*[39m,
     extraProperties: *[32m'Yes!'*[39m,
     [cause]: TypeError: Inner error
         at *
+    *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
@@ -66,17 +71,18 @@ RangeError: New Stack Frames
 Error: Stack causes
     at *
 *[90m    at *[39m
-*[90m    ... 4 lines matching cause stack trace ...*[39m
+*[90m    ... 5 lines matching cause stack trace ...*[39m
 *[90m    at *[39m {
   [cause]: FoobarError: Individual message
       at *
   *[90m    at *[39m
-  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    ... 5 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     status: *[32m'Feeling good'*[39m,
     extraProperties: *[32m'Yes!'*[39m,
     [cause]: TypeError: Inner error
         at *
+    *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
@@ -91,17 +97,18 @@ RangeError: New Stack Frames
   [cause]: Error: Stack causes
       at *
   *[90m    at *[39m
-  *[90m    ... 4 lines matching cause stack trace ...*[39m
+  *[90m    ... 5 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     [cause]: FoobarError: Individual message
         at *
     *[90m    at *[39m
-    *[90m    ... 4 lines matching cause stack trace ...*[39m
+    *[90m    ... 5 lines matching cause stack trace ...*[39m
     *[90m    at *[39m {
       status: *[32m'Feeling good'*[39m,
       extraProperties: *[32m'Yes!'*[39m,
       [cause]: TypeError: Inner error
           at *
+      *[90m    at *[39m
       *[90m    at *[39m
       *[90m    at *[39m
       *[90m    at *[39m
@@ -117,11 +124,12 @@ RangeError: New Stack Frames
   [cause]: FoobarError: Individual message
       at *
       at *
-      ... 4 lines matching cause stack trace ...
+      ... 5 lines matching cause stack trace ...
       at * {
     status: 'Feeling good',
     extraProperties: 'Yes!',
     [cause]: TypeError: Inner error
+        at *
         at *
         at *
         at *
@@ -134,16 +142,17 @@ RangeError: New Stack Frames
 Error: Stack causes
     at *
     at *
-    ... 4 lines matching cause stack trace ...
+    ... 5 lines matching cause stack trace ...
     at * {
   [cause]: FoobarError: Individual message
       at *
       at *
-      ... 4 lines matching cause stack trace ...
+      ... 5 lines matching cause stack trace ...
       at *
     status: 'Feeling good',
     extraProperties: 'Yes!',
     [cause]: TypeError: Inner error
+        at *
         at *
         at *
         at *
@@ -159,16 +168,17 @@ RangeError: New Stack Frames
   [cause]: Error: Stack causes
       at *
       at *
-      ... 4 lines matching cause stack trace ...
+      ... 5 lines matching cause stack trace ...
       at * {
     [cause]: FoobarError: Individual message
         at *
         at *
-        ... 4 lines matching cause stack trace ...
+        ... 5 lines matching cause stack trace ...
         at * {
       status: 'Feeling good',
       extraProperties: 'Yes!',
       [cause]: TypeError: Inner error
+          at *
           at *
           at *
           at *

--- a/test/message/util_inspect_error.out
+++ b/test/message/util_inspect_error.out
@@ -8,11 +8,13 @@
        at *
        at *
        at *
+       at *
   nested:
    { err:
       Error: foo
       bar
           at *util_inspect_error*
+          at *
           at *
           at *
           at *
@@ -29,10 +31,12 @@
       at *
       at *
       at *
+      at *
   nested: {
     err: Error: foo
     bar
         at *util_inspect_error*
+        at *
         at *
         at *
         at *
@@ -44,6 +48,7 @@
 { Error: foo
 bar
     at *util_inspect_error*
+    at *
     at *
     at *
     at *

--- a/test/pseudo-tty/console_colors.out
+++ b/test/pseudo-tty/console_colors.out
@@ -12,6 +12,7 @@ foobar
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
+[90m    at *[39m
 
 Error: Should not ever get here.
     at Object.<anonymous> [90m(*node_modules*[4m*node_modules*[24m*bar.js:*:*[90m)[39m

--- a/test/pseudo-tty/test-fatal-error.out
+++ b/test/pseudo-tty/test-fatal-error.out
@@ -9,6 +9,7 @@ TypeError: foobar
 [90m    at *(node:internal*loader:*:*)[39m
 [90m    at *(node:internal*loader:*:*)[39m
 [90m    at *[39m
+[90m    at *[39m
 [90m    at *[39m {
   bla: [33mtrue[39m
 }

--- a/test/pseudo-tty/test-trace-sigint.out
+++ b/test/pseudo-tty/test-trace-sigint.out
@@ -7,3 +7,4 @@ KEYBOARD_INTERRUPT: Script execution was interrupted by `SIGINT`
     at *
     at *
     at *
+    at *


### PR DESCRIPTION
This refactors the `try`/`catch` added in #52093 to happen in C++, so that the rethrown error preserves the same origin, source arrow and source map-translated stack trace. This gets us much closer to being able to unflag `--experimental-detect-module` and have all the tests pass. The C++ was written by @targos 

There’s currently only one test failing on this branch, and I’d love some help getting it to pass. `./node test/parallel/test-debugger-exceptions.js` is failing because in `node inspect`, for some reason the inspector sees the exception as being thrown by the new `TryCatchRethrow` rather than the rethrown exception. If anyone can figure out why this is and what we can do about it, I would be very grateful. cc @jkrems @nodejs/loaders @nodejs/inspector @nodejs/v8-inspector 
