### PR TITLE
module: skip NODE_COMPILE_CACHE when policy is enabled

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1096,6 +1096,12 @@ void Environment::InitializeCompileCache() {
       dir_from_env.empty()) {
     return;
   }
+  if (!options()->experimental_policy.empty()) {
+    Debug(this,
+          DebugCategory::COMPILE_CACHE,
+          "[compile cache] skipping cache because policy is enabled");
+    return;
+  }
   auto handler = std::make_unique<CompileCacheHandler>(this);
   if (handler->InitializeDirectory(this, dir_from_env)) {
     compile_cache_handler_ = std::move(handler);

--- a/test/parallel/test-compile-cache-policy.js
+++ b/test/parallel/test-compile-cache-policy.js
@@ -2,7 +2,10 @@
 
 // This tests NODE_COMPILE_CACHE is disabled when policy is used.
 
-require('../common');
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
 const { spawnSyncAndAssert } = require('../common/child_process');
 const assert = require('assert');
 const fs = require('fs');

--- a/test/parallel/test-compile-cache-policy.js
+++ b/test/parallel/test-compile-cache-policy.js
@@ -33,4 +33,3 @@ const fixtures = require('../common/fixtures');
     });
   assert(!fs.existsSync(dir));
 }
-

--- a/test/parallel/test-compile-cache-policy.js
+++ b/test/parallel/test-compile-cache-policy.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE is disabled when policy is used.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('policy', 'parent.js');
+  const policy = fixtures.path(
+    'policy',
+    'dependencies',
+    'dependencies-redirect-policy.json');
+  spawnSyncAndAssert(
+    process.execPath,
+    ['--experimental-policy', policy, script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr: /skipping cache because policy is enabled/
+    });
+  assert(!fs.existsSync(dir));
+}
+


### PR DESCRIPTION
It might be worth designing a policy for the compilation cache. For now, just skip the cache when policy is enabled.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
