### PR TITLE
lib: speed up MessageEvent creation internally

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -85,6 +85,8 @@ const messageTypes = {
   LOAD_SCRIPT: 'loadScript',
 };
 
+// createFastMessageEvent skips webidl argument validation when the arguments
+// passed are known to be valid.
 let fastCreateMessageEvent;
 function lazyMessageEvent(type, init) {
   fastCreateMessageEvent ??= require('internal/deps/undici/undici').createFastMessageEvent;

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -85,9 +85,10 @@ const messageTypes = {
   LOAD_SCRIPT: 'loadScript',
 };
 
-let messageEvent;
-function lazyMessageEvent() {
-  return messageEvent ??= require('internal/deps/undici/undici').MessageEvent;
+let fastCreateMessageEvent;
+function lazyMessageEvent(type, init) {
+  fastCreateMessageEvent ??= require('internal/deps/undici/undici').createFastMessageEvent;
+  return fastCreateMessageEvent(type, init);
 }
 
 // We have to mess with the MessagePort prototype a bit, so that a) we can make
@@ -128,7 +129,7 @@ ObjectDefineProperty(
       }
       const ports = this[kCurrentlyReceivingPorts];
       this[kCurrentlyReceivingPorts] = undefined;
-      return new (lazyMessageEvent())(type, { data, ports });
+      return lazyMessageEvent(type, { data, ports });
     },
     configurable: false,
     writable: false,
@@ -321,7 +322,7 @@ function receiveMessageOnPort(port) {
 }
 
 function onMessageEvent(type, data) {
-  this.dispatchEvent(new (lazyMessageEvent())(type, { data }));
+  this.dispatchEvent(lazyMessageEvent(type, { data }));
 }
 
 function isBroadcastChannel(value) {


### PR DESCRIPTION
`createFastMessageEvent` can be used when the arguments passed to the MessageEvent constructor do not need to be validated.

Refs: https://github.com/nodejs/undici/pull/3170
Refs: https://github.com/nodejs/node/pull/52370#pullrequestreview-1984568503