### PR TITLE
repl: print errors in red

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -772,6 +772,10 @@ function REPLServer(prompt,
         const ln = lines.length === 1 ? ' ' : ':\n';
         errStack = `Uncaught${ln}${errStack}`;
       }
+      // if colors are allowed, print in red
+      if (self.useColors) {
+        errStack = '\u001b[31m' + errStack + '\u001b[39m';
+      }
       // Normalize line endings.
       errStack += StringPrototypeEndsWith(errStack, '\n') ? '' : '\n';
       self.output.write(errStack);

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -772,7 +772,7 @@ function REPLServer(prompt,
         const ln = lines.length === 1 ? ' ' : ':\n';
         errStack = `Uncaught${ln}${errStack}`;
       }
-      // if colors are allowed, print in red
+      // If colors are allowed, print in red
       if (self.useColors) {
         errStack = '\u001b[31m' + errStack + '\u001b[39m';
       }

--- a/test/parallel/test-repl-pretty-stack.js
+++ b/test/parallel/test-repl-pretty-stack.js
@@ -64,8 +64,8 @@ const tests = [
   {
     command: '(() => { const err = Error(\'Whoops!\'); ' +
              'err.foo = \'bar\'; throw err; })()',
-    expected: 'Uncaught Error: Whoops!\n    at REPL5:*:* {\n  foo: ' +
-              "\u001b[32m'bar'\u001b[39m\n}\n",
+    expected: '\x1B[31mUncaught Error: Whoops!\n    at REPL5:*:* {\n  foo: ' +
+              "\u001b[32m'bar'\u001b[39m\n}\x1B[31m\n",
     useColors: true
   },
   {

--- a/test/parallel/test-repl-uncaught-exception.js
+++ b/test/parallel/test-repl-uncaught-exception.js
@@ -40,12 +40,12 @@ const tests = [
   {
     useColors: true,
     command: 'x',
-    expected: 'Uncaught ReferenceError: x is not defined\n'
+    expected: '\x1B[31mUncaught ReferenceError: x is not defined\x1B[39m\n'
   },
   {
     useColors: true,
     command: 'throw { foo: "test" }',
-    expected: "Uncaught { foo: \x1B[32m'test'\x1B[39m }\n"
+    expected: "\x1B[31mUncaught { foo: \x1B[32m'test'\x1B[39m }\x1B[39m\n"
   },
   {
     command: 'process.on("uncaughtException", () => console.log("Foobar"));\n',


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This change will have NodeJS REPLs print errors in red, so that they are easily distinguishable from traditional loggings. This change *will not* affect `console.error`