### PR TITLE
build: make simdjson a public dep in GN build

### DIFF
--- a/unofficial.gni
+++ b/unofficial.gni
@@ -140,6 +140,7 @@ template("node_gn_build") {
       "deps/ada",
       "deps/uv",
       "deps/base64",
+      "deps/simdjson",
       "$node_v8_path",
     ]
     deps = [
@@ -151,7 +152,6 @@ template("node_gn_build") {
       "deps/nghttp2",
       "deps/ngtcp2",
       "deps/postject",
-      "deps/simdjson",
       "deps/simdutf",
       "deps/uvwasi",
       "//third_party/zlib",


### PR DESCRIPTION
With a6b80c72678, `simdjson.h` got exposed to public headers (via `env.h` -> `inspector_profiler.h`), and the `simdjson` should be listed as a public dep to make it's header available to libnode's dependents.