### PR TITLE
http: correctly translate HTTP method

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -28,7 +28,7 @@ const {
 } = primordials;
 const { setImmediate } = require('timers');
 
-const { methods, HTTPParser } = internalBinding('http_parser');
+const { methods, allMethods, HTTPParser } = internalBinding('http_parser');
 const { getOptionValue } = require('internal/options');
 const insecureHTTPParser = getOptionValue('--insecure-http-parser');
 
@@ -109,7 +109,7 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
 
   if (typeof method === 'number') {
     // server only
-    incoming.method = methods[method];
+    incoming.method = allMethods[method];
   } else {
     // client only
     incoming.statusCode = statusCode;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1304,7 +1304,9 @@ void InitializeHttpParser(Local<Object> target,
          Integer::NewFromUnsigned(env->isolate(), kLenientAll));
 
   Local<Array> methods = Array::New(env->isolate());
+  Local<Array> all_methods = Array::New(env->isolate());
   size_t method_index = -1;
+  size_t all_method_index = -1;
 #define V(num, name, string)                                                   \
   methods                                                                      \
       ->Set(env->context(),                                                    \
@@ -1313,9 +1315,23 @@ void InitializeHttpParser(Local<Object> target,
       .Check();
   HTTP_METHOD_MAP(V)
 #undef V
+#define V(num, name, string)                                                   \
+  all_methods                                                                  \
+      ->Set(env->context(),                                                    \
+            ++all_method_index,                                                \
+            FIXED_ONE_BYTE_STRING(env->isolate(), #string))                    \
+      .Check();
+  HTTP_ALL_METHOD_MAP(V)
+#undef V
+
   target->Set(env->context(),
               FIXED_ONE_BYTE_STRING(env->isolate(), "methods"),
               methods).Check();
+  target
+      ->Set(env->context(),
+            FIXED_ONE_BYTE_STRING(env->isolate(), "allMethods"),
+            all_methods)
+      .Check();
 
   t->Inherit(AsyncWrap::GetConstructorTemplate(env));
   SetProtoMethod(isolate, t, "close", Parser::Close);

--- a/test/parallel/test-http-server-method.query.js
+++ b/test/parallel/test-http-server-method.query.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const { strictEqual } = require('assert');
+const { createServer, request } = require('http');
+
+const server = createServer(common.mustCall((req, res) => {
+  strictEqual(req.method, 'QUERY');
+  res.end('OK');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const req = request({ port: server.address().port, method: 'QUERY' }, common.mustCall((res) => {
+    strictEqual(res.statusCode, 200);
+
+    let buffer = '';
+    res.setEncoding('utf-8');
+
+    res.on('data', (c) => buffer += c);
+    res.on('end', common.mustCall(() => {
+      strictEqual(buffer, 'OK');
+      server.close();
+    }));
+  }));
+
+  req.end();
+}));


### PR DESCRIPTION
This PR correctly maps the HTTP method reported by llhttp (which is an index of an array) to the right array.

Fixes #51562.