### PR TITLE
test_runner: make end of work check stricter

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -822,11 +822,20 @@ class Test extends AsyncResource {
         this.parent.activeSubtests--;
       }
 
+      // The call to processPendingSubtests() below can change the number of
+      // pending subtests. When detecting if we are done running tests, we want
+      // to check if there are no pending subtests both before and after
+      // calling processPendingSubtests(). Otherwise, it is possible to call
+      // root.run() multiple times (which is harmless but can trigger an
+      // EventEmitter leak warning).
+      const pendingSiblingCount = this.parent.pendingSubtests.length;
+
       this.parent.addReadySubtest(this);
       this.parent.processReadySubtestRange(false);
       this.parent.processPendingSubtests();
 
       if (this.parent === this.root &&
+          pendingSiblingCount === 0 &&
           this.root.activeSubtests === 0 &&
           this.root.pendingSubtests.length === 0 &&
           this.root.readySubtests.size === 0) {

--- a/test/parallel/test-runner-filter-warning.js
+++ b/test/parallel/test-runner-filter-warning.js
@@ -1,0 +1,11 @@
+// Flags: --test-only
+'use strict';
+const common = require('../common');
+const { test } = require('node:test');
+const { defaultMaxListeners } = require('node:events');
+
+process.on('warning', common.mustNotCall());
+
+for (let i = 0; i < defaultMaxListeners + 1; ++i) {
+  test(`test ${i + 1}`);
+}


### PR DESCRIPTION
This commit updates the logic that checks for the end of the test run. Prior to this change, it was possible for `root.run()` to be called multiple times because of the way pending subtests were tracked. The extra calls to `root.run()` were harmless, but could trigger an `EventEmitter` leak warning due to `'abort'` listeners being created.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
