### PR TITLE
build: harmonize Clang checks and update V8 warning cflags

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -3,7 +3,6 @@
     'configuring_node%': 0,
     'asan%': 0,
     'ubsan%': 0,
-    'werror': '',                     # Turn off -Werror in V8 build.
     'visibility%': 'hidden',          # V8's visibility setting
     'target_arch%': 'ia32',           # set v8's target architecture
     'host_arch%': 'ia32',             # set v8's host architecture

--- a/common.gypi
+++ b/common.gypi
@@ -107,7 +107,6 @@
         'v8_base': '<(PRODUCT_DIR)/obj.target/tools/v8_gypfiles/libv8_snapshot.a',
       }],
       ['OS=="mac"', {
-        'clang%': 1,
         'obj_dir%': '<(PRODUCT_DIR)/obj.target',
         'v8_base': '<(PRODUCT_DIR)/libv8_snapshot.a',
       }],
@@ -182,10 +181,10 @@
             }, {
               'MSVC_runtimeType': 2   # MultiThreadedDLL (/MD)
             }],
-            ['llvm_version=="0.0"', {
-              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
-            }, {
+            ['clang==1', {
               'lto': ' -flto ', # Clang
+            }, {
+              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
             }],
           ],
         },

--- a/configure.py
+++ b/configure.py
@@ -1042,6 +1042,7 @@ def get_gas_version(cc):
 # quite prepared to go that far yet.
 def check_compiler(o):
   if sys.platform == 'win32':
+    o['variables']['clang'] = 0
     o['variables']['llvm_version'] = '0.0'
     if not options.openssl_no_asm and options.dest_cpu in ('x86', 'x64'):
       nasm_version = get_nasm_version('nasm')
@@ -1051,6 +1052,7 @@ def check_compiler(o):
     return
 
   ok, is_clang, clang_version, gcc_version = try_check_compiler(CXX, 'c++')
+  o['variables']['clang'] = B(is_clang)
   version_str = ".".join(map(str, clang_version if is_clang else gcc_version))
   print_verbose(f"Detected {'clang ' if is_clang else ''}C++ compiler (CXX={CXX}) version: {version_str}")
   if not ok:

--- a/deps/openssl/openssl_common.gypi
+++ b/deps/openssl/openssl_common.gypi
@@ -67,7 +67,7 @@
         'TERMIOS',
       ],
       'conditions': [
-        [ 'llvm_version=="0.0"', {
+        [ 'clang==0', {
           'cflags': ['-Wno-old-style-declaration',],
         }],
       ],

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -7,7 +7,6 @@
     'ZLIB_ROOT': '.',
     'use_system_zlib%': 0,
     'arm_fpu%': '',
-    'llvm_version%': '0.0',
   },
   'conditions': [
     ['use_system_zlib==0', {
@@ -24,7 +23,7 @@
                 },{
                   'defines': [ 'X86_NOT_WINDOWS' ],
                 }],
-                ['OS!="win" or llvm_version!="0.0"', {
+                ['OS!="win" or clang==1', {
                   'cflags': [ '-mssse3' ],
                   'xcode_settings': {
                     'OTHER_CFLAGS': [ '-mssse3' ],
@@ -65,7 +64,7 @@
           'conditions': [
             ['OS!="ios"', {
               'conditions': [
-                ['OS!="win" and llvm_version=="0.0"', {
+                ['OS!="win" and clang==0', {
                   'cflags': [ '-march=armv8-a+aes+crc' ],
                 }],
                 ['OS=="android"', {
@@ -111,7 +110,7 @@
         #   'target_name': 'zlib_crc32_simd',
         #   'type': 'static_library',
         #   'conditions': [
-        #     ['OS!="win" or llvm_version!="0.0"', {
+        #     ['OS!="win" or clang==1', {
         #       'cflags': [
         #         '-msse4.2',
         #         '-mpclmul',

--- a/node.gyp
+++ b/node.gyp
@@ -504,7 +504,7 @@
           '-Wl,-bnoerrmsg',
         ],
       }],
-      ['OS == "linux" and llvm_version != "0.0"', {
+      ['OS=="linux" and clang==1', {
         'libraries': ['-latomic'],
       }],
     ],

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -82,7 +82,6 @@
     'v8_toolset_for_shell%': 'target',
 
     'host_os%': '<(OS)',
-    'werror%': '-Werror',
     # For a shared library build, results in "libv8-<(soname_version).so".
     'soname_version%': '',
 
@@ -133,21 +132,33 @@
       '<(V8_ROOT)',
       '<(V8_ROOT)/include',
     ],
+    'cflags!': ['-Wall', '-Wextra'],
     'conditions': [
-      ['clang==1', {
-        'cflags': [ '-Werror', '-Wno-unknown-pragmas' ],
-      },{
-        'cflags!': [ '-Wall', '-Wextra' ],
+      ['clang==0 and OS!="win"', {
         'cflags': [
+          # In deps/v8/BUILD.gn: if (!is_clang && !is_win) { cflags += [...] }
+          '-Wno-strict-overflow',
           '-Wno-return-type',
+          '-Wno-int-in-bool-context',
+          '-Wno-deprecated',
+          '-Wno-stringop-overflow',
+          '-Wno-stringop-overread',
+          '-Wno-restrict',
+          '-Wno-array-bounds',
+          '-Wno-nonnull',
+          '-Wno-dangling-pointer',
           # On by default in Clang and V8 requires it at least for arm64.
           '-flax-vector-conversions',
         ],
       }],
       ['clang==1 or OS!="win"', {
-        'cflags': [ '-Wno-invalid-offsetof' ],
+        'cflags_cc': [
+          # In deps/v8/BUILD.gn: if (is_clang || !is_win) { cflags += [...] }
+          '-Wno-invalid-offsetof',
+        ],
         'xcode_settings': {
-          'WARNING_CFLAGS': ['-Wno-invalid-offsetof']
+          # -Wno-invalid-offsetof
+          'GCC_WARN_ABOUT_INVALID_OFFSETOF_MACRO': 'NO',
         },
       }],
       ['v8_target_arch=="arm"', {
@@ -434,9 +445,6 @@
           ['_toolset=="target"', {
             'conditions': [
               ['v8_target_arch==target_arch', {
-                'cflags': [
-                  '-Wno-error=array-bounds',  # Workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56273
-                ],
                 'conditions': [
                   ['v8_target_arch=="mips64el"', {
                     'cflags': ['-EL'],

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -134,7 +134,7 @@
       '<(V8_ROOT)/include',
     ],
     'conditions': [
-      ['clang', {
+      ['clang==1', {
         'cflags': [ '-Werror', '-Wno-unknown-pragmas' ],
       },{
         'cflags!': [ '-Wall', '-Wextra' ],
@@ -144,7 +144,7 @@
           '-flax-vector-conversions',
         ],
       }],
-      ['clang or OS!="win"', {
+      ['clang==1 or OS!="win"', {
         'cflags': [ '-Wno-invalid-offsetof' ],
         'xcode_settings': {
           'WARNING_CFLAGS': ['-Wno-invalid-offsetof']

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1879,7 +1879,7 @@
           ['enable_lto=="true"', {
             'cflags_cc': [ '-fno-lto' ],
           }],
-          ['clang or OS!="win"', {
+          ['clang==1 or OS!="win"', {
             'conditions': [
               ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
                 'sources': [

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -2132,12 +2132,6 @@
           ]
         }],
       ],
-      # -Wno-invalid-offsetof flag is not valid for C.
-      # The flag is initially set in `toolchain.gypi` for all targets.
-      'cflags!': [ '-Wno-invalid-offsetof' ],
-      'xcode_settings': {
-        'WARNING_CFLAGS!': ['-Wno-invalid-offsetof']
-      },
       'direct_dependent_settings': {
         'include_dirs': [
           '<(V8_ROOT)/third_party/zlib',


### PR DESCRIPTION
- Set the clang variable in `config.gypi` so it depends on compiler
  checks made by the configure script.
- Replace gyp conditions with `llvm_version` and "0.0" with conditions
  that use the `clang` variable.
- Always use `clang==1` or `clang==0` in gyp conditions

This will help for https://github.com/nodejs/node/pull/52870
