### PR TITLE
lib: allow map in querystring

### DIFF
--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -114,6 +114,10 @@ querystring.parse('w=%D6%D0%CE%C4&foo=bar', null, null,
 
 <!-- YAML
 added: v0.1.25
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/__PR__
+    description: Maps are now accepted as a valid `obj`.
 -->
 
 * `obj` {Object} The object to serialize into a URL query string

--- a/doc/api/querystring.md
+++ b/doc/api/querystring.md
@@ -116,7 +116,7 @@ querystring.parse('w=%D6%D0%CE%C4&foo=bar', null, null,
 added: v0.1.25
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/__PR__
+    pr-url: https://github.com/nodejs/node/pull/52533
     description: Maps are now accepted as a valid `obj`.
 -->
 

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -36,7 +36,6 @@ const {
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeSlice,
-  SymbolIterator,
   decodeURIComponent,
 } = primordials;
 
@@ -241,9 +240,10 @@ function stringify(obj, sep, eq, options) {
     (encode === qsEscape ? encodeStringified : encodeStringifiedCustom);
 
   if (obj !== null && typeof obj === 'object') {
+    // eslint-disable-next-line node-core/prefer-primordials
     if (FunctionPrototypeSymbolHasInstance(obj, Map)) {
       obj = ObjectFromEntries(MapPrototypeEntries(obj));
-    };
+    }
 
     const keys = ObjectKeys(obj);
     const len = keys.length;

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -26,13 +26,17 @@
 const {
   Array,
   ArrayIsArray,
+  FunctionPrototypeSymbolHasInstance,
   Int8Array,
+  MapPrototypeEntries,
   MathAbs,
   NumberIsFinite,
+  ObjectFromEntries,
   ObjectKeys,
   String,
   StringPrototypeCharCodeAt,
   StringPrototypeSlice,
+  SymbolIterator,
   decodeURIComponent,
 } = primordials;
 
@@ -218,7 +222,8 @@ function encodeStringifiedCustom(v, encode) {
 
 /**
  * @param {Record<string, string | number | boolean
- * | ReadonlyArray<string | number | boolean> | null>} obj
+ * | ReadonlyArray<string | number | boolean> | null>
+ * | Map<string, string | number | boolean>} obj
  * @param {string} [sep]
  * @param {string} [eq]
  * @param {{ encodeURIComponent?: (v: string) => string }} [options]
@@ -236,6 +241,10 @@ function stringify(obj, sep, eq, options) {
     (encode === qsEscape ? encodeStringified : encodeStringifiedCustom);
 
   if (obj !== null && typeof obj === 'object') {
+    if (FunctionPrototypeSymbolHasInstance(obj, Map)) {
+      obj = ObjectFromEntries(MapPrototypeEntries(obj));
+    };
+
     const keys = ObjectKeys(obj);
     const len = keys.length;
     let fields = '';

--- a/lib/querystring.js
+++ b/lib/querystring.js
@@ -241,7 +241,7 @@ function stringify(obj, sep, eq, options) {
 
   if (obj !== null && typeof obj === 'object') {
     // eslint-disable-next-line node-core/prefer-primordials
-    if (FunctionPrototypeSymbolHasInstance(obj, Map)) {
+    if (FunctionPrototypeSymbolHasInstance(Map, obj)) {
       obj = ObjectFromEntries(MapPrototypeEntries(obj));
     }
 

--- a/test/parallel/test-querystring.js
+++ b/test/parallel/test-querystring.js
@@ -343,6 +343,9 @@ assert.strictEqual(qs.stringify([]), '');
 assert.strictEqual(qs.stringify(null), '');
 assert.strictEqual(qs.stringify(true), '');
 
+// maps
+assert.strictEqual(qs.stringify(new Map([['a', 'b'], ['c', 'd']])), 'a=b&c=d');
+
 check(qs.parse(), {});
 
 // empty sep


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #22782

Allows `querystring.stringify` to accept a map as an `obj` input.
