### PR TITLE
net: add CLI option for autoSelectFamilyAttemptTimeout

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1329,6 +1329,15 @@ added: v7.10.0
 
 This option is a no-op. It is kept for compatibility.
 
+### `--network-family-autoselection-attempt-timeout`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Sets the default value for the network family autoselection attempt timeout.
+For more information, see [`net.getDefaultAutoSelectFamilyAttemptTimeout()`][].
+
 ### `--no-addons`
 
 <!-- YAML
@@ -2635,6 +2644,7 @@ one is included in the list below.
 * `--inspect`
 * `--max-http-header-size`
 * `--napi-modules`
+* `--network-family-autoselection-attempt-timeout`
 * `--no-addons`
 * `--no-deprecation`
 * `--no-experimental-fetch`
@@ -3161,6 +3171,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`dns.setDefaultResultOrder()`]: dns.md#dnssetdefaultresultorderorder
 [`dnsPromises.lookup()`]: dns.md#dnspromiseslookuphostname-options
 [`import` specifier]: esm.md#import-specifiers
+[`net.getDefaultAutoSelectFamilyAttemptTimeout()`]: net.md#netgetdefaultautoselectfamilyattempttimeout
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#processsetuncaughtexceptioncapturecallbackfn
 [`process.setuid()`]: process.md#processsetuidid
 [`setuid(2)`]: https://man7.org/linux/man-pages/man2/setuid.2.html

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1748,7 +1748,8 @@ added:
 -->
 
 Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
-The initial default value is `250`.
+The initial default value is `250` or the value specified via the command line
+option `--network-family-autoselection-attempt-timeout`.
 
 * Returns: {number} The current default value of the `autoSelectFamilyAttemptTimeout` option.
 
@@ -1763,7 +1764,8 @@ added:
 Sets the default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
 
 * `value` {number} The new default value, which must be a positive number. If the number is less than `10`,
-  the value `10` is used instead. The initial default value is `250`.
+  the value `10` is used instead. The initial default value is `250` or the value specified via the command line
+  option `--network-family-autoselection-attempt-timeout`.
 
 ## `net.isIP(input)`
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -134,7 +134,7 @@ let dns;
 let BlockList;
 let SocketAddress;
 let autoSelectFamilyDefault = getOptionValue('--network-family-autoselection');
-let autoSelectFamilyAttemptTimeoutDefault = 250;
+let autoSelectFamilyAttemptTimeoutDefault = getOptionValue('--network-family-autoselection-attempt-timeout');
 
 const { clearTimeout, setTimeout } = require('timers');
 const { kTimeout } = require('internal/timers');

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -383,6 +383,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::network_family_autoselection,
             kAllowedInEnvvar,
             true);
+  AddOption("--network-family-autoselection-attempt-timeout",
+            "Sets the default value for the network family autoselection "
+            "attempt timeout.",
+            &EnvironmentOptions::network_family_autoselection_attempt_timeout,
+            kAllowedInEnvvar);
   AddAlias("--enable-network-family-autoselection",
            "--network-family-autoselection");
   AddOption("--enable-source-maps",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -136,6 +136,7 @@ class EnvironmentOptions : public Options {
   int64_t heap_snapshot_near_heap_limit = 0;
   std::string heap_snapshot_signal;
   bool network_family_autoselection = true;
+  uint64_t network_family_autoselection_attempt_timeout = 250;
   uint64_t max_http_header_size = 16 * 1024;
   bool deprecation = true;
   bool force_async_hooks_checks = true;

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -146,12 +146,8 @@ const isPi = (() => {
 const isDumbTerminal = process.env.TERM === 'dumb';
 
 // When using high concurrency or in the CI we need much more time for each connection attempt
-const defaultAutoSelectFamilyAttemptTimeout = platformTimeout(2500);
-// Since this is also used by tools outside of the test suite,
-// make sure setDefaultAutoSelectFamilyAttemptTimeout
-if (typeof net.setDefaultAutoSelectFamilyAttemptTimeout === 'function') {
-  net.setDefaultAutoSelectFamilyAttemptTimeout(platformTimeout(defaultAutoSelectFamilyAttemptTimeout));
-}
+net.setDefaultAutoSelectFamilyAttemptTimeout(platformTimeout(net.getDefaultAutoSelectFamilyAttemptTimeout() * 10));
+const defaultAutoSelectFamilyAttemptTimeout = net.getDefaultAutoSelectFamilyAttemptTimeout();
 
 const buildType = process.config.target_defaults ?
   process.config.target_defaults.default_configuration :

--- a/test/parallel/test-net-autoselectfamily-attempt-timeout-cli-option.js
+++ b/test/parallel/test-net-autoselectfamily-attempt-timeout-cli-option.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Flags: --network-family-autoselection-attempt-timeout=123
+
+require('../common');
+
+const assert = require('assert');
+const { getDefaultAutoSelectFamilyAttemptTimeout } = require('net');
+
+// Note that in test/common/index the default value is multiplied by 10.
+assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), 1230);

--- a/test/parallel/test-net-autoselectfamily-attempt-timeout-cli-option.js
+++ b/test/parallel/test-net-autoselectfamily-attempt-timeout-cli-option.js
@@ -2,10 +2,9 @@
 
 // Flags: --network-family-autoselection-attempt-timeout=123
 
-require('../common');
+const { platformTimeout } = require('../common');
 
 const assert = require('assert');
 const { getDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
-// Note that in test/common/index the default value is multiplied by 10.
-assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), 1230);
+assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), platformTimeout(123 * 10));

--- a/test/parallel/test-net-autoselectfamily-attempt-timeout-default-value.js
+++ b/test/parallel/test-net-autoselectfamily-attempt-timeout-default-value.js
@@ -1,9 +1,8 @@
 'use strict';
 
-require('../common');
+const { platformTimeout } = require('../common');
 
 const assert = require('assert');
 const { getDefaultAutoSelectFamilyAttemptTimeout } = require('net');
 
-// Note that in test/common/index the default value is multiplied by 10.
-assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), 2500);
+assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), platformTimeout(2500));

--- a/test/parallel/test-net-autoselectfamily-attempt-timeout-default-value.js
+++ b/test/parallel/test-net-autoselectfamily-attempt-timeout-default-value.js
@@ -1,0 +1,9 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const { getDefaultAutoSelectFamilyAttemptTimeout } = require('net');
+
+// Note that in test/common/index the default value is multiplied by 10.
+assert.strictEqual(getDefaultAutoSelectFamilyAttemptTimeout(), 2500);


### PR DESCRIPTION
This PR introduces a `--network-family-autoselection-attempt-timeout` CLI option to set the default value for the `autoSelectFamilyAttemptTimeout` option of `socket.connect`.

Fixes #52216.