### PR TITLE
src: avoid unused variable 'error' warning

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -182,10 +182,13 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       return NameAndDisplacement(pSymbol->Name, dwDisplacement);
     } else {
       // SymFromAddr failed
-      const DWORD error = GetLastError();  // "eat" the error anyway
 #ifdef DEBUG
+      const DWORD error = GetLastError();
       fprintf(stderr, "SymFromAddr returned error : %lu\n", error);
-#endif
+#else
+      // "eat" the error anyway
+      USE(GetLastError());
+#endif  // DEBUG
     }
     // End MSDN code
 
@@ -217,10 +220,13 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       sym.line = line.LineNumber;
     } else {
       // SymGetLineFromAddr64 failed
-      const DWORD error = GetLastError();  // "eat" the error anyway
 #ifdef DEBUG
+      const DWORD error = GetLastError();
       fprintf(stderr, "SymGetLineFromAddr64 returned error : %lu\n", error);
-#endif
+#else
+      // "eat" the error anyway
+      USE(GetLastError());
+#endif  // DEBUG
     }
     // End MSDN code
 
@@ -240,10 +246,13 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       return szUndName;
     } else {
       // UnDecorateSymbolName failed
-      const DWORD error = GetLastError();  // "eat" the error anyway
 #ifdef DEBUG
+      const DWORD error = GetLastError();
       fprintf(stderr, "UnDecorateSymbolName returned error %lu\n", error);
-#endif
+#else
+      // "eat" the error anyway
+      USE(GetLastError());
+#endif  // DEBUG
     }
     return nullptr;
   }

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -186,7 +186,7 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       const DWORD error = GetLastError();
       fprintf(stderr, "SymFromAddr returned error : %lu\n", error);
 #else
-      // "eat" the error anyway
+      // Consume the error anyway
       USE(GetLastError());
 #endif  // DEBUG
     }
@@ -224,7 +224,7 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       const DWORD error = GetLastError();
       fprintf(stderr, "SymGetLineFromAddr64 returned error : %lu\n", error);
 #else
-      // "eat" the error anyway
+      // Consume the error anyway
       USE(GetLastError());
 #endif  // DEBUG
     }
@@ -250,7 +250,7 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       const DWORD error = GetLastError();
       fprintf(stderr, "UnDecorateSymbolName returned error %lu\n", error);
 #else
-      // "eat" the error anyway
+      // Consume the error anyway
       USE(GetLastError());
 #endif  // DEBUG
     }


### PR DESCRIPTION
The variable is only used in DEBUG mode. Define it only in that case.
