### PR TITLE
crypto: move DEP0182 to runtime deprecation

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3078,10 +3078,9 @@ and initialization vector (`iv`).
 The `options` argument controls stream behavior and is optional except when a
 cipher in CCM or OCB mode (e.g. `'aes-128-ccm'`) is used. In that case, the
 `authTagLength` option is required and specifies the length of the
-authentication tag in bytes, see [CCM mode][]. In GCM mode, the `authTagLength`
-option is not required but can be used to restrict accepted authentication tags
-to those with the specified length.
-For `chacha20-poly1305`, the `authTagLength` option defaults to 16 bytes.
+authentication tag in bytes, see [CCM mode][].
+For AES-GCM and `chacha20-poly1305`, the `authTagLength` option defaults to 16
+bytes and must be set to a different value if a different length is used.
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
 recent OpenSSL releases, `openssl list -cipher-algorithms` will

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3624,14 +3624,17 @@ Please use the [`crypto.createHmac()`][] method to create Hmac instances.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52552
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/52345
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 Applications that intend to use authentication tags that are shorter than the
-default authentication tag length should set the `authTagLength` option of the
+default authentication tag length must set the `authTagLength` option of the
 [`crypto.createDecipheriv()`][] function to the appropriate length.
 
 For ciphers in GCM mode, the [`decipher.setAuthTag()`][] function accepts

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -698,8 +698,7 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (mode == EVP_CIPH_GCM_MODE && cipher->auth_tag_len_ == kNoAuthTagLength &&
-      tag_len != 16 && env->options()->pending_deprecation &&
-      env->EmitProcessEnvWarning()) {
+      tag_len != 16 && env->EmitProcessEnvWarning()) {
     if (ProcessEmitDeprecationWarning(
             env,
             "Using AES-GCM authentication tags of less than 128 bits without "

--- a/test/parallel/test-crypto-gcm-implicit-short-tag.js
+++ b/test/parallel/test-crypto-gcm-implicit-short-tag.js
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)


### PR DESCRIPTION
This introduces a runtime deprecation for using GCM authentication tags that are shorter than the cipher's block size, unless the user specified the authTagLength option. This behavior has been doc-only deprecated since 8f61b658de1e440839a076d3e5337193af960239.

I'd suggest to release this in Node.js 23. If it turns out to break some use cases, we can re-evaluate before moving to end-of-life.

Refs: https://github.com/nodejs/node/issues/52327
Refs: https://github.com/nodejs/node/pull/52345

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
