### PR TITLE
cli: allow `--test-[name/skip]-pattern` in `NODE_OPTIONS`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2993,10 +2993,12 @@ one is included in the list below.
 * `--snapshot-blob`
 * `--test-coverage-exclude`
 * `--test-coverage-include`
+* `--test-name-pattern`
 * `--test-only`
 * `--test-reporter-destination`
 * `--test-reporter`
 * `--test-shard`
+* `--test-skip-pattern`
 * `--throw-deprecation`
 * `--title`
 * `--tls-cipher-list`

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -658,7 +658,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::test_runner_snapshots);
   AddOption("--test-name-pattern",
             "run tests whose name matches this regular expression",
-            &EnvironmentOptions::test_name_pattern);
+            &EnvironmentOptions::test_name_pattern,
+            kAllowedInEnvvar);
   AddOption("--test-reporter",
             "report test output using the given reporter",
             &EnvironmentOptions::test_reporter,
@@ -677,7 +678,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvvar);
   AddOption("--test-skip-pattern",
             "run tests whose name do not match this regular expression",
-            &EnvironmentOptions::test_skip_pattern);
+            &EnvironmentOptions::test_skip_pattern,
+            kAllowedInEnvvar);
   AddOption("--test-coverage-include",
             "include files in coverage report that match this glob pattern",
             &EnvironmentOptions::coverage_include_pattern,


### PR DESCRIPTION
workaround for #51384
> `NODE_OPTIONS="--test-name-pattern=XXX" node my_test.js`

Allows `--test-name-pattern` and `--test-skip-pattern` to appear in the `NODE_OPTIONS` environment variable.