### PR TITLE
lib, url: Use primordials in URL

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -22,10 +22,21 @@
 'use strict';
 
 const {
+  ArrayPrototypeJoin,
+  ArrayPrototypeShift,
+  ArrayPrototypeUnshift,
   Boolean,
   Int8Array,
   ObjectKeys,
   StringPrototypeCharCodeAt,
+  StringPrototypeIndexOf,
+  StringPrototypeIncludes,
+  StringPrototypeSplit,
+  StringPrototypeSlice,
+  StringPrototypeToLowerCase,
+  StringPrototypeSubstring,
+  RegExpPrototypeExec,
+  RegExpPrototypeTest,
   decodeURIComponent,
 } = primordials;
 
@@ -179,7 +190,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   let rest = '';
   let lastPos = 0;
   for (let i = 0, inWs = false, split = false; i < url.length; ++i) {
-    const code = url.charCodeAt(i);
+    const code = StringPrototypeCharCodeAt(url, i);
 
     // Find first and last non-whitespace characters for trimming
     const isWs = code < 33 ||
@@ -213,7 +224,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
           break;
         case CHAR_BACKWARD_SLASH:
           if (i - lastPos > 0)
-            rest += url.slice(lastPos, i);
+            rest += StringPrototypeSlice(url, lastPos, i);
           rest += '/';
           lastPos = i + 1;
           break;
@@ -232,22 +243,22 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         if (start === 0)
           rest = url;
         else
-          rest = url.slice(start);
+          rest = StringPrototypeSlice(url, start);
       } else {
-        rest = url.slice(start, end);
+        rest = StringPrototypeSlice(url, start, end);
       }
     } else if (end === -1 && lastPos < url.length) {
       // We converted some backslashes and have only part of the entire string
-      rest += url.slice(lastPos);
+      rest += StringPrototypeSlice(url, lastPos);
     } else if (end !== -1 && lastPos < end) {
       // We converted some backslashes and have only part of the entire string
-      rest += url.slice(lastPos, end);
+      rest += StringPrototypeSlice(url, lastPos, end);
     }
   }
 
   if (!slashesDenoteHost && !hasHash && !hasAt) {
     // Try fast path regexp
-    const simplePath = simplePathPattern.exec(rest);
+    const simplePath = RegExpPrototypeExec(simplePathPattern, rest);
     if (simplePath) {
       this.path = rest;
       this.href = rest;
@@ -255,9 +266,9 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search.slice(1));
+          this.query = querystring.parse(StringPrototypeSlice(this.search, 1));
         } else {
-          this.query = this.search.slice(1);
+          this.query = StringPrototypeSlice(this.search, 1);
         }
       } else if (parseQueryString) {
         this.search = null;
@@ -267,13 +278,13 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     }
   }
 
-  let proto = protocolPattern.exec(rest);
+  let proto = RegExpPrototypeExec(protocolPattern, rest);
   let lowerProto;
   if (proto) {
     proto = proto[0];
-    lowerProto = proto.toLowerCase();
+    lowerProto = StringPrototypeToLowerCase(proto);
     this.protocol = lowerProto;
-    rest = rest.slice(proto.length);
+    rest = StringPrototypeSlice(rest, proto.length);
   }
 
   // Figure out if it's got a host
@@ -281,11 +292,11 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   // resolution will treat //foo/bar as host=foo,path=bar because that's
   // how the browser resolves relative URLs.
   let slashes;
-  if (slashesDenoteHost || proto || hostPattern.test(rest)) {
-    slashes = rest.charCodeAt(0) === CHAR_FORWARD_SLASH &&
-              rest.charCodeAt(1) === CHAR_FORWARD_SLASH;
+  if (slashesDenoteHost || proto || RegExpPrototypeTest(hostPattern, rest)) {
+    slashes = StringPrototypeCharCodeAt(rest, 0) === CHAR_FORWARD_SLASH &&
+              StringPrototypeCharCodeAt(rest, 1) === CHAR_FORWARD_SLASH;
     if (slashes && !(proto && hostlessProtocol.has(lowerProto))) {
-      rest = rest.slice(2);
+      rest = StringPrototypeSlice(rest, 2);
       this.slashes = true;
     }
   }
@@ -309,12 +320,12 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     let atSign = -1;
     let nonHost = -1;
     for (let i = 0; i < rest.length; ++i) {
-      switch (rest.charCodeAt(i)) {
+      switch (StringPrototypeCharCodeAt(rest, i)) {
         case CHAR_TAB:
         case CHAR_LINE_FEED:
         case CHAR_CARRIAGE_RETURN:
           // WHATWG URL removes tabs, newlines, and carriage returns. Let's do that too.
-          rest = rest.slice(0, i) + rest.slice(i + 1);
+          rest = StringPrototypeSlice(rest, 0, 1) + StringPrototypeSlice(rest, i + 1);
           i -= 1;
           break;
         case CHAR_SPACE:
@@ -354,15 +365,15 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     }
     start = 0;
     if (atSign !== -1) {
-      this.auth = decodeURIComponent(rest.slice(0, atSign));
+      this.auth = decodeURIComponent(StringPrototypeSlice(rest, 0, atSign));
       start = atSign + 1;
     }
     if (nonHost === -1) {
-      this.host = rest.slice(start);
+      this.host = StringPrototypeSlice(rest, start);
       rest = '';
     } else {
-      this.host = rest.slice(start, nonHost);
-      rest = rest.slice(nonHost);
+      this.host = StringPrototypeSlice(rest, start, nonHost);
+      rest = StringPrototypeSlice(rest, nonHost);
     }
 
     // pull out port.
@@ -388,12 +399,12 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
       this.hostname = '';
     } else {
       // Hostnames are always lower case.
-      this.hostname = this.hostname.toLowerCase();
+      this.hostname = StringPrototypeToLowerCase(this.hostname);
     }
 
     if (this.hostname !== '') {
       if (ipv6Hostname) {
-        if (forbiddenHostCharsIpv6.test(this.hostname)) {
+        if (RegExpPrototypeTest(forbiddenHostCharsIpv6, this.hostname)) {
           throw new ERR_INVALID_URL(url);
         }
       } else {
@@ -412,7 +423,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
         // Rather than trying to correct this by moving the non-host part into
         // the pathname as we've done in getHostname, throw an exception to
         // convey the severity of this issue.
-        if (this.hostname === '' || forbiddenHostChars.test(this.hostname)) {
+        if (this.hostname === '' || RegExpPrototypeTest(forbiddenHostChars, this.hostname)) {
           throw new ERR_INVALID_URL(url);
         }
       }
@@ -425,7 +436,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     // strip [ and ] from the hostname
     // the host field still retains them, though
     if (ipv6Hostname) {
-      this.hostname = this.hostname.slice(1, -1);
+      this.hostname = StringPrototypeSlice(this.hostname, 1, -1);
       if (rest[0] !== '/') {
         rest = '/' + rest;
       }
@@ -444,9 +455,9 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   let questionIdx = -1;
   let hashIdx = -1;
   for (let i = 0; i < rest.length; ++i) {
-    const code = rest.charCodeAt(i);
+    const code = StringPrototypeCharCodeAt(rest, i);
     if (code === CHAR_HASH) {
-      this.hash = rest.slice(i);
+      this.hash = StringPrototypeSlice(rest, i);
       hashIdx = i;
       break;
     } else if (code === CHAR_QUESTION_MARK && questionIdx === -1) {
@@ -456,11 +467,11 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
 
   if (questionIdx !== -1) {
     if (hashIdx === -1) {
-      this.search = rest.slice(questionIdx);
-      this.query = rest.slice(questionIdx + 1);
+      this.search = StringPrototypeSlice(rest, questionIdx);
+      this.query = StringPrototypeSlice(rest, questionIdx + 1);
     } else {
-      this.search = rest.slice(questionIdx, hashIdx);
-      this.query = rest.slice(questionIdx + 1, hashIdx);
+      this.search = StringPrototypeSlice(rest, questionIdx, hashIdx);
+      this.query = StringPrototypeSlice(rest, questionIdx + 1, hashIdx);
     }
     if (parseQueryString) {
       this.query = querystring.parse(this.query);
@@ -478,7 +489,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
     if (rest.length > 0)
       this.pathname = rest;
   } else if (firstIdx > 0) {
-    this.pathname = rest.slice(0, firstIdx);
+    this.pathname = StringPrototypeSlice(rest, 0, firstIdx);
   }
   if (slashedProtocol.has(lowerProto) &&
       this.hostname && !this.pathname) {
@@ -500,7 +511,7 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
 let warnInvalidPort = true;
 function getHostname(self, rest, hostname, url) {
   for (let i = 0; i < hostname.length; ++i) {
-    const code = hostname.charCodeAt(i);
+    const code = StringPrototypeCharCodeAt(hostname, i);
     const isValid = (code !== CHAR_FORWARD_SLASH &&
                      code !== CHAR_BACKWARD_SLASH &&
                      code !== CHAR_HASH &&
@@ -516,8 +527,8 @@ function getHostname(self, rest, hostname, url) {
         process.emitWarning(detail, 'DeprecationWarning', 'DEP0170');
         warnInvalidPort = false;
       }
-      self.hostname = hostname.slice(0, i);
-      return `/${hostname.slice(i)}${rest}`;
+      self.hostname = StringPrototypeSlice(hostname, 0, i);
+      return `/${StringPrototypeSlice(hostname, i)}${rest}`;
     }
   }
   return rest;
@@ -549,11 +560,11 @@ function autoEscapeStr(rest) {
   let lastEscapedPos = 0;
   for (let i = 0; i < rest.length; ++i) {
     // `escaped` contains substring up to the last escaped character.
-    const escapedChar = escapedCodes[rest.charCodeAt(i)];
+    const escapedChar = escapedCodes[StringPrototypeCharCodeAt(rest, i)];
     if (escapedChar) {
       // Concat if there are ordinary characters in the middle.
       if (i > lastEscapedPos)
-        escaped += rest.slice(lastEscapedPos, i);
+        escaped += StringPrototypeSlice(rest, lastEscapedPos, i);
       escaped += escapedChar;
       lastEscapedPos = i + 1;
     }
@@ -563,7 +574,7 @@ function autoEscapeStr(rest) {
 
   // There are ordinary characters at the end.
   if (lastEscapedPos < rest.length)
-    escaped += rest.slice(lastEscapedPos);
+    escaped += StringPrototypeSlice(rest, lastEscapedPos);
 
   return escaped;
 }
@@ -589,19 +600,19 @@ function urlFormat(urlObject, options) {
       validateObject(options, 'options');
 
       if (options.fragment != null) {
-        fragment = Boolean(options.fragment);
+        fragment = !!options.fragment;
       }
 
       if (options.unicode != null) {
-        unicode = Boolean(options.unicode);
+        unicode = !!options.unicode;
       }
 
       if (options.search != null) {
-        search = Boolean(options.search);
+        search = !!options.search;
       }
 
       if (options.auth != null) {
-        auth = Boolean(options.auth);
+        auth = !!options.auth;
       }
     }
 
@@ -645,7 +656,7 @@ Url.prototype.format = function format() {
     host = auth + this.host;
   } else if (this.hostname) {
     host = auth + (
-      this.hostname.includes(':') && !isIpv6Hostname(this.hostname) ?
+      StringPrototypeIncludes(this.hostname, ':') && !isIpv6Hostname(this.hostname) ?
         '[' + this.hostname + ']' :
         this.hostname
     );
@@ -660,22 +671,22 @@ Url.prototype.format = function format() {
 
   let search = this.search || (query && ('?' + query)) || '';
 
-  if (protocol && protocol.charCodeAt(protocol.length - 1) !== 58/* : */)
+  if (protocol && StringPrototypeCharCodeAt(protocol, protocol.length - 1) !== 58/* : */)
     protocol += ':';
 
   let newPathname = '';
   let lastPos = 0;
   for (let i = 0; i < pathname.length; ++i) {
-    switch (pathname.charCodeAt(i)) {
+    switch (StringPrototypeCharCodeAt(pathname, i)) {
       case CHAR_HASH:
         if (i - lastPos > 0)
-          newPathname += pathname.slice(lastPos, i);
+          newPathname += StringPrototypeSlice(pathname, lastPos, i);
         newPathname += '%23';
         lastPos = i + 1;
         break;
       case CHAR_QUESTION_MARK:
         if (i - lastPos > 0)
-          newPathname += pathname.slice(lastPos, i);
+          newPathname += StringPrototypeSlice(pathname, lastPos, i);
         newPathname += '%3F';
         lastPos = i + 1;
         break;
@@ -683,7 +694,7 @@ Url.prototype.format = function format() {
   }
   if (lastPos > 0) {
     if (lastPos !== pathname.length)
-      pathname = newPathname + pathname.slice(lastPos);
+      pathname = newPathname + StringPrototypeSlice(pathname, lastPos);
     else
       pathname = newPathname;
   }
@@ -692,23 +703,23 @@ Url.prototype.format = function format() {
   // unless they had them to begin with.
   if (this.slashes || slashedProtocol.has(protocol)) {
     if (this.slashes || host) {
-      if (pathname && pathname.charCodeAt(0) !== CHAR_FORWARD_SLASH)
+      if (pathname && StringPrototypeCharCodeAt(pathname, 0) !== CHAR_FORWARD_SLASH)
         pathname = '/' + pathname;
       host = '//' + host;
     } else if (protocol.length >= 4 &&
-               protocol.charCodeAt(0) === 102/* f */ &&
-               protocol.charCodeAt(1) === 105/* i */ &&
-               protocol.charCodeAt(2) === 108/* l */ &&
-               protocol.charCodeAt(3) === 101/* e */) {
+               StringPrototypeCharCodeAt(protocol, 0) === 102/* f */ &&
+               StringPrototypeCharCodeAt(protocol, 1) === 105/* i */ &&
+               StringPrototypeCharCodeAt(pathname, 2) === 108/* l */ &&
+               StringPrototypeCharCodeAt(pathname, 3) === 101/* e */) {
       host = '//';
     }
   }
 
   search = search.replace(/#/g, '%23');
 
-  if (hash && hash.charCodeAt(0) !== CHAR_HASH)
+  if (hash && StringPrototypeCharCodeAt(hash, 0) !== CHAR_HASH)
     hash = '#' + hash;
-  if (search && search.charCodeAt(0) !== CHAR_QUESTION_MARK)
+  if (search && StringPrototypeCharCodeAt(hash, 0) !== CHAR_QUESTION_MARK)
     search = '?' + search;
 
   return protocol + host + pathname + search + hash;
@@ -792,15 +803,15 @@ Url.prototype.resolveObject = function resolveObject(relative) {
 
     result.protocol = relative.protocol;
     if (!relative.host &&
-        !/^file:?$/.test(relative.protocol) &&
+        !RegExpPrototypeTest(/^file:?$/, relative.protocol) &&
         !hostlessProtocol.has(relative.protocol)) {
-      const relPath = (relative.pathname || '').split('/');
-      while (relPath.length && !(relative.host = relPath.shift()));
+      const relPath = ArrayPrototypeSplit(relative.pathname || '', '/');
+      while (relPath.length && !(relative.host = ArrayPrototypeShift(relPath)));
       if (!relative.host) relative.host = '';
       if (!relative.hostname) relative.hostname = '';
-      if (relPath[0] !== '') relPath.unshift('');
-      if (relPath.length < 2) relPath.unshift('');
-      result.pathname = relPath.join('/');
+      if (relPath[0] !== '') ArrayPrototypeUnshift(relpath, '');
+      if (relPath.length < 2) ArrayPrototypeUnshift(relpath, '');
+      result.pathname = ArrayPrototypeJoin(relPath, '/');
     } else {
       result.pathname = relative.pathname;
     }
@@ -821,15 +832,15 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     return result;
   }
 
-  const isSourceAbs = (result.pathname && result.pathname.charAt(0) === '/');
+  const isSourceAbs = (result.pathname && result.pathname[0] === '/');
   const isRelAbs = (
-    relative.host || (relative.pathname && relative.pathname.charAt(0) === '/')
+    relative.host || (relative.pathname && relative.pathname[0] === '/')
   );
   let mustEndAbs = (isRelAbs || isSourceAbs ||
                     (result.host && relative.pathname));
   const removeAllDots = mustEndAbs;
-  let srcPath = (result.pathname && result.pathname.split('/')) || [];
-  const relPath = (relative.pathname && relative.pathname.split('/')) || [];
+  let srcPath = (result.pathname && StringPrototypeSplit(result.pathname, '/')) || [];
+  const relPath = (relative.pathname && StringPrototypeSplit(relative.pathname, '/')) || [];
   const noLeadingSlashes = result.protocol &&
       !slashedProtocol.has(result.protocol);
 
@@ -843,7 +854,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     result.port = null;
     if (result.host) {
       if (srcPath[0] === '') srcPath[0] = result.host;
-      else srcPath.unshift(result.host);
+      else ArrayPrototypeUnshift(srcPath, result.host);
     }
     result.host = '';
     if (relative.protocol) {
@@ -852,7 +863,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
       result.auth = null;
       if (relative.host) {
         if (relPath[0] === '') relPath[0] = relative.host;
-        else relPath.unshift(relative.host);
+        else ArrayPrototypeUnshift(relPath, relative.host);
       }
       relative.host = null;
     }
@@ -887,15 +898,15 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     // like href='?foo'.
     // Put this after the other two cases because it simplifies the booleans
     if (noLeadingSlashes) {
-      result.hostname = result.host = srcPath.shift();
+      result.hostname = result.host = ArrayPrototypeShift(srcPath);
       // Occasionally the auth can get stuck only in host.
       // This especially happens in cases like
       // url.resolveObject('mailto:local1@domain1', 'local2@domain2')
       const authInHost =
-        result.host && result.host.indexOf('@') > 0 && result.host.split('@');
+        result.host && StringPrototypeIndexOf(result.host, '@') > 0 && StringPrototypeSplit(result.host, '@');
       if (authInHost) {
-        result.auth = authInHost.shift();
-        result.host = result.hostname = authInHost.shift();
+        result.auth = ArrayPrototypeShift(authInHost);
+        result.host = result.hostname = ArrayPrototypeShift(authInHost);
       }
     }
     result.search = relative.search;
@@ -925,7 +936,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // If a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
-  let last = srcPath.slice(-1)[0];
+  let last = StringPrototypeSlice(srcPath, -1)[0];
   const hasTrailingSlash = (
     ((result.host || relative.host || srcPath.length > 1) &&
     (last === '.' || last === '..')) || last === '');
@@ -949,48 +960,48 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // If the path is allowed to go above the root, restore leading ..s
   if (!mustEndAbs && !removeAllDots) {
     while (up--) {
-      srcPath.unshift('..');
+      ArrayPrototypeUnshift(srcPath, '..');
     }
   }
 
   if (mustEndAbs && srcPath[0] !== '' &&
-      (!srcPath[0] || srcPath[0].charAt(0) !== '/')) {
-    srcPath.unshift('');
+      (!srcPath[0] || srcPath[0][0] !== '/')) {
+    ArrayPrototypeUnshift(srcPath, '');
   }
 
-  if (hasTrailingSlash && (srcPath.join('/').substr(-1) !== '/')) {
+  if (hasTrailingSlash && StringPrototypeSubstring(ArrayPrototypeJoin(srcPath, '/'), -1) !== '/')) {
     srcPath.push('');
   }
 
   const isAbsolute = srcPath[0] === '' ||
-      (srcPath[0] && srcPath[0].charAt(0) === '/');
+      (srcPath[0] && srcPath[0][0] === '/');
 
   // put the host back
   if (noLeadingSlashes) {
     result.hostname =
-      result.host = isAbsolute ? '' : srcPath.length ? srcPath.shift() : '';
+      result.host = isAbsolute ? '' : srcPath.length ? ArrayPrototypeShift(srcPath) : '';
     // Occasionally the auth can get stuck only in host.
     // This especially happens in cases like
     // url.resolveObject('mailto:local1@domain1', 'local2@domain2')
-    const authInHost = result.host && result.host.indexOf('@') > 0 ?
-      result.host.split('@') : false;
+    const authInHost = result.host && StringPrototypeIndexOf(result.host, '@') > 0 ?
+      StringPrototypeSplit(result.host, '@') : false;
     if (authInHost) {
-      result.auth = authInHost.shift();
-      result.host = result.hostname = authInHost.shift();
+      result.auth = ArrayPrototypeShift(authInHost);
+      result.host = result.hostname = ArrayPrototypeShift(authInHost);
     }
   }
 
   mustEndAbs = mustEndAbs || (result.host && srcPath.length);
 
   if (mustEndAbs && !isAbsolute) {
-    srcPath.unshift('');
+    ArrayPrototypeUnshift(srcPath, '');
   }
 
   if (!srcPath.length) {
     result.pathname = null;
     result.path = null;
   } else {
-    result.pathname = srcPath.join('/');
+    result.pathname = ArrayPrototypeJoin(srcPath, '/');
   }
 
   // To support request.http
@@ -1006,13 +1017,13 @@ Url.prototype.resolveObject = function resolveObject(relative) {
 
 Url.prototype.parseHost = function parseHost() {
   let host = this.host;
-  let port = portPattern.exec(host);
+  let port = RegExpPrototypeExec(portPattern, host);
   if (port) {
     port = port[0];
     if (port !== ':') {
-      this.port = port.slice(1);
+      this.port = StringPrototypeSlice(port, 1);
     }
-    host = host.slice(0, host.length - port.length);
+    host = StringPrototypeSlice(host, 0, host.length - port.length);
   }
   if (host) this.hostname = host;
 };


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR uses primordials in the `URL` class in place of the previous implementation. This will probably have some performance problems, but it is much safer in regards to prototype pollution (and similar) exploits.