### PR TITLE
src: add UV_PIPE_NO_TRUNCATE for bind in pipe_wrap.cc

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -29,11 +29,11 @@ sockets on other operating systems.
 [`socket.connect()`][] take a `path` parameter to identify IPC endpoints.
 
 On Unix, the local domain is also known as the Unix domain. The path is a
-file system pathname. It gets truncated to an OS-dependent length of
-`sizeof(sockaddr_un.sun_path) - 1`. Typical values are 107 bytes on Linux and
-103 bytes on macOS. If a Node.js API abstraction creates the Unix domain socket,
-it will unlink the Unix domain socket as well. For example,
-[`net.createServer()`][] may create a Unix domain socket and
+file system pathname. It will throw an error when the length of pathname is
+greater than the length of `sizeof(sockaddr_un.sun_path)`. Typical values are
+107 bytes on Linux and 103 bytes on macOS. If a Node.js API abstraction creates
+the Unix domain socket, it will unlink the Unix domain socket as well. For
+example, [`net.createServer()`][] may create a Unix domain socket and
 [`server.close()`][] will unlink it. But if a user creates the Unix domain
 socket outside of these abstractions, the user will need to remove it. The same
 applies when a Node.js API creates a Unix domain socket but the program then

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -162,7 +162,8 @@ void PipeWrap::Bind(const FunctionCallbackInfo<Value>& args) {
   PipeWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.Holder());
   node::Utf8Value name(args.GetIsolate(), args[0]);
-  int err = uv_pipe_bind2(&wrap->handle_, *name, name.length(), 0);
+  int err =
+      uv_pipe_bind2(&wrap->handle_, *name, name.length(), UV_PIPE_NO_TRUNCATE);
   args.GetReturnValue().Set(err);
 }
 
@@ -225,8 +226,12 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
   ConnectWrap* req_wrap =
       new ConnectWrap(env, req_wrap_obj, AsyncWrap::PROVIDER_PIPECONNECTWRAP);
-  int err = req_wrap->Dispatch(
-      uv_pipe_connect2, &wrap->handle_, *name, name.length(), 0, AfterConnect);
+  int err = req_wrap->Dispatch(uv_pipe_connect2,
+                               &wrap->handle_,
+                               *name,
+                               name.length(),
+                               UV_PIPE_NO_TRUNCATE,
+                               AfterConnect);
   if (err) {
     delete req_wrap;
   } else {

--- a/test/parallel/test-net-pipe-with-long-path.js
+++ b/test/parallel/test-net-pipe-with-long-path.js
@@ -1,0 +1,36 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+// Test UV_PIPE_NO_TRUNCATE
+
+// See pipe_overlong_path in https://github.com/libuv/libuv/blob/master/test/test-pipe-bind-error.c
+if (common.isWindows) {
+  common.skip('UV_PIPE_NO_TRUNCATE is not supported on window');
+}
+
+// See https://github.com/libuv/libuv/issues/4231
+const pipePath = `${tmpdir.path}/${'x'.repeat(10000)}.sock`;
+
+const server = net.createServer()
+  .listen(pipePath)
+  // It may work on some operating systems
+  .on('listening', () => {
+    // The socket file must exsit
+    assert.ok(fs.existsSync(pipePath));
+    const socket = net.connect(pipePath, common.mustCall(() => {
+      socket.destroy();
+      server.close();
+    }));
+  })
+  .on('error', (error) => {
+    assert.ok(error.code === 'EINVAL', error.message);
+    net.connect(pipePath)
+      .on('error', common.mustCall((error) => {
+        assert.ok(error.code === 'EINVAL', error.message);
+      }));
+  });


### PR DESCRIPTION
Binding a pipe path that is too long can cause problems and confuse the user.

example1:
```js
const net = require('net');
const fs = require('fs');

const filePath = `/tmp/${'x'.repeat(1000)}.sock`;
const server = net.createServer()
    // the path will be truncated
    .listen(filePath)
    .on('listening', () => {
        // here will output true but the socket is not actually bound to filePath
        console.log(server.address() === filePath);
        // here will output false because the file do not exist
        console.log(fs.existsSync(filePath))
    })
```

example2:
```js
const net = require('net');

const filePath1 = `/tmp/${'x'.repeat(1001)}.sock`;
const filePath2 = `/tmp/${'x'.repeat(1002)}.sock`;
// listen successfully
net.createServer().listen(filePath1);
// here will fail with EADDRINUSE error
net.createServer().listen(filePath2);
```
I think it is better to throw an error when the pipe path is truncated. But it maybe a breaking change.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
