### PR TITLE
lib: avoid repl.setupHistory() blocks node exit after repl closed

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -136,6 +136,11 @@ function setupHistory(repl, historyPath, ready) {
 
   function flushHistory() {
     timer = null;
+
+    if (repl.close) {
+      return;
+    }
+
     if (writing) {
       pending = true;
       return;

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -137,7 +137,7 @@ function setupHistory(repl, historyPath, ready) {
   function flushHistory() {
     timer = null;
 
-    if (repl.close) {
+    if (repl.closed) {
       return;
     }
 

--- a/test/parallel/test-repl-close-before-setupHistory.js
+++ b/test/parallel/test-repl-close-before-setupHistory.js
@@ -1,7 +1,13 @@
 'use strict';
-const common = require('../common');
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
 const repl = require('repl');
 
-var r = repl.start({});
-r.setupHistory(__dirname + '/history', () => { }); // Different results will occur here
+tmpdir.refresh();
+const r = repl.start({});
+const historyPath = tmpdir.resolve('.history');
+
+r.setupHistory(historyPath, () => { assert.strictEqual(r.closed, true); });
 r.close();

--- a/test/parallel/test-repl-close-before-setupHistory.js
+++ b/test/parallel/test-repl-close-before-setupHistory.js
@@ -1,0 +1,7 @@
+'use strict';
+const common = require('../common');
+const repl = require('repl');
+
+var r = repl.start({});
+r.setupHistory(__dirname + '/history', () => { }); // Different results will occur here
+r.close();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/52386