### PR TITLE
doc: improve ninja build for --built-in-modules-path

### DIFF
--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -7,7 +7,7 @@ doing so can be significantly quicker than using `make`. Please see
 [Ninja][] is supported in the Makefile. Run `./configure --ninja` to configure
 the project to run the regular `make` commands with Ninja.
 
-If you wish to only modify JS layer in `lib`, you can use:
+When modifying only the JS layer in `lib`, you can use:
 
 ```bash
 ./configure --ninja --node-builtin-modules-path "$(pwd)"

--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -7,6 +7,12 @@ doing so can be significantly quicker than using `make`. Please see
 [Ninja][] is supported in the Makefile. Run `./configure --ninja` to configure
 the project to run the regular `make` commands with Ninja.
 
+If you wish to only modify JS layer in `lib`, you can use:
+
+```bash
+./configure --ninja --node-builtin-modules-path "$(pwd)"
+```
+
 For example, `make` will execute `ninja -C out/Release` internally
 to produce a compiled release binary, It will also execute
 `ln -fs out/Release/node node`, so that you can execute `./node` at


### PR DESCRIPTION
The current ninja build does not work with `--node-builtin-modules-path` flag if without passing `--ninja` in, as it will use `make` to build from scratch again.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
