### PR TITLE
streams: fix util inspect returning undefined for CompressionStream & DecompressionStream

### DIFF
--- a/lib/internal/webstreams/compression.js
+++ b/lib/internal/webstreams/compression.js
@@ -78,7 +78,7 @@ class CompressionStream {
   }
 
   [kInspect](depth, options) {
-    customInspect(depth, options, 'CompressionStream', {
+    return customInspect(depth, options, 'CompressionStream', {
       readable: this.#transform.readable,
       writable: this.#transform.writable,
     });
@@ -128,7 +128,7 @@ class DecompressionStream {
   }
 
   [kInspect](depth, options) {
-    customInspect(depth, options, 'DecompressionStream', {
+    return customInspect(depth, options, 'DecompressionStream', {
       readable: this.#transform.readable,
       writable: this.#transform.writable,
     });

--- a/test/parallel/test-compression-decompression-stream.js
+++ b/test/parallel/test-compression-decompression-stream.js
@@ -3,7 +3,7 @@
 
 require('../common');
 
-const assert = require('assert');
+const assert = require('node:assert');
 const { describe, it } = require('node:test');
 const {
   CompressionStream,

--- a/test/parallel/test-compression-decompression-stream.js
+++ b/test/parallel/test-compression-decompression-stream.js
@@ -1,0 +1,41 @@
+// Flags: --no-warnings --expose-internals
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const { describe, it } = require('node:test');
+const {
+  CompressionStream,
+  DecompressionStream,
+} = require('stream/web');
+
+const {
+  customInspectSymbol: kInspect,
+} = require('internal/util');
+
+describe('DecompressionStream kInspect method', () => {
+  it('should return a predictable inspection string with DecompressionStream', () => {
+    const decompressionStream = new DecompressionStream('deflate');
+    const depth = 1;
+    const options = {};
+    const actual = decompressionStream[kInspect](depth, options);
+
+    assert(actual.includes('DecompressionStream'));
+    assert(actual.includes('ReadableStream'));
+    assert(actual.includes('WritableStream'));
+  });
+});
+
+describe('CompressionStream kInspect method', () => {
+  it('should return a predictable inspection string with CompressionStream', () => {
+    const compressionStream = new CompressionStream('deflate');
+    const depth = 1;
+    const options = {};
+    const actual = compressionStream[kInspect](depth, options);
+
+    assert(actual.includes('CompressionStream'));
+    assert(actual.includes('ReadableStream'));
+    assert(actual.includes('WritableStream'));
+  });
+});

--- a/test/parallel/test-compression-decompression-stream.js
+++ b/test/parallel/test-compression-decompression-stream.js
@@ -8,7 +8,7 @@ const { describe, it } = require('node:test');
 const {
   CompressionStream,
   DecompressionStream,
-} = require('stream/web');
+} = require('node:stream/web');
 
 const {
   customInspectSymbol: kInspect,


### PR DESCRIPTION
The customInspect method within the internal module node/lib/internal/webstreams/compression.js was missing a return statement, causing util.inspect to return undefined when inspecting instances of CompressionStream and DecompressionStream. This commit adds the missing return statement to ensure that util.inspect displays the correct information for these stream instances.

Fixes: https://github.com/nodejs/node/issues/52263