### PR TITLE
module: detect ESM syntax by trying to recompile as SourceTextModule

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -114,7 +114,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
         // but this gets called again from `defaultLoad`/`defaultLoadSync`.
         if (getOptionValue('--experimental-detect-module')) {
           const format = source ?
-            (containsModuleSyntax(`${source}`, fileURLToPath(url)) ? 'module' : 'commonjs') :
+            (containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs') :
             null;
           if (format === 'module') {
             // This module has a .js extension, a package.json with no `type` field, and ESM syntax.
@@ -158,7 +158,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
           if (!source) { return null; }
           const format = getFormatOfExtensionlessFile(url);
           if (format === 'module') {
-            return containsModuleSyntax(`${source}`, fileURLToPath(url)) ? 'module' : 'commonjs';
+            return containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs';
           }
           return format;
         }

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -19,15 +19,6 @@ const {
 } = require('internal/errors').codes;
 const { BuiltinModule } = require('internal/bootstrap/realm');
 
-const {
-  shouldRetryAsESM: contextifyShouldRetryAsESM,
-  constants: {
-    syntaxDetectionErrors: {
-      esmSyntaxErrorMessages,
-      throwsOnlyInCommonJSErrorMessages,
-    },
-  },
-} = internalBinding('contextify');
 const { validateString } = require('internal/validators');
 const fs = require('fs'); // Import all of `fs` so that it can be monkey-patched.
 const internalFS = require('internal/fs/utils');
@@ -329,31 +320,6 @@ function normalizeReferrerURL(referrerName) {
 }
 
 
-let esmSyntaxErrorMessagesSet; // Declared lazily in shouldRetryAsESM
-let throwsOnlyInCommonJSErrorMessagesSet; // Declared lazily in shouldRetryAsESM
-/**
- * After an attempt to parse a module as CommonJS throws an error, should we try again as ESM?
- * We only want to try again as ESM if the error is due to syntax that is only valid in ESM; and if the CommonJS parse
- * throws on an error that would not have been a syntax error in ESM (like via top-level `await` or a lexical
- * redeclaration of one of the CommonJS variables) then we need to parse again to see if it would have thrown in ESM.
- * @param {string} errorMessage The string message thrown by V8 when attempting to parse as CommonJS
- * @param {string} source Module contents
- */
-function shouldRetryAsESM(errorMessage, source) {
-  esmSyntaxErrorMessagesSet ??= new SafeSet(esmSyntaxErrorMessages);
-  if (esmSyntaxErrorMessagesSet.has(errorMessage)) {
-    return true;
-  }
-
-  throwsOnlyInCommonJSErrorMessagesSet ??= new SafeSet(throwsOnlyInCommonJSErrorMessages);
-  if (throwsOnlyInCommonJSErrorMessagesSet.has(errorMessage)) {
-    return /** @type {boolean} */(contextifyShouldRetryAsESM(source));
-  }
-
-  return false;
-}
-
-
 // Whether we have started executing any user-provided CJS code.
 // This is set right before we call the wrapped CJS code (not after,
 // in case we are half-way in the execution when internals check this).
@@ -373,7 +339,6 @@ module.exports = {
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,
-  shouldRetryAsESM,
   stripBOM,
   toRealPath,
   hasStartedUserCJSExecution() {

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ObjectGetPrototypeOf,
+  SyntaxErrorPrototype,
   StringPrototypeEndsWith,
   globalThis,
 } = primordials;
@@ -159,7 +161,7 @@ function runEntryPointWithESMLoader(callback) {
 function executeUserEntryPoint(main = process.argv[1]) {
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
-
+  let mainURL;
   // Unless we know we should use the ESM loader to handle the entry point per the checks in `shouldUseESMLoader`, first
   // try to run the entry point via the CommonJS loader; and if that fails under certain conditions, retry as ESM.
   let retryAsESM = false;
@@ -167,19 +169,21 @@ function executeUserEntryPoint(main = process.argv[1]) {
     const cjsLoader = require('internal/modules/cjs/loader');
     const { Module } = cjsLoader;
     if (getOptionValue('--experimental-detect-module')) {
+      // TODO(joyeecheung): handle this in the CJS loader. Don't try-catch here.
       try {
         // Module._load is the monkey-patchable CJS module loader.
         Module._load(main, null, true);
       } catch (error) {
-        const source = cjsLoader.entryPointSource;
-        const { shouldRetryAsESM } = require('internal/modules/helpers');
-        retryAsESM = shouldRetryAsESM(error.message, source);
-        // In case the entry point is a large file, such as a bundle,
-        // ensure no further references can prevent it being garbage-collected.
-        cjsLoader.entryPointSource = undefined;
+        if (ObjectGetPrototypeOf(error) === SyntaxErrorPrototype) {
+          const { shouldRetryAsESM } = internalBinding('contextify');
+          const mainPath = resolvedMain || main;
+          mainURL = pathToFileURL(mainPath).href;
+          retryAsESM = shouldRetryAsESM(error.message, cjsLoader.entryPointSource, mainPath);
+          // In case the entry point is a large file, such as a bundle,
+          // ensure no further references can prevent it being garbage-collected.
+          cjsLoader.entryPointSource = undefined;
+        }
         if (!retryAsESM) {
-          const { enrichCJSError } = require('internal/modules/esm/translators');
-          enrichCJSError(error, source, resolvedMain);
           throw error;
         }
       }
@@ -190,7 +194,9 @@ function executeUserEntryPoint(main = process.argv[1]) {
 
   if (useESMLoader || retryAsESM) {
     const mainPath = resolvedMain || main;
-    const mainURL = pathToFileURL(mainPath).href;
+    if (mainURL === undefined) {
+      mainURL = pathToFileURL(mainPath).href;
+    }
 
     runEntryPointWithESMLoader((cascadedLoader) => {
       // Note that if the graph contains unsettled TLA, this may never resolve

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -3,10 +3,12 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <unordered_map>
+#include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "base_object.h"
+#include "v8-script.h"
 
 namespace node {
 
@@ -68,6 +70,23 @@ class ModuleWrap : public BaseObject {
     // Do these objects ever get GC'd? Are we just okay with leaking them?
     return true;
   }
+
+  static v8::Local<v8::PrimitiveArray> GetHostDefinedOptions(
+      v8::Isolate* isolate, v8::Local<v8::Symbol> symbol);
+
+  // When user_cached_data is not std::nullopt, use the code cache if it's not
+  // nullptr, otherwise don't use code cache.
+  // TODO(joyeecheung): when it is std::nullopt, use on-disk cache
+  // See: https://github.com/nodejs/node/issues/47472
+  static v8::MaybeLocal<v8::Module> CompileSourceTextModule(
+      Realm* realm,
+      v8::Local<v8::String> source_text,
+      v8::Local<v8::String> url,
+      int line_offset,
+      int column_offset,
+      v8::Local<v8::PrimitiveArray> host_defined_options,
+      std::optional<v8::ScriptCompiler::CachedData*> user_cached_data,
+      bool* cache_rejected);
 
  private:
   ModuleWrap(Realm* realm,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -344,16 +344,12 @@ void ContextifyContext::CreatePerIsolateProperties(
   Isolate* isolate = isolate_data->isolate();
   SetMethod(isolate, target, "makeContext", MakeContext);
   SetMethod(isolate, target, "compileFunction", CompileFunction);
-  SetMethod(isolate, target, "containsModuleSyntax", ContainsModuleSyntax);
-  SetMethod(isolate, target, "shouldRetryAsESM", ShouldRetryAsESM);
 }
 
 void ContextifyContext::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(MakeContext);
   registry->Register(CompileFunction);
-  registry->Register(ContainsModuleSyntax);
-  registry->Register(ShouldRetryAsESM);
   registry->Register(PropertyGetterCallback);
   registry->Register(PropertySetterCallback);
   registry->Register(PropertyDescriptorCallback);
@@ -1159,15 +1155,6 @@ ContextifyScript::ContextifyScript(Environment* env, Local<Object> object)
 
 ContextifyScript::~ContextifyScript() {}
 
-static Local<PrimitiveArray> GetHostDefinedOptions(Isolate* isolate,
-                                                   Local<Symbol> id_symbol) {
-  Local<PrimitiveArray> host_defined_options =
-      PrimitiveArray::New(isolate, loader::HostDefinedOptions::kLength);
-  host_defined_options->Set(
-      isolate, loader::HostDefinedOptions::kID, id_symbol);
-  return host_defined_options;
-}
-
 void ContextifyContext::CompileFunction(
     const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1241,16 +1228,27 @@ void ContextifyContext::CompileFunction(
   }
 
   Local<PrimitiveArray> host_defined_options =
-      GetHostDefinedOptions(isolate, id_symbol);
-  ScriptCompiler::Source source =
-      GetCommonJSSourceInstance(isolate,
-                                code,
-                                filename,
-                                line_offset,
-                                column_offset,
-                                host_defined_options,
-                                cached_data);
-  ScriptCompiler::CompileOptions options = GetCompileOptions(source);
+      loader::ModuleWrap::GetHostDefinedOptions(isolate, id_symbol);
+
+  ScriptOrigin origin(isolate,
+                      filename,
+                      line_offset,     // line offset
+                      column_offset,   // column offset
+                      true,            // is cross origin
+                      -1,              // script id
+                      Local<Value>(),  // source map URL
+                      false,           // is opaque (?)
+                      false,           // is WASM
+                      false,           // is ES Module
+                      host_defined_options);
+  ScriptCompiler::Source source(code, origin, cached_data);
+
+  ScriptCompiler::CompileOptions options;
+  if (source.GetCachedData() != nullptr) {
+    options = ScriptCompiler::kConsumeCodeCache;
+  } else {
+    options = ScriptCompiler::kNoCompileOptions;
+  }
 
   Context::Scope scope(parsing_context);
 
@@ -1296,39 +1294,6 @@ void ContextifyContext::CompileFunction(
     return;
   }
   args.GetReturnValue().Set(result);
-}
-
-ScriptCompiler::Source ContextifyContext::GetCommonJSSourceInstance(
-    Isolate* isolate,
-    Local<String> code,
-    Local<String> filename,
-    int line_offset,
-    int column_offset,
-    Local<PrimitiveArray> host_defined_options,
-    ScriptCompiler::CachedData* cached_data) {
-  ScriptOrigin origin(isolate,
-                      filename,
-                      line_offset,     // line offset
-                      column_offset,   // column offset
-                      true,            // is cross origin
-                      -1,              // script id
-                      Local<Value>(),  // source map URL
-                      false,           // is opaque (?)
-                      false,           // is WASM
-                      false,           // is ES Module
-                      host_defined_options);
-  return ScriptCompiler::Source(code, origin, cached_data);
-}
-
-ScriptCompiler::CompileOptions ContextifyContext::GetCompileOptions(
-    const ScriptCompiler::Source& source) {
-  ScriptCompiler::CompileOptions options;
-  if (source.GetCachedData() != nullptr) {
-    options = ScriptCompiler::kConsumeCodeCache;
-  } else {
-    options = ScriptCompiler::kNoCompileOptions;
-  }
-  return options;
 }
 
 static std::vector<Local<String>> GetCJSParameters(IsolateData* data) {
@@ -1436,160 +1401,17 @@ static std::vector<std::string_view> throws_only_in_cjs_error_messages = {
     "await is only valid in async functions and "
     "the top level bodies of modules"};
 
-void ContextifyContext::ContainsModuleSyntax(
-    const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-  Local<Context> context = env->context();
-
-  if (args.Length() == 0) {
-    return THROW_ERR_MISSING_ARGS(
-        env, "containsModuleSyntax needs at least 1 argument");
-  }
-
-  // Argument 1: source code
-  CHECK(args[0]->IsString());
-  auto code = args[0].As<String>();
-
-  // Argument 2: filename; if undefined, use empty string
-  Local<String> filename = String::Empty(isolate);
-  if (!args[1]->IsUndefined()) {
-    CHECK(args[1]->IsString());
-    filename = args[1].As<String>();
-  }
-
-  // TODO(geoffreybooth): Centralize this rather than matching the logic in
-  // cjs/loader.js and translators.js
-  Local<String> script_id = String::Concat(
-      isolate, String::NewFromUtf8(isolate, "cjs:").ToLocalChecked(), filename);
-  Local<Symbol> id_symbol = Symbol::New(isolate, script_id);
-
-  Local<PrimitiveArray> host_defined_options =
-      GetHostDefinedOptions(isolate, id_symbol);
-  ScriptCompiler::Source source = GetCommonJSSourceInstance(
-      isolate, code, filename, 0, 0, host_defined_options, nullptr);
-  ScriptCompiler::CompileOptions options = GetCompileOptions(source);
-
-  std::vector<Local<String>> params = GetCJSParameters(env->isolate_data());
-
-  TryCatchScope try_catch(env);
-  ShouldNotAbortOnUncaughtScope no_abort_scope(env);
-
-  ContextifyContext::CompileFunctionAndCacheResult(env,
-                                                   context,
-                                                   &source,
-                                                   params,
-                                                   std::vector<Local<Object>>(),
-                                                   options,
-                                                   true,
-                                                   id_symbol,
-                                                   try_catch);
-
-  bool should_retry_as_esm = false;
-  if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
-    should_retry_as_esm =
-        ContextifyContext::ShouldRetryAsESMInternal(env, code);
-  }
-  args.GetReturnValue().Set(should_retry_as_esm);
-}
-
-void ContextifyContext::ShouldRetryAsESM(
-    const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  CHECK_EQ(args.Length(), 1);  // code
-
-  // Argument 1: source code
-  Local<String> code;
-  CHECK(args[0]->IsString());
-  code = args[0].As<String>();
-
-  bool should_retry_as_esm =
-      ContextifyContext::ShouldRetryAsESMInternal(env, code);
-
-  args.GetReturnValue().Set(should_retry_as_esm);
-}
-
-bool ContextifyContext::ShouldRetryAsESMInternal(Environment* env,
-                                                 Local<String> code) {
-  Isolate* isolate = env->isolate();
-
-  Local<String> script_id =
-      FIXED_ONE_BYTE_STRING(isolate, "[retry_as_esm_check]");
-  Local<Symbol> id_symbol = Symbol::New(isolate, script_id);
-
-  Local<PrimitiveArray> host_defined_options =
-      GetHostDefinedOptions(isolate, id_symbol);
-  ScriptCompiler::Source source =
-      GetCommonJSSourceInstance(isolate,
-                                code,
-                                script_id,  // filename
-                                0,          // line offset
-                                0,          // column offset
-                                host_defined_options,
-                                nullptr);  // cached_data
-
-  TryCatchScope try_catch(env);
-  ShouldNotAbortOnUncaughtScope no_abort_scope(env);
-
-  // Try parsing where instead of the CommonJS wrapper we use an async function
-  // wrapper. If the parse succeeds, then any CommonJS parse error for this
-  // module was caused by either a top-level declaration of one of the CommonJS
-  // module variables, or a top-level `await`.
-  code = String::Concat(
-      isolate, FIXED_ONE_BYTE_STRING(isolate, "(async function() {"), code);
-  code = String::Concat(isolate, code, FIXED_ONE_BYTE_STRING(isolate, "})();"));
-
-  ScriptCompiler::Source wrapped_source = GetCommonJSSourceInstance(
-      isolate, code, script_id, 0, 0, host_defined_options, nullptr);
-
-  Local<Context> context = env->context();
-  std::vector<Local<String>> params = GetCJSParameters(env->isolate_data());
-  USE(ScriptCompiler::CompileFunction(
-      context,
-      &wrapped_source,
-      params.size(),
-      params.data(),
-      0,
-      nullptr,
-      ScriptCompiler::kNoCompileOptions,
-      v8::ScriptCompiler::NoCacheReason::kNoCacheNoReason));
-
-  if (!try_catch.HasTerminated()) {
-    if (try_catch.HasCaught()) {
-      // If on the second parse an error is thrown by ESM syntax, then
-      // what happened was that the user had top-level `await` or a
-      // top-level declaration of one of the CommonJS module variables
-      // above the first `import` or `export`.
-      Utf8Value message_value(env->isolate(), try_catch.Message()->Get());
-      auto message_view = message_value.ToStringView();
-      for (const auto& error_message : esm_syntax_error_messages) {
-        if (message_view.find(error_message) != std::string_view::npos) {
-          return true;
-        }
-      }
-    } else {
-      // No errors thrown in the second parse, so most likely the error
-      // was caused by a top-level `await` or a top-level declaration of
-      // one of the CommonJS module variables.
-      return true;
-    }
-  }
-  return false;
-}
-
-static void CompileFunctionForCJSLoader(
-    const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsString());
-  CHECK(args[1]->IsString());
-  Local<String> code = args[0].As<String>();
-  Local<String> filename = args[1].As<String>();
-  Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
-  Environment* env = Environment::GetCurrent(context);
+static MaybeLocal<Function> CompileFunctionForCJSLoader(Environment* env,
+                                                        Local<Context> context,
+                                                        Local<String> code,
+                                                        Local<String> filename,
+                                                        bool* cache_rejected) {
+  Isolate* isolate = context->GetIsolate();
+  EscapableHandleScope scope(isolate);
 
   Local<Symbol> symbol = env->vm_dynamic_import_default_internal();
-  Local<PrimitiveArray> hdo = GetHostDefinedOptions(isolate, symbol);
+  Local<PrimitiveArray> hdo =
+      loader::ModuleWrap::GetHostDefinedOptions(isolate, symbol);
   ScriptOrigin origin(isolate,
                       filename,
                       0,               // line offset
@@ -1618,11 +1440,7 @@ static void CompileFunctionForCJSLoader(
   }
 #endif
   ScriptCompiler::Source source(code, origin, cached_data);
-
-  TryCatchScope try_catch(env);
-
   std::vector<Local<String>> params = GetCJSParameters(env->isolate_data());
-
   MaybeLocal<Function> maybe_fn = ScriptCompiler::CompileFunction(
       context,
       &source,
@@ -1637,21 +1455,42 @@ static void CompileFunctionForCJSLoader(
 
   Local<Function> fn;
   if (!maybe_fn.ToLocal(&fn)) {
-    if (try_catch.HasCaught() && !try_catch.HasTerminated()) {
+    return scope.EscapeMaybe(MaybeLocal<Function>());
+  }
+
+#ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
+  if (used_cache_from_sea) {
+    *cache_rejected = source.GetCachedData()->rejected;
+  }
+#endif
+
+  return scope.Escape(fn);
+}
+
+static void CompileFunctionForCJSLoader(
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsString());
+  CHECK(args[1]->IsString());
+  Local<String> code = args[0].As<String>();
+  Local<String> filename = args[1].As<String>();
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+
+  bool cache_rejected = false;
+  Local<Function> fn;
+  {
+    TryCatchScope try_catch(env);
+    if (!CompileFunctionForCJSLoader(
+             env, context, code, filename, &cache_rejected)
+             .ToLocal(&fn)) {
+      CHECK(try_catch.HasCaught());
+      CHECK(!try_catch.HasTerminated());
       errors::DecorateErrorStack(env, try_catch);
-      if (!try_catch.HasTerminated()) {
-        try_catch.ReThrow();
-      }
+      try_catch.ReThrow();
       return;
     }
   }
-
-  bool cache_rejected = false;
-#ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
-  if (used_cache_from_sea) {
-    cache_rejected = source.GetCachedData()->rejected;
-  }
-#endif
 
   std::vector<Local<Name>> names = {
       env->cached_data_rejected_string(),
@@ -1665,6 +1504,108 @@ static void CompileFunctionForCJSLoader(
   };
   Local<Object> result = Object::New(
       isolate, v8::Null(isolate), names.data(), values.data(), names.size());
+  args.GetReturnValue().Set(result);
+}
+
+static bool ShouldRetryAsESM(Realm* realm,
+                             Local<String> message,
+                             Local<String> code,
+                             Local<String> resource_name) {
+  Isolate* isolate = realm->isolate();
+
+  Utf8Value message_value(isolate, message);
+  auto message_view = message_value.ToStringView();
+
+  // These indicates that the file contains syntaxes that are only valid in
+  // ESM. So it must be true.
+  for (const auto& error_message : esm_syntax_error_messages) {
+    if (message_view.find(error_message) != std::string_view::npos) {
+      return true;
+    }
+  }
+
+  // Check if the error message is allowed in ESM but not in CommonJS. If it
+  // is the case, let's check if file can be compiled as ESM.
+  bool maybe_valid_in_esm = false;
+  for (const auto& error_message : throws_only_in_cjs_error_messages) {
+    if (message_view.find(error_message) != std::string_view::npos) {
+      maybe_valid_in_esm = true;
+      break;
+    }
+  }
+  if (!maybe_valid_in_esm) {
+    return false;
+  }
+
+  bool cache_rejected = false;
+  TryCatchScope try_catch(realm->env());
+  ShouldNotAbortOnUncaughtScope no_abort_scope(realm->env());
+  Local<v8::Module> module;
+  Local<PrimitiveArray> hdo = loader::ModuleWrap::GetHostDefinedOptions(
+      isolate, realm->isolate_data()->source_text_module_default_hdo());
+  if (loader::ModuleWrap::CompileSourceTextModule(
+          realm, code, resource_name, 0, 0, hdo, nullptr, &cache_rejected)
+          .ToLocal(&module)) {
+    return true;
+  }
+
+  return false;
+}
+
+static void ShouldRetryAsESM(const FunctionCallbackInfo<Value>& args) {
+  Realm* realm = Realm::GetCurrent(args);
+
+  CHECK_EQ(args.Length(), 3);  // message, code, resource_name
+  CHECK(args[0]->IsString());
+  Local<String> message = args[0].As<String>();
+  CHECK(args[1]->IsString());
+  Local<String> code = args[1].As<String>();
+  CHECK(args[2]->IsString());
+  Local<String> resource_name = args[2].As<String>();
+
+  args.GetReturnValue().Set(
+      ShouldRetryAsESM(realm, message, code, resource_name));
+}
+
+static void ContainsModuleSyntax(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Realm* realm = Realm::GetCurrent(context);
+  Environment* env = realm->env();
+
+  CHECK_GE(args.Length(), 2);
+
+  // Argument 1: source code
+  CHECK(args[0]->IsString());
+  Local<String> code = args[0].As<String>();
+
+  // Argument 2: filename
+  CHECK(args[1]->IsString());
+  Local<String> filename = args[1].As<String>();
+
+  // Argument 2: resource name (URL for module).
+  Local<String> resource_name = filename;
+  if (args[2]->IsString()) {
+    resource_name = args[2].As<String>();
+  }
+
+  bool cache_rejected = false;
+  Local<String> message;
+  {
+    Local<Function> fn;
+    TryCatchScope try_catch(env);
+    ShouldNotAbortOnUncaughtScope no_abort_scope(env);
+    if (CompileFunctionForCJSLoader(
+            env, context, code, filename, &cache_rejected)
+            .ToLocal(&fn)) {
+      args.GetReturnValue().Set(false);
+      return;
+    }
+    CHECK(try_catch.HasCaught());
+    message = try_catch.Message()->Get();
+  }
+
+  bool result = ShouldRetryAsESM(realm, message, code, resource_name);
   args.GetReturnValue().Set(result);
 }
 
@@ -1724,6 +1665,9 @@ void CreatePerIsolateProperties(IsolateData* isolate_data,
             target,
             "compileFunctionForCJSLoader",
             CompileFunctionForCJSLoader);
+
+  SetMethod(isolate, target, "containsModuleSyntax", ContainsModuleSyntax);
+  SetMethod(isolate, target, "shouldRetryAsESM", ShouldRetryAsESM);
 }
 
 static void CreatePerContextProperties(Local<Object> target,
@@ -1736,7 +1680,6 @@ static void CreatePerContextProperties(Local<Object> target,
   Local<Object> constants = Object::New(env->isolate());
   Local<Object> measure_memory = Object::New(env->isolate());
   Local<Object> memory_execution = Object::New(env->isolate());
-  Local<Object> syntax_detection_errors = Object::New(env->isolate());
 
   {
     Local<Object> memory_mode = Object::New(env->isolate());
@@ -1757,25 +1700,6 @@ static void CreatePerContextProperties(Local<Object> target,
 
   READONLY_PROPERTY(constants, "measureMemory", measure_memory);
 
-  {
-    Local<Value> esm_syntax_error_messages_array =
-        ToV8Value(context, esm_syntax_error_messages).ToLocalChecked();
-    READONLY_PROPERTY(syntax_detection_errors,
-                      "esmSyntaxErrorMessages",
-                      esm_syntax_error_messages_array);
-  }
-
-  {
-    Local<Value> throws_only_in_cjs_error_messages_array =
-        ToV8Value(context, throws_only_in_cjs_error_messages).ToLocalChecked();
-    READONLY_PROPERTY(syntax_detection_errors,
-                      "throwsOnlyInCommonJSErrorMessages",
-                      throws_only_in_cjs_error_messages_array);
-  }
-
-  READONLY_PROPERTY(
-      constants, "syntaxDetectionErrors", syntax_detection_errors);
-
   target->Set(context, env->constants_string(), constants).Check();
 }
 
@@ -1788,6 +1712,8 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(StopSigintWatchdog);
   registry->Register(WatchdogHasPendingSigint);
   registry->Register(MeasureMemory);
+  registry->Register(ContainsModuleSyntax);
+  registry->Register(ShouldRetryAsESM);
 }
 }  // namespace contextify
 }  // namespace node

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -94,21 +94,6 @@ class ContextifyContext : public BaseObject {
       bool produce_cached_data,
       v8::Local<v8::Symbol> id_symbol,
       const errors::TryCatchScope& try_catch);
-  static v8::ScriptCompiler::Source GetCommonJSSourceInstance(
-      v8::Isolate* isolate,
-      v8::Local<v8::String> code,
-      v8::Local<v8::String> filename,
-      int line_offset,
-      int column_offset,
-      v8::Local<v8::PrimitiveArray> host_defined_options,
-      v8::ScriptCompiler::CachedData* cached_data);
-  static v8::ScriptCompiler::CompileOptions GetCompileOptions(
-      const v8::ScriptCompiler::Source& source);
-  static void ContainsModuleSyntax(
-      const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void ShouldRetryAsESM(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static bool ShouldRetryAsESMInternal(Environment* env,
-                                       v8::Local<v8::String> code);
   static void WeakCallback(
       const v8::WeakCallbackInfo<ContextifyContext>& data);
   static void PropertyGetterCallback(


### PR DESCRIPTION
Instead of using an async function wrapper, just try compiling code with unknown module format as SourceTextModule when it cannot be compiled as CJS and the error message indicates that it's worth a retry. If it can be parsed as SourceTextModule then it's considered ESM.

Also, move shouldRetryAsESM() to C++ completely so that we can reuse it in the CJS module loader for require(esm).

Drive-by: move methods that don't belong to ContextifyContext out as static methods and move GetHostDefinedOptions to ModuleWrap.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
