### PR TITLE
doc: include followTags and GPG=TTY mention

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -712,10 +712,10 @@ npm install -g git-secure-tag
 
 > Ensure to disable `--follow-tags` in your git settings using: `git config push.followTags false`
 
-If your GPG key is protected by a password, you might need to run:
+If your private key is protected by a passphrase, you might need to run:
 
-```console
-$ export GPG_TTY=$(tty)
+```bash
+export GPG_TTY=$(tty)
 ```
 
 before creating the tag.

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -712,7 +712,15 @@ npm install -g git-secure-tag
 
 > Ensure to disable `--follow-tags` in your git settings using: `git config push.followTags false`
 
-Create a tag using the following command:
+If your GPG key is protected by a password, you might need to run:
+
+```console
+$ export GPG_TTY=$(tty)
+```
+
+before creating the tag.
+
+To create a tag use the following command:
 
 ```bash
 git secure-tag <vx.y.z> <commit-sha> -sm "YYYY-MM-DD Node.js vx.y.z (<release-type>) Release"

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -710,6 +710,8 @@ Install `git-secure-tag` npm module:
 npm install -g git-secure-tag
 ```
 
+> Ensure to disable `--follow-tags` in your git settings using: `git config push.followTags false`
+
 Create a tag using the following command:
 
 ```bash


### PR DESCRIPTION
I have noticed these points missing while helping Marco in the last Node.js 20 release (v20.13.0)