### PR TITLE
src: fix loadEnvFile ENOENT error

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -492,7 +492,7 @@ static void LoadEnvFile(const v8::FunctionCallbackInfo<v8::Value>& args) {
       break;
     }
     case dotenv.ParseResult::FileError: {
-      env->ThrowUVException(UV_ENOENT, "Failed to load '%s'.", path.c_str());
+      env->ThrowUVException(UV_ENOENT, "open", nullptr, path.c_str());
       break;
     }
     default:

--- a/test/parallel/test-process-load-env-file.js
+++ b/test/parallel/test-process-load-env-file.js
@@ -45,13 +45,13 @@ describe('process.loadEnvFile()', () => {
   it('should throw when file does not exist', async () => {
     assert.throws(() => {
       process.loadEnvFile(missingEnvFile);
-    }, { code: 'ENOENT' });
+    }, { code: 'ENOENT', syscall: 'open', path: missingEnvFile });
   });
 
   it('should throw when `.env` does not exist', async () => {
     assert.throws(() => {
       process.loadEnvFile();
-    }, { code: 'ENOENT' });
+    }, { code: 'ENOENT', syscall: 'open', path: '.env' });
   });
 
   it('should check for permissions', async () => {


### PR DESCRIPTION
Before this change the error message for `process.loadEnvFile()` without an `.env` file present in the current working directory was looking like this: `ENOENT: .env, Failed to load '%s'.` This obviously isn't what the author intended.

To fix that, just return a "plain" ENOENT open error. It should be descriptive enough. That means for the above example, the error message is now `ENOENT: no such file or directory, open '.env'`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
