### PR TITLE
tools: fix V8 update workflow

### DIFF
--- a/tools/dep_updaters/update-v8-patch.sh
+++ b/tools/dep_updaters/update-v8-patch.sh
@@ -9,9 +9,9 @@ BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 
 cd "$BASE_DIR"
 
-IS_UP_TO_DATE=$(git node v8 minor | grep "V8 is up-to-date")
+CAN_UPDATE=$(git node v8 minor --v8-dir /Users/duhamean/Documents/v8/v8/ | grep -q "V8 is up-to-date" || echo "1")
 
-if [ -n "$IS_UP_TO_DATE" ]; then
+if [ -z "$CAN_UPDATE" ]; then
   echo "Skipped because V8 is on the latest version."
   exit 0
 fi

--- a/tools/dep_updaters/update-v8-patch.sh
+++ b/tools/dep_updaters/update-v8-patch.sh
@@ -9,7 +9,7 @@ BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 
 cd "$BASE_DIR"
 
-CAN_UPDATE=$(git node v8 minor --v8-dir /Users/duhamean/Documents/v8/v8/ | grep -q "V8 is up-to-date" || echo "1")
+CAN_UPDATE=$(git node v8 minor | grep -q "V8 is up-to-date" || echo "1")
 
 if [ -z "$CAN_UPDATE" ]; then
   echo "Skipped because V8 is on the latest version."


### PR DESCRIPTION
IIUC the workflow is currently failing when an update is available because `grep "V8 is up-to-date"` returns a non-zero exit code. I tested locally, and can confirm it does fix the script.

Fixes: https://github.com/nodejs/node/issues/50497

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
