### PR TITLE
module: centralize SourceTextModule compilation for builtin loader

### DIFF
--- a/lib/internal/modules/esm/create_dynamic_module.js
+++ b/lib/internal/modules/esm/create_dynamic_module.js
@@ -55,8 +55,8 @@ ${ArrayPrototypeJoin(ArrayPrototypeMap(imports, createImport), '\n')}
 ${ArrayPrototypeJoin(ArrayPrototypeMap(exports, createExport), '\n')}
 import.meta.done();
 `;
-  const { ModuleWrap } = internalBinding('module_wrap');
-  const m = new ModuleWrap(`${url}`, undefined, source, 0, 0);
+  const { registerModule, compileSourceTextModule } = require('internal/modules/esm/utils');
+  const m = compileSourceTextModule(`${url}`, source);
 
   const readyfns = new SafeSet();
   /** @type {DynamicModuleReflect} */
@@ -68,7 +68,6 @@ import.meta.done();
   if (imports.length) {
     reflect.imports = { __proto__: null };
   }
-  const { registerModule } = require('internal/modules/esm/utils');
   registerModule(m, {
     __proto__: null,
     initializeImportMeta: (meta, wrap) => {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -25,13 +25,10 @@ const { getOptionValue } = require('internal/options');
 const { isURL, pathToFileURL, URL } = require('internal/url');
 const { emitExperimentalWarning, kEmptyObject } = require('internal/util');
 const {
-  registerModule,
+  compileSourceTextModule,
   getDefaultConditions,
 } = require('internal/modules/esm/utils');
 const { kImplicitAssertType } = require('internal/modules/esm/assert');
-const {
-  maybeCacheSourceMap,
-} = require('internal/source_map/source_map_cache');
 const { canParse } = internalBinding('url');
 const { ModuleWrap } = internalBinding('module_wrap');
 let defaultResolve, defaultLoad, defaultLoadSync, importMetaInitializer;
@@ -193,16 +190,7 @@ class ModuleLoader {
 
   async eval(source, url, isEntryPoint = false) {
     const evalInstance = (url) => {
-      const module = new ModuleWrap(url, undefined, source, 0, 0);
-      registerModule(module, {
-        __proto__: null,
-        initializeImportMeta: (meta, wrap) => this.importMetaInitialize(meta, { url }),
-        importModuleDynamically: (specifier, { url }, importAttributes) => {
-          return this.import(specifier, url, importAttributes);
-        },
-      });
-
-      return module;
+      return compileSourceTextModule(url, source, this);
     };
     const { ModuleJob } = require('internal/modules/esm/module_job');
     const job = new ModuleJob(
@@ -273,26 +261,10 @@ class ModuleLoader {
     if (job !== undefined) {
       return job.module.getNamespaceSync();
     }
-
     // TODO(joyeecheung): refactor this so that we pre-parse in C++ and hit the
     // cache here, or use a carrier object to carry the compiled module script
     // into the constructor to ensure cache hit.
-    const wrap = new ModuleWrap(url, undefined, source, 0, 0);
-    // Cache the source map for the module if present.
-    if (wrap.sourceMapURL) {
-      maybeCacheSourceMap(url, source, null, false, undefined, wrap.sourceMapURL);
-    }
-    const { registerModule } = require('internal/modules/esm/utils');
-    // TODO(joyeecheung): refactor so that the default options are shared across
-    // the built-in loaders.
-    registerModule(wrap, {
-      __proto__: null,
-      initializeImportMeta: (meta, wrap) => this.importMetaInitialize(meta, { url }),
-      importModuleDynamically: (specifier, wrap, importAttributes) => {
-        return this.import(specifier, url, importAttributes);
-      },
-    });
-
+    const wrap = compileSourceTextModule(url, source, this);
     const inspectBrk = (isMain && getOptionValue('--inspect-brk'));
 
     const { ModuleJobSync } = require('internal/modules/esm/module_job');

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -156,35 +156,13 @@ function errPath(url) {
   return url;
 }
 
-/**
- * Dynamically imports a module using the ESM loader.
- * @param {string} specifier - The module specifier to import.
- * @param {object} options - An object containing options for the import.
- * @param {string} options.url - The URL of the module requesting the import.
- * @param {Record<string, string>} [attributes] - An object containing attributes for the import.
- * @returns {Promise<import('internal/modules/esm/loader.js').ModuleExports>} The imported module.
- */
-async function importModuleDynamically(specifier, { url }, attributes) {
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-  return cascadedLoader.import(specifier, url, attributes);
-}
-
 // Strategy for loading a standard JavaScript module.
 translators.set('module', function moduleStrategy(url, source, isMain) {
   assertBufferSource(source, true, 'load');
   source = stringify(source);
   debug(`Translating StandardModule ${url}`);
-  const module = new ModuleWrap(url, undefined, source, 0, 0);
-  // Cache the source map for the module if present.
-  if (module.sourceMapURL) {
-    maybeCacheSourceMap(url, source, null, false, undefined, module.sourceMapURL);
-  }
-  const { registerModule } = require('internal/modules/esm/utils');
-  registerModule(module, {
-    __proto__: null,
-    initializeImportMeta: (meta, wrap) => this.importMetaInitialize(meta, { url }),
-    importModuleDynamically,
-  });
+  const { compileSourceTextModule } = require('internal/modules/esm/utils');
+  const module = compileSourceTextModule(url, source, this);
   return module;
 });
 

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -13,11 +13,17 @@ const {
   },
 } = internalBinding('util');
 const {
+  source_text_module_default_hdo,
   vm_dynamic_import_default_internal,
   vm_dynamic_import_main_context_default,
   vm_dynamic_import_missing_flag,
   vm_dynamic_import_no_callback,
 } = internalBinding('symbols');
+
+const { ModuleWrap } = internalBinding('module_wrap');
+const {
+  maybeCacheSourceMap,
+} = require('internal/source_map/source_map_cache');
 
 const {
   ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG,
@@ -168,27 +174,54 @@ function registerModule(referrer, registry) {
 }
 
 /**
+ * Proxy the import meta handling to the default loader for source text modules.
+ * @param {Record<string, string | Function>} meta - The import.meta object to initialize.
+ * @param {ModuleWrap} wrap - The ModuleWrap of the SourceTextModule where `import.meta` is referenced.
+ */
+function defaultInitializeImportMetaForModule(meta, wrap) {
+  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  return cascadedLoader.importMetaInitialize(meta, { url: wrap.url });
+}
+
+/**
  * Defines the `import.meta` object for a given module.
  * @param {symbol} symbol - Reference to the module.
  * @param {Record<string, string | Function>} meta - The import.meta object to initialize.
+ * @param {ModuleWrap} wrap - The ModuleWrap of the SourceTextModule where `import.meta` is referenced.
  */
-function initializeImportMetaObject(symbol, meta) {
-  if (moduleRegistries.has(symbol)) {
-    const { initializeImportMeta, callbackReferrer } = moduleRegistries.get(symbol);
-    if (initializeImportMeta !== undefined) {
-      meta = initializeImportMeta(meta, callbackReferrer);
-    }
+function initializeImportMetaObject(symbol, meta, wrap) {
+  if (symbol === source_text_module_default_hdo) {
+    defaultInitializeImportMetaForModule(meta, wrap);
+    return;
+  }
+  const data = moduleRegistries.get(symbol);
+  assert(data, `import.meta registry not found for ${wrap.url}`);
+  const { initializeImportMeta, callbackReferrer } = data;
+  if (initializeImportMeta !== undefined) {
+    meta = initializeImportMeta(meta, callbackReferrer);
   }
 }
 
 /**
- * Proxy the dynamic import to the default loader.
+ * Proxy the dynamic import handling to the default loader for source text modules.
  * @param {string} specifier - The module specifier string.
  * @param {Record<string, string>} attributes - The import attributes object.
  * @param {string|null|undefined} referrerName - name of the referrer.
  * @returns {Promise<import('internal/modules/esm/loader.js').ModuleExports>} - The imported module object.
  */
-function defaultImportModuleDynamically(specifier, attributes, referrerName) {
+function defaultImportModuleDynamicallyForModule(specifier, attributes, referrerName) {
+  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  return cascadedLoader.import(specifier, referrerName, attributes);
+}
+
+/**
+ * Proxy the dynamic import to the default loader for classic scripts.
+ * @param {string} specifier - The module specifier string.
+ * @param {Record<string, string>} attributes - The import attributes object.
+ * @param {string|null|undefined} referrerName - name of the referrer.
+ * @returns {Promise<import('internal/modules/esm/loader.js').ModuleExports>} - The imported module object.
+ */
+function defaultImportModuleDynamicallyForScript(specifier, attributes, referrerName) {
   const parentURL = normalizeReferrerURL(referrerName);
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
   return cascadedLoader.import(specifier, parentURL, attributes);
@@ -208,12 +241,16 @@ async function importModuleDynamicallyCallback(referrerSymbol, specifier, attrib
   // and fall back to the default loader.
   if (referrerSymbol === vm_dynamic_import_main_context_default) {
     emitExperimentalWarning('vm.USE_MAIN_CONTEXT_DEFAULT_LOADER');
-    return defaultImportModuleDynamically(specifier, attributes, referrerName);
+    return defaultImportModuleDynamicallyForScript(specifier, attributes, referrerName);
   }
   // For script compiled internally that should use the default loader to handle dynamic
   // import, proxy the request to the default loader without the warning.
   if (referrerSymbol === vm_dynamic_import_default_internal) {
-    return defaultImportModuleDynamically(specifier, attributes, referrerName);
+    return defaultImportModuleDynamicallyForScript(specifier, attributes, referrerName);
+  }
+  // For SourceTextModules compiled internally, proxy the request to the default loader.
+  if (referrerSymbol === source_text_module_default_hdo) {
+    return defaultImportModuleDynamicallyForModule(specifier, attributes, referrerName);
   }
 
   if (moduleRegistries.has(referrerSymbol)) {
@@ -286,6 +323,29 @@ async function initializeHooks() {
   return hooks;
 }
 
+/**
+ * Compile a SourceTextModule for the built-in ESM loader. Register it for default
+ * source map and import.meta and dynamic import() handling if cascadedLoader is provided.
+ * @param {string} url URL of the module.
+ * @param {string} source Source code of the module.
+ * @param {typeof import('./loader.js').ModuleLoader|undefined} cascadedLoader If provided,
+ *        register the module for default handling.
+ * @returns {ModuleWrap}
+ */
+function compileSourceTextModule(url, source, cascadedLoader) {
+  const hostDefinedOption = cascadedLoader ? source_text_module_default_hdo : undefined;
+  const wrap = new ModuleWrap(url, undefined, source, 0, 0, hostDefinedOption);
+
+  if (!cascadedLoader) {
+    return wrap;
+  }
+  // Cache the source map for the module if present.
+  if (wrap.sourceMapURL) {
+    maybeCacheSourceMap(url, source, null, false, undefined, wrap.sourceMapURL);
+  }
+  return wrap;
+}
+
 module.exports = {
   registerModule,
   initializeESM,
@@ -294,4 +354,5 @@ module.exports = {
   getConditionsSet,
   loaderWorkerId: 'internal/modules/esm/worker',
   forceDefaultLoader,
+  compileSourceTextModule,
 };

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -141,18 +141,17 @@ class Module {
           importModuleDynamicallyWrap(options.importModuleDynamically) :
           undefined,
       };
+      // This will take precedence over the referrer as the object being
+      // passed into the callbacks.
+      registry.callbackReferrer = this;
+      const { registerModule } = require('internal/modules/esm/utils');
+      registerModule(this[kWrap], registry);
     } else {
       assert(syntheticEvaluationSteps);
       this[kWrap] = new ModuleWrap(identifier, context,
                                    syntheticExportNames,
                                    syntheticEvaluationSteps);
     }
-
-    // This will take precedence over the referrer as the object being
-    // passed into the callbacks.
-    registry.callbackReferrer = this;
-    const { registerModule } = require('internal/modules/esm/utils');
-    registerModule(this[kWrap], registry);
 
     this[kContext] = context;
   }

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -49,6 +49,7 @@
   V(onpskexchange_symbol, "onpskexchange")                                     \
   V(resource_symbol, "resource_symbol")                                        \
   V(trigger_async_id_symbol, "trigger_async_id_symbol")                        \
+  V(source_text_module_default_hdo, "source_text_module_default_hdo")          \
   V(vm_dynamic_import_default_internal, "vm_dynamic_import_default_internal")  \
   V(vm_dynamic_import_main_context_default,                                    \
     "vm_dynamic_import_main_context_default")                                  \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -142,8 +142,10 @@ v8::Maybe<bool> ModuleWrap::CheckUnsettledTopLevelAwait() {
   return v8::Just(false);
 }
 
-// new ModuleWrap(url, context, source, lineOffset, columnOffset)
-// new ModuleWrap(url, context, exportNames, syntheticExecutionFunction)
+// new ModuleWrap(url, context, source, lineOffset, columnOffset, cachedData)
+// new ModuleWrap(url, context, source, lineOffset, columOffset,
+// hostDefinedOption) new ModuleWrap(url, context, exportNames,
+// syntheticExecutionFunction)
 void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   CHECK_GE(args.Length(), 3);
@@ -172,22 +174,36 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
   int column_offset = 0;
 
   bool synthetic = args[2]->IsArray();
+
+  Local<PrimitiveArray> host_defined_options =
+      PrimitiveArray::New(isolate, HostDefinedOptions::kLength);
+  Local<Symbol> id_symbol;
   if (synthetic) {
     // new ModuleWrap(url, context, exportNames, syntheticExecutionFunction)
     CHECK(args[3]->IsFunction());
   } else {
     // new ModuleWrap(url, context, source, lineOffset, columOffset, cachedData)
+    // new ModuleWrap(url, context, source, lineOffset, columOffset,
+    // hostDefinedOption)
     CHECK(args[2]->IsString());
     CHECK(args[3]->IsNumber());
     line_offset = args[3].As<Int32>()->Value();
     CHECK(args[4]->IsNumber());
     column_offset = args[4].As<Int32>()->Value();
-  }
+    if (args[5]->IsSymbol()) {
+      id_symbol = args[5].As<Symbol>();
+    } else {
+      id_symbol = Symbol::New(isolate, url);
+    }
+    host_defined_options->Set(isolate, HostDefinedOptions::kID, id_symbol);
 
-  Local<PrimitiveArray> host_defined_options =
-      PrimitiveArray::New(isolate, HostDefinedOptions::kLength);
-  Local<Symbol> id_symbol = Symbol::New(isolate, url);
-  host_defined_options->Set(isolate, HostDefinedOptions::kID, id_symbol);
+    if (that->SetPrivate(context,
+                         realm->isolate_data()->host_defined_option_symbol(),
+                         id_symbol)
+            .IsNothing()) {
+      return;
+    }
+  }
 
   ShouldNotAbortOnUncaughtScope no_abort_scope(realm->env());
   TryCatchScope try_catch(realm->env());
@@ -215,8 +231,7 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
           isolate, url, span, SyntheticModuleEvaluationStepsCallback);
     } else {
       ScriptCompiler::CachedData* cached_data = nullptr;
-      if (!args[5]->IsUndefined()) {
-        CHECK(args[5]->IsArrayBufferView());
+      if (args[5]->IsArrayBufferView()) {
         Local<ArrayBufferView> cached_data_buf = args[5].As<ArrayBufferView>();
         uint8_t* data =
             static_cast<uint8_t*>(cached_data_buf->Buffer()->Data());
@@ -276,13 +291,6 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
 
   if (!that->Set(context, realm->isolate_data()->url_string(), url)
            .FromMaybe(false)) {
-    return;
-  }
-
-  if (that->SetPrivate(context,
-                       realm->isolate_data()->host_defined_option_symbol(),
-                       id_symbol)
-          .IsNothing()) {
     return;
   }
 
@@ -879,7 +887,7 @@ void ModuleWrap::HostInitializeImportMetaObjectCallback(
     return;
   }
   DCHECK(id->IsSymbol());
-  Local<Value> args[] = {id, meta};
+  Local<Value> args[] = {id, meta, wrap};
   TryCatchScope try_catch(env);
   USE(callback->Call(
       context, Undefined(realm->isolate()), arraysize(args), args));


### PR DESCRIPTION
This refactors the code that compiles SourceTextModule for the built-in ESM loader to use a common routine so that it's easier to customize cache handling for the ESM loader. In addition this introduces a common symbol for import.meta and import() so that we don't need to create additional closures as handlers, since we can get all the information we need from the V8 callback already. This should reduce the memory footprint of ESM as well.

Refs: https://github.com/nodejs/node/issues/47472

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
