### PR TITLE
events: improve creation time of EventTarget

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -541,6 +541,7 @@ class Listener {
   }
 }
 
+// Updating this function will require updating the EventTarget as well
 function initEventTarget(self) {
   self[kEvents] = new SafeMap();
   self[kMaxEventTargetListeners] = EventEmitter.defaultMaxListeners;
@@ -554,9 +555,12 @@ class EventTarget {
   // Ref: https://github.com/nodejs/node/pull/33661
   static [kIsEventTarget] = true;
 
-  constructor() {
-    initEventTarget(this);
-  }
+  // From here: Same as initEventTarget code, added here due to performance reasons
+  [kEvents] = new SafeMap();
+  [kMaxEventTargetListeners] = EventEmitter.defaultMaxListeners;
+  [kMaxEventTargetListenersWarned] = false;
+  [kHandlers] = new SafeMap();
+  // Until here
 
   [kNewListener](size, type, listener, once, capture, passive, weak) {
     if (this[kMaxEventTargetListeners] > 0 &&
@@ -868,6 +872,8 @@ ObjectDefineProperties(EventTarget.prototype, {
   },
 });
 
+// If you update this function please add to node event target as well,
+// not used in NodeEventTarget due to performance reasons
 function initNodeEventTarget(self) {
   initEventTarget(self);
 }
@@ -875,11 +881,6 @@ function initNodeEventTarget(self) {
 class NodeEventTarget extends EventTarget {
   static [kIsNodeEventTarget] = true;
   static defaultMaxListeners = 10;
-
-  constructor() {
-    super();
-    initNodeEventTarget(this);
-  }
 
   /**
    * @param {number} n


### PR DESCRIPTION
# Benchmarks
may not be accurate until https://github.com/nodejs/build/issues/3657#issuecomment-204153499 is resolved

[Benchmark URL](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1509/console)


No change:
```
23:20:03                                                         confidence improvement accuracy (*)   (**)  (***)
23:20:03 events/eventtarget-add-remove.js nListener=10 n=1000000                 0.01 %       ±0.63% ±0.84% ±1.10%
23:20:03 events/eventtarget-add-remove.js nListener=5 n=1000000                  0.31 %       ±0.52% ±0.69% ±0.90%
23:20:03 events/eventtarget-creation.js n=1000000                               -0.59 %       ±2.34% ±3.11% ±4.04%
23:20:03 events/eventtarget.js listeners=1 n=1000000                            -0.26 %       ±0.38% ±0.51% ±0.66%
23:20:03 events/eventtarget.js listeners=10 n=1000000                            0.25 %       ±0.38% ±0.50% ±0.66%
23:20:03 events/eventtarget.js listeners=5 n=1000000                            -0.34 %       ±0.94% ±1.25% ±1.63%
23:20:03 
```