### PR TITLE
[v18.x] deps: V8: cherry-pick d15d49b09dc7

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.36',
+    'v8_embedder_string': '-node.37',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/ast/ast.h
+++ b/deps/v8/src/ast/ast.h
@@ -999,7 +999,7 @@ class Literal final : public Expression {
   friend class AstNodeFactory;
   friend Zone;
 
-  using TypeField = Expression::NextBitField<Type, 4>;
+  using TypeField = Expression::NextBitField<Type, 3>;
 
   Literal(int smi, int position) : Expression(position, kLiteral), smi_(smi) {
     bit_field_ = TypeField::update(bit_field_, kSmi);

--- a/deps/v8/src/base/bit-field.h
+++ b/deps/v8/src/base/bit-field.h
@@ -40,6 +40,11 @@ class BitField final {
   static constexpr U kNumValues = U{1} << kSize;
 
   // Value for the field with all bits set.
+  // If clang complains
+  // "constexpr variable 'kMax' must be initialized by a constant expression"
+  // on this line, then you're creating a BitField for an enum with more bits
+  // than needed for the enum values. Either reduce the BitField size,
+  // or give the enum an explicit underlying type.
   static constexpr T kMax = static_cast<T>(kNumValues - 1);
 
   template <class T2, int size2>

--- a/deps/v8/src/compiler/backend/instruction-codes.h
+++ b/deps/v8/src/compiler/backend/instruction-codes.h
@@ -195,7 +195,7 @@ V8_EXPORT_PRIVATE std::ostream& operator<<(std::ostream& os,
   V(None)                       \
   TARGET_ADDRESSING_MODE_LIST(V)
 
-enum AddressingMode {
+enum AddressingMode : uint8_t {
 #define DECLARE_ADDRESSING_MODE(Name) kMode_##Name,
   ADDRESSING_MODE_LIST(DECLARE_ADDRESSING_MODE)
 #undef DECLARE_ADDRESSING_MODE
@@ -306,7 +306,7 @@ using MiscField = base::BitField<int, 22, 10>;
 // LaneSizeField and AccessModeField are helper types to encode/decode a lane
 // size, an access mode, or both inside the overlapping MiscField.
 using LaneSizeField = base::BitField<int, 22, 8>;
-using AccessModeField = base::BitField<MemoryAccessMode, 30, 2>;
+using AccessModeField = base::BitField<MemoryAccessMode, 30, 1>;
 // TODO(turbofan): {HasMemoryAccessMode} is currently only used to guard
 // decoding (in CodeGenerator and InstructionScheduler). Encoding (in
 // InstructionSelector) is not yet guarded. There are in fact instructions for

--- a/deps/v8/src/compiler/backend/instruction.h
+++ b/deps/v8/src/compiler/backend/instruction.h
@@ -586,8 +586,8 @@ class LocationOperand : public InstructionOperand {
   }
 
   STATIC_ASSERT(KindField::kSize == 3);
-  using LocationKindField = base::BitField64<LocationKind, 3, 2>;
-  using RepresentationField = base::BitField64<MachineRepresentation, 5, 8>;
+  using LocationKindField = base::BitField64<LocationKind, 3, 1>;
+  using RepresentationField = LocationKindField::Next<MachineRepresentation, 8>;
   using IndexField = base::BitField64<int32_t, 35, 29>;
 };
 

--- a/deps/v8/src/maglev/maglev-ir.h
+++ b/deps/v8/src/maglev/maglev-ir.h
@@ -196,7 +196,7 @@ class OpProperties {
   }
 
   constexpr bool is_pure() const {
-    return (bitfield_ | kPureMask) == kPureValue;
+    return (bitfield_ & kPureMask) == kPureValue;
   }
   constexpr bool is_required_when_unused() const {
     return can_write() || non_memory_side_effects();

--- a/deps/v8/src/wasm/wasm-code-manager.h
+++ b/deps/v8/src/wasm/wasm-code-manager.h
@@ -474,7 +474,7 @@ class V8_EXPORT_PRIVATE WasmCode final {
   int trap_handler_index_ = -1;
 
   // Bits encoded in {flags_}:
-  using KindField = base::BitField8<Kind, 0, 3>;
+  using KindField = base::BitField8<Kind, 0, 2>;
   using ExecutionTierField = KindField::Next<ExecutionTier, 2>;
   using ForDebuggingField = ExecutionTierField::Next<ForDebugging, 2>;
 


### PR DESCRIPTION
Original commit message:

    Make bitfields only as wide as necessary for enums

    clang now complains when a BitField for an enum is too wide.
    We could suppress this, but it seems kind of useful from an
    uninformed distance, so I made a few bitfields smaller instead.

    (For AddressingMode, since its size is target-dependent, I added
    an explicit underlying type to the enum instead, which suppresses
    the diag on a per-enum basis.)

    This is without any understanding of the code I'm touching.
    Especially the change in v8-internal.h feels a bit risky to me.

    Bug: chromium:1348574
    Change-Id: I73395de593045036b72dadf4e3147b5f7e13c958
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/3794708
    Commit-Queue: Nico Weber <thakis@chromium.org>
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Hannes Payer <hpayer@chromium.org>
    Auto-Submit: Nico Weber <thakis@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#82109}

Refs: https://github.com/v8/v8/commit/d15d49b09dc7aef9edcc4cf6a0cb2b77a0db203f
Fixes: #52230

(Note that this change is already in the baseline v8 of v20.x and newer, hence why this is a v18-only cherry-pick)

I carefully combed through this patch. The `NodeState` changes (`include/v8-internal.h` and `src/handles/global-handles.cc`) are not included, as the enum on v18.x is slightly larger ([v18.x](https://github.com/nodejs/node/blob/8c8961da05af446e9650a73d8661997116bf7b40/deps/v8/src/handles/global-handles.cc#L439-L446) vs [at time of v8 patch](https://github.com/v8/v8/blob/d15d49b09dc7aef9edcc4cf6a0cb2b77a0db203f/src/handles/global-handles.cc#L421-L430)) so the current 3 bits is correct. And just to check: `make jstest` was able to catch this correctly.

I can confirm this patch fixes the build on Xcode 15.3.

We also have advance notice that this will be a hard error in LLVM Clang 19 (later this year) so `-Wno-enum-constexpr-conversion` would not have been a long-term fix:

> The warning _-Wenum-constexpr-conversion_ is now also enabled by default on system headers and macros. It will be turned into a hard (non-downgradable) error in the next Clang release.

https://releases.llvm.org/18.1.0/tools/clang/docs/ReleaseNotes.html

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
