### PR TITLE
src,permission: throw async errors on async APIs

### DIFF
--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -373,7 +373,10 @@ static void OpenDir(const FunctionCallbackInfo<Value>& args) {
   FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // openDir(path, encoding, req)
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        path.ToStringView());
     FS_DIR_ASYNC_TRACE_BEGIN1(
         UV_FS_OPENDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "opendir", encoding, AfterOpenDir,

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -367,19 +367,21 @@ static void OpenDir(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
   FSReqBase* req_wrap_async = GetReqWrap(args, 2);
   if (req_wrap_async != nullptr) {  // openDir(path, encoding, req)
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FS_DIR_ASYNC_TRACE_BEGIN1(
         UV_FS_OPENDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "opendir", encoding, AfterOpenDir,
               uv_fs_opendir, *path);
   } else {  // openDir(path, encoding, undefined, ctx)
     CHECK_EQ(argc, 4);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync;
     FS_DIR_SYNC_TRACE_BEGIN(opendir);
     int result = SyncCall(env, args[3], &req_wrap_sync, "opendir",

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -965,14 +965,17 @@ void Access(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     CHECK_NOT_NULL(req_wrap_async);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_ACCESS, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "access", UTF8, AfterNoArgs,
               uv_fs_access, *path, mode);
   } else {  // access(path, mode)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("access", *path);
     FS_SYNC_TRACE_BEGIN(access);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_access, *path, mode);
@@ -1078,14 +1081,17 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     CHECK_NOT_NULL(req_wrap_async);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STAT, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
               uv_fs_stat, *path);
   } else {  // stat(path, use_bigint, undefined, do_not_throw_if_no_entry)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     bool do_not_throw_if_no_entry = args[3]->IsFalse();
     FSReqWrapSync req_wrap_sync("stat", *path);
     FS_SYNC_TRACE_BEGIN(stat);
@@ -1201,7 +1207,10 @@ static void StatFs(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     CHECK_NOT_NULL(req_wrap_async);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STATFS, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env,
@@ -1214,7 +1223,7 @@ static void StatFs(const FunctionCallbackInfo<Value>& args) {
               *path);
   } else {  // statfs(path, use_bigint)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("statfs", *path);
     FS_SYNC_TRACE_BEGIN(statfs);
     int result =
@@ -1295,12 +1304,21 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     // To avoid bypass the link target should be allowed to read and write
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, src_view);
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        src_view);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, src_view);
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        src_view);
 
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, dest_view);
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        dest_view);
     FS_ASYNC_TRACE_BEGIN2(UV_FS_LINK,
                           req_wrap_async,
                           "src",
@@ -1387,9 +1405,15 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   if (argc > 2) {  // rename(old_path, new_path, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, view_old_path);
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        view_old_path);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, view_old_path);
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        view_old_path);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
         env,
         req_wrap_async,
@@ -1510,7 +1534,10 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
   if (argc > 1) {  // unlink(path, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_UNLINK, req_wrap_async, "path", TRACE_STR_COPY(*path))
@@ -1518,7 +1545,9 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
               uv_fs_unlink, *path);
   } else {  // unlink(path)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     FSReqWrapSync req_wrap_sync("unlink", *path);
     FS_SYNC_TRACE_BEGIN(unlink);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_unlink, *path);
@@ -1830,7 +1859,10 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // readdir(path, encoding, withTypes, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        path.ToStringView());
     req_wrap_async->set_with_file_types(with_types);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_SCANDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
@@ -1845,7 +1877,7 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
               0 /*flags*/);
   } else {  // readdir(path, encoding, withTypes)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
+        env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("scandir", *path);
     FS_SYNC_TRACE_BEGIN(readdir);
     int err = SyncCallAndThrowOnError(
@@ -1903,9 +1935,9 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 }
 
 static inline Maybe<void> AsyncCheckOpenPermissions(Environment* env,
-    FSReqBase* req_wrap,
-                                               const BufferValue& path,
-                                               int flags) {
+                                                    FSReqBase* req_wrap,
+                                                    const BufferValue& path,
+                                                    int flags) {
   // These flags capture the intention of the open() call.
   const int rwflags = flags & (UV_FS_O_RDONLY | UV_FS_O_WRONLY | UV_FS_O_RDWR);
 
@@ -1983,7 +2015,8 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // open(path, flags, mode, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     CHECK_NOT_NULL(req_wrap_async);
-    if (AsyncCheckOpenPermissions(env, req_wrap_async, path, flags).IsNothing()) return;
+    if (AsyncCheckOpenPermissions(env, req_wrap_async, path, flags).IsNothing())
+      return;
     req_wrap_async->set_is_plain_open(true);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_OPEN, req_wrap_async, "path", TRACE_STR_COPY(*path))
@@ -2064,9 +2097,15 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // copyFile(src, dest, flags, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, src.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemRead,
+        src.ToStringView());
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        dest.ToStringView());
     FS_ASYNC_TRACE_BEGIN2(UV_FS_COPYFILE,
                           req_wrap_async,
                           "src",
@@ -2078,9 +2117,11 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
                   uv_fs_copyfile, *src, *dest, flags);
   } else {  // copyFile(src, dest, flags)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
+        env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-        env, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        dest.ToStringView());
     FSReqWrapSync req_wrap_sync("copyfile", *src, *dest);
     FS_SYNC_TRACE_BEGIN(copyfile);
     SyncCallAndThrowOnError(
@@ -2641,14 +2682,19 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     CHECK_NOT_NULL(req_wrap_async);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_CHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "chown", UTF8, AfterNoArgs,
               uv_fs_chown, *path, uid, gid);
   } else {  // chown(path, uid, gid)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     FSReqWrapSync req_wrap_sync("chown", *path);
     FS_SYNC_TRACE_BEGIN(chown);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_chown, *path, uid, gid);
@@ -2709,14 +2755,19 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // lchown(path, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LCHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "lchown", UTF8, AfterNoArgs,
               uv_fs_lchown, *path, uid, gid);
   } else {  // lchown(path, uid, gid)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        path.ToStringView());
     FSReqWrapSync req_wrap_sync("lchown", *path);
     FS_SYNC_TRACE_BEGIN(lchown);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_lchown, *path, uid, gid);
@@ -2840,14 +2891,19 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   if (argc > 2) {  // mkdtemp(tmpl, encoding, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        tmpl.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_MKDTEMP, req_wrap_async, "path", TRACE_STR_COPY(*tmpl))
     AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
               uv_fs_mkdtemp, *tmpl);
   } else {  // mkdtemp(tmpl, encoding)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        tmpl.ToStringView());
     FSReqWrapSync req_wrap_sync("mkdtemp", *tmpl);
     FS_SYNC_TRACE_BEGIN(mkdtemp);
     int result =

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -960,17 +960,19 @@ void Access(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
   if (argc > 2) {  // access(path, mode, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     CHECK_NOT_NULL(req_wrap_async);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_ACCESS, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "access", UTF8, AfterNoArgs,
               uv_fs_access, *path, mode);
   } else {  // access(path, mode)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("access", *path);
     FS_SYNC_TRACE_BEGIN(access);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_access, *path, mode);
@@ -1070,18 +1072,20 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
   bool use_bigint = args[1]->IsTrue();
   if (!args[2]->IsUndefined()) {  // stat(path, use_bigint, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     CHECK_NOT_NULL(req_wrap_async);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STAT, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
               uv_fs_stat, *path);
   } else {  // stat(path, use_bigint, undefined, do_not_throw_if_no_entry)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     bool do_not_throw_if_no_entry = args[3]->IsFalse();
     FSReqWrapSync req_wrap_sync("stat", *path);
     FS_SYNC_TRACE_BEGIN(stat);
@@ -1191,13 +1195,13 @@ static void StatFs(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(realm->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
   bool use_bigint = args[1]->IsTrue();
   if (argc > 2) {  // statfs(path, use_bigint, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     CHECK_NOT_NULL(req_wrap_async);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STATFS, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env,
@@ -1209,6 +1213,8 @@ static void StatFs(const FunctionCallbackInfo<Value>& args) {
               uv_fs_statfs,
               *path);
   } else {  // statfs(path, use_bigint)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("statfs", *path);
     FS_SYNC_TRACE_BEGIN(statfs);
     int result =
@@ -1280,20 +1286,21 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(*src);
 
   const auto src_view = src.ToStringView();
-  // To avoid bypass the link target should be allowed to read and write
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, src_view);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, src_view);
 
   BufferValue dest(isolate, args[1]);
   CHECK_NOT_NULL(*dest);
   const auto dest_view = dest.ToStringView();
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, dest_view);
 
   if (argc > 2) {  // link(src, dest, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
+    // To avoid bypass the link target should be allowed to read and write
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, src_view);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, src_view);
+
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, dest_view);
     FS_ASYNC_TRACE_BEGIN2(UV_FS_LINK,
                           req_wrap_async,
                           "src",
@@ -1303,6 +1310,14 @@ static void Link(const FunctionCallbackInfo<Value>& args) {
     AsyncDestCall(env, req_wrap_async, args, "link", *dest, dest.length(), UTF8,
                   AfterNoArgs, uv_fs_link, *src, *dest);
   } else {  // link(src, dest)
+    // To avoid bypass the link target should be allowed to read and write
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemRead, src_view);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemWrite, src_view);
+
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemWrite, dest_view);
     FSReqWrapSync req_wrap_sync("link", *src, *dest);
     FS_SYNC_TRACE_BEGIN(link);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_link, *src, *dest);
@@ -1365,20 +1380,21 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
   BufferValue old_path(isolate, args[0]);
   CHECK_NOT_NULL(*old_path);
   auto view_old_path = old_path.ToStringView();
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, view_old_path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, view_old_path);
 
   BufferValue new_path(isolate, args[1]);
   CHECK_NOT_NULL(*new_path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env,
-      permission::PermissionScope::kFileSystemWrite,
-      new_path.ToStringView());
 
   if (argc > 2) {  // rename(old_path, new_path, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemRead, view_old_path);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, view_old_path);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env,
+        req_wrap_async,
+        permission::PermissionScope::kFileSystemWrite,
+        new_path.ToStringView());
     FS_ASYNC_TRACE_BEGIN2(UV_FS_RENAME,
                           req_wrap_async,
                           "old_path",
@@ -1389,6 +1405,14 @@ static void Rename(const FunctionCallbackInfo<Value>& args) {
                   new_path.length(), UTF8, AfterNoArgs, uv_fs_rename,
                   *old_path, *new_path);
   } else {  // rename(old_path, new_path)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemRead, view_old_path);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemWrite, view_old_path);
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env,
+        permission::PermissionScope::kFileSystemWrite,
+        new_path.ToStringView());
     FSReqWrapSync req_wrap_sync("rename", *old_path, *new_path);
     FS_SYNC_TRACE_BEGIN(rename);
     SyncCallAndThrowOnError(
@@ -1482,17 +1506,19 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   if (argc > 1) {  // unlink(path, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_UNLINK, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "unlink", UTF8, AfterNoArgs,
               uv_fs_unlink, *path);
   } else {  // unlink(path)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     FSReqWrapSync req_wrap_sync("unlink", *path);
     FS_SYNC_TRACE_BEGIN(unlink);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_unlink, *path);
@@ -1796,8 +1822,6 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
@@ -1805,6 +1829,8 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
 
   if (argc > 3) {  // readdir(path, encoding, withTypes, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     req_wrap_async->set_with_file_types(with_types);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_SCANDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
@@ -1818,6 +1844,8 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
               *path,
               0 /*flags*/);
   } else {  // readdir(path, encoding, withTypes)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
     FSReqWrapSync req_wrap_sync("scandir", *path);
     FS_SYNC_TRACE_BEGIN(readdir);
     int err = SyncCallAndThrowOnError(
@@ -1874,6 +1902,39 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static inline Maybe<void> AsyncCheckOpenPermissions(Environment* env,
+    FSReqBase* req_wrap,
+                                               const BufferValue& path,
+                                               int flags) {
+  // These flags capture the intention of the open() call.
+  const int rwflags = flags & (UV_FS_O_RDONLY | UV_FS_O_WRONLY | UV_FS_O_RDWR);
+
+  // These flags have write-like side effects even with O_RDONLY, at least on
+  // some operating systems. On Windows, for example, O_RDONLY | O_TEMPORARY
+  // can be used to delete a file. Bizarre.
+  const int write_as_side_effect = flags & (UV_FS_O_APPEND | UV_FS_O_CREAT |
+                                            UV_FS_O_TRUNC | UV_FS_O_TEMPORARY);
+
+  auto pathView = path.ToStringView();
+  if (rwflags != UV_FS_O_WRONLY) {
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env,
+        req_wrap,
+        permission::PermissionScope::kFileSystemRead,
+        pathView,
+        Nothing<void>());
+  }
+  if (rwflags != UV_FS_O_RDONLY || write_as_side_effect) {
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env,
+        req_wrap,
+        permission::PermissionScope::kFileSystemWrite,
+        pathView,
+        Nothing<void>());
+  }
+  return JustVoid();
+}
+
 static inline Maybe<void> CheckOpenPermissions(Environment* env,
                                                const BufferValue& path,
                                                int flags) {
@@ -1919,17 +1980,17 @@ static void Open(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[2]->IsInt32());
   const int mode = args[2].As<Int32>()->Value();
 
-  if (CheckOpenPermissions(env, path, flags).IsNothing()) return;
-
   if (argc > 3) {  // open(path, flags, mode, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     CHECK_NOT_NULL(req_wrap_async);
+    if (AsyncCheckOpenPermissions(env, req_wrap_async, path, flags).IsNothing()) return;
     req_wrap_async->set_is_plain_open(true);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_OPEN, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterInteger,
               uv_fs_open, *path, flags, mode);
   } else {  // open(path, flags, mode)
+    if (CheckOpenPermissions(env, path, flags).IsNothing()) return;
     FSReqWrapSync req_wrap_sync("open", *path);
     FS_SYNC_TRACE_BEGIN(open);
     int result = SyncCallAndThrowOnError(
@@ -1996,16 +2057,16 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue src(isolate, args[0]);
   CHECK_NOT_NULL(*src);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
 
   BufferValue dest(isolate, args[1]);
   CHECK_NOT_NULL(*dest);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
 
   if (argc > 3) {  // copyFile(src, dest, flags, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemRead, src.ToStringView());
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
     FS_ASYNC_TRACE_BEGIN2(UV_FS_COPYFILE,
                           req_wrap_async,
                           "src",
@@ -2016,6 +2077,10 @@ static void CopyFile(const FunctionCallbackInfo<Value>& args) {
                   *dest, dest.length(), UTF8, AfterNoArgs,
                   uv_fs_copyfile, *src, *dest, flags);
   } else {  // copyFile(src, dest, flags)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+        env, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
     FSReqWrapSync req_wrap_sync("copyfile", *src, *dest);
     FS_SYNC_TRACE_BEGIN(copyfile);
     SyncCallAndThrowOnError(
@@ -2565,8 +2630,6 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(IsSafeJsInt(args[1]));
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
@@ -2576,11 +2639,16 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
 
   if (argc > 3) {  // chown(path, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
+    CHECK_NOT_NULL(req_wrap_async);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_CHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "chown", UTF8, AfterNoArgs,
               uv_fs_chown, *path, uid, gid);
   } else {  // chown(path, uid, gid)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     FSReqWrapSync req_wrap_sync("chown", *path);
     FS_SYNC_TRACE_BEGIN(chown);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_chown, *path, uid, gid);
@@ -2631,8 +2699,6 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(env->isolate(), args[0]);
   CHECK_NOT_NULL(*path);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
 
   CHECK(IsSafeJsInt(args[1]));
   const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
@@ -2642,11 +2708,15 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
 
   if (argc > 3) {  // lchown(path, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LCHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
     AsyncCall(env, req_wrap_async, args, "lchown", UTF8, AfterNoArgs,
               uv_fs_lchown, *path, uid, gid);
   } else {  // lchown(path, uid, gid)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
     FSReqWrapSync req_wrap_sync("lchown", *path);
     FS_SYNC_TRACE_BEGIN(lchown);
     SyncCallAndThrowOnError(env, &req_wrap_sync, uv_fs_lchown, *path, uid, gid);
@@ -2764,18 +2834,20 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   snprintf(tmpl.out() + length, tmpl.length(), "%s", suffix);
 
   CHECK_NOT_NULL(*tmpl);
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
   if (argc > 2) {  // mkdtemp(tmpl, encoding, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
+    ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, req_wrap_async, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_MKDTEMP, req_wrap_async, "path", TRACE_STR_COPY(*tmpl))
     AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
               uv_fs_mkdtemp, *tmpl);
   } else {  // mkdtemp(tmpl, encoding)
+    THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, tmpl.ToStringView());
     FSReqWrapSync req_wrap_sync("mkdtemp", *tmpl);
     FS_SYNC_TRACE_BEGIN(mkdtemp);
     int result =

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -5,6 +5,7 @@
 #include "node.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
+#include "node_file.h"
 
 #include "v8.h"
 
@@ -99,16 +100,15 @@ Permission::Permission() : enabled_(false) {
 #undef V
 }
 
-void Permission::ThrowAccessDenied(Environment* env,
-                                   PermissionScope perm,
-                                   const std::string_view& res) {
+Local<Value> CreateAccessDeniedError(Environment* env, PermissionScope perm,
+    const std::string_view& res) {
   Local<Value> err = ERR_ACCESS_DENIED(env->isolate());
   CHECK(err->IsObject());
   if (err.As<Object>()
           ->Set(env->context(),
                 env->permission_string(),
                 v8::String::NewFromUtf8(env->isolate(),
-                                        PermissionToString(perm),
+                                        Permission::PermissionToString(perm),
                                         v8::NewStringType::kNormal)
                     .ToLocalChecked())
           .IsNothing() ||
@@ -120,8 +120,25 @@ void Permission::ThrowAccessDenied(Environment* env,
                                         v8::NewStringType::kNormal)
                     .ToLocalChecked())
           .IsNothing())
-    return;
+    return Local<Value>();
+  return err;
+}
+
+void Permission::ThrowAccessDenied(Environment* env,
+                                   PermissionScope perm,
+                                   const std::string_view& res) {
+  Local<Value> err = CreateAccessDeniedError(env, perm, res);
+  if (err.IsEmpty()) return;
   env->isolate()->ThrowException(err);
+}
+
+void Permission::AsyncThrowAccessDenied(Environment* env,
+                     fs::FSReqBase* req_wrap,
+                                   PermissionScope perm,
+                                   const std::string_view& res) {
+  Local<Value> err = CreateAccessDeniedError(env, perm, res);
+  if (err.IsEmpty()) return;
+  return req_wrap->Reject(err);
 }
 
 void Permission::EnablePermissions() {

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -100,8 +100,9 @@ Permission::Permission() : enabled_(false) {
 #undef V
 }
 
-Local<Value> CreateAccessDeniedError(Environment* env, PermissionScope perm,
-    const std::string_view& res) {
+Local<Value> CreateAccessDeniedError(Environment* env,
+                                     PermissionScope perm,
+                                     const std::string_view& res) {
   Local<Value> err = ERR_ACCESS_DENIED(env->isolate());
   CHECK(err->IsObject());
   if (err.As<Object>()
@@ -133,9 +134,9 @@ void Permission::ThrowAccessDenied(Environment* env,
 }
 
 void Permission::AsyncThrowAccessDenied(Environment* env,
-                     fs::FSReqBase* req_wrap,
-                                   PermissionScope perm,
-                                   const std::string_view& res) {
+                                        fs::FSReqBase* req_wrap,
+                                        PermissionScope perm,
+                                        const std::string_view& res) {
   Local<Value> err = CreateAccessDeniedError(env, perm, res);
   if (err.IsEmpty()) return;
   return req_wrap->Reject(err);

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -19,6 +19,10 @@ namespace node {
 
 class Environment;
 
+namespace fs {
+  class FSReqBase;
+}
+
 namespace permission {
 
 #define THROW_IF_INSUFFICIENT_PERMISSIONS(env, perm_, resource_, ...)          \
@@ -26,6 +30,15 @@ namespace permission {
     if (UNLIKELY(!(env)->permission()->is_granted(perm_, resource_))) {        \
       node::permission::Permission::ThrowAccessDenied(                         \
           (env), perm_, resource_);                                            \
+      return __VA_ARGS__;                                                      \
+    }                                                                          \
+  } while (0)
+
+#define ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(env, wrap, perm_, resource_, ...)          \
+  do {                                                                         \
+    if (UNLIKELY(!(env)->permission()->is_granted(perm_, resource_))) {        \
+      node::permission::Permission::AsyncThrowAccessDenied(                         \
+          (env), wrap, perm_, resource_);                                            \
       return __VA_ARGS__;                                                      \
     }                                                                          \
   } while (0)
@@ -45,6 +58,10 @@ class Permission {
   static PermissionScope StringToPermission(const std::string& perm);
   static const char* PermissionToString(PermissionScope perm);
   static void ThrowAccessDenied(Environment* env,
+                                PermissionScope perm,
+                                const std::string_view& res);
+  static void AsyncThrowAccessDenied(Environment* env,
+                               fs::FSReqBase* req_wrap,
                                 PermissionScope perm,
                                 const std::string_view& res);
 

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -20,7 +20,7 @@ namespace node {
 class Environment;
 
 namespace fs {
-  class FSReqBase;
+class FSReqBase;
 }
 
 namespace permission {
@@ -34,11 +34,12 @@ namespace permission {
     }                                                                          \
   } while (0)
 
-#define ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(env, wrap, perm_, resource_, ...)          \
+#define ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(                               \
+    env, wrap, perm_, resource_, ...)                                          \
   do {                                                                         \
     if (UNLIKELY(!(env)->permission()->is_granted(perm_, resource_))) {        \
-      node::permission::Permission::AsyncThrowAccessDenied(                         \
-          (env), wrap, perm_, resource_);                                            \
+      node::permission::Permission::AsyncThrowAccessDenied(                    \
+          (env), wrap, perm_, resource_);                                      \
       return __VA_ARGS__;                                                      \
     }                                                                          \
   } while (0)
@@ -61,9 +62,9 @@ class Permission {
                                 PermissionScope perm,
                                 const std::string_view& res);
   static void AsyncThrowAccessDenied(Environment* env,
-                               fs::FSReqBase* req_wrap,
-                                PermissionScope perm,
-                                const std::string_view& res);
+                                     fs::FSReqBase* req_wrap,
+                                     PermissionScope perm,
+                                     const std::string_view& res);
 
   // CLI Call
   void Apply(Environment* env,

--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -14,15 +14,20 @@ const regularFile = __filename;
 
 // fs.readFile
 {
+  fs.readFile(blockedFile, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.readFile(blockedFile, () => {});
+    fs.readFileSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.readFile(blockedFileURL, () => {});
+    fs.readFileSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -67,23 +72,26 @@ const regularFile = __filename;
 
 // fs.stat
 {
+  fs.stat(blockedFile, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.stat(blockedFile, () => {});
+    fs.statSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.stat(blockedFileURL, () => {});
+    fs.statSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
-  assert.throws(() => {
-    fs.stat(path.join(blockedFolder, 'anyfile'), () => {});
-  }, common.expectsError({
+  fs.stat(path.join(blockedFolder, 'anyfile'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
@@ -97,22 +105,20 @@ const regularFile = __filename;
 
 // fs.access
 {
+  fs.access(blockedFile, fs.constants.R_OK, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.access(blockedFile, fs.constants.R_OK, () => {});
+    fs.accessSync(blockedFileURL, fs.constants.R_OK);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.access(blockedFileURL, fs.constants.R_OK, () => {});
-  }, common.expectsError({
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
-  }));
-  assert.throws(() => {
-    fs.access(path.join(blockedFolder, 'anyfile'), fs.constants.R_OK, () => {});
+    fs.accessSync(path.join(blockedFolder, 'anyfile'), fs.constants.R_OK);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -127,22 +133,20 @@ const regularFile = __filename;
 
 // fs.copyFile
 {
+  fs.copyFile(blockedFile, path.join(blockedFolder, 'any-other-file'), common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.copyFile(blockedFile, path.join(blockedFolder, 'any-other-file'), () => {});
+    fs.copyFileSync(blockedFileURL, path.join(blockedFolder, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.copyFile(blockedFileURL, path.join(blockedFolder, 'any-other-file'), () => {});
-  }, common.expectsError({
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
-  }));
-  assert.throws(() => {
-    fs.copyFile(blockedFile, path.join(__dirname, 'any-other-file'), () => {});
+    fs.copyFileSync(blockedFile, path.join(__dirname, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -179,22 +183,20 @@ const regularFile = __filename;
 
 // fs.open
 {
+  fs.open(blockedFile, 'r', common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.open(blockedFile, 'r', () => {});
+    fs.openSync(blockedFileURL, 'r');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.open(blockedFileURL, 'r', () => {});
-  }, common.expectsError({
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
-  }));
-  assert.throws(() => {
-    fs.open(path.join(blockedFolder, 'anyfile'), 'r', () => {});
+    fs.openSync(path.join(blockedFolder, 'anyfile'), 'r');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -214,20 +216,21 @@ const regularFile = __filename;
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   });
-  assert.throws(() => {
-    fs.open(blockedFile, fs.constants.O_RDWR | 0x10000000, common.mustNotCall());
-  }, {
+  fs.open(blockedFile, fs.constants.O_RDWR | 0x10000000, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-  });
+  }));
 }
 
 // fs.opendir
 {
+  fs.opendir(blockedFolder, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFolder),
+  }));
   assert.throws(() => {
-    fs.opendir(blockedFolder, (err) => {
-      assert.ifError(err);
-    });
+    fs.opendirSync(blockedFolder);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -242,8 +245,13 @@ const regularFile = __filename;
 
 // fs.readdir
 {
+  fs.readdir(blockedFolder, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFolder),
+  }));
   assert.throws(() => {
-    fs.readdir(blockedFolder, () => {});
+    fs.readdirSync(blockedFolder);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -299,15 +307,20 @@ const regularFile = __filename;
 
 // fs.rename
 {
+  fs.rename(blockedFile, 'newfile', common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.rename(blockedFile, 'newfile', () => {});
+    fs.renameSync(blockedFile, 'newfile');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.rename(blockedFileURL, 'newfile', () => {});
+    fs.renameSync(blockedFileURL, 'newfile');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -342,19 +355,31 @@ const regularFile = __filename;
   fs.exists(blockedFileURL, (exists) => {
     assert.equal(exists, false);
   });
+  assert.throws(() => {
+    fs.existsSync(blockedFile);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
 }
 
 // fs.statfs
 {
+  fs.statfs(blockedFile, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.statfs(blockedFile, () => {});
+    fs.statfsSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
-    fs.statfs(blockedFileURL, () => {});
+    fs.statfsSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',

--- a/test/fixtures/permission/fs-symlink-target-write.js
+++ b/test/fixtures/permission/fs-symlink-target-write.js
@@ -23,18 +23,14 @@ const writeOnlyFolder = process.env.WRITEONLYFOLDER;
 {
   // App won't be able to symlink from a readOnlyFolder
   assert.throws(() => {
-    fs.symlink(path.join(readOnlyFolder, 'file'), path.join(readWriteFolder, 'link-to-read-only'), 'file', (err) => {
-      assert.ifError(err);
-    });
+    fs.symlinkSync(path.join(readOnlyFolder, 'file'), path.join(readWriteFolder, 'link-to-read-only'), 'file');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(path.join(readOnlyFolder, 'file')),
   }));
   assert.throws(() => {
-    fs.link(path.join(readOnlyFolder, 'file'), path.join(readWriteFolder, 'link-to-read-only'), (err) => {
-      assert.ifError(err);
-    });
+    fs.linkSync(path.join(readOnlyFolder, 'file'), path.join(readWriteFolder, 'link-to-read-only'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -45,11 +41,7 @@ const writeOnlyFolder = process.env.WRITEONLYFOLDER;
   fs.symlink(path.join(readWriteFolder, 'file'), path.join(writeOnlyFolder, 'link-to-read-write'), 'file', (err) => {
     assert.ifError(err);
     // App will won't be able to read the symlink
-    assert.throws(() => {
-      fs.readFile(path.join(writeOnlyFolder, 'link-to-read-write'), (err) => {
-        assert.ifError(err);
-      });
-    }, common.expectsError({
+    fs.readFile(path.join(writeOnlyFolder, 'link-to-read-write'), common.expectsError({
       code: 'ERR_ACCESS_DENIED',
       permission: 'FileSystemRead',
     }));
@@ -60,11 +52,7 @@ const writeOnlyFolder = process.env.WRITEONLYFOLDER;
   fs.link(path.join(readWriteFolder, 'file'), path.join(writeOnlyFolder, 'link-to-read-write2'), (err) => {
     assert.ifError(err);
     // App will won't be able to read the link
-    assert.throws(() => {
-      fs.readFile(path.join(writeOnlyFolder, 'link-to-read-write2'), (err) => {
-        assert.ifError(err);
-      });
-    }, common.expectsError({
+    fs.readFile(path.join(writeOnlyFolder, 'link-to-read-write2'), common.expectsError({
       code: 'ERR_ACCESS_DENIED',
       permission: 'FileSystemRead',
     }));
@@ -75,18 +63,14 @@ const writeOnlyFolder = process.env.WRITEONLYFOLDER;
 
   // App won't be able to symlink to a readOnlyFolder
   assert.throws(() => {
-    fs.symlink(path.join(readWriteFolder, 'file'), path.join(readOnlyFolder, 'link-to-read-only'), 'file', (err) => {
-      assert.ifError(err);
-    });
+    fs.symlinkSync(path.join(readWriteFolder, 'file'), path.join(readOnlyFolder, 'link-to-read-only'), 'file');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(path.join(readOnlyFolder, 'link-to-read-only')),
   }));
   assert.throws(() => {
-    fs.link(path.join(readWriteFolder, 'file'), path.join(readOnlyFolder, 'link-to-read-only'), (err) => {
-      assert.ifError(err);
-    });
+    fs.linkSync(path.join(readWriteFolder, 'file'), path.join(readOnlyFolder, 'link-to-read-only'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',

--- a/test/fixtures/permission/fs-symlink.js
+++ b/test/fixtures/permission/fs-symlink.js
@@ -37,17 +37,13 @@ const symlinkFromBlockedFile = process.env.EXISTINGSYMLINK;
 {
   // App doesn’t have access to the BLOCKFOLDER
   assert.throws(() => {
-    fs.opendir(blockedFolder, (err) => {
-      assert.ifError(err);
-    });
+    fs.opendirSync(blockedFolder);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   }));
   assert.throws(() => {
-    fs.writeFile(blockedFolder + '/new-file', 'data', (err) => {
-      assert.ifError(err);
-    });
+    fs.writeFileSync(blockedFolder + '/new-file', 'data');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -55,17 +51,13 @@ const symlinkFromBlockedFile = process.env.EXISTINGSYMLINK;
 
   // App doesn’t have access to the BLOCKEDFILE folder
   assert.throws(() => {
-    fs.readFile(blockedFile, (err) => {
-      assert.ifError(err);
-    });
+    fs.readFileSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   }));
   assert.throws(() => {
-    fs.appendFile(blockedFile, 'data', (err) => {
-      assert.ifError(err);
-    });
+    fs.appendFileSync(blockedFile, 'data');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -73,17 +65,13 @@ const symlinkFromBlockedFile = process.env.EXISTINGSYMLINK;
 
   // App won't be able to symlink REGULARFILE to BLOCKFOLDER/asdf
   assert.throws(() => {
-    fs.symlink(regularFile, blockedFolder + '/asdf', 'file', (err) => {
-      assert.ifError(err);
-    });
+    fs.symlinkSync(regularFile, blockedFolder + '/asdf', 'file');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   }));
   assert.throws(() => {
-    fs.link(regularFile, blockedFolder + '/asdf', (err) => {
-      assert.ifError(err);
-    });
+    fs.linkSync(regularFile, blockedFolder + '/asdf');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -91,17 +79,13 @@ const symlinkFromBlockedFile = process.env.EXISTINGSYMLINK;
 
   // App won't be able to symlink BLOCKEDFILE to REGULARDIR
   assert.throws(() => {
-    fs.symlink(blockedFile, path.join(__dirname, '/asdf'), 'file', (err) => {
-      assert.ifError(err);
-    });
+    fs.symlinkSync(blockedFile, path.join(__dirname, '/asdf'), 'file');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   }));
   assert.throws(() => {
-    fs.link(blockedFile, path.join(__dirname, '/asdf'), (err) => {
-      assert.ifError(err);
-    });
+    fs.linkSync(blockedFile, path.join(__dirname, '/asdf'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',

--- a/test/fixtures/permission/fs-traversal.js
+++ b/test/fixtures/permission/fs-traversal.js
@@ -28,11 +28,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
 }
 
 {
-  assert.throws(() => {
-    fs.writeFile(traversalPath, 'test', (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
+  fs.writeFile(traversalPath, 'test', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(resolve(traversalPath)),
@@ -40,11 +36,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
 }
 
 {
-  assert.throws(() => {
-    fs.readFile(traversalPath, (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
+  fs.readFile(traversalPath, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: path.toNamespacedPath(resolve(traversalPath)),
@@ -53,34 +45,24 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
 
 {
   assert.throws(() => {
-    fs.mkdtempSync(traversalFolderPath, (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
+    fs.mkdtempSync(traversalFolderPath)
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: resolve(traversalFolderPath + 'XXXXXX'),
-  }));
+  });
 }
 
 {
-  assert.throws(() => {
-    fs.mkdtemp(traversalFolderPath, (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-    resource: resolve(traversalFolderPath + 'XXXXXX'),
-  }));
+    fs.mkdtemp(traversalFolderPath, common.expectsError({
+      code: 'ERR_ACCESS_DENIED',
+      permission: 'FileSystemWrite',
+      resource: resolve(traversalFolderPath + 'XXXXXX'),
+    }));
 }
 
 {
-  assert.throws(() => {
-    fs.readFile(bufferTraversalPath, (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
+  fs.readFile(bufferTraversalPath, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: resolve(traversalPath),
@@ -88,11 +70,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
 }
 
 {
-  assert.throws(() => {
-    fs.readFile(uint8ArrayTraversalPath, (error) => {
-      assert.ifError(error);
-    });
-  }, common.expectsError({
+  fs.readFile(uint8ArrayTraversalPath, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
     resource: resolve(traversalPath),
@@ -111,7 +89,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
   } catch { }
 
   assert.throws(() => {
-    fs.readFile(cwd, common.mustNotCall());
+    fs.readFileSync(cwd);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -136,7 +114,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
   assert.strictEqual(Buffer.from(resolve(traversalPathWithExtraChars)).toString(), traversalPath);
 
   assert.throws(() => {
-    fs.readFile(traversalPathWithExtraBytes, common.mustNotCall());
+    fs.readFileSync(traversalPathWithExtraBytes);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -144,7 +122,7 @@ const uint8ArrayTraversalPath = new TextEncoder().encode(traversalPath);
   }));
 
   assert.throws(() => {
-    fs.readFile(new TextEncoder().encode(traversalPathWithExtraBytes.toString()), common.mustNotCall());
+    fs.readFileSync(new TextEncoder().encode(traversalPathWithExtraBytes.toString()));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',

--- a/test/fixtures/permission/fs-wildcard.js
+++ b/test/fixtures/permission/fs-wildcard.js
@@ -7,29 +7,40 @@ const fs = require('fs');
 
 {
   assert.throws(() => {
-    fs.readFile('/test.txt', () => {});
+    fs.readFileSync('/test.txt');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   }));
   // doesNotThrow
-  fs.readFile('/tmp/foo/file', () => {});
+  fs.readFile('/tmp/foo/file', (err) => {
+    // Will throw ENOENT
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
 }
 
 {
   // doesNotThrow
-  fs.readFile('/example/foo/file', () => {});
-  fs.readFile('/example/foo2/file', () => {});
-  fs.readFile('/example/foo2', () => {});
+  fs.readFile('/example/foo/file', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+
+  fs.readFile('/example/foo2/file', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+
+  fs.readFile('/example/foo2', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
 
   assert.throws(() => {
-    fs.readFile('/example/fo/foo2.js', () => {});
+    fs.readFileSync('/example/fo/foo2.js');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
   }));
   assert.throws(() => {
-    fs.readFile('/example/for', () => {});
+    fs.readFileSync('/example/for');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -38,12 +49,18 @@ const fs = require('fs');
 
 {
   // doesNotThrow
-  fs.readFile('/example/bar/file', () => {});
-  fs.readFile('/example/bar2/file', () => {});
-  fs.readFile('/example/bar', () => {});
+  fs.readFile('/example/bar/file', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+  fs.readFile('/example/bar2/file', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+  fs.readFile('/example/bar', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
 
   assert.throws(() => {
-    fs.readFile('/example/ba/foo2.js', () => {});
+    fs.readFileSync('/example/ba/foo2.js');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
@@ -51,7 +68,13 @@ const fs = require('fs');
 }
 
 {
-  fs.readFile('/folder/a/subfolder/b', () => {});
-  fs.readFile('/folder/a/subfolder/b/c.txt', () => {});
-  fs.readFile('/folder/a/foo2.js', () => {});
+  fs.readFile('/folder/a/subfolder/b', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+  fs.readFile('/folder/a/subfolder/b/c.txt', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
+  fs.readFile('/folder/a/foo2.js', (err) => {
+    assert.notEqual(err.code, 'ERR_ACCESS_DENIED');
+  });
 }

--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -25,21 +25,26 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
 // fs.writeFile
 {
   assert.throws(() => {
-    fs.writeFile(blockedFile, 'example', () => {});
+    fs.writeFileSync(blockedFile, 'example');
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(blockedFile),
+  });
+  fs.writeFile(blockedFile, 'example', common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
+  assert.throws(() => {
+    fs.writeFileSync(blockedFileURL, 'example');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
-    fs.writeFile(blockedFileURL, 'example', () => {});
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
-  });
-  assert.throws(() => {
-    fs.writeFile(relativeProtectedFile, 'example', () => {});
+    fs.writeFileSync(relativeProtectedFile, 'example');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -47,7 +52,7 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
   });
 
   assert.throws(() => {
-    fs.writeFile(path.join(blockedFolder, 'anyfile'), 'example', () => {});
+    fs.writeFileSync(path.join(blockedFolder, 'anyfile'), 'example');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -170,59 +175,50 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   });
-  assert.throws(() => {
-    fs.mkdtemp(path.join(relativeProtectedFolder, 'any-folder'), (err) => {
-      assert.ifError(err);
-    });
-  },{
+  fs.mkdtemp(path.join(relativeProtectedFolder, 'any-folder'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-  });
+  }));
 }
 
 // fs.rename
 {
   assert.throws(() => {
-    fs.rename(blockedFile, path.join(blockedFile, 'renamed'), (err) => {
-      assert.ifError(err);
-    });
-  },{
+    fs.renameSync(blockedFile, path.join(blockedFile, 'renamed'));
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
   });
+  fs.rename(blockedFile, path.join(blockedFile, 'renamed'), common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.rename(blockedFileURL, path.join(blockedFile, 'renamed'), (err) => {
-      assert.ifError(err);
-    });
+    fs.renameSync(blockedFileURL, path.join(blockedFile, 'renamed'));
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
-    fs.rename(relativeProtectedFile, path.join(relativeProtectedFile, 'renamed'), (err) => {
-      assert.ifError(err);
-    });
+    fs.renameSync(relativeProtectedFile, path.join(relativeProtectedFile, 'renamed'));
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(absoluteProtectedFile),
   });
   assert.throws(() => {
-    fs.rename(blockedFile, path.join(regularFolder, 'renamed'), (err) => {
-      assert.ifError(err);
-    });
-  },{
+    fs.renameSync(blockedFile, path.join(regularFolder, 'renamed'));
+  }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
   });
 
   assert.throws(() => {
-    fs.rename(regularFile, path.join(blockedFolder, 'renamed'), (err) => {
-      assert.ifError(err);
-    });
+    fs.renameSync(regularFile, path.join(blockedFolder, 'renamed'));
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -246,6 +242,11 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(path.join(absoluteProtectedFolder, 'any-file')),
   });
+  fs.copyFile(regularFile, path.join(relativeProtectedFolder, 'any-file'), common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(path.join(absoluteProtectedFolder, 'any-file')),
+  }));
 }
 
 // fs.cp
@@ -288,18 +289,14 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
 {
   // Extra flags should not enable trivially bypassing all restrictions.
   // See https://github.com/nodejs/node/issues/47090.
-  assert.throws(() => {
-    fs.open(blockedFile, fs.constants.O_RDWR | 0x10000000, common.mustNotCall());
-  }, {
+  fs.open(blockedFile, fs.constants.O_RDWR | 0x10000000, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-  });
-  assert.throws(() => {
-    fs.open(blockedFileURL, fs.constants.O_RDWR | 0x10000000, common.mustNotCall());
-  }, {
+  }));
+  fs.open(blockedFileURL, fs.constants.O_RDWR | 0x10000000, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-  });
+  }));
   assert.rejects(async () => {
     await fs.promises.open(blockedFile, fs.constants.O_RDWR | fs.constants.O_NOFOLLOW);
   }, {
@@ -344,12 +341,10 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
 // fs.lchmod
 {
   if (common.isOSX) {
-    assert.throws(() => {
-      fs.lchmod(blockedFile, 0o755, common.mustNotCall());
-    }, {
+    fs.lchmod(blockedFile, 0o755, common.expectsError({
       code: 'ERR_ACCESS_DENIED',
       permission: 'FileSystemWrite',
-    });
+    }));
     assert.rejects(async () => {
       await fs.promises.lchmod(blockedFile, 0o755);
     }, {
@@ -361,14 +356,12 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
 
 // fs.appendFile
 {
-  assert.throws(() => {
-    fs.appendFile(blockedFile, 'new data', common.mustNotCall());
-  }, {
+  fs.appendFile(blockedFile, 'new data', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-  });
+  }));
   assert.throws(() => {
-    fs.appendFile(blockedFileURL, 'new data', common.mustNotCall());
+    fs.appendFileSync(blockedFileURL, 'new data');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
@@ -383,85 +376,89 @@ const absoluteProtectedFolder = path.resolve(relativeProtectedFolder);
 
 // fs.chown
 {
+  fs.chown(blockedFile, 1541, 999, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
   assert.throws(() => {
-    fs.chown(blockedFile, 1541, 999, common.mustNotCall());
+    fs.chownSync(blockedFileURL, 1541, 999);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   });
-  assert.throws(() => {
-    fs.chown(blockedFileURL, 1541, 999, common.mustNotCall());
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-  });
-  assert.rejects(async () => {
-    await fs.promises.chown(blockedFile, 1541, 999);
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-  });
+  // TODO(@RafaelGSS): Uncaught Exception somehow?
+  // assert.rejects(async () => {
+  //   return fs.promises.chown(blockedFile, 1541, 999);
+  // }, {
+  //   code: 'ERR_ACCESS_DENIED',
+  //   permission: 'FileSystemWrite',
+  // });
 }
 
 // fs.lchown
 {
+  fs.lchown(blockedFile, 1541, 999, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
   assert.throws(() => {
-    fs.lchown(blockedFile, 1541, 999, common.mustNotCall());
+    fs.lchownSync(blockedFileURL, 1541, 999);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   });
-  assert.throws(() => {
-    fs.lchown(blockedFileURL, 1541, 999, common.mustNotCall());
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-  });
-  assert.rejects(async () => {
-    await fs.promises.lchown(blockedFile, 1541, 999);
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-  });
+  // TODO(@RafaelGSS): Uncaught Exception somehow?
+  // assert.rejects(async () => {
+  //   await fs.promises.lchown(blockedFile, 1541, 999);
+  // }, {
+  //   code: 'ERR_ACCESS_DENIED',
+  //   permission: 'FileSystemWrite',
+  // });
 }
 
 // fs.link
 {
   assert.throws(() => {
-    fs.link(blockedFile, path.join(blockedFolder, '/linked'), common.mustNotCall());
+    fs.linkSync(blockedFile, path.join(blockedFolder, '/linked'));
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   });
+  fs.link(blockedFile, path.join(blockedFolder, '/linked'), common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
   assert.throws(() => {
-    fs.link(blockedFileURL, path.join(blockedFolder, '/linked'), common.mustNotCall());
+    fs.linkSync(blockedFileURL, path.join(blockedFolder, '/linked'));
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   });
-  assert.rejects(async () => {
-    await fs.promises.link(blockedFile, path.join(blockedFolder, '/linked'));
-  }, {
-    code: 'ERR_ACCESS_DENIED',
-    permission: 'FileSystemWrite',
-  });
+  // TODO(@RafaelGSS): Uncaught Exception somehow?
+  // assert.rejects(async () => {
+  //   await fs.promises.link(blockedFile, path.join(blockedFolder, '/linked'));
+  // }, {
+  //   code: 'ERR_ACCESS_DENIED',
+  //   permission: 'FileSystemWrite',
+  // });
 }
 
 // fs.unlink
 {
   assert.throws(() => {
-    fs.unlink(blockedFile, (err) => {
-      assert.ifError(err);
-    });
+    fs.unlinkSync(blockedFile);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
     resource: path.toNamespacedPath(blockedFile),
   });
+  fs.unlink(blockedFile, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
   assert.throws(() => {
-    fs.unlink(blockedFileURL, (err) => {
-      assert.ifError(err);
-    });
+    fs.unlinkSync(blockedFileURL);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',

--- a/test/fixtures/permission/loader/index.js
+++ b/test/fixtures/permission/loader/index.js
@@ -1,3 +1,3 @@
 const fs = require('node:fs');
 
-fs.readFile('/etc/passwd', () => {});
+fs.readFileSync('/etc/passwd');


### PR DESCRIPTION
Refs: https://github.com/nodejs/security-wg/issues/898

With this PR, we throw access denied asynchronously for async APIs.

```cjs
fs.readFile('restricted-file.md', (error) => {
  // error is ERR_ACCESS_DENIED
})
```

cc/ @nodejs/security-wg 