### PR TITLE
lib: improve perf of `AbortSignal` creation

### DIFF
--- a/benchmark/abort_controller/abort-signal-static-abort.js
+++ b/benchmark/abort_controller/abort-signal-static-abort.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  n: [5e6],
+  kind: ['default-reason', 'same-reason'],
+});
+
+function main({ n, kind }) {
+  switch (kind) {
+    case 'default-reason':
+      bench.start();
+      for (let i = 0; i < n; ++i)
+        AbortSignal.abort();
+      bench.end(n);
+      break;
+    case 'same-reason': {
+      const reason = new Error('same reason');
+
+      bench.start();
+      for (let i = 0; i < n; ++i)
+        AbortSignal.abort(reason);
+      bench.end(n);
+      break;
+    }
+    default:
+      throw new Error('Invalid kind');
+  }
+}

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -6,7 +6,6 @@
 const {
   ObjectAssign,
   ObjectDefineProperties,
-  ObjectSetPrototypeOf,
   ObjectDefineProperty,
   PromiseResolve,
   SafeFinalizationRegistry,
@@ -68,6 +67,8 @@ const {
 
 let _MessageChannel;
 let markTransferMode;
+
+const kDontThrowSymbol = Symbol('kDontThrowSymbol');
 
 // Loading the MessageChannel and markTransferable have to be done lazily
 // because otherwise we'll end up with a require cycle that ends up with
@@ -137,8 +138,35 @@ function setWeakAbortSignalTimeout(weakRef, delay) {
 }
 
 class AbortSignal extends EventTarget {
-  constructor() {
-    throw new ERR_ILLEGAL_CONSTRUCTOR();
+
+  /**
+   * @param {symbol | undefined} dontThrowSymbol
+   * @param {{
+   *   aborted? : boolean,
+   *   reason? : any,
+   *   transferable? : boolean,
+   *   composite? : boolean,
+   * }} [init]
+   * @private
+   */
+  constructor(dontThrowSymbol = undefined, init = kEmptyObject) {
+    if (dontThrowSymbol !== kDontThrowSymbol) {
+      throw new ERR_ILLEGAL_CONSTRUCTOR();
+    }
+    super();
+
+    const {
+      aborted = false,
+      reason = undefined,
+      transferable = false,
+      composite = false,
+    } = init;
+    this[kAborted] = aborted;
+    this[kReason] = reason;
+    this[kComposite] = composite;
+    if (transferable) {
+      lazyMarkTransferMode(this, false, true);
+    }
   }
 
   /**
@@ -176,7 +204,7 @@ class AbortSignal extends EventTarget {
    */
   static abort(
     reason = new DOMException('This operation was aborted', 'AbortError')) {
-    return createAbortSignal({ aborted: true, reason });
+    return new AbortSignal(kDontThrowSymbol, { aborted: true, reason });
   }
 
   /**
@@ -185,7 +213,7 @@ class AbortSignal extends EventTarget {
    */
   static timeout(delay) {
     validateUint32(delay, 'delay', false);
-    const signal = createAbortSignal();
+    const signal = new AbortSignal(kDontThrowSymbol);
     signal[kTimeout] = true;
     clearTimeoutRegistry.register(
       signal,
@@ -199,7 +227,7 @@ class AbortSignal extends EventTarget {
    */
   static any(signals) {
     validateAbortSignalArray(signals, 'signals');
-    const resultSignal = createAbortSignal({ composite: true });
+    const resultSignal = new AbortSignal(kDontThrowSymbol, { composite: true });
     if (!signals.length) {
       return resultSignal;
     }
@@ -319,7 +347,7 @@ class AbortSignal extends EventTarget {
 }
 
 function ClonedAbortSignal() {
-  return createAbortSignal({ transferable: true });
+  return new AbortSignal(kDontThrowSymbol, { transferable: true });
 }
 ClonedAbortSignal.prototype[kDeserialize] = () => {};
 
@@ -336,33 +364,6 @@ ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
 });
 
 defineEventHandler(AbortSignal.prototype, 'abort');
-
-/**
- * @param {{
- *   aborted? : boolean,
- *   reason? : any,
- *   transferable? : boolean,
- *   composite? : boolean,
- * }} [init]
- * @returns {AbortSignal}
- */
-function createAbortSignal(init = kEmptyObject) {
-  const {
-    aborted = false,
-    reason = undefined,
-    transferable = false,
-    composite = false,
-  } = init;
-  const signal = new EventTarget();
-  ObjectSetPrototypeOf(signal, AbortSignal.prototype);
-  signal[kAborted] = aborted;
-  signal[kReason] = reason;
-  signal[kComposite] = composite;
-  if (transferable) {
-    lazyMarkTransferMode(signal, false, true);
-  }
-  return signal;
-}
 
 function abortSignal(signal, reason) {
   if (signal[kAborted]) return;
@@ -385,7 +386,7 @@ class AbortController {
    * @type {AbortSignal}
    */
   get signal() {
-    this.#signal ??= createAbortSignal();
+    this.#signal ??= new AbortSignal(kDontThrowSymbol);
     return this.#signal;
   }
 
@@ -393,7 +394,7 @@ class AbortController {
    * @param {any} [reason]
    */
   abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
-    abortSignal(this.#signal ??= createAbortSignal(), reason);
+    abortSignal(this.#signal ??= new AbortSignal(kDontThrowSymbol), reason);
   }
 
   [customInspectSymbol](depth, options) {
@@ -404,7 +405,7 @@ class AbortController {
 
   static [kMakeTransferable]() {
     const controller = new AbortController();
-    controller.#signal = createAbortSignal({ transferable: true });
+    controller.#signal = new AbortSignal(kDontThrowSymbol, { transferable: true });
     return controller;
   }
 }


### PR DESCRIPTION
# Benchmarks
even thought the following issue https://github.com/nodejs/build/issues/3657#issuecomment-204153499, I ran 3 times to make sure it's consistent and it is

## `AbortSignal.abort()` creation
[Benchmark URL 1](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1508/console)

```
                                                                              confidence improvement accuracy (*)    (**)   (***)
abort_controller/abort-signal-static-abort.js kind='default-reason' n=5000000        ***     76.76 %       ±0.46%  ±0.62%  ±0.80%
abort_controller/abort-signal-static-abort.js kind='same-reason' n=5000000           ***   2166.62 %      ±11.82% ±15.93% ±21.15%
```

[Benchmark URL 2](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1516/console)
```
                                                                              confidence improvement accuracy (*)    (**)   (***)
abort_controller/abort-signal-static-abort.js kind='default-reason' n=5000000        ***     75.92 %       ±0.68%  ±0.90%  ±1.18%
abort_controller/abort-signal-static-abort.js kind='same-reason' n=5000000           ***   2191.80 %      ±10.63% ±14.32% ±19.01%
```

[Benchmark URL 3](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1518/console)

```
                                                                              confidence improvement accuracy (*)    (**)   (***)
abort_controller/abort-signal-static-abort.js kind='default-reason' n=5000000        ***     75.79 %       ±0.45%  ±0.60%  ±0.79%
abort_controller/abort-signal-static-abort.js kind='same-reason' n=5000000           ***   2192.39 %      ±26.46% ±35.66% ±47.34%
```

## Test runner Benchmark
My original intent was to improve this so this is why I ran this

[Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1507/console)

```
                                                                                                     confidence improvement accuracy (*)   (**)   (***)
test_runner/global-concurrent-tests.js type='async' n=100                                                           3.46 %       ±4.37% ±5.81%  ±7.57%
test_runner/global-concurrent-tests.js type='async' n=1000                                                 ***      5.92 %       ±2.26% ±3.03%  ±3.97%
test_runner/global-concurrent-tests.js type='async' n=10000                                                ***     15.70 %       ±0.55% ±0.73%  ±0.96%
test_runner/global-concurrent-tests.js type='sync' n=100                                                    **      3.89 %       ±2.47% ±3.29%  ±4.29%
test_runner/global-concurrent-tests.js type='sync' n=1000                                                  ***      5.00 %       ±1.82% ±2.44%  ±3.21%
test_runner/global-concurrent-tests.js type='sync' n=10000                                                 ***     15.41 %       ±0.39% ±0.52%  ±0.68%
test_runner/global-sequential-tests.js type='async' n=100                                                           6.22 %       ±7.36% ±9.81% ±12.78%
test_runner/global-sequential-tests.js type='async' n=1000                                                          2.51 %       ±5.83% ±7.77% ±10.12%
test_runner/global-sequential-tests.js type='async' n=10000                                                         0.00 %       ±2.77% ±3.68%  ±4.79%
test_runner/global-sequential-tests.js type='sync' n=100                                                            1.06 %       ±4.42% ±5.90%  ±7.70%
test_runner/global-sequential-tests.js type='sync' n=1000                                                           0.13 %       ±3.39% ±4.51%  ±5.88%
test_runner/global-sequential-tests.js type='sync' n=10000                                                         -3.01 %       ±3.11% ±4.14%  ±5.39%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=10            ***      5.77 %       ±2.99% ±4.01%  ±5.27%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=10 numberOfSuites=100           ***     12.06 %       ±0.71% ±0.94%  ±1.23%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=10           ***      9.29 %       ±1.05% ±1.40%  ±1.83%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=100 numberOfSuites=100          ***     15.06 %       ±0.38% ±0.50%  ±0.65%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=10          ***     16.90 %       ±1.59% ±2.15%  ±2.84%
test_runner/suite-tests.js concurrency='no' testType='async' testsPerSuite=1000 numberOfSuites=100         ***     17.62 %       ±1.01% ±1.35%  ±1.79%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=10                      3.59 %       ±4.91% ±6.54%  ±8.51%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=10 numberOfSuites=100            ***     11.88 %       ±0.78% ±1.04%  ±1.36%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=10            ***     10.44 %       ±1.64% ±2.20%  ±2.89%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=100 numberOfSuites=100           ***     15.72 %       ±0.51% ±0.68%  ±0.88%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=10           ***     18.30 %       ±1.72% ±2.32%  ±3.07%
test_runner/suite-tests.js concurrency='no' testType='sync' testsPerSuite=1000 numberOfSuites=100          ***     17.40 %       ±1.26% ±1.70%  ±2.25%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=10             *      4.00 %       ±3.31% ±4.41%  ±5.74%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=10 numberOfSuites=100          ***     10.96 %       ±0.66% ±0.87%  ±1.14%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=10          ***      9.11 %       ±0.79% ±1.05%  ±1.37%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=100 numberOfSuites=100         ***     16.58 %       ±0.42% ±0.56%  ±0.73%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=10         ***     16.72 %       ±0.40% ±0.53%  ±0.70%
test_runner/suite-tests.js concurrency='yes' testType='async' testsPerSuite=1000 numberOfSuites=100        ***     15.42 %       ±0.19% ±0.26%  ±0.33%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=10            ***      6.09 %       ±1.99% ±2.65%  ±3.47%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=10 numberOfSuites=100           ***      9.95 %       ±1.28% ±1.71%  ±2.22%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=10           ***      9.46 %       ±1.58% ±2.10%  ±2.73%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=100 numberOfSuites=100          ***     16.19 %       ±0.47% ±0.63%  ±0.81%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=10          ***     17.06 %       ±0.25% ±0.33%  ±0.43%
test_runner/suite-tests.js concurrency='yes' testType='sync' testsPerSuite=1000 numberOfSuites=100         ***     15.00 %       ±0.17% ±0.23%  ±0.30%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 36 comparisons, you can thus
expect the following amount of false-positive results:
1.80 false positives, when considering a   5% risk acceptance (*, **, ***),
0.36 false positives, when considering a   1% risk acceptance (**, ***),
0.04 false positives, when considering a 0.1% risk acceptance (***)
```
