### PR TITLE
tools: support rewriting links in code blocks

### DIFF
--- a/tools/doc/html.mjs
+++ b/tools/doc/html.mjs
@@ -205,6 +205,7 @@ function linkJsTypeDocs(text) {
 }
 
 const isJSFlavorSnippet = (node) => node.lang === 'cjs' || node.lang === 'mjs';
+const isPreSnippet = (node) => node.lang === 'pre';
 
 // Preprocess headers, stability blockquotes, and YAML blocks.
 export function preprocessElements({ filename }) {
@@ -265,6 +266,8 @@ export function preprocessElements({ filename }) {
             // Isolated JS snippet, no need to add the checkbox.
             node.value = `<pre>${highlighted} ${copyButton}</pre>`;
           }
+        } else if (isPreSnippet(node)) {
+          node.value = `<pre>${node.value}</pre>`;
         } else {
           node.value = `<pre>${highlighted} ${copyButton}</pre>`;
         }

--- a/tools/doc/markdown.mjs
+++ b/tools/doc/markdown.mjs
@@ -1,6 +1,7 @@
 import { visit } from 'unist-util-visit';
 
 export const referenceToLocalMdFile = /^(?![+a-z]+:)([^#?]+)\.md(#.+)?$/i;
+export const referenceToLocalMdFileInPre = /<a href="([^#"]+)\.md(#[^"]+)?">/g;
 
 export function replaceLinks({ filename, linksMapper }) {
   return (tree) => {
@@ -11,6 +12,14 @@ export function replaceLinks({ filename, linksMapper }) {
         node.url = node.url.replace(
           referenceToLocalMdFile,
           (_, filename, hash) => `${filename}.html${hash || ''}`,
+        );
+      }
+    });
+    visit(tree, 'code', (node) => {
+      if (node.meta === 'html') {
+        node.value = node.value.replace(
+          referenceToLocalMdFileInPre,
+          (_, path, fragment) => `<a href="${path}.html${fragment || ''}">`,
         );
       }
     });

--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -23409,6 +23409,7 @@ const plugins = [
         "markdown",
         "mjs",
         "powershell",
+        "pre",
         "r",
         "text",
         "ts",


### PR DESCRIPTION
Within the API documentation for modules, there is a section of pseudo-code which contains links to another file. This pseudo-code is inside of a pre-formatted element (`<pre>`), but that prevents the build process from rewriting those links from the Markdown source to their corresponding HTML output.

This addresses that by adding a new language, "pre", whose output remains unformatted but allows code fences to be annotated with metadata - code fences must have a language before the metadata. When the right metadata ("html") is present, it indicates that the code block should be processed so that anchor tags are rewritten just like other references.

The actual change to the documentation will happen in a later commit.

(This was split out from https://github.com/nodejs/node/pull/52883)