### PR TITLE
doc: add note about `--expose-internals`

### DIFF
--- a/lib/internal/README.md
+++ b/lib/internal/README.md
@@ -1,6 +1,13 @@
 # Internal Modules
 
-The modules in `lib/internal` are intended for internal use in Node.js core
-only, and are not accessible with `require()` from user modules. These modules
-can be changed at **any** time. Reliance on these modules outside of core
-is **not supported** in any way.
+The modules located in `lib/internal` directory are exclusively meant
+for internal usage within the Node.js core. They are not intended to
+be accessed via user modules `require()`. These modules may change at
+any point in time. Relying on these internal modules outside the core
+is not supported and can lead to unpredictable behavior.
+
+In certain scenarios, accessing these internal modules for debugging or
+experimental purposes might be necessary. Node.js provides the `--expose-internals`
+flag to expose these modules to userland code. Exercise caution when using
+this flag, as it can lead to unexpected results and is primarily intended
+for advanced users and debugging purposes.

--- a/lib/internal/README.md
+++ b/lib/internal/README.md
@@ -8,6 +8,6 @@ is not supported and can lead to unpredictable behavior.
 
 In certain scenarios, accessing these internal modules for debugging or
 experimental purposes might be necessary. Node.js provides the `--expose-internals`
-flag to expose these modules to userland code. Exercise caution when using
-this flag, as it can lead to unexpected results and is primarily intended
-for advanced users and debugging purposes.
+flag to expose these modules to userland code. This flag only exists to
+assist Node.js maintainers with debugging internals. It is not meant for
+use outside the project.


### PR DESCRIPTION
This PR adds a note about `--expose-internals`, as the flag allows the `internal/` directory to be `require()`ed.