### PR TITLE
lib: pass through net.Server options during ipc

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayIsArray,
+  ArrayPrototypeForEach,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
   ArrayPrototypeSlice,
@@ -105,11 +106,16 @@ const handleConversion = {
     simultaneousAccepts: true,
 
     send(message, server, options) {
+      const serverOptions = ['allowHalfOpen', 'pauseOnConnect', 'noDelay', 'keepAlive', 'keepAliveInitialDelay'];
+      message.serverConfig = {};
+      ArrayPrototypeForEach(serverOptions, (option) => {
+        server[option] !== undefined && (message.serverConfig[option] = server[option]);
+      });
       return server._handle;
     },
 
     got(message, handle, emit) {
-      const server = new net.Server();
+      const server = new net.Server(message.serverConfig || {});
       server.listen(handle, () => {
         emit(server);
       });

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -106,11 +106,14 @@ const handleConversion = {
     simultaneousAccepts: true,
 
     send(message, server, options) {
-      const serverOptions = ['allowHalfOpen', 'pauseOnConnect', 'noDelay', 'keepAlive', 'keepAliveInitialDelay'];
+      const serverOptions = ['allowHalfOpen', 'pauseOnConnect', 'noDelay', 'keepAlive'];
       message.serverConfig = {};
       ArrayPrototypeForEach(serverOptions, (option) => {
         server[option] !== undefined && (message.serverConfig[option] = server[option]);
       });
+      // Revert keepAliveInitialDelay unit
+      server.keepAliveInitialDelay !== undefined &&
+        (message.serverConfig.keepAliveInitialDelay = server.keepAliveInitialDelay * 1000);
       return server._handle;
     },
 

--- a/test/parallel/test-child-process-pass-net-server-config-ipc.js
+++ b/test/parallel/test-child-process-pass-net-server-config-ipc.js
@@ -1,0 +1,38 @@
+'use strict';
+const { mustCall } = require('../common');
+const net = require('net');
+const child_process = require('child_process');
+const assert = require('assert');
+// preset server config
+const netServerConfig = {
+  allowHalfOpen: true,
+  pauseOnConnect: false,
+  noDelay: false,
+  keepAliveInitialDelay: 1000,
+  keepAlive: true,
+};
+
+if (process.argv[2] !== 'child') {
+  const childProcess = child_process.fork(__filename, ['child']);
+  const server = net.createServer(netServerConfig);
+  server.listen(9999,
+                mustCall(() => {
+                  childProcess.send(null, server);
+                }),
+  );
+} else {
+  process.on(
+    'message',
+    mustCall((msg, handle) => {
+      // Pass through all of net.Server config from parent process
+      assert.ok(handle.allowHalfOpen, netServerConfig.allowHalfOpen);
+      assert.ok(handle.pauseOnConnect, netServerConfig.pauseOnConnect);
+      assert.ok(handle.noDelay, netServerConfig.noDelay);
+      assert.ok(
+        handle.keepAliveInitialDelay,
+        netServerConfig.keepAliveInitialDelay,
+      );
+      assert.ok(handle.keepAlive, netServerConfig.keepAlive);
+    }),
+  );
+}

--- a/test/parallel/test-child-process-pass-net-server-config-ipc.js
+++ b/test/parallel/test-child-process-pass-net-server-config-ipc.js
@@ -15,24 +15,27 @@ const netServerConfig = {
 if (process.argv[2] !== 'child') {
   const childProcess = child_process.fork(__filename, ['child']);
   const server = net.createServer(netServerConfig);
-  server.listen(9999,
-                mustCall(() => {
-                  childProcess.send(null, server);
-                }),
+  server.listen(0, mustCall(() => {
+    childProcess.send(null, server);
+  }),
   );
+  childProcess.on('exit', mustCall(() => {
+    process.exit();
+  }));
 } else {
   process.on(
     'message',
     mustCall((msg, handle) => {
       // Pass through all of net.Server config from parent process
-      assert.ok(handle.allowHalfOpen, netServerConfig.allowHalfOpen);
-      assert.ok(handle.pauseOnConnect, netServerConfig.pauseOnConnect);
-      assert.ok(handle.noDelay, netServerConfig.noDelay);
-      assert.ok(
+      assert.strictEqual(handle.allowHalfOpen, netServerConfig.allowHalfOpen);
+      assert.strictEqual(handle.pauseOnConnect, netServerConfig.pauseOnConnect);
+      assert.strictEqual(handle.noDelay, netServerConfig.noDelay);
+      assert.strictEqual(
         handle.keepAliveInitialDelay,
-        netServerConfig.keepAliveInitialDelay,
+        ~~(netServerConfig.keepAliveInitialDelay / 1000),
       );
-      assert.ok(handle.keepAlive, netServerConfig.keepAlive);
+      assert.strictEqual(handle.keepAlive, netServerConfig.keepAlive);
+      process.exit();
     }),
   );
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
I send net.Server instance with any options,but finally get a whole new net.Server instance in child process.For example, I create a new net.Server instance with `{allowHalfOpen: true}`,then will get a new net.Server instance with `{allowHalfOpen: false}` in child process.The example is as follows.
```javascript
const assert = require('assert')
const net = require('net');
const child_process = require('child_process');

if (process.argv[2] !== 'child') {
  const childProcess = child_process.fork(__filename, ['child']);
  const server = net.createServer({
    allowHalfOpen: true
  })
  server.listen(9999, () => {
    childProcess.send(null, server)
  })
} else {
  process.on('message', (msg, handle) => {
    // the handle.allowHalfOpen will be false,indicates that the attribute of the server instance sent from the parent process has been modified
    assert.ok(handle.allowHalfOpen, true) // will throw AssertionError
  });
}
```
So I pull this request to fix the issue like above.

- [x] make -j4 test (UNIX), or vcbuild test (Windows) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
