### PR TITLE
fs: add skipSymlinkDir option to skip symbolic dirs for fs.readdir

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1368,6 +1368,9 @@ closed after the iterator exits.
 <!-- YAML
 added: v10.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52553
+    description: New option `skipSymlinkDir` was added.
   - version:
     - v20.1.0
     - v18.17.0
@@ -1385,6 +1388,9 @@ changes:
   * `recursive` {boolean} If `true`, reads the contents of a directory
     recursively. In recursive mode, it will list all files, sub files, and
     directories. **Default:** `false`.
+  * `skipSymlinkDir` {boolean} This option is only effective when `recursive`
+    is set to `true`. If `true`, symbolic link directories are skipped. If
+    `false`, symbolic link directories are included. **Default:** `false`.
 * Returns: {Promise}  Fulfills with an array of the names of the files in
   the directory excluding `'.'` and `'..'`.
 
@@ -3728,6 +3734,9 @@ above values.
 <!-- YAML
 added: v0.1.8
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52553
+    description: New option `skipSymlinkDir` was added.
   - version:
     - v20.1.0
     - v18.17.0
@@ -3765,6 +3774,9 @@ changes:
   * `recursive` {boolean} If `true`, reads the contents of a directory
     recursively. In recursive mode, it will list all files, sub files and
     directories. **Default:** `false`.
+  * `skipSymlinkDir` {boolean} This option is only effective when `recursive`
+    is set to `true`. If `true`, symbolic link directories are skipped. If
+    `false`, symbolic link directories are included. **Default:** `false`.
 * `callback` {Function}
   * `err` {Error}
   * `files` {string\[]|Buffer\[]|fs.Dirent\[]}
@@ -5857,6 +5869,9 @@ this API: [`fs.open()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52553
+    description: New option `skipSymlinkDir` was added.
   - version:
     - v20.1.0
     - v18.17.0
@@ -5878,6 +5893,9 @@ changes:
   * `recursive` {boolean} If `true`, reads the contents of a directory
     recursively. In recursive mode, it will list all files, sub files, and
     directories. **Default:** `false`.
+  * `skipSymlinkDir` {boolean} This option is only effective when `recursive`
+    is set to `true`. If `true`, symbolic link directories are skipped. If
+    `false`, symbolic link directories are included. **Default:** `false`.
 * Returns: {string\[]|Buffer\[]|fs.Dirent\[]}
 
 Reads the contents of the directory.

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1389,13 +1389,19 @@ function mkdirSync(path, options) {
 function readdirSyncRecursive(basePath, options) {
   const withFileTypes = Boolean(options.withFileTypes);
   const encoding = options.encoding;
-
+  const skipSymlinkDir = options.skipSymlinkDir || false;
   const readdirResults = [];
   const pathsQueue = [basePath];
 
   function read(path) {
+    const namespacePath = pathModule.toNamespacedPath(path);
+    if (skipSymlinkDir) {
+      if (lstatSync(namespacePath).isSymbolicLink()) {
+        return;
+      }
+    }
     const readdirResult = binding.readdir(
-      pathModule.toNamespacedPath(path),
+      namespacePath,
       encoding,
       withFileTypes,
     );
@@ -1413,7 +1419,14 @@ function readdirSyncRecursive(basePath, options) {
       for (let i = 0; i < length; i++) {
         const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
-        if (dirent.isDirectory()) {
+        if (skipSymlinkDir) {
+          if (dirent.isSymbolicLink()) {
+            continue;
+          }
+        }
+        const resultPath = pathModule.join(path, dirent.name);
+        const stat = binding.internalModuleStat(resultPath);
+        if (stat === 1) {
           ArrayPrototypePush(pathsQueue, pathModule.join(dirent.parentPath, dirent.name));
         }
       }
@@ -1421,8 +1434,13 @@ function readdirSyncRecursive(basePath, options) {
       for (let i = 0; i < readdirResult.length; i++) {
         const resultPath = pathModule.join(path, readdirResult[i]);
         const relativeResultPath = pathModule.relative(basePath, resultPath);
-        const stat = binding.internalModuleStat(resultPath);
         ArrayPrototypePush(readdirResults, relativeResultPath);
+        if (skipSymlinkDir) {
+          if (lstatSync(resultPath).isSymbolicLink()) {
+            continue;
+          }
+        }
+        const stat = binding.internalModuleStat(resultPath);
         // 1 indicates directory
         if (stat === 1) {
           ArrayPrototypePush(pathsQueue, resultPath);
@@ -1497,7 +1515,9 @@ function readdirSync(path, options) {
   if (options.recursive != null) {
     validateBoolean(options.recursive, 'options.recursive');
   }
-
+  if (options.skipSymlinkDir != null) {
+    validateBoolean(options.skipSymlinkDir, 'options.skipSymlinkDir');
+  }
   if (options.recursive) {
     return readdirSyncRecursive(path, options);
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -868,6 +868,14 @@ async function mkdir(path, options) {
 
 async function readdirRecursive(originalPath, options) {
   const result = [];
+  const skipSymlinkDir = options.skipSymlinkDir || false;
+
+  if (skipSymlinkDir) {
+    const stats = await lstat(originalPath);
+    if (stats.isSymbolicLink()) {
+      return result;
+    }
+  }
   const queue = [
     [
       originalPath,
@@ -890,8 +898,15 @@ async function readdirRecursive(originalPath, options) {
       // If we want to implement BFS make this a `shift` call instead of `pop`
       const { 0: path, 1: readdir } = ArrayPrototypePop(queue);
       for (const dirent of getDirents(path, readdir)) {
+        if (skipSymlinkDir) {
+          if (dirent.isSymbolicLink()) {
+            continue;
+          }
+        }
         ArrayPrototypePush(result, dirent);
-        if (dirent.isDirectory()) {
+        const direntPath = pathModule.join(path, dirent.name);
+        const stat = binding.internalModuleStat(direntPath);
+        if (stat === 1) {
           const direntPath = pathModule.join(path, dirent.name);
           ArrayPrototypePush(queue, [
             direntPath,
@@ -919,6 +934,12 @@ async function readdirRecursive(originalPath, options) {
           result,
           pathModule.relative(originalPath, direntPath),
         );
+        if (skipSymlinkDir) {
+          const stats = await lstat(direntPath);
+          if (stats.isSymbolicLink()) {
+            continue;
+          }
+        }
         if (stat === 1) {
           ArrayPrototypePush(queue, [
             direntPath,


### PR DESCRIPTION
- Add a `skipSymlinkDir ` option to the `fs.readdir` to allow for behavior similar to the `find [path] -print` and `find -L [path] -print` commands. This option would control whether symbolic link directories are skipped or traversed during directory listing.
- Ensure that checking if the current directory is a symlink leads to consistent file listings in `fs.readdir([path], {withFileTypes: false}) ` and `fs.readdir([path], {withFileTypes: true})`

Refs: https://github.com/nodejs/node/issues/51858
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
