### PR TITLE
events,doc: mark CustomEvent as stable

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -2426,9 +2426,13 @@ Removes the `listener` from the list of handlers for event `type`.
 added:
   - v18.7.0
   - v16.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52618
+    description: CustomEvent is now stable.
 -->
 
-> Stability: 1 - Experimental.
+> Stability: 2 - Stable
 
 * Extends: {Event}
 
@@ -2441,9 +2445,13 @@ Instances are created internally by Node.js.
 added:
   - v18.7.0
   - v16.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52618
+    description: CustomEvent is now stable.
 -->
 
-> Stability: 1 - Experimental.
+> Stability: 2 - Stable
 
 * Type: {any} Returns custom data passed when initializing.
 


### PR DESCRIPTION
CustomEvent has been exposed to globals since v19.x and remains in the experimental stage. I suggest moving it to stable.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>
