### PR TITLE
doc: accommodate upcoming stricter .md linting

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -121,6 +121,8 @@ platforms. This is true regardless of entries in the table below.
 | AIX              | ppc64be >=power8 | >= 7.2 TL04                       | Tier 2                                          |                                      |
 | FreeBSD          | x64              | >= 13.2                           | Experimental                                    |                                      |
 
+<!--lint disable final-definition-->
+
 [^1]: Older kernel versions may work. However official Node.js release
     binaries are [built on RHEL 8 systems](#official-binary-platforms-and-toolchains)
     with kernel 4.18.
@@ -146,6 +148,8 @@ platforms. This is true regardless of entries in the table below.
 
 [^5]: Our macOS x64 Binaries are compiled with 11.0 as a target. Xcode 13 is
     required to compile.
+
+<!--lint enable final-definition-->
 
 ### Supported toolchains
 
@@ -173,6 +177,8 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | linux-x64               | RHEL 8 with gcc-toolset-10[^6]                                                                              |
 | win-x64 and win-x86     | Windows Server 2022 (x64) with Visual Studio 2022                                                           |
 
+<!--lint disable final-definition-->
+
 [^6]: Binaries produced on these systems are compatible with glibc >= 2.28
     and libstdc++ >= 6.0.25 (`GLIBCXX_3.4.25`). These are available on
     distributions natively supporting GCC 8.1 or higher, such as Debian 10,
@@ -182,6 +188,8 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
     and libstdc++ >= 6.0.28 (`GLIBCXX_3.4.28`). These are available on
     distributions natively supporting GCC 9.3 or higher, such as Debian 11,
     Ubuntu 20.04.
+
+<!--lint enable final-definition-->
 
 #### OpenSSL asm support
 


### PR DESCRIPTION
remark-lint-final-definition@4.0.0 will start flagging footnotes in BUILDING.md. I don't think we want to move them to the bottom, so I've disabled the lint rule where relevant.

Ref: https://github.com/nodejs/remark-preset-lint-node/pull/511

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
