### PR TITLE
build: drop base64 dep in GN build

### DIFF
--- a/unofficial.gni
+++ b/unofficial.gni
@@ -139,7 +139,6 @@ template("node_gn_build") {
     public_deps = [
       "deps/ada",
       "deps/uv",
-      "deps/base64",
       "deps/simdjson",
       "$node_v8_path",
     ]


### PR DESCRIPTION
It is no longer a dependency after https://github.com/nodejs/node/pull/52714.