### PR TITLE
stream: make Duplex inherit destroy from Writable

### DIFF
--- a/lib/internal/streams/duplex.js
+++ b/lib/internal/streams/duplex.js
@@ -59,6 +59,9 @@ ObjectSetPrototypeOf(Duplex, Readable);
   }
 }
 
+// Use the `destroy` method of `Writable`.
+Duplex.prototype.destroy = Writable.prototype.destroy;
+
 function Duplex(options) {
   if (!(this instanceof Duplex))
     return new Duplex(options);

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -238,6 +238,7 @@ const assert = require('assert');
   });
   duplex.on('close', common.mustCall());
 }
+
 {
   // Check abort signal
   const controller = new AbortController();
@@ -254,4 +255,17 @@ const assert = require('assert');
   }));
   duplex.on('close', common.mustCall());
   controller.abort();
+}
+
+{
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, enc, cb) { cb(); }
+  });
+
+  duplex.cork();
+  duplex.write('foo', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+  }));
+  duplex.destroy();
 }


### PR DESCRIPTION
Make `Duplex` inherit the `destroy` method from `Writable` instead of `Readable` so that pending write callbacks are correctly invoked when the stream is destroyed.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
