### PR TITLE
cli: add OpenJSF slack to man-page

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -767,7 +767,7 @@ See
 for the full license text.
 .
 .\"======================================================================
-.SH SEE ALSO
+.Sh SEE ALSO
 Website:
 .Sy https://nodejs.org/
 .

--- a/doc/node.1
+++ b/doc/node.1
@@ -767,7 +767,7 @@ See
 for the full license text.
 .
 .\"======================================================================
-.Sh SEE ALSO
+.SH SEE ALSO
 Website:
 .Sy https://nodejs.org/
 .
@@ -780,10 +780,13 @@ GitHub repository and issue tracker:
 .Sy https://github.com/nodejs/node
 .
 .Pp
+OpenJS Foundation Slack:
+.Sy "https://slack-invite.openjsf.org/ #nodejs"
+.
+.Pp
 IRC (general questions):
 .Sy "libera.chat #node.js"
 (unofficial)
-.
 .\"======================================================================
 .Sh AUTHORS
 Written and maintained by 1000+ contributors:

--- a/doc/node.1
+++ b/doc/node.1
@@ -787,6 +787,7 @@ OpenJS Foundation Slack:
 IRC (general questions):
 .Sy "libera.chat #node.js"
 (unofficial)
+.
 .\"======================================================================
 .Sh AUTHORS
 Written and maintained by 1000+ contributors:


### PR DESCRIPTION
This PR updates the man-page to contain a link to the OpenJSF slack page.