### PR TITLE
lib: refactor lazy loading of undici for fetch method

### DIFF
--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -57,32 +57,19 @@ defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 const { installObjectURLMethods } = require('internal/url');
 installObjectURLMethods();
 
-{
-  // https://fetch.spec.whatwg.org/#fetch-method
-  function set(value) {
-    ObjectDefineProperty(globalThis, 'fetch', {
-      __proto__: null,
-      writable: true,
-      value,
-    });
-  }
-  ObjectDefineProperty(globalThis, 'fetch', {
-    __proto__: null,
-    configurable: true,
-    enumerable: true,
-    set,
-    get() {
-      function fetch(input, init = undefined) {
-        // Loading undici alone lead to promises which breaks lots of tests so we
-        // have to load it really lazily for now.
-        const { fetch: impl } = require('internal/deps/undici/undici');
-        return impl(input, init);
-      }
-      set(fetch);
-      return fetch;
-    },
-  });
-}
+// https://fetch.spec.whatwg.org/#fetch-method
+ObjectDefineProperty(globalThis, 'fetch', {
+  __proto__: null,
+  configurable: true,
+  enumerable: true,
+  writable: true,
+  value: function fetch(input, init = undefined) { // eslint-disable-line func-name-matching
+    // Loading undici alone lead to promises which breaks lots of tests so we
+    // have to load it really lazily for now.
+    const { fetch: impl } = require('internal/deps/undici/undici');
+    return impl(input, init);
+  },
+});
 
 // https://xhr.spec.whatwg.org/#interface-formdata
 // https://fetch.spec.whatwg.org/#headers-class

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -57,17 +57,19 @@ defineReplaceableLazyAttribute(globalThis, 'perf_hooks', ['performance']);
 const { installObjectURLMethods } = require('internal/url');
 installObjectURLMethods();
 
+let fetchImpl;
 // https://fetch.spec.whatwg.org/#fetch-method
 ObjectDefineProperty(globalThis, 'fetch', {
   __proto__: null,
   configurable: true,
   enumerable: true,
   writable: true,
-  value: function fetch(input, init = undefined) { // eslint-disable-line func-name-matching
-    // Loading undici alone lead to promises which breaks lots of tests so we
-    // have to load it really lazily for now.
-    const { fetch: impl } = require('internal/deps/undici/undici');
-    return impl(input, init);
+  value: function value(input, init = undefined) {
+    if (!fetchImpl) { // Implement lazy loading of undici module for fetch function
+      const undiciModule = require('internal/deps/undici/undici');
+      fetchImpl = undiciModule.fetch;
+    }
+    return fetchImpl(input, init);
   },
 });
 

--- a/test/parallel/test-fetch-mock.js
+++ b/test/parallel/test-fetch-mock.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const { mock, test } = require('node:test');
+const assert = require('node:assert');
+
+test('should correctly stub globalThis.fetch', async () => {
+  const customFetch = async (url) => {
+    return {
+      text: async () => 'foo',
+    };
+  };
+
+  mock.method(globalThis, 'fetch', customFetch);
+
+  const response = await globalThis.fetch('some-url');
+  const text = await response.text();
+
+  assert.strictEqual(text, 'foo');
+  mock.restoreAll();
+});


### PR DESCRIPTION
Object.defineProperty is updated to lazily load the undici dependency for the fetch method. This change allows for simpler and more reliable mocking of the fetch method for testing purposes, resolving issues encountered with premature method invocation during testing.

Fixes: https://github.com/nodejs/node/issues/52015
