### PR TITLE
Revert "tools: run `build-windows` workflow only on source changes"

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,13 +2,10 @@ name: Build Windows
 
 on:
   pull_request:
-    paths:
-      - lib/**/*.js
-      - Makefile
-      - src/**/*.cc
-      - src/**/*.h
-      - tools/gyp/**
-      - .github/workflows/build-windows.yml
+    paths-ignore:
+      - README.md
+      - .github/**
+      - '!.github/workflows/build-windows.yml'
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
@@ -16,13 +13,10 @@ on:
       - canary
       - v[0-9]+.x-staging
       - v[0-9]+.x
-    paths:
-      - lib/**/*.js
-      - Makefile
-      - src/**/*.cc
-      - src/**/*.h
-      - tools/gyp/**
-      - .github/workflows/build-windows.yml
+    paths-ignore:
+      - README.md
+      - .github/**
+      - '!.github/workflows/build-windows.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This reverts commit 4ab63db9e207b5dbb6c046946716a49b6e2c3e53.

Refs: https://github.com/nodejs/node/pull/51596

- It prevents `build-windows` from running on build configuration changes (for example gyp file updates like https://github.com/nodejs/node/pull/52083)
- It also doesn't run when dependencies are updated
