### PR TITLE
test: update ESM loader hooks to allow ambiguous format

### DIFF
--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -751,15 +751,15 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
       '--no-warnings',
       '--experimental-loader',
       `data:text/javascript,import{readFile}from"node:fs/promises";import{fileURLToPath}from"node:url";export ${
-        async function load(u, c, n) {
-          const r = await n(u, c);
-          if (u.endsWith('/common/index.js')) {
-            r.source = '"use strict";module.exports=require("node:module").createRequire(' +
-                     `${JSON.stringify(u)})(${JSON.stringify(fileURLToPath(u))});\n`;
-          } else if (c.format === 'commonjs') {
-            r.source = await readFile(new URL(u));
+        async function load(url, context, nextLoad) {
+          const resolved = await nextLoad(url, context);
+          if (url.endsWith('/common/index.js')) {
+            resolved.source = '"use strict";module.exports=require("node:module").createRequire(' +
+                     `${JSON.stringify(url)})(${JSON.stringify(fileURLToPath(url))});\n`;
+          } else if (context.format === 'commonjs' || context.format === null) {
+            resolved.source = await readFile(new URL(url));
           }
-          return r;
+          return resolved;
         }}`,
       '--experimental-loader',
       fixtures.fileURL('es-module-loaders/loader-resolve-passthru.mjs'),


### PR DESCRIPTION
Pull request #50314 added support for a `null` format value in addition to the existing `commonjs` or `module`. However, the test for ESM hooks relied on the default value of `commonjs`, causing it to fail when run with the `--experimental-detect-module` flag. This PR enables the test to detect `null` formats, ensuring it runs successfully with experimental detection enabled.

Sidenote: While @GeoffreyBooth and I were debugging this behavior, the single-character function arguments made it *very* difficult to understand, so this PR also expands them into the full names.