### PR TITLE
doc: correct unsafe URL example in http docs

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -488,7 +488,7 @@ const proxy = createServer((req, res) => {
 });
 proxy.on('connect', (req, clientSocket, head) => {
   // Connect to an origin server
-  const { port, hostname } = new URL(`http://${req.url}`);
+  const { port, hostname } = new URL(`http://${req.headers.host}${req.url}`);
   const serverSocket = connect(port || 80, hostname, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                     'Proxy-agent: Node.js-Proxy\r\n' +
@@ -543,7 +543,7 @@ const proxy = http.createServer((req, res) => {
 });
 proxy.on('connect', (req, clientSocket, head) => {
   // Connect to an origin server
-  const { port, hostname } = new URL(`http://${req.url}`);
+  const { port, hostname } = new URL(`http://${req.headers.host}${req.url}`);
   const serverSocket = net.connect(port || 80, hostname, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                     'Proxy-agent: Node.js-Proxy\r\n' +
@@ -2886,7 +2886,7 @@ Accept: text/plain
 To parse the URL into its parts:
 
 ```js
-new URL(request.url, `http://${request.headers.host}`);
+new URL(`http://${req.headers.host}${req.url}`);
 ```
 
 When `request.url` is `'/status?name=ryan'` and `request.headers.host` is
@@ -2894,7 +2894,7 @@ When `request.url` is `'/status?name=ryan'` and `request.headers.host` is
 
 ```console
 $ node
-> new URL(request.url, `http://${request.headers.host}`)
+> new URL(`http://${req.headers.host}${req.url}`)
 URL {
   href: 'http://localhost:3000/status?name=ryan',
   origin: 'http://localhost:3000',

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -488,7 +488,7 @@ const proxy = createServer((req, res) => {
 });
 proxy.on('connect', (req, clientSocket, head) => {
   // Connect to an origin server
-  const { port, hostname } = new URL(`http://${req.headers.host}${req.url}`);
+  const { port, hostname } = new URL(`http://${req.url}`);
   const serverSocket = connect(port || 80, hostname, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                     'Proxy-agent: Node.js-Proxy\r\n' +
@@ -543,7 +543,7 @@ const proxy = http.createServer((req, res) => {
 });
 proxy.on('connect', (req, clientSocket, head) => {
   // Connect to an origin server
-  const { port, hostname } = new URL(`http://${req.headers.host}${req.url}`);
+  const { port, hostname } = new URL(`http://${req.url}`);
   const serverSocket = net.connect(port || 80, hostname, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n' +
                     'Proxy-agent: Node.js-Proxy\r\n' +


### PR DESCRIPTION
The previous documentation example for converting request.url to an URL object was unsafe, as it could allow a server crash through malformed URL inputs and potentially enable host header attacks. This commit revises the example to use string concatenation, mitigating both the crash and security risks by ensuring the host part of the URL remains controlled and predictable.

Fixes: https://github.com/nodejs/node/issues/52494

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
