### PR TITLE
deps: V8: cherry-pick 500de8bd371b

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1716,6 +1716,10 @@ config("toolchain") {
 
       # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108517
       "-Wno-nonnull",
+
+      # Disable dangling pointer warnings, which are often false positives when
+      # using scopes.
+      "-Wno-dangling-pointer",
     ]
   }
 

--- a/deps/v8/src/compiler/turboshaft/assembler.h
+++ b/deps/v8/src/compiler/turboshaft/assembler.h
@@ -6,6 +6,7 @@
 #define V8_COMPILER_TURBOSHAFT_ASSEMBLER_H_
 
 #include <cstring>
+#include <iomanip>
 #include <iterator>
 #include <limits>
 #include <memory>

--- a/deps/v8/src/wasm/wasm-disassembler.cc
+++ b/deps/v8/src/wasm/wasm-disassembler.cc
@@ -4,6 +4,8 @@
 
 #include "src/wasm/wasm-disassembler.h"
 
+#include <iomanip>
+
 #include "src/debug/debug-interface.h"
 #include "src/numbers/conversions.h"
 #include "src/wasm/module-decoder-impl.h"


### PR DESCRIPTION
Original commit message:

    [gcc] Fix gcc / bazel build

    Add <iomanip> includes to fix gcc/blaze builds. Also ignore a dangling
    pointer warning introduced in newer gcc, since it has false positives
    on some uses of scope classes.

    Change-Id: Ib86a2437ffc34b5497a5b8619013d6d5b4ea30fe
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5380192
    Auto-Submit: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Adam Klein <adamk@chromium.org>
    Reviewed-by: Michael Achenbach <machenbach@chromium.org>
    Commit-Queue: Michael Achenbach <machenbach@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#92977}

Refs: https://github.com/v8/v8/commit/500de8bd371b224bb5274e88d6c7b165a146d378
Fixes: https://github.com/nodejs/node/issues/52675
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
