### PR TITLE
Use StringPrototypeStartsWith instead of .startsWith

### DIFF
--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -6,7 +6,7 @@ const {
 } = internalBinding('options');
 
 const {
-  StringPrototypeStartsWith
+  StringPrototypeStartsWith,
 } = primordials;
 
 let warnOnAllowUnauthorized = true;

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -5,6 +5,10 @@ const {
   getEmbedderOptions: getEmbedderOptionsFromBinding,
 } = internalBinding('options');
 
+const {
+  StringPrototypeStartsWith
+} = primordials;
+
 let warnOnAllowUnauthorized = true;
 
 let optionsMap;
@@ -43,7 +47,7 @@ function refreshOptions() {
 
 function getOptionValue(optionName) {
   const options = getCLIOptionsFromBinding();
-  if (optionName.startsWith('--no-')) {
+  if (StringPrototypeStartsWith(optionName, '--no-')) {
     const option = options.get('--' + optionName.slice(5));
     return option && !option.value;
   }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR changes the `getOptionValue` function to use a primordial (`StringPrototypeStartsWith`) instead of `.startsWith`. While this does not present a security issue at the current point, it may show one in the future.

With this change, the `getOptionValue` function cannot be overwritten during runtime.