### PR TITLE
doc: remove mold use on mac for speeding up build

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -536,10 +536,13 @@ If you encounter any difficulties, consider disabling `mold` as a
 troubleshooting step.
 
 If you plan to frequently rebuild Node.js, especially if using several
-branches, installing `ccache` and `mold` can help to greatly reduce build
+branches, installing `ccache` can help to greatly reduce build
 times. Set up with:
 
 On GNU/Linux:
+
+Tips: `mold` can speed up the link process, which can't be cached, you may
+need to install the latest version but not the apt version.
 
 ```bash
 sudo apt install ccache mold   # for Debian/Ubuntu, included in most Linux distros
@@ -548,13 +551,17 @@ export CXX="ccache g++"        # add to your .profile
 export LDFLAGS="-fuse-ld=mold" # add to your .profile
 ```
 
+Refs:
+
+1. <https://ccache.dev/performance.html>
+2. <https://github.com/rui314/mold>
+
 On macOS:
 
 ```bash
-brew install ccache mold       # see https://brew.sh
+brew install ccache            # see https://brew.sh
 export CC="ccache cc"          # add to ~/.zshrc or other shell config file
 export CXX="ccache c++"        # add to ~/.zshrc or other shell config file
-export LDFLAGS="-fuse-ld=mold" # add to ~/.zshrc or other shell config file
 ```
 
 This will allow for near-instantaneous rebuilds when switching branches back
@@ -571,11 +578,6 @@ The resulting binary won't include any JS files and will try to load them from
 the specified directory. The JS debugger of Visual Studio Code supports this
 configuration since the November 2020 version and allows for setting
 breakpoints.
-
-Refs:
-
-1. <https://ccache.dev/performance.html>
-2. <https://github.com/rui314/mold>
 
 #### Troubleshooting Unix and macOS builds
 


### PR DESCRIPTION
As title, the the mold/sold does not fit for mac, so related info need be remove.
