### PR TITLE
events: extract events file to a separate files

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -23,8 +23,6 @@
 
 const {
   ArrayPrototypeJoin,
-  ArrayPrototypePop,
-  ArrayPrototypePush,
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
   Boolean,
@@ -32,26 +30,17 @@ const {
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
-  NumberMAX_SAFE_INTEGER,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
-  ObjectSetPrototypeOf,
-  Promise,
-  PromiseReject,
-  PromiseResolve,
-  ReflectApply,
   ReflectOwnKeys,
   String,
   StringPrototypeSplit,
   Symbol,
-  SymbolAsyncIterator,
-  SymbolDispose,
   SymbolFor,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 
-const { kEmptyObject } = require('internal/util');
 
 const {
   inspect,
@@ -59,12 +48,8 @@ const {
 } = require('internal/util/inspect');
 
 let spliceOne;
-let FixedQueue;
-let kFirstEventParam;
-let kResistStopPropagation;
 
 const {
-  AbortError,
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_UNHANDLED_ERROR,
@@ -74,14 +59,12 @@ const {
 } = require('internal/errors');
 
 const {
-  validateInteger,
-  validateAbortSignal,
   validateBoolean,
   validateFunction,
   validateNumber,
-  validateObject,
 } = require('internal/validators');
 const { addAbortListener } = require('internal/events/abort_listener');
+const { on, once, getEventListeners } = require('internal/events/event_emitter_helpers');
 
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
@@ -89,7 +72,6 @@ const kShapeMode = Symbol('shapeMode');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
   Symbol('events.maxEventTargetListenersWarned');
-const kWatermarkData = SymbolFor('nodejs.watermarkData');
 
 let EventEmitterAsyncResource;
 // The EventEmitterAsyncResource has to be initialized lazily because event.js
@@ -806,37 +788,6 @@ function unwrapListeners(arr) {
 }
 
 /**
- * Returns a copy of the array of listeners for the event name
- * specified as `type`.
- * @param {EventEmitter | EventTarget} emitterOrTarget
- * @param {string | symbol} type
- * @returns {Function[]}
- */
-function getEventListeners(emitterOrTarget, type) {
-  // First check if EventEmitter
-  if (typeof emitterOrTarget.listeners === 'function') {
-    return emitterOrTarget.listeners(type);
-  }
-  // Require event target lazily to avoid always loading it
-  const { isEventTarget, kEvents } = require('internal/event_target');
-  if (isEventTarget(emitterOrTarget)) {
-    const root = emitterOrTarget[kEvents].get(type);
-    const listeners = [];
-    let handler = root?.next;
-    while (handler?.listener !== undefined) {
-      const listener = handler.listener?.deref ?
-        handler.listener.deref() : handler.listener;
-      listeners.push(listener);
-      handler = handler.next;
-    }
-    return listeners;
-  }
-  throw new ERR_INVALID_ARG_TYPE('emitter',
-                                 ['EventEmitter', 'EventTarget'],
-                                 emitterOrTarget);
-}
-
-/**
  * Returns the max listeners set.
  * @param {EventEmitter | EventTarget} emitterOrTarget
  * @returns {number}
@@ -851,267 +802,4 @@ function getMaxListeners(emitterOrTarget) {
   throw new ERR_INVALID_ARG_TYPE('emitter',
                                  ['EventEmitter', 'EventTarget'],
                                  emitterOrTarget);
-}
-
-/**
- * Creates a `Promise` that is fulfilled when the emitter
- * emits the given event.
- * @param {EventEmitter} emitter
- * @param {string} name
- * @param {{ signal: AbortSignal; }} [options]
- * @returns {Promise}
- */
-async function once(emitter, name, options = kEmptyObject) {
-  validateObject(options, 'options');
-  const signal = options?.signal;
-  validateAbortSignal(signal, 'options.signal');
-  if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
-  return new Promise((resolve, reject) => {
-    const errorListener = (err) => {
-      emitter.removeListener(name, resolver);
-      if (signal != null) {
-        eventTargetAgnosticRemoveListener(signal, 'abort', abortListener);
-      }
-      reject(err);
-    };
-    const resolver = (...args) => {
-      if (typeof emitter.removeListener === 'function') {
-        emitter.removeListener('error', errorListener);
-      }
-      if (signal != null) {
-        eventTargetAgnosticRemoveListener(signal, 'abort', abortListener);
-      }
-      resolve(args);
-    };
-
-    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-    const opts = { __proto__: null, once: true, [kResistStopPropagation]: true };
-    eventTargetAgnosticAddListener(emitter, name, resolver, opts);
-    if (name !== 'error' && typeof emitter.once === 'function') {
-      // EventTarget does not have `error` event semantics like Node
-      // EventEmitters, we listen to `error` events only on EventEmitters.
-      emitter.once('error', errorListener);
-    }
-    function abortListener() {
-      eventTargetAgnosticRemoveListener(emitter, name, resolver);
-      eventTargetAgnosticRemoveListener(emitter, 'error', errorListener);
-      reject(new AbortError(undefined, { cause: signal?.reason }));
-    }
-    if (signal != null) {
-      eventTargetAgnosticAddListener(
-        signal, 'abort', abortListener, { __proto__: null, once: true, [kResistStopPropagation]: true });
-    }
-  });
-}
-
-const AsyncIteratorPrototype = ObjectGetPrototypeOf(
-  ObjectGetPrototypeOf(async function* () {}).prototype);
-
-function createIterResult(value, done) {
-  return { value, done };
-}
-
-function eventTargetAgnosticRemoveListener(emitter, name, listener, flags) {
-  if (typeof emitter.removeListener === 'function') {
-    emitter.removeListener(name, listener);
-  } else if (typeof emitter.removeEventListener === 'function') {
-    emitter.removeEventListener(name, listener, flags);
-  } else {
-    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
-  }
-}
-
-function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
-  if (typeof emitter.on === 'function') {
-    if (flags?.once) {
-      emitter.once(name, listener);
-    } else {
-      emitter.on(name, listener);
-    }
-  } else if (typeof emitter.addEventListener === 'function') {
-    emitter.addEventListener(name, listener, flags);
-  } else {
-    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
-  }
-}
-
-/**
- * Returns an `AsyncIterator` that iterates `event` events.
- * @param {EventEmitter} emitter
- * @param {string | symbol} event
- * @param {{
- *    signal: AbortSignal;
- *    close?: string[];
- *    highWaterMark?: number,
- *    lowWaterMark?: number
- *   }} [options]
- * @returns {AsyncIterator}
- */
-function on(emitter, event, options = kEmptyObject) {
-  // Parameters validation
-  validateObject(options, 'options');
-  const signal = options.signal;
-  validateAbortSignal(signal, 'options.signal');
-  if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
-  // Support both highWaterMark and highWatermark for backward compatibility
-  const highWatermark = options.highWaterMark ?? options.highWatermark ?? NumberMAX_SAFE_INTEGER;
-  validateInteger(highWatermark, 'options.highWaterMark', 1);
-  // Support both lowWaterMark and lowWatermark for backward compatibility
-  const lowWatermark = options.lowWaterMark ?? options.lowWatermark ?? 1;
-  validateInteger(lowWatermark, 'options.lowWaterMark', 1);
-
-  // Preparing controlling queues and variables
-  FixedQueue ??= require('internal/fixed_queue');
-  const unconsumedEvents = new FixedQueue();
-  const unconsumedPromises = new FixedQueue();
-  let paused = false;
-  let error = null;
-  let finished = false;
-  let size = 0;
-
-  const iterator = ObjectSetPrototypeOf({
-    next() {
-      // First, we consume all unread events
-      if (size) {
-        const value = unconsumedEvents.shift();
-        size--;
-        if (paused && size < lowWatermark) {
-          emitter.resume();
-          paused = false;
-        }
-        return PromiseResolve(createIterResult(value, false));
-      }
-
-      // Then we error, if an error happened
-      // This happens one time if at all, because after 'error'
-      // we stop listening
-      if (error) {
-        const p = PromiseReject(error);
-        // Only the first element errors
-        error = null;
-        return p;
-      }
-
-      // If the iterator is finished, resolve to done
-      if (finished) return closeHandler();
-
-      // Wait until an event happens
-      return new Promise(function(resolve, reject) {
-        unconsumedPromises.push({ resolve, reject });
-      });
-    },
-
-    return() {
-      return closeHandler();
-    },
-
-    throw(err) {
-      if (!err || !(err instanceof Error)) {
-        throw new ERR_INVALID_ARG_TYPE('EventEmitter.AsyncIterator',
-                                       'Error', err);
-      }
-      errorHandler(err);
-    },
-    [SymbolAsyncIterator]() {
-      return this;
-    },
-    [kWatermarkData]: {
-      /**
-       * The current queue size
-       */
-      get size() {
-        return size;
-      },
-      /**
-       * The low watermark. The emitter is resumed every time size is lower than it
-       */
-      get low() {
-        return lowWatermark;
-      },
-      /**
-       * The high watermark. The emitter is paused every time size is higher than it
-       */
-      get high() {
-        return highWatermark;
-      },
-      /**
-       * It checks whether the emitter is paused by the watermark controller or not
-       */
-      get isPaused() {
-        return paused;
-      },
-    },
-  }, AsyncIteratorPrototype);
-
-  // Adding event handlers
-  const { addEventListener, removeAll } = listenersController();
-  kFirstEventParam ??= require('internal/events/symbols').kFirstEventParam;
-  addEventListener(emitter, event, options[kFirstEventParam] ? eventHandler : function(...args) {
-    return eventHandler(args);
-  });
-  if (event !== 'error' && typeof emitter.on === 'function') {
-    addEventListener(emitter, 'error', errorHandler);
-  }
-  const closeEvents = options?.close;
-  if (closeEvents?.length) {
-    for (let i = 0; i < closeEvents.length; i++) {
-      addEventListener(emitter, closeEvents[i], closeHandler);
-    }
-  }
-
-  const abortListenerDisposable = signal ? addAbortListener(signal, abortListener) : null;
-
-  return iterator;
-
-  function abortListener() {
-    errorHandler(new AbortError(undefined, { cause: signal?.reason }));
-  }
-
-  function eventHandler(value) {
-    if (unconsumedPromises.isEmpty()) {
-      size++;
-      if (!paused && size > highWatermark) {
-        paused = true;
-        emitter.pause();
-      }
-      unconsumedEvents.push(value);
-    } else unconsumedPromises.shift().resolve(createIterResult(value, false));
-  }
-
-  function errorHandler(err) {
-    if (unconsumedPromises.isEmpty()) error = err;
-    else unconsumedPromises.shift().reject(err);
-
-    closeHandler();
-  }
-
-  function closeHandler() {
-    abortListenerDisposable?.[SymbolDispose]();
-    removeAll();
-    finished = true;
-    const doneResult = createIterResult(undefined, true);
-    while (!unconsumedPromises.isEmpty()) {
-      unconsumedPromises.shift().resolve(doneResult);
-    }
-
-    return PromiseResolve(doneResult);
-  }
-}
-
-function listenersController() {
-  const listeners = [];
-
-  return {
-    addEventListener(emitter, event, handler, flags) {
-      eventTargetAgnosticAddListener(emitter, event, handler, flags);
-      ArrayPrototypePush(listeners, [emitter, event, handler, flags]);
-    },
-    removeAll() {
-      while (listeners.length > 0) {
-        ReflectApply(eventTargetAgnosticRemoveListener, undefined, ArrayPrototypePop(listeners));
-      }
-    },
-  };
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,62 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+  },
+} = require('internal/errors');
+
+const { addAbortListener } = require('internal/events/abort_listener');
+const { on, once, getEventListeners } = require('internal/events/event_emitter_helpers');
+const { EventEmitter, _getMaxListeners, kMaxEventTargetListeners } = require('internal/events/event_emitter');
+
+/**
+ * Creates a new `EventEmitter` instance.
+ * @param {{ captureRejections?: boolean; }} [opts]
+ * @constructs {EventEmitter}
+ */
+module.exports = EventEmitter;
+module.exports.addAbortListener = addAbortListener;
+module.exports.once = once;
+module.exports.on = on;
+module.exports.getEventListeners = getEventListeners;
+module.exports.getMaxListeners = getMaxListeners;
+
+
+/**
+ * Returns the max listeners set.
+ * @param {EventEmitter | EventTarget} emitterOrTarget
+ * @returns {number}
+ */
+function getMaxListeners(emitterOrTarget) {
+  if (typeof emitterOrTarget?.getMaxListeners === 'function') {
+    return _getMaxListeners(emitterOrTarget);
+  } else if (emitterOrTarget?.[kMaxEventTargetListeners]) {
+    return emitterOrTarget[kMaxEventTargetListeners];
+  }
+
+  throw new ERR_INVALID_ARG_TYPE('emitter',
+                                 ['EventEmitter', 'EventTarget'],
+                                 emitterOrTarget);
+}

--- a/lib/events.js
+++ b/lib/events.js
@@ -27,7 +27,6 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   ArrayPrototypeSplice,
-  ArrayPrototypeUnshift,
   Boolean,
   Error,
   ErrorCaptureStackTrace,
@@ -68,7 +67,6 @@ const {
   AbortError,
   codes: {
     ERR_INVALID_ARG_TYPE,
-    ERR_INVALID_THIS,
     ERR_UNHANDLED_ERROR,
   },
   genericNodeError,
@@ -82,7 +80,6 @@ const {
   validateFunction,
   validateNumber,
   validateObject,
-  validateString,
 } = require('internal/validators');
 const { addAbortListener } = require('internal/events/abort_listener');
 
@@ -102,114 +99,7 @@ let EventEmitterAsyncResource;
 // eventemitter-asyncresource MIT-licensed userland module.
 // https://github.com/addaleax/eventemitter-asyncresource
 function lazyEventEmitterAsyncResource() {
-  if (EventEmitterAsyncResource === undefined) {
-    const {
-      AsyncResource,
-    } = require('async_hooks');
-
-    const kEventEmitter = Symbol('kEventEmitter');
-    const kAsyncResource = Symbol('kAsyncResource');
-    class EventEmitterReferencingAsyncResource extends AsyncResource {
-      /**
-       * @param {EventEmitter} ee
-       * @param {string} [type]
-       * @param {{
-       *   triggerAsyncId?: number,
-       *   requireManualDestroy?: boolean,
-       * }} [options]
-       */
-      constructor(ee, type, options) {
-        super(type, options);
-        this[kEventEmitter] = ee;
-      }
-
-      /**
-       * @type {EventEmitter}
-       */
-      get eventEmitter() {
-        if (this[kEventEmitter] === undefined)
-          throw new ERR_INVALID_THIS('EventEmitterReferencingAsyncResource');
-        return this[kEventEmitter];
-      }
-    }
-
-    EventEmitterAsyncResource =
-      class EventEmitterAsyncResource extends EventEmitter {
-        /**
-         * @param {{
-         *   name?: string,
-         *   triggerAsyncId?: number,
-         *   requireManualDestroy?: boolean,
-         * }} [options]
-         */
-        constructor(options = undefined) {
-          let name;
-          if (typeof options === 'string') {
-            name = options;
-            options = undefined;
-          } else {
-            if (new.target === EventEmitterAsyncResource) {
-              validateString(options?.name, 'options.name');
-            }
-            name = options?.name || new.target.name;
-          }
-          super(options);
-
-          this[kAsyncResource] =
-            new EventEmitterReferencingAsyncResource(this, name, options);
-        }
-
-        /**
-         * @param {symbol,string} event
-         * @param  {...any} args
-         * @returns {boolean}
-         */
-        emit(event, ...args) {
-          if (this[kAsyncResource] === undefined)
-            throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
-          const { asyncResource } = this;
-          ArrayPrototypeUnshift(args, super.emit, this, event);
-          return ReflectApply(asyncResource.runInAsyncScope, asyncResource,
-                              args);
-        }
-
-        /**
-         * @returns {void}
-         */
-        emitDestroy() {
-          if (this[kAsyncResource] === undefined)
-            throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
-          this.asyncResource.emitDestroy();
-        }
-
-        /**
-         * @type {number}
-         */
-        get asyncId() {
-          if (this[kAsyncResource] === undefined)
-            throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
-          return this.asyncResource.asyncId();
-        }
-
-        /**
-         * @type {number}
-         */
-        get triggerAsyncId() {
-          if (this[kAsyncResource] === undefined)
-            throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
-          return this.asyncResource.triggerAsyncId();
-        }
-
-        /**
-         * @type {EventEmitterReferencingAsyncResource}
-         */
-        get asyncResource() {
-          if (this[kAsyncResource] === undefined)
-            throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
-          return this[kAsyncResource];
-        }
-      };
-  }
+  EventEmitterAsyncResource ??= require('internal/events/event_emitter_async_resource');
   return EventEmitterAsyncResource;
 }
 

--- a/lib/internal/events/event_emitter.js
+++ b/lib/internal/events/event_emitter.js
@@ -63,8 +63,6 @@ const {
   validateFunction,
   validateNumber,
 } = require('internal/validators');
-const { addAbortListener } = require('internal/events/abort_listener');
-const { on, once, getEventListeners } = require('internal/events/event_emitter_helpers');
 
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
@@ -96,7 +94,7 @@ function EventEmitter(opts) {
 module.exports = {
   EventEmitter,
   _getMaxListeners,
-  kMaxEventTargetListeners
+  kMaxEventTargetListeners,
 };
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
@@ -785,4 +783,3 @@ function unwrapListeners(arr) {
   }
   return ret;
 }
-

--- a/lib/internal/events/event_emitter.js
+++ b/lib/internal/events/event_emitter.js
@@ -93,12 +93,11 @@ function lazyEventEmitterAsyncResource() {
 function EventEmitter(opts) {
   EventEmitter.init.call(this, opts);
 }
-module.exports = EventEmitter;
-module.exports.addAbortListener = addAbortListener;
-module.exports.once = once;
-module.exports.on = on;
-module.exports.getEventListeners = getEventListeners;
-module.exports.getMaxListeners = getMaxListeners;
+module.exports = {
+  EventEmitter,
+  _getMaxListeners,
+  kMaxEventTargetListeners
+};
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 
@@ -787,19 +786,3 @@ function unwrapListeners(arr) {
   return ret;
 }
 
-/**
- * Returns the max listeners set.
- * @param {EventEmitter | EventTarget} emitterOrTarget
- * @returns {number}
- */
-function getMaxListeners(emitterOrTarget) {
-  if (typeof emitterOrTarget?.getMaxListeners === 'function') {
-    return _getMaxListeners(emitterOrTarget);
-  } else if (emitterOrTarget?.[kMaxEventTargetListeners]) {
-    return emitterOrTarget[kMaxEventTargetListeners];
-  }
-
-  throw new ERR_INVALID_ARG_TYPE('emitter',
-                                 ['EventEmitter', 'EventTarget'],
-                                 emitterOrTarget);
-}

--- a/lib/internal/events/event_emitter_async_resource.js
+++ b/lib/internal/events/event_emitter_async_resource.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const {
+  ArrayPrototypeUnshift,
+  ReflectApply,
+  Symbol,
+} = primordials;
+const {
+  codes: {
+    ERR_INVALID_THIS,
+  },
+} = require('internal/errors');
+
+const { validateString } = require('internal/validators');
+
+const {
+  AsyncResource,
+} = require('async_hooks');
+const EventEmitter = require('events');
+
+const kEventEmitter = Symbol('kEventEmitter');
+const kAsyncResource = Symbol('kAsyncResource');
+class EventEmitterReferencingAsyncResource extends AsyncResource {
+  /**
+   * @param {EventEmitter} ee
+   * @param {string} [type]
+   * @param {{
+   *   triggerAsyncId?: number,
+   *   requireManualDestroy?: boolean,
+   * }} [options]
+   */
+  constructor(ee, type, options) {
+    super(type, options);
+    this[kEventEmitter] = ee;
+  }
+
+  /**
+   * @type {EventEmitter}
+   */
+  get eventEmitter() {
+    if (this[kEventEmitter] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterReferencingAsyncResource');
+    return this[kEventEmitter];
+  }
+}
+
+class EventEmitterAsyncResource extends EventEmitter {
+  /**
+   * @param {{
+   *   name?: string,
+   *   triggerAsyncId?: number,
+   *   requireManualDestroy?: boolean,
+   * }} [options]
+   */
+  constructor(options = undefined) {
+    let name;
+    if (typeof options === 'string') {
+      name = options;
+      options = undefined;
+    } else {
+      if (new.target === EventEmitterAsyncResource) {
+        validateString(options?.name, 'options.name');
+      }
+      name = options?.name || new.target.name;
+    }
+    super(options);
+
+    this[kAsyncResource] =
+      new EventEmitterReferencingAsyncResource(this, name, options);
+  }
+
+  /**
+   * @param {symbol,string} event
+   * @param  {...any} args
+   * @returns {boolean}
+   */
+  emit(event, ...args) {
+    if (this[kAsyncResource] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
+    const { asyncResource } = this;
+    ArrayPrototypeUnshift(args, super.emit, this, event);
+    return ReflectApply(asyncResource.runInAsyncScope, asyncResource,
+                        args);
+  }
+
+  /**
+   * @returns {void}
+   */
+  emitDestroy() {
+    if (this[kAsyncResource] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
+    this.asyncResource.emitDestroy();
+  }
+
+  /**
+   * @type {number}
+   */
+  get asyncId() {
+    if (this[kAsyncResource] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
+    return this.asyncResource.asyncId();
+  }
+
+  /**
+   * @type {number}
+   */
+  get triggerAsyncId() {
+    if (this[kAsyncResource] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
+    return this.asyncResource.triggerAsyncId();
+  }
+
+  /**
+   * @type {EventEmitterReferencingAsyncResource}
+   */
+  get asyncResource() {
+    if (this[kAsyncResource] === undefined)
+      throw new ERR_INVALID_THIS('EventEmitterAsyncResource');
+    return this[kAsyncResource];
+  }
+}
+
+module.exports = EventEmitterAsyncResource;

--- a/lib/internal/events/event_emitter_helpers.js
+++ b/lib/internal/events/event_emitter_helpers.js
@@ -1,0 +1,362 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const {
+  ArrayPrototypePop,
+  ArrayPrototypePush,
+  Error,
+  NumberMAX_SAFE_INTEGER,
+  ObjectGetPrototypeOf,
+  ObjectSetPrototypeOf,
+  Promise,
+  PromiseReject,
+  PromiseResolve,
+  ReflectApply,
+  SymbolAsyncIterator,
+  SymbolDispose,
+  SymbolFor,
+} = primordials;
+
+const { addAbortListener } = require('internal/events/abort_listener');
+const { kEmptyObject } = require('internal/util');
+
+
+let FixedQueue;
+let kFirstEventParam;
+let kResistStopPropagation;
+
+const {
+  AbortError,
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+  },
+} = require('internal/errors');
+
+const {
+  validateInteger,
+  validateAbortSignal,
+  validateObject,
+} = require('internal/validators');
+
+const kWatermarkData = SymbolFor('nodejs.watermarkData');
+
+
+module.exports.once = once;
+module.exports.on = on;
+module.exports.getEventListeners = getEventListeners;
+
+
+/**
+ * Returns a copy of the array of listeners for the event name
+ * specified as `type`.
+ * @param {EventEmitter | EventTarget} emitterOrTarget
+ * @param {string | symbol} type
+ * @returns {Function[]}
+ */
+function getEventListeners(emitterOrTarget, type) {
+  // First check if EventEmitter
+  if (typeof emitterOrTarget.listeners === 'function') {
+    return emitterOrTarget.listeners(type);
+  }
+  // Require event target lazily to avoid always loading it
+  const { isEventTarget, kEvents } = require('internal/event_target');
+  if (isEventTarget(emitterOrTarget)) {
+    const root = emitterOrTarget[kEvents].get(type);
+    const listeners = [];
+    let handler = root?.next;
+    while (handler?.listener !== undefined) {
+      const listener = handler.listener?.deref ?
+        handler.listener.deref() : handler.listener;
+      listeners.push(listener);
+      handler = handler.next;
+    }
+    return listeners;
+  }
+  throw new ERR_INVALID_ARG_TYPE('emitter',
+                                 ['EventEmitter', 'EventTarget'],
+                                 emitterOrTarget);
+}
+
+
+/**
+ * Creates a `Promise` that is fulfilled when the emitter
+ * emits the given event.
+ * @param {EventEmitter} emitter
+ * @param {string} name
+ * @param {{ signal: AbortSignal; }} [options]
+ * @returns {Promise}
+ */
+async function once(emitter, name, options = kEmptyObject) {
+  validateObject(options, 'options');
+  const signal = options?.signal;
+  validateAbortSignal(signal, 'options.signal');
+  if (signal?.aborted)
+    throw new AbortError(undefined, { cause: signal?.reason });
+  return new Promise((resolve, reject) => {
+    const errorListener = (err) => {
+      emitter.removeListener(name, resolver);
+      if (signal != null) {
+        eventTargetAgnosticRemoveListener(signal, 'abort', abortListener);
+      }
+      reject(err);
+    };
+    const resolver = (...args) => {
+      if (typeof emitter.removeListener === 'function') {
+        emitter.removeListener('error', errorListener);
+      }
+      if (signal != null) {
+        eventTargetAgnosticRemoveListener(signal, 'abort', abortListener);
+      }
+      resolve(args);
+    };
+
+    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+    const opts = { __proto__: null, once: true, [kResistStopPropagation]: true };
+    eventTargetAgnosticAddListener(emitter, name, resolver, opts);
+    if (name !== 'error' && typeof emitter.once === 'function') {
+      // EventTarget does not have `error` event semantics like Node
+      // EventEmitters, we listen to `error` events only on EventEmitters.
+      emitter.once('error', errorListener);
+    }
+    function abortListener() {
+      eventTargetAgnosticRemoveListener(emitter, name, resolver);
+      eventTargetAgnosticRemoveListener(emitter, 'error', errorListener);
+      reject(new AbortError(undefined, { cause: signal?.reason }));
+    }
+    if (signal != null) {
+      eventTargetAgnosticAddListener(
+        signal, 'abort', abortListener, { __proto__: null, once: true, [kResistStopPropagation]: true });
+    }
+  });
+}
+
+const AsyncIteratorPrototype = ObjectGetPrototypeOf(
+  ObjectGetPrototypeOf(async function* () {}).prototype);
+
+function createIterResult(value, done) {
+  return { value, done };
+}
+
+function eventTargetAgnosticRemoveListener(emitter, name, listener, flags) {
+  if (typeof emitter.removeListener === 'function') {
+    emitter.removeListener(name, listener);
+  } else if (typeof emitter.removeEventListener === 'function') {
+    emitter.removeEventListener(name, listener, flags);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
+  }
+}
+
+function eventTargetAgnosticAddListener(emitter, name, listener, flags) {
+  if (typeof emitter.on === 'function') {
+    if (flags?.once) {
+      emitter.once(name, listener);
+    } else {
+      emitter.on(name, listener);
+    }
+  } else if (typeof emitter.addEventListener === 'function') {
+    emitter.addEventListener(name, listener, flags);
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('emitter', 'EventEmitter', emitter);
+  }
+}
+
+/**
+ * Returns an `AsyncIterator` that iterates `event` events.
+ * @param {EventEmitter} emitter
+ * @param {string | symbol} event
+ * @param {{
+ *    signal: AbortSignal;
+ *    close?: string[];
+ *    highWaterMark?: number,
+ *    lowWaterMark?: number
+ *   }} [options]
+ * @returns {AsyncIterator}
+ */
+function on(emitter, event, options = kEmptyObject) {
+  // Parameters validation
+  validateObject(options, 'options');
+  const signal = options.signal;
+  validateAbortSignal(signal, 'options.signal');
+  if (signal?.aborted)
+    throw new AbortError(undefined, { cause: signal?.reason });
+  // Support both highWaterMark and highWatermark for backward compatibility
+  const highWatermark = options.highWaterMark ?? options.highWatermark ?? NumberMAX_SAFE_INTEGER;
+  validateInteger(highWatermark, 'options.highWaterMark', 1);
+  // Support both lowWaterMark and lowWatermark for backward compatibility
+  const lowWatermark = options.lowWaterMark ?? options.lowWatermark ?? 1;
+  validateInteger(lowWatermark, 'options.lowWaterMark', 1);
+
+  // Preparing controlling queues and variables
+  FixedQueue ??= require('internal/fixed_queue');
+  const unconsumedEvents = new FixedQueue();
+  const unconsumedPromises = new FixedQueue();
+  let paused = false;
+  let error = null;
+  let finished = false;
+  let size = 0;
+
+  const iterator = ObjectSetPrototypeOf({
+    next() {
+      // First, we consume all unread events
+      if (size) {
+        const value = unconsumedEvents.shift();
+        size--;
+        if (paused && size < lowWatermark) {
+          emitter.resume();
+          paused = false;
+        }
+        return PromiseResolve(createIterResult(value, false));
+      }
+
+      // Then we error, if an error happened
+      // This happens one time if at all, because after 'error'
+      // we stop listening
+      if (error) {
+        const p = PromiseReject(error);
+        // Only the first element errors
+        error = null;
+        return p;
+      }
+
+      // If the iterator is finished, resolve to done
+      if (finished) return closeHandler();
+
+      // Wait until an event happens
+      return new Promise(function(resolve, reject) {
+        unconsumedPromises.push({ resolve, reject });
+      });
+    },
+
+    return() {
+      return closeHandler();
+    },
+
+    throw(err) {
+      if (!err || !(err instanceof Error)) {
+        throw new ERR_INVALID_ARG_TYPE('EventEmitter.AsyncIterator',
+                                       'Error', err);
+      }
+      errorHandler(err);
+    },
+    [SymbolAsyncIterator]() {
+      return this;
+    },
+    [kWatermarkData]: {
+      /**
+       * The current queue size
+       */
+      get size() {
+        return size;
+      },
+      /**
+       * The low watermark. The emitter is resumed every time size is lower than it
+       */
+      get low() {
+        return lowWatermark;
+      },
+      /**
+       * The high watermark. The emitter is paused every time size is higher than it
+       */
+      get high() {
+        return highWatermark;
+      },
+      /**
+       * It checks whether the emitter is paused by the watermark controller or not
+       */
+      get isPaused() {
+        return paused;
+      },
+    },
+  }, AsyncIteratorPrototype);
+
+  // Adding event handlers
+  const { addEventListener, removeAll } = listenersController();
+  kFirstEventParam ??= require('internal/events/symbols').kFirstEventParam;
+  addEventListener(emitter, event, options[kFirstEventParam] ? eventHandler : function(...args) {
+    return eventHandler(args);
+  });
+  if (event !== 'error' && typeof emitter.on === 'function') {
+    addEventListener(emitter, 'error', errorHandler);
+  }
+  const closeEvents = options?.close;
+  if (closeEvents?.length) {
+    for (let i = 0; i < closeEvents.length; i++) {
+      addEventListener(emitter, closeEvents[i], closeHandler);
+    }
+  }
+
+  const abortListenerDisposable = signal ? addAbortListener(signal, abortListener) : null;
+
+  return iterator;
+
+  function abortListener() {
+    errorHandler(new AbortError(undefined, { cause: signal?.reason }));
+  }
+
+  function eventHandler(value) {
+    if (unconsumedPromises.isEmpty()) {
+      size++;
+      if (!paused && size > highWatermark) {
+        paused = true;
+        emitter.pause();
+      }
+      unconsumedEvents.push(value);
+    } else unconsumedPromises.shift().resolve(createIterResult(value, false));
+  }
+
+  function errorHandler(err) {
+    if (unconsumedPromises.isEmpty()) error = err;
+    else unconsumedPromises.shift().reject(err);
+
+    closeHandler();
+  }
+
+  function closeHandler() {
+    abortListenerDisposable?.[SymbolDispose]();
+    removeAll();
+    finished = true;
+    const doneResult = createIterResult(undefined, true);
+    while (!unconsumedPromises.isEmpty()) {
+      unconsumedPromises.shift().resolve(doneResult);
+    }
+
+    return PromiseResolve(doneResult);
+  }
+}
+
+function listenersController() {
+  const listeners = [];
+
+  return {
+    addEventListener(emitter, event, handler, flags) {
+      eventTargetAgnosticAddListener(emitter, event, handler, flags);
+      ArrayPrototypePush(listeners, [emitter, event, handler, flags]);
+    },
+    removeAll() {
+      while (listeners.length > 0) {
+        ReflectApply(eventTargetAgnosticRemoveListener, undefined, ArrayPrototypePop(listeners));
+      }
+    },
+  };
+}


### PR DESCRIPTION
The reason I did this is that I want to create another PR to add a fast event emitter for the common cases and the `events` file is already large enough, if you want I can extract this PR to multiple PRs one for each file 

Before merging needs `git squash` to avoid having commits in main that not working by themself

I extracted the following:
1. `EventEmitter` to `lib/internal/events/event_emitter.js`
2. `on`, `once`, and `getEventListeners` to `internal/events/event_emitter_helpers.js`
3. `EventEmitterAsyncResource` to `lib/internal/events/event_emitter_async_resource.js`