### PR TITLE
util: mark deprecated objects with symbol

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -3060,6 +3060,20 @@ util.isDate({});
 // Returns: false
 ```
 
+### `util.isDeprecated(object)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 2 - Stable
+
+* `object` {any}
+* Returns: {boolean}
+
+Returns `true` if the given `object` was deprecated via `util.deprecate`
+otherwise, returns `false`.
+
 ### `util.isError(object)`
 
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -239,6 +239,22 @@ The `--throw-deprecation` command-line flag and `process.throwDeprecation`
 property take precedence over `--trace-deprecation` and
 `process.traceDeprecation`.
 
+## `util.deprecate.isDeprecated`
+<!-- YAML
+added: REPLACEME
+-->
+After a function is deprecated with `util.deprecate`, a symbol is attached to
+mark the function's deprecation
+
+```js
+const util = require('node:util');
+
+const fn1 = util.deprecate(someFunction, someMessage, 'DEP0001');
+
+fn1[util.deprecate.isDeprecated]; // true
+(()=>{})[util.deprecate.isDeprecated]; // undefined
+```
+
 ## `util.format(format[, ...args])`
 
 <!-- YAML

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -250,9 +250,10 @@ mark the function's deprecation
 const util = require('node:util');
 
 const fn1 = util.deprecate(someFunction, someMessage, 'DEP0001');
+const fn2 = () => {};
 
 fn1[util.deprecate.isDeprecated]; // true
-(()=>{})[util.deprecate.isDeprecated]; // undefined
+fn2[util.deprecate.isDeprecated]; // undefined
 ```
 
 ## `util.format(format[, ...args])`

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -136,7 +136,7 @@ function pendingDeprecate(fn, msg, code) {
     emitDeprecationWarning();
     return ReflectApply(fn, this, args);
   }
-  deprecated[Symbol.isDeprecated] = true;
+  deprecated[deprecate.isDeprecated] = true;
   return deprecated;
 }
 
@@ -174,9 +174,11 @@ function deprecate(fn, msg, code, useEmitSync) {
     // constructor.
     deprecated.prototype = fn.prototype;
   }
-  deprecated[Symbol.isDeprecated] = true;
+  deprecated[deprecate.isDeprecated] = true;
   return deprecated;
 }
+
+deprecate.isDeprecated = Symbol.for('nodejs.util.deprecate.isDeprecated');
 
 function decorateErrorStack(err) {
   if (!(isError(err) && err.stack) || err[decorated_private_symbol])

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -908,6 +908,7 @@ module.exports = {
   getSystemErrorName,
   guessHandleType,
   isArrayBufferDetached,
+  isDeprecated,
   isError,
   isInsideNodeModules,
   join,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -136,6 +136,7 @@ function pendingDeprecate(fn, msg, code) {
     emitDeprecationWarning();
     return ReflectApply(fn, this, args);
   }
+  deprecated[Symbol.isDeprecated] = true;
   return deprecated;
 }
 
@@ -173,7 +174,7 @@ function deprecate(fn, msg, code, useEmitSync) {
     // constructor.
     deprecated.prototype = fn.prototype;
   }
-
+  deprecated[Symbol.isDeprecated] = true;
   return deprecated;
 }
 

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -178,7 +178,7 @@ function deprecate(fn, msg, code, useEmitSync) {
   return deprecated;
 }
 
-deprecate.isDeprecated = Symbol.for('nodejs.util.deprecate.isDeprecated');
+deprecate.isDeprecated = SymbolFor('nodejs.util.deprecate.isDeprecated');
 
 function decorateErrorStack(err) {
   if (!(isError(err) && err.stack) || err[decorated_private_symbol])

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -75,6 +75,16 @@ const colorRegExp = /\u001b\[\d\d?m/g; // eslint-disable-line no-control-regex
 
 let uvBinding;
 
+function addDeprecationSymbol(obj) {
+  ObjectDefineProperty(obj, deprecate.isDeprecated, {
+    __proto__: null,
+    value: true,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+}
+
 function lazyUv() {
   uvBinding ??= internalBinding('uv');
   return uvBinding;
@@ -136,7 +146,7 @@ function pendingDeprecate(fn, msg, code) {
     emitDeprecationWarning();
     return ReflectApply(fn, this, args);
   }
-  deprecated[deprecate.isDeprecated] = true;
+  addDeprecationSymbol(deprecated);
   return deprecated;
 }
 
@@ -174,11 +184,15 @@ function deprecate(fn, msg, code, useEmitSync) {
     // constructor.
     deprecated.prototype = fn.prototype;
   }
-  deprecated[deprecate.isDeprecated] = true;
+  addDeprecationSymbol(deprecated);
   return deprecated;
 }
 
 deprecate.isDeprecated = SymbolFor('nodejs.util.deprecate.isDeprecated');
+
+function isDeprecated(obj) {
+  return obj[deprecate.isDeprecated] || false;
+}
 
 function decorateErrorStack(err) {
   if (!(isError(err) && err.stack) || err[decorated_private_symbol])

--- a/lib/util.js
+++ b/lib/util.js
@@ -78,6 +78,7 @@ const {
   deprecate,
   getSystemErrorMap,
   getSystemErrorName: internalErrorName,
+  isDeprecated,
   promisify,
   defineLazyProperties,
 } = require('internal/util');
@@ -455,6 +456,7 @@ module.exports = {
     }
     return internalDeepEqual(a, b);
   },
+  isDeprecated,
   isNull: deprecate(isNull,
                     'The `util.isNull` API is deprecated. Please use `arg === null` instead.',
                     'DEP0050'),


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #22543

This PR marks deprecated objects with a custom symbol, to make it easier for developers to know what functions have been deprecated.