### PR TITLE
tools: update stale bot messaging

### DIFF
--- a/.github/workflows/close-stale-feature-requests.yml
+++ b/.github/workflows/close-stale-feature-requests.yml
@@ -19,9 +19,11 @@ env:
 
   WARN_MESSAGE: >
     There has been no activity on this feature request for
-    5 months and it is unlikely to be implemented.
-    It will be closed 6 months after the last non-automated comment.
-
+    5 months. To help maintain relevant open issues, please
+    add the https://github.com/nodejs/node/labels/never-stale
+    label or close this issue if it should be closed. If not,
+    the issue will be automatically closed 6 months after the
+    last non-automated comment.
 
     For more information on how the project manages
     feature requests, please consult the


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This proposes an update to the stale bot messaging to help clarify the actions one should take in response to a warning that it will be closed soon. 

cc @ruyadorno @targos 

reference: https://openjs-foundation.slack.com/archives/CK9Q4MB53/p1712580250007649

