### PR TITLE
cli: remove --no-experimental-global-customevent flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1364,14 +1364,6 @@ added: v0.8.0
 
 Silence deprecation warnings.
 
-### `--no-experimental-global-customevent`
-
-<!-- YAML
-added: v19.0.0
--->
-
-Disable exposition of [CustomEvent Web API][] on the global scope.
-
 ### `--no-experimental-global-navigator`
 
 <!-- YAML
@@ -2682,7 +2674,6 @@ one is included in the list below.
 * `--network-family-autoselection-attempt-timeout`
 * `--no-addons`
 * `--no-deprecation`
-* `--no-experimental-global-customevent`
 * `--no-experimental-global-navigator`
 * `--no-experimental-repl-await`
 * `--no-experimental-websocket`
@@ -3153,7 +3144,6 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
 [CommonJS]: modules.md
 [CommonJS module]: modules.md
-[CustomEvent Web API]: https://dom.spec.whatwg.org/#customevent
 [DEP0025 warning]: deprecations.md#dep0025-requirenodesys
 [ECMAScript module]: esm.md#modules-ecmascript-modules
 [ExperimentalWarning: `vm.measureMemory` is an experimental feature]: vm.md#vmmeasurememoryoptions

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -422,13 +422,15 @@ added:
   - v18.7.0
   - v16.17.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52723
+    description: No longer experimental.
   - version: v19.0.0
     pr-url: https://github.com/nodejs/node/pull/44860
     description: No longer behind `--experimental-global-customevent` CLI flag.
 -->
 
-> Stability: 1 - Experimental. Disable this API with the
-> [`--no-experimental-global-customevent`][] CLI flag.
+> Stability: 2 - Stable
 
 <!-- type=global -->
 
@@ -1150,7 +1152,6 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [Navigator API]: https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
 [RFC 5646]: https://www.rfc-editor.org/rfc/rfc5646.txt
 [Web Crypto API]: webcrypto.md
-[`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
 [`--no-experimental-global-navigator`]: cli.md#--no-experimental-global-navigator
 [`--no-experimental-websocket`]: cli.md#--no-experimental-websocket
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController

--- a/doc/node.1
+++ b/doc/node.1
@@ -186,9 +186,6 @@ Enable code coverage in the test runner.
 .It Fl -no-experimental-websocket
 Disable experimental support for the WebSocket API.
 .
-.It Fl -no-experimental-global-customevent
-Disable exposition of the CustomEvent on the global scope.
-.
 .It Fl -no-experimental-repl-await
 Disable top-level await keyword support in REPL.
 .

--- a/lib/internal/bootstrap/web/exposed-wildcard.js
+++ b/lib/internal/bootstrap/web/exposed-wildcard.js
@@ -50,6 +50,7 @@ const {
 } = require('internal/event_target');
 exposeInterface(globalThis, 'Event', Event);
 exposeInterface(globalThis, 'EventTarget', EventTarget);
+exposeLazyInterfaces(globalThis, 'internal/event_target', ['CustomEvent']);
 
 // https://encoding.spec.whatwg.org/#textencoder
 // https://encoding.spec.whatwg.org/#textdecoder

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -28,7 +28,6 @@ const {
 } = require('internal/options');
 const { reconnectZeroFillToggle } = require('internal/buffer');
 const {
-  exposeInterface,
   exposeLazyInterfaces,
   defineReplaceableLazyAttribute,
   setupCoverageHooks,
@@ -104,7 +103,6 @@ function prepareExecution(options) {
   setupNavigator();
   setupWarningHandler();
   setupWebsocket();
-  setupCustomEvent();
   setupCodeCoverage();
   setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
@@ -339,17 +337,6 @@ function setupCodeCoverage() {
     process.env.NODE_V8_COVERAGE =
       setupCoverageHooks(process.env.NODE_V8_COVERAGE);
   }
-}
-
-// TODO(daeyeon): move this to internal/bootstrap/web/* when the CLI flag is
-//                removed.
-function setupCustomEvent() {
-  if (getEmbedderOptions().noBrowserGlobals ||
-      getOptionValue('--no-experimental-global-customevent')) {
-    return;
-  }
-  const { CustomEvent } = require('internal/event_target');
-  exposeInterface(globalThis, 'CustomEvent', CustomEvent);
 }
 
 function setupStacktracePrinterOnSigint() {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -402,11 +402,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::experimental_websocket,
             kAllowedInEnvvar,
             true);
-  AddOption("--experimental-global-customevent",
-            "expose experimental CustomEvent on the global scope",
-            &EnvironmentOptions::experimental_global_customevent,
-            kAllowedInEnvvar,
-            true);
+  AddOption("--experimental-global-customevent", "", NoOp{}, kAllowedInEnvvar);
   AddOption("--experimental-global-navigator",
             "expose experimental Navigator API on the global scope",
             &EnvironmentOptions::experimental_global_navigator,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -111,7 +111,6 @@ class EnvironmentOptions : public Options {
   bool enable_source_maps = false;
   bool experimental_fetch = true;
   bool experimental_websocket = true;
-  bool experimental_global_customevent = true;
   bool experimental_global_navigator = true;
   bool experimental_global_web_crypto = true;
   bool experimental_https_modules = false;

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -79,6 +79,7 @@ const webIdlExposedWildcard = new Set([
   'TextDecoder',
   'AbortController',
   'AbortSignal',
+  'CustomEvent',
   'EventTarget',
   'Event',
   'URL',

--- a/test/parallel/test-global-customevent-disabled.js
+++ b/test/parallel/test-global-customevent-disabled.js
@@ -1,7 +1,0 @@
-// Flags: --no-experimental-global-customevent
-'use strict';
-
-require('../common');
-const { strictEqual } = require('node:assert');
-
-strictEqual(typeof CustomEvent, 'undefined');

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -100,6 +100,7 @@ assert(undocumented.delete('--debug-arraybuffer-allocations'));
 assert(undocumented.delete('--no-debug-arraybuffer-allocations'));
 assert(undocumented.delete('--es-module-specifier-resolution'));
 assert(undocumented.delete('--experimental-fetch'));
+assert(undocumented.delete('--experimental-global-customevent'));
 assert(undocumented.delete('--experimental-global-webcrypto'));
 assert(undocumented.delete('--experimental-report'));
 assert(undocumented.delete('--experimental-worker'));


### PR DESCRIPTION
This removes the `--no-experimental-global-customevent` flag as a follow-up for #52618.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>
