### PR TITLE
doc: fix email pattern to be wrapped with `<<` instead of single `<`

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ For information about the governance of the Node.js project, see
 * [ZYSzys](https://github.com/ZYSzys) -
   **Yongsheng Zhang** <<zyszys98@gmail.com>> (he/him)
 * [zcbenz](https://github.com/zcbenz) -
-  **Cheng Zhao** <zcbenz@gmail.com> (he/him)
+  **Cheng Zhao** <<zcbenz@gmail.com>> (he/him)
 
 <details>
 


### PR DESCRIPTION
the email should be wrapped with `<<{email}>>` and not `<{email}>`

https://github.com/nodejs/node/blob/0408f6380498c4c3c4c9a4ef786d6158d02dac38/tools/find-inactive-collaborators.mjs#L82