### PR TITLE
test_runner: support module mocking

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -981,6 +981,16 @@ generated as part of the test runner output. If no tests are run, a coverage
 report is not generated. See the documentation on
 [collecting code coverage from tests][] for more details.
 
+### `--experimental-test-module-mocks`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+Enable module mocking in the test runner.
+
 ### `--experimental-vm-modules`
 
 <!-- YAML

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1775,6 +1775,25 @@ added:
 Resets the implementation of the mock function to its original behavior. The
 mock can still be used after calling this function.
 
+## Class: `MockModuleContext`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+The `MockModuleContext` class is used to manipulate the behavior of module mocks
+created via the [`MockTracker`][] APIs.
+
+### `ctx.restore()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Resets the implementation of the mock module.
+
 ## Class: `MockTracker`
 
 <!-- YAML
@@ -1905,6 +1924,68 @@ test('spies on an object method', (t) => {
   assert.strictEqual(call.error, undefined);
   assert.strictEqual(call.target, undefined);
   assert.strictEqual(call.this, number);
+});
+```
+
+### `mock.module(specifier[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+* `specifier` {string} A string identifying the module to mock.
+* `options` {Object} Optional configuration options for the mock module. The
+  following properties are supported:
+  * `cache` {boolean} If `false`, each call to `require()` or `import()`
+    generates a new mock module. If `true`, subsequent calls will return the same
+    module mock, and the mock module is inserted into the CommonJS cache.
+    **Default:** false.
+  * `defaultExport` {any} An optional value used as the mocked module's default
+    export. If this value is not provided, ESM mocks do not include a default
+    export. If the mock is a CommonJS or builtin module, this setting is used as
+    the value of `module.exports`. If this value is not provided, CJS and builtin
+    mocks use an empty object as the value of `module.exports`.
+  * `namedExports` {Object} An optional object whose keys and values are used to
+    create the named exports of the mock module. If the mock is a CommonJS or
+    builtin module, these values are copied onto `module.exports`. Therefore, if a
+    mock is created with both named exports and a non-object default export, the
+    mock will throw an exception when used as a CJS or builtin module.
+* Returns: {MockModuleContext} An object that can be used to manipulate the mock.
+
+This function is used to mock the exports of ECMAScript modules, CommonJS
+modules, and Node.js builtin modules. Any references to the original module
+prior to mocking are not impacted. The following example demonstrates how a mock
+is created for a module.
+
+```js
+test('mocks a builtin module in both module systems', async (t) => {
+  // Create a mock of 'node:readline' with a named export named 'fn', which
+  // does not exist in the original 'node:readline' module.
+  const mock = t.mock.module('node:readline', {
+    namedExports: { fn() { return 42; } },
+  });
+
+  let esmImpl = await import('node:readline');
+  let cjsImpl = require('node:readline');
+
+  // cursorTo() is an export of the original 'node:readline' module.
+  assert.strictEqual(esmImpl.cursorTo, undefined);
+  assert.strictEqual(cjsImpl.cursorTo, undefined);
+  assert.strictEqual(esmImpl.fn(), 42);
+  assert.strictEqual(cjsImpl.fn(), 42);
+
+  mock.restore();
+
+  // The mock is restored, so the original builtin module is returned.
+  esmImpl = await import('node:readline');
+  cjsImpl = require('node:readline');
+
+  assert.strictEqual(typeof esmImpl.cursorTo, 'function');
+  assert.strictEqual(typeof cjsImpl.cursorTo, 'function');
+  assert.strictEqual(esmImpl.fn, undefined);
+  assert.strictEqual(cjsImpl.fn, undefined);
 });
 ```
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -185,6 +185,9 @@ Use this flag to enable ShadowRealm support.
 .It Fl -experimental-test-coverage
 Enable code coverage in the test runner.
 .
+.It Fl -experimental-test-module-mocks
+Enable module mocking in the test runner.
+.
 .It Fl -experimental-eventsource
 Enable experimental support for the EventSource Web API.
 .

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -3,32 +3,70 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   Error,
+  FunctionPrototypeBind,
   FunctionPrototypeCall,
+  Int32Array,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetPrototypeOf,
+  ObjectKeys,
   Proxy,
   ReflectApply,
   ReflectConstruct,
   ReflectGet,
   SafeMap,
+  StringPrototypeSlice,
+  StringPrototypeStartsWith,
+  globalThis: {
+    Atomics: {
+      store: AtomicsStore,
+      wait: AtomicsWait,
+    },
+    SharedArrayBuffer,
+  },
 } = primordials;
 const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
+    ERR_INVALID_STATE,
   },
 } = require('internal/errors');
-const { kEmptyObject } = require('internal/util');
+const esmLoader = require('internal/modules/esm/loader');
+const { getOptionValue } = require('internal/options');
+const { fileURLToPath, toPathIfFileURL, URL } = require('internal/url');
+const {
+  emitExperimentalWarning,
+  getStructuredStack,
+  kEmptyObject,
+} = require('internal/util');
+let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
+  debug = fn;
+});
 const {
   validateBoolean,
   validateFunction,
   validateInteger,
   validateObject,
+  validateOneOf,
+  validateString,
 } = require('internal/validators');
 const { MockTimers } = require('internal/test_runner/mock/mock_timers');
-
+const { strictEqual, notStrictEqual } = require('assert');
+const { isBuiltin, Module, register } = require('module');
+const { MessageChannel } = require('worker_threads');
+const { _load, _nodeModulePaths, _resolveFilename } = Module;
 function kDefaultFunction() {}
+const enableModuleMocking = getOptionValue('--experimental-test-module-mocks');
+const kMockSearchParam = 'node-test-mock';
+const kMockSuccess = 1;
+const kMockExists = 2;
+const kMockUnknownMessage = 3;
+const kWaitTimeout = 5_000;
+const kBadExportsMessage = 'Cannot create mock because named exports ' +
+  'cannot be applied to the provided default export.';
+const kSupportedFormats = ['builtin', 'commonjs', 'module'];
+let sharedModuleState;
 
 class MockFunctionContext {
   #calls;
@@ -132,9 +170,107 @@ class MockFunctionContext {
   }
 }
 
-const { nextImpl, restore, trackCall } = MockFunctionContext.prototype;
+const {
+  nextImpl,
+  restore: restoreFn,
+  trackCall,
+} = MockFunctionContext.prototype;
 delete MockFunctionContext.prototype.trackCall;
 delete MockFunctionContext.prototype.nextImpl;
+
+class MockModuleContext {
+  #restore;
+  #sharedState;
+
+  constructor({
+    baseURL,
+    cache,
+    caller,
+    defaultExport,
+    format,
+    fullPath,
+    hasDefaultExport,
+    namedExports,
+    sharedState,
+  }) {
+    const ack = new Int32Array(new SharedArrayBuffer(4));
+    const config = {
+      __proto__: null,
+      cache,
+      defaultExport,
+      hasDefaultExport,
+      namedExports,
+      caller: toPathIfFileURL(caller),
+    };
+
+    sharedState.mockMap.set(baseURL, config);
+    sharedState.mockMap.set(fullPath, config);
+
+    this.#sharedState = sharedState;
+    this.#restore = {
+      __proto__: null,
+      ack,
+      baseURL,
+      cached: fullPath in Module._cache,
+      format,
+      fullPath,
+      value: Module._cache[fullPath],
+    };
+
+    sharedState.loaderPort.postMessage({
+      __proto__: null,
+      type: 'node:test:register',
+      payload: {
+        __proto__: null,
+        ack,
+        baseURL,
+        cache,
+        exportNames: ObjectKeys(namedExports),
+        hasDefaultExport,
+        format,
+      },
+    });
+    waitForAck(ack);
+    delete Module._cache[fullPath];
+    sharedState.mockExports.set(baseURL, {
+      __proto__: null,
+      defaultExport,
+      namedExports,
+    });
+  }
+
+  restore() {
+    if (this.#restore === undefined) {
+      return;
+    }
+
+    // Delete the mock CJS cache entry. If the module was previously in the
+    // cache then restore the old value.
+    delete Module._cache[this.#restore.fullPath];
+
+    if (this.#restore.cached) {
+      Module._cache[this.#restore.fullPath] = this.#restore.value;
+    }
+
+    AtomicsStore(this.#restore.ack, 0, 0);
+    this.#sharedState.loaderPort.postMessage({
+      __proto__: null,
+      type: 'node:test:unregister',
+      payload: {
+        __proto__: null,
+        ack: this.#restore.ack,
+        baseURL: this.#restore.baseURL,
+      },
+    });
+    waitForAck(this.#restore.ack);
+
+    this.#sharedState.mockMap.delete(this.#restore.baseURL);
+    this.#sharedState.mockMap.delete(this.#restore.fullPath);
+    this.#restore = undefined;
+  }
+}
+
+const { restore: restoreModule } = MockModuleContext.prototype;
 
 class MockTracker {
   #mocks = [];
@@ -350,6 +486,72 @@ class MockTracker {
     });
   }
 
+  module(specifier, options = kEmptyObject) {
+    emitExperimentalWarning('Module mocking');
+    validateString(specifier, 'specifier');
+    validateObject(options, 'options');
+    debug('module mock entry, specifier = "%s", options = %o', specifier, options);
+
+    const {
+      cache = false,
+      namedExports = kEmptyObject,
+      defaultExport,
+    } = options;
+    const hasDefaultExport = 'defaultExport' in options;
+
+    validateBoolean(cache, 'options.cache');
+    validateObject(namedExports, 'options.namedExports');
+
+    const sharedState = setupSharedModuleState();
+    const mockSpecifier = StringPrototypeStartsWith(specifier, 'node:') ?
+      StringPrototypeSlice(specifier, 5) : specifier;
+
+    // Get the file that called this function. We need four stack frames:
+    // vm context -> getStructuredStack() -> this function -> actual caller.
+    const caller = getStructuredStack()[3]?.getFileName();
+    const { format, url } = sharedState.moduleLoader.resolveSync(
+      mockSpecifier, caller, null,
+    );
+    debug('module mock, url = "%s", format = "%s", caller = "%s"', url, format, caller);
+    validateOneOf(format, 'format', kSupportedFormats);
+    const baseURL = URL.parse(url);
+
+    if (!baseURL) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'specifier', specifier, 'cannot compute URL',
+      );
+    }
+
+    if (baseURL.searchParams.has(kMockSearchParam)) {
+      throw new ERR_INVALID_STATE(
+        `Cannot mock '${specifier}.' The module is already mocked.`,
+      );
+    }
+
+    const fullPath = StringPrototypeStartsWith(url, 'file://') ?
+      fileURLToPath(url) : null;
+    const ctx = new MockModuleContext({
+      __proto__: null,
+      baseURL: baseURL.href,
+      cache,
+      caller,
+      defaultExport,
+      format,
+      fullPath,
+      hasDefaultExport,
+      namedExports,
+      sharedState,
+      specifier: mockSpecifier,
+    });
+
+    ArrayPrototypePush(this.#mocks, {
+      __proto__: null,
+      ctx,
+      restore: restoreModule,
+    });
+    return ctx;
+  }
+
   /**
    * Resets the mock tracker, restoring all mocks and clearing timers.
    */
@@ -364,7 +566,9 @@ class MockTracker {
    */
   restoreAll() {
     for (let i = 0; i < this.#mocks.length; i++) {
-      FunctionPrototypeCall(restore, this.#mocks[i]);
+      const { ctx, restore } = this.#mocks[i];
+
+      FunctionPrototypeCall(restore, ctx);
     }
   }
 
@@ -430,9 +634,96 @@ class MockTracker {
       },
     });
 
-    ArrayPrototypePush(this.#mocks, ctx);
+    ArrayPrototypePush(this.#mocks, {
+      __proto__: null,
+      ctx,
+      restore: restoreFn,
+    });
     return mock;
   }
+}
+
+function setupSharedModuleState() {
+  if (sharedModuleState === undefined) {
+    const { mock } = require('test');
+    const mockExports = new SafeMap();
+    const { port1, port2 } = new MessageChannel();
+
+    register('node:test/mock_loader', {
+      __proto__: null,
+      data: { __proto__: null, port: port2 },
+      transferList: [port2],
+    });
+
+    sharedModuleState = {
+      __proto__: null,
+      loaderPort: port1,
+      mockExports,
+      mockMap: new SafeMap(),
+      moduleLoader: esmLoader.getOrInitializeCascadedLoader(),
+    };
+    mock._mockExports = mockExports;
+    Module._load = FunctionPrototypeBind(cjsMockModuleLoad, sharedModuleState);
+  }
+
+  return sharedModuleState;
+}
+
+function cjsMockModuleLoad(request, parent, isMain) {
+  let resolved;
+
+  if (isBuiltin(request)) {
+    resolved = ensureNodeScheme(request);
+  } else {
+    resolved = _resolveFilename(request, parent, isMain);
+  }
+
+  const config = this.mockMap.get(resolved);
+  if (config === undefined) {
+    return _load(request, parent, isMain);
+  }
+
+  const {
+    cache,
+    caller,
+    defaultExport,
+    hasDefaultExport,
+    namedExports,
+  } = config;
+
+  if (cache && Module._cache[resolved]) {
+    // The CJS cache entry is deleted when the mock is configured. If it has
+    // been repopulated, return the exports from that entry.
+    return Module._cache[resolved].exports;
+  }
+
+  // eslint-disable-next-line node-core/set-proto-to-null-in-object
+  const modExports = hasDefaultExport ? defaultExport : {};
+  const exportNames = ObjectKeys(namedExports);
+
+  if ((typeof modExports !== 'object' || modExports === null) &&
+      exportNames.length > 0) {
+    // eslint-disable-next-line no-restricted-syntax
+    throw new Error(kBadExportsMessage);
+  }
+
+  for (let i = 0; i < exportNames.length; ++i) {
+    const name = exportNames[i];
+    const descriptor = ObjectGetOwnPropertyDescriptor(namedExports, name);
+    ObjectDefineProperty(modExports, name, descriptor);
+  }
+
+  if (cache) {
+    const entry = new Module(resolved, caller);
+
+    entry.exports = modExports;
+    entry.filename = resolved;
+    entry.loaded = true;
+    entry.paths = _nodeModulePaths(entry.path);
+    Module._cache[resolved] = entry;
+  }
+
+  return modExports;
 }
 
 function validateStringOrSymbol(value, name) {
@@ -466,4 +757,31 @@ function findMethodOnPrototypeChain(instance, methodName) {
   return descriptor;
 }
 
-module.exports = { MockTracker };
+function waitForAck(buf) {
+  const result = AtomicsWait(buf, 0, 0, kWaitTimeout);
+
+  notStrictEqual(result, 'timed-out', 'test mocking synchronization failed');
+  strictEqual(buf[0], kMockSuccess);
+}
+
+function ensureNodeScheme(specifier) {
+  if (!StringPrototypeStartsWith(specifier, 'node:')) {
+    return `node:${specifier}`;
+  }
+
+  return specifier;
+}
+
+if (!enableModuleMocking) {
+  delete MockTracker.prototype.module;
+}
+
+module.exports = {
+  ensureNodeScheme,
+  kBadExportsMessage,
+  kMockSearchParam,
+  kMockSuccess,
+  kMockExists,
+  kMockUnknownMessage,
+  MockTracker,
+};

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -479,16 +479,16 @@ function spliceOne(list, index) {
 
 const kNodeModulesRE = /^(?:.*)[\\/]node_modules[\\/]/;
 
-let getStructuredStack;
+let getStructuredStackImpl;
 
-function isInsideNodeModules() {
-  if (getStructuredStack === undefined) {
+function lazyGetStructuredStack() {
+  if (getStructuredStackImpl === undefined) {
     // Lazy-load to avoid a circular dependency.
     const { runInNewContext } = require('vm');
     // Use `runInNewContext()` to get something tamper-proof and
-    // side-effect-free. Since this is currently only used for a deprecated API,
-    // the perf implications should be okay.
-    getStructuredStack = runInNewContext(`(function() {
+    // side-effect-free. Since this is currently only used for a deprecated API
+    // and module mocking, the perf implications should be okay.
+    getStructuredStackImpl = runInNewContext(`(function() {
       try { Error.stackTraceLimit = Infinity; } catch {}
       return function structuredStack() {
         const e = new Error();
@@ -498,6 +498,16 @@ function isInsideNodeModules() {
     })()`, { overrideStackTrace }, { filename: 'structured-stack' });
   }
 
+  return getStructuredStackImpl;
+}
+
+function getStructuredStack() {
+  const getStructuredStackImpl = lazyGetStructuredStack();
+
+  return getStructuredStackImpl();
+}
+
+function isInsideNodeModules() {
   const stack = getStructuredStack();
 
   // Iterate over all stack frames and look for the first one not coming
@@ -895,6 +905,7 @@ module.exports = {
   getConstructorOf,
   getCWDURL,
   getInternalGlobal,
+  getStructuredStack,
   getSystemErrorMap,
   getSystemErrorName,
   guessHandleType,

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -17,13 +17,12 @@ const {
   kMockExists,
   kMockUnknownMessage,
 } = require('internal/test_runner/mock/mock');
-const { defaultResolve } = require('internal/modules/esm/resolve');
-const { URL } = require('internal/url');
+const { pathToFileURL, URL } = require('internal/url');
 const { normalizeReferrerURL } = require('internal/modules/helpers');
 let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
-const { isBuiltin } = require('module');
+const { createRequire, isBuiltin } = require('module');
 
 // TODO(cjihrig): This file should not be exposed publicly, but register() does
 // not handle internal loaders. Before marking this API as stable, one of the
@@ -96,8 +95,20 @@ async function resolve(specifier, context, nextResolve) {
   if (isBuiltin(specifier)) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
-    const parentURL = normalizeReferrerURL(context.parentURL);
-    specifier = await defaultResolve(specifier, { parentURL }).url;
+    // TODO(cjihrig): This try...catch should be replaced by defaultResolve(),
+    // but there are some edge cases that caused the tests to fail on Windows.
+    try {
+      const req = createRequire(context.parentURL);
+      specifier = pathToFileURL(req.resolve(specifier)).href;
+    } catch {
+      const parentURL = normalizeReferrerURL(context.parentURL);
+      const parsedURL = URL.parse(specifier, parentURL)?.href;
+
+      if (parsedURL) {
+        specifier = parsedURL;
+      }
+    }
+
     mockSpecifier = specifier;
   }
 

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -1,0 +1,216 @@
+'use strict';
+const {
+  JSONStringify,
+  SafeMap,
+  globalThis: {
+    Atomics: {
+      notify: AtomicsNotify,
+      store: AtomicsStore,
+    },
+  },
+} = primordials;
+const {
+  ensureNodeScheme,
+  kBadExportsMessage,
+  kMockSearchParam,
+  kMockSuccess,
+  kMockExists,
+  kMockUnknownMessage,
+} = require('internal/test_runner/mock/mock');
+const { defaultResolve } = require('internal/modules/esm/resolve');
+const { URL } = require('internal/url');
+const { normalizeReferrerURL } = require('internal/modules/helpers');
+let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
+  debug = fn;
+});
+const { isBuiltin } = require('module');
+
+// TODO(cjihrig): This file should not be exposed publicly, but register() does
+// not handle internal loaders. Before marking this API as stable, one of the
+// following issues needs to be implemented:
+// https://github.com/nodejs/node/issues/49473
+// or https://github.com/nodejs/node/issues/52219
+
+// TODO(cjihrig): The mocks need to be thread aware because the exports are
+// evaluated on the thread that creates the mock. Before marking this API as
+// stable, one of the following issues needs to be implemented:
+// https://github.com/nodejs/node/issues/49472
+// or https://github.com/nodejs/node/issues/52219
+
+// TODO(cjihrig): Network imports should be supported. There are two current
+// hurdles:
+// - The module format returned by the load() hook is not known. This could be
+//   implemented as an option, or default to 'module' for network imports.
+// - The generated mock module imports 'node:test', which is not allowed by
+//   checkIfDisallowedImport() in the ESM code.
+
+const mocks = new SafeMap();
+
+async function initialize(data) {
+  data?.port.on('message', ({ type, payload }) => {
+    debug('mock loader received message type "%s" with payload %o', type, payload);
+
+    if (type === 'node:test:register') {
+      const { baseURL } = payload;
+      const mock = mocks.get(baseURL);
+
+      if (mock?.active) {
+        debug('already mocking "%s"', baseURL);
+        sendAck(payload.ack, kMockExists);
+        return;
+      }
+
+      const localVersion = mock?.localVersion ?? 0;
+
+      debug('new mock version %d for "%s"', localVersion, baseURL);
+      mocks.set(baseURL, {
+        __proto__: null,
+        active: true,
+        cache: payload.cache,
+        exportNames: payload.exportNames,
+        format: payload.format,
+        hasDefaultExport: payload.hasDefaultExport,
+        localVersion,
+        url: baseURL,
+      });
+      sendAck(payload.ack);
+    } else if (type === 'node:test:unregister') {
+      const mock = mocks.get(payload.baseURL);
+
+      if (mock !== undefined) {
+        mock.active = false;
+        mock.localVersion++;
+      }
+
+      sendAck(payload.ack);
+    } else {
+      sendAck(payload.ack, kMockUnknownMessage);
+    }
+  });
+}
+
+async function resolve(specifier, context, nextResolve) {
+  debug('resolve hook entry, specifier = "%s", context = %o', specifier, context);
+  let mockSpecifier;
+
+  if (isBuiltin(specifier)) {
+    mockSpecifier = ensureNodeScheme(specifier);
+  } else {
+    const parentURL = normalizeReferrerURL(context.parentURL);
+    specifier = await defaultResolve(specifier, { parentURL }).url;
+    mockSpecifier = specifier;
+  }
+
+  const mock = mocks.get(mockSpecifier);
+  debug('resolve hook, specifier = "%s", mock = %o', specifier, mock);
+
+  if (mock?.active !== true) {
+    return nextResolve(specifier, context);
+  }
+
+  const url = new URL(mockSpecifier);
+
+  url.searchParams.set(kMockSearchParam, mock.localVersion);
+
+  if (!mock.cache) {
+    // With ESM, we can't remove modules from the cache. Bump the module's
+    // version instead so that the next import will be uncached.
+    mock.localVersion++;
+  }
+
+  debug('resolve hook finished, url = "%s"', url.href);
+  return nextResolve(url.href, context);
+}
+
+async function load(url, context, nextLoad) {
+  debug('load hook entry, url = "%s", context = %o', url, context);
+  const parsedURL = URL.parse(url);
+  if (parsedURL) {
+    parsedURL.searchParams.delete(kMockSearchParam);
+  }
+
+  const baseURL = parsedURL ? parsedURL.href : url;
+  const mock = mocks.get(baseURL);
+
+  debug('load hook, mock = %o', mock);
+  if (mock?.active !== true) {
+    return nextLoad(url);
+  }
+
+  // Treat builtins as commonjs because customization hooks do not allow a
+  // core module to be replaced.
+  const format = mock.format === 'builtin' ? 'commonjs' : mock.format;
+
+  return {
+    __proto__: null,
+    format,
+    shortCircuit: true,
+    source: await createSourceFromMock(mock),
+  };
+}
+
+async function createSourceFromMock(mock) {
+  // Create mock implementation from provided exports.
+  const { exportNames, format, hasDefaultExport, url } = mock;
+  const useESM = format === 'module';
+  const source = `${testImportSource(useESM)}
+if (!$__test.mock._mockExports.has('${url}')) {
+  throw new Error(${JSONStringify(`mock exports not found for "${url}"`)});
+}
+
+const $__exports = $__test.mock._mockExports.get(${JSONStringify(url)});
+${defaultExportSource(useESM, hasDefaultExport)}
+${namedExportsSource(useESM, exportNames)}
+`;
+
+  return source;
+}
+
+function testImportSource(useESM) {
+  if (useESM) {
+    return "import $__test from 'node:test';";
+  }
+
+  return "const $__test = require('node:test');";
+}
+
+function defaultExportSource(useESM, hasDefaultExport) {
+  if (!hasDefaultExport) {
+    return '';
+  } else if (useESM) {
+    return 'export default $__exports.defaultExport;';
+  }
+
+  return 'module.exports = $__exports.defaultExport;';
+}
+
+function namedExportsSource(useESM, exportNames) {
+  let source = '';
+
+  if (!useESM && exportNames.length > 0) {
+    source += `
+if (module.exports === null || typeof module.exports !== 'object') {
+  throw new Error('${JSONStringify(kBadExportsMessage)}');
+}
+`;
+  }
+
+  for (let i = 0; i < exportNames.length; ++i) {
+    const name = exportNames[i];
+
+    if (useESM) {
+      source += `export let ${name} = $__exports.namedExports[${JSONStringify(name)}];\n`;
+    } else {
+      source += `module.exports[${JSONStringify(name)}] = $__exports.namedExports[${JSONStringify(name)}];\n`;
+    }
+  }
+
+  return source;
+}
+
+function sendAck(buf, status = kMockSuccess) {
+  AtomicsStore(buf, 0, status);
+  AtomicsNotify(buf, 0);
+}
+
+module.exports = { initialize, load, resolve };

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -626,6 +626,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-test-coverage",
             "enable code coverage in the test runner",
             &EnvironmentOptions::test_runner_coverage);
+  AddOption("--experimental-test-module-mocks",
+            "enable module mocking in the test runner",
+            &EnvironmentOptions::test_runner_module_mocks);
   AddOption("--test-name-pattern",
             "run tests whose name matches this regular expression",
             &EnvironmentOptions::test_name_pattern);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -173,6 +173,7 @@ class EnvironmentOptions : public Options {
   uint64_t test_runner_timeout = 0;
   bool test_runner_coverage = false;
   bool test_runner_force_exit = false;
+  bool test_runner_module_mocks = false;
   std::vector<std::string> test_name_pattern;
   std::vector<std::string> test_reporter;
   std::vector<std::string> test_reporter_destination;

--- a/test/fixtures/module-mocking/basic-cjs.js
+++ b/test/fixtures/module-mocking/basic-cjs.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  string: 'original cjs string',
+};

--- a/test/fixtures/module-mocking/basic-esm-mock.mjs
+++ b/test/fixtures/module-mocking/basic-esm-mock.mjs
@@ -1,0 +1,1 @@
+export let string = 'mocked esm string';

--- a/test/fixtures/module-mocking/basic-esm.mjs
+++ b/test/fixtures/module-mocking/basic-esm.mjs
@@ -1,0 +1,1 @@
+export let string = 'original esm string';

--- a/test/fixtures/test-runner/mock-nm.js
+++ b/test/fixtures/test-runner/mock-nm.js
@@ -1,0 +1,21 @@
+'use strict';
+const assert = require('node:assert');
+const { test } = require('node:test');
+const fixture = 'reporter-cjs';
+
+test('mock node_modules dependency', async (t) => {
+  const mock = t.mock.module(fixture, {
+    namedExports: { fn() { return 42; } },
+  });
+  let cjsImpl = require(fixture);
+  let esmImpl = await import(fixture);
+
+  assert.strictEqual(cjsImpl.fn(), 42);
+  assert.strictEqual(esmImpl.fn(), 42);
+
+  mock.restore();
+  cjsImpl = require(fixture);
+  esmImpl = await import(fixture);
+  assert.strictEqual(cjsImpl.fn, undefined);
+  assert.strictEqual(esmImpl.fn, undefined);
+});

--- a/test/parallel/test-runner-module-mocking.js
+++ b/test/parallel/test-runner-module-mocking.js
@@ -1,0 +1,640 @@
+// Flags: --experimental-test-module-mocks --experimental-require-module
+'use strict';
+const common = require('../common');
+
+if (!common.isMainThread) {
+  common.skip('registering customization hooks in Workers does not work');
+}
+
+const fixtures = require('../common/fixtures');
+const assert = require('node:assert');
+const { relative } = require('node:path');
+const { test } = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+test('input validation', async (t) => {
+  await t.test('throws if specifier is not a string', (t) => {
+    assert.throws(() => {
+      t.mock.module(5);
+    }, { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+
+  await t.test('throws if options is not an object', (t) => {
+    assert.throws(() => {
+      t.mock.module(__filename, null);
+    }, { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+
+  await t.test('throws if cache is not a boolean', (t) => {
+    assert.throws(() => {
+      t.mock.module(__filename, { cache: 5 });
+    }, { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+
+  await t.test('throws if namedExports is not an object', async (t) => {
+    assert.throws(() => {
+      t.mock.module(__filename, {
+        namedExports: null,
+      });
+    }, { code: 'ERR_INVALID_ARG_TYPE' });
+  });
+});
+
+test('core module mocking with namedExports option', async (t) => {
+  await t.test('does not cache by default', async (t) => {
+    const original = require('readline');
+
+    assert.strictEqual(typeof original.cursorTo, 'function');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module('readline', {
+      namedExports: { fn() { return 42; } },
+    });
+    const mocked = require('readline');
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, require('readline'));
+    assert.notStrictEqual(mocked, require('node:readline'));
+    assert.strictEqual(mocked.cursorTo, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require('readline'));
+  });
+
+  await t.test('explicitly enables caching', async (t) => {
+    const original = require('readline');
+
+    assert.strictEqual(typeof original.cursorTo, 'function');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module('readline', {
+      namedExports: { fn() { return 42; } },
+      cache: true,
+    });
+    const mocked = require('readline');
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked, require('readline'));
+    assert.strictEqual(mocked, require('node:readline'));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require('readline'));
+  });
+
+  await t.test('explicitly disables caching', async (t) => {
+    const original = require('readline');
+
+    assert.strictEqual(typeof original.cursorTo, 'function');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module('readline', {
+      namedExports: { fn() { return 42; } },
+      cache: false,
+    });
+    const mocked = require('readline');
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, require('readline'));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require('readline'));
+  });
+
+  await t.test('named exports are applied to defaultExport', async (t) => {
+    const original = require('readline');
+
+    assert.strictEqual(typeof original.cursorTo, 'function');
+    assert.strictEqual(original.val1, undefined);
+    assert.strictEqual(original.val2, undefined);
+
+    const defaultExport = { val1: 5, val2: 3 };
+
+    t.mock.module('readline', {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    const mocked = require('readline');
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked.cursorTo, undefined);
+    assert.strictEqual(mocked.val1, 'mock value');
+    assert.strictEqual(mocked.val2, 3);
+    t.mock.reset();
+    assert.strictEqual(original, require('readline'));
+  });
+
+  await t.test('throws if named exports cannot be applied to defaultExport', async (t) => {
+    const fixture = 'readline';
+    const original = require(fixture);
+
+    assert.strictEqual(typeof original.cursorTo, 'function');
+    assert.strictEqual(original.val1, undefined);
+
+    const defaultExport = null;
+
+    t.mock.module(fixture, {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    assert.throws(() => {
+      require(fixture);
+    }, /Cannot create mock/);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+});
+
+test('CJS mocking with namedExports option', async (t) => {
+  await t.test('does not cache by default', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = require(fixture);
+
+    assert.strictEqual(original.string, 'original cjs string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+    });
+    const mocked = require(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, require(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+
+  await t.test('explicitly enables caching', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = require(fixture);
+
+    assert.strictEqual(original.string, 'original cjs string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+      cache: true,
+    });
+    const mocked = require(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked, require(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+
+  await t.test('explicitly disables caching', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = require(fixture);
+
+    assert.strictEqual(original.string, 'original cjs string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+      cache: false,
+    });
+    const mocked = require(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, require(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+
+  await t.test('named exports are applied to defaultExport', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = require(fixture);
+
+    assert.strictEqual(original.string, 'original cjs string');
+    assert.strictEqual(original.val1, undefined);
+    assert.strictEqual(original.val2, undefined);
+
+    const defaultExport = { val1: 5, val2: 3 };
+
+    t.mock.module(fixture, {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    const mocked = require(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.val1, 'mock value');
+    assert.strictEqual(mocked.val2, 3);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+
+  await t.test('throws if named exports cannot be applied to defaultExport', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = require(fixture);
+
+    assert.strictEqual(original.string, 'original cjs string');
+    assert.strictEqual(original.val1, undefined);
+
+    const defaultExport = null;
+
+    t.mock.module(fixture, {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    assert.throws(() => {
+      require(fixture);
+    }, /Cannot create mock/);
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+});
+
+test('ESM mocking with namedExports option', async (t) => {
+  await t.test('does not cache by default', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+    const original = await import(fixture);
+
+    assert.strictEqual(original.string, 'original esm string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+    });
+    const mocked = await import(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, await import(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, await import(fixture));
+  });
+
+  await t.test('explicitly enables caching', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+    const original = await import(fixture);
+
+    assert.strictEqual(original.string, 'original esm string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+      cache: true,
+    });
+    const mocked = await import(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked, await import(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, await import(fixture));
+  });
+
+  await t.test('explicitly disables caching', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+    const original = await import(fixture);
+
+    assert.strictEqual(original.string, 'original esm string');
+    assert.strictEqual(original.fn, undefined);
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+      cache: false,
+    });
+    const mocked = await import(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.notStrictEqual(mocked, await import(fixture));
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.fn(), 42);
+    t.mock.reset();
+    assert.strictEqual(original, await import(fixture));
+  });
+
+  await t.test('named exports are not applied to defaultExport', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+    const original = await import(fixture);
+
+    assert.strictEqual(original.string, 'original esm string');
+    assert.strictEqual(original.val1, undefined);
+    assert.strictEqual(original.val2, undefined);
+
+    const defaultExport = 'mock default';
+
+    t.mock.module(fixture, {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    const mocked = await import(fixture);
+
+    assert.notStrictEqual(original, mocked);
+    assert.strictEqual(mocked.string, undefined);
+    assert.strictEqual(mocked.default, 'mock default');
+    assert.strictEqual(mocked.val1, 'mock value');
+    t.mock.reset();
+    assert.strictEqual(original, require(fixture));
+  });
+
+  await t.test('throws if named exports cannot be applied to defaultExport as CJS', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+    const original = await import(fixture);
+
+    assert.strictEqual(original.default.string, 'original cjs string');
+    assert.strictEqual(original.default.val1, undefined);
+
+    const defaultExport = null;
+
+    t.mock.module(fixture, {
+      defaultExport,
+      namedExports: { val1: 'mock value' },
+    });
+    await assert.rejects(async () => {
+      await import(fixture);
+    }, /Cannot create mock/);
+
+    t.mock.reset();
+    assert.strictEqual(original, await import(fixture));
+  });
+});
+
+test('modules cannot be mocked multiple times at once', async (t) => {
+  await t.test('CJS', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+    });
+
+    assert.throws(() => {
+      t.mock.module(fixture, {
+        namedExports: { fn() { return 55; } },
+      });
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /The module is already mocked/,
+    });
+
+    const mocked = require(fixture);
+
+    assert.strictEqual(mocked.fn(), 42);
+  });
+
+  await t.test('ESM', async (t) => {
+    const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+
+    t.mock.module(fixture, {
+      namedExports: { fn() { return 42; } },
+    });
+
+    assert.throws(() => {
+      t.mock.module(fixture, {
+        namedExports: { fn() { return 55; } },
+      });
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /The module is already mocked/,
+    });
+
+    const mocked = await import(fixture);
+
+    assert.strictEqual(mocked.fn(), 42);
+  });
+});
+
+test('mocks are automatically restored', async (t) => {
+  const cjsFixture = fixtures.path('module-mocking', 'basic-cjs.js');
+  const esmFixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+
+  await t.test('CJS', async (t) => {
+    t.mock.module(cjsFixture, {
+      namedExports: { fn() { return 42; } },
+    });
+
+    const mocked = require(cjsFixture);
+
+    assert.strictEqual(mocked.fn(), 42);
+  });
+
+  await t.test('ESM', async (t) => {
+    t.mock.module(esmFixture, {
+      namedExports: { fn() { return 43; } },
+    });
+
+    const mocked = await import(esmFixture);
+
+    assert.strictEqual(mocked.fn(), 43);
+  });
+
+  const cjsMock = require(cjsFixture);
+  const esmMock = await import(esmFixture);
+
+  assert.strictEqual(cjsMock.string, 'original cjs string');
+  assert.strictEqual(cjsMock.fn, undefined);
+  assert.strictEqual(esmMock.string, 'original esm string');
+  assert.strictEqual(esmMock.fn, undefined);
+});
+
+test('mocks can be restored independently', async (t) => {
+  const cjsFixture = fixtures.path('module-mocking', 'basic-cjs.js');
+  const esmFixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+
+  const cjsMock = t.mock.module(cjsFixture, {
+    namedExports: { fn() { return 42; } },
+  });
+
+  const esmMock = t.mock.module(esmFixture, {
+    namedExports: { fn() { return 43; } },
+  });
+
+  let cjsImpl = require(cjsFixture);
+  let esmImpl = await import(esmFixture);
+
+  assert.strictEqual(cjsImpl.fn(), 42);
+  assert.strictEqual(esmImpl.fn(), 43);
+
+  cjsMock.restore();
+  cjsImpl = require(cjsFixture);
+
+  assert.strictEqual(cjsImpl.fn, undefined);
+  assert.strictEqual(esmImpl.fn(), 43);
+
+  esmMock.restore();
+  esmImpl = await import(esmFixture);
+
+  assert.strictEqual(cjsImpl.fn, undefined);
+  assert.strictEqual(esmImpl.fn, undefined);
+});
+
+test('core module mocks can be used by both module systems', async (t) => {
+  const coreMock = t.mock.module('readline', {
+    namedExports: { fn() { return 42; } },
+  });
+
+  let esmImpl = await import('readline');
+  let cjsImpl = require('readline');
+
+  assert.strictEqual(esmImpl.fn(), 42);
+  assert.strictEqual(cjsImpl.fn(), 42);
+
+  coreMock.restore();
+  esmImpl = await import('readline');
+  cjsImpl = require('readline');
+
+  assert.strictEqual(typeof esmImpl.cursorTo, 'function');
+  assert.strictEqual(typeof cjsImpl.cursorTo, 'function');
+});
+
+test('node:- core module mocks can be used by both module systems', async (t) => {
+  const coreMock = t.mock.module('node:readline', {
+    namedExports: { fn() { return 42; } },
+  });
+
+  let esmImpl = await import('node:readline');
+  let cjsImpl = require('node:readline');
+
+  assert.strictEqual(esmImpl.fn(), 42);
+  assert.strictEqual(cjsImpl.fn(), 42);
+
+  coreMock.restore();
+  esmImpl = await import('node:readline');
+  cjsImpl = require('node:readline');
+
+  assert.strictEqual(typeof esmImpl.cursorTo, 'function');
+  assert.strictEqual(typeof cjsImpl.cursorTo, 'function');
+});
+
+test('CJS mocks can be used by both module systems', async (t) => {
+  const cjsFixture = fixtures.path('module-mocking', 'basic-cjs.js');
+  const cjsMock = t.mock.module(cjsFixture, {
+    namedExports: { fn() { return 42; } },
+  });
+  let esmImpl = await import(cjsFixture);
+  let cjsImpl = require(cjsFixture);
+
+  assert.strictEqual(esmImpl.fn(), 42);
+  assert.strictEqual(cjsImpl.fn(), 42);
+
+  cjsMock.restore();
+
+  esmImpl = await import(cjsFixture);
+  cjsImpl = require(cjsFixture);
+
+  assert.strictEqual(esmImpl.default.string, 'original cjs string');
+  assert.strictEqual(cjsImpl.string, 'original cjs string');
+});
+
+test('ESM mocks can be used by both module systems', async (t) => {
+  const esmFixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+  const esmMock = t.mock.module(esmFixture, {
+    namedExports: { fn() { return 42; } },
+  });
+
+  let cjsImpl = require(esmFixture);
+  let esmImpl = await import(esmFixture);
+
+  assert.strictEqual(cjsImpl.fn(), 42);
+  assert.strictEqual(esmImpl.fn(), 42);
+
+  esmMock.restore();
+  cjsImpl = require(esmFixture);
+  esmImpl = await import(esmFixture);
+
+  assert.strictEqual(esmImpl.string, 'original esm string');
+  assert.strictEqual(cjsImpl.string, 'original esm string');
+});
+
+test('relative paths can be used by both module systems', async (t) => {
+  const fixture = relative(
+    __dirname, fixtures.path('module-mocking', 'basic-esm.mjs')
+  );
+  const mock = t.mock.module(fixture, {
+    namedExports: { fn() { return 42; } },
+  });
+  let cjsImpl = require(fixture);
+  let esmImpl = await import(fixture);
+
+  assert.strictEqual(cjsImpl.fn(), 42);
+  assert.strictEqual(esmImpl.fn(), 42);
+
+  mock.restore();
+  cjsImpl = require(fixture);
+  esmImpl = await import(fixture);
+
+  assert.strictEqual(esmImpl.string, 'original esm string');
+  assert.strictEqual(cjsImpl.string, 'original esm string');
+});
+
+test('node_modules can be used by both module systems', async (t) => {
+  const cwd = fixtures.path('test-runner');
+  const fixture = fixtures.path('test-runner', 'mock-nm.js');
+  const args = ['--experimental-test-module-mocks', fixture];
+  const {
+    code,
+    stdout,
+    signal,
+  } = await common.spawnPromisified(process.execPath, args, { cwd });
+
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+  assert.match(stdout, /# pass 1/);
+});
+
+test('file:// imports are supported in ESM only', async (t) => {
+  const fixture = pathToFileURL(
+    fixtures.path('module-mocking', 'basic-esm.mjs')
+  ).href;
+  const mock = t.mock.module(fixture, {
+    namedExports: { fn() { return 42; } },
+  });
+  let impl = await import(fixture);
+
+  assert.strictEqual(impl.fn(), 42);
+  assert.throws(() => {
+    require(fixture);
+  }, { code: 'MODULE_NOT_FOUND' });
+  mock.restore();
+  impl = await import(fixture);
+  assert.strictEqual(impl.string, 'original esm string');
+});
+
+test('mocked modules do not impact unmocked modules', async (t) => {
+  const mockedFixture = fixtures.path('module-mocking', 'basic-cjs.js');
+  const unmockedFixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+  t.mock.module(mockedFixture, {
+    namedExports: { fn() { return 42; } },
+  });
+  const mockedImpl = await import(mockedFixture);
+  const unmockedImpl = await import(unmockedFixture);
+
+  assert.strictEqual(mockedImpl.fn(), 42);
+  assert.strictEqual(unmockedImpl.fn, undefined);
+  assert.strictEqual(unmockedImpl.string, 'original esm string');
+});
+
+test('defaultExports work with CJS mocks in both module systems', async (t) => {
+  const fixture = fixtures.path('module-mocking', 'basic-cjs.js');
+  const original = require(fixture);
+  const defaultExport = Symbol('default');
+
+  assert.strictEqual(original.string, 'original cjs string');
+  t.mock.module(fixture, { defaultExport });
+  assert.strictEqual(require(fixture), defaultExport);
+  assert.strictEqual((await import(fixture)).default, defaultExport);
+});
+
+test('defaultExports work with ESM mocks in both module systems', async (t) => {
+  const fixture = fixtures.path('module-mocking', 'basic-esm.mjs');
+  const original = await import(fixture);
+  const defaultExport = Symbol('default');
+
+  assert.strictEqual(original.string, 'original esm string');
+  t.mock.module(fixture, { defaultExport });
+  assert.strictEqual((await import(fixture)).default, defaultExport);
+  assert.strictEqual(require(fixture), defaultExport);
+});

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -162,6 +162,8 @@ const customTypesMap = {
   'module.SourceMap':
     'module.html#class-modulesourcemap',
 
+  'MockModuleContext': 'test.html#class-mockmodulecontext',
+
   'require': 'modules.html#requireid',
 
   'Handle': 'net.html#serverlistenhandle-backlog-callback',


### PR DESCRIPTION
This commit adds experimental module mocking to the test runner.

Fixes: https://github.com/nodejs/node/issues/51164

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
