### PR TITLE
lib: remove unused 'patternDependencies'

### DIFF
--- a/lib/internal/policy/manifest.js
+++ b/lib/internal/policy/manifest.js
@@ -87,10 +87,6 @@ class DependencyMapperInstance {
    */
   #dependencies;
   /**
-   * @type {PatternDependencyMap | undefined}
-   */
-  #patternDependencies;
-  /**
    * @type {DependencyMapperInstance | null | undefined}
    */
   #parentDependencyMapper;
@@ -118,38 +114,7 @@ class DependencyMapperInstance {
     cascade = false,
     allowSameHREFScope = false) {
     this.href = parentHREF;
-    if (dependencies === kFallThrough ||
-        dependencies === undefined ||
-        dependencies === null) {
-      this.#dependencies = dependencies;
-      this.#patternDependencies = undefined;
-    } else {
-      const patterns = [];
-      const keys = ObjectKeys(dependencies);
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        if (StringPrototypeEndsWith(key, '*')) {
-          const target = RegExpPrototypeExec(/^([^*]*)\*([^*]*)$/);
-          if (!target) {
-            throw new ERR_MANIFEST_INVALID_SPECIFIER(
-              this.href,
-              `${target}, pattern needs to have a single trailing "*" in target`,
-            );
-          }
-          const prefix = target[1];
-          const suffix = target[2];
-          patterns.push([
-            target.slice(0, -1),
-            [prefix, suffix],
-          ]);
-        }
-      }
-      ArrayPrototypeSort(patterns, (a, b) => {
-        return a[0] < b[0] ? -1 : 1;
-      });
-      this.#dependencies = dependencies;
-      this.#patternDependencies = patterns;
-    }
+    this.#dependencies = dependencies;
     this.cascade = cascade;
     this.allowSameHREFScope = allowSameHREFScope;
     ObjectFreeze(this);
@@ -339,7 +304,6 @@ function findScopeHREF(href, scopeStore, allowSame) {
 
 /**
  * @typedef {Record<string, string> | typeof kFallThrough} DependencyMap
- * @typedef {Array<[string, [string, string]]>} PatternDependencyMap
  * @typedef {Record<string, string> | null | true} JSONDependencyMap
  */
 /**

--- a/test/parallel/test-policy-manifest.js
+++ b/test/parallel/test-policy-manifest.js
@@ -14,37 +14,6 @@ const fixtures = require('../common/fixtures.js');
 const tmpdir = require('../common/tmpdir.js');
 
 {
-  const policyFilepath = fixtures.path('policy-manifest', 'invalid.json');
-  const result = spawnSync(process.execPath, [
-    '--experimental-policy',
-    policyFilepath,
-    './fhqwhgads.js',
-  ]);
-
-  assert.notStrictEqual(result.status, 0);
-  const stderr = result.stderr.toString();
-  assert.match(stderr, /ERR_MANIFEST_INVALID_SPECIFIER/);
-  assert.match(stderr, /pattern needs to have a single trailing "\*"/);
-}
-
-{
-  tmpdir.refresh();
-  const policyFilepath = tmpdir.resolve('file with % in its name.json');
-  cpSync(fixtures.path('policy-manifest', 'invalid.json'), policyFilepath);
-  const result = spawnSync(process.execPath, [
-    '--experimental-policy',
-    policyFilepath,
-    './fhqwhgads.js',
-  ]);
-
-  assert.notStrictEqual(result.status, 0);
-  const stderr = result.stderr.toString();
-  assert.match(stderr, /ERR_MANIFEST_INVALID_SPECIFIER/);
-  assert.match(stderr, /pattern needs to have a single trailing "\*"/);
-  rmSync(policyFilepath);
-}
-
-{
   const policyFilepath = fixtures.path('policy-manifest', 'onerror-exit.json');
   const result = spawnSync(process.execPath, [
     '--experimental-policy',


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR removes the unused `#patternDependencies` property of a manifest.