### PR TITLE
tools: move webcrypto into no-restricted-properties

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,6 @@ import toolsConfig from './tools/eslint.config_partial.mjs';
 import {
   noRestrictedSyntaxCommonAll,
   noRestrictedSyntaxCommonLib,
-  noRestrictedSyntaxCommonTest,
   requireEslintTool,
   resolveEslintTool,
 } from './tools/eslint.config_utils.mjs';
@@ -191,12 +190,15 @@ export default [
           property: '__defineSetter__',
           message: '__defineSetter__ is deprecated.',
         },
+        {
+          property: 'webcrypto',
+          message: 'Use `globalThis.crypto`.',
+        },
       ],
       'no-restricted-syntax': [
         'error',
         ...noRestrictedSyntaxCommonAll,
         ...noRestrictedSyntaxCommonLib,
-        ...noRestrictedSyntaxCommonTest,
       ],
       'no-self-compare': 'error',
       'no-template-curly-in-string': 'error',

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -2,7 +2,6 @@
 
 import {
   noRestrictedSyntaxCommonAll,
-  noRestrictedSyntaxCommonTest,
   requireEslintTool,
 } from '../tools/eslint.config_utils.mjs';
 
@@ -26,7 +25,6 @@ export default [
       'no-restricted-syntax': [
         'error',
         ...noRestrictedSyntaxCommonAll,
-        ...noRestrictedSyntaxCommonTest,
         {
           selector: "CallExpression:matches([callee.name='deepStrictEqual'], [callee.property.name='deepStrictEqual']):matches([arguments.1.type='Literal']:not([arguments.1.regex]), [arguments.1.type='Identifier'][arguments.1.name='undefined'])",
           message: 'Use strictEqual instead of deepStrictEqual for literals or undefined.',

--- a/test/parallel/test-global-webcrypto-classes.js
+++ b/test/parallel/test-global-webcrypto-classes.js
@@ -7,7 +7,6 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 
-/* eslint-disable no-restricted-syntax */
 const webcrypto = require('internal/crypto/webcrypto');
 assert.strictEqual(Crypto, webcrypto.Crypto);
 assert.strictEqual(CryptoKey, webcrypto.CryptoKey);

--- a/test/parallel/test-global-webcrypto.js
+++ b/test/parallel/test-global-webcrypto.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-restricted-properties */
 assert.strictEqual(globalThis.crypto, crypto.webcrypto);
 assert.strictEqual(Crypto, crypto.webcrypto.constructor);
 assert.strictEqual(SubtleCrypto, crypto.webcrypto.subtle.constructor);

--- a/tools/eslint.config_utils.mjs
+++ b/tools/eslint.config_utils.mjs
@@ -24,12 +24,3 @@ export const noRestrictedSyntaxCommonLib = [
     message: '`setTimeout()` must be invoked with at least two arguments.',
   },
 ];
-
-export const noRestrictedSyntaxCommonTest = [
-  {
-    // TODO(@panva): move this to no-restricted-properties
-    // when https://github.com/eslint/eslint/issues/16412 is fixed.
-    selector: "Identifier[name='webcrypto']",
-    message: 'Use `globalThis.crypto`.',
-  },
-];


### PR DESCRIPTION
Since `eslint` fixed https://github.com/eslint/eslint/issues/16412 in `v8.56.0` [here](https://github.com/eslint/eslint/releases/tag/v8.56.0) and we are on `eslint` `v8.57.0` so that we can take advantage of `no-restricted-properties` rule for `webcrypto`.

This is my first pull request to node.js. Please let me know if there is anything to fix.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
