### PR TITLE
test: limit stack size in `test-error-serdes`

### DIFF
--- a/test/parallel/test-error-serdes-recursive-fast.js
+++ b/test/parallel/test-error-serdes-recursive-fast.js
@@ -1,0 +1,29 @@
+// Flags: --expose-internals --stack-size=128
+'use strict';
+require('../common');
+const assert = require('assert');
+const { serializeError, deserializeError } = require('internal/error_serdes');
+
+function cycle(err) {
+  return deserializeError(serializeError(err));
+}
+
+class ErrorWithCyclicCause extends Error {
+  get cause() {
+    return new ErrorWithCyclicCause();
+  }
+}
+const errorWithCyclicCause = Object
+  .defineProperty(new Error('Error with cause'), 'cause', { get() { return errorWithCyclicCause; } });
+
+assert.strictEqual(Object.hasOwn(cycle(errorWithCyclicCause), 'cause'), true);
+
+// When the cause is cyclic, it is serialized until Maxiumum call stack size is reached
+let depth = 0;
+let e = cycle(new ErrorWithCyclicCause('Error with cause'));
+while (e.cause) {
+  e = e.cause;
+  depth++;
+}
+assert(depth > 1);
+console.log('Successfully completed stack exhaust test at', depth);

--- a/test/parallel/test-error-serdes-recursive-slow.js
+++ b/test/parallel/test-error-serdes-recursive-slow.js
@@ -1,0 +1,29 @@
+// Flags: --expose-internals --stack-size=3072
+'use strict';
+require('../common');
+const assert = require('assert');
+const { serializeError, deserializeError } = require('internal/error_serdes');
+
+function cycle(err) {
+  return deserializeError(serializeError(err));
+}
+
+class ErrorWithCyclicCause extends Error {
+  get cause() {
+    return new ErrorWithCyclicCause();
+  }
+}
+const errorWithCyclicCause = Object
+  .defineProperty(new Error('Error with cause'), 'cause', { get() { return errorWithCyclicCause; } });
+
+assert.strictEqual(Object.hasOwn(cycle(errorWithCyclicCause), 'cause'), true);
+
+// When the cause is cyclic, it is serialized until Maxiumum call stack size is reached
+let depth = 0;
+let e = cycle(new ErrorWithCyclicCause('Error with cause'));
+while (e.cause) {
+  e = e.cause;
+  depth++;
+}
+assert(depth > 1);
+console.log('Successfully completed stack exhaust test at', depth);

--- a/test/parallel/test-error-serdes-recursive.js
+++ b/test/parallel/test-error-serdes-recursive.js
@@ -1,0 +1,29 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const { serializeError, deserializeError } = require('internal/error_serdes');
+
+function cycle(err) {
+  return deserializeError(serializeError(err));
+}
+
+class ErrorWithCyclicCause extends Error {
+  get cause() {
+    return new ErrorWithCyclicCause();
+  }
+}
+const errorWithCyclicCause = Object
+  .defineProperty(new Error('Error with cause'), 'cause', { get() { return errorWithCyclicCause; } });
+
+assert.strictEqual(Object.hasOwn(cycle(errorWithCyclicCause), 'cause'), true);
+
+// When the cause is cyclic, it is serialized until Maxiumum call stack size is reached
+let depth = 0;
+let e = cycle(new ErrorWithCyclicCause('Error with cause'));
+while (e.cause) {
+  e = e.cause;
+  depth++;
+}
+assert(depth > 1);
+console.log('Successfully completed stack exhaust test at', depth);

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --expose-internals --stack-size=128
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/parallel/test-error-serdes.js
+++ b/test/parallel/test-error-serdes.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --stack-size=128
+// Flags: --expose-internals
 'use strict';
 require('../common');
 const assert = require('assert');
@@ -57,17 +57,10 @@ class ErrorWithThowingCause extends Error {
     throw new Error('err');
   }
 }
-class ErrorWithCyclicCause extends Error {
-  get cause() {
-    return new ErrorWithCyclicCause();
-  }
-}
 const errorWithCause = Object
   .defineProperty(new Error('Error with cause'), 'cause', { get() { return { foo: 'bar' }; } });
 const errorWithThrowingCause = Object
   .defineProperty(new Error('Error with cause'), 'cause', { get() { throw new Error('err'); } });
-const errorWithCyclicCause = Object
-  .defineProperty(new Error('Error with cause'), 'cause', { get() { return errorWithCyclicCause; } });
 
 assert.strictEqual(cycle(new Error('Error with cause', { cause: 0 })).cause, 0);
 assert.strictEqual(cycle(new Error('Error with cause', { cause: -1 })).cause, -1);
@@ -79,19 +72,9 @@ assert.strictEqual(cycle(new Error('Error with cause', { cause: 'foo' })).cause,
 assert.deepStrictEqual(cycle(new Error('Error with cause', { cause: new Error('err') })).cause, new Error('err'));
 assert.deepStrictEqual(cycle(errorWithCause).cause, { foo: 'bar' });
 assert.strictEqual(Object.hasOwn(cycle(errorWithThrowingCause), 'cause'), false);
-assert.strictEqual(Object.hasOwn(cycle(errorWithCyclicCause), 'cause'), true);
 assert.deepStrictEqual(cycle(new ErrorWithCause('Error with cause')).cause, new Error('err'));
 assert.strictEqual(cycle(new ErrorWithThowingCause('Error with cause')).cause, undefined);
 assert.strictEqual(Object.hasOwn(cycle(new ErrorWithThowingCause('Error with cause')), 'cause'), false);
-// When the cause is cyclic, it is serialized until Maxiumum call stack size is reached
-let depth = 0;
-let e = cycle(new ErrorWithCyclicCause('Error with cause'));
-while (e.cause) {
-  e = e.cause;
-  depth++;
-}
-assert(depth > 1);
-
 
 {
   const err = new ERR_INVALID_ARG_TYPE('object', 'Object', 42);


### PR DESCRIPTION
This should significantly speed up the part of test that exceeds the maximum call stack size and hopefully deflake it on CI.

Might fix: https://github.com/nodejs/node/issues/52630