### PR TITLE
Update fs.read() documentation for clarity on length argument

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -3649,7 +3649,8 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView} The buffer that the data will be
   written to.
 * `offset` {integer} The position in `buffer` to write the data to.
-* `length` {integer} The number of bytes to read.
+* `length` {integer} The number of bytes to read. This specifies the maximum number of bytes to read from the file. However, the actual number of bytes that are read (`bytesRead`) may be less than `length` for several reasons, such as reaching the end of the file (EOF), reading from a slow network filesystem, or other system-related constraints. If a specific minimum number of bytes is required, it may be necessary to call `fs.read()` multiple times until the desired amount of data is read.
+
 * `position` {integer|bigint|null} Specifies where to begin reading from in the
   file. If `position` is `null` or `-1 `, data will be read from the current
   file position, and the file position will be updated. If `position` is
@@ -3658,6 +3659,8 @@ changes:
   * `err` {Error}
   * `bytesRead` {integer}
   * `buffer` {Buffer}
+
+
 
 Read data from the file specified by `fd`.
 


### PR DESCRIPTION
This change clarifies the behavior of the `length` argument in the fs.read() method, explaining that the actual number of bytes read (`bytesRead`) may be less than the specified `length` for various reasons such as EOF or reading from a slow network filesystem. It also notes the necessity of looping for a specific minimum number of bytes.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
