### PR TITLE
build: compile with C++20 support when using Clang

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -528,6 +528,10 @@
           }],
         ],
         'conditions': [
+          [ 'clang==1', {
+            'cflags_cc': [ '-std=gnu++20' ],
+            'cflags_cc!': [ '-std=gnu++17' ],
+          }],
           [ 'OS=="solaris"', {
             'cflags': [ '-pthreads' ],
             'ldflags': [ '-pthreads' ],
@@ -634,7 +638,7 @@
           ['clang==1', {
             'xcode_settings': {
               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
-              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++17',  # -std=gnu++17
+              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++20',  # -std=gnu++20
               'CLANG_CXX_LIBRARY': 'libc++',
             },
           }],


### PR DESCRIPTION
This is required by V8 12.6+

Refs: https://github.com/v8/v8/commit/4421c3672a09788b36317b88a3f6f1e2ebadaa39
Refs: https://github.com/nodejs/node/issues/45402