### PR TITLE
[v20.x] Revert "module: print location of unsettled top-level await in entry points"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,6 +96,7 @@
 /doc/api/packages.md @nodejs/loaders
 /lib/internal/bootstrap/realm.js @nodejs/loaders
 /lib/internal/modules/* @nodejs/loaders
+/lib/internal/process/esm_loader.js @nodejs/loaders
 /lib/internal/process/execution.js @nodejs/loaders
 /lib/module.js @nodejs/loaders
 /src/module_wrap* @nodejs/loaders @nodejs/vm

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -50,7 +50,8 @@ function loadESMIfNeeded(cb) {
   const hasModulePreImport = getOptionValue('--import').length > 0;
 
   if (hasModulePreImport) {
-    require('internal/modules/run_main').runEntryPointWithESMLoader(cb);
+    const { loadESM } = require('internal/process/esm_loader');
+    loadESM(cb);
     return;
   }
   cb();
@@ -75,5 +76,7 @@ async function checkSyntax(source, filename) {
     return;
   }
 
-  wrapSafe(filename, source);
+  const { loadESM } = require('internal/process/esm_loader');
+  const { handleMainPromise } = require('internal/modules/run_main');
+  handleMainPromise(loadESM((loader) => wrapSafe(filename, source)));
 }

--- a/lib/internal/main/eval_stdin.js
+++ b/lib/internal/main/eval_stdin.js
@@ -10,7 +10,7 @@ const {
 const { getOptionValue } = require('internal/options');
 
 const {
-  evalModuleEntryPoint,
+  evalModule,
   evalScript,
   readStdin,
 } = require('internal/process/execution');
@@ -24,15 +24,15 @@ readStdin((code) => {
   process._eval = code;
 
   const print = getOptionValue('--print');
-  const shouldLoadESM = getOptionValue('--import').length > 0;
+  const loadESM = getOptionValue('--import').length > 0;
   if (getOptionValue('--input-type') === 'module' ||
     (getOptionValue('--experimental-default-type') === 'module' && getOptionValue('--input-type') !== 'commonjs')) {
-    evalModuleEntryPoint(code, print);
+    evalModule(code, print);
   } else {
     evalScript('[stdin]',
                code,
                getOptionValue('--inspect-brk'),
                print,
-               shouldLoadESM);
+               loadESM);
   }
 });

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -13,7 +13,7 @@ const {
   prepareMainThreadExecution,
   markBootstrapComplete,
 } = require('internal/process/pre_execution');
-const { evalModuleEntryPoint, evalScript } = require('internal/process/execution');
+const { evalModule, evalScript } = require('internal/process/execution');
 const { addBuiltinLibsToObject } = require('internal/modules/helpers');
 
 const { getOptionValue } = require('internal/options');
@@ -24,10 +24,10 @@ markBootstrapComplete();
 
 const source = getOptionValue('--eval');
 const print = getOptionValue('--print');
-const shouldLoadESM = getOptionValue('--import').length > 0 || getOptionValue('--experimental-loader').length > 0;
+const loadESM = getOptionValue('--import').length > 0 || getOptionValue('--experimental-loader').length > 0;
 if (getOptionValue('--input-type') === 'module' ||
   (getOptionValue('--experimental-default-type') === 'module' && getOptionValue('--input-type') !== 'commonjs')) {
-  evalModuleEntryPoint(source, print);
+  evalModule(source, print);
 } else {
   // For backward compatibility, we want the identifier crypto to be the
   // `node:crypto` module rather than WebCrypto.
@@ -54,5 +54,5 @@ if (getOptionValue('--input-type') === 'module' ||
              ) : source,
              getOptionValue('--inspect-brk'),
              print,
-             shouldLoadESM);
+             loadESM);
 }

--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -35,7 +35,8 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
     process.exit(kInvalidCommandLineArgument);
   }
 
-  require('internal/modules/run_main').runEntryPointWithESMLoader(() => {
+  const esmLoader = require('internal/process/esm_loader');
+  esmLoader.loadESM(() => {
     console.log(`Welcome to Node.js ${process.version}.\n` +
       'Type ".help" for more information.');
 
@@ -63,7 +64,5 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
                  getOptionValue('--inspect-brk'),
                  getOptionValue('--print'));
     }
-    // The TLAs in the REPL are still run as scripts, just transformed as async
-    // IIFEs for the REPL code itself to await on.
   });
 }

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -170,8 +170,8 @@ port.on('message', (message) => {
       }
 
       case 'module': {
-        const { evalModuleEntryPoint } = require('internal/process/execution');
-        PromisePrototypeThen(evalModuleEntryPoint(filename), undefined, (e) => {
+        const { evalModule } = require('internal/process/execution');
+        PromisePrototypeThen(evalModule(filename), undefined, (e) => {
           workerOnGlobalUncaughtException(e, true);
         });
         break;

--- a/lib/internal/modules/esm/handle_process_exit.js
+++ b/lib/internal/modules/esm/handle_process_exit.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { exitCodes: { kUnfinishedTopLevelAwait } } = internalBinding('errors');
+
+/**
+ * Handle a Promise from running code that potentially does Top-Level Await.
+ * In that case, it makes sense to set the exit code to a specific non-zero value
+ * if the main code never finishes running.
+ */
+function handleProcessExit() {
+  process.exitCode ??= kUnfinishedTopLevelAwait;
+}
+
+module.exports = {
+  handleProcessExit,
+};

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -161,8 +161,8 @@ class Hooks {
    * loader (user-land) to the worker.
    */
   async register(urlOrSpecifier, parentURL, data) {
-    const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-    const keyedExports = await cascadedLoader.import(
+    const moduleLoader = require('internal/process/esm_loader').esmLoader;
+    const keyedExports = await moduleLoader.import(
       urlOrSpecifier,
       parentURL,
       kEmptyObject,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -20,7 +20,7 @@ const {
   ERR_UNKNOWN_MODULE_FORMAT,
 } = require('internal/errors').codes;
 const { getOptionValue } = require('internal/options');
-const { isURL } = require('internal/url');
+const { pathToFileURL, isURL } = require('internal/url');
 const { emitExperimentalWarning } = require('internal/util');
 const {
   getDefaultConditions,
@@ -84,6 +84,11 @@ class ModuleLoader {
    * The conditions for resolving packages if `--conditions` is not used.
    */
   #defaultConditions = getDefaultConditions();
+
+  /**
+   * The index for assigning unique URLs to anonymous module evaluation
+   */
+  evalIndex = 0;
 
   /**
    * Registry of resolved specifiers
@@ -182,7 +187,10 @@ class ModuleLoader {
     }
   }
 
-  async eval(source, url) {
+  async eval(
+    source,
+    url = pathToFileURL(`${process.cwd()}/[eval${++this.evalIndex}]`).href,
+  ) {
     const evalInstance = (url) => {
       const { ModuleWrap } = internalBinding('module_wrap');
       const { registerModule } = require('internal/modules/esm/utils');
@@ -206,7 +214,6 @@ class ModuleLoader {
     return {
       __proto__: null,
       namespace: module.getNamespace(),
-      module,
     };
   }
 
@@ -561,23 +568,6 @@ function getHooksProxy() {
   return hooksProxy;
 }
 
-let cascadedLoader;
-
-/**
- * This is a singleton ESM loader that integrates the loader hooks, if any.
- * It it used by other internal built-ins when they need to load ESM code
- * while also respecting hooks.
- * When built-ins need access to this loader, they should do
- * require('internal/module/esm/loader').getOrInitializeCascadedLoader()
- * lazily only right before the loader is actually needed, and don't do it
- * in the top-level, to avoid circular dependencies.
- * @returns {ModuleLoader}
- */
-function getOrInitializeCascadedLoader() {
-  cascadedLoader ??= createModuleLoader();
-  return cascadedLoader;
-}
-
 /**
  * Register a single loader programmatically.
  * @param {string|import('url').URL} specifier
@@ -608,11 +598,12 @@ function getOrInitializeCascadedLoader() {
  * ```
  */
 function register(specifier, parentURL = undefined, options) {
+  const moduleLoader = require('internal/process/esm_loader').esmLoader;
   if (parentURL != null && typeof parentURL === 'object' && !isURL(parentURL)) {
     options = parentURL;
     parentURL = options.parentURL;
   }
-  getOrInitializeCascadedLoader().register(
+  moduleLoader.register(
     specifier,
     parentURL ?? 'data:',
     options?.data,
@@ -623,6 +614,5 @@ function register(specifier, parentURL = undefined, options) {
 module.exports = {
   createModuleLoader,
   getHooksProxy,
-  getOrInitializeCascadedLoader,
   register,
 };

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -59,6 +59,7 @@ const {
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
+const asyncESM = require('internal/process/esm_loader');
 const { emitWarningSync } = require('internal/process/warning');
 
 // Lazy-loading to avoid circular dependencies.
@@ -157,8 +158,7 @@ function errPath(url) {
  * @returns {Promise<import('internal/modules/esm/loader.js').ModuleExports>} The imported module.
  */
 async function importModuleDynamically(specifier, { url }, attributes) {
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-  return cascadedLoader.import(specifier, url, attributes);
+  return asyncESM.esmLoader.import(specifier, url, attributes);
 }
 
 // Strategy for loading a standard JavaScript module.
@@ -224,7 +224,6 @@ function loadCJSModule(module, source, url, filename) {
 
   const compiledWrapper = compileResult.function;
 
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
   const __dirname = dirname(filename);
   // eslint-disable-next-line func-name-matching,func-style
   const requireFn = function require(specifier) {
@@ -243,7 +242,7 @@ function loadCJSModule(module, source, url, filename) {
       }
       specifier = `${pathToFileURL(path)}`;
     }
-    const job = cascadedLoader.getModuleJobSync(specifier, url, importAttributes);
+    const job = asyncESM.esmLoader.getModuleJobSync(specifier, url, importAttributes);
     job.runSync();
     return cjsCache.get(job.url).exports;
   };
@@ -254,7 +253,7 @@ function loadCJSModule(module, source, url, filename) {
         specifier = `${pathToFileURL(path)}`;
       }
     }
-    const { url: resolvedURL } = cascadedLoader.resolveSync(specifier, url, kEmptyObject);
+    const { url: resolvedURL } = asyncESM.esmLoader.resolveSync(specifier, url, kEmptyObject);
     return StringPrototypeStartsWith(resolvedURL, 'file://') ? fileURLToPath(resolvedURL) : resolvedURL;
   });
   setOwnProperty(requireFn, 'main', process.mainModule);

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -32,6 +32,7 @@ const {
 const {
   emitExperimentalWarning,
   getCWDURL,
+  getLazy,
 } = require('internal/util');
 const {
   setImportModuleDynamicallyCallback,
@@ -180,6 +181,9 @@ function initializeImportMetaObject(symbol, meta) {
     }
   }
 }
+const getCascadedLoader = getLazy(
+  () => require('internal/process/esm_loader').esmLoader,
+);
 
 /**
  * Proxy the dynamic import to the default loader.
@@ -190,8 +194,7 @@ function initializeImportMetaObject(symbol, meta) {
  */
 function defaultImportModuleDynamically(specifier, attributes, referrerName) {
   const parentURL = normalizeReferrerURL(referrerName);
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-  return cascadedLoader.import(specifier, parentURL, attributes);
+  return getCascadedLoader().import(specifier, parentURL, attributes);
 }
 
 /**
@@ -260,10 +263,10 @@ async function initializeHooks() {
   const customLoaderURLs = getOptionValue('--experimental-loader');
 
   const { Hooks } = require('internal/modules/esm/hooks');
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  const esmLoader = require('internal/process/esm_loader').esmLoader;
 
   const hooks = new Hooks();
-  cascadedLoader.setCustomizations(hooks);
+  esmLoader.setCustomizations(hooks);
 
   // We need the loader customizations to be set _before_ we start invoking
   // `--require`, otherwise loops can happen because a `--require` script

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -7,15 +7,6 @@ const {
 const { containsModuleSyntax } = internalBinding('contextify');
 const { getOptionValue } = require('internal/options');
 const path = require('path');
-const { pathToFileURL } = require('internal/url');
-const { kEmptyObject, getCWDURL } = require('internal/util');
-const {
-  hasUncaughtExceptionCaptureCallback,
-} = require('internal/process/execution');
-const {
-  triggerUncaughtException,
-  exitCodes: { kUnfinishedTopLevelAwait },
-} = internalBinding('errors');
 
 /**
  * Get the absolute path to the main entry point.
@@ -96,56 +87,33 @@ function shouldUseESMLoader(mainPath) {
 }
 
 /**
- * Handle a Promise from running code that potentially does Top-Level Await.
- * In that case, it makes sense to set the exit code to a specific non-zero value
- * if the main code never finishes running.
+ * Run the main entry point through the ESM Loader.
+ * @param {string} mainPath - Absolute path for the main entry point
  */
-function handleProcessExit() {
-  process.exitCode ??= kUnfinishedTopLevelAwait;
+function runMainESM(mainPath) {
+  const { loadESM } = require('internal/process/esm_loader');
+  const { pathToFileURL } = require('internal/url');
+  const main = pathToFileURL(mainPath).href;
+
+  handleMainPromise(loadESM((esmLoader) => {
+    return esmLoader.import(main, undefined, { __proto__: null });
+  }));
 }
 
 /**
- * @param {function(ModuleLoader):ModuleWrap|undefined} callback
+ * Handle process exit events around the main entry point promise.
+ * @param {Promise} promise - Main entry point promise
  */
-async function asyncRunEntryPointWithESMLoader(callback) {
+async function handleMainPromise(promise) {
+  const {
+    handleProcessExit,
+  } = require('internal/modules/esm/handle_process_exit');
   process.on('exit', handleProcessExit);
-  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
   try {
-    const userImports = getOptionValue('--import');
-    if (userImports.length > 0) {
-      const parentURL = getCWDURL().href;
-      for (let i = 0; i < userImports.length; i++) {
-        await cascadedLoader.import(userImports[i], parentURL, kEmptyObject);
-      }
-    } else {
-      cascadedLoader.forceLoadHooks();
-    }
-    await callback(cascadedLoader);
-  } catch (err) {
-    if (hasUncaughtExceptionCaptureCallback()) {
-      process._fatalException(err);
-      return;
-    }
-    triggerUncaughtException(
-      err,
-      true, /* fromPromise */
-    );
+    return await promise;
   } finally {
     process.off('exit', handleProcessExit);
   }
-}
-
-/**
- * This initializes the ESM loader and runs --import (if any) before executing the
- * callback to run the entry point.
- * If the callback intends to evaluate a ESM module as entry point, it should return
- * the corresponding ModuleWrap so that stalled TLA can be checked a process exit.
- * @param {function(ModuleLoader):ModuleWrap|undefined} callback
- * @returns {Promise}
- */
-function runEntryPointWithESMLoader(callback) {
-  const promise = asyncRunEntryPointWithESMLoader(callback);
-  return promise;
 }
 
 /**
@@ -160,14 +128,7 @@ function executeUserEntryPoint(main = process.argv[1]) {
   const resolvedMain = resolveMainPath(main);
   const useESMLoader = shouldUseESMLoader(resolvedMain);
   if (useESMLoader) {
-    const mainPath = resolvedMain || main;
-    const mainURL = pathToFileURL(mainPath).href;
-
-    runEntryPointWithESMLoader((cascadedLoader) => {
-      // Note that if the graph contains unfinished TLA, this may never resolve
-      // even after the event loop stops running.
-      return cascadedLoader.import(mainURL, undefined, { __proto__: null }, true);
-    });
+    runMainESM(resolvedMain || main);
   } else {
     // Module._load is the monkey-patchable CJS module loader.
     const { Module } = require('internal/modules/cjs/loader');
@@ -177,6 +138,5 @@ function executeUserEntryPoint(main = process.argv[1]) {
 
 module.exports = {
   executeUserEntryPoint,
-  runEntryPointWithESMLoader,
-  handleProcessExit,
+  handleMainPromise,
 };

--- a/lib/internal/process/esm_loader.js
+++ b/lib/internal/process/esm_loader.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { createModuleLoader } = require('internal/modules/esm/loader');
+const { getOptionValue } = require('internal/options');
+const {
+  hasUncaughtExceptionCaptureCallback,
+} = require('internal/process/execution');
+const { kEmptyObject, getCWDURL } = require('internal/util');
+
+let esmLoader;
+
+module.exports = {
+  get esmLoader() {
+    return esmLoader ??= createModuleLoader();
+  },
+  async loadESM(callback) {
+    esmLoader ??= createModuleLoader();
+    try {
+      const userImports = getOptionValue('--import');
+      if (userImports.length > 0) {
+        const parentURL = getCWDURL().href;
+        for (let i = 0; i < userImports.length; i++) {
+          await esmLoader.import(userImports[i], parentURL, kEmptyObject);
+        }
+      } else {
+        esmLoader.forceLoadHooks();
+      }
+      await callback(esmLoader);
+    } catch (err) {
+      if (hasUncaughtExceptionCaptureCallback()) {
+        process._fatalException(err);
+        return;
+      }
+      internalBinding('errors').triggerUncaughtException(
+        err,
+        true, /* fromPromise */
+      );
+    }
+  },
+};

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -15,7 +15,6 @@ const {
     ERR_EVAL_ESM_CANNOT_PRINT,
   },
 } = require('internal/errors');
-const { pathToFileURL } = require('internal/url');
 const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 
 const {
@@ -47,30 +46,19 @@ function tryGetCwd() {
   }
 }
 
-let evalIndex = 0;
-function getEvalModuleUrl() {
-  return pathToFileURL(`${process.cwd()}/[eval${++evalIndex}]`).href;
-}
-
-/**
- * Evaluate an ESM entry point and return the promise that gets fulfilled after
- * it finishes evaluation.
- * @param {string} source Source code the ESM
- * @param {boolean} print Whether the result should be printed.
- * @returns {Promise}
- */
-function evalModuleEntryPoint(source, print) {
+function evalModule(source, print) {
   if (print) {
     throw new ERR_EVAL_ESM_CANNOT_PRINT();
   }
+  const { loadESM } = require('internal/process/esm_loader');
+  const { handleMainPromise } = require('internal/modules/run_main');
   RegExpPrototypeExec(/^/, ''); // Necessary to reset RegExp statics before user code runs.
-  return require('internal/modules/run_main').runEntryPointWithESMLoader(
-    (loader) => loader.eval(source, getEvalModuleUrl(), true),
-  );
+  return handleMainPromise(loadESM((loader) => loader.eval(source)));
 }
 
 function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
   const CJSModule = require('internal/modules/cjs/loader').Module;
+  const { pathToFileURL } = require('internal/url');
 
   const cwd = tryGetCwd();
   const origModule = globalThis.module;  // Set e.g. when called from the REPL.
@@ -79,12 +67,15 @@ function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
   module.filename = path.join(cwd, name);
   module.paths = CJSModule._nodeModulePaths(cwd);
 
+  const { handleMainPromise } = require('internal/modules/run_main');
+  const asyncESM = require('internal/process/esm_loader');
   const baseUrl = pathToFileURL(module.filename).href;
+  const { loadESM } = asyncESM;
 
   if (getOptionValue('--experimental-detect-module') &&
     getOptionValue('--input-type') === '' && getOptionValue('--experimental-default-type') === '' &&
     containsModuleSyntax(body, name)) {
-    return evalModuleEntryPoint(body, print);
+    return evalModule(body, print);
   }
 
   const runScript = () => {
@@ -101,8 +92,8 @@ function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
     const result = module._compile(script, `${name}-wrapper`)(() => {
       const hostDefinedOptionId = Symbol(name);
       async function importModuleDynamically(specifier, _, importAttributes) {
-        const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-        return cascadedLoader.import(specifier, baseUrl, importAttributes);
+        const loader = asyncESM.esmLoader;
+        return loader.import(specifier, baseUrl, importAttributes);
       }
       const script = makeContextifyScript(
         body,                    // code
@@ -127,10 +118,9 @@ function evalScript(name, body, breakFirstLine, print, shouldLoadESM = false) {
   };
 
   if (shouldLoadESM) {
-    require('internal/modules/run_main').runEntryPointWithESMLoader(runScript);
-    return;
+    return handleMainPromise(loadESM(runScript));
   }
-  runScript();
+  return runScript();
 }
 
 const exceptionHandlerState = {
@@ -238,7 +228,7 @@ function readStdin(callback) {
 module.exports = {
   readStdin,
   tryGetCwd,
-  evalModuleEntryPoint,
+  evalModule,
   evalScript,
   onGlobalUncaughtException: createOnGlobalUncaughtException(),
   setUncaughtExceptionCaptureCallback,

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -173,7 +173,9 @@ function wrapProcessMethods(binding) {
   memoryUsage.rss = rss;
 
   function exit(code) {
-    const { handleProcessExit } = require('internal/modules/run_main');
+    const {
+      handleProcessExit,
+    } = require('internal/modules/esm/handle_process_exit');
     process.off('exit', handleProcessExit);
 
     if (arguments.length !== 0) {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -160,8 +160,8 @@ async function getReportersMap(reporters, destinations) {
         parentURL = 'file:///';
       }
 
-      const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-      reporter = await cascadedLoader.import(name, parentURL, { __proto__: null });
+      const { esmLoader } = require('internal/process/esm_loader');
+      reporter = await esmLoader.import(name, parentURL, { __proto__: null });
     }
 
     if (reporter?.default) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -463,8 +463,9 @@ function REPLServer(prompt,
       // Continue regardless of error.
     }
     async function importModuleDynamically(specifier, _, importAttributes) {
-      const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-      return cascadedLoader.import(specifier, parentURL, importAttributes);
+      const asyncESM = require('internal/process/esm_loader');
+      return asyncESM.esmLoader.import(specifier, parentURL,
+                                       importAttributes);
     }
     // `experimentalREPLAwait` is set to true by default.
     // Shall be false in case `--no-experimental-repl-await` flag is used.

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -303,27 +303,17 @@ std::string FormatCaughtException(Isolate* isolate,
                                   Local<Value> err,
                                   Local<Message> message,
                                   bool add_source_line = true) {
+  std::string result;
   node::Utf8Value reason(isolate,
                          err->ToDetailString(context)
                              .FromMaybe(Local<String>()));
-  std::string reason_str = reason.ToString();
-  return FormatErrorMessage(
-      isolate, context, reason_str, message, add_source_line);
-}
-
-std::string FormatErrorMessage(Isolate* isolate,
-                               Local<Context> context,
-                               const std::string& reason,
-                               Local<Message> message,
-                               bool add_source_line) {
-  std::string result;
   if (add_source_line) {
     bool added_exception_line = false;
     std::string source =
         GetErrorSource(isolate, context, message, &added_exception_line);
     result = source + '\n';
   }
-  result += reason + '\n';
+  result += reason.ToString() + '\n';
 
   Local<v8::StackTrace> stack = message->GetStackTrace();
   if (!stack.IsEmpty()) result += FormatStackTrace(isolate, stack);

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -98,11 +98,7 @@ void PrintCaughtException(v8::Isolate* isolate,
 std::string FormatCaughtException(v8::Isolate* isolate,
                                   v8::Local<v8::Context> context,
                                   const v8::TryCatch& try_catch);
-std::string FormatErrorMessage(v8::Isolate* isolate,
-                               v8::Local<v8::Context> context,
-                               const std::string& reason,
-                               v8::Local<v8::Message> message,
-                               bool add_source_line = true);
+
 void ResetStdio();  // Safe to call more than once and from signal handlers.
 #ifdef __POSIX__
 void SignalExit(int signal, siginfo_t* info, void* ucontext);


### PR DESCRIPTION
Revert 2 commits from https://github.com/nodejs/node/pull/51999