### PR TITLE
doc: specify that preloaded modules affect subprocesses

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1220,6 +1220,9 @@ Follows [ECMAScript module][] resolution rules.
 Use [`--require`][] to load a [CommonJS module][].
 Modules preloaded with `--require` will run before modules preloaded with `--import`.
 
+Modules are preloaded into the main thread as well as any worker threads,
+forked processes, or clustered processes.
+
 ### `--input-type=type`
 
 <!-- YAML
@@ -1820,6 +1823,9 @@ rules. `module` may be either a path to a file, or a node module name.
 Only CommonJS modules are supported.
 Use [`--import`][] to preload an [ECMAScript module][].
 Modules preloaded with `--require` will run before modules preloaded with `--import`.
+
+Modules are preloaded into the main thread as well as any worker threads,
+forked processes, or clustered processes.
 
 ### `--run`
 


### PR DESCRIPTION
Fixes #52930

Marking author as `Co-Author`, as they specified where the preloaded modules will appear.