### PR TITLE
test: add `--test-random-seed` cli argument

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1992,6 +1992,16 @@ changes:
 Configures the test runner to only execute top level tests that have the `only`
 option set.
 
+### `--test-random-seed`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+Passes a random seed to every test's `TestContext`. If this variable is not
+defined, a random seed will be passed.
+
 ### `--test-reporter`
 
 <!-- YAML

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -390,6 +390,18 @@ test('a test that creates asynchronous activity', (t) => {
 });
 ```
 
+## Randomness
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+Every instance of `TestContext` contains a `.seed` getter, which contains a
+randomly generated seed, or the seed passed via `--test-random-seed`. While
+this seed may be helpful for configuring pseudorandom generators, it should not
+be relied on for cryptography.
+
 ## Watch mode
 
 <!-- YAML

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -113,7 +113,7 @@ function filterExecArgv(arg, i, arr) {
   !ArrayPrototypeSome(kFilterArgValues, (p) => arg === p || (i > 0 && arr[i - 1] === p) || StringPrototypeStartsWith(arg, `${p}=`));
 }
 
-function getRunArgs(path, { forceExit, inspectPort, testNamePatterns, testSkipPatterns, only }) {
+function getRunArgs(path, { forceExit, inspectPort, testNamePatterns, testSkipPatterns, only, seed }) {
   const argv = ArrayPrototypeFilter(process.execArgv, filterExecArgv);
   if (forceExit === true) {
     ArrayPrototypePush(argv, '--test-force-exit');
@@ -129,6 +129,9 @@ function getRunArgs(path, { forceExit, inspectPort, testNamePatterns, testSkipPa
   }
   if (only === true) {
     ArrayPrototypePush(argv, '--test-only');
+  }
+  if (seed != null) {
+    ArrayPrototypePush(argv, `--test-random-seed=${seed}`);
   }
   ArrayPrototypePush(argv, path);
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -10,7 +10,10 @@ const {
   ArrayPrototypeUnshift,
   FunctionPrototype,
   MathMax,
+  MathFloor,
+  MathRandom,
   Number,
+  NumberIsNaN,
   ObjectSeal,
   PromisePrototypeThen,
   PromiseResolve,
@@ -86,10 +89,22 @@ const {
   testNamePatterns,
   testSkipPatterns,
   testOnlyFlag,
+  seed: cliSeed,
 } = parseCommandLine();
 let kResistStopPropagation;
 let findSourceMap;
 let noopTestStream;
+let seed;
+
+function getSeed() {
+  if (seed === undefined) {
+    if (NumberIsNaN(cliSeed) || cliSeed === null) {
+      seed = MathFloor(MathRandom() * 0x7fffffff);
+    }
+  }
+
+  return seed;
+}
 
 function lazyFindSourceMap(file) {
   if (findSourceMap === undefined) {
@@ -156,6 +171,10 @@ class TestContext {
 
   constructor(test) {
     this.#test = test;
+  }
+
+  get seed() {
+    return getSeed();
   }
 
   get signal() {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -19,6 +19,7 @@ const {
   StringPrototypePadEnd,
   StringPrototypeRepeat,
   StringPrototypeSlice,
+  NumberParseFloat,
 } = primordials;
 
 const { AsyncResource } = require('async_hooks');
@@ -195,6 +196,7 @@ function parseCommandLine() {
   const coverage = getOptionValue('--experimental-test-coverage');
   const forceExit = getOptionValue('--test-force-exit');
   const sourceMaps = getOptionValue('--enable-source-maps');
+  const seed = NumberParseFloat(getOptionValue('--test-random-seed'));
   const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
   const isChildProcessV8 = process.env.NODE_TEST_CONTEXT === 'child-v8';
   let destinations;
@@ -257,6 +259,7 @@ function parseCommandLine() {
     testSkipPatterns,
     reporters,
     destinations,
+    seed,
   };
 
   return globalTestOptions;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -647,6 +647,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--test-name-pattern",
             "run tests whose name matches this regular expression",
             &EnvironmentOptions::test_name_pattern);
+  AddOption("--test-random-seed",
+            "supply a seed to the test runner",
+            &EnvironmentOptions::test_random_seed);
   AddOption("--test-reporter",
             "report test output using the given reporter",
             &EnvironmentOptions::test_reporter,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -166,6 +166,7 @@ class EnvironmentOptions : public Options {
   std::string diagnostic_dir;
   std::string env_file;
   bool has_env_file_string = false;
+  std::string test_random_seed;
   bool test_runner = false;
   uint64_t test_runner_concurrency = 0;
   uint64_t test_runner_timeout = 0;

--- a/test/parallel/test-runner-seed.js
+++ b/test/parallel/test-runner-seed.js
@@ -1,0 +1,10 @@
+// Flags: --test-random-seed=42
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const test = require('node:test');
+
+test('test-runner-seed', (context) => {
+  assert.strictEqual(context.seed, 42);
+});


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #51870

Adds a new CLI argument, `--test-random-seed`. This exposes a TestContext `seed` property containing the value of this argument, or generated with `Math.random`