### PR TITLE
doc: remove buffered flag from performance hooks examples

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1804,7 +1804,7 @@ const obs = new PerformanceObserver((list, observer) => {
   performance.clearMeasures();
   observer.disconnect();
 });
-obs.observe({ entryTypes: ['measure'], buffered: true });
+obs.observe({ entryTypes: ['measure'] });
 
 setTimeout(() => {}, 1000);
 ```
@@ -1839,7 +1839,7 @@ const obs = new PerformanceObserver((list) => {
   performance.clearMeasures();
   obs.disconnect();
 });
-obs.observe({ entryTypes: ['function'], buffered: true });
+obs.observe({ entryTypes: ['function'] });
 
 require('some-module');
 ```


### PR DESCRIPTION
The actual implementation of the `observe` method does not count the `buffered` flag if we use the `entryTypes` with it. Therefore, examples with both `entryTypes` and `buffered` are confusing because it doesn't have any effect on the actual behaviour.

I see that we have somewhat [similar PR](https://github.com/nodejs/node/pull/47025) on the same topic. However, it doesn't provide changes to the examples. Also, I'm not sure at what stage the PR I linked is. If it stuck and not going anywhere I can work on it and deliver the whole fix instead of just examples.