### PR TITLE
http,net: use preallocate events to improve performance

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -542,6 +542,21 @@ function Server(options, requestListener) {
   }
 
   storeHTTPOptions.call(this, options);
+  this._events ??= {
+    checkContinue: undefined,
+    checkExpectation: undefined,
+    clientError: undefined,
+    connect: undefined,
+    dropRequest: undefined,
+    request: undefined,
+    upgrade: undefined,
+    close: undefined,
+    connection: undefined,
+    error: undefined,
+    listening: undefined,
+    drop: undefined,
+  };
+
   net.Server.call(
     this,
     { allowHalfOpen: true, noDelay: options.noDelay ?? true,

--- a/lib/net.js
+++ b/lib/net.js
@@ -406,6 +406,31 @@ function Socket(options) {
   options.autoDestroy = true;
   // Handle strings directly.
   options.decodeStrings = false;
+  this._events ??= {
+    close: undefined,
+    error: undefined,
+    prefinish: undefined,
+    finish: undefined,
+    drain: undefined,
+    data: undefined,
+    end: undefined,
+    readable: undefined,
+    connect: undefined,
+    connectionAttempt: undefined,
+    connectionAttemptFailed: undefined,
+    connectionAttemptTimeout: undefined,
+    lookup: undefined,
+    ready: undefined,
+    timeout: undefined,
+    // Skip uncommon events...
+    // pause: undefined,
+    // resume: undefined,
+    // pipe: undefined,
+    // unpipe: undefined,
+    // [destroyImpl.kConstruct]: undefined,
+    // [destroyImpl.kDestroy]: undefined,
+  };
+
   stream.Duplex.call(this, options);
 
   if (options.handle) {
@@ -1732,6 +1757,14 @@ function addServerAbortSignalOption(self, options) {
 function Server(options, connectionListener) {
   if (!(this instanceof Server))
     return new Server(options, connectionListener);
+
+  this._events ??= {
+    close: undefined,
+    connection: undefined,
+    error: undefined,
+    listening: undefined,
+    drop: undefined,
+  };
 
   EventEmitter.call(this);
 


### PR DESCRIPTION
Improving the performance of event-emitter related subclasses by preallocating the events

[HTTP benchmark](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1527/console)

stopped the HTTP benchmark after 7 hours as it's too long, no improvement there

[`net` benchmark](https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1533/console)