### PR TITLE
tls: fix negative sessionTimeout handling

### DIFF
--- a/lib/internal/tls/secure-context.js
+++ b/lib/internal/tls/secure-context.js
@@ -311,7 +311,7 @@ function configSecureContext(context, options = kEmptyObject, name = 'options') 
   }
 
   if (sessionTimeout !== undefined && sessionTimeout !== null) {
-    validateInt32(sessionTimeout, `${name}.sessionTimeout`);
+    validateInt32(sessionTimeout, `${name}.sessionTimeout`, 0);
     context.setSessionTimeout(sessionTimeout);
   }
 }

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -998,6 +998,7 @@ void SecureContext::SetSessionTimeout(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
 
   int32_t sessionTimeout = args[0].As<Int32>()->Value();
+  CHECK_GE(sessionTimeout, 0);
   SSL_CTX_set_timeout(sc->ctx_.get(), sessionTimeout);
 }
 

--- a/test/sequential/test-tls-session-timeout.js
+++ b/test/sequential/test-tls-session-timeout.js
@@ -22,14 +22,42 @@
 'use strict';
 const common = require('../common');
 
-if (!common.opensslCli)
-  common.skip('node compiled without OpenSSL CLI.');
-
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const key = fixtures.readKey('rsa_private.pem');
+const cert = fixtures.readKey('rsa_cert.crt');
+
+{
+  // Node.js should not allow setting negative timeouts since new versions of
+  // OpenSSL do not handle those as users might expect
+
+  for (const sessionTimeout of [-1, -100, -(2 ** 31)]) {
+    assert.throws(() => {
+      tls.createServer({
+        key: key,
+        cert: cert,
+        ca: [cert],
+        sessionTimeout,
+        maxVersion: 'TLSv1.2',
+      });
+    }, {
+      code: 'ERR_OUT_OF_RANGE',
+      message: 'The value of "options.sessionTimeout" is out of range. It ' +
+               `must be >= 0 && <= ${2 ** 31 - 1}. Received ${sessionTimeout}`,
+    });
+  }
+}
+
+if (!common.opensslCli)
+  common.skip('node compiled without OpenSSL CLI.');
 
 doTest();
 
@@ -42,16 +70,11 @@ doTest();
 //   that we used has expired by now.
 
 function doTest() {
-  const assert = require('assert');
-  const tls = require('tls');
   const fs = require('fs');
-  const fixtures = require('../common/fixtures');
   const spawn = require('child_process').spawn;
 
   const SESSION_TIMEOUT = 1;
 
-  const key = fixtures.readKey('rsa_private.pem');
-  const cert = fixtures.readKey('rsa_cert.crt');
   const options = {
     key: key,
     cert: cert,


### PR DESCRIPTION
For historical reasons, the second argument of `SSL_CTX_set_timeout` is a signed integer, and Node.js has so far passed arbitrary (signed) `int32_t` values. However, new versions of OpenSSL have changed the handling of negative values inside `SSL_CTX_set_timeout`, and we should shield users of Node.js from both the old and the new behavior. Hence, reject any negative values by throwing an error from within `createSecureContext`.

Refs: https://github.com/openssl/openssl/pull/19082

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
