### PR TITLE
tools: update Ruff to v0.3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1512,15 +1512,15 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing ruff on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.0.272 || \
-		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.0.272
+	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.3.4 || \
+		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.3.4
 
 .PHONY: lint-py
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")
 # Lint the Python code with ruff.
 lint-py:
 	tools/pip/site-packages/bin/ruff --version
-	tools/pip/site-packages/bin/ruff .
+	tools/pip/site-packages/bin/ruff check .
 else
 lint-py:
 	$(warning Python linting with ruff is not available)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,15 @@
 [tool.ruff]
+exclude = [
+  "deps",
+  "tools/cpplint.py",
+  "tools/gyp",
+  "tools/inspector_protocol",
+  "tools/node_modules",
+]
+line-length = 172
+target-version = "py37"
+
+[tool.ruff.lint]
 select = [
   "C90",    # McCabe cyclomatic complexity
   "E",      # pycodestyle
@@ -17,12 +28,6 @@ select = [
   "W",      # pycodestyle
   "YTT",    # flake8-2020
 ]
-exclude = [
-  "deps",
-  "tools/gyp",
-  "tools/inspector_protocol",
-  "tools/node_modules",
-]
 ignore = [
   "E401",
   "E402",
@@ -31,19 +36,17 @@ ignore = [
   "RUF005",
   "RUF100",
 ]
-line-length = 172
-target-version = "py37"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 100
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tools/checkimports.py" = ["W605"]
 "tools/gyp/pylib/gyp/xcodeproj_file.py" = ["PLE0101"]
 "tools/icu/shrink-icu-src.py" = ["W605"]
 "tools/mkssldef.py" = ["W605"]
 
-[tool.ruff.pylint]
+[tool.ruff.lint.pylint]
 max-args = 12
 max-branches = 110
 max-returns = 12


### PR DESCRIPTION
- Use `check` command as suggested
- Adapt deprecated config
- Ignore cpplint.py as it's a third-party script

