### PR TITLE
doc: add lint-js-fix into BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -319,6 +319,8 @@ documentation tests.
 To run the linter without running tests, use
 `make lint`/`vcbuild lint`. It will lint JavaScript, C++, and Markdown files.
 
+To fix auto fixable JavaScript linting errors, use `make lint-js-fix`.
+
 If you are updating tests and want to run tests in a single test file
 (e.g. `test/parallel/test-stream2-transform.js`):
 


### PR DESCRIPTION
Currently there isn't a way to pass `--fix` into `make lint-js` as far as I am aware of. Spent quiet some time fixing them one by one and just realised `lint-js-fix` exists.

Tried [node-code-ide-configs](https://github.com/nodejs/node-code-ide-configs) and thought [this](https://github.com/nodejs/node-code-ide-configs/blob/main/.vscode/settings.json#L2C1-L2C32) will provide some sort of format on save but didn't make it work. Feels a bit painful to deal with small things like this when making a contribution. Happy to be educated a better way to deal / fix with lint errors.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
