### PR TITLE
module: ensure `format` is never `null`

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -35,7 +35,7 @@ const protocolHandlers = {
 
 /**
  * @param {URL} parsed
- * @returns {string | null}
+ * @returns {string | undefined}
  */
 function getDataProtocolModuleFormat(parsed) {
   const { 1: mime } = RegExpPrototypeExec(
@@ -43,7 +43,7 @@ function getDataProtocolModuleFormat(parsed) {
     parsed.pathname,
   ) || [ null, null, null ];
 
-  return mimeToFormat(mime);
+  return mimeToFormat(mime) ?? undefined;
 }
 
 const DOT_CODE = 46;
@@ -115,7 +115,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
         if (getOptionValue('--experimental-detect-module')) {
           const format = source ?
             (containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs') :
-            null;
+            undefined;
           if (format === 'module') {
             // This module has a .js extension, a package.json with no `type` field, and ESM syntax.
             // Warn about the missing `type` field so that the user can avoid the performance penalty of detection.
@@ -155,7 +155,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
       }
       default: { // The user did not pass `--experimental-default-type`.
         if (getOptionValue('--experimental-detect-module')) {
-          if (!source) { return null; }
+          if (!source) { return undefined; }
           const format = getFormatOfExtensionlessFile(url);
           if (format === 'module') {
             return containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs';
@@ -187,7 +187,7 @@ function getHttpProtocolModuleFormat(url, context) {
     return PromisePrototypeThen(
       PromiseResolve(fetchModule(url, context)),
       (entry) => {
-        return mimeToFormat(entry.headers['content-type']);
+        return mimeToFormat(entry.headers['content-type']) ?? undefined;
       },
     );
   }
@@ -201,7 +201,7 @@ function getHttpProtocolModuleFormat(url, context) {
 function defaultGetFormatWithoutErrors(url, context) {
   const protocol = url.protocol;
   if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
-    return null;
+    return undefined;
   }
   return protocolHandlers[protocol](url, context, true);
 }
@@ -214,7 +214,7 @@ function defaultGetFormatWithoutErrors(url, context) {
 function defaultGetFormat(url, context) {
   const protocol = url.protocol;
   if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
-    return null;
+    return undefined;
   }
   return protocolHandlers[protocol](url, context, false);
 }

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -20,6 +20,7 @@ const defaultType =
 const { Buffer: { from: BufferFrom } } = require('buffer');
 
 const { URL } = require('internal/url');
+const assert = require('internal/assert');
 const {
   ERR_INVALID_URL,
   ERR_UNKNOWN_MODULE_FORMAT,
@@ -128,7 +129,7 @@ async function defaultLoad(url, context = kEmptyObject) {
       context = { __proto__: context, source };
     }
 
-    if (format == null) {
+    if (!format) {
       // Now that we have the source for the module, run `defaultGetFormat` to detect its format.
       format = await defaultGetFormat(urlInstance, context);
 
@@ -146,6 +147,9 @@ async function defaultLoad(url, context = kEmptyObject) {
   if (format === 'commonjs' && getOptionValue('--experimental-require-module')) {
     format = 'commonjs-sync';
   }
+
+  // Format can be a string or undefined, but not null.
+  assert(format !== null, 'format must not be null');
 
   return {
     __proto__: null,

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -129,7 +129,7 @@ async function defaultLoad(url, context = kEmptyObject) {
       context = { __proto__: context, source };
     }
 
-    if (!format) {
+    if (format == null) {
       // Now that we have the source for the module, run `defaultGetFormat` to detect its format.
       format = await defaultGetFormat(urlInstance, context);
 

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -172,7 +172,7 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
       ]);
 
       strictEqual(stderr, '');
-      strictEqual(stdout, 'null\nexecuted\n');
+      strictEqual(stdout, 'undefined\nexecuted\n');
       strictEqual(code, 0);
       strictEqual(signal, null);
 

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -756,7 +756,7 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
           if (u.endsWith('/common/index.js')) {
             r.source = '"use strict";module.exports=require("node:module").createRequire(' +
                      `${JSON.stringify(u)})(${JSON.stringify(fileURLToPath(u))});\n`;
-          } else if (c.format === 'commonjs') {
+          } else if (r.format === 'commonjs') {
             r.source = await readFile(new URL(u));
           }
           return r;

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -756,7 +756,7 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
           if (u.endsWith('/common/index.js')) {
             r.source = '"use strict";module.exports=require("node:module").createRequire(' +
                      `${JSON.stringify(u)})(${JSON.stringify(fileURLToPath(u))});\n`;
-          } else if (r.format === 'commonjs') {
+          } else if (c.format === 'commonjs') {
             r.source = await readFile(new URL(u));
           }
           return r;


### PR DESCRIPTION
This PR ensures that the `format` value for module resolution will always be either a `string` or `undefined`, never `null`. 

Further context for this change can be found on Slack: <https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1715696560302379>. Essentially, returning a `null` value for the `format` property is not documented or expected.

(CC) @GeoffreyBooth 
(CC) @aduh95