### PR TITLE
Reduce likelihood of race conditions on keep-alive timeout calculatio…

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -488,6 +488,7 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
   socket.unref();
 
   let agentTimeout = this.options.timeout || 0;
+  let canKeepSocketAlive = true;
 
   if (socket._httpMessage?.res) {
     const keepAliveHint = socket._httpMessage.res.headers['keep-alive'];
@@ -496,9 +497,14 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
       const hint = RegExpPrototypeExec(/^timeout=(\d+)/, keepAliveHint)?.[1];
 
       if (hint) {
-        const serverHintTimeout = NumberParseInt(hint) * 1000;
-
-        if (serverHintTimeout < agentTimeout) {
+        // Let the timer expires before the announced timeout to reduce
+        // the likelihood of ECONNRESET errors
+        let serverHintTimeout = (NumberParseInt(hint) * 1000) - 1000;
+        serverHintTimeout = serverHintTimeout > 0 ? serverHintTimeout : 0;
+        if (serverHintTimeout === 0) {
+          // Cannot safely reuse the socket because the server timeout is too short
+          canKeepSocketAlive = false;
+        } else if (!agentTimeout || serverHintTimeout < agentTimeout) {
           agentTimeout = serverHintTimeout;
         }
       }
@@ -509,7 +515,7 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
     socket.setTimeout(agentTimeout);
   }
 
-  return true;
+  return canKeepSocketAlive;
 };
 
 Agent.prototype.reuseSocket = function reuseSocket(socket, req) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -1010,7 +1010,9 @@ function resOnFinish(req, res, socket, state, server) {
     }
   } else if (state.outgoing.length === 0) {
     if (server.keepAliveTimeout && typeof socket.setTimeout === 'function') {
-      socket.setTimeout(server.keepAliveTimeout);
+      // Increase the internal timeout wrt the advertised value to reduce likeliwood of ECONNRESET errors
+      // due to race conditions between the client and server timeout calculation
+      socket.setTimeout(server.keepAliveTimeout + 1000);
       state.keepAliveTimeoutSet = true;
     }
   } else {


### PR DESCRIPTION
Added 1 seconds threshold in keepalive timeout client-side
Added 1 second threshold in keepalive timeout server-side (expire the socket timeout 1 sec after the announced timeout)

Probably better to use a configurable threshold like in undici keepAliveTimeoutThreshold (https://github.com/nodejs/undici/pull/291)