### PR TITLE
path: add `matchesGlob` method

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -279,7 +279,7 @@ path.format({
 // Returns: 'C:\\path\\dir\\file.txt'
 ```
 
-## `path.matchGlob(path, pattern)`
+## `path.matchesGlob(path, pattern)`
 
 <!-- YAML
 added: REPLACEME
@@ -291,13 +291,13 @@ added: REPLACEME
 * `pattern` {string} The glob to check the path against.
 * Returns: {boolean} Whether or not the `path` matched the `pattern`.
 
-The `path.matchGlob()` method determines if `path` matches the `pattern`.
+The `path.matchesGlob()` method determines if `path` matches the `pattern`.
 
 For example:
 
 ```js
-path.matchGlob('/foo/bar', '/foo/*'); // true
-path.matchGlob('/foo/bar*', 'foo/bird'); // false
+path.matchesGlob('/foo/bar', '/foo/*'); // true
+path.matchesGlob('/foo/bar*', 'foo/bird'); // false
 ```
 
 A [`TypeError`][] is thrown if `path` or `pattern` are not strings.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -279,6 +279,29 @@ path.format({
 // Returns: 'C:\\path\\dir\\file.txt'
 ```
 
+## `path.matchGlob(path, pattern)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `path` {string} The path to glob-match against.
+* `pattern` {string} The glob to check the path against.
+* Returns: {boolean} Whether or not the `path` matched the `pattern`.
+
+The `path.matchGlob()` method determines if `path` matches the `pattern`.
+
+For example:
+
+```js
+path.matchGlob('/foo/bar', '/foo/*'); // true
+path.matchGlob('/foo/bar*', 'foo/bird'); // false
+```
+
+A [`TypeError`][] is thrown if `path` or `pattern` are not strings.
+
 ## `path.isAbsolute(path)`
 
 <!-- YAML

--- a/lib/path.js
+++ b/lib/path.js
@@ -47,7 +47,14 @@ const {
   validateString,
 } = require('internal/validators');
 
+const {
+  getLazy,
+} = require('internal/util');
+
+const lazyMinimatch = getLazy(() => require('internal/deps/minimatch/index'));
+
 const platformIsWin32 = (process.platform === 'win32');
+const platformIsOSX = (process.platform === 'darwin');
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -151,6 +158,21 @@ function _format(sep, pathObject) {
     return base;
   }
   return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
+}
+
+function glob(path, pattern, windows) {
+  validateString(path, 'path');
+  validateString(pattern, 'pattern');
+  return lazyMinimatch().minimatch(path, pattern, {
+    __proto__: null,
+    nocase: platformIsOSX || platformIsWin32,
+    windowsPathsNoEscape: true,
+    nonegate: true,
+    nocomment: true,
+    optimizationLevel: 2,
+    platform: windows ? 'win32' : 'posix',
+    nocaseMagicOnly: true,
+  });
 }
 
 const win32 = {
@@ -1065,6 +1087,10 @@ const win32 = {
     return ret;
   },
 
+  matchGlob(path, pattern) {
+    return glob(path, pattern, true);
+  },
+
   sep: '\\',
   delimiter: ';',
   win32: null,
@@ -1528,6 +1554,10 @@ const posix = {
       ret.dir = '/';
 
     return ret;
+  },
+
+  matchGlob(path, pattern) {
+    return glob(path, pattern, false);
   },
 
   sep: '/',

--- a/lib/path.js
+++ b/lib/path.js
@@ -161,6 +161,7 @@ function _format(sep, pathObject) {
 }
 
 function glob(path, pattern, windows) {
+  emitExperimentalWarning('glob');
   validateString(path, 'path');
   validateString(pattern, 'pattern');
   return lazyMinimatch().minimatch(path, pattern, {

--- a/lib/path.js
+++ b/lib/path.js
@@ -49,6 +49,7 @@ const {
 
 const {
   getLazy,
+  emitExperimentalWarning,
 } = require('internal/util');
 
 const lazyMinimatch = getLazy(() => require('internal/deps/minimatch/index'));
@@ -1088,7 +1089,7 @@ const win32 = {
     return ret;
   },
 
-  matchGlob(path, pattern) {
+  matchesGlob(path, pattern) {
     return glob(path, pattern, true);
   },
 
@@ -1557,7 +1558,7 @@ const posix = {
     return ret;
   },
 
-  matchGlob(path, pattern) {
+  matchesGlob(path, pattern) {
     return glob(path, pattern, false);
   },
 

--- a/test/parallel/test-path-glob.js
+++ b/test/parallel/test-path-glob.js
@@ -34,7 +34,7 @@ const globs = {
 
 for (const [platform, platformGlobs] of Object.entries(globs)) {
   for (const [pathStr, glob, expected] of platformGlobs) {
-    const actual = path[platform].glob(pathStr, glob);
+    const actual = path[platform].matchGlob(pathStr, glob);
     assert.strictEqual(actual, expected, `Expected ${pathStr} to ` + (expected ? '' : 'not ') + `match ${glob} on ${platform}`);
   }
 }

--- a/test/parallel/test-path-glob.js
+++ b/test/parallel/test-path-glob.js
@@ -34,11 +34,11 @@ const globs = {
 
 for (const [platform, platformGlobs] of Object.entries(globs)) {
   for (const [pathStr, glob, expected] of platformGlobs) {
-    const actual = path[platform].matchGlob(pathStr, glob);
+    const actual = path[platform].matchesGlob(pathStr, glob);
     assert.strictEqual(actual, expected, `Expected ${pathStr} to ` + (expected ? '' : 'not ') + `match ${glob} on ${platform}`);
   }
 }
 
 // Test for non-string input
-assert.throws(() => path.matchGlob(123, 'foo/bar/baz'), /.*must be of type string.*/);
-assert.throws(() => path.matchGlob('foo/bar/baz', 123), /.*must be of type string.*/);
+assert.throws(() => path.matchesGlob(123, 'foo/bar/baz'), /.*must be of type string.*/);
+assert.throws(() => path.matchesGlob('foo/bar/baz', 123), /.*must be of type string.*/);

--- a/test/parallel/test-path-glob.js
+++ b/test/parallel/test-path-glob.js
@@ -1,0 +1,44 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const path = require('path');
+
+const globs = {
+  win32: [
+    ['foo\\bar\\baz', 'foo\\[bcr]ar\\baz', true], // Matches 'bar' or 'car' in 'foo\\bar'
+    ['foo\\bar\\baz', 'foo\\[!bcr]ar\\baz', false], // Matches anything except 'bar' or 'car' in 'foo\\bar'
+    ['foo\\bar\\baz', 'foo\\[bc-r]ar\\baz', true], // Matches 'bar' or 'car' using range in 'foo\\bar'
+    ['foo\\bar\\baz', 'foo\\*\\!bar\\*\\baz', false], // Matches anything with 'foo' and 'baz' but not 'bar' in between
+    ['foo\\bar1\\baz', 'foo\\bar[0-9]\\baz', true], // Matches 'bar' followed by any digit in 'foo\\bar1'
+    ['foo\\bar5\\baz', 'foo\\bar[0-9]\\baz', true], // Matches 'bar' followed by any digit in 'foo\\bar5'
+    ['foo\\barx\\baz', 'foo\\bar[a-z]\\baz', true], // Matches 'bar' followed by any lowercase letter in 'foo\\barx'
+    ['foo\\bar\\baz\\boo', 'foo\\[bc-r]ar\\baz\\*', true], // Matches 'bar' or 'car' in 'foo\\bar'
+    ['foo\\bar\\baz', 'foo/**', true], // Matches anything in 'foo'
+    ['foo\\bar\\baz', '*', false], // No match
+  ],
+  posix: [
+    ['foo/bar/baz', 'foo/[bcr]ar/baz', true], // Matches 'bar' or 'car' in 'foo/bar'
+    ['foo/bar/baz', 'foo/[!bcr]ar/baz', false], // Matches anything except 'bar' or 'car' in 'foo/bar'
+    ['foo/bar/baz', 'foo/[bc-r]ar/baz', true], // Matches 'bar' or 'car' using range in 'foo/bar'
+    ['foo/bar/baz', 'foo/*/!bar/*/baz', false], // Matches anything with 'foo' and 'baz' but not 'bar' in between
+    ['foo/bar1/baz', 'foo/bar[0-9]/baz', true], // Matches 'bar' followed by any digit in 'foo/bar1'
+    ['foo/bar5/baz', 'foo/bar[0-9]/baz', true], // Matches 'bar' followed by any digit in 'foo/bar5'
+    ['foo/barx/baz', 'foo/bar[a-z]/baz', true], // Matches 'bar' followed by any lowercase letter in 'foo/barx'
+    ['foo/bar/baz/boo', 'foo/[bc-r]ar/baz/*', true], // Matches 'bar' or 'car' in 'foo/bar'
+    ['foo/bar/baz', 'foo/**', true], // Matches anything in 'foo'
+    ['foo/bar/baz', '*', false], // No match
+  ],
+};
+
+
+for (const [platform, platformGlobs] of Object.entries(globs)) {
+  for (const [pathStr, glob, expected] of platformGlobs) {
+    const actual = path[platform].glob(pathStr, glob);
+    assert.strictEqual(actual, expected, `Expected ${pathStr} to ` + (expected ? '' : 'not ') + `match ${glob} on ${platform}`);
+  }
+}
+
+// Test for non-string input
+assert.throws(() => path.matchGlob(123, 'foo/bar/baz'), /.*must be of type string.*/);
+assert.throws(() => path.matchGlob('foo/bar/baz', 123), /.*must be of type string.*/);


### PR DESCRIPTION
Fixes #52779

This PR adds a new function: `path.matchesGlob(path, pattern)`. It checks whether a glob (`pattern`) matches the input path (`path`).

Notable change text, if you'd like to include it:
```md
Glob patterns can now be tested against individual paths via the `path.matchesGlob(path, pattern)` method.
```