### PR TITLE
v8: update v8 patch to avoid breaking building with clang

### DIFF
--- a/deps/v8/src/compiler/turboshaft/assembler.h
+++ b/deps/v8/src/compiler/turboshaft/assembler.h
@@ -3934,7 +3934,7 @@ class TSAssembler
     : public Assembler<reducer_list<TurboshaftAssemblerOpInterface, Reducers...,
                                     TSReducerBase>> {
  public:
-#ifdef _WIN32
+#if defined(_MSC_VER) && !defined(__clang__)
   explicit TSAssembler(Graph& input_graph, Graph& output_graph,
                        Zone* phase_zone)
       : Assembler(input_graph, output_graph, phase_zone) {}

--- a/deps/v8/src/compiler/turboshaft/copying-phase.h
+++ b/deps/v8/src/compiler/turboshaft/copying-phase.h
@@ -193,7 +193,12 @@ class GraphVisitor : public Next {
     DCHECK(old_index.valid());
     OpIndex result = op_mapping_[old_index];
 
+#if defined(_MSC_VER) && !defined(__clang__)
     if (contains_variable_reducer_) {
+#else
+    if constexpr (reducer_list_contains<typename Next::ReducerList,
+                                        VariableReducer>::value) {
+#endif
       if (!result.valid()) {
         // {op_mapping} doesn't have a mapping for {old_index}. The assembler
         // should provide the mapping.
@@ -1309,7 +1314,12 @@ class GraphVisitor : public Next {
     DCHECK(Asm().input_graph().BelongsToThisGraph(old_index));
     DCHECK_IMPLIES(new_index.valid(),
                    Asm().output_graph().BelongsToThisGraph(new_index));
+#if defined(_MSC_VER) && !defined(__clang__)
     if (contains_variable_reducer_) {
+#else
+    if constexpr (reducer_list_contains<typename Next::ReducerList,
+                                        VariableReducer>::value) {
+#endif
       if (current_block_needs_variables_) {
         MaybeVariable var = GetVariableFor(old_index);
         if (!var.has_value()) {


### PR DESCRIPTION
When building with C++20 using a very new clang (which is used by the GN build), compilation would fail caused because of the change in https://github.com/nodejs/node/commit/b9d806a2dd7d6b137cd9f0099ec0f8ed0abea4d6.

The detailed errors can be found in:
https://github.com/photoionization/node_with_gn/actions/runs/8501717771/job/23284924676

My understanding of the error is that, after changing `if constexpr` to `if`, some code that were not supposed to be compiled are now compiled, and it is causing problems for certain compiler settings.