### PR TITLE
module: ensure `format` is never `null` with `experimental-detect-module`

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -24,6 +24,8 @@ const { getPackageScopeConfig, getPackageType } = require('internal/modules/pack
 const { fileURLToPath } = require('internal/url');
 const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
 
+const kFormatHasNoSource = Symbol('kFormatHasNoSource');
+
 const protocolHandlers = {
   '__proto__': null,
   'data:': getDataProtocolModuleFormat,
@@ -224,4 +226,5 @@ module.exports = {
   defaultGetFormatWithoutErrors,
   extensionFormatMap,
   extname,
+  kFormatHasNoSource,
 };

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -141,7 +141,9 @@ async function defaultLoad(url, context = kEmptyObject) {
   }
 
   validateAttributes(url, format, importAttributes);
-
+  if (format == null && getOptionValue('--experimental-detect-module')) {
+    format = 'commonjs';
+  }
   // Use the synchronous commonjs translator which can deal with cycles.
   if (format === 'commonjs' && getOptionValue('--experimental-require-module')) {
     format = 'commonjs-sync';
@@ -195,6 +197,9 @@ function defaultLoadSync(url, context = kEmptyObject) {
   format ??= defaultGetFormat(urlInstance, context);
 
   validateAttributes(url, format, importAttributes);
+  if (format == null && getOptionValue('--experimental-detect-module')) {
+    format = 'commonjs';
+  }
 
   // Use the synchronous commonjs translator which can deal with cycles.
   if (format === 'commonjs' && getOptionValue('--experimental-require-module')) {

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -7,7 +7,7 @@ const {
 } = primordials;
 const { kEmptyObject } = require('internal/util');
 
-const { defaultGetFormat } = require('internal/modules/esm/get_format');
+const { defaultGetFormat, kFormatHasNoSource } = require('internal/modules/esm/get_format');
 const { validateAttributes, emitImportAssertionWarning } = require('internal/modules/esm/assert');
 const { getOptionValue } = require('internal/options');
 const { readFileSync } = require('fs');
@@ -141,7 +141,7 @@ async function defaultLoad(url, context = kEmptyObject) {
   }
 
   validateAttributes(url, format, importAttributes);
-  if (format == null && getOptionValue('--experimental-detect-module')) {
+  if (format === kFormatHasNoSource) {
     format = 'commonjs';
   }
   // Use the synchronous commonjs translator which can deal with cycles.
@@ -197,7 +197,7 @@ function defaultLoadSync(url, context = kEmptyObject) {
   format ??= defaultGetFormat(urlInstance, context);
 
   validateAttributes(url, format, importAttributes);
-  if (format == null && getOptionValue('--experimental-detect-module')) {
+  if (format === kFormatHasNoSource) {
     format = 'commonjs';
   }
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -110,7 +110,7 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   std::vector<std::string> conditions;
-  bool detect_module = false;
+  bool detect_module = true;
   bool print_required_tla = false;
   bool require_module = false;
   std::string dns_result_order;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -110,7 +110,7 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   std::vector<std::string> conditions;
-  bool detect_module = true;
+  bool detect_module = false;
   bool print_required_tla = false;
   bool require_module = false;
   std::string dns_result_order;


### PR DESCRIPTION
This change ensures that the format is consistently defined when `experimental-detect-module` is enabled, allowing tests to pass in both experimental detection and standard Node environments.

(Fourth PR is the charm)