### PR TITLE
module: address coverity warning of memory leak

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -261,13 +261,15 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
                           host_defined_options);
 
       CompileCacheEntry* cache_entry = nullptr;
-      if (can_use_builtin_cache && realm->env()->use_compile_cache()) {
-        cache_entry = realm->env()->compile_cache_handler()->GetOrInsert(
-            source_text, url, CachedCodeType::kESM);
-      }
-      if (cache_entry != nullptr && cache_entry->cache != nullptr) {
-        // source will take ownership of cached_data.
-        cached_data = cache_entry->CopyCache();
+      if (!used_cache_from_user) {
+        if (can_use_builtin_cache && realm->env()->use_compile_cache()) {
+          cache_entry = realm->env()->compile_cache_handler()->GetOrInsert(
+              source_text, url, CachedCodeType::kESM);
+        }
+        if (cache_entry != nullptr && cache_entry->cache != nullptr) {
+          // source will take ownership of cached_data.
+          cached_data = cache_entry->CopyCache();
+        }
       }
 
       ScriptCompiler::Source source(source_text, origin, cached_data);


### PR DESCRIPTION
Covery reported the cach passed in the user as being overwritten by newly added automatic caching. Guard the automatica cachine to avoid this.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
