### PR TITLE
test benchmark change

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -6,6 +6,7 @@
 const {
   ObjectAssign,
   ObjectDefineProperties,
+  ObjectSetPrototypeOf,
   ObjectDefineProperty,
   PromiseResolve,
   SafeFinalizationRegistry,
@@ -67,8 +68,6 @@ const {
 
 let _MessageChannel;
 let markTransferMode;
-
-const kDontThrowSymbol = Symbol('kDontThrowSymbol');
 
 // Loading the MessageChannel and markTransferable have to be done lazily
 // because otherwise we'll end up with a require cycle that ends up with
@@ -138,35 +137,8 @@ function setWeakAbortSignalTimeout(weakRef, delay) {
 }
 
 class AbortSignal extends EventTarget {
-
-  /**
-   * @param {symbol | undefined} dontThrowSymbol
-   * @param {{
-   *   aborted? : boolean,
-   *   reason? : any,
-   *   transferable? : boolean,
-   *   composite? : boolean,
-   * }} [init]
-   * @private
-   */
-  constructor(dontThrowSymbol = undefined, init = kEmptyObject) {
-    if (dontThrowSymbol !== kDontThrowSymbol) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
-    super();
-
-    const {
-      aborted = false,
-      reason = undefined,
-      transferable = false,
-      composite = false,
-    } = init;
-    this[kAborted] = aborted;
-    this[kReason] = reason;
-    this[kComposite] = composite;
-    if (transferable) {
-      lazyMarkTransferMode(this, false, true);
-    }
+  constructor() {
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
   /**
@@ -204,7 +176,7 @@ class AbortSignal extends EventTarget {
    */
   static abort(
     reason = new DOMException('This operation was aborted', 'AbortError')) {
-    return new AbortSignal(kDontThrowSymbol, { aborted: true, reason });
+    return createAbortSignal({ aborted: true, reason });
   }
 
   /**
@@ -213,7 +185,7 @@ class AbortSignal extends EventTarget {
    */
   static timeout(delay) {
     validateUint32(delay, 'delay', false);
-    const signal = new AbortSignal(kDontThrowSymbol);
+    const signal = createAbortSignal();
     signal[kTimeout] = true;
     clearTimeoutRegistry.register(
       signal,
@@ -227,7 +199,7 @@ class AbortSignal extends EventTarget {
    */
   static any(signals) {
     validateAbortSignalArray(signals, 'signals');
-    const resultSignal = new AbortSignal(kDontThrowSymbol, { composite: true });
+    const resultSignal = createAbortSignal({ composite: true });
     if (!signals.length) {
       return resultSignal;
     }
@@ -347,7 +319,7 @@ class AbortSignal extends EventTarget {
 }
 
 function ClonedAbortSignal() {
-  return new AbortSignal(kDontThrowSymbol, { transferable: true });
+  return createAbortSignal({ transferable: true });
 }
 ClonedAbortSignal.prototype[kDeserialize] = () => {};
 
@@ -364,6 +336,33 @@ ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
 });
 
 defineEventHandler(AbortSignal.prototype, 'abort');
+
+/**
+ * @param {{
+ *   aborted? : boolean,
+ *   reason? : any,
+ *   transferable? : boolean,
+ *   composite? : boolean,
+ * }} [init]
+ * @returns {AbortSignal}
+ */
+function createAbortSignal(init = kEmptyObject) {
+  const {
+    aborted = false,
+    reason = undefined,
+    transferable = false,
+    composite = false,
+  } = init;
+  const signal = new EventTarget();
+  ObjectSetPrototypeOf(signal, AbortSignal.prototype);
+  signal[kAborted] = aborted;
+  signal[kReason] = reason;
+  signal[kComposite] = composite;
+  if (transferable) {
+    lazyMarkTransferMode(signal, false, true);
+  }
+  return signal;
+}
 
 function abortSignal(signal, reason) {
   if (signal[kAborted]) return;
@@ -386,7 +385,7 @@ class AbortController {
    * @type {AbortSignal}
    */
   get signal() {
-    this.#signal ??= new AbortSignal(kDontThrowSymbol);
+    this.#signal ??= createAbortSignal();
     return this.#signal;
   }
 
@@ -394,7 +393,7 @@ class AbortController {
    * @param {any} [reason]
    */
   abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
-    abortSignal(this.#signal ??= new AbortSignal(kDontThrowSymbol), reason);
+    abortSignal(this.#signal ??= createAbortSignal(), reason);
   }
 
   [customInspectSymbol](depth, options) {
@@ -405,7 +404,7 @@ class AbortController {
 
   static [kMakeTransferable]() {
     const controller = new AbortController();
-    controller.#signal = new AbortSignal(kDontThrowSymbol, { transferable: true });
+    controller.#signal = createAbortSignal({ transferable: true });
     return controller;
   }
 }


### PR DESCRIPTION
This reverts commit 818c10e86d9c44b7e99197a0983ba143754474be to check https://github.com/nodejs/node/pull/52456 works

[benchmark url](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1524/console)

```
21:45:57 ++ Rscript benchmark/compare.R
21:45:58                                                                               confidence improvement accuracy (*)   (**)  (***)
21:45:58 abort_controller/abort-signal-static-abort.js kind='default-reason' n=5000000        ***    -43.28 %       ±0.55% ±0.74% ±0.98%
21:45:58 abort_controller/abort-signal-static-abort.js kind='same-reason' n=5000000           ***    -95.83 %       ±0.45% ±0.60% ±0.80%
```