### PR TITLE
module,cli: fix module loading for paths ending with `/.` or `/..`

### DIFF
--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -65,16 +65,16 @@ function resolveMainPath(main) {
 function maybeAddTrailingSlash(filename) {
   let trailingSlash = false;
   if (filename && filename.length) {
-    // we do not want to add a slash to a root path `/`
-    // this is the only path where path.resolve returns a slash at the end
+    // We do not want to add a slash to a root path `/`
+    // This is the only path where path.resolve returns a slash at the end
     trailingSlash = filename.length > 1 &&
       filename.charAt(filename.length - 1) === path.sep;
     if (!trailingSlash) {
       if (path.sep === '/') {
-        // support *nix /
+        // Support *nix /
         trailingSlash = /(?:^|\/+)\.?\.$/.test(filename);
       } else {
-        // support windows \
+        // Support windows \
         trailingSlash = /(?:^|\\+)\.?\.$/.test(filename);
       }
     }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -2,6 +2,7 @@
 
 const {
   StringPrototypeEndsWith,
+  RegExpPrototypeTest,
   globalThis,
 } = primordials;
 
@@ -62,6 +63,8 @@ function resolveMainPath(main) {
 // This function fixes a bug where the module loader would load the wrong file
 // (E.G. /app.js instead of /app/index.js with 'node .' in the /app cwd)
 // Adopted from PR #24256
+const UNIX_SEP_REGEX = /(?:^|\/+)\.?\.$/;
+const WIN_SEP_REGEX = /(?:^|\\+)\.?\.$/;
 function maybeAddTrailingSlash(filename) {
   let trailingSlash = false;
   if (filename && filename.length) {
@@ -72,10 +75,10 @@ function maybeAddTrailingSlash(filename) {
     if (!trailingSlash) {
       if (path.sep === '/') {
         // Support *nix /
-        trailingSlash = /(?:^|\/+)\.?\.$/.test(filename);
+        trailingSlash = RegExpPrototypeTest(UNIX_SEP_REGEX, filename);
       } else {
         // Support windows \
-        trailingSlash = /(?:^|\\+)\.?\.$/.test(filename);
+        trailingSlash = RegExpPrototypeTest(WIN_SEP_REGEX, filename);
       }
     }
   }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -2,7 +2,7 @@
 
 const {
   StringPrototypeEndsWith,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   globalThis,
 } = primordials;
 
@@ -75,10 +75,10 @@ function maybeAddTrailingSlash(filename) {
     if (!trailingSlash) {
       if (path.sep === '/') {
         // Support *nix /
-        trailingSlash = RegExpPrototypeTest(UNIX_SEP_REGEX, filename);
+        trailingSlash = RegExpPrototypeExec(UNIX_SEP_REGEX, filename);
       } else {
         // Support windows \
-        trailingSlash = RegExpPrototypeTest(WIN_SEP_REGEX, filename);
+        trailingSlash = RegExpPrototypeExec(WIN_SEP_REGEX, filename);
       }
     }
   }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -32,12 +32,12 @@ function resolveMainPath(main) {
   let mainPath;
   if (defaultType === 'module') {
     if (getOptionValue('--preserve-symlinks-main')) { return; }
-    mainPath = path.resolve(main);
+    mainPath = maybeAddTrailingSlash(path.resolve(main));
   } else {
     // Extension searching for the main entry point is supported only in legacy mode.
     // Module._findPath is monkey-patchable here.
     const { Module } = require('internal/modules/cjs/loader');
-    mainPath = Module._findPath(path.resolve(main), null, true);
+    mainPath = Module._findPath(maybeAddTrailingSlash(path.resolve(main)), null, true);
   }
   if (!mainPath) { return; }
 
@@ -57,6 +57,29 @@ function resolveMainPath(main) {
   }
 
   return mainPath;
+}
+
+// This function fixes a bug where the module loader would load the wrong file
+// (E.G. /app.js instead of /app/index.js with 'node .' in the /app cwd)
+// Adopted from PR #24256
+function maybeAddTrailingSlash(filename) {
+  let trailingSlash = false;
+  if (filename && filename.length) {
+    // we do not want to add a slash to a root path `/`
+    // this is the only path where path.resolve returns a slash at the end
+    trailingSlash = filename.length > 1 &&
+      filename.charAt(filename.length - 1) === path.sep;
+    if (!trailingSlash) {
+      if (path.sep === '/') {
+        // support *nix /
+        trailingSlash = /(?:^|\/+)\.?\.$/.test(filename);
+      } else {
+        // support windows \
+        trailingSlash = /(?:^|\\+)\.?\.$/.test(filename);
+      }
+    }
+  }
+  return filename + (trailingSlash ? '/' : '');
 }
 
 /**

--- a/test/fixtures/main-runner-order/app.js
+++ b/test/fixtures/main-runner-order/app.js
@@ -1,0 +1,2 @@
+console.log("./app.js")
+module.exports = "./app.js"

--- a/test/fixtures/main-runner-order/app/index.js
+++ b/test/fixtures/main-runner-order/app/index.js
@@ -1,0 +1,2 @@
+console.log('./app/index.js')
+module.exports = './app/index.js'

--- a/test/fixtures/main-runner-order/app/test.js
+++ b/test/fixtures/main-runner-order/app/test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+require('../../../common');
+const assert = require('assert');
+const child_process = require('child_process');
+
+async function spawnNodeRunner(path) {
+    return new Promise((resolve, reject) => {
+        child_process.exec(`node ${path}`, (err, stdout, stderr) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(stdout);
+            }
+        });
+    });
+};
+
+async function main() {
+    assert.strictEqual((await spawnNodeRunner('.')).trim(), require('.').trim());
+}
+
+main();


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Related to #24256
Fixes #32008
Fixes #24210

This PR appends a trailing slash to certain paths to ensure they resolve correctly. Before this page, the module loader would prefer `(cwd).js` instead of `(cwd)/index.js` when running `node .`.