### PR TITLE
build: fix arm64 cross-compilation bug on non-arm machines

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -479,8 +479,20 @@
     },
 
     'conditions': [
+      # Pointer authentication for ARM64.
       ['target_arch=="arm64"', {
-        'cflags': ['-mbranch-protection=standard'],  # Pointer authentication.
+          'target_conditions': [
+              ['_toolset=="host"', {
+                  'conditions': [
+                      ['host_arch=="arm64"', {
+                          'cflags': ['-mbranch-protection=standard'],
+                      }],
+                  ],
+              }],
+              ['_toolset=="target"', {
+                  'cflags': ['-mbranch-protection=standard'],
+              }],
+          ],
       }],
       ['OS in "aix os400"', {
         'ldflags': [


### PR DESCRIPTION
Fix the ARM64 cross-compilation bug on non-arm machines that's explained in detail in issue #52512.