### PR TITLE
buffer: improve `base64` and `base64url` performance

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -362,12 +362,12 @@ size_t StringBytes::Write(Isolate* isolate,
       } else {
         String::Value value(isolate, str);
         size_t written_len = buflen;
-        auto result =
-            simdutf::base64_to_binary_safe(reinterpret_cast<const char16_t*>(*value),
-                                      value.length(),
-                                      buf,
-                                      written_len,
-                                      simdutf::base64_url);
+        auto result = simdutf::base64_to_binary_safe(
+            reinterpret_cast<const char16_t*>(*value),
+            value.length(),
+            buf,
+            written_len,
+            simdutf::base64_url);
         if (result.error == simdutf::error_code::SUCCESS) {
           nbytes = written_len;
         } else {

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -348,10 +348,11 @@ size_t StringBytes::Write(Isolate* isolate,
     case BASE64URL:
       if (str->IsExternalOneByte()) {  // 8-bit case
         auto ext = str->GetExternalOneByteStringResource();
+        size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            ext->data(), ext->length(), buf, buflen, simdutf::base64_url);
+            ext->data(), ext->length(), buf, written_len, simdutf::base64_url);
         if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = result.count;
+          nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
           // adapted for base64url
@@ -360,13 +361,15 @@ size_t StringBytes::Write(Isolate* isolate,
         }
       } else {
         String::Value value(isolate, str);
+        size_t written_len = buflen;
         auto result =
-            simdutf::base64_to_binary(reinterpret_cast<const char16_t*>(*value),
+            simdutf::base64_to_binary_safe(reinterpret_cast<const char16_t*>(*value),
                                       value.length(),
                                       buf,
+                                      written_len,
                                       simdutf::base64_url);
         if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = result.count;
+          nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
           // (adapted for base64url with + and / replaced by - and _).
@@ -379,10 +382,11 @@ size_t StringBytes::Write(Isolate* isolate,
     case BASE64: {
       if (str->IsExternalOneByte()) {  // 8-bit case
         auto ext = str->GetExternalOneByteStringResource();
+        size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            ext->data(), ext->length(), buf, buflen);
+            ext->data(), ext->length(), buf, written_len);
         if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = buflen;
+          nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
@@ -390,13 +394,14 @@ size_t StringBytes::Write(Isolate* isolate,
         }
       } else {
         String::Value value(isolate, str);
+        size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
             reinterpret_cast<const char16_t*>(*value),
             value.length(),
             buf,
-            buflen);
+            written_len);
         if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = buflen;
+          nbytes = written_len;
         } else {
           // The input does not follow the WHATWG base64 specification
           // https://infra.spec.whatwg.org/#forgiving-base64-decode

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -346,17 +346,65 @@ size_t StringBytes::Write(Isolate* isolate,
     }
 
     case BASE64URL:
-      // Fall through
-    case BASE64:
-      if (str->IsExternalOneByte()) {
+      if (str->IsExternalOneByte()) {  // 8-bit case
         auto ext = str->GetExternalOneByteStringResource();
-        nbytes = base64_decode(buf, buflen, ext->data(), ext->length());
+        auto result = simdutf::base64_to_binary_safe(
+            ext->data(), ext->length(), buf, buflen, simdutf::base64_url);
+        if (result.error == simdutf::error_code::SUCCESS) {
+          nbytes = result.count;
+        } else {
+          // The input does not follow the WHATWG forgiving-base64 specification
+          // adapted for base64url
+          // https://infra.spec.whatwg.org/#forgiving-base64-decode
+          nbytes = base64_decode(buf, buflen, ext->data(), ext->length());
+        }
       } else {
         String::Value value(isolate, str);
-        nbytes = base64_decode(buf, buflen, *value, value.length());
+        auto result =
+            simdutf::base64_to_binary(reinterpret_cast<const char16_t*>(*value),
+                                      value.length(),
+                                      buf,
+                                      simdutf::base64_url);
+        if (result.error == simdutf::error_code::SUCCESS) {
+          nbytes = result.count;
+        } else {
+          // The input does not follow the WHATWG forgiving-base64 specification
+          // (adapted for base64url with + and / replaced by - and _).
+          // https://infra.spec.whatwg.org/#forgiving-base64-decode
+          nbytes = base64_decode(buf, buflen, *value, value.length());
+        }
       }
       break;
 
+    case BASE64: {
+      if (str->IsExternalOneByte()) {  // 8-bit case
+        auto ext = str->GetExternalOneByteStringResource();
+        auto result = simdutf::base64_to_binary_safe(
+            ext->data(), ext->length(), buf, buflen);
+        if (result.error == simdutf::error_code::SUCCESS) {
+          nbytes = buflen;
+        } else {
+          // The input does not follow the WHATWG forgiving-base64 specification
+          // https://infra.spec.whatwg.org/#forgiving-base64-decode
+          nbytes = base64_decode(buf, buflen, ext->data(), ext->length());
+        }
+      } else {
+        String::Value value(isolate, str);
+        auto result = simdutf::base64_to_binary_safe(
+            reinterpret_cast<const char16_t*>(*value),
+            value.length(),
+            buf,
+            buflen);
+        if (result.error == simdutf::error_code::SUCCESS) {
+          nbytes = buflen;
+        } else {
+          // The input does not follow the WHATWG base64 specification
+          // https://infra.spec.whatwg.org/#forgiving-base64-decode
+          nbytes = base64_decode(buf, buflen, *value, value.length());
+        }
+      }
+      break;
+    }
     case HEX:
       if (str->IsExternalOneByte()) {
         auto ext = str->GetExternalOneByteStringResource();
@@ -411,9 +459,12 @@ Maybe<size_t> StringBytes::StorageSize(Isolate* isolate,
       break;
 
     case BASE64URL:
-      // Fall through
+      data_size = simdutf::base64_length_from_binary(str->Length(),
+                                                     simdutf::base64_url);
+      break;
+
     case BASE64:
-      data_size = base64_decoded_size_fast(str->Length());
+      data_size = simdutf::base64_length_from_binary(str->Length());
       break;
 
     case HEX:
@@ -452,11 +503,15 @@ Maybe<size_t> StringBytes::Size(Isolate* isolate,
     case UCS2:
       return Just(str->Length() * sizeof(uint16_t));
 
-    case BASE64URL:
-      // Fall through
+    case BASE64URL: {
+      String::Value value(isolate, str);
+      return Just(simdutf::base64_length_from_binary(value.length(),
+                                                     simdutf::base64_url));
+    }
+
     case BASE64: {
       String::Value value(isolate, str);
-      return Just(base64_decoded_size(*value, value.length()));
+      return Just(simdutf::base64_length_from_binary(value.length()));
     }
 
     case HEX:
@@ -609,28 +664,30 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
       return ExternOneByteString::NewFromCopy(isolate, buf, buflen, error);
 
     case BASE64: {
-      size_t dlen = base64_encoded_size(buflen);
+      size_t dlen = simdutf::base64_length_from_binary(buflen);
       char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
         *error = node::ERR_MEMORY_ALLOCATION_FAILED(isolate);
         return MaybeLocal<Value>();
       }
 
-      size_t written = base64_encode(buf, buflen, dst, dlen);
+      size_t written = simdutf::binary_to_base64(buf, buflen, dst);
       CHECK_EQ(written, dlen);
 
       return ExternOneByteString::New(isolate, dst, dlen, error);
     }
 
     case BASE64URL: {
-      size_t dlen = base64_encoded_size(buflen, Base64Mode::URL);
+      size_t dlen =
+          simdutf::base64_length_from_binary(buflen, simdutf::base64_url);
       char* dst = node::UncheckedMalloc(dlen);
       if (dst == nullptr) {
         *error = node::ERR_MEMORY_ALLOCATION_FAILED(isolate);
         return MaybeLocal<Value>();
       }
 
-      size_t written = base64_encode(buf, buflen, dst, dlen, Base64Mode::URL);
+      size_t written =
+          simdutf::binary_to_base64(buf, buflen, dst, simdutf::base64_url);
       CHECK_EQ(written, dlen);
 
       return ExternOneByteString::New(isolate, dst, dlen, error);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -359,9 +359,13 @@ size_t StringBytes::Write(Isolate* isolate,
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
           nbytes = base64_decode(buf, buflen, ext->data(), ext->length());
         }
-      } else if(str->IsOneByte()) {
+      } else if (str->IsOneByte()) {
         MaybeStackBuffer<uint8_t> stack_buf(str->Length());
-        str->WriteOneByte(isolate, stack_buf.out(), 0, str->Length(), String::NO_NULL_TERMINATION);
+        str->WriteOneByte(isolate,
+                          stack_buf.out(),
+                          0,
+                          str->Length(),
+                          String::NO_NULL_TERMINATION);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
             reinterpret_cast<const char*>(*stack_buf),
@@ -410,9 +414,13 @@ size_t StringBytes::Write(Isolate* isolate,
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
           nbytes = base64_decode(buf, buflen, ext->data(), ext->length());
         }
-      } else if(str->IsOneByte()) {
+      } else if (str->IsOneByte()) {
         MaybeStackBuffer<uint8_t> stack_buf(str->Length());
-        str->WriteOneByte(isolate, stack_buf.out(), 0, str->Length(), String::NO_NULL_TERMINATION);
+        str->WriteOneByte(isolate,
+                          stack_buf.out(),
+                          0,
+                          str->Length(),
+                          String::NO_NULL_TERMINATION);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
             reinterpret_cast<const char*>(*stack_buf),


### PR DESCRIPTION
> The work is mostly done by @lemire.

Suggested changes improves the performance of base64 and base64url operations.

## Benchmarks

```
                                                                                confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-base64-decode-wrapped.js n=32 linesCount=524288 charsPerLine=76        ***    196.05 %       ±2.25% ±3.03% ±4.01%
buffers/buffer-base64-decode.js size=8388608 n=32                                     ***    218.27 %       ±3.45% ±4.65% ±6.16%
buffers/buffer-base64-encode.js n=32 len=67108864                                     ***      2.95 %       ±0.67% ±0.89% ±1.16%
buffers/buffer-base64url-decode.js size=8388608 n=32                                  ***    218.32 %       ±4.34% ±5.84% ±7.74%
buffers/buffer-base64url-encode.js n=32 len=67108864                                  ***    246.27 %       ±2.68% ±3.61% ±4.79%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 5 comparisons, you can thus expect the following amount of false-positive results:
  0.25 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.05 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```