### PR TITLE
test: unskip v8-updates/test-linux-perf-logger

### DIFF
--- a/test/v8-updates/test-linux-perf-logger.js
+++ b/test/v8-updates/test-linux-perf-logger.js
@@ -52,7 +52,8 @@ const testCases = [
   },
   {
     title: '--perf-basic-prof compiled',
-    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-turbofan', '--minimum-invocations-before-optimization=0'],
+    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-turbofan',
+    '--minimum-invocations-before-optimization=0'],
     matches: [
       'test-regex',
       '~functionOne .+/linux-perf-logger.js',
@@ -70,7 +71,8 @@ const testCases = [
   },
   {
     title: '--perf-basic-prof-only-functions compiled',
-    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-turbofan', '--minimum-invocations-before-optimization=0'],
+    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-turbofan',
+    '--minimum-invocations-before-optimization=0'],
     matches: [
       '~functionOne .+/linux-perf-logger.js',
       '~functionTwo .+/linux-perf-logger.js',

--- a/test/v8-updates/test-linux-perf-logger.js
+++ b/test/v8-updates/test-linux-perf-logger.js
@@ -20,7 +20,11 @@
 //
 // NOTE: This test runs only on linux, as that is the only platform supported by perf, and
 // accordingly the only platform where `perf-basic-prof*` v8 flags are available.
-
+//
+// MAINTAINERS' NOTE: As of early 2024, the most common failure mode for this test suite
+// is for v8 options to change from version to version. If this suite fails, look there first.
+// We use options to forcibly require certain test cases to JIT code, and the nodeFlags to do
+// so can change.
 
 const common = require('../common');
 if (!common.isLinux) {
@@ -48,7 +52,7 @@ const testCases = [
   },
   {
     title: '--perf-basic-prof compiled',
-    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-turbofan'],
+    nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-turbofan', '--minimum-invocations-before-optimization=0'],
     matches: [
       'test-regex',
       '~functionOne .+/linux-perf-logger.js',
@@ -66,7 +70,7 @@ const testCases = [
   },
   {
     title: '--perf-basic-prof-only-functions compiled',
-    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-turbofan'],
+    nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-turbofan', '--minimum-invocations-before-optimization=0'],
     matches: [
       '~functionOne .+/linux-perf-logger.js',
       '~functionTwo .+/linux-perf-logger.js',

--- a/test/v8-updates/test-linux-perf-logger.js
+++ b/test/v8-updates/test-linux-perf-logger.js
@@ -53,7 +53,7 @@ const testCases = [
   {
     title: '--perf-basic-prof compiled',
     nodeFlags: ['--perf-basic-prof', '--no-turbo-inlining', '--always-turbofan',
-    '--minimum-invocations-before-optimization=0'],
+                '--minimum-invocations-before-optimization=0'],
     matches: [
       'test-regex',
       '~functionOne .+/linux-perf-logger.js',
@@ -72,7 +72,7 @@ const testCases = [
   {
     title: '--perf-basic-prof-only-functions compiled',
     nodeFlags: ['--perf-basic-prof-only-functions', '--no-turbo-inlining', '--always-turbofan',
-    '--minimum-invocations-before-optimization=0'],
+                '--minimum-invocations-before-optimization=0'],
     matches: [
       '~functionOne .+/linux-perf-logger.js',
       '~functionTwo .+/linux-perf-logger.js',

--- a/test/v8-updates/v8-updates.status
+++ b/test/v8-updates/v8-updates.status
@@ -7,8 +7,6 @@ prefix v8-updates
 [true] # This section applies to all platforms
 # https://github.com/nodejs/node/issues/50079
 test-linux-perf: SKIP
-# https://github.com/nodejs/node/issues/51308
-test-linux-perf-logger: SKIP
 
 [$system==win32]
 


### PR DESCRIPTION
This patch fixes #51308. It includes commit to re-enable the test by reverting #52821.

Explanation

This test suite is a dependency-free port of `test/v8-updates/test-linux-perf.js`. In both cases, js code is evaluated in a child process with v8 options set to emit a symbol table for `perf(1)`. Verification is done by regex lookup. In the output, a function `foo` will be distinguished as compiled or interpreted based on a unary prefix character. Test cases use v8 option arguments to the child process to ensure compilation when applicable.

In 2023 (I don't know how to identify the release version), v8 added a new additional flag to guard optimization ([link](https://chromium-review.googlesource.com/c/v8/v8/+/4370020/9/test/unittests/deoptimizer/deoptimization-unittest.cc)). This patch includes that in the child process options.