### PR TITLE
doc: remove reference to AUTHORS file

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -778,8 +778,3 @@ GitHub repository and issue tracker:
 IRC (general questions):
 .Sy "libera.chat #node.js"
 (unofficial)
-.
-.\"======================================================================
-.Sh AUTHORS
-Written and maintained by 1000+ contributors:
-.Sy https://github.com/nodejs/node/blob/HEAD/AUTHORS


### PR DESCRIPTION
AUTHORS file has been removed in https://github.com/nodejs/node/pull/46845, so that reference is useless
