### PR TITLE
ignore me, just checking the perf improvement of using built error for abort signal

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -128,9 +128,8 @@ function setWeakAbortSignalTimeout(weakRef, delay) {
       gcPersistentSignals.delete(signal);
       abortSignal(
         signal,
-        new DOMException(
-          'The operation was aborted due to timeout',
-          'TimeoutError'));
+        new Error(
+          'The operation was aborted due to timeout'));
     }
   }, delay);
   timeout.unref();
@@ -203,7 +202,7 @@ class AbortSignal extends EventTarget {
    * @returns {AbortSignal}
    */
   static abort(
-    reason = new DOMException('This operation was aborted', 'AbortError')) {
+    reason = new Error('This operation was aborted')) {
     return new AbortSignal(kDontThrowSymbol, { aborted: true, reason });
   }
 
@@ -393,7 +392,7 @@ class AbortController {
   /**
    * @param {any} [reason]
    */
-  abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
+  abort(reason = new Error('This operation was aborted')) {
     abortSignal(this.#signal ??= new AbortSignal(kDontThrowSymbol), reason);
   }
 


### PR DESCRIPTION
Benchmark url:
https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1521/console