### PR TITLE
module: cache synchronous module jobs before linking

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -295,22 +295,33 @@ class ModuleJobSync extends ModuleJobBase {
   #loader = null;
   constructor(loader, url, importAttributes, moduleWrap, isMain, inspectBrk) {
     super(url, importAttributes, moduleWrap, isMain, inspectBrk, true);
-    assert(this.module instanceof ModuleWrap);
     this.#loader = loader;
-    const moduleRequests = this.module.getModuleRequests();
-    // Specifiers should be aligned with the moduleRequests array in order.
-    const specifiers = Array(moduleRequests.length);
-    const modules = Array(moduleRequests.length);
-    const jobs = Array(moduleRequests.length);
-    for (let i = 0; i < moduleRequests.length; ++i) {
-      const { specifier, attributes } = moduleRequests[i];
-      const job = this.#loader.getModuleJobForRequire(specifier, url, attributes);
-      specifiers[i] = specifier;
-      modules[i] = job.module;
-      jobs[i] = job;
+
+    assert(this.module instanceof ModuleWrap);
+    // Store itself into the cache first before linking in case there are circular
+    // references in the linking.
+    loader.loadCache.set(url, importAttributes.type, this);
+
+    try {
+      const moduleRequests = this.module.getModuleRequests();
+      // Specifiers should be aligned with the moduleRequests array in order.
+      const specifiers = Array(moduleRequests.length);
+      const modules = Array(moduleRequests.length);
+      const jobs = Array(moduleRequests.length);
+      for (let i = 0; i < moduleRequests.length; ++i) {
+        const { specifier, attributes } = moduleRequests[i];
+        const job = this.#loader.getModuleJobForRequire(specifier, url, attributes);
+        specifiers[i] = specifier;
+        modules[i] = job.module;
+        jobs[i] = job;
+      }
+      this.module.link(specifiers, modules);
+      this.linked = jobs;
+    } finally {
+      // Restore it - if it succeeds, we'll reset in the caller; Otherwise it's
+      // not cached and if the error is caught, subsequent attempt would still fail.
+      loader.loadCache.delete(url, importAttributes.type);
     }
-    this.module.link(specifiers, modules);
-    this.linked = jobs;
   }
 
   get modulePromise() {

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -114,6 +114,12 @@ class LoadCache extends SafeMap {
     validateString(type, 'type');
     return super.get(url)?.[type] !== undefined;
   }
+  delete(url, type = kImplicitAssertType) {
+    const cached = super.get(url);
+    if (cached) {
+      cached[type] = undefined;
+    }
+  }
 }
 
 module.exports = {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -32,6 +32,7 @@ const net = require('net');
 const path = require('path');
 const { inspect } = require('util');
 const { isMainThread } = require('worker_threads');
+const { isModuleNamespaceObject } = require('util/types');
 
 const tmpdir = require('./tmpdir');
 const bits = ['arm64', 'loong64', 'mips', 'mipsel', 'ppc64', 'riscv64', 's390x', 'x64']
@@ -938,6 +939,18 @@ function getPrintedStackTrace(stderr) {
   return result;
 }
 
+/**
+ * Check the exports of require(esm).
+ * TODO(joyeecheung): use it in all the test-require-module-* tests to minimize changes
+ * if/when we change the layout of the result returned by require(esm).
+ * @param {object} mod result returned by require()
+ * @param {object} expectation shape of expected namespace.
+ */
+function expectRequiredModule(mod, expectation) {
+  assert(isModuleNamespaceObject(mod));
+  assert.deepStrictEqual({ ...mod }, { ...expectation });
+}
+
 const common = {
   allowGlobals,
   buildType,
@@ -946,6 +959,7 @@ const common = {
   createZeroFilledFile,
   defaultAutoSelectFamilyAttemptTimeout,
   expectsError,
+  expectRequiredModule,
   expectWarning,
   gcUntil,
   getArrayBufferViews,

--- a/test/es-module/test-require-module-cycle-cjs-esm-esm.js
+++ b/test/es-module/test-require-module-cycle-cjs-esm-esm.js
@@ -1,0 +1,8 @@
+// Flags: --experimental-require-module
+'use strict';
+
+// This tests that ESM <-> ESM cycle is allowed in a require()-d graph.
+const common = require('../common');
+const cycle = require('../fixtures/es-modules/cjs-esm-esm-cycle/c.cjs');
+
+common.expectRequiredModule(cycle, { b: 5 });

--- a/test/fixtures/es-modules/cjs-esm-esm-cycle/a.mjs
+++ b/test/fixtures/es-modules/cjs-esm-esm-cycle/a.mjs
@@ -1,2 +1,1 @@
 export { b } from './b.mjs';
-

--- a/test/fixtures/es-modules/cjs-esm-esm-cycle/a.mjs
+++ b/test/fixtures/es-modules/cjs-esm-esm-cycle/a.mjs
@@ -1,0 +1,2 @@
+export { b } from './b.mjs';
+

--- a/test/fixtures/es-modules/cjs-esm-esm-cycle/b.mjs
+++ b/test/fixtures/es-modules/cjs-esm-esm-cycle/b.mjs
@@ -1,0 +1,2 @@
+import './a.mjs'
+export const b = 5;

--- a/test/fixtures/es-modules/cjs-esm-esm-cycle/c.cjs
+++ b/test/fixtures/es-modules/cjs-esm-esm-cycle/c.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./a.mjs');


### PR DESCRIPTION
#### test: add common.expectRequiredModule()

To minimize changes if/when we change the layout of the
result returned by require(esm).

#### module: cache synchronous module jobs before linking

So that if there are circular dependencies in the synchronous
module graph, they could be resolved using the cached jobs.
In case linking fails and the error gets caught, reset the
cache right after linking. If it succeeds, the caller will
cache it again. Otherwise the error bubbles up to users,
and since we unset the cache for the unlinkable module
the next attempt would still fail.

Fixes: https://github.com/nodejs/node/issues/52864

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
