### PR TITLE
build: define `NOMINMAX` in common.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -458,6 +458,10 @@
           '_HAS_EXCEPTIONS=0',
           'BUILDING_V8_SHARED=1',
           'BUILDING_UV_SHARED=1',
+          # Stop <windows.h> from defining macros that conflict with
+          # std::min() and std::max().  We don't use <windows.h> (much)
+          # but we still inherit it from uv.h.
+          'NOMINMAX',
         ],
       }],
       [ 'OS in "linux freebsd openbsd solaris aix os400"', {

--- a/node.gypi
+++ b/node.gypi
@@ -63,10 +63,6 @@
         'FD_SETSIZE=1024',
         # we need to use node's preferred "win32" rather than gyp's preferred "win"
         'NODE_PLATFORM="win32"',
-        # Stop <windows.h> from defining macros that conflict with
-        # std::min() and std::max().  We don't use <windows.h> (much)
-        # but we still inherit it from uv.h.
-        'NOMINMAX',
         '_UNICODE=1',
       ],
       'msvs_precompiled_header': 'tools/msvs/pch/node_pch.h',

--- a/test/addons/hello-world/binding.gyp
+++ b/test/addons/hello-world/binding.gyp
@@ -4,6 +4,11 @@
       'target_name': 'binding',
       'sources': [ 'binding.cc' ],
       'includes': ['../common.gypi'],
+    },
+    {
+      'target_name': 'binding2',
+      'sources': [ 'binding2.cc' ],
+      'includes': ['../common.gypi'],
     }
   ]
 }

--- a/test/addons/hello-world/binding2.cc
+++ b/test/addons/hello-world/binding2.cc
@@ -1,0 +1,21 @@
+// Include uv.h and v8.h ahead of node.h to verify that node.h doesn't need to
+// be included first. Disable clang-format as it will sort the include lists.
+// clang-format off
+#include <uv.h>
+#include <v8.h>
+#include <node.h>
+// clang-format on
+
+static void Method(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  args.GetReturnValue().Set(
+      v8::String::NewFromUtf8(isolate, "world").ToLocalChecked());
+}
+
+static void InitModule(v8::Local<v8::Object> exports,
+                       v8::Local<v8::Value> module,
+                       v8::Local<v8::Context> context) {
+  NODE_SET_METHOD(exports, "hello", Method);
+}
+
+NODE_MODULE(NODE_GYP_MODULE_NAME, InitModule)

--- a/test/addons/hello-world/test.js
+++ b/test/addons/hello-world/test.js
@@ -6,6 +6,9 @@ const binding = require(bindingPath);
 assert.strictEqual(binding.hello(), 'world');
 console.log('binding.hello() =', binding.hello());
 
+const binding2 = require(require.resolve(`./build/${common.buildType}/binding2`));
+assert.strictEqual(binding2.hello(), 'world');
+
 // Test multiple loading of the same module.
 delete require.cache[bindingPath];
 const rebinding = require(bindingPath);


### PR DESCRIPTION
V8 and Node.js had defined `NOMINMAX` on Windows for a long time.  In
recent changes, V8 added `std::numeric_limits::min` usages in its
header files which caused addons without `NOMINMAX` defines failed
to compile.

Define `NOMINMAX` in common.gypi so that addons can be compiled with
the latest V8 header files.

[NAN](https://github.com/nodejs/nan/blob/56585a1cd21f25b4d56168063cedaf0831c63fef/nan.h#L61-L62) includes `uv.h` before `node.h`, which makes
[these defines](https://github.com/nodejs/node/blob/743aa42df1ae15fceef5a7d657f6c298a59ac150/src/node.h#L59-L61) effectiveless. Nevertheless, the include order should not be
significant.

Fixes: https://github.com/nodejs/nan/issues/968
Refs: https://github.com/nodejs/gyp-next/pull/244