### PR TITLE
doc: use consistent plural form of "index"

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -2224,7 +2224,7 @@ added: v1.1.0
 
 * Returns: {Iterator}
 
-Creates and returns an [iterator][] of `buf` keys (indices).
+Creates and returns an [iterator][] of `buf` keys (indexes).
 
 ```mjs
 import { Buffer } from 'node:buffer';
@@ -3343,7 +3343,7 @@ added: v3.0.0
 * Returns: {Buffer}
 
 Returns a new `Buffer` that references the same memory as the original, but
-offset and cropped by the `start` and `end` indices.
+offset and cropped by the `start` and `end` indexes.
 
 Specifying `end` greater than [`buf.length`][] will return the same result as
 that of `end` equal to [`buf.length`][].
@@ -3470,7 +3470,7 @@ changes:
 > Stability: 0 - Deprecated: Use [`buf.subarray`][] instead.
 
 Returns a new `Buffer` that references the same memory as the original, but
-offset and cropped by the `start` and `end` indices.
+offset and cropped by the `start` and `end` indexes.
 
 This method is not compatible with the `Uint8Array.prototype.slice()`,
 which is a superclass of `Buffer`. To copy the slice, use

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -741,7 +741,7 @@ added: v8.6.0
 * `multicastInterface` {string}
 
 _All references to scope in this section are referring to
-[IPv6 Zone Indices][], which are defined by [RFC 4007][]. In string form, an IP
+[IPv6 Zone Indexes][], which are defined by [RFC 4007][]. In string form, an IP
 with a scope index is written as `'IP%scope'` where scope is an interface name
 or interface number._
 
@@ -988,7 +988,7 @@ interfaces" address on a random port (it does the right thing for both `udp4`
 and `udp6` sockets). The bound address and port can be retrieved using
 [`socket.address().address`][] and [`socket.address().port`][].
 
-[IPv6 Zone Indices]: https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses
+[IPv6 Zone Indexes]: https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses
 [RFC 4007]: https://tools.ietf.org/html/rfc4007
 [`'close'`]: #event-close
 [`ERR_SOCKET_BAD_PORT`]: errors.md#err_socket_bad_port

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -21,7 +21,7 @@ Throughout the documentation are indications of a section's stability. Some APIs
 are so proven and so relied upon that they are unlikely to ever change at all.
 Others are brand new and experimental, or known to be hazardous.
 
-The stability indices are as follows:
+The stability indexes are as follows:
 
 > Stability: 0 - Deprecated. The feature may emit warnings. Backward
 > compatibility is not guaranteed.

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -962,7 +962,7 @@ myEmitter.emit('event');
 ```
 
 Because listeners are managed using an internal array, calling this will
-change the position indices of any listener registered _after_ the listener
+change the position indexes of any listener registered _after_ the listener
 being removed. This will not impact the order in which listeners are called,
 but it means that any copies of the listener array as returned by
 the `emitter.listeners()` method will need to be recreated.

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2218,9 +2218,9 @@ typedef enum {
 } napi_key_conversion;
 ```
 
-`napi_key_numbers_to_strings` will convert integer indices to
+`napi_key_numbers_to_strings` will convert integer indexes to
 strings. `napi_key_keep_numbers` will return numbers for integer
-indices.
+indexes.
 
 #### `napi_valuetype`
 


### PR DESCRIPTION
Our documentation uses both "indices" and "indexes" as the plural form of "index". The Microsoft Style Guide, which we've adopted for documentation, says to use "indexes" so let's standardize on that.

Ref: https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/i/index-indexes-indices

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
