### PR TITLE
fs: add support for minimatch overrides

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1082,6 +1082,8 @@ added: v22.0.0
   * `cwd` {string} current working directory. **Default:** `process.cwd()`
   * `exclude` {Function} Function to filter out files/directories. Return
     `true` to exclude the item, `false` to include it. **Default:** `undefined`.
+  * `overrides` {Object} override the default `minimatch` behavior with
+    the options specified. **Default:** `{}`.
 * Returns: {AsyncIterator} An AsyncIterator that yields the paths of files
   that match the pattern.
 
@@ -3119,6 +3121,8 @@ added: v22.0.0
   * `cwd` {string} current working directory. **Default:** `process.cwd()`
   * `exclude` {Function} Function to filter out files/directories. Return
     `true` to exclude the item, `false` to include it. **Default:** `undefined`.
+  * `overrides` {Object} override the default `minimatch` behavior with
+    the options specified. **Default:** `{}`.
 
 * `callback` {Function}
   * `err` {Error}

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -178,8 +178,11 @@ class Glob {
   constructor(pattern, options = kEmptyObject) {
     validateObject(options, 'options');
     const { exclude, cwd } = options;
-    const overrides = options.overrides || kEmptyObject;
-    validateObject(overrides, 'options.overrides');
+    const overrides = kEmptyObject;
+    if (options.overrides != null) {
+      validateObject(options.overrides, 'options.overrides');
+      overrides = options.overrides;
+    }  
     if (exclude != null) {
       validateFunction(exclude, 'options.exclude');
     }

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -178,6 +178,8 @@ class Glob {
   constructor(pattern, options = kEmptyObject) {
     validateObject(options, 'options');
     const { exclude, cwd } = options;
+    const overrides = options.overrides || kEmptyObject;
+    validateObject(overrides, 'options.overrides');
     if (exclude != null) {
       validateFunction(exclude, 'options.exclude');
     }
@@ -200,6 +202,7 @@ class Glob {
       optimizationLevel: 2,
       platform: process.platform,
       nocaseMagicOnly: true,
+      ...overrides,
     }));
 
     this.#patterns = ArrayPrototypeFlatMap(this.matchers, (matcher) => ArrayPrototypeMap(matcher.set,


### PR DESCRIPTION
This PR adds an additional `overrides` parameter to the `options` argument of `fs.glob`. This allows users to override the default `minimatch` glob options.

Fixes #52779