### PR TITLE
module: prevent `format` from being set to `null` internaly

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -474,11 +474,6 @@ register('./path-to-my-hooks.js', {
 <!-- YAML
 changes:
   - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/53015
-    description: The property `context.format` will no longer return `null`
-                 in place of `undefined`.
-  - version:
     - v21.0.0
     - v20.10.0
     - v18.19.0
@@ -514,7 +509,7 @@ changes:
   * `specifier` {string}
   * `context` {Object}
 * Returns: {Object|Promise}
-  * `format` {string|undefined} A hint to the load hook (it might be
+  * `format` {string|null|undefined} A hint to the load hook (it might be
     ignored)
     `'builtin' | 'commonjs' | 'json' | 'module' | 'wasm'`
   * `importAttributes` {Object|undefined} The import attributes to use when
@@ -584,11 +579,6 @@ export async function resolve(specifier, context, nextResolve) {
 
 <!-- YAML
 changes:
-  - version:
-    - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/53015
-    description: The property `context.format` will no longer return `null`
-                 in place of `undefined`.
   - version: v20.6.0
     pr-url: https://github.com/nodejs/node/pull/47999
     description: Add support for `source` with format `commonjs`.
@@ -606,7 +596,7 @@ changes:
 * `url` {string} The URL returned by the `resolve` chain
 * `context` {Object}
   * `conditions` {string\[]} Export conditions of the relevant `package.json`
-  * `format` {string|undefined} The format optionally supplied by the
+  * `format` {string|null|undefined} The format optionally supplied by the
     `resolve` hook chain
   * `importAttributes` {Object}
 * `nextLoad` {Function} The subsequent `load` hook in the chain, or the

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -474,6 +474,11 @@ register('./path-to-my-hooks.js', {
 <!-- YAML
 changes:
   - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53015
+    description: The property `context.format` will no longer return `null`
+                 in place of `undefined`.
+  - version:
     - v21.0.0
     - v20.10.0
     - v18.19.0
@@ -509,7 +514,7 @@ changes:
   * `specifier` {string}
   * `context` {Object}
 * Returns: {Object|Promise}
-  * `format` {string|null|undefined} A hint to the load hook (it might be
+  * `format` {string|undefined} A hint to the load hook (it might be
     ignored)
     `'builtin' | 'commonjs' | 'json' | 'module' | 'wasm'`
   * `importAttributes` {Object|undefined} The import attributes to use when
@@ -579,6 +584,11 @@ export async function resolve(specifier, context, nextResolve) {
 
 <!-- YAML
 changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53015
+    description: The property `context.format` will no longer return `null`
+                 in place of `undefined`.
   - version: v20.6.0
     pr-url: https://github.com/nodejs/node/pull/47999
     description: Add support for `source` with format `commonjs`.
@@ -596,7 +606,7 @@ changes:
 * `url` {string} The URL returned by the `resolve` chain
 * `context` {Object}
   * `conditions` {string\[]} Export conditions of the relevant `package.json`
-  * `format` {string|null|undefined} The format optionally supplied by the
+  * `format` {string|undefined} The format optionally supplied by the
     `resolve` hook chain
   * `importAttributes` {Object}
 * `nextLoad` {Function} The subsequent `load` hook in the chain, or the

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -26,7 +26,7 @@ if (experimentalWasmModules) {
 
 /**
  * @param {string} mime
- * @returns {string | null}
+ * @returns {string | undefined}
  */
 function mimeToFormat(mime) {
   if (
@@ -37,6 +37,7 @@ function mimeToFormat(mime) {
   ) { return 'module'; }
   if (mime === 'application/json') { return 'json'; }
   if (experimentalWasmModules && mime === 'application/wasm') { return 'wasm'; }
+  return undefined;
 }
 
 /**

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -37,7 +37,6 @@ function mimeToFormat(mime) {
   ) { return 'module'; }
   if (mime === 'application/json') { return 'json'; }
   if (experimentalWasmModules && mime === 'application/wasm') { return 'wasm'; }
-  return;
 }
 
 /**

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -37,7 +37,7 @@ function mimeToFormat(mime) {
   ) { return 'module'; }
   if (mime === 'application/json') { return 'json'; }
   if (experimentalWasmModules && mime === 'application/wasm') { return 'wasm'; }
-  return null;
+  return;
 }
 
 /**

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -35,7 +35,7 @@ const protocolHandlers = {
 
 /**
  * @param {URL} parsed
- * @returns {string | null}
+ * @returns {string | undefined}
  */
 function getDataProtocolModuleFormat(parsed) {
   const { 1: mime } = RegExpPrototypeExec(
@@ -115,7 +115,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
         if (getOptionValue('--experimental-detect-module')) {
           const format = source ?
             (containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs') :
-            null;
+            undefined;
           if (format === 'module') {
             // This module has a .js extension, a package.json with no `type` field, and ESM syntax.
             // Warn about the missing `type` field so that the user can avoid the performance penalty of detection.
@@ -155,7 +155,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
       }
       default: { // The user did not pass `--experimental-default-type`.
         if (getOptionValue('--experimental-detect-module')) {
-          if (!source) { return null; }
+          if (!source) { return; }
           const format = getFormatOfExtensionlessFile(url);
           if (format === 'module') {
             return containsModuleSyntax(`${source}`, fileURLToPath(url), url) ? 'module' : 'commonjs';
@@ -201,7 +201,7 @@ function getHttpProtocolModuleFormat(url, context) {
 function defaultGetFormatWithoutErrors(url, context) {
   const protocol = url.protocol;
   if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
-    return null;
+    return;
   }
   return protocolHandlers[protocol](url, context, true);
 }
@@ -214,7 +214,7 @@ function defaultGetFormatWithoutErrors(url, context) {
 function defaultGetFormat(url, context) {
   const protocol = url.protocol;
   if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
-    return null;
+    return;
   }
   return protocolHandlers[protocol](url, context, false);
 }

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -172,7 +172,7 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
       ]);
 
       strictEqual(stderr, '');
-      strictEqual(stdout, 'null\nexecuted\n');
+      strictEqual(stdout, 'undefined\nexecuted\n');
       strictEqual(code, 0);
       strictEqual(signal, null);
 


### PR DESCRIPTION
With all the changes and backtraces my PR's have caused regarding changes similar to this, @GeoffreyBooth and I agreed that preventing `format` from being set to `null` internaly would at least be a step in the right direction.