### PR TITLE
buffer: remove lines setting indexes to integer value from `Blob.slice`

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -243,14 +243,12 @@ class Blob {
     } else {
       start = MathMin(start, this[kLength]);
     }
-    start |= 0;
 
     if (end < 0) {
       end = MathMax(this[kLength] + end, 0);
     } else {
       end = MathMin(end, this[kLength]);
     }
-    end |= 0;
 
     contentType = `${contentType}`;
     if (RegExpPrototypeExec(disallowedTypeCharacters, contentType) !== null) {

--- a/test/pummel/test-blob-slice-with-large-size.js
+++ b/test/pummel/test-blob-slice-with-large-size.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+
+// Buffer with size > INT32_MAX
+common.skipIf32Bits();
+
+const assert = require('assert');
+
+const size = 2 ** 31;
+
+try {
+  const buf = Buffer.allocUnsafe(size);
+  const blob = new Blob([buf]);
+  const slicedBlob = blob.slice(size - 1, size);
+  assert.strictEqual(slicedBlob.size, 1);
+} catch (e) {
+  if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
+    throw e;
+  }
+  common.skip('insufficient space for Buffer.allocUnsafe');
+}


### PR DESCRIPTION
Since `blob` allows maximum `kLength` of 2GB, the indexes maybe out of signed integer range.
remove lines setting indexes to integer value from `Blob.slice`.
they will be checked in Cpp side(`Blob::ToSlice`) if they were not in unsigned integer range.
Refs: #52585
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
