### PR TITLE
fs: ensure return value type of `options.filter` in `cpSync` consistent with doc

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -46,7 +46,6 @@ const {
   parse,
   resolve,
 } = require('path');
-const { isPromise } = require('util/types');
 
 function cpSyncFn(src, dest, opts) {
   // Warn about using preserveTimestamps on 32-bit node
@@ -64,7 +63,7 @@ function cpSyncFn(src, dest, opts) {
 function checkPathsSync(src, dest, opts) {
   if (opts.filter) {
     const shouldCopy = opts.filter(src, dest);
-    if (isPromise(shouldCopy)) {
+    if (typeof shouldCopy !== 'boolean') {
       throw new ERR_INVALID_RETURN_VALUE('boolean', 'filter', shouldCopy);
     }
     if (!shouldCopy) return { __proto__: null, skipped: true };

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -826,6 +826,22 @@ if (!isWindows) {
   cpSync(src, dest, opts);
 }
 
+// It will throw error for invalid return value from filter
+{
+  const src = nextdir();
+  const dest = nextdir();
+
+  const opts = {
+    filter: (path) => {
+      // Undefined is not a valid return value.
+    },
+  };
+  assert.throws(
+    () => cpSync(src, dest, opts),
+    { code: 'ERR_INVALID_RETURN_VALUE' }
+  );
+}
+
 // Copy should not throw exception if dest is invalid but filtered out.
 {
   // Create dest as a file.


### PR DESCRIPTION
Ensure return type of options.filter in cpsync matches doc.
according to the [documentation](https://nodejs.org/docs/latest/api/fs.html#fscpsyncsrc-dest-options), the return value of  `options.filter` has `boolean` type.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
