### PR TITLE
doc: deprecate NaN or negative number as delay to setTimeout and setInterval

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3687,21 +3687,6 @@ changes:
 
 Type: Runtime
 
-### DEP0183: Passing `NaN` or a negative number as `delay`
-
-<!-- YAML
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/53005
-    description: Passing `NaN` or a negative number as `delay` is deprecated.
--->
-
-Type: Runtime
-
-Calling `setTimeout` or `setInterval` with `NaN` or a negative number will
-result the process emitting a warning, the warning will only be emitted once per
-process.
-
 Applications that intend to use authentication tags that are shorter than the
 default authentication tag length must set the `authTagLength` option of the
 [`crypto.createDecipheriv()`][] function to the appropriate length.
@@ -3709,6 +3694,21 @@ default authentication tag length must set the `authTagLength` option of the
 For ciphers in GCM mode, the [`decipher.setAuthTag()`][] function accepts
 authentication tags of any valid length (see [DEP0090](#DEP0090)). This behavior
 is deprecated to better align with recommendations per [NIST SP 800-38D][].
+
+### DEP0183: Passing `NaN` or a negative number as `delay` in `node:timers` functions
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53005
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Calling `setTimeout` or `setInterval` with `NaN` or a negative number will
+result the process emitting a warning, the warning will only be emitted once per
+process.
 
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3687,6 +3687,21 @@ changes:
 
 Type: Runtime
 
+### DEP0183: Passing `NaN` or a negative number as `delay`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53005
+    description: Passing `NaN` or a negative number as `delay` is deprecated.
+-->
+
+Type: Runtime
+
+Calling `setTimeout` or `setInterval` with `NaN` or a negative number will
+result the process emitting a warning, the warning will only be emitted once per
+process.
+
 Applications that intend to use authentication tags that are shorter than the
 default authentication tag length must set the `authTagLength` option of the
 [`crypto.createDecipheriv()`][] function to the appropriate length.

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -224,6 +224,10 @@ This method has a custom variant for promises that is available using
 <!-- YAML
 added: v0.0.1
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46678
+    description: Passing `NaN` or negative number as `delay` will result
+                 the process to emit a warning, the warning will only be emitted once per process.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument
@@ -252,6 +256,10 @@ This method has a custom variant for promises that is available using
 <!-- YAML
 added: v0.0.1
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/46678
+    description: Passing `NaN` or negative number as `delay` will result
+                 the process to emit a warning, the warning will only be emitted once per process.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -225,9 +225,8 @@ This method has a custom variant for promises that is available using
 added: v0.0.1
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/46678
-    description: Passing `NaN` or negative number as `delay` will result
-                 the process to emit a warning, the warning will only be emitted once per process.
+    pr-url: https://github.com/nodejs/node/pull/53005
+    description: Passing `NaN` or a negative number as `delay` is deprecated.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument
@@ -257,9 +256,8 @@ This method has a custom variant for promises that is available using
 added: v0.0.1
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/46678
-    description: Passing `NaN` or negative number as `delay` will result
-                 the process to emit a warning, the warning will only be emitted once per process.
+    pr-url: https://github.com/nodejs/node/pull/53005
+    description: Passing `NaN` or a negative number as `delay` is deprecated.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument


### PR DESCRIPTION
This is a `Documentation-only deprecation`, the aim is to encourage developers not using `NaN` or negative number for delay in `setTimeout` and `setInterval`.

This is my first doc-only deprecation PR, please let me know if anything I need to fix 🙏 

Refs: https://github.com/nodejs/node/pull/46678

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
