### PR TITLE
build: support `lint-md-fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1364,6 +1364,11 @@ tools/.mdlintstamp: $(LINT_MD_FILES)
 # Lints the markdown documents maintained by us in the codebase.
 lint-md: lint-js-doc | tools/.mdlintstamp
 
+.PHONY: lint-md-fix
+# Fixes the markdown documents maintained by us in the codebase.
+lint-md-fix: lint-js-doc
+	@$(call available-node,$(run-lint-md) --fix)
+
 run-format-md = tools/lint-md/lint-md.mjs --format $(LINT_MD_FILES)
 .PHONY: format-md
 # Formats the markdown documents maintained by us in the codebase.

--- a/tools/lint-md/lint-md.src.mjs
+++ b/tools/lint-md/lint-md.src.mjs
@@ -16,7 +16,7 @@ if (!paths.length) {
 
 let format = false;
 const formatFlags = ['--fix', '--format'];
-if (formatFlags.includes(paths[0]) {
+if (formatFlags.includes(paths[0])) {
   paths.shift();
   format = true;
 }

--- a/tools/lint-md/lint-md.src.mjs
+++ b/tools/lint-md/lint-md.src.mjs
@@ -15,8 +15,8 @@ if (!paths.length) {
 }
 
 let format = false;
-
-if (paths[0] === '--format') {
+const formatFlags = ['--fix', '--format'];
+if (formatFlags.includes(paths[0]) {
   paths.shift();
   format = true;
 }


### PR DESCRIPTION
Similar to `lint-js-fix`, this PR adds submit for `lint-md-fix`, which supplies the `--fix` CLI argument to the Markdown linter.