### PR TITLE
url: improve isURL performance by adding a typecheck

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -8,7 +8,6 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeReduce,
   ArrayPrototypeSlice,
-  Boolean,
   Int8Array,
   IteratorPrototype,
   Number,
@@ -767,7 +766,7 @@ ObjectDefineProperties(URLSearchParams.prototype, {
  * @returns {self is URL}
  */
 function isURL(self) {
-  return typeof self === 'object' && Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
+  return typeof self === 'object' && self.href && self.protocol && self.auth === undefined && self.path === undefined;
 }
 
 /**

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -767,7 +767,7 @@ ObjectDefineProperties(URLSearchParams.prototype, {
  * @returns {self is URL}
  */
 function isURL(self) {
-  return Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
+  return typeof self === 'object' && Boolean(self?.href && self.protocol && self.auth === undefined && self.path === undefined);
 }
 
 /**

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -8,6 +8,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeReduce,
   ArrayPrototypeSlice,
+  Boolean,
   Int8Array,
   IteratorPrototype,
   Number,
@@ -766,7 +767,11 @@ ObjectDefineProperties(URLSearchParams.prototype, {
  * @returns {self is URL}
  */
 function isURL(self) {
-  return typeof self === 'object' && self?.href && self.protocol && self.auth === undefined && self.path === undefined;
+  return Boolean(typeof self === 'object' &&
+                 self?.href &&
+                 self.protocol &&
+                 self.auth === undefined &&
+                 self.path === undefined);
 }
 
 /**

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -766,7 +766,7 @@ ObjectDefineProperties(URLSearchParams.prototype, {
  * @returns {self is URL}
  */
 function isURL(self) {
-  return typeof self === 'object' && self.href && self.protocol && self.auth === undefined && self.path === undefined;
+  return typeof self === 'object' && self?.href && self.protocol && self.auth === undefined && self.path === undefined;
 }
 
 /**


### PR DESCRIPTION
This PR makes the `isURL` function first verify that the input (`self`) is an object. This should make the benchmarking time much faster for non-urls, as shown in #52672 