### PR TITLE
meta: add module label for the lib/internal/modules folder

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -97,6 +97,7 @@ subSystemLabels:
   /^lib\/test.js$/: test_runner
   /^lib\/internal\/url\.js$/: whatwg-url
   /^lib\/internal\/modules\/esm/: esm
+  /^lib\/internal\/modules/: esm
   /^lib\/internal\/webstreams/: web streams
   /^lib\/internal\/test_runner/: test_runner
 

--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -97,7 +97,7 @@ subSystemLabels:
   /^lib\/test.js$/: test_runner
   /^lib\/internal\/url\.js$/: whatwg-url
   /^lib\/internal\/modules\/esm/: esm
-  /^lib\/internal\/modules/: esm
+  /^lib\/internal\/modules/: module
   /^lib\/internal\/webstreams/: web streams
   /^lib\/internal\/test_runner/: test_runner
 


### PR DESCRIPTION
This PR updates the `lib/internal/modules` folder to use the `module` label