### PR TITLE
test_runner: disable highWatermark on TestsStream

### DIFF
--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -2,6 +2,7 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
+  NumberMAX_SAFE_INTEGER,
   Symbol,
 } = primordials;
 const Readable = require('internal/streams/readable');
@@ -12,7 +13,11 @@ class TestsStream extends Readable {
   #canPush;
 
   constructor() {
-    super({ __proto__: null, objectMode: true });
+    super({
+      __proto__: null,
+      objectMode: true,
+      highWaterMark: NumberMAX_SAFE_INTEGER,
+    });
     this.#buffer = [];
     this.#canPush = true;
   }


### PR DESCRIPTION
The default `highWatermark` of 16 on the `TestsStream` class can have a substantial impact on reporting performance. This commit sets the `TestsStream` `highWatermark` to a very large value and lets the destination streams (which are more likely to have meaningful `highWatermark`s) handle backpressure.

To test this, I ran the following code:

```js
'use strict';
const { describe, it } = require('node:test');

for (let i = 0; i < 100; ++i) {
  describe(`suite ${i + 1}`, () => {
    for (let j = 0; j < 100; ++j) {
      it(`test ${i + 1}-${j + 1}`, () => {});
    }
  });
}
```

Running the command `time ./node test.js` on my machine before and after this change yielded:

Before this change:
- With `--test`: 2.12 seconds
- Without `--test`: 1.43 seconds

After this change:
- With `--test`: 0.94 seconds
- Without `--test`: 0.42 seconds

For reference, mocha (`time ./node ./node_modules/.bin/mocha test.js`, with the `node:test` import removed) yielded 0.95 seconds.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
