### PR TITLE
test: ensure that all worker servers are ready

### DIFF
--- a/test/parallel/test-tls-ticket-cluster.js
+++ b/test/parallel/test-tls-ticket-cluster.js
@@ -33,10 +33,10 @@ const workerCount = 4;
 const expectedReqCount = 16;
 
 if (cluster.isPrimary) {
+  let listeningCount = 0;
   let reusedCount = 0;
   let reqCount = 0;
   let lastSession = null;
-  let shootOnce = false;
   let workerPort = null;
 
   function shoot() {
@@ -73,9 +73,8 @@ if (cluster.isPrimary) {
       console.error('[primary] got %j', msg);
       if (msg === 'reused') {
         ++reusedCount;
-      } else if (msg === 'listening' && !shootOnce) {
-        workerPort = port || workerPort;
-        shootOnce = true;
+      } else if (msg === 'listening' && ++listeningCount === workerCount) {
+        workerPort = port;
         shoot();
       }
     });


### PR DESCRIPTION
Wait for the `'listening'` message from all workers before creating the first connection. This fixes an `EMFILE` error that is raised on Windows when running the following command

```
python tools/test.py -J --repeat=1000 parallel/test-tls-ticket-cluster
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
