### PR TITLE
fs,permission: make handling of buffers consistent

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1793,7 +1793,11 @@ function symlinkSync(target, path, type) {
   if (permission.isEnabled()) {
     // The permission model's security guarantees fall apart in the presence of
     // relative symbolic links. Thus, we have to prevent their creation.
-    if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
+    if (BufferIsBuffer(target)) {
+      if (!isAbsolute(BufferToString(target))) {
+        throw new ERR_ACCESS_DENIED('relative symbolic link target');
+      }
+    } else if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
       throw new ERR_ACCESS_DENIED('relative symbolic link target');
     }
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -17,6 +17,7 @@ const {
   SymbolAsyncDispose,
   Uint8Array,
   FunctionPrototypeBind,
+  uncurryThis,
 } = primordials;
 
 const { fs: constants } = internalBinding('constants');
@@ -30,6 +31,8 @@ const {
 
 const binding = internalBinding('fs');
 const { Buffer } = require('buffer');
+const { isBuffer: BufferIsBuffer } = Buffer;
+const BufferToString = uncurryThis(Buffer.prototype.toString);
 
 const {
   codes: {
@@ -985,7 +988,11 @@ async function symlink(target, path, type_) {
   if (permission.isEnabled()) {
     // The permission model's security guarantees fall apart in the presence of
     // relative symbolic links. Thus, we have to prevent their creation.
-    if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
+    if (BufferIsBuffer(target)) {
+      if (!isAbsolute(BufferToString(target))) {
+        throw new ERR_ACCESS_DENIED('relative symbolic link target');
+      }
+    } else if (typeof target !== 'string' || !isAbsolute(toPathIfFileURL(target))) {
       throw new ERR_ACCESS_DENIED('relative symbolic link target');
     }
   }


### PR DESCRIPTION
Commit 2000c267ddff5b59d8649275a4bef9e27a5eb0ee added explicit handling of Buffers to `fs.symlink`, but not to `fs.symlinkSync` or `fs.promises.symlink`. This change adapts the latter two functions to behave like `fs.symlink`.

Refs: https://github.com/nodejs/node/pull/49156
Refs: https://github.com/nodejs/node/pull/51212

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
