### PR TITLE
test: fix test-tls-ticket-cluster.js

### DIFF
--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -46,7 +46,9 @@ if (cluster.isPrimary) {
       session: lastSession,
       rejectUnauthorized: false
     }, () => {
-      c.end();
+      c.on('end', () => {
+        c.end();
+      });
     }).on('close', () => {
       // Wait for close to shoot off another connection. We don't want to shoot
       // until a new session is allocated, if one will be. The new session is


### PR DESCRIPTION
### Problem
I've investigated the related issue in depth and found out that this test sometimes fails because of the handshake process. When the error happens and I look at the Wireshark logs, I see that the client doesn't send a `Change Cipher Spec` packet, but instead sends a `FIN` packet after a while. The `FIN` packet is sent in approximately 10ms. This may be some timeout, but I wasn't able to find proof for that.

I've added 2 screenshots from the Wireshark logs (which I can provide too if requested). The first one shows the expected packet flow when the test passes, and the second one shows the packet flow when the test fails.
#### Pass:
![2510_log2](https://github.com/JaneaSystems/node-private/assets/110401522/12acb331-2963-4496-b68d-e76442eacc98)
#### Failure:
![2510_log1](https://github.com/JaneaSystems/node-private/assets/110401522/6bfce8c4-71ae-40f1-942d-3503add98959)

As can be seen, the `Change Cipher Spec` packet was missing, and the `FIN` packet had already been sent before the handshake was complete.

I've seen discussions about the issues in the handshake process of Node.js in the following links: https://github.com/openssl/openssl/issues/8069, https://github.com/openssl/openssl/issues/7199, https://github.com/nodejs/node/issues/18770. 

As I don't have in-depth knowledge about OpenSSL, I'm not sure if this issue is caused by the way OpenSSL is used by Node. If there is a need to investigate it, a new issue can be opened.

### Fix
In this PR, I’ve made the `Primary` (client) wait for the `FIN` packet from the `Worker` (server) to close the connection. This approach ensures that the `Primary` waits until it receives a `FIN` packet from the `Worker` and doesn’t time out during the handshake. I've run the test with the fix roughly 11k times and it hasn't failed once. Without the fix, I would usually get a failure with 1k runs easily.

Fixes: https://github.com/nodejs/node/issues/2510