### PR TITLE
crypto: make timingSafeEqual faster for Uint8Array

### DIFF
--- a/benchmark/crypto/timingSafeEqual.js
+++ b/benchmark/crypto/timingSafeEqual.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('node:assert');
+const { randomBytes, timingSafeEqual } = require('node:crypto');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  bufferSize: [10, 100, 200, 2_100, 22_023],
+});
+
+function main({ n, bufferSize }) {
+  const bufs = [randomBytes(bufferSize), randomBytes(bufferSize)];
+  bench.start();
+  let count = 0;
+  for (let i = 0; i < n; i++) {
+    const ret = timingSafeEqual(bufs[i % 2], bufs[1]);
+    if (ret) count++;
+  }
+  bench.end(n);
+  assert.strictEqual(count, Math.floor(n / 2));
+}

--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -9,6 +9,8 @@
 
 namespace node {
 
+using v8::FastApiCallbackOptions;
+using v8::FastApiTypedArray;
 using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::Object;
@@ -46,12 +48,32 @@ void TimingSafeEqual(const FunctionCallbackInfo<Value>& args) {
       CRYPTO_memcmp(buf1.data(), buf2.data(), buf1.size()) == 0);
 }
 
+bool FastTimingSafeEqual(Local<Value> receiver,
+                         const FastApiTypedArray<uint8_t>& a,
+                         const FastApiTypedArray<uint8_t>& b,
+                         // NOLINTNEXTLINE(runtime/references)
+                         FastApiCallbackOptions& options) {
+  uint8_t* data_a;
+  uint8_t* data_b;
+  if (a.length() != b.length() || !a.getStorageIfAligned(&data_a) ||
+      !b.getStorageIfAligned(&data_b)) {
+    options.fallback = true;
+    return false;
+  }
+
+  return CRYPTO_memcmp(data_a, data_b, a.length()) == 0;
+}
+
+static v8::CFunction fast_equal(v8::CFunction::Make(FastTimingSafeEqual));
+
 void Initialize(Environment* env, Local<Object> target) {
-  SetMethodNoSideEffect(
-      env->context(), target, "timingSafeEqual", TimingSafeEqual);
+  SetFastMethodNoSideEffect(
+      env->context(), target, "timingSafeEqual", TimingSafeEqual, &fast_equal);
 }
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(TimingSafeEqual);
+  registry->Register(FastTimingSafeEqual);
+  registry->Register(fast_equal.GetTypeInfo());
 }
 }  // namespace Timing
 

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -27,6 +27,11 @@ using CFunctionCallbackWithStrings =
     bool (*)(v8::Local<v8::Value>,
              const v8::FastOneByteString& input,
              const v8::FastOneByteString& base);
+using CFunctionCallbackWithTwoUint8ArraysFallback =
+    bool (*)(v8::Local<v8::Value>,
+             const v8::FastApiTypedArray<uint8_t>&,
+             const v8::FastApiTypedArray<uint8_t>&,
+             v8::FastApiCallbackOptions&);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
 using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
@@ -51,6 +56,7 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithBool)                                                 \
   V(CFunctionCallbackWithString)                                               \
   V(CFunctionCallbackWithStrings)                                              \
+  V(CFunctionCallbackWithTwoUint8ArraysFallback)                               \
   V(CFunctionWithUint32)                                                       \
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \


### PR DESCRIPTION
Add a fast API that V8 can use if the user supplies `Uint8Array`s (including `Buffer`s) to `timingSafeEqual`.

Benchmark CI:

```
                                                   confidence improvement accuracy (*)   (**)  (***)
crypto/timingSafeEqual.js bufferSize=10 n=100000           ***     53.66 %       ±5.44% ±7.25% ±9.46%
crypto/timingSafeEqual.js bufferSize=100 n=100000          ***     40.93 %       ±4.56% ±6.08% ±7.94%
crypto/timingSafeEqual.js bufferSize=200 n=100000          ***     22.19 %       ±3.30% ±4.41% ±5.76%
crypto/timingSafeEqual.js bufferSize=2100 n=100000         ***      2.82 %       ±0.46% ±0.61% ±0.80%
crypto/timingSafeEqual.js bufferSize=22023 n=100000        ***      0.25 %       ±0.05% ±0.07% ±0.09%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 5 comparisons, you can thus
expect the following amount of false-positive results:
  0.25 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.05 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

Local benchmark:

```
                                                    confidence improvement accuracy (*)    (**)   (***)
crypto/timingSafeEqual.js bufferSize=10 n=100000           ***     51.19 %      ±18.92% ±25.21% ±32.86%
crypto/timingSafeEqual.js bufferSize=100 n=100000          ***     31.63 %      ±17.65% ±23.51% ±30.63%
crypto/timingSafeEqual.js bufferSize=200 n=100000           **     24.00 %      ±17.51% ±23.31% ±30.35%
crypto/timingSafeEqual.js bufferSize=2100 n=100000                  1.26 %      ±15.88% ±21.12% ±27.49%
crypto/timingSafeEqual.js bufferSize=22023 n=100000                -0.40 %      ±14.46% ±19.24% ±25.05%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 5 comparisons, you can thus expect the following amount of false-positive results:
  0.25 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.05 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

V8 has rudimentary support for fast APIs that consume `TypedArray`s only, which is why this is limited to `Uint8Array` for now.