### PR TITLE
src: sync NODE_REPL_EXTERNAL_MODULE and kDisableNodeOptionsEnv

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2844,6 +2844,13 @@ equivalent to using the `--redirect-warnings=file` command-line flag.
 added:
  - v13.0.0
  - v12.16.0
+changes:
+  - version:
+     - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/52905
+    description:
+      Remove the possibility to use this env var with
+      kDisableNodeOptionsEnv for embedders.
 -->
 
 Path to a Node.js module which will be loaded in place of the built-in REPL.

--- a/src/node.cc
+++ b/src/node.cc
@@ -872,6 +872,15 @@ static ExitCode InitializeNodeWithArgsInternal(
           &env_argv, nullptr, errors, kAllowedInEnvvar);
       if (exit_code != ExitCode::kNoFailure) return exit_code;
     }
+  } else {
+    std::string node_repl_external_env = {};
+    if (credentials::SafeGetenv("NODE_REPL_EXTERNAL_MODULE",
+                                &node_repl_external_env) ||
+        !node_repl_external_env.empty()) {
+      errors->emplace_back("NODE_REPL_EXTERNAL_MODULE can't be used with "
+                           "kDisableNodeOptionsEnv");
+      return ExitCode::kInvalidCommandLineArgument;
+    }
   }
 #endif
 

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -33,8 +33,15 @@ int main(int argc, char** argv) {
   std::shared_ptr<node::InitializationResult> result =
       node::InitializeOncePerProcess(
           args,
-          {node::ProcessInitializationFlags::kNoInitializeV8,
-           node::ProcessInitializationFlags::kNoInitializeNodeV8Platform});
+          {
+              node::ProcessInitializationFlags::kNoInitializeV8,
+              node::ProcessInitializationFlags::kNoInitializeNodeV8Platform,
+              // This is used to test NODE_REPL_EXTERNAL_MODULE is disabled with
+              // kDisableNodeOptionsEnv. If other tests need NODE_OPTIONS
+              // support in the future, split this configuration out as a
+              // command line option.
+              node::ProcessInitializationFlags::kDisableNodeOptionsEnv,
+          });
 
   for (const std::string& error : result->errors())
     fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -151,3 +151,20 @@ for (const extraSnapshotArgs of [
     [ '--', ...runEmbeddedArgs ],
     { cwd: tmpdir.path });
 }
+
+// Guarantee NODE_REPL_EXTERNAL_MODULE won't bypass kDisableNodeOptionsEnv
+{
+  spawnSyncAndExit(
+    binary,
+    ['require("os")'],
+    {
+      env: {
+        'NODE_REPL_EXTERNAL_MODULE': 'fs',
+      },
+    },
+    {
+      status: 9,
+      signal: null,
+      stderr: `${binary}: NODE_REPL_EXTERNAL_MODULE can't be used with kDisableNodeOptionsEnv\n`,
+    });
+}

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -159,6 +159,7 @@ for (const extraSnapshotArgs of [
     ['require("os")'],
     {
       env: {
+        ...process.env,
         'NODE_REPL_EXTERNAL_MODULE': 'fs',
       },
     },


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51227

Currently, I'm throwing kBootstrapError, but I'm almost sure this is not the appropriate error. In this case, should I create a new error?

Technically, this is a fix for `kDisableNodeOptionsEnv`, but it can be considered a breaking change for the ones relying on the current behavior (which is unlikely).