### PR TITLE
stream: use Buffer.byteLength() to get the string length

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -453,6 +453,7 @@ function _write(stream, chunk, encoding, cb) {
     throw new ERR_STREAM_NULL_VALUES();
   }
 
+  let length = 0;
   if ((state[kState] & kObjectMode) === 0) {
     if (!encoding) {
       encoding = (state[kState] & kDefaultUTF8Encoding) !== 0 ? 'utf8' : state.defaultEncoding;
@@ -463,12 +464,17 @@ function _write(stream, chunk, encoding, cb) {
     if (typeof chunk === 'string') {
       if ((state[kState] & kDecodeStrings) !== 0) {
         chunk = Buffer.from(chunk, encoding);
+        length = chunk.length;
         encoding = 'buffer';
+      } else {
+        length = Buffer.byteLength(chunk, encoding);
       }
     } else if (chunk instanceof Buffer) {
+      length = chunk.length;
       encoding = 'buffer';
     } else if (Stream._isArrayBufferView(chunk)) {
       chunk = Stream._uint8ArrayToBuffer(chunk);
+      length = chunk.length;
       encoding = 'buffer';
     } else {
       throw new ERR_INVALID_ARG_TYPE(
@@ -490,7 +496,7 @@ function _write(stream, chunk, encoding, cb) {
   }
 
   state.pendingcb++;
-  return writeOrBuffer(stream, state, chunk, encoding, cb);
+  return writeOrBuffer(stream, state, chunk, length, encoding, cb);
 }
 
 Writable.prototype.write = function(chunk, encoding, cb) {
@@ -537,8 +543,8 @@ Writable.prototype.setDefaultEncoding = function setDefaultEncoding(encoding) {
 // If we're already writing something, then just put this
 // in the queue, and wait our turn.  Otherwise, call _write
 // If we return false, then we need a drain event, so set that flag.
-function writeOrBuffer(stream, state, chunk, encoding, callback) {
-  const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
+function writeOrBuffer(stream, state, chunk, length, encoding, callback) {
+  const len = (state[kState] & kObjectMode) !== 0 ? 1 : length;
 
   state.length += len;
 
@@ -548,7 +554,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
       state[kBufferedValue] = [];
     }
 
-    state[kBufferedValue].push({ chunk, encoding, callback });
+    state[kBufferedValue].push({ chunk, length, encoding, callback });
     if ((state[kState] & kAllBuffers) !== 0 && encoding !== 'buffer') {
       state[kState] &= ~kAllBuffers;
     }
@@ -718,8 +724,8 @@ function errorBuffer(state) {
 
   if ((state[kState] & kBuffered) !== 0) {
     for (let n = state.bufferedIndex; n < state.buffered.length; ++n) {
-      const { chunk, callback } = state[kBufferedValue][n];
-      const len = (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
+      const { length, callback } = state[kBufferedValue][n];
+      const len = (state[kState] & kObjectMode) !== 0 ? 1 : length;
       state.length -= len;
       callback(state.errored ?? new ERR_STREAM_DESTROYED('write'));
     }
@@ -768,9 +774,9 @@ function clearBuffer(stream, state) {
     resetBuffer(state);
   } else {
     do {
-      const { chunk, encoding, callback } = buffered[i];
+      const { chunk, length, encoding, callback } = buffered[i];
       buffered[i++] = null;
-      const len = objectMode ? 1 : chunk.length;
+      const len = objectMode ? 1 : length;
       doWrite(stream, state, false, len, chunk, encoding, callback);
     } while (i < buffered.length && (state[kState] & kWriting) === 0);
 

--- a/test/parallel/test-stream-writable-decoded-encoding.js
+++ b/test/parallel/test-stream-writable-decoded-encoding.js
@@ -103,3 +103,25 @@ class MyWritable extends stream.Writable {
   m.write({ foo: 'bar' }, 'utf8');
   m.end();
 }
+
+{
+  const w = new stream.Writable({
+    decodeStrings: false,
+    write() {}
+  });
+
+  w.write('€');
+
+  assert.strictEqual(w.writableLength, 3);
+}
+
+{
+  const w = new stream.Writable({
+    decodeStrings: false,
+    write() {}
+  });
+
+  w.write('aGVsbG8=', 'base64');
+
+  assert.strictEqual(w.writableLength, 5);
+}


### PR DESCRIPTION
Use the byte length of the string when the `decodeStrings` option is set to `false`.

Fixes: https://github.com/nodejs/node/issues/52818

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
