### PR TITLE
test: skip v8-updates/test-linux-perf-logger

### DIFF
--- a/test/v8-updates/v8-updates.status
+++ b/test/v8-updates/v8-updates.status
@@ -7,6 +7,8 @@ prefix v8-updates
 [true] # This section applies to all platforms
 # https://github.com/nodejs/node/issues/50079
 test-linux-perf: SKIP
+# https://github.com/nodejs/node/issues/51308
+test-linux-perf-logger: SKIP
 
 [$system==win32]
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/51308

Recent V8 CI failure: https://ci.nodejs.org/job/node-test-commit-v8-linux/5954/nodes=benchmark-ubuntu2204-intel-64,v8test=v8test/console