### PR TITLE
doc: call out http(s).globalAgent defaults

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -180,9 +180,6 @@ changes:
 
 `options` in [`socket.connect()`][] are also supported.
 
-The default [`http.globalAgent`][] that is used by [`http.request()`][] has all
-of these values set to their respective defaults.
-
 To configure any of them, a custom [`http.Agent`][] instance must be created.
 
 ```mjs
@@ -3654,13 +3651,15 @@ changes:
   - version:
       - v19.0.0
     pr-url: https://github.com/nodejs/node/pull/43522
-    description: The agent now uses HTTP Keep-Alive by default.
+    description: The agent now uses HTTP Keep-Alive and a 5 second timeout by
+                 default.
 -->
 
 * {http.Agent}
 
 Global instance of `Agent` which is used as the default for all HTTP client
-requests.
+requests. Diverges from a default `Agent` configuration by having `keepAlive`
+enabled and a `timeout` of 5 seconds.
 
 ## `http.maxHeaderSize`
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -327,10 +327,13 @@ changes:
   - version:
       - v19.0.0
     pr-url: https://github.com/nodejs/node/pull/43522
-    description: The agent now uses HTTP Keep-Alive by default.
+    description: The agent now uses HTTP Keep-Alive and a 5 second timeout by
+                 default.
 -->
 
-Global instance of [`https.Agent`][] for all HTTPS client requests.
+Global instance of [`https.Agent`][] for all HTTPS client requests. Diverges
+from a default [`https.Agent`][] configuration by having `keepAlive` enabled and
+a `timeout` of 5 seconds.
 
 ## `https.request(options[, callback])`
 


### PR DESCRIPTION
Despite the `http.Agent` stating:

> The default `http.globalAgent` that is used by `http.request()` has all of these values set to their respective defaults.

this [isn't true anymore](https://github.com/nodejs/node/pull/43522) since node.js 19. Both, the http and the https `globalAgent` now set `{ keepAlive: true, scheduling: 'lifo', timeout: 5000 }` as options. `'lifo'` is the default anyway, but `keepAlive` is turned off and no `timeout` is set on `new Agent()`.

Document the diverging behavior in the `globalAgent` sections, remove the false statement from `http.Agent` section, and extend the changelog to call out the timeout change as well.

Closes [#48821](https://github.com/nodejs/node/issues/48821)
Closes #51115