### PR TITLE
build: exit on unsupported host OS for Android

### DIFF
--- a/android_configure.py
+++ b/android_configure.py
@@ -10,8 +10,8 @@ def patch_android():
         os.system('patch -f ./deps/v8/src/trap-handler/trap-handler.h < ./android-patches/trap-handler.h.patch')
     print("\033[92mInfo: \033[0m" + "Tried to patch.")
 
-if platform.system() == "Windows":
-    print("android-configure is not supported on Windows yet.")
+if platform.system() != "Linux" and platform.system() != "Darwin":
+    print("android-configure is currently only supported on Linux and Darwin.")
     sys.exit(1)
 
 if len(sys.argv) == 2 and sys.argv[1] == "patch":


### PR DESCRIPTION
The Android configure script throws an unhelpful error message telling the user that `toolchain_path` is not defined when the script is run on an unsupported host OS, exit with a more helpful message instead while listing the supported host OSes.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
