### PR TITLE
dgram: do not call callback if socket is closed

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -221,7 +221,10 @@ function bindServerHandle(self, options, errCb) {
   const state = self[kStateSymbol];
   cluster._getServer(self, options, (err, handle) => {
     if (err) {
-      errCb(err);
+      // Do not call callback if socket is closed
+      if (state.handle) {
+        errCb(err);
+      }
       return;
     }
 

--- a/test/parallel/test-dgram-bind-socket-close-before-cluster-reply.js
+++ b/test/parallel/test-dgram-bind-socket-close-before-cluster-reply.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+const cluster = require('cluster');
+
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  // When the socket attempts to bind, it requests a handle from the cluster.
+  // Force the cluster to send back an error code.
+  const socket = dgram.createSocket('udp4');
+  cluster._getServer = function(self, options, callback) {
+    socket.close(() => { cluster.worker.disconnect(); });
+    callback(-1);
+  };
+  socket.on('error', common.mustNotCall());
+  socket.bind();
+}


### PR DESCRIPTION
Do not call callback if socket is closed.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
