### PR TITLE
doc: correct naming convention in C++ style guide

### DIFF
--- a/doc/contributing/cpp-style-guide.md
+++ b/doc/contributing/cpp-style-guide.md
@@ -13,7 +13,7 @@ Node.js codebase not related to stylistic issues.
   * [4 spaces of indentation for statement continuations](#4-spaces-of-indentation-for-statement-continuations)
   * [Align function arguments vertically](#align-function-arguments-vertically)
   * [Initialization lists](#initialization-lists)
-  * [CamelCase for methods, functions, and classes](#camelcase-for-methods-functions-and-classes)
+  * [PascalCase for methods, functions, and classes](#pascalcase-for-methods-functions-and-classes)
   * [`snake_case` for local variables and parameters](#snake_case-for-local-variables-and-parameters)
   * [`snake_case_` for private class fields](#snake_case_-for-private-class-fields)
   * [`snake_case` for C-like structs](#snake_case-for-c-like-structs)
@@ -139,7 +139,7 @@ HandleWrap::HandleWrap(Environment* env,
       handle_(handle) {
 ```
 
-### CamelCase for methods, functions, and classes
+### PascalCase for methods, functions, and classes
 
 Exceptions are simple getters/setters, which are named `property_name()` and
 `set_property_name()`, respectively.


### PR DESCRIPTION
The code and documentation uses PascalCase for C++ functions, methods, and classes but the C++ style guide incorrectly says to use camelCase.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
