### PR TITLE
buffer: even faster atob

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1233,29 +1233,27 @@ static void Atob(const FunctionCallbackInfo<Value>& args) {
     buffer.SetLength(expected_length);
     result = simdutf::base64_to_binary(
         ext->data(), ext->length(), buffer.out(), simdutf::base64_default);
-  } else if(input->IsOneByte()) {  
+  } else if (input->IsOneByte()) {
     MaybeStackBuffer<uint8_t> stack_buf(input->Length());
     input->WriteOneByte(args.GetIsolate(),
-                      stack_buf.out(),
-                      0,
-                      input->Length(),
-                      String::NO_NULL_TERMINATION);
+                        stack_buf.out(),
+                        0,
+                        input->Length(),
+                        String::NO_NULL_TERMINATION);
     const char* data = reinterpret_cast<const char*>(*stack_buf);
     size_t expected_length =
         simdutf::maximal_binary_length_from_base64(data, input->Length());
     buffer.AllocateSufficientStorage(expected_length);
     buffer.SetLength(expected_length);
-    result = simdutf::base64_to_binary(
-        data, input->Length(), buffer.out());
-  } else { // 16-bit case
+    result = simdutf::base64_to_binary(data, input->Length(), buffer.out());
+  } else {  // 16-bit case
     String::Value value(env->isolate(), input);
     auto data = reinterpret_cast<const char16_t*>(*value);
     size_t expected_length =
         simdutf::maximal_binary_length_from_base64(data, value.length());
     buffer.AllocateSufficientStorage(expected_length);
     buffer.SetLength(expected_length);
-    result = simdutf::base64_to_binary(
-        data, value.length(), buffer.out());
+    result = simdutf::base64_to_binary(data, value.length(), buffer.out());
   }
 
   if (result.error == simdutf::error_code::SUCCESS) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1229,19 +1229,33 @@ static void Atob(const FunctionCallbackInfo<Value>& args) {
     auto ext = input->GetExternalOneByteStringResource();
     size_t expected_length =
         simdutf::maximal_binary_length_from_base64(ext->data(), ext->length());
-    buffer.AllocateSufficientStorage(expected_length + 1);
-    buffer.SetLengthAndZeroTerminate(expected_length);
+    buffer.AllocateSufficientStorage(expected_length);
+    buffer.SetLength(expected_length);
     result = simdutf::base64_to_binary(
         ext->data(), ext->length(), buffer.out(), simdutf::base64_default);
-  } else {  // 16-bit case
+  } else if(input->IsOneByte()) {  
+    MaybeStackBuffer<uint8_t> stack_buf(input->Length());
+    input->WriteOneByte(args.GetIsolate(),
+                      stack_buf.out(),
+                      0,
+                      input->Length(),
+                      String::NO_NULL_TERMINATION);
+    const char* data = reinterpret_cast<const char*>(*stack_buf);
+    size_t expected_length =
+        simdutf::maximal_binary_length_from_base64(data, input->Length());
+    buffer.AllocateSufficientStorage(expected_length);
+    buffer.SetLength(expected_length);
+    result = simdutf::base64_to_binary(
+        data, input->Length(), buffer.out());
+  } else { // 16-bit case
     String::Value value(env->isolate(), input);
     auto data = reinterpret_cast<const char16_t*>(*value);
     size_t expected_length =
         simdutf::maximal_binary_length_from_base64(data, value.length());
-    buffer.AllocateSufficientStorage(expected_length + 1);
-    buffer.SetLengthAndZeroTerminate(expected_length);
+    buffer.AllocateSufficientStorage(expected_length);
+    buffer.SetLength(expected_length);
     result = simdutf::base64_to_binary(
-        data, value.length(), buffer.out(), simdutf::base64_default);
+        data, value.length(), buffer.out());
   }
 
   if (result.error == simdutf::error_code::SUCCESS) {


### PR DESCRIPTION
Improves atob slightly more by adding a special case (one-byte non-external): this avoids the overhead of copying the string to 16-bit units. The gains are over 25% on a server with an Intel Ice Lake processor, GCC 12. I expect that gains of the same order will be observed generally.

This is a follow-up to https://github.com/nodejs/node/pull/52381 by @anonrig 

And yes, I am aware that the use of `atob` is discouraged but these performance gains are expected to be basically free.

```
                                          confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-atob.js n=1000000 size=128        ***     26.48 %       ±1.52% ±2.10% ±2.91%
buffers/buffer-atob.js n=1000000 size=16         ***     35.41 %       ±0.53% ±0.75% ±1.06%
buffers/buffer-atob.js n=1000000 size=32         ***     32.09 %       ±1.04% ±1.45% ±2.03%
buffers/buffer-atob.js n=1000000 size=64         ***     31.39 %       ±0.54% ±0.75% ±1.03%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 4 comparisons, you can thus expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```