### PR TITLE
tools: remove pr approval condition for collaborators

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -69,7 +69,7 @@ status. Emeriti may request that the TSC restore them to active status.
 
 A collaborator is automatically made emeritus (and removed from active
 collaborator status) if it has been more than 12 months since the collaborator
-has authored or approved a commit that has landed.
+has authored a commit that has landed.
 
 ## Technical Steering Committee
 

--- a/tools/find-inactive-collaborators.mjs
+++ b/tools/find-inactive-collaborators.mjs
@@ -53,12 +53,6 @@ const authors = await runGitCommand(
   (line) => line.trim().split('\t', 2)[1],
 );
 
-// Get all approving reviewers of landed commits during the time period.
-const approvingReviewers = await runGitCommand(
-  `git log --since="${SINCE}" | egrep "^    Reviewed-By: "`,
-  (line) => /^ {4}Reviewed-By: ([^<]+)/.exec(line)[1].trim(),
-);
-
 async function getCollaboratorsFromReadme() {
   const readmeText = readline.createInterface({
     input: fs.createReadStream(new URL('../README.md', import.meta.url)),
@@ -186,13 +180,9 @@ const collaborators = await getCollaboratorsFromReadme();
 if (verbose) {
   console.log(`Since ${SINCE}:\n`);
   console.log(`* ${authors.size.toLocaleString()} authors have made commits.`);
-  console.log(`* ${approvingReviewers.size.toLocaleString()} reviewers have approved landed commits.`);
   console.log(`* ${collaborators.length.toLocaleString()} collaborators currently in the project.`);
 }
-const inactive = collaborators.filter((collaborator) =>
-  !authors.has(collaborator.mailmap) &&
-  !approvingReviewers.has(collaborator.name),
-);
+const inactive = collaborators.filter((collaborator) => !authors.has(collaborator.mailmap));
 
 if (inactive.length) {
   console.log('\nInactive collaborators:\n');


### PR DESCRIPTION
**Proposal**

I'm proposing removing the following from the requirement to stay as an active collaborator:

- Approved a commit that has landed

Prior to this change, approving a single pull-request every 12 months (previously it was 18 months) was sufficient to maintain the node.js collaborator requirements. I propose removing this requirement and just keeping `Has authored a commit in the last 12 months` as the requirement.

cc @nodejs/tsc