### PR TITLE
lib: throw error when pass overlapped to spawn_sync

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -855,7 +855,16 @@ function spawnSync(file, args, options) {
 
   // We may want to pass data in on any given fd, ensure it is a valid buffer
   for (let i = 0; i < options.stdio.length; i++) {
-    const input = options.stdio[i] && options.stdio[i].input;
+    if (!options.stdio[i]) {
+      continue;
+    }
+    const type = options.stdio[i].type;
+    if (type === 'overlapped') {
+      throw new ERR_INVALID_ARG_VALUE(`options.stdio[${i}].type`,
+                                      options.stdio[i],
+                                      'overlapped is not supported');
+    }
+    const input = options.stdio[i].input;
     if (input != null) {
       const pipe = options.stdio[i] = { ...options.stdio[i] };
       if (isArrayBufferView(input)) {

--- a/test/parallel/test-child-process-spawnsync-with-overlapped.js
+++ b/test/parallel/test-child-process-spawnsync-with-overlapped.js
@@ -1,0 +1,19 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync, execFileSync, execSync } = require('child_process');
+
+// See https://github.com/nodejs/node/issues/52265
+const args = { stdio: ['pipe', 'overlapped', 'pipe'] };
+
+assert.throws(() => {
+  spawnSync(process.execPath, ['--version'], args);
+}, /ERR_INVALID_ARG_VALUE/);
+
+assert.throws(() => {
+  execFileSync(process.execPath, ['--version'], args);
+}, /ERR_INVALID_ARG_VALUE/);
+
+assert.throws(() => {
+  execSync(`${process.execPath} --version`, args);
+}, /ERR_INVALID_ARG_VALUE/);


### PR DESCRIPTION
`overlapped` is not supported in *Sync API of `child_process` module currently.
fix: https://github.com/nodejs/node/issues/52265

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
