### PR TITLE
child_process: throw different error message for executing batch files w/o shell: true

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -426,6 +426,7 @@ ChildProcess.prototype.spawn = function(options) {
       exception.message = '"shell" must be "true" when spawning ' +
                           'a batch executable';
     }
+    throw exception;
   } else {
     process.nextTick(onSpawnNT, this);
   }

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -11,6 +11,7 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   StringPrototypeSlice,
+  StringPrototypeToLowerCase,
   Symbol,
   SymbolDispose,
   Uint8Array,
@@ -61,6 +62,7 @@ const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');
 const dc = require('diagnostics_channel');
+const { extname } = require('path');
 const childProcessChannel = dc.channel('child_process');
 
 const {
@@ -418,7 +420,12 @@ ChildProcess.prototype.spawn = function(options) {
 
     this._handle.close();
     this._handle = null;
-    throw new ErrnoException(err, 'spawn');
+    const exception = new ErrnoException(err, 'spawn');
+    const ext = StringPrototypeToLowerCase(extname(options.file));
+    if (ext === '.cmd' || ext === '.bat') {
+      exception.message = '"shell" must be "true" when spawning ' +
+                          'a batch executable';
+    }
   } else {
     process.nextTick(onSpawnNT, this);
   }

--- a/test/parallel/test-child-process-spawn-windows-batch-file.js
+++ b/test/parallel/test-child-process-spawn-windows-batch-file.js
@@ -57,6 +57,7 @@ function testSpawn(filename, code) {
     }
     if (!e) throw new Error(`Exception expected for ${filename}`);
     assert.strictEqual(e.code, code);
+    assert.match(e.message, /"shell" must be "true"/);
   } else {
     return new Promise((resolve) => {
       cp.spawn(filename).once('error', common.mustCall(function(e) {


### PR DESCRIPTION
This PR changes the error thrown when executing batch files without `shell: true` from an standard `UV_EINVAL` error to one with a few more details on how to resolve the issue.