### PR TITLE
events: improve `addAbortListener` perf by saving the same options object

### DIFF
--- a/lib/internal/events/abort_listener.js
+++ b/lib/internal/events/abort_listener.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ObjectFreeze,
   SymbolDispose,
 } = primordials;
 const {
@@ -15,6 +16,7 @@ const {
 
 let queueMicrotask;
 let kResistStopPropagation;
+let abortListenerOptions;
 
 /**
  * @param {AbortSignal} signal
@@ -34,8 +36,9 @@ function addAbortListener(signal, listener) {
     queueMicrotask(() => listener());
   } else {
     kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+    abortListenerOptions ??= ObjectFreeze({ __proto__: null, once: true, [kResistStopPropagation]: true });
     // TODO(atlowChemi) add { subscription: true } and return directly
-    signal.addEventListener('abort', listener, { __proto__: null, once: true, [kResistStopPropagation]: true });
+    signal.addEventListener('abort', listener, abortListenerOptions);
     removeEventListener = () => {
       signal.removeEventListener('abort', listener);
     };


### PR DESCRIPTION
Benchmarks for `test_runner` (I tried to improve test_runner so this is why):

[Benchmark link](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1506/)

```
15:12:27                                                                                                     confidence improvement accuracy (*)   (**)  (***)
15:12:27 test_runner/global-concurrent-tests.js type='async' n=100                                                           0.97 %       ±4.05% ±5.38% ±7.01%
15:12:27 test_runner/global-concurrent-tests.js type='async' n=1000                                                          0.43 %       ±0.84% ±1.12% ±1.46%
15:12:27 test_runner/global-concurrent-tests.js type='async' n=10000                                                ***      0.81 %       ±0.42% ±0.57% ±0.74%
15:12:27 test_runner/global-concurrent-tests.js type='sync' n=100                                                           -1.55 %       ±2.57% ±3.42% ±4.45%
15:12:27 test_runner/global-concurrent-tests.js type='sync' n=1000                                                          -0.63 %       ±1.19% ±1.59% ±2.09%
15:12:27 test_runner/global-concurrent-tests.js type='sync' n=10000                                                 ***      1.00 %       ±0.44% ±0.58% ±0.76%
15:12:27 test_runner/global-sequential-tests.js type='async' n=100                                                           2.79 %       ±3.51% ±4.69% ±6.15%
15:12:27 test_runner/global-sequential-tests.js type='async' n=1000                                                          0.76 %       ±2.50% ±3.33% ±4.34%
15:12:27 test_runner/global-sequential-tests.js type='async' n=10000                                                        -1.11 %       ±3.73% ±4.96% ±6.46%
15:12:27 test_runner/global-sequential-tests.js type='sync' n=100                                                            0.81 %       ±4.60% ±6.13% ±7.97%
15:12:27 test_runner/global-sequential-tests.js type='sync' n=1000                                                          -4.10 %       ±4.14% ±5.54% ±7.27%
15:12:27 test_runner/global-sequential-tests.js type='sync' n=10000                                                          1.71 %       ±4.23% ±5.65% ±7.40%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=10                    -2.51 %       ±3.61% ±4.83% ±6.35%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=100                   -0.34 %       ±0.72% ±0.96% ±1.25%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=10                    0.69 %       ±0.96% ±1.28% ±1.66%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=100            *      0.46 %       ±0.41% ±0.55% ±0.71%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=10            *     -3.30 %       ±2.69% ±3.58% ±4.67%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=100         ***      2.49 %       ±1.42% ±1.89% ±2.48%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=10                     -2.59 %       ±3.02% ±4.07% ±5.39%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=100                    -0.19 %       ±0.76% ±1.01% ±1.31%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=10                     0.46 %       ±1.46% ±1.96% ±2.57%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=100                    0.24 %       ±0.40% ±0.54% ±0.70%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=10                   -0.39 %       ±2.18% ±2.91% ±3.79%
15:12:27 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=100                   0.34 %       ±1.88% ±2.50% ±3.26%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=10                   -1.81 %       ±4.40% ±5.87% ±7.67%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=100                   0.49 %       ±0.70% ±0.93% ±1.21%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=10            *      1.25 %       ±1.19% ±1.59% ±2.08%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=100                  0.37 %       ±0.55% ±0.74% ±0.96%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=10         ***      0.78 %       ±0.38% ±0.50% ±0.65%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=100         **      0.26 %       ±0.19% ±0.25% ±0.33%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=10                     0.48 %       ±4.18% ±5.57% ±7.25%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=100                    0.58 %       ±1.19% ±1.59% ±2.07%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=10                    1.26 %       ±1.66% ±2.21% ±2.89%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=100            *      0.49 %       ±0.43% ±0.57% ±0.74%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=10           **      0.64 %       ±0.39% ±0.52% ±0.68%
15:12:27 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=100         ***      0.47 %       ±0.15% ±0.20% ±0.27%
15:12:27 
15:12:27 Be aware that when doing many comparisons the risk of a false-positive
15:12:27 result increases. In this case, there are 36 comparisons, you can thus
15:12:27 expect the following amount of false-positive results:
15:12:27   1.80 false positives, when considering a   5% risk acceptance (*, **, ***),
15:12:27   0.36 false positives, when considering a   1% risk acceptance (**, ***),
15:12:27   0.04 false positives, when considering a 0.1% risk acceptance (***)
```

<details>
<summary>Benchmarks before the primordial use (just for comparison with the new machines</summary>


Ran 3 times after @mcollina suggestion (ref https://github.com/nodejs/node/pull/52253)

[Run 1](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1503/console):
```
13:18:51                                                                                                     confidence improvement accuracy (*)   (**)  (***)
13:18:51 test_runner/global-concurrent-tests.js type='async' n=100                                                           1.55 %       ±2.93% ±3.92% ±5.12%
13:18:51 test_runner/global-concurrent-tests.js type='async' n=1000                                                          0.09 %       ±2.00% ±2.67% ±3.48%
13:18:51 test_runner/global-concurrent-tests.js type='async' n=10000                                                         0.40 %       ±0.42% ±0.57% ±0.74%
13:18:51 test_runner/global-concurrent-tests.js type='sync' n=100                                                           -0.51 %       ±2.74% ±3.64% ±4.74%
13:18:51 test_runner/global-concurrent-tests.js type='sync' n=1000                                                          -0.03 %       ±1.38% ±1.84% ±2.41%
13:18:51 test_runner/global-concurrent-tests.js type='sync' n=10000                                                 ***      1.27 %       ±0.50% ±0.67% ±0.87%
13:18:51 test_runner/global-sequential-tests.js type='async' n=100                                                           0.38 %       ±5.64% ±7.50% ±9.76%
13:18:51 test_runner/global-sequential-tests.js type='async' n=1000                                                         -0.17 %       ±2.78% ±3.69% ±4.81%
13:18:51 test_runner/global-sequential-tests.js type='async' n=10000                                                         0.79 %       ±2.92% ±3.88% ±5.06%
13:18:51 test_runner/global-sequential-tests.js type='sync' n=100                                                            1.93 %       ±4.57% ±6.08% ±7.91%
13:18:51 test_runner/global-sequential-tests.js type='sync' n=1000                                                           2.57 %       ±3.89% ±5.20% ±6.80%
13:18:51 test_runner/global-sequential-tests.js type='sync' n=10000                                                         -1.32 %       ±3.92% ±5.21% ±6.79%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=10                     0.37 %       ±3.81% ±5.07% ±6.60%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=100            **      1.19 %       ±0.85% ±1.14% ±1.49%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=10                    0.84 %       ±1.52% ±2.03% ±2.65%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=100            *      0.41 %       ±0.34% ±0.46% ±0.59%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=10                  -0.44 %       ±2.10% ±2.80% ±3.65%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=100                  0.74 %       ±1.75% ±2.33% ±3.04%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=10                      0.36 %       ±1.79% ±2.38% ±3.11%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=100                    -0.45 %       ±0.76% ±1.01% ±1.32%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=10                     0.31 %       ±0.70% ±0.93% ±1.21%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=100             *      0.53 %       ±0.46% ±0.61% ±0.80%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=10                    1.69 %       ±2.09% ±2.78% ±3.63%
13:18:51 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=100                  -0.48 %       ±1.46% ±1.94% ±2.53%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=10                   -2.50 %       ±3.55% ±4.76% ±6.28%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=100                   0.78 %       ±1.05% ±1.40% ±1.83%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=10                  -0.45 %       ±1.03% ±1.37% ±1.79%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=100           *      0.43 %       ±0.39% ±0.52% ±0.68%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=10           *      0.39 %       ±0.38% ±0.50% ±0.66%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=100        ***      0.42 %       ±0.14% ±0.19% ±0.24%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=10                    -1.56 %       ±3.26% ±4.35% ±5.68%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=100                    0.72 %       ±1.10% ±1.47% ±1.91%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=10                   -0.06 %       ±0.75% ±1.00% ±1.31%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=100            *      0.55 %       ±0.45% ±0.60% ±0.79%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=10            *      0.41 %       ±0.34% ±0.45% ±0.59%
13:18:51 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=100          **      0.30 %       ±0.19% ±0.25% ±0.33%
13:18:51 
13:18:51 Be aware that when doing many comparisons the risk of a false-positive
13:18:51 result increases. In this case, there are 36 comparisons, you can thus
13:18:51 expect the following amount of false-positive results:
13:18:51   1.80 false positives, when considering a   5% risk acceptance (*, **, ***),
13:18:51   0.36 false positives, when considering a   1% risk acceptance (**, ***),
13:18:51   0.04 false positives, when considering a 0.1% risk acceptance (***)
```



[Run 2](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1504/console):
```
13:43:16                                                                                                     confidence improvement accuracy (*)   (**)  (***)
13:43:16 test_runner/global-concurrent-tests.js type='async' n=100                                                           2.26 %       ±3.77% ±5.02% ±6.56%
13:43:16 test_runner/global-concurrent-tests.js type='async' n=1000                                                          0.64 %       ±0.70% ±0.94% ±1.22%
13:43:16 test_runner/global-concurrent-tests.js type='async' n=10000                                                 **      0.86 %       ±0.51% ±0.67% ±0.88%
13:43:16 test_runner/global-concurrent-tests.js type='sync' n=100                                                            1.33 %       ±2.84% ±3.78% ±4.93%
13:43:16 test_runner/global-concurrent-tests.js type='sync' n=1000                                                    *      0.93 %       ±0.74% ±0.99% ±1.30%
13:43:16 test_runner/global-concurrent-tests.js type='sync' n=10000                                                 ***      1.15 %       ±0.29% ±0.39% ±0.51%
13:43:16 test_runner/global-sequential-tests.js type='async' n=100                                                           2.16 %       ±3.72% ±4.97% ±6.52%
13:43:16 test_runner/global-sequential-tests.js type='async' n=1000                                                         -0.65 %       ±3.16% ±4.20% ±5.48%
13:43:16 test_runner/global-sequential-tests.js type='async' n=10000                                                         0.33 %       ±3.47% ±4.62% ±6.01%
13:43:16 test_runner/global-sequential-tests.js type='sync' n=100                                                           -1.13 %       ±4.43% ±5.90% ±7.68%
13:43:16 test_runner/global-sequential-tests.js type='sync' n=1000                                                           0.39 %       ±4.21% ±5.60% ±7.29%
13:43:16 test_runner/global-sequential-tests.js type='sync' n=10000                                                          0.29 %       ±3.11% ±4.15% ±5.40%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=10                    -0.96 %       ±3.11% ±4.14% ±5.40%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=100                   -0.11 %       ±0.82% ±1.10% ±1.43%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=10                    0.65 %       ±1.38% ±1.83% ±2.39%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=100                   0.05 %       ±0.38% ±0.50% ±0.65%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=10                   0.19 %       ±2.27% ±3.02% ±3.93%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=100                  0.85 %       ±1.64% ±2.19% ±2.85%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=10                     -3.23 %       ±5.23% ±6.97% ±9.11%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=100                     0.33 %       ±0.70% ±0.93% ±1.21%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=10                    -0.09 %       ±1.16% ±1.54% ±2.01%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=100                    0.20 %       ±0.45% ±0.60% ±0.78%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=10                    0.83 %       ±2.46% ±3.28% ±4.26%
13:43:16 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=100                   0.64 %       ±1.78% ±2.37% ±3.09%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=10                    2.48 %       ±2.96% ±3.94% ±5.15%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=100                  -0.15 %       ±1.34% ±1.78% ±2.32%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=10                   0.60 %       ±0.64% ±0.85% ±1.11%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=100                  0.36 %       ±0.48% ±0.64% ±0.83%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=10                  0.40 %       ±0.45% ±0.60% ±0.79%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=100        ***      0.44 %       ±0.19% ±0.25% ±0.33%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=10                    -2.04 %       ±4.21% ±5.65% ±7.46%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=100                    0.56 %       ±1.20% ±1.60% ±2.08%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=10                    0.79 %       ±0.95% ±1.27% ±1.65%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=100           **      0.71 %       ±0.50% ±0.67% ±0.87%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=10                   0.32 %       ±0.41% ±0.55% ±0.71%
13:43:16 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=100         ***      0.45 %       ±0.16% ±0.21% ±0.27%
13:43:16 
13:43:16 Be aware that when doing many comparisons the risk of a false-positive
13:43:16 result increases. In this case, there are 36 comparisons, you can thus
13:43:16 expect the following amount of false-positive results:
13:43:16   1.80 false positives, when considering a   5% risk acceptance (*, **, ***),
13:43:16   0.36 false positives, when considering a   1% risk acceptance (**, ***),
13:43:16   0.04 false positives, when considering a 0.1% risk acceptance (***)
```



[Run 3](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1505/console):
```
14:04:10                                                                                                     confidence improvement accuracy (*)   (**)  (***)
14:04:10 test_runner/global-concurrent-tests.js type='async' n=100                                                          -0.20 %       ±3.59% ±4.77% ±6.21%
14:04:10 test_runner/global-concurrent-tests.js type='async' n=1000                                                          0.92 %       ±1.58% ±2.10% ±2.73%
14:04:10 test_runner/global-concurrent-tests.js type='async' n=10000                                                 **      0.52 %       ±0.33% ±0.44% ±0.57%
14:04:10 test_runner/global-concurrent-tests.js type='sync' n=100                                                            0.81 %       ±2.61% ±3.48% ±4.54%
14:04:10 test_runner/global-concurrent-tests.js type='sync' n=1000                                                           0.08 %       ±0.75% ±1.00% ±1.30%
14:04:10 test_runner/global-concurrent-tests.js type='sync' n=10000                                                 ***      1.11 %       ±0.35% ±0.46% ±0.60%
14:04:10 test_runner/global-sequential-tests.js type='async' n=100                                                           2.72 %       ±3.96% ±5.27% ±6.87%
14:04:10 test_runner/global-sequential-tests.js type='async' n=1000                                                          2.57 %       ±4.77% ±6.35% ±8.26%
14:04:10 test_runner/global-sequential-tests.js type='async' n=10000                                                         3.49 %       ±4.32% ±5.76% ±7.52%
14:04:10 test_runner/global-sequential-tests.js type='sync' n=100                                                           -3.66 %       ±4.10% ±5.45% ±7.11%
14:04:10 test_runner/global-sequential-tests.js type='sync' n=1000                                                           0.00 %       ±3.11% ±4.15% ±5.44%
14:04:10 test_runner/global-sequential-tests.js type='sync' n=10000                                                         -1.04 %       ±3.59% ±4.78% ±6.23%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=10                     0.56 %       ±2.86% ±3.81% ±4.98%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=100                   -0.79 %       ±0.89% ±1.19% ±1.55%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=10                   -0.50 %       ±1.34% ±1.79% ±2.35%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=100            *      0.37 %       ±0.36% ±0.48% ±0.62%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=10                  -0.88 %       ±2.29% ±3.05% ±3.97%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=100                  0.40 %       ±1.67% ±2.23% ±2.90%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=10                      4.31 %       ±5.09% ±6.82% ±8.96%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=100                    -0.24 %       ±0.75% ±1.00% ±1.30%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=10                     0.73 %       ±0.95% ±1.27% ±1.66%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=100                   -0.03 %       ±0.41% ±0.54% ±0.71%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=10                   -1.17 %       ±2.20% ±2.93% ±3.82%
14:04:10 test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=100                  -1.11 %       ±2.01% ±2.68% ±3.49%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=10                   -2.61 %       ±4.14% ±5.51% ±7.18%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=100                   1.04 %       ±1.12% ±1.49% ±1.96%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=10                   0.04 %       ±0.88% ±1.17% ±1.52%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=100                  0.44 %       ±0.46% ±0.61% ±0.79%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=10           *      0.46 %       ±0.40% ±0.53% ±0.69%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=100        ***      0.37 %       ±0.14% ±0.18% ±0.24%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=10                     1.14 %       ±2.60% ±3.46% ±4.52%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=100                    0.68 %       ±1.16% ±1.54% ±2.01%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=10                   -0.13 %       ±1.45% ±1.93% ±2.53%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=100            *      0.51 %       ±0.50% ±0.66% ±0.87%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=10            *      0.39 %       ±0.35% ±0.46% ±0.61%
14:04:10 test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=100         ***      0.42 %       ±0.18% ±0.23% ±0.31%
14:04:10 
14:04:10 Be aware that when doing many comparisons the risk of a false-positive
14:04:10 result increases. In this case, there are 36 comparisons, you can thus
14:04:10 expect the following amount of false-positive results:
14:04:10   1.80 false positives, when considering a   5% risk acceptance (*, **, ***),
14:04:10   0.36 false positives, when considering a   1% risk acceptance (**, ***),
14:04:10   0.04 false positives, when considering a 0.1% risk acceptance (***)
```

</details>

