### PR TITLE
lib: avoid swapping prototype in AbortSignal creation

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -25,6 +25,7 @@ const {
   kRemoveListener,
   kResistStopPropagation,
   kWeakHandler,
+  initEventTarget,
 } = require('internal/event_target');
 const {
   createDeferredPromise,
@@ -337,6 +338,16 @@ ObjectDefineProperty(AbortSignal.prototype, SymbolToStringTag, {
 
 defineEventHandler(AbortSignal.prototype, 'abort');
 
+function InternalAbortSignal(aborted, reason, composite) {
+  initEventTarget(this);
+  this[kAborted] = aborted;
+  this[kReason] = reason;
+  this[kComposite] = composite;
+}
+
+InternalAbortSignal.prototype = AbortSignal.prototype
+
+
 /**
  * @param {{
  *   aborted? : boolean,
@@ -353,11 +364,7 @@ function createAbortSignal(init = kEmptyObject) {
     transferable = false,
     composite = false,
   } = init;
-  const signal = new EventTarget();
-  ObjectSetPrototypeOf(signal, AbortSignal.prototype);
-  signal[kAborted] = aborted;
-  signal[kReason] = reason;
-  signal[kComposite] = composite;
+  const signal = new InternalAbortSignal(aborted, reason, composite);
   if (transferable) {
     lazyMarkTransferMode(signal, false, true);
   }


### PR DESCRIPTION
This avoid swapping the prototype when creating an `AbortSignal`, improving V8 optimizations for it.