### PR TITLE
[WIP] Fix ClangCL ARM64 cross-compilation

### DIFF
--- a/deps/icu-small/source/tools/genccode/genccode.c
+++ b/deps/icu-small/source/tools/genccode/genccode.c
@@ -70,6 +70,7 @@ enum {
 #ifdef CAN_GENERATE_OBJECTS
   kOptObject,
   kOptMatchArch,
+  kOptCpuArch,
   kOptSkipDllExport,
 #endif
   kOptFilename,
@@ -86,6 +87,7 @@ static UOption options[]={
 #ifdef CAN_GENERATE_OBJECTS
 /*6*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
      UOPTION_DEF("match-arch", 'm', UOPT_REQUIRES_ARG),
+     UOPTION_DEF("cpu-arch", 'c', UOPT_REQUIRES_ARG),
      UOPTION_DEF("skip-dll-export", '\0', UOPT_NO_ARG),
 #endif
      UOPTION_DEF("filename", 'f', UOPT_REQUIRES_ARG),
@@ -131,6 +133,7 @@ main(int argc, char* argv[]) {
             "\t-o or --object      write a .obj file instead of .c\n"
             "\t-m or --match-arch file.o  match the architecture (CPU, 32/64 bits) of the specified .o\n"
             "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n"
+            "\t-c or --cpu-arch    Specify a CPU architecture for which to write a .obj file for ClangCL on Windows\n"
             "\t--skip-dll-export   Don't export the ICU data entry point symbol (for use when statically linking)\n");
 #endif
         fprintf(stderr,
@@ -196,6 +199,7 @@ main(int argc, char* argv[]) {
                 writeObjectCode(filename, options[kOptDestDir].value,
                                 options[kOptEntryPoint].doesOccur ? options[kOptEntryPoint].value : NULL,
                                 options[kOptMatchArch].doesOccur ? options[kOptMatchArch].value : NULL,
+                                options[kOptCpuArch].doesOccur ? options[kOptCpuArch].value : NULL,
                                 options[kOptFilename].doesOccur ? options[kOptFilename].value : NULL,
                                 NULL,
                                 0,

--- a/deps/icu-small/source/tools/pkgdata/pkgdata.cpp
+++ b/deps/icu-small/source/tools/pkgdata/pkgdata.cpp
@@ -776,6 +776,7 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         o->entryName,
                         (optMatchArch[0] == 0 ? nullptr : optMatchArch),
                         nullptr,
+                        nullptr,
                         gencFilePath,
                         sizeof(gencFilePath),
                         true);

--- a/deps/icu-small/source/tools/toolutil/pkg_genc.cpp
+++ b/deps/icu-small/source/tools/toolutil/pkg_genc.cpp
@@ -799,7 +799,12 @@ getOutFilename(
 
 #ifdef CAN_GENERATE_OBJECTS
 static void
-getArchitecture(uint16_t *pCPU, uint16_t *pBits, UBool *pIsBigEndian, const char *optMatchArch) {
+getArchitecture(
+    uint16_t *pCPU,
+    uint16_t *pBits,
+    UBool *pIsBigEndian,
+    const char *optMatchArch,
+    const char *optCpuArch) {
     union {
         char        bytes[2048];
 #ifdef U_ELF
@@ -847,7 +852,24 @@ getArchitecture(uint16_t *pCPU, uint16_t *pBits, UBool *pIsBigEndian, const char
 #   if defined(_M_IX86)
         *pCPU = IMAGE_FILE_MACHINE_I386;
 #   else
-        *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+        // Linker for ClangCL doesn't handle IMAGE_FILE_MACHINE_UNKNOWN the same as
+        // linker for MSVC. Because of this optCpuArch is used to define the CPU
+        // architecture in that case. While _M_AMD64 and _M_ARM64 could be used,
+        // this would potentially be problematic when cross-compiling as this code
+        // would most likely be ran on host machine to generate the .obj file for
+        // the target architecture.
+#       if defined(__clang__)
+            if (strcmp(optCpuArch, "x64") == 0) {
+                *pCPU = IMAGE_FILE_MACHINE_AMD64;
+            } else if (strcmp(optCpuArch, "arm64") == 0) {
+                *pCPU = IMAGE_FILE_MACHINE_ARM64;
+            } else {
+                // This should never happen.
+                *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+            }
+#       else
+            *pCPU = IMAGE_FILE_MACHINE_UNKNOWN;
+#       endif
 #   endif
 #   if defined(_M_IA64) || defined(_M_AMD64) || defined (_M_ARM64)
         *pBits = 64; // Doesn't seem to be used for anything interesting though?
@@ -934,6 +956,7 @@ writeObjectCode(
         const char *destdir,
         const char *optEntryPoint,
         const char *optMatchArch,
+        const char *optCpuArch,
         const char *optFilename,
         char *outFilePath,
         size_t outFilePathCapacity,
@@ -1201,7 +1224,7 @@ writeObjectCode(
 #endif
 
     /* deal with options, files and the entry point name */
-    getArchitecture(&cpu, &bits, &makeBigEndian, optMatchArch);
+    getArchitecture(&cpu, &bits, &makeBigEndian, optMatchArch, optCpuArch);
     if (optMatchArch)
     {
         printf("genccode: --match-arch cpu=%hu bits=%hu big-endian=%d\n", cpu, bits, makeBigEndian);

--- a/deps/icu-small/source/tools/toolutil/pkg_genc.h
+++ b/deps/icu-small/source/tools/toolutil/pkg_genc.h
@@ -99,6 +99,7 @@ writeObjectCode(
     const char *destdir,
     const char *optEntryPoint,
     const char *optMatchArch,
+    const char *optCpuArch,
     const char *optFilename,
     char *outFilePath,
     size_t outFilePathCapacity,

--- a/deps/v8/third_party/fp16/src/include/fp16/bitcasts.h
+++ b/deps/v8/third_party/fp16/src/include/fp16/bitcasts.h
@@ -12,7 +12,7 @@
 	#include <immintrin.h>
 #endif
 
-#if defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#if defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 	#include <intrin.h>
 #endif
 
@@ -24,7 +24,7 @@ static inline float fp32_from_bits(uint32_t w) {
 	return __uint_as_float((unsigned int) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu32_f32(w);
-#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 	return _CopyFloatFromInt32((__int32) w);
 #else
 	union {
@@ -42,7 +42,7 @@ static inline uint32_t fp32_to_bits(float f) {
 	return (uint32_t) __float_as_uint(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf32_u32(f);
-#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 	return (uint32_t) _CopyInt32FromFloat(f);
 #else
 	union {
@@ -60,7 +60,7 @@ static inline double fp64_from_bits(uint64_t w) {
 	return __longlong_as_double((long long) w);
 #elif defined(__INTEL_COMPILER)
 	return _castu64_f64(w);
-#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 	return _CopyDoubleFromInt64((__int64) w);
 #else
 	union {
@@ -78,7 +78,7 @@ static inline uint64_t fp64_to_bits(double f) {
 	return (uint64_t) __double_as_longlong(f);
 #elif defined(__INTEL_COMPILER)
 	return _castf64_u64(f);
-#elif defined(_MSC_VER) && (defined(_M_ARM) || defined(_M_ARM64))
+#elif defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || defined(_M_ARM64))
 	return (uint64_t) _CopyInt64FromDouble(f);
 #else
 	union {

--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -148,6 +148,7 @@
                   # on Windows, we can go directly to .obj file (-o) option.
                   'action': [ '<(PRODUCT_DIR)/genccode<(EXECUTABLE_SUFFIX)',
                               '<@(icu_asm_opts)', # -o
+                              '-c', '<(target_arch)',
                               '-d', '<(SHARED_INTERMEDIATE_DIR)',
                               '-n', 'icudata',
                               '-e', 'icudt<(icu_ver_major)',
@@ -185,6 +186,7 @@
                   'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)<(icu_endianness)_dat.<(icu_asm_ext)' ],
                   'action': [ '<(PRODUCT_DIR)/genccode<(EXECUTABLE_SUFFIX)',
                               '<@(icu_asm_opts)', # -o
+                              '-c', '<(target_arch)',
                               '-d', '<(SHARED_INTERMEDIATE_DIR)/',
                               '-n', 'icudata',
                               '-e', 'icusmdt<(icu_ver_major)',


### PR DESCRIPTION
This PR is a WIP for fixing the ClangCL cross-compilation to ARM64. It consists of 2 dependency updates that should be done upstream and 1 change in Node.js itself to make everything work:

A fix in ICU https://github.com/nodejs/node/commit/a6932add8e154e004242efc0828f345d9727f895 - To increase the chances of this landing upstream, the change is done by adding an option for this use case so it doesn't break any previously experienced behavior. After this is reviewed and discussed, I plan to open a PR in the ICU and try to land it there.

A fix in FP16 https://github.com/nodejs/node/commit/f8b52b51e04c5c1caab87bbd7fce3a49c1d58129 - This already landed in the base repo. Since that project is a dependency of the V8, a CL to update it in V8 will be opened.

Node.js changes https://github.com/nodejs/node/commit/176f1c64cc8c77537cdc43cac86bed1e52d4cde1 - Once everything else is done, the change in the main repo is a simple one.

**NOTE:** Depending on the affected upstream projects and their release cycles and updates, we may need to use the patches on our side for some time.

cc @targos @lemire @nodejs/i18n-api

Refs: https://github.com/nodejs/node/issues/52809