### PR TITLE
buffer: add missing ARG_TYPE(ArrayBuffer) for isUtf8

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1284,7 +1284,7 @@ function isUtf8(input) {
     return bindingIsUtf8(input);
   }
 
-  throw new ERR_INVALID_ARG_TYPE('input', ['TypedArray', 'Buffer'], input);
+  throw new ERR_INVALID_ARG_TYPE('input', ['ArrayBuffer', 'Buffer', 'TypedArray'], input);
 }
 
 function isAscii(input) {


### PR DESCRIPTION
Added due to inconsistencies between code and documentation.

https://github.com/nodejs/node/blob/21211a3fa93993b363f25964da5dac3282b3b453/doc/api/buffer.md?plain=1#L5200-L5209

Reference was made to `isAscii` in the same API format.

https://github.com/nodejs/node/blob/21211a3fa93993b363f25964da5dac3282b3b453/doc/api/buffer.md?plain=1#L5184-L5198

https://github.com/nodejs/node/blob/21211a3fa93993b363f25964da5dac3282b3b453/lib/buffer.js#L1290-L1296


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
