### PR TITLE
test_runner: don't exceed call stack when filtering

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -29,6 +29,7 @@ const {
 } = primordials;
 const { getCallerLocation } = internalBinding('util');
 const { addAbortListener } = require('internal/events/abort_listener');
+const { queueMicrotask } = require('internal/process/task_queues');
 const { AsyncResource } = require('async_hooks');
 const { AbortController } = require('internal/abort_controller');
 const {
@@ -673,7 +674,7 @@ class Test extends AsyncResource {
     this.pass();
     this.subtests = [];
     this.report = noop;
-    this.postRun();
+    queueMicrotask(() => this.postRun());
   }
 
   async run() {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -829,29 +829,9 @@ class Test extends AsyncResource {
         this.parent.activeSubtests--;
       }
 
-      // The call to processPendingSubtests() below can change the number of
-      // pending subtests. When detecting if we are done running tests, we want
-      // to check if there are no pending subtests both before and after
-      // calling processPendingSubtests(). Otherwise, it is possible to call
-      // root.run() multiple times (which is harmless but can trigger an
-      // EventEmitter leak warning).
-      const pendingSiblingCount = this.parent.pendingSubtests.length;
-
       this.parent.addReadySubtest(this);
       this.parent.processReadySubtestRange(false);
       this.parent.processPendingSubtests();
-
-      if (this.parent === this.root &&
-          pendingSiblingCount === 0 &&
-          this.root.activeSubtests === 0 &&
-          this.root.pendingSubtests.length === 0 &&
-          this.root.readySubtests.size === 0) {
-        // At this point all of the tests have finished running. However, there
-        // might be ref'ed handles keeping the event loop alive. This gives the
-        // global after() hook a chance to clean them up. The user may also
-        // want to force the test runner to exit despite ref'ed handles.
-        this.root.run();
-      }
     } else if (!this.reported) {
       const {
         diagnostics,
@@ -914,6 +894,15 @@ class Test extends AsyncResource {
     this.report();
     this.parent.waitingOn++;
     this.finished = true;
+
+    if (this.parent === this.root &&
+        this.root.waitingOn > this.root.subtests.length) {
+      // At this point all of the tests have finished running. However, there
+      // might be ref'ed handles keeping the event loop alive. This gives the
+      // global after() hook a chance to clean them up. The user may also
+      // want to force the test runner to exit despite ref'ed handles.
+      this.root.run();
+    }
   }
 
   duration() {


### PR DESCRIPTION
##### test_runner: move end of work check to finalize()

This commit moves the end of work check from postRun() to
finalize(). The reasoning is that finalize() is guaranteed to
run in the order that the tests are defined, while postRun() is
not. This makes the check a little simpler.

##### test_runner: don't exceed call stack when filtering

This commit updates filteredRun() to call postRun() after a
microtask instead of synchronously. Currently, if approximately
1,545 subtests are filtered, enough synchronous calls can be
made to cause a call stack exceeded exception.

I'm not sure if it is a good use of CI cycles to run a few thousand no-op tests to try to exceed the maximum call stack size. If people want to do that, I can update `test/parallel/test-runner-filter-warning.js` to do that.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
