### PR TITLE
build: compile with C++20 support on Windows

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -286,7 +286,7 @@
       'VCCLCompilerTool': {
         'AdditionalOptions': [
           '/Zc:__cplusplus',
-          '-std:c++17'
+          '-std:c++20'
         ],
         'BufferSecurityCheck': 'true',
         'DebugInformationFormat': 1,          # /Z7 embed info in .obj files


### PR DESCRIPTION
Our Linux build infra is not ready for it yet,
but V8 is making it difficult to compile on Windows
without it.

Refs: https://github.com/nodejs/node/issues/45402
