### PR TITLE
doc: emphasize "timeout" and "request.setTimeout()" difference

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1299,7 +1299,7 @@ changes:
 Calls [`socket.setTimeout()`][] on the socket assigned to this request
 after that socket emits the `connect` event.
 
-Unlike the `timeout` option on `http.Agent` and `http.request()`, the
+Unlike the `timeout` option of [`http.Agent`][] and `http.request()`, the
 `request.setTimeout()` method disregards the socket connection time
 as the timeout starts _after_ the socket connection has been established.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1297,7 +1297,7 @@ changes:
 * Returns: {http.ClientRequest}
 
 Calls [`socket.setTimeout()`][] on the socket assigned to this request
-after that socket emits the `connect` event.
+after that socket emits the `'connect'` event.
 
 Unlike the `timeout` option of [`http.Agent`][] and `http.request()`, the
 `request.setTimeout()` method disregards the socket connection time

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -176,7 +176,7 @@ changes:
     while the `'lifo'` scheduling will keep it as low as possible.
     **Default:** `'lifo'`.
   * `timeout` {number} Socket timeout in milliseconds.
-    This will set the timeout when the socket is created.
+    This will immediately set the timeout when the socket is created.
 
 `options` in [`socket.connect()`][] are also supported.
 
@@ -1296,8 +1296,12 @@ changes:
   Same as binding to the `'timeout'` event.
 * Returns: {http.ClientRequest}
 
-Once a socket is assigned to this request and is connected
-[`socket.setTimeout()`][] will be called.
+Calls [`socket.setTimeout()`][] on the socket assigned to this request
+after that socket emits the `connect` event.
+
+Unlike the `timeout` option on `http.Agent` and `http.request()`, the
+`request.setTimeout()` method disregards the socket connection time
+as the timeout starts _after_ the socket connection has been established.
 
 ### `request.socket`
 
@@ -3769,8 +3773,9 @@ changes:
     request.
   * `socketPath` {string} Unix domain socket. Cannot be used if one of `host`
     or `port` is specified, as those specify a TCP Socket.
-  * `timeout` {number}: A number specifying the socket timeout in milliseconds.
-    This will set the timeout before the socket is connected.
+  * `timeout` {number}: Socket timeout in milliseconds.
+    This is forwarded to the [`http.Agent`][], which will set the timeout
+    immediately when the socket is created.
   * `uniqueHeaders` {Array} A list of request headers that should be sent
     only once. If the header's value is an array, the items will be joined
     using `; `.


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This change brings emphasis on the difference between these two ways of setting a socket timeout on an HTTP request:

```js
http.request(url, { timeout: n })
http.request(url).setTimeout(n)
```

The two are completely different, and the current state of the docs failed to highlight that difference when I was debugging an issue. 

- The `timeout` option on `http.request()` is forwarded to the `http.Agent` and _applies timeout immediately_ when the socket is created.
- The `request.setTimeout()` method is _not_ forwarded to the `http.Agent`, and _applies timeout **after** the socket has connected_. 
