### PR TITLE
path: fix toNamespacedPath on Windows

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -647,7 +647,7 @@ const win32 = {
       return `\\\\?\\${resolvedPath}`;
     }
 
-    return path;
+    return resolvedPath;
   },
 
   /**

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -79,7 +79,8 @@ assert.strictEqual(path.win32.toNamespacedPath('\\\\foo\\bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
 assert.strictEqual(path.win32.toNamespacedPath('//foo//bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
-assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo');
+assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo\\');
+assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\c:\\Windows/System'), '\\\\?\\c:\\Windows\\System');
 assert.strictEqual(path.win32.toNamespacedPath(null), null);
 assert.strictEqual(path.win32.toNamespacedPath(true), true);
 assert.strictEqual(path.win32.toNamespacedPath(1), 1);


### PR DESCRIPTION
There was an inconsistency in the implementation of `win32.toNamespacedPath()`. It appears that the forward slash `/` wasn't consistently being converted to a backslash `\`. This PR fixes this issue by returning `resolvedPath` in the `toNamespacedPath()`.

I've also added a test case to make sure that there will not be any regression.

Fixes: https://github.com/nodejs/node/issues/30224