### PR TITLE
buffer: fix default value for `sourceEnd` in `copy()`

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -224,7 +224,7 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
   if (sourceEnd === undefined) {
     sourceEnd = source.length;
   } else {
-    sourceEnd = toInteger(sourceEnd, 0);
+    sourceEnd = toInteger(sourceEnd, source.length);
     if (sourceEnd < 0)
       throw new ERR_OUT_OF_RANGE('sourceEnd', '>= 0', sourceEnd);
   }

--- a/test/parallel/test-buffer-copy.js
+++ b/test/parallel/test-buffer-copy.js
@@ -194,6 +194,13 @@ assert.strictEqual(b.copy(c, 0, 100, 10), 0);
 // When targetStart > targetLength, zero copied
 assert.strictEqual(b.copy(c, 512, 0, 10), 0);
 
+// When sourceEnd is NaN, buf length copied
+assert.strictEqual(b.copy(c, 0, 0, NaN), 512);
+// When sourceEnd < Number.MIN_SAFE_INTEGER, buf length copied
+assert.strictEqual(b.copy(c, 0, 0, Number.MIN_SAFE_INTEGER - 1), 512);
+// When sourceEnd > Number.MAX_SAFE_INTEGER, buf length copied
+assert.strictEqual(b.copy(c, 0, 0, Number.MAX_SAFE_INTEGER + 1), 512);
+
 // Test that the `target` can be a Uint8Array.
 {
   const d = new Uint8Array(c);


### PR DESCRIPTION
In the documentation, the default value for `sourceEnd` is `buf.length`.  
However, when calling `toInteger()`, the default value is incorrectly set to 0.
I'm not sure if the test is appropriate.

https://github.com/nodejs/node/blob/9efc84a2cb32af325f06c465ba82175b67089fe0/doc/api/buffer.md?plain=1#L1708-L1721
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
