### PR TITLE
buffer: make compare/equals faster

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -57,6 +57,7 @@ using v8::ArrayBufferView;
 using v8::BackingStore;
 using v8::Context;
 using v8::EscapableHandleScope;
+using v8::FastApiTypedArray;
 using v8::FunctionCallbackInfo;
 using v8::Global;
 using v8::HandleScope;
@@ -843,6 +844,23 @@ void Compare(const FunctionCallbackInfo<Value> &args) {
   args.GetReturnValue().Set(val);
 }
 
+int32_t FastCompare(v8::Local<v8::Value>,
+                    const FastApiTypedArray<uint8_t>& a,
+                    const FastApiTypedArray<uint8_t>& b) {
+  uint8_t* data_a;
+  uint8_t* data_b;
+  CHECK(a.getStorageIfAligned(&data_a));
+  CHECK(b.getStorageIfAligned(&data_b));
+
+  size_t cmp_length = std::min(a.length(), b.length());
+
+  return normalizeCompareVal(
+      cmp_length > 0 ? memcmp(data_a, data_b, cmp_length) : 0,
+      a.length(),
+      b.length());
+}
+
+static v8::CFunction fast_compare(v8::CFunction::Make(FastCompare));
 
 // Computes the offset for starting an indexOf or lastIndexOf search.
 // Returns either a valid offset in [0...<length - 1>], ie inside the Buffer,
@@ -1409,7 +1427,7 @@ void Initialize(Local<Object> target,
                             SlowByteLengthUtf8,
                             &fast_byte_length_utf8);
   SetMethod(context, target, "copy", Copy);
-  SetMethodNoSideEffect(context, target, "compare", Compare);
+  SetFastMethodNoSideEffect(context, target, "compare", Compare, &fast_compare);
   SetMethodNoSideEffect(context, target, "compareOffset", CompareOffset);
   SetMethod(context, target, "fill", Fill);
   SetMethodNoSideEffect(context, target, "indexOfBuffer", IndexOfBuffer);
@@ -1469,6 +1487,8 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(FastByteLengthUtf8);
   registry->Register(Copy);
   registry->Register(Compare);
+  registry->Register(FastCompare);
+  registry->Register(fast_compare.GetTypeInfo());
   registry->Register(CompareOffset);
   registry->Register(Fill);
   registry->Register(IndexOfBuffer);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -27,6 +27,10 @@ using CFunctionCallbackWithStrings =
     bool (*)(v8::Local<v8::Value>,
              const v8::FastOneByteString& input,
              const v8::FastOneByteString& base);
+using CFunctionCallbackWithTwoUint8Arrays =
+    int32_t (*)(v8::Local<v8::Value>,
+                const v8::FastApiTypedArray<uint8_t>&,
+                const v8::FastApiTypedArray<uint8_t>&);
 using CFunctionCallbackWithTwoUint8ArraysFallback =
     bool (*)(v8::Local<v8::Value>,
              const v8::FastApiTypedArray<uint8_t>&,
@@ -56,6 +60,7 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithBool)                                                 \
   V(CFunctionCallbackWithString)                                               \
   V(CFunctionCallbackWithStrings)                                              \
+  V(CFunctionCallbackWithTwoUint8Arrays)                                       \
   V(CFunctionCallbackWithTwoUint8ArraysFallback)                               \
   V(CFunctionWithUint32)                                                       \
   V(CFunctionWithDoubleReturnDouble)                                           \


### PR DESCRIPTION
This patch adds a V8 fast API implementation for the `buffer.compare` binding, which is used both by `Buffer.prototype.equals` and `Buffer.prototype.compare`. In particular, it significantly improves the performance of comparing buffers for equality.

Local benchmark:
```
                                                                      confidence improvement accuracy (*)    (**)   (***)
buffers/buffer-compare-instance-method.js n=1000000 args=1 size=16           ***    225.73 %      ±16.81% ±22.62% ±29.94%
buffers/buffer-compare-instance-method.js n=1000000 args=1 size=16386        ***     15.57 %       ±1.32%  ±1.76%  ±2.29%
buffers/buffer-compare-instance-method.js n=1000000 args=1 size=4096         ***     61.44 %       ±6.15%  ±8.27% ±10.93%
buffers/buffer-compare-instance-method.js n=1000000 args=1 size=512          ***    181.97 %       ±7.02%  ±9.45% ±12.52%
buffers/buffer-compare-instance-method.js n=1000000 args=2 size=16                    1.82 %       ±3.08%  ±4.11%  ±5.39%
buffers/buffer-compare-instance-method.js n=1000000 args=2 size=16386                -0.02 %       ±1.38%  ±1.84%  ±2.39%
buffers/buffer-compare-instance-method.js n=1000000 args=2 size=4096           *     -2.30 %       ±2.21%  ±2.93%  ±3.82%
buffers/buffer-compare-instance-method.js n=1000000 args=2 size=512            *     -3.92 %       ±3.02%  ±4.02%  ±5.24%
buffers/buffer-compare-instance-method.js n=1000000 args=5 size=16                   -2.86 %       ±3.69%  ±4.93%  ±6.48%
buffers/buffer-compare-instance-method.js n=1000000 args=5 size=16386                -0.17 %       ±2.94%  ±3.93%  ±5.13%
buffers/buffer-compare-instance-method.js n=1000000 args=5 size=4096                 -0.62 %       ±2.00%  ±2.67%  ±3.47%
buffers/buffer-compare-instance-method.js n=1000000 args=5 size=512                  -1.16 %       ±3.34%  ±4.45%  ±5.79%
buffers/buffer-compare-offset.js n=1000000 size=16 method='offset'                   -0.75 %       ±3.85%  ±5.13%  ±6.68%
buffers/buffer-compare-offset.js n=1000000 size=16 method='slice'            ***     55.75 %       ±3.72%  ±4.97%  ±6.51%
buffers/buffer-compare-offset.js n=1000000 size=16386 method='offset'                 0.60 %       ±2.39%  ±3.19%  ±4.15%
buffers/buffer-compare-offset.js n=1000000 size=16386 method='slice'         ***     54.36 %       ±4.39%  ±5.85%  ±7.62%
buffers/buffer-compare-offset.js n=1000000 size=4096 method='offset'                 -0.17 %       ±2.52%  ±3.37%  ±4.41%
buffers/buffer-compare-offset.js n=1000000 size=4096 method='slice'          ***     53.48 %       ±4.26%  ±5.69%  ±7.44%
buffers/buffer-compare-offset.js n=1000000 size=512 method='offset'                   1.06 %       ±1.97%  ±2.63%  ±3.45%
buffers/buffer-compare-offset.js n=1000000 size=512 method='slice'           ***     49.36 %       ±5.02%  ±6.73%  ±8.88%
buffers/buffer-compare.js n=1000000 size=16                                  ***    136.22 %       ±6.78%  ±9.07% ±11.90%
buffers/buffer-compare.js n=1000000 size=16386                                 *      4.93 %       ±4.56%  ±6.10%  ±8.01%
buffers/buffer-compare.js n=1000000 size=4096                                ***     36.27 %       ±5.07%  ±6.79%  ±8.92%
buffers/buffer-compare.js n=1000000 size=512                                 ***    113.32 %       ±6.16%  ±8.27% ±10.92%
buffers/buffer-equals.js n=1000000 difflen='false' size=0                             0.39 %       ±2.76%  ±3.69%  ±4.84%
buffers/buffer-equals.js n=1000000 difflen='false' size=16386                ***     18.69 %       ±5.35%  ±7.20%  ±9.52%
buffers/buffer-equals.js n=1000000 difflen='false' size=512                  ***    141.31 %      ±10.23% ±13.77% ±18.22%
buffers/buffer-equals.js n=1000000 difflen='true' size=0                              0.23 %       ±2.81%  ±3.74%  ±4.87%
buffers/buffer-equals.js n=1000000 difflen='true' size=16386                 ***     -4.23 %       ±1.99%  ±2.66%  ±3.48%
buffers/buffer-equals.js n=1000000 difflen='true' size=512                           -1.28 %       ±4.89%  ±6.50%  ±8.47%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 30 comparisons, you can thus expect the following amount of false-positive results:
  1.50 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.30 false positives, when considering a   1% risk acceptance (**, ***),
  0.03 false positives, when considering a 0.1% risk acceptance (***)
```

![image](https://github.com/nodejs/node/assets/3109072/99ec2644-9ad6-4afd-aced-8fcdebc83d18)

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1566/

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
