### PR TITLE
module: fix submodules loaded by require() and import()

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -308,7 +308,7 @@ class ModuleLoader {
    * @param {string} specifier Specifier of the the imported module.
    * @param {string} parentURL Where the import comes from.
    * @param {object} importAttributes import attributes from the import statement.
-   * @returns {ModuleWrap}
+   * @returns {ModuleJobBase}
    */
   getModuleWrapForRequire(specifier, parentURL, importAttributes) {
     assert(getOptionValue('--experimental-require-module'));
@@ -347,7 +347,7 @@ class ModuleLoader {
       // completed (e.g. the require call is lazy) so it's okay. We will return the
       // module now and check asynchronicity of the entire graph later, after the
       // graph is instantiated.
-      return job.module;
+      return job;
     }
 
     defaultLoadSync ??= require('internal/modules/esm/load').defaultLoadSync;
@@ -391,7 +391,7 @@ class ModuleLoader {
     job = new ModuleJobSync(this, url, importAttributes, wrap, isMain, inspectBrk);
 
     this.loadCache.set(url, importAttributes.type, job);
-    return job.module;
+    return job;
   }
 
   /**

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -19,6 +19,9 @@ const {
   StringPrototypeStartsWith,
   globalThis,
 } = primordials;
+let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
+  debug = fn;
+});
 
 const { ModuleWrap, kEvaluated } = internalBinding('module_wrap');
 const {
@@ -53,8 +56,7 @@ const isCommonJSGlobalLikeNotDefinedError = (errorMessage) =>
   );
 
 class ModuleJobBase {
-  constructor(loader, url, importAttributes, moduleWrapMaybePromise, isMain, inspectBrk) {
-    this.loader = loader;
+  constructor(url, importAttributes, moduleWrapMaybePromise, isMain, inspectBrk) {
     this.importAttributes = importAttributes;
     this.isMain = isMain;
     this.inspectBrk = inspectBrk;
@@ -67,11 +69,13 @@ class ModuleJobBase {
 /* A ModuleJob tracks the loading of a single Module, and the ModuleJobs of
  * its dependencies, over time. */
 class ModuleJob extends ModuleJobBase {
+  #loader = null;
   // `loader` is the Loader instance used for loading dependencies.
   constructor(loader, url, importAttributes = { __proto__: null },
               moduleProvider, isMain, inspectBrk, sync = false) {
     const modulePromise = ReflectApply(moduleProvider, loader, [url, isMain]);
-    super(loader, url, importAttributes, modulePromise, isMain, inspectBrk);
+    super(url, importAttributes, modulePromise, isMain, inspectBrk);
+    this.#loader = loader;
     // Expose the promise to the ModuleWrap directly for linking below.
     // `this.module` is also filled in below.
     this.modulePromise = modulePromise;
@@ -94,7 +98,8 @@ class ModuleJob extends ModuleJobBase {
       // these `link` callbacks depending on each other.
       const dependencyJobs = [];
       const promises = this.module.link(async (specifier, attributes) => {
-        const job = await this.loader.getModuleJob(specifier, url, attributes);
+        const job = await this.#loader.getModuleJob(specifier, url, attributes);
+        debug(`async link() ${this.url} -> ${specifier}`, job);
         ArrayPrototypePush(dependencyJobs, job);
         return job.modulePromise;
       });
@@ -126,6 +131,8 @@ class ModuleJob extends ModuleJobBase {
   async _instantiate() {
     const jobsInGraph = new SafeSet();
     const addJobsToDependencyGraph = async (moduleJob) => {
+      debug(`async addJobsToDependencyGraph() ${this.url}`, moduleJob);
+
       if (jobsInGraph.has(moduleJob)) {
         return;
       }
@@ -161,7 +168,7 @@ class ModuleJob extends ModuleJobBase {
         const { 1: childSpecifier, 2: name } = RegExpPrototypeExec(
           /module '(.*)' does not provide an export named '(.+)'/,
           e.message);
-        const { url: childFileURL } = await this.loader.resolve(
+        const { url: childFileURL } = await this.#loader.resolve(
           childSpecifier,
           parentFileUrl,
           kEmptyObject,
@@ -172,7 +179,7 @@ class ModuleJob extends ModuleJobBase {
           // in the import attributes and some formats require them; but we only
           // care about CommonJS for the purposes of this error message.
           ({ format } =
-            await this.loader.load(childFileURL));
+            await this.#loader.load(childFileURL));
         } catch {
           // Continue regardless of error.
         }
@@ -265,18 +272,27 @@ class ModuleJob extends ModuleJobBase {
 // All the steps are ensured to be synchronous and it throws on instantiating
 // an asynchronous graph.
 class ModuleJobSync extends ModuleJobBase {
+  #loader = null;
   constructor(loader, url, importAttributes, moduleWrap, isMain, inspectBrk) {
-    super(loader, url, importAttributes, moduleWrap, isMain, inspectBrk, true);
+    super(url, importAttributes, moduleWrap, isMain, inspectBrk, true);
     assert(this.module instanceof ModuleWrap);
+    this.#loader = loader;
     const moduleRequests = this.module.getModuleRequestsSync();
+    const linked = [];
     for (let i = 0; i < moduleRequests.length; ++i) {
       const { 0: specifier, 1: attributes } = moduleRequests[i];
-      const wrap = this.loader.getModuleWrapForRequire(specifier, url, attributes);
+      const job = this.#loader.getModuleWrapForRequire(specifier, url, attributes);
       const isLast = (i === moduleRequests.length - 1);
       // TODO(joyeecheung): make the resolution callback deal with both promisified
       // an raw module wraps, then we don't need to wrap it with a promise here.
-      this.module.cacheResolvedWrapsSync(specifier, PromiseResolve(wrap), isLast);
+      this.module.cacheResolvedWrapsSync(specifier, PromiseResolve(job.module), isLast);
+      ArrayPrototypePush(linked, job);
     }
+    this.linked = linked;
+  }
+
+  get modulePromise() {
+    return PromiseResolve(this.module);
   }
 
   async run() {

--- a/test/es-module/test-require-module-dynamic-import-3.js
+++ b/test/es-module/test-require-module-dynamic-import-3.js
@@ -1,0 +1,14 @@
+// Flags: --experimental-require-module
+'use strict';
+
+// This tests that previously synchronously loaded submodule can still
+// be loaded by dynamic import().
+
+const common = require('../common');
+const assert = require('assert');
+
+(async () => {
+  const required = require('../fixtures/es-modules/require-and-import/load.cjs');
+  const imported = await import('../fixtures/es-modules/require-and-import/load.mjs');
+  assert.deepStrictEqual({ ...required }, { ...imported });
+})().then(common.mustCall());

--- a/test/es-module/test-require-module-dynamic-import-4.js
+++ b/test/es-module/test-require-module-dynamic-import-4.js
@@ -1,0 +1,14 @@
+// Flags: --experimental-require-module
+'use strict';
+
+// This tests that previously asynchronously loaded submodule can still
+// be loaded by require().
+
+const common = require('../common');
+const assert = require('assert');
+
+(async () => {
+  const imported = await import('../fixtures/es-modules/require-and-import/load.mjs');
+  const required = require('../fixtures/es-modules/require-and-import/load.cjs');
+  assert.deepStrictEqual({ ...required }, { ...imported });
+})().then(common.mustCall());

--- a/test/fixtures/es-modules/require-and-import/load.cjs
+++ b/test/fixtures/es-modules/require-and-import/load.cjs
@@ -1,0 +1,2 @@
+module.exports = require('dep');
+

--- a/test/fixtures/es-modules/require-and-import/load.mjs
+++ b/test/fixtures/es-modules/require-and-import/load.mjs
@@ -1,0 +1,2 @@
+export * from 'dep';
+

--- a/test/fixtures/es-modules/require-and-import/node_modules/dep/mod.js
+++ b/test/fixtures/es-modules/require-and-import/node_modules/dep/mod.js
@@ -1,0 +1,2 @@
+export const hello = 'world';
+

--- a/test/fixtures/es-modules/require-and-import/node_modules/dep/package.json
+++ b/test/fixtures/es-modules/require-and-import/node_modules/dep/package.json
@@ -1,0 +1,5 @@
+{
+  "type": "module",
+  "main": "mod.js"
+}
+


### PR DESCRIPTION
Previously there is an edge case where submodules loaded by require() may not be loaded by import() again from different intermediate edges in the graph. This patch fixes that, added tests, and added debug logs.

Drive-by: make loader a private field so it doesn't show up in logs.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
