### PR TITLE
module: default to commonjs when format cannot be detected

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -112,10 +112,8 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
       default: { // The user did not pass `--experimental-default-type`.
         // `source` is undefined when this is called from `defaultResolve`;
         // but this gets called again from `defaultLoad`/`defaultLoadSync`.
-        if (getOptionValue('--experimental-detect-module')) {
-          const format = source ?
-            (containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs') :
-            null;
+        if (getOptionValue('--experimental-detect-module') && source) {
+          const format = containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs';
           if (format === 'module') {
             // This module has a .js extension, a package.json with no `type` field, and ESM syntax.
             // Warn about the missing `type` field so that the user can avoid the performance penalty of detection.

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -152,8 +152,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
         return 'commonjs';
       }
       default: { // The user did not pass `--experimental-default-type`.
-        if (getOptionValue('--experimental-detect-module')) {
-          if (!source) { return null; }
+        if (getOptionValue('--experimental-detect-module') && source) {
           const format = getFormatOfExtensionlessFile(url);
           if (format === 'module') {
             return containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs';


### PR DESCRIPTION
When `--experimental-detect-module` is enabled, the default format will no longer be `commonjs`; instead, it will be `null` until the source is loaded. In this PR, the behavior is changed to default to `commonjs`, aligning with the non-experimental behavior.