### PR TITLE
src: reduce unnecessary serialization of CLI options in C++

### DIFF
--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -24,6 +24,8 @@ const {
   markBootstrapComplete,
 } = require('internal/process/pre_execution');
 
+const { getCLIOptionsInfo, getOptionValue } = require('internal/options');
+
 const typeLookup = [];
 for (const key of ObjectKeys(types))
   typeLookup[types[key]] = key;
@@ -134,9 +136,10 @@ function format(
   );
 
   for (const {
-    0: name, 1: { helpText, type, value, defaultIsTrue },
+    0: name, 1: { helpText, type, defaultIsTrue },
   } of sortedOptions) {
     if (!helpText) continue;
+    const value = getOptionValue(name);
 
     let displayName = name;
 
@@ -198,7 +201,7 @@ function format(
 }
 
 function print(stream) {
-  const { options, aliases } = require('internal/options');
+  const { options, aliases } = getCLIOptionsInfo();
 
   // Use 75 % of the available width, and at least 70 characters.
   const width = MathMax(70, (stream.columns || 0) * 0.75);

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -1,36 +1,33 @@
 'use strict';
 
 const {
-  StringPrototypeSlice,
-} = primordials;
-
-const {
-  getCLIOptions,
+  getCLIOptionsValues,
+  getCLIOptionsInfo,
   getEmbedderOptions: getEmbedderOptionsFromBinding,
 } = internalBinding('options');
 
 let warnOnAllowUnauthorized = true;
 
-let optionsMap;
-let aliasesMap;
+let optionsDict;
+let cliInfo;
 let embedderOptions;
 
-// getCLIOptions() would serialize the option values from C++ land.
+// getCLIOptionsValues() would serialize the option values from C++ land.
 // It would error if the values are queried before bootstrap is
 // complete so that we don't accidentally include runtime-dependent
 // states into a runtime-independent snapshot.
 function getCLIOptionsFromBinding() {
-  if (!optionsMap) {
-    ({ options: optionsMap } = getCLIOptions());
+  if (!optionsDict) {
+    optionsDict = getCLIOptionsValues();
   }
-  return optionsMap;
+  return optionsDict;
 }
 
-function getAliasesFromBinding() {
-  if (!aliasesMap) {
-    ({ aliases: aliasesMap } = getCLIOptions());
+function getCLIOptionsInfoFromBinding() {
+  if (!cliInfo) {
+    cliInfo = getCLIOptionsInfo();
   }
-  return aliasesMap;
+  return cliInfo;
 }
 
 function getEmbedderOptions() {
@@ -41,24 +38,12 @@ function getEmbedderOptions() {
 }
 
 function refreshOptions() {
-  optionsMap = undefined;
-  aliasesMap = undefined;
+  optionsDict = undefined;
 }
 
 function getOptionValue(optionName) {
-  const options = getCLIOptionsFromBinding();
-  if (
-    optionName.length > 5 &&
-    optionName[0] === '-' &&
-    optionName[1] === '-' &&
-    optionName[2] === 'n' &&
-    optionName[3] === 'o' &&
-    optionName[4] === '-'
-  ) {
-    const option = options.get('--' + StringPrototypeSlice(optionName, 5));
-    return option && !option.value;
-  }
-  return options.get(optionName)?.value;
+  const optionsDict = getCLIOptionsFromBinding();
+  return optionsDict[optionName];
 }
 
 function getAllowUnauthorized() {
@@ -76,12 +61,7 @@ function getAllowUnauthorized() {
 }
 
 module.exports = {
-  get options() {
-    return getCLIOptionsFromBinding();
-  },
-  get aliases() {
-    return getAliasesFromBinding();
-  },
+  getCLIOptionsInfo: getCLIOptionsInfoFromBinding,
   getOptionValue,
   getAllowUnauthorized,
   getEmbedderOptions,

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -284,7 +284,8 @@ function buildAllowedFlags() {
     envSettings: { kAllowedInEnvvar },
     types: { kBoolean },
   } = internalBinding('options');
-  const { options, aliases } = require('internal/options');
+  const { getCLIOptionsInfo } = require('internal/options');
+  const { options, aliases } = getCLIOptionsInfo();
 
   const allowedNodeEnvironmentFlags = [];
   for (const { 0: name, 1: info } of options) {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -11,6 +11,7 @@
 #endif
 
 #include <algorithm>
+#include <array>
 #include <charconv>
 #include <limits>
 #include <sstream>
@@ -23,11 +24,12 @@ using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::Map;
+using v8::Name;
+using v8::Null;
 using v8::Number;
 using v8::Object;
 using v8::Undefined;
 using v8::Value;
-
 namespace node {
 
 namespace per_process {
@@ -1161,11 +1163,32 @@ std::string GetBashCompletion() {
   return out.str();
 }
 
+struct IterateCLIOptionsScope {
+  IterateCLIOptionsScope(Environment* env) {
+    // Temporarily act as if the current Environment's/IsolateData's options
+    // were the default options, i.e. like they are the ones we'd access for
+    // global options parsing, so that all options are available from the main
+    // parser.
+    original_per_isolate = per_process::cli_options->per_isolate;
+    per_process::cli_options->per_isolate = env->isolate_data()->options();
+    original_per_env = per_process::cli_options->per_isolate->per_env;
+    per_process::cli_options->per_isolate->per_env = env->options();
+  }
+  ~IterateCLIOptionsScope() {
+    per_process::cli_options->per_isolate->per_env = original_per_env;
+    per_process::cli_options->per_isolate = original_per_isolate;
+  }
+  std::shared_ptr<node::EnvironmentOptions> original_per_env;
+  std::shared_ptr<node::PerIsolateOptions> original_per_isolate;
+};
+
 // Return a map containing all the options and their metadata as well
 // as the aliases
-void GetCLIOptions(const FunctionCallbackInfo<Value>& args) {
-  Mutex::ScopedLock lock(per_process::cli_options_mutex);
-  Environment* env = Environment::GetCurrent(args);
+void GetCLIOptionsValues(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+
   if (!env->has_run_bootstrapping_code()) {
     // No code because this is an assertion.
     return env->ThrowError(
@@ -1173,49 +1196,49 @@ void GetCLIOptions(const FunctionCallbackInfo<Value>& args) {
   }
   env->set_has_serialized_options(true);
 
-  Isolate* isolate = env->isolate();
-  Local<Context> context = env->context();
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
+  IterateCLIOptionsScope s(env);
 
-  // Temporarily act as if the current Environment's/IsolateData's options were
-  // the default options, i.e. like they are the ones we'd access for global
-  // options parsing, so that all options are available from the main parser.
-  auto original_per_isolate = per_process::cli_options->per_isolate;
-  per_process::cli_options->per_isolate = env->isolate_data()->options();
-  auto original_per_env = per_process::cli_options->per_isolate->per_env;
-  per_process::cli_options->per_isolate->per_env = env->options();
-  auto on_scope_leave = OnScopeLeave([&]() {
-    per_process::cli_options->per_isolate->per_env = original_per_env;
-    per_process::cli_options->per_isolate = original_per_isolate;
-  });
+  std::vector<Local<Name>> option_names;
+  std::vector<Local<Value>> option_values;
+  option_names.reserve(_ppop_instance.options_.size() * 2);
+  option_values.reserve(_ppop_instance.options_.size() * 2);
 
-  Local<Map> options = Map::New(isolate);
-  if (options
-          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
-          .IsNothing()) {
-    return;
-  }
+  Local<Value> undefined_value = Undefined(isolate);
+  Local<Value> null_value = Null(isolate);
 
   for (const auto& item : _ppop_instance.options_) {
     Local<Value> value;
     const auto& option_info = item.second;
     auto field = option_info.field;
     PerProcessOptions* opts = per_process::cli_options.get();
+
     switch (option_info.type) {
       case kNoOp:
       case kV8Option:
         // Special case for --abort-on-uncaught-exception which is also
         // respected by Node.js internals
         if (item.first == "--abort-on-uncaught-exception") {
-          value = Boolean::New(
-            isolate, original_per_env->abort_on_uncaught_exception);
+          value = Boolean::New(isolate,
+                               s.original_per_env->abort_on_uncaught_exception);
         } else {
-          value = Undefined(isolate);
+          value = undefined_value;
         }
         break;
-      case kBoolean:
-        value = Boolean::New(isolate,
-                             *_ppop_instance.Lookup<bool>(field, opts));
+      case kBoolean: {
+        bool original_value = *_ppop_instance.Lookup<bool>(field, opts);
+        value = Boolean::New(isolate, original_value);
+
+        // Add --no-* entries.
+        std::string negated_name =
+            "--no" + item.first.substr(1, item.first.size());
+        Local<Value> negated_value = Boolean::New(isolate, !original_value);
+        Local<Name> negated_name_v8 =
+            ToV8Value(context, negated_name).ToLocalChecked().As<Name>();
+        option_names.push_back(negated_name_v8);
+        option_values.push_back(negated_value);
         break;
+      }
       case kInteger:
         value = Number::New(
             isolate,
@@ -1242,46 +1265,86 @@ void GetCLIOptions(const FunctionCallbackInfo<Value>& args) {
         break;
       case kHostPort: {
         const HostPort& host_port =
-          *_ppop_instance.Lookup<HostPort>(field, opts);
-        Local<Object> obj = Object::New(isolate);
+            *_ppop_instance.Lookup<HostPort>(field, opts);
         Local<Value> host;
-        if (!ToV8Value(context, host_port.host()).ToLocal(&host) ||
-            obj->Set(context, env->host_string(), host).IsNothing() ||
-            obj->Set(context,
-                     env->port_string(),
-                     Integer::New(isolate, host_port.port()))
-                .IsNothing()) {
+        if (!ToV8Value(context, host_port.host()).ToLocal(&host)) {
           return;
         }
-        value = obj;
+        constexpr size_t kHostPortLength = 2;
+        std::array<Local<Name>, kHostPortLength> names = {env->host_string(),
+                                                          env->port_string()};
+        std::array<Local<Value>, kHostPortLength> values = {
+            host, Integer::New(isolate, host_port.port())};
+        value = Object::New(
+            isolate, null_value, names.data(), values.data(), kHostPortLength);
         break;
       }
       default:
         UNREACHABLE();
     }
     CHECK(!value.IsEmpty());
+    Local<Name> name =
+        ToV8Value(context, item.first).ToLocalChecked().As<Name>();
+    option_names.push_back(name);
+    option_values.push_back(value);
+  }
 
-    Local<Value> name = ToV8Value(context, item.first).ToLocalChecked();
-    Local<Object> info = Object::New(isolate);
+  Local<Object> options = Object::New(isolate,
+                                      null_value,
+                                      option_names.data(),
+                                      option_values.data(),
+                                      option_values.size());
+  args.GetReturnValue().Set(options);
+}
+
+void GetCLIOptionsInfo(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+
+  if (!env->has_run_bootstrapping_code()) {
+    // No code because this is an assertion.
+    return env->ThrowError(
+        "Should not query options before bootstrapping is done");
+  }
+
+  Mutex::ScopedLock lock(per_process::cli_options_mutex);
+  IterateCLIOptionsScope s(env);
+
+  Local<Map> options = Map::New(isolate);
+  if (options
+          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
+          .IsNothing()) {
+    return;
+  }
+
+  Local<Value> null_value = Null(isolate);
+  for (const auto& item : _ppop_instance.options_) {
+    const auto& option_info = item.second;
+    auto field = option_info.field;
+
+    Local<Name> name =
+        ToV8Value(context, item.first).ToLocalChecked().As<Name>();
     Local<Value> help_text;
-    if (!ToV8Value(context, option_info.help_text).ToLocal(&help_text) ||
-        !info->Set(context, env->help_text_string(), help_text)
-             .FromMaybe(false) ||
-        !info->Set(context,
-                   env->env_var_settings_string(),
-                   Integer::New(isolate,
-                                static_cast<int>(option_info.env_setting)))
-             .FromMaybe(false) ||
-        !info->Set(context,
-                   env->type_string(),
-                   Integer::New(isolate, static_cast<int>(option_info.type)))
-             .FromMaybe(false) ||
-        !info->Set(context,
-                   env->default_is_true_string(),
-                   Boolean::New(isolate, option_info.default_is_true))
-             .FromMaybe(false) ||
-        info->Set(context, env->value_string(), value).IsNothing() ||
-        options->Set(context, name, info).IsEmpty()) {
+    if (!ToV8Value(context, option_info.help_text).ToLocal(&help_text)) {
+      return;
+    }
+    constexpr size_t kInfoSize = 4;
+    std::array<Local<Name>, kInfoSize> names = {
+        env->help_text_string(),
+        env->env_var_settings_string(),
+        env->type_string(),
+        env->default_is_true_string(),
+    };
+    std::array<Local<Value>, kInfoSize> values = {
+        help_text,
+        Integer::New(isolate, static_cast<int>(option_info.env_setting)),
+        Integer::New(isolate, static_cast<int>(option_info.type)),
+        Boolean::New(isolate, option_info.default_is_true),
+    };
+    Local<Object> info = Object::New(
+        isolate, null_value, names.data(), values.data(), kInfoSize);
+    if (options->Set(context, name, info).IsEmpty()) {
       return;
     }
   }
@@ -1295,12 +1358,12 @@ void GetCLIOptions(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  Local<Object> ret = Object::New(isolate);
-  if (ret->Set(context, env->options_string(), options).IsNothing() ||
-      ret->Set(context, env->aliases_string(), aliases).IsNothing()) {
-    return;
-  }
-
+  constexpr size_t kRetLength = 2;
+  std::array<Local<Name>, kRetLength> names = {env->options_string(),
+                                               env->aliases_string()};
+  std::array<Local<Value>, kRetLength> values = {options, aliases};
+  Local<Value> ret =
+      Object::New(isolate, null_value, names.data(), values.data(), kRetLength);
   args.GetReturnValue().Set(ret);
 }
 
@@ -1312,30 +1375,22 @@ void GetEmbedderOptions(const FunctionCallbackInfo<Value>& args) {
         "Should not query options before bootstrapping is done");
   }
   Isolate* isolate = args.GetIsolate();
-  Local<Context> context = env->context();
-  Local<Object> ret = Object::New(isolate);
 
-  if (ret->Set(context,
-           FIXED_ONE_BYTE_STRING(env->isolate(), "shouldNotRegisterESMLoader"),
-           Boolean::New(isolate, env->should_not_register_esm_loader()))
-      .IsNothing()) return;
+  constexpr size_t kOptionsSize = 4;
+  std::array<Local<Name>, kOptionsSize> names = {
+      FIXED_ONE_BYTE_STRING(env->isolate(), "shouldNotRegisterESMLoader"),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "noGlobalSearchPaths"),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "noBrowserGlobals"),
+      FIXED_ONE_BYTE_STRING(env->isolate(), "hasEmbedderPreload")};
 
-  if (ret->Set(context,
-           FIXED_ONE_BYTE_STRING(env->isolate(), "noGlobalSearchPaths"),
-           Boolean::New(isolate, env->no_global_search_paths()))
-      .IsNothing()) return;
+  std::array<Local<Value>, kOptionsSize> values = {
+      Boolean::New(isolate, env->should_not_register_esm_loader()),
+      Boolean::New(isolate, env->no_global_search_paths()),
+      Boolean::New(isolate, env->no_browser_globals()),
+      Boolean::New(isolate, env->embedder_preload() != nullptr)};
 
-  if (ret->Set(context,
-               FIXED_ONE_BYTE_STRING(env->isolate(), "noBrowserGlobals"),
-               Boolean::New(isolate, env->no_browser_globals()))
-          .IsNothing())
-    return;
-
-  if (ret->Set(context,
-               FIXED_ONE_BYTE_STRING(env->isolate(), "hasEmbedderPreload"),
-               Boolean::New(isolate, env->embedder_preload() != nullptr))
-          .IsNothing())
-    return;
+  Local<Object> ret = Object::New(
+      isolate, Null(isolate), names.data(), values.data(), kOptionsSize);
 
   args.GetReturnValue().Set(ret);
 }
@@ -1346,7 +1401,10 @@ void Initialize(Local<Object> target,
                 void* priv) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
-  SetMethodNoSideEffect(context, target, "getCLIOptions", GetCLIOptions);
+  SetMethodNoSideEffect(
+      context, target, "getCLIOptionsValues", GetCLIOptionsValues);
+  SetMethodNoSideEffect(
+      context, target, "getCLIOptionsInfo", GetCLIOptionsInfo);
   SetMethodNoSideEffect(
       context, target, "getEmbedderOptions", GetEmbedderOptions);
 
@@ -1372,7 +1430,8 @@ void Initialize(Local<Object> target,
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
-  registry->Register(GetCLIOptions);
+  registry->Register(GetCLIOptionsValues);
+  registry->Register(GetCLIOptionsInfo);
   registry->Register(GetEmbedderOptions);
 }
 }  // namespace options_parser

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1164,7 +1164,7 @@ std::string GetBashCompletion() {
 }
 
 struct IterateCLIOptionsScope {
-  IterateCLIOptionsScope(Environment* env) {
+  explicit IterateCLIOptionsScope(Environment* env) {
     // Temporarily act as if the current Environment's/IsolateData's options
     // were the default options, i.e. like they are the ones we'd access for
     // global options parsing, so that all options are available from the main

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -519,7 +519,10 @@ class OptionsParser {
   template <typename OtherOptions>
   friend class OptionsParser;
 
-  friend void GetCLIOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
+  friend void GetCLIOptionsValues(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  friend void GetCLIOptionsInfo(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   friend std::string GetBashCompletion();
 };
 

--- a/test/parallel/test-options-binding.js
+++ b/test/parallel/test-options-binding.js
@@ -2,17 +2,15 @@
 'use strict';
 
 const common = require('../common');
-const { primordials: { SafeMap } } = require('internal/test/binding');
-
-const { options, aliases, getOptionValue } = require('internal/options');
 const assert = require('assert');
-
-assert(options instanceof SafeMap,
-       "require('internal/options').options is a SafeMap");
-
-assert(aliases instanceof SafeMap,
-       "require('internal/options').aliases is a SafeMap");
+const { getOptionValue } = require('internal/options');
 
 Map.prototype.get =
   common.mustNotCall('`getOptionValue` must not call user-mutable method');
 assert.strictEqual(getOptionValue('--expose-internals'), true);
+
+Object.prototype['--nonexistent-option'] = 'foo';
+assert.strictEqual(getOptionValue('--nonexistent-option'), undefined);
+
+// Make the test common global leak test happy.
+delete Object.prototype['--nonexistent-option'];


### PR DESCRIPTION
In this patch we split the serialization routine into two different routines: `getCLIOptionsValues()` for only serializing the key-value pairs and `getCLIOptionsInfo()` for getting additional information such as help text etc. The former is used a lot more frequently than the latter, which is only used for generating `--help` and building `process.allowedNodeEnvironmentFlags`.

`getCLIOptionsValues()` also adds `--no-` entries for boolean options so there is no need to special case in the JS land.
This patch also refactors the option serialization routines to use v8::Object constructor that takes key-value pairs in one go to avoid calling Map::Set or Object::Set repeatedly which can go up to a patched prototype.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
