### PR TITLE
Fix h2-over-h2 connection proxying

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -177,6 +177,7 @@ const {
   kUpdateTimer,
   kHandle,
   kSession,
+  kBoundSession,
   setStreamTimeout,
 } = require('internal/stream_base_commons');
 const { kTimeout } = require('internal/timers');
@@ -1121,7 +1122,7 @@ function cleanupSession(session) {
   if (handle)
     handle.ondone = null;
   if (socket) {
-    socket[kSession] = undefined;
+    socket[kBoundSession] = undefined;
     socket[kServer] = undefined;
   }
 }
@@ -1235,10 +1236,10 @@ class Http2Session extends EventEmitter {
     // If the session property already exists on the socket,
     // then it has already been bound to an Http2Session instance
     // and cannot be attached again.
-    if (socket[kSession] !== undefined)
+    if (socket[kBoundSession] !== undefined)
       throw new ERR_HTTP2_SOCKET_BOUND();
 
-    socket[kSession] = this;
+    socket[kBoundSession] = this;
 
     if (!socket._handle || !socket._handle.isStreamBase) {
       socket = new JSStreamSocket(socket);
@@ -1617,7 +1618,7 @@ class Http2Session extends EventEmitter {
   }
 
   _onTimeout() {
-    callTimeout(this);
+    callTimeout(this, this);
   }
 
   ref() {
@@ -2093,7 +2094,7 @@ class Http2Stream extends Duplex {
   }
 
   _onTimeout() {
-    callTimeout(this, kSession);
+    callTimeout(this, this[kSession]);
   }
 
   // True if the HEADERS frame has been sent
@@ -2419,7 +2420,7 @@ class Http2Stream extends Duplex {
   }
 }
 
-function callTimeout(self, kSession) {
+function callTimeout(self, session) {
   // If the session is destroyed, this should never actually be invoked,
   // but just in case...
   if (self.destroyed)
@@ -2430,7 +2431,7 @@ function callTimeout(self, kSession) {
   // happens, meaning that if a write is ongoing it should never equal the
   // newly fetched, updated value.
   if (self[kState].writeQueueSize > 0) {
-    const handle = kSession ? self[kSession][kHandle] : self[kHandle];
+    const handle = session[kHandle];
     const chunksSentSinceLastWrite = handle !== undefined ?
       handle.chunksSentSinceLastWrite : null;
     if (chunksSentSinceLastWrite !== null &&
@@ -3017,7 +3018,7 @@ ObjectDefineProperty(Http2Session.prototype, 'setTimeout', setTimeoutValue);
 // When the socket emits an error, destroy the associated Http2Session and
 // forward it the same error.
 function socketOnError(error) {
-  const session = this[kSession];
+  const session = this[kBoundSession];
   if (session !== undefined) {
     // We can ignore ECONNRESET after GOAWAY was received as there's nothing
     // we can do and the other side is fully within its rights to do so.
@@ -3300,7 +3301,7 @@ function setupCompat(ev) {
 }
 
 function socketOnClose() {
-  const session = this[kSession];
+  const session = this[kBoundSession];
   if (session !== undefined) {
     debugSessionObj(session, 'socket closed');
     const err = session.connecting ? new ERR_SOCKET_CLOSED() : null;

--- a/lib/internal/js_stream_socket.js
+++ b/lib/internal/js_stream_socket.js
@@ -17,7 +17,7 @@ let debug = require('internal/util/debuglog').debuglog(
 );
 const { owner_symbol } = require('internal/async_hooks').symbols;
 const { ERR_STREAM_WRAP } = require('internal/errors').codes;
-const { kSession } = require('internal/stream_base_commons');
+const { kBoundSession } = require('internal/stream_base_commons');
 
 const kCurrentWriteRequest = Symbol('kCurrentWriteRequest');
 const kCurrentShutdownRequest = Symbol('kCurrentShutdownRequest');
@@ -265,12 +265,12 @@ class JSStreamSocket extends Socket {
     });
   }
 
-  get [kSession]() {
-    return this.stream[kSession];
+  get [kBoundSession]() {
+    return this.stream[kBoundSession];
   }
 
-  set [kSession](session) {
-    this.stream[kSession] = session;
+  set [kBoundSession](session) {
+    this.stream[kBoundSession] = session;
   }
 }
 

--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -33,6 +33,7 @@ const kMaybeDestroy = Symbol('kMaybeDestroy');
 const kUpdateTimer = Symbol('kUpdateTimer');
 const kAfterAsyncWrite = Symbol('kAfterAsyncWrite');
 const kHandle = Symbol('kHandle');
+const kBoundSession = Symbol('kBoundSession');
 const kSession = Symbol('kSession');
 
 let debug = require('internal/util/debuglog').debuglog('stream', (fn) => {
@@ -255,6 +256,7 @@ function setStreamTimeout(msecs, callback) {
   } else {
     this[kTimeout] = setUnrefTimeout(this._onTimeout.bind(this), msecs);
     if (this[kSession]) this[kSession][kUpdateTimer]();
+    if (this[kBoundSession]) this[kBoundSession][kUpdateTimer]();
 
     if (callback !== undefined) {
       validateFunction(callback, 'callback');

--- a/test/parallel/test-http2-client-proxy-over-http2.js
+++ b/test/parallel/test-http2-client-proxy-over-http2.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+
+server.listen(0, common.mustCall(function() {
+  const proxyClient = h2.connect(`http://localhost:${server.address().port}`);
+
+  const request = proxyClient.request({
+    ':method': 'CONNECT',
+    ':authority': 'example.com:80'
+  });
+
+  request.on('response', common.mustCall((connectResponse) => {
+    assert.strictEqual(connectResponse[':status'], 200);
+
+    const proxiedClient = h2.connect('http://example.com', {
+      createConnection: () => request // Tunnel via first request stream
+    });
+
+    const proxiedRequest = proxiedClient.request();
+    proxiedRequest.on('response', common.mustCall((proxiedResponse) => {
+      assert.strictEqual(proxiedResponse[':status'], 204);
+
+      proxiedClient.close();
+      proxyClient.close();
+      server.close();
+    }));
+  }));
+}));
+
+server.once('connect', common.mustCall((req, res) => {
+  assert.strictEqual(req.headers[':method'], 'CONNECT');
+  res.writeHead(200); // Accept the CONNECT tunnel
+
+  // Handle this stream as a new 'proxied' connection (pretend to forward
+  // but actually just unwrap the tunnel ourselves):
+  server.emit('connection', res.stream);
+}));
+
+// Handle the 'proxied' request itself:
+server.once('request', common.mustCall((req, res) => {
+  res.writeHead(204);
+  res.end();
+}));


### PR DESCRIPTION
This fixes #52344.

Previously, `kSession` was used on sockets to track the HTTP/2 session happening within that socket, and used on HTTP/2 streams to track the HTTP/2 session containing that stream (i.e. opposite directions in the connection 'stack').

This works fine most of the time, but when a HTTP/2 stream is used as the base for another HTTP/2 connection (using CONNECT proxying over an HTTP/2 stream) these two meanings conflict.

This didn't break until v20.12.0 because in that scenario a JS stream socket is used, and `kSession` was not passed through that layer until https://github.com/nodejs/node/commit/c50524a9fc19cd2fe6e61bb7f8ad22685024842b#diff-8dd7127678f00bf090a030256bad7ae645834f7100e54154b4fc81c8cbe9c3fc.

This fixes the issue by splitting into `kBoundSession` (the HTTP/2 session the socket is bound to) and `kSession` (the HTTP/2 session containing an HTTP/2 stream). I'm fairly sure I've updated all socket-specific use cases correctly to make that change, but it's worth carefully checking the uses of `kSession` to confirm. Notable parts include:

* A slight simplification to `callTimeout`
* Duplicating the `kUpdateTimer` call in `setStreamTimeout`

I think all these changes are exactly equivalent to the previous behaviour, except in the one edge case where something both contains and is contained by an HTTP/2 session.

I'm not sure the `setStreamTimeout` behaviour is actually correct (I'm not sure I fully understand the wider implications of that logic) but it is equivalent to the previous behaviour anyway so hopefully that's OK for now. Happy to change that to only do one or the other call if only one is actually correct.