### PR TITLE
lib: use || instead of ArrayPrototypeIncludes

### DIFF
--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -13,24 +13,24 @@ module.exports = {
     return ObjectFromEntries(new SafeArrayIterator(ArrayPrototypeFilter(
       ObjectEntries(types),
       ({ 0: key }) => {
-        return ArrayPrototypeIncludes([
-          'isArrayBuffer',
-          'isArrayBufferView',
-          'isAsyncFunction',
-          'isDataView',
-          'isDate',
-          'isExternal',
-          'isMap',
-          'isMapIterator',
-          'isNativeError',
-          'isPromise',
-          'isRegExp',
-          'isSet',
-          'isSetIterator',
-          'isTypedArray',
-          'isUint8Array',
-          'isAnyArrayBuffer',
-        ], key);
+        return (
+            key === 'isArrayBuffer' ||
+            key === 'isArrayBufferView' ||
+            key === 'isAsyncFunction' ||
+            key === 'isDataView' ||
+            key === 'isDate' ||
+            key === 'isExternal' ||
+            key === 'isMap' ||
+            key === 'isMapIterator' ||
+            key === 'isNativeError' ||
+            key === 'isPromise' ||
+            key === 'isRegExp' ||
+            key === 'isSet' ||
+            key === 'isSetIterator' ||
+            key === 'isTypedArray' ||
+            key === 'isUint8Array' ||
+            key === 'isAnyArrayBuffer'
+        )
       })));
   },
   natives() {

--- a/lib/internal/legacy/processbinding.js
+++ b/lib/internal/legacy/processbinding.js
@@ -1,7 +1,6 @@
 'use strict';
 const {
   ArrayPrototypeFilter,
-  ArrayPrototypeIncludes,
   ObjectFromEntries,
   ObjectEntries,
   SafeArrayIterator,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR changes the `ArrayPrototypeIncludes` call to an `... || ...` statement, which is a much faster statement.