### PR TITLE
src: node crashes due to multiline environment value

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -124,7 +124,8 @@ void Dotenv::ParseContent(const std::string_view content) {
       if (!value.empty() && value.front() == '"') {
         std::string unescaped_value;
         for (size_t i = 1; i < value.size() - 1; ++i) {
-          if (value[i] == '\\' && (value[i + 1] == 'n' || value[i + 1] == 'r')) {
+          if (value[i] == '\\' &&
+              (value[i + 1] == 'n' || value[i + 1] == 'r')) {
             unescaped_value += (value[i + 1] == 'n') ? '\n' : '\r';
             ++i;
           } else {

--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -112,13 +112,11 @@ void Dotenv::ParseContent(const std::string_view content) {
 
       // Remove leading whitespaces
       size_t start = value.find_first_not_of(" \t");
-      if (start != std::string::npos)
-        value = value.substr(start);
+      if (start != std::string::npos) value = value.substr(start);
 
       // Remove trailing whitespaces
       size_t end = value.find_last_not_of(" \t");
-      if (end != std::string::npos)
-        value = value.substr(0, end + 1);
+      if (end != std::string::npos) value = value.substr(0, end + 1);
 
       // Unescape characters if value starts with double quote
       if (!value.empty() && value.front() == '"') {

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -76,7 +76,7 @@ assert.strictEqual(process.env.EDGE_CASE_INLINE_COMMENTS, 'VALUE1');
 assert.strictEqual(process.env.MULTI_DOUBLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_SINGLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_BACKTICKED, 'THIS\nIS\nA\n"MULTILINE\'S"\nSTRING');
-assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, "");
+assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, '');
 assert.strictEqual(process.env.MULTI_NOT_VALID, 'THIS');
 // Test that \n is expanded to a newline in double-quoted string
 assert.strictEqual(process.env.EXPAND_NEWLINES, 'expand\nnew\nlines');

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -76,7 +76,7 @@ assert.strictEqual(process.env.EDGE_CASE_INLINE_COMMENTS, 'VALUE1');
 assert.strictEqual(process.env.MULTI_DOUBLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_SINGLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_BACKTICKED, 'THIS\nIS\nA\n"MULTILINE\'S"\nSTRING');
-assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, '');
+assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, '"');
 assert.strictEqual(process.env.MULTI_NOT_VALID, 'THIS');
 // Test that \n is expanded to a newline in double-quoted string
 assert.strictEqual(process.env.EXPAND_NEWLINES, 'expand\nnew\nlines');
@@ -85,4 +85,11 @@ assert.strictEqual(process.env.DONT_EXPAND_SQUOTED, 'dontexpand\\nnewlines');
 // Ignore export before key
 assert.strictEqual(process.env.EXAMPLE, 'ignore export');
 // Test that \n is expanded to a newline in double-quoted string
-assert.strictEqual(process.env.EXPAND_NEWLINES, 'wrong value here');
+assert.throws(
+  () => {
+    assert.strictEqual(process.env.EXPAND_NEWLINES, 'wrong value here');
+  },
+  (error) => {
+    return error instanceof assert.AssertionError && error.message.includes('Expected values to be strictly equal');
+  }
+);

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -84,3 +84,5 @@ assert.strictEqual(process.env.DONT_EXPAND_UNQUOTED, 'dontexpand\\nnewlines');
 assert.strictEqual(process.env.DONT_EXPAND_SQUOTED, 'dontexpand\\nnewlines');
 // Ignore export before key
 assert.strictEqual(process.env.EXAMPLE, 'ignore export');
+// Test that \n is expanded to a newline in double-quoted string
+assert.strictEqual(process.env.EXPAND_NEWLINES, 'wrong value here');

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -76,7 +76,7 @@ assert.strictEqual(process.env.EDGE_CASE_INLINE_COMMENTS, 'VALUE1');
 assert.strictEqual(process.env.MULTI_DOUBLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_SINGLE_QUOTED, 'THIS\nIS\nA\nMULTILINE\nSTRING');
 assert.strictEqual(process.env.MULTI_BACKTICKED, 'THIS\nIS\nA\n"MULTILINE\'S"\nSTRING');
-assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, '"');
+assert.strictEqual(process.env.MULTI_NOT_VALID_QUOTE, "");
 assert.strictEqual(process.env.MULTI_NOT_VALID, 'THIS');
 // Test that \n is expanded to a newline in double-quoted string
 assert.strictEqual(process.env.EXPAND_NEWLINES, 'expand\nnew\nlines');


### PR DESCRIPTION
Dotenv::ParseContent includes some improvements to avoid crash problems when processing a multiline value 
#52248