### PR TITLE
deps: V8: cherry-pick f6bef09b3b0a

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/compiler/turboshaft/index.h
+++ b/deps/v8/src/compiler/turboshaft/index.h
@@ -480,7 +480,7 @@ class ConstOrV {
   template <typename U,
             typename = std::enable_if_t<std::is_constructible_v<V<T>, V<U>>>>
   ConstOrV(V<U> index)  // NOLINT(runtime/explicit)
-      : constant_value_(), value_(index) {}
+      : constant_value_(std::nullopt), value_(index) {}
 
   bool is_constant() const { return constant_value_.has_value(); }
   constant_type constant_value() const {


### PR DESCRIPTION
Original commit message:

    [turboshaft] initialize constant_value_ to an empty value

    gcc-10 seems to have a bug were not initializing this value
    throws this compilation error:
    ```
    src/compiler/turboshaft/assembler.h:680:16: error: ‘<anonymous>’ is used uninitialized in this function [-Werror=uninitialized]
      680 |     return Get();
    ```
    https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86465

    Bug: v8:12783
    Change-Id: I7a5fee5009b866a801326fba734c156c3cfdb1b0
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5503350
    Reviewed-by: Nico Hartmann <nicohartmann@chromium.org>
    Commit-Queue: Milad Farazmand <mfarazma@redhat.com>
    Cr-Commit-Position: refs/heads/main@{#93675}

Refs: https://github.com/v8/v8/commit/f6bef09b3b0a4aedaa59ff86a33c9f1d7427357b
Fixes: https://github.com/nodejs/node/issues/52661
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
