### PR TITLE
test_runner: fix clearing final timeout inside own callback

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -652,7 +652,7 @@ class MockTimers {
 
       // Check if the timeout was cleared by calling clearTimeout inside its own callback
       const afterCallback = this.#executionQueue.peek();
-      if (afterCallback.id === timer.id) {
+      if (afterCallback?.id === timer.id) {
         this.#executionQueue.shift();
         timer.priorityQueuePosition = undefined;
       }

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -548,6 +548,19 @@ describe('Mock Timers Test Suite', () => {
           t.mock.timers.runAll();
           assert.strictEqual(f.mock.callCount(), 3);
         });
+
+        it('should allow clearing timeout inside own callback', (t) => {
+          t.mock.timers.enable({ apis: ['setTimeout'] });
+          const f = t.mock.fn();
+
+          const timer = nodeTimers.setTimeout(() => {
+            f();
+            nodeTimers.clearTimeout(timer);
+          }, 50);
+
+          t.mock.timers.runAll();
+          assert.strictEqual(f.mock.callCount(), 1);
+        });
       });
 
       describe('setInterval Suite', () => {


### PR DESCRIPTION
Fixes: #52325

Clearing the final mocked timeout left in the execution queue inside its own callback causes an error to be thrown when trying to access its `id` because it is not treated as nullable.