### PR TITLE
watch: ensure watch mode detects deleted and re-added files

### DIFF
--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -16,10 +16,10 @@ const { TIMEOUT_MAX } = require('internal/timers');
 
 const EventEmitter = require('events');
 const { addAbortListener } = require('internal/events/abort_listener');
-const { watch } = require('fs');
+const { watch, existsSync } = require('fs');
 const { fileURLToPath } = require('internal/url');
 const { resolve, dirname } = require('path');
-const { setTimeout } = require('timers');
+const { setTimeout, clearTimeout, setInterval, clearInterval } = require('timers');
 
 const supportsRecursiveWatching = process.platform === 'win32' ||
   process.platform === 'darwin';
@@ -31,18 +31,28 @@ class FilesWatcher extends EventEmitter {
   #depencencyOwners = new SafeMap();
   #ownerDependencies = new SafeMap();
   #debounce;
+  #renameInterval;
+  #renameTimeout;
   #mode;
   #signal;
   #passthroughIPC = false;
   #ipcHandlers = new SafeWeakMap();
 
-  constructor({ debounce = 200, mode = 'filter', signal } = kEmptyObject) {
+  constructor({
+    debounce = 200,
+    mode = 'filter',
+    renameInterval = 1000,
+    renameTimeout = 60_000,
+    signal,
+  } = kEmptyObject) {
     super({ __proto__: null, captureRejections: true });
 
     validateNumber(debounce, 'options.debounce', 0, TIMEOUT_MAX);
     validateOneOf(mode, 'options.mode', ['filter', 'all']);
     this.#debounce = debounce;
     this.#mode = mode;
+    this.#renameInterval = renameInterval;
+    this.#renameTimeout = renameTimeout;
     this.#signal = signal;
     this.#passthroughIPC = Boolean(process.send);
 
@@ -79,7 +89,10 @@ class FilesWatcher extends EventEmitter {
     watcher.handle.close();
   }
 
-  #onChange(trigger) {
+  #onChange(eventType, trigger, recursive) {
+    if (eventType === 'rename' && !recursive) {
+      return this.#rewatch(trigger);
+    }
     if (this.#debouncing.has(trigger)) {
       return;
     }
@@ -94,6 +107,39 @@ class FilesWatcher extends EventEmitter {
     }, this.#debounce).unref();
   }
 
+  // When a file is removed, wait for it to be re-added.
+  // Often this re-add is immediate - some editors (e.g., gedit) and some docker mount modes do this.
+  #rewatch(path) {
+    if (this.#isPathWatched(path)) {
+      this.#unwatch(this.#watchers.get(path));
+      this.#watchers.delete(path);
+      if (existsSync(path)) {
+        this.watchPath(path, false);
+        // This might be redundant. If the file was re-added due to a save event, we will probably see change -> rename.
+        // However, in certain situations it's entirely possible for the content to have changed after the rename
+        // In these situations we'd miss the change after the rename event
+        this.#onChange('change', path, false);
+        return;
+      }
+      let timeout;
+
+      // Wait for the file to exist - check every `renameInterval` ms
+      const interval = setInterval(async () => {
+        if (existsSync(path)) {
+          clearInterval(interval);
+          clearTimeout(timeout);
+          this.watchPath(path, false);
+          this.#onChange('change', path, false);
+        }
+      }, this.#renameInterval).unref();
+
+      // Don't wait forever - after `renameTimeout` ms, stop trying
+      timeout = setTimeout(() => {
+        clearInterval(interval);
+      }, this.#renameTimeout).unref();
+    }
+  }
+
   get watchedPaths() {
     return [...this.#watchers.keys()];
   }
@@ -106,7 +152,7 @@ class FilesWatcher extends EventEmitter {
     watcher.on('change', (eventType, fileName) => {
       // `fileName` can be `null` if it cannot be determined. See
       // https://github.com/nodejs/node/pull/49891#issuecomment-1744673430.
-      this.#onChange(recursive ? resolve(path, fileName ?? '') : path);
+      this.#onChange(eventType, recursive ? resolve(path, fileName) : path, recursive);
     });
     this.#watchers.set(path, { handle: watcher, recursive });
     if (recursive) {


### PR DESCRIPTION
In systems that don't support recursive file watching, If you watch a file that gets replaced as sometimes happens (e.g., gedit and certain configurations of docker), subsequent changes wont be watched. 

This PR detects `rename` events and adds a 60s timeout with a 1s interval to watch for the path to exist, then emits a change event for that file, ensuring that:
1. if the contents of the file changed between being removed and re-added that change is detected
2. subsequent changes are detected

Split out from https://github.com/nodejs/node/pull/50890

