### PR TITLE
src: fix test local edge case

### DIFF
--- a/test/parallel/test-process-load-env-file.js
+++ b/test/parallel/test-process-load-env-file.js
@@ -58,13 +58,17 @@ describe('process.loadEnvFile()', () => {
     const originalCwd = process.cwd();
 
     try {
-      process.chdir(join(originalCwd, 'lib'));
+      if (common.isMainThread) {
+        process.chdir(join(originalCwd, 'lib'));
+      }
 
       assert.throws(() => {
         process.loadEnvFile();
       }, { code: 'ENOENT', syscall: 'open', path: '.env' });
     } finally {
-      process.chdir(originalCwd);
+      if (common.isMainThread) {
+        process.chdir(originalCwd);
+      }
     }
   });
 

--- a/test/parallel/test-process-load-env-file.js
+++ b/test/parallel/test-process-load-env-file.js
@@ -4,6 +4,7 @@ const common = require('../common');
 const fixtures = require('../../test/common/fixtures');
 const assert = require('node:assert');
 const { describe, it } = require('node:test');
+const { join } = require('node:path');
 
 const basicValidEnvFilePath = fixtures.path('dotenv/basic-valid.env');
 const validEnvFilePath = fixtures.path('dotenv/valid.env');
@@ -48,10 +49,23 @@ describe('process.loadEnvFile()', () => {
     }, { code: 'ENOENT', syscall: 'open', path: missingEnvFile });
   });
 
+  // The whole chdir flow here is to address a case where a developer
+  // has a .env in the worktree which is probably in the global .gitignore.
+  // In that case this test would fail. To avoid confusion, chdir to lib will
+  // make this way less likely to happen. Probably a temporary directory would
+  // be the best choice but given how edge this case is this is fine.
   it('should throw when `.env` does not exist', async () => {
-    assert.throws(() => {
-      process.loadEnvFile();
-    }, { code: 'ENOENT', syscall: 'open', path: '.env' });
+    const originalCwd = process.cwd();
+
+    try {
+      process.chdir(join(originalCwd, 'lib'));
+
+      assert.throws(() => {
+        process.loadEnvFile();
+      }, { code: 'ENOENT', syscall: 'open', path: '.env' });
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 
   it('should check for permissions', async () => {


### PR DESCRIPTION
This PR fixes a edge case for a test which will fail if the `.env` file exists in the developer local worktree.