### PR TITLE
test: simplify ASan build checks

### DIFF
--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -45,7 +45,6 @@ jobs:
       CXX: clang++
       LINK: clang++
       CONFIG_FLAGS: --enable-asan
-      ASAN: true
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -128,7 +128,7 @@ const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isOSX = process.platform === 'darwin';
-const isAsan = process.config.variables.asan === 1;
+const isASan = process.config.variables.asan === 1;
 const isPi = (() => {
   try {
     // Normal Raspberry Pi detection is to find the `Raspberry Pi` string in
@@ -965,7 +965,7 @@ const common = {
   hasMultiLocalhost,
   invalidArgTypeHelper,
   isAlive,
-  isAsan,
+  isASan,
   isDumbTerminal,
   isFreeBSD,
   isLinux,

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -128,7 +128,7 @@ const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isOSX = process.platform === 'darwin';
-const isAsan = process.env.ASAN !== undefined;
+const isAsan = process.config.variables.asan === 1;
 const isPi = (() => {
   try {
     // Normal Raspberry Pi detection is to find the `Raspberry Pi` string in

--- a/test/parallel/test-crypto-dh-leak.js
+++ b/test/parallel/test-crypto-dh-leak.js
@@ -4,8 +4,8 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-if (process.config.variables.asan)
-  common.skip('ASAN messes with memory measurements');
+if (common.isAsan)
+  common.skip('ASan messes with memory measurements');
 
 const assert = require('assert');
 const crypto = require('crypto');

--- a/test/parallel/test-crypto-dh-leak.js
+++ b/test/parallel/test-crypto-dh-leak.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-if (common.isAsan)
+if (common.isASan)
   common.skip('ASan messes with memory measurements');
 
 const assert = require('assert');

--- a/test/parallel/test-crypto-secure-heap.js
+++ b/test/parallel/test-crypto-secure-heap.js
@@ -7,8 +7,8 @@ if (!common.hasCrypto)
 if (common.isWindows)
   common.skip('Not supported on Windows');
 
-if (process.config.variables.asan)
-  common.skip('ASAN does not play well with secure heap allocations');
+if (common.isAsan)
+  common.skip('ASan does not play well with secure heap allocations');
 
 const assert = require('assert');
 const { fork } = require('child_process');

--- a/test/parallel/test-crypto-secure-heap.js
+++ b/test/parallel/test-crypto-secure-heap.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 if (common.isWindows)
   common.skip('Not supported on Windows');
 
-if (common.isAsan)
+if (common.isASan)
   common.skip('ASan does not play well with secure heap allocations');
 
 const assert = require('assert');

--- a/test/parallel/test-strace-openat-openssl.js
+++ b/test/parallel/test-strace-openat-openssl.js
@@ -9,7 +9,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 if (!common.isLinux)
   common.skip('linux only');
-if (common.isAsan)
+if (common.isASan)
   common.skip('strace does not work well with address sanitizer builds');
 if (spawnSync('strace').error !== undefined) {
   common.skip('missing strace');

--- a/test/parallel/test-v8-serialize-leak.js
+++ b/test/parallel/test-v8-serialize-leak.js
@@ -18,7 +18,7 @@ for (let i = 0; i < 1000000; i++) {
 async function main() {
   await common.gcUntil('RSS should go down', () => {
     const after = process.memoryUsage.rss();
-    if (common.isAsan) {
+    if (common.isASan) {
       console.log(`ASan: before=${before} after=${after}`);
       return after < before * 10;
     } else if (process.config.variables.node_builtin_modules_path) {

--- a/test/parallel/test-v8-serialize-leak.js
+++ b/test/parallel/test-v8-serialize-leak.js
@@ -18,8 +18,8 @@ for (let i = 0; i < 1000000; i++) {
 async function main() {
   await common.gcUntil('RSS should go down', () => {
     const after = process.memoryUsage.rss();
-    if (process.config.variables.asan) {
-      console.log(`asan: before=${before} after=${after}`);
+    if (common.isAsan) {
+      console.log(`ASan: before=${before} after=${after}`);
       return after < before * 10;
     } else if (process.config.variables.node_builtin_modules_path) {
       console.log(`node_builtin_modules_path: before=${before} after=${after}`);

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -24,8 +24,8 @@
 
 const common = require('../common');
 
-if (process.config.variables.asan) {
-  common.skip('ASAN messes with memory measurements');
+if (common.isAsan) {
+  common.skip('ASan messes with memory measurements');
 }
 
 const assert = require('assert');

--- a/test/pummel/test-vm-memleak.js
+++ b/test/pummel/test-vm-memleak.js
@@ -24,7 +24,7 @@
 
 const common = require('../common');
 
-if (common.isAsan) {
+if (common.isASan) {
   common.skip('ASan messes with memory measurements');
 }
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -1588,8 +1588,9 @@ def get_env_type(vm, options_type, context):
   return env_type
 
 
-def get_asan_state():
-  return "on" if os.environ.get('ASAN') is not None else "off"
+def get_asan_state(vm, context):
+  asan = Execute([vm, '-p', 'process.config.variables.asan'], context).stdout
+  return "on" if asan == "1" else "off"
 
 
 def Main():
@@ -1684,7 +1685,7 @@ def Main():
           'system': utils.GuessOS(),
           'arch': vmArch,
           'type': get_env_type(vm, options.type, context),
-          'asan': get_asan_state(),
+          'asan': get_asan_state(vm, context),
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list


### PR DESCRIPTION
Always use `process.config.variables.asan`.
This removes the need for a special ASAN env var.
