### PR TITLE
lib,doc: replace references to import assertions

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -611,7 +611,7 @@ changes:
 
 The `load` hook provides a way to define a custom method of determining how a
 URL should be interpreted, retrieved, and parsed. It is also in charge of
-validating the import assertion.
+validating the import attributes.
 
 The final value of `format` must be one of the following:
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -148,7 +148,7 @@ There is the ECMAScript module loader:
   `'./startup/index.js'`) must be fully specified.
 * It does no extension searching. A file extension must be provided
   when the specifier is a relative or absolute file URL.
-* It can load JSON modules, but an import assertion is required.
+* It can load JSON modules, but an import type attribute is required.
 * It accepts only `.js`, `.mjs`, and `.cjs` extensions for JavaScript text
   files.
 * It can be used to load JavaScript CommonJS modules. Such modules

--- a/lib/internal/modules/esm/assert.js
+++ b/lib/internal/modules/esm/assert.js
@@ -16,7 +16,7 @@ const {
 } = require('internal/errors').codes;
 
 // The HTML spec has an implied default type of `'javascript'`.
-const kImplicitAssertType = 'javascript';
+const kImplicitTypeAttribute = 'javascript';
 
 /**
  * Define a map of module formats to import attributes types (the value of
@@ -25,11 +25,11 @@ const kImplicitAssertType = 'javascript';
  */
 const formatTypeMap = {
   '__proto__': null,
-  'builtin': kImplicitAssertType,
-  'commonjs': kImplicitAssertType,
+  'builtin': kImplicitTypeAttribute,
+  'commonjs': kImplicitTypeAttribute,
   'json': 'json',
-  'module': kImplicitAssertType,
-  'wasm': kImplicitAssertType, // It's unclear whether the HTML spec will require an attribute type or not for Wasm; see https://github.com/WebAssembly/esm-integration/issues/42
+  'module': kImplicitTypeAttribute,
+  'wasm': kImplicitTypeAttribute, // It's unclear whether the HTML spec will require an type attribute or not for Wasm; see https://github.com/WebAssembly/esm-integration/issues/42
 };
 
 /**
@@ -38,9 +38,9 @@ const formatTypeMap = {
  * `import './file.js' with { type: 'javascript' }` throws.
  * @type {Array<string, string>}
  */
-const supportedAssertionTypes = ArrayPrototypeFilter(
+const supportedTypeAttributes = ArrayPrototypeFilter(
   ObjectValues(formatTypeMap),
-  (type) => type !== kImplicitAssertType);
+  (type) => type !== kImplicitTypeAttribute);
 
 
 /**
@@ -50,7 +50,7 @@ const supportedAssertionTypes = ArrayPrototypeFilter(
  * @param {Record<string, string>} importAttributes Validations for the
  *                                                  module import.
  * @returns {true}
- * @throws {TypeError} If the format and assertion type are incompatible.
+ * @throws {TypeError} If the format and type attribute are incompatible.
  */
 function validateAttributes(url, format,
                             importAttributes = { __proto__: null }) {
@@ -68,8 +68,8 @@ function validateAttributes(url, format,
       // formats in the future.
       return true;
 
-    case kImplicitAssertType:
-      // This format doesn't allow an import assertion type, so the property
+    case kImplicitTypeAttribute:
+      // This format doesn't allow an import type attribute, so the property
       // must not be set on the import attributes object.
       if (!ObjectPrototypeHasOwnProperty(importAttributes, 'type')) {
         return true;
@@ -77,7 +77,7 @@ function validateAttributes(url, format,
       return handleInvalidType(url, importAttributes.type);
 
     case importAttributes.type:
-      // The asserted type is the valid type for this format.
+      // The type attribute is the valid type for this format.
       return true;
 
     default:
@@ -92,16 +92,16 @@ function validateAttributes(url, format,
 }
 
 /**
- * Throw the correct error depending on what's wrong with the type assertion.
+ * Throw the correct error depending on what's wrong with the type attribute.
  * @param {string} url The resolved URL for the module to be imported
- * @param {string} type The value of the import assertion `type` property
+ * @param {string} type The value of the import attributes' `type` property
  */
 function handleInvalidType(url, type) {
   // `type` might have not been a string.
   validateString(type, 'type');
 
   // `type` might not have been one of the types we understand.
-  if (!ArrayPrototypeIncludes(supportedAssertionTypes, type)) {
+  if (!ArrayPrototypeIncludes(supportedTypeAttributes, type)) {
     throw new ERR_IMPORT_ATTRIBUTE_UNSUPPORTED('type', type);
   }
 
@@ -111,6 +111,6 @@ function handleInvalidType(url, type) {
 
 
 module.exports = {
-  kImplicitAssertType,
+  kImplicitTypeAttribute,
   validateAttributes,
 };

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -35,7 +35,7 @@ const {
   compileSourceTextModule,
   getDefaultConditions,
 } = require('internal/modules/esm/utils');
-const { kImplicitAssertType } = require('internal/modules/esm/assert');
+const { kImplicitTypeAttribute } = require('internal/modules/esm/assert');
 const { canParse } = internalBinding('url');
 const { ModuleWrap, kEvaluating, kEvaluated } = internalBinding('module_wrap');
 const {
@@ -276,7 +276,7 @@ class ModuleLoader {
    */
   importSyncForRequire(mod, filename, source, isMain, parent) {
     const url = pathToFileURL(filename).href;
-    let job = this.loadCache.get(url, kImplicitAssertType);
+    let job = this.loadCache.get(url, kImplicitTypeAttribute);
     // This module job is already created:
     // 1. If it was loaded by `require()` before, at this point the instantiation
     //    is already completed and we can check the whether it is in a cycle
@@ -307,7 +307,7 @@ class ModuleLoader {
 
     const { ModuleJobSync } = require('internal/modules/esm/module_job');
     job = new ModuleJobSync(this, url, kEmptyObject, wrap, isMain, inspectBrk);
-    this.loadCache.set(url, kImplicitAssertType, job);
+    this.loadCache.set(url, kImplicitTypeAttribute, job);
     mod[kRequiredModuleSymbol] = job.module;
     return job.runSync().namespace;
   }

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -8,7 +8,7 @@ const {
   ObjectKeys,
   SafeMap,
 } = primordials;
-const { kImplicitAssertType } = require('internal/modules/esm/assert');
+const { kImplicitTypeAttribute } = require('internal/modules/esm/assert');
 let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
@@ -88,12 +88,12 @@ class ResolveCache extends SafeMap {
  */
 class LoadCache extends SafeMap {
   constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-  get(url, type = kImplicitAssertType) {
+  get(url, type = kImplicitTypeAttribute) {
     validateString(url, 'url');
     validateString(type, 'type');
     return super.get(url)?.[type];
   }
-  set(url, type = kImplicitAssertType, job) {
+  set(url, type = kImplicitTypeAttribute, job) {
     validateString(url, 'url');
     validateString(type, 'type');
 
@@ -103,18 +103,18 @@ class LoadCache extends SafeMap {
       throw new ERR_INVALID_ARG_TYPE('job', 'ModuleJob', job);
     }
     debug(`Storing ${url} (${
-      type === kImplicitAssertType ? 'implicit type' : type
+      type === kImplicitTypeAttribute ? 'implicit type' : type
     }) in ModuleLoadMap`);
     const cachedJobsForUrl = super.get(url) ?? { __proto__: null };
     cachedJobsForUrl[type] = job;
     return super.set(url, cachedJobsForUrl);
   }
-  has(url, type = kImplicitAssertType) {
+  has(url, type = kImplicitTypeAttribute) {
     validateString(url, 'url');
     validateString(type, 'type');
     return super.get(url)?.[type] !== undefined;
   }
-  delete(url, type = kImplicitAssertType) {
+  delete(url, type = kImplicitTypeAttribute) {
     const cached = super.get(url);
     if (cached) {
       cached[type] = undefined;


### PR DESCRIPTION
Use "import attributes" and "type attribute" instead.
