### PR TITLE
src: remove erroneous CVE-2024-27980 revert option

### DIFF
--- a/src/node_revert.h
+++ b/src/node_revert.h
@@ -15,9 +15,8 @@
  **/
 namespace node {
 
-#define SECURITY_REVERSIONS(XX)                                            \
-  XX(CVE_2024_27980, "CVE-2024-27980", "Unsafe Windows batch file execution")
-//  XX(CVE_2016_PEND, "CVE-2016-PEND", "Vulnerability Title")
+#define SECURITY_REVERSIONS(XX)                                                \
+  //  XX(CVE_2016_PEND, "CVE-2016-PEND", "Vulnerability Title")
 
 enum reversion {
 #define V(code, ...) SECURITY_REVERT_##code,

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -648,9 +648,8 @@ bool IsWindowsBatchFile(const char* filename) {
   static constexpr bool kIsWindows = false;
 #endif  // _WIN32
   if (kIsWindows)
-    if (!IsReverted(SECURITY_REVERT_CVE_2024_27980))
-      if (const char* p = strrchr(filename, '.'))
-        return StringEqualNoCase(p, ".bat") || StringEqualNoCase(p, ".cmd");
+    if (const char* p = strrchr(filename, '.'))
+      return StringEqualNoCase(p, ".bat") || StringEqualNoCase(p, ".cmd");
   return false;
 }
 

--- a/test/parallel/test-child-process-spawn-windows-batch-file.js
+++ b/test/parallel/test-child-process-spawn-windows-batch-file.js
@@ -19,23 +19,12 @@ const cp = require('child_process');
 const assert = require('assert');
 const { isWindows } = common;
 
-const arg = '--security-revert=CVE-2024-27980';
-const isRevert = process.execArgv.includes(arg);
-
-const expectedCode = isWindows && !isRevert ? 'EINVAL' : 'ENOENT';
+const expectedCode = isWindows ? 'EINVAL' : 'ENOENT';
 const expectedStatus = isWindows ? 1 : 127;
 
 const suffixes =
     'BAT bAT BaT baT BAt bAt Bat bat CMD cMD CmD cmD CMd cMd Cmd cmd'
     .split(' ');
-
-if (process.argv[2] === undefined) {
-  const a = cp.spawnSync(process.execPath, [__filename, 'child']);
-  const b = cp.spawnSync(process.execPath, [arg, __filename, 'child']);
-  assert.strictEqual(a.status, 0);
-  assert.strictEqual(b.status, 0);
-  return;
-}
 
 function testExec(filename) {
   return new Promise((resolve) => {


### PR DESCRIPTION
No security reverts should exist on the main branch.

It seems to me that this was done correctly by @bnoordhuis in https://github.com/nodejs-private/node-private/pull/565 but that commit somehow didn't end up on the `main` branch in this repository.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
