### PR TITLE
meta: move `@anonrig` to TSC regular member

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,6 @@ For information about the governance of the Node.js project, see
 
 * [aduh95](https://github.com/aduh95) -
   **Antoine du Hamel** <<duhamelantoine1995@gmail.com>> (he/him)
-* [anonrig](https://github.com/anonrig) -
-  **Yagiz Nizipli** <<yagiz.nizipli@sentry.io>> (he/him)
 * [apapirovski](https://github.com/apapirovski) -
   **Anatoli Papirovski** <<apapirovski@mac.com>> (he/him)
 * [benjamingr](https://github.com/benjamingr) -
@@ -205,6 +203,8 @@ For information about the governance of the Node.js project, see
 
 #### TSC regular members
 
+* [anonrig](https://github.com/anonrig) -
+  **Yagiz Nizipli** <<yagiz.nizipli@sentry.io>> (he/him)
 * [BethGriggs](https://github.com/BethGriggs) -
   **Beth Griggs** <<bethanyngriggs@gmail.com>> (she/her)
 * [bnoordhuis](https://github.com/bnoordhuis) -


### PR DESCRIPTION
It's been a honor and a privilege to be a Node.js Technical Steering Committee voting member. At the current time, I'm not able to give Node.js the time and attention it needs and deserves from a voting TSC member.

I hope my 2 years of contribution followed by TSC voting membership has made an impact justifying the time I've put for the community and the friendships I've found. 

As a wise-man said (@trott): "I want to leave before I'm less happy with my efforts. Thanks for all the trust and good will over the years."

I'd like to end this pull-request with a quote from a children's book: "You're my little honey bunny":

> You're my baby buttercup. As long as I'm around...
> There's always time to cuddle up,
> I'll keep you safe and sound.
> You're my little chirping chick, we snuggle up so tight.
> Our day has been so sunny,
> And now we say "good night!"

cc @nodejs/tsc