### PR TITLE
http2: fix excessive CPU usage when using `allowHTTP1=true`

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3185,6 +3185,7 @@ class Http2SecureServer extends TLSServer {
     if (options.allowHTTP1 === true) {
       this.headersTimeout = 60_000; // Minimum between 60 seconds or requestTimeout
       this.requestTimeout = 300_000; // 5 minutes
+      this.connectionsCheckingInterval = 30_000; // 30 seconds
       this.on('listening', setupConnectionsTracking);
     }
     if (typeof requestListener === 'function')


### PR DESCRIPTION
In Node `v20.12` a new feature was added for HTTP2 servers to [close idle connections when allowHTTP1 is true](https://github.com/nodejs/node/pull/51569). The implementation mirrors HTTP1 server behavior and leans on  [setupConnectionsTracking](https://github.com/nodejs/node/blob/e4c1d020dc2932cdc7a44040f4180346f0cbc3fc/lib/_http_server.js#L512-L525). `setupConnectionsTracking` works by calling `setInterval` using the `this.connectionsCheckingInterval` value which does not exist on `Http2SecureServer`. Therefore, `undefined` is passed to `setInterval`, which leads to `checkConnections` being called on every tick. This creates a significant additional load on the server CPU. The fix is to define `this.connectionsCheckingInterval` on the Http2SecureServer instance.

We run 10-20 app instances per server, and our CPU usage increased by ~20% when upgrading from `v20.11.1` to `v20.12.0` due to this issue.

Refs: https://github.com/nodejs/node/pull/51569
