### PR TITLE
[v20.x backport]  test_runner: support source mapped test locations

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -15,6 +15,7 @@ const {
   PromisePrototypeThen,
   PromiseResolve,
   SafePromisePrototypeFinally,
+  StringPrototypeStartsWith,
   ReflectApply,
   RegExpPrototypeExec,
   SafeMap,
@@ -58,6 +59,7 @@ const {
 } = require('internal/validators');
 const { setTimeout } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
+const { fileURLToPath } = require('internal/url');
 const { availableParallelism } = require('os');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
@@ -384,6 +386,10 @@ class Test extends AsyncResource {
           this.loc.column = entry.originalColumn + 1;
           this.loc.file = entry.originalSource;
         }
+      }
+
+      if (StringPrototypeStartsWith(this.loc.file, 'file://')) {
+        this.loc.file = fileURLToPath(this.loc.file);
       }
     }
   }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -76,8 +76,17 @@ const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 const kUnwrapErrors = new SafeSet()
   .add(kTestCodeFailure).add(kHookFailure)
   .add('uncaughtException').add('unhandledRejection');
-const { testNamePatterns, testOnlyFlag } = parseCommandLine();
+const { sourceMaps, testNamePatterns, testOnlyFlag } = parseCommandLine();
 let kResistStopPropagation;
+let findSourceMap;
+
+function lazyFindSourceMap(file) {
+  if (findSourceMap === undefined) {
+    ({ findSourceMap } = require('internal/source_map/source_map_cache'));
+  }
+
+  return findSourceMap(file);
+}
 
 function stopTest(timeout, signal) {
   const deferred = createDeferredPromise();
@@ -365,6 +374,17 @@ class Test extends AsyncResource {
         column: loc[1],
         file: loc[2],
       };
+
+      if (sourceMaps === true) {
+        const map = lazyFindSourceMap(this.loc.file);
+        const entry = map?.findEntry(this.loc.line - 1, this.loc.column - 1);
+
+        if (entry !== undefined) {
+          this.loc.line = entry.originalLine + 1;
+          this.loc.column = entry.originalColumn + 1;
+          this.loc.file = entry.originalSource;
+        }
+      }
     }
   }
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -199,6 +199,7 @@ function parseCommandLine() {
 
   const isTestRunner = getOptionValue('--test');
   const coverage = getOptionValue('--experimental-test-coverage');
+  const sourceMaps = getOptionValue('--enable-source-maps');
   const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
   const isChildProcessV8 = process.env.NODE_TEST_CONTEXT === 'child-v8';
   let destinations;
@@ -250,6 +251,7 @@ function parseCommandLine() {
     __proto__: null,
     isTestRunner,
     coverage,
+    sourceMaps,
     testOnlyFlag,
     testNamePatterns,
     reporters,

--- a/test/fixtures/test-runner/output/source_mapped_locations.mjs
+++ b/test/fixtures/test-runner/output/source_mapped_locations.mjs
@@ -1,0 +1,7 @@
+// Flags: --enable-source-maps
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert';
+test('fails', () => {
+    strictEqual(1, 2);
+});
+//# sourceMappingURL=source_mapped_locations.mjs.map

--- a/test/fixtures/test-runner/output/source_mapped_locations.mjs.map
+++ b/test/fixtures/test-runner/output/source_mapped_locations.mjs.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"source_mapped_locations.mjs","sourceRoot":"","sources":["source_mapped_locations.ts"],"names":[],"mappings":"AAAA,8BAA8B;AAC9B,OAAO,EAAE,IAAI,EAAE,MAAM,WAAW,CAAC;AACjC,OAAO,EAAE,WAAW,EAAE,MAAM,aAAa,CAAC;AAE1C,IAAI,CAAC,OAAO,EAAE,GAAG,EAAE;IACjB,WAAW,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC;AACpB,CAAC,CAAC,CAAC"}

--- a/test/fixtures/test-runner/output/source_mapped_locations.snapshot
+++ b/test/fixtures/test-runner/output/source_mapped_locations.snapshot
@@ -1,0 +1,33 @@
+TAP version 13
+# Subtest: fails
+not ok 1 - fails
+  ---
+  duration_ms: *
+  location: 'file:///test/fixtures/test-runner/output/source_mapped_locations.ts:5:1'
+  failureType: 'testCodeFailure'
+  error: |-
+    Expected values to be strictly equal:
+    
+    1 !== 2
+    
+  code: 'ERR_ASSERTION'
+  name: 'AssertionError'
+  expected: 2
+  actual: 1
+  operator: 'strictEqual'
+  stack: |-
+    *
+    *
+    *
+    *
+    *
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/fixtures/test-runner/output/source_mapped_locations.snapshot
+++ b/test/fixtures/test-runner/output/source_mapped_locations.snapshot
@@ -3,7 +3,7 @@ TAP version 13
 not ok 1 - fails
   ---
   duration_ms: *
-  location: 'file:///test/fixtures/test-runner/output/source_mapped_locations.ts:5:1'
+  location: '/test/fixtures/test-runner/output/source_mapped_locations.ts:5:1'
   failureType: 'testCodeFailure'
   error: |-
     Expected values to be strictly equal:

--- a/test/fixtures/test-runner/output/source_mapped_locations.ts
+++ b/test/fixtures/test-runner/output/source_mapped_locations.ts
@@ -1,0 +1,7 @@
+// Flags: --enable-source-maps
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert';
+
+test('fails', () => {
+  strictEqual(1, 2);
+});

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -114,6 +114,7 @@ const tests = [
   { name: 'test-runner/output/spec_reporter_successful.js', transform: specTransform },
   { name: 'test-runner/output/spec_reporter.js', transform: specTransform },
   { name: 'test-runner/output/spec_reporter_cli.js', transform: specTransform },
+  { name: 'test-runner/output/source_mapped_locations.mjs' },
   process.features.inspector ? { name: 'test-runner/output/lcov_reporter.js', transform: lcovTransform } : false,
   { name: 'test-runner/output/output.js' },
   { name: 'test-runner/output/output_cli.js' },


### PR DESCRIPTION
Backport for https://github.com/nodejs/node/pull/52010