### PR TITLE
test: add env variable test for --run

### DIFF
--- a/test/fixtures/run-script/node_modules/.bin/path-env
+++ b/test/fixtures/run-script/node_modules/.bin/path-env
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$PATH"

--- a/test/fixtures/run-script/node_modules/.bin/path-env.bat
+++ b/test/fixtures/run-script/node_modules/.bin/path-env.bat
@@ -1,0 +1,2 @@
+@shift
+echo %PATH%

--- a/test/fixtures/run-script/package.json
+++ b/test/fixtures/run-script/package.json
@@ -6,6 +6,8 @@
     "positional-args": "positional-args",
     "positional-args-windows": "positional-args.bat",
     "custom-env": "custom-env",
-    "custom-env-windows": "custom-env.bat"
+    "custom-env-windows": "custom-env.bat",
+    "path-env": "path-env",
+    "path-env-windows": "path-env.bat"
   }
 }

--- a/test/message/node_run_non_existent.out
+++ b/test/message/node_run_non_existent.out
@@ -8,3 +8,5 @@ Available scripts are:
   positional-args-windows: positional-args.bat
   custom-env: custom-env
   custom-env-windows: custom-env.bat
+  path-env: path-env
+  path-env-windows: path-env.bat

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -64,4 +64,15 @@ describe('node run [command]', () => {
     assert.strictEqual(child.stderr, '');
     assert.strictEqual(child.code, 0);
   });
+
+  it('should set PATH environment variable to node_modules/.bin', async () => {
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--no-warnings', '--run', `path-env${envSuffix}`],
+      { cwd: fixtures.path('run-script') },
+    );
+    assert.ok(child.stdout.includes(fixtures.path('run-script/node_modules/.bin')));
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
 });


### PR DESCRIPTION
We don't test for PATH variable on `--run`. Thanks to @lemire we now do.