### PR TITLE
doc: fix incorrect language identifiers causing duplicated code blocks in test.md

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -641,7 +641,7 @@ test('mocks setTimeout to be executed synchronously without having to actually w
 });
 ```
 
-```js
+```cjs
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
 
@@ -660,7 +660,7 @@ test('mocks setTimeout to be executed synchronously without having to actually w
   // Reset the globally tracked mocks.
   mock.timers.reset();
 
-  // If you call reset mock instance, it'll also reset timers instance
+  // If you call reset mock instance, it will also reset timers instance
   mock.reset();
 });
 ```
@@ -688,7 +688,7 @@ test('mocks setTimeout to be executed synchronously without having to actually w
 });
 ```
 
-```js
+```cjs
 const assert = require('node:assert');
 const { test } = require('node:test');
 


### PR DESCRIPTION
Two code blocks were incorrectly labeled as `js` instead of `cjs`, causing them to always be shown on https://nodejs.org/api/test.html#timers instead of being conditionally shown depending on the value of the `CJS / ESM` toggle.

The screenshot below shows the duplicated blocks
![image](https://github.com/nodejs/node/assets/8008842/b55c09db-16d7-480b-85ba-ffe65937b105)

This change should cause a single block with a `CJS / ESM` toggle to be shown
![image](https://github.com/nodejs/node/assets/8008842/e548bcb5-7189-41fd-9b2c-81be85214f3a)
