### PR TITLE
build: set "clang" in config.gypi in GN build

### DIFF
--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -79,6 +79,7 @@ def translate_config(out_dir, config, v8_config):
     },
     'variables': {
       'asan': bool_string_to_number(config['is_asan']),
+      'clang': bool_to_number(config['is_clang']),
       'enable_lto': config['use_thin_lto'],
       'is_debug': bool_string_to_number(config['is_debug']),
       'llvm_version': 13,


### PR DESCRIPTION
Update the GN build's handling of `config.gypi` to match the behavior in https://github.com/nodejs/node/pull/52873.
