### PR TITLE
module: move `require` calls to lazy loading

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -159,6 +159,7 @@ const { getOptionValue, getEmbedderOptions } = require('internal/options');
 const policy = getLazy(
   () => (getOptionValue('--experimental-policy') ? require('internal/process/policy') : null),
 );
+const lazyESMResolve = getLazy(() => require('internal/modules/esm/resolve'));
 const shouldReportRequiredModules = getLazy(() => process.env.WATCH_REPORT_DEPENDENCIES);
 
 const permission = require('internal/process/permission');
@@ -414,6 +415,7 @@ ObjectDefineProperty(Module.prototype, 'parent', {
 Module._debug = pendingDeprecate(debug, 'Module._debug is deprecated.', 'DEP0077');
 Module.isBuiltin = BuiltinModule.isBuiltin;
 
+const lazyRunMain = getLazy(() => require('internal/modules/run_main'));
 /**
  * Prepare to run CommonJS code.
  * This function is called during pre-execution, before any user code is run.
@@ -430,8 +432,7 @@ function initializeCJS() {
   }
 
   // TODO(joyeecheung): deprecate this in favor of a proper hook?
-  Module.runMain =
-    require('internal/modules/run_main').executeUserEntryPoint;
+  Module.runMain = lazyRunMain().lazyExecuteUserEntryPoint;
 
   if (getOptionValue('--experimental-require-module')) {
     emitExperimentalWarning('Support for loading ES Module in require()');
@@ -596,8 +597,7 @@ function trySelf(parentPath, request) {
   }
 
   try {
-    const { packageExportsResolve } = require('internal/modules/esm/resolve');
-    return finalizeEsmResolution(packageExportsResolve(
+    return finalizeEsmResolution(lazyESMResolve().packageExportsResolve(
       pathToFileURL(pkg.path + '/package.json'), expansion, pkg.data,
       pathToFileURL(parentPath), getCjsConditions()), parentPath, pkg.path);
   } catch (e) {
@@ -629,8 +629,7 @@ function resolveExports(nmPath, request) {
   const pkg = _readPackage(pkgPath);
   if (pkg.exists && pkg.exports != null) {
     try {
-      const { packageExportsResolve } = require('internal/modules/esm/resolve');
-      return finalizeEsmResolution(packageExportsResolve(
+      return finalizeEsmResolution(lazyESMResolve().packageExportsResolve(
         pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
         getCjsConditions()), null, pkgPath);
     } catch (e) {
@@ -1182,10 +1181,9 @@ Module._resolveFilename = function(request, parent, isMain, options) {
     const pkg = packageJsonReader.getNearestParentPackageJSON(parentPath) || { __proto__: null };
     if (pkg.data?.imports != null) {
       try {
-        const { packageImportsResolve } = require('internal/modules/esm/resolve');
         return finalizeEsmResolution(
-          packageImportsResolve(request, pathToFileURL(parentPath),
-                                getCjsConditions()), parentPath,
+          lazyESMResolve().packageImportsResolve(request, pathToFileURL(parentPath), getCjsConditions()),
+          parentPath,
           pkg.path);
       } catch (e) {
         if (e.code === 'ERR_MODULE_NOT_FOUND') {
@@ -1236,8 +1234,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
  * @throws {Error} If the module cannot be found
  */
 function finalizeEsmResolution(resolved, parentPath, pkgPath) {
-  const { encodedSepRegEx } = require('internal/modules/esm/resolve');
-  if (RegExpPrototypeExec(encodedSepRegEx, resolved) !== null) {
+  if (RegExpPrototypeExec(lazyESMResolve().encodedSepRegEx, resolved) !== null) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
       resolved, 'must not include encoded "/" or "\\" characters', parentPath);
   }
@@ -1321,7 +1318,7 @@ Module.prototype.require = function(id) {
 let resolvedArgv;
 let hasPausedEntry = false;
 /** @type {import('vm').Script} */
-
+const lazyCascadedLoader = getLazy(() => require('internal/modules/esm/loader').getOrInitializeCascadedLoader());
 /**
  * Resolve and evaluate it synchronously as ESM if it's ESM.
  * @param {Module} mod CJS module instance
@@ -1329,10 +1326,10 @@ let hasPausedEntry = false;
  */
 function loadESMFromCJS(mod, filename) {
   const source = getMaybeCachedSource(mod, filename);
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  const cascadedLoader = lazyCascadedLoader();
   const isMain = mod[kIsMainSymbol];
   if (isMain) {
-    require('internal/modules/run_main').runEntryPointWithESMLoader((cascadedLoader) => {
+    lazyRunMain().runEntryPointWithESMLoader((cascadedLoader) => {
       const mainURL = pathToFileURL(filename).href;
       cascadedLoader.import(mainURL, undefined, { __proto__: null }, true);
     });


### PR DESCRIPTION
This PR replaces the redundant re-calling of `require()` with lazy-loading via the `getLazy()` function.