### PR TITLE
test: fix Windows compiler warnings in overlapped-checker

### DIFF
--- a/test/overlapped-checker/main_win.c
+++ b/test/overlapped-checker/main_win.c
@@ -6,7 +6,6 @@
 
 static char buf[256];
 static DWORD read_count;
-static DWORD write_count;
 static HANDLE stdin_h;
 static OVERLAPPED stdin_o;
 
@@ -34,7 +33,7 @@ static void write(const char* buf, size_t buf_size) {
   if (!WriteFile(stdout_h, buf, buf_size, &write_count, NULL)) {
     die("overlapped write failed");
   }
-  fprintf(stderr, "%d", write_count);
+  fprintf(stderr, "%ld", write_count);
   fflush(stderr);
 }
 


### PR DESCRIPTION
Fixes two warnings:
- `test\overlapped-checker\main_win.c(37,25): warning : format specifies type 'int' but the argument has type 'DWORD' (aka 'unsigned long') [-Wformat]`
- `test\overlapped-checker\main_win.c(9,14): warning : unused variable 'write_count' [-Wunused-variable]`
