### PR TITLE
[v20.x] deps: V8: remove references to non-existent flags

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/flags/flags.cc
+++ b/deps/v8/src/flags/flags.cc
@@ -586,10 +586,6 @@ uint32_t ComputeFlagListHash() {
     // The following flags are implied by --predictable (some negated).
     if (flag.PointsTo(&v8_flags.concurrent_sparkplug) ||
         flag.PointsTo(&v8_flags.concurrent_recompilation) ||
-#ifdef V8_ENABLE_MAGLEV
-        flag.PointsTo(&v8_flags.maglev_deopt_data_on_background) ||
-        flag.PointsTo(&v8_flags.maglev_build_code_on_background) ||
-#endif
         flag.PointsTo(&v8_flags.parallel_scavenge) ||
         flag.PointsTo(&v8_flags.concurrent_marking) ||
         flag.PointsTo(&v8_flags.concurrent_array_buffer_sweeping) ||


### PR DESCRIPTION
https://github.com/nodejs/node/pull/49703 cherry-picked a commit from upstream V8 which references some maglev-related flags that are not present in the version of V8 in Node.js 20.

---

V8 CI on x64 is currently broken, e.g. https://ci.nodejs.org/job/node-test-commit-v8-linux/5892/nodes=benchmark-ubuntu2204-intel-64,v8test=v8test/console
```console
16:38:36 ../../src/flags/flags.cc:590:33: error: no member named 'maglev_deopt_data_on_background' in 'v8::internal::FlagValues'
16:38:36         flag.PointsTo(&v8_flags.maglev_deopt_data_on_background) ||
16:38:36                        ~~~~~~~~ ^
16:38:36 ../../src/flags/flags.cc:591:33: error: no member named 'maglev_build_code_on_background' in 'v8::internal::FlagValues'
16:38:36         flag.PointsTo(&v8_flags.maglev_build_code_on_background) ||
16:38:36                        ~~~~~~~~ ^
16:38:36 2 errors generated.
```

This comes from https://github.com/nodejs/node/pull/49703 which went out in Node.js 20.8.0 and was presumably missed because the x64 V8 CI has been unreliable due to networking issues on the machine. The V8 CI has been moved onto new x64 machines, which have revealed this compilation failure. (Other release lines successfully compile but are failing [perf-related tests](https://github.com/nodejs/build/issues/3515#issuecomment-2025624457).)

Other platforms tested in the V8 CI, Linux on ppc64le and s390x, do not enable maglev so didn't surface this.

This is a fairly naive attempt to fix the compilation failure -- I don't know if there are alternate flags for the version of V8 in Node.js 20 that should be implied by `--predictable`. cc @joyeecheung 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
