### PR TITLE
tools: change inactive limit to 12 months

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -68,7 +68,7 @@ The TSC can remove inactive collaborators or provide them with _emeritus_
 status. Emeriti may request that the TSC restore them to active status.
 
 A collaborator is automatically made emeritus (and removed from active
-collaborator status) if it has been more than 18 months since the collaborator
+collaborator status) if it has been more than 12 months since the collaborator
 has authored or approved a commit that has landed.
 
 ## Technical Steering Committee

--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -15,7 +15,7 @@ const args = parseArgs({
 });
 
 const verbose = args.values.verbose;
-const SINCE = args.positionals[0] || '18 months ago';
+const SINCE = args.positionals[0] || '12 months ago';
 
 async function runGitCommand(cmd, mapFn) {
   const childProcess = cp.spawn('/bin/sh', ['-c', cmd], {


### PR DESCRIPTION
I'm proposing reducing the inactive collaborator contribution limit.

Referencing https://github.com/nodejs/TSC/issues/1524, I recommend reducing the inactive collaborator duration to 12 months from 18 months.

cc @nodejs/tsc 