### PR TITLE
src: add `string_view` overload to snapshot FromBlob

### DIFF
--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -315,6 +315,11 @@ EmbedderSnapshotData::Pointer EmbedderSnapshotData::BuiltinSnapshotData() {
 
 EmbedderSnapshotData::Pointer EmbedderSnapshotData::FromBlob(
     const std::vector<char>& in) {
+  return FromBlob(std::string_view(in.data(), in.size()));
+}
+
+EmbedderSnapshotData::Pointer EmbedderSnapshotData::FromBlob(
+    std::string_view in) {
   SnapshotData* snapshot_data = new SnapshotData();
   CHECK_EQ(snapshot_data->data_ownership, SnapshotData::DataOwnership::kOwned);
   EmbedderSnapshotData::Pointer result{

--- a/src/node.h
+++ b/src/node.h
@@ -537,6 +537,7 @@ class EmbedderSnapshotData {
   // If the snapshot is invalid, this returns an empty pointer.
   static Pointer FromFile(FILE* in);
   static Pointer FromBlob(const std::vector<char>& in);
+  static Pointer FromBlob(std::string_view in);
 
   // Write this EmbedderSnapshotData object to an output file.
   // Calling this method will not close the FILE* handle.


### PR DESCRIPTION
The `const std::vector<char>&` variant only delegates to a method that converts it to a `std::string_view` anyway, but adding this capability to the public API as well means that it’s easier to store snapshot data in embedding applications (because using `std::vector<>` enforces heap allocation and `std::string_view` does not).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
