### PR TITLE
doc: replace U+00A0 with U+0020

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -725,7 +725,7 @@ added:
 * `ip` {string} The IP which the socket attempted to connect to.
 * `port` {number} The port which the socket attempted to connect to.
 * `family` {number} The family of the IP. It can be `6` for IPv6 or `4` for IPv4.
-  \* `error` {Error} The error associated with the failure.
+* `error` {Error} The error associated with the failure.
 
 Emitted when a connection attempt failed. This may be emitted multiple times
 if the family autoselection algorithm is enabled in [`socket.connect(options)`][].

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -725,7 +725,7 @@ added:
 * `ip` {string} The IP which the socket attempted to connect to.
 * `port` {number} The port which the socket attempted to connect to.
 * `family` {number} The family of the IP. It can be `6` for IPv6 or `4` for IPv4.
-  \* `error` {Error} The error associated with the failure.
+  \* `error` {Error} The error associated with the failure.
 
 Emitted when a connection attempt failed. This may be emitted multiple times
 if the family autoselection algorithm is enabled in [`socket.connect(options)`][].
@@ -1723,7 +1723,7 @@ nc -U /tmp/echo.sock
 added: v19.4.0
 -->
 
-Gets the current default value of the `autoSelectFamily` option of [`socket.connect(options)`][].
+Gets the current default value of the `autoSelectFamily` option of [`socket.connect(options)`][].
 The initial default value is `true`, unless the command line option
 `--no-network-family-autoselection` is provided.
 
@@ -1735,9 +1735,9 @@ The initial default value is `true`, unless the command line option
 added: v19.4.0
 -->
 
-Sets the default value of the `autoSelectFamily` option of [`socket.connect(options)`][].
+Sets the default value of the `autoSelectFamily` option of [`socket.connect(options)`][].
 
-* `value` {boolean} The new default value. The initial default value is `false`.
+* `value` {boolean} The new default value. The initial default value is `false`.
 
 ## `net.getDefaultAutoSelectFamilyAttemptTimeout()`
 
@@ -1747,7 +1747,7 @@ added:
  - v18.18.0
 -->
 
-Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
+Gets the current default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
 The initial default value is `250` or the value specified via the command line
 option `--network-family-autoselection-attempt-timeout`.
 
@@ -1761,9 +1761,9 @@ added:
  - v18.18.0
 -->
 
-Sets the default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
+Sets the default value of the `autoSelectFamilyAttemptTimeout` option of [`socket.connect(options)`][].
 
-* `value` {number} The new default value, which must be a positive number. If the number is less than `10`,
+* `value` {number} The new default value, which must be a positive number. If the number is less than `10`,
   the value `10` is used instead. The initial default value is `250` or the value specified via the command line
   option `--network-family-autoselection-attempt-timeout`.
 


### PR DESCRIPTION
Replace NO-BREAK SPACE (U+00A0) with SPACE (U+0020) in `doc/api/net.md`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
