### PR TITLE
crypto: move Hmac and Hash constructor to eol

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1762,8 +1762,7 @@ be used in one of two ways:
 * Using the [`hmac.update()`][] and [`hmac.digest()`][] methods to produce the
   computed HMAC digest.
 
-The [`crypto.createHmac()`][] method is used to create `Hmac` instances. `Hmac`
-objects are not to be created directly using the `new` keyword.
+The [`crypto.createHmac()`][] method is used to create `Hmac` instances.
 
 Example: Using `Hmac` objects as streams:
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3622,6 +3622,9 @@ release lines. Please use [`dirent.parentPath`][] instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53026
+    description: End-of-Life deprecation.
   - version: v22.0.0
     pr-url: https://github.com/nodejs/node/pull/51880
     description: Runtime deprecation.
@@ -3632,10 +3635,10 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-Calling `Hash` class directly with `Hash()` or `new Hash()` is
-deprecated due to being internals, not intended for public use.
+Calling `Hash` class directly with `Hash()` or `new Hash()` has
+been removed due to being internals, not intended for public use.
 Please use the [`crypto.createHash()`][] method to create Hash instances.
 
 ### DEP0180: `fs.Stats` constructor

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3659,6 +3659,9 @@ deprecated due to being internals, not intended for public use.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53026
+    description: End-of-Life deprecation.
   - version: v22.0.0
     pr-url: https://github.com/nodejs/node/pull/52071
     description: Runtime deprecation.
@@ -3667,10 +3670,10 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-Calling `Hmac` class directly with `Hmac()` or `new Hmac()` is
-deprecated due to being internals, not intended for public use.
+Calling `Hmac` class directly with `Hmac()` or `new Hmac()` has been
+removed due to being internals, not intended for public use.
 Please use the [`crypto.createHmac()`][] method to create Hmac instances.
 
 ### DEP0182: Short GCM authentication tags without explicit `authTagLength`

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -232,7 +232,6 @@ module.exports = {
   DiffieHellmanGroup,
   ECDH,
   Hash: deprecate(Hash, 'crypto.Hash constructor is deprecated.', 'DEP0179'),
-  Hmac: deprecate(Hmac, 'crypto.Hmac constructor is deprecated.', 'DEP0181'),
   KeyObject,
   Sign,
   Verify,

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -231,7 +231,6 @@ module.exports = {
   DiffieHellman,
   DiffieHellmanGroup,
   ECDH,
-  Hash: deprecate(Hash, 'crypto.Hash constructor is deprecated.', 'DEP0179'),
   KeyObject,
   Sign,
   Verify,

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -10,7 +10,6 @@ const crypto = require('crypto');
 
 // 'ClassName' : ['args', 'for', 'constructor']
 const TEST_CASES = {
-  'Hash': ['sha1'],
   'Cipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
   'Decipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
   'Sign': ['RSA-SHA1'],

--- a/test/parallel/test-crypto-classes.js
+++ b/test/parallel/test-crypto-classes.js
@@ -11,7 +11,6 @@ const crypto = require('crypto');
 // 'ClassName' : ['args', 'for', 'constructor']
 const TEST_CASES = {
   'Hash': ['sha1'],
-  'Hmac': ['sha1', 'Node'],
   'Cipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
   'Decipheriv': ['des-ede3-cbc', '0123456789abcd0123456789', '12345678'],
   'Sign': ['RSA-SHA1'],

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -173,13 +173,6 @@ assert.throws(
   }
 );
 
-{
-  const Hash = crypto.Hash;
-  const instance = crypto.Hash('sha256');
-  assert(instance instanceof Hash, 'Hash is expected to return a new instance' +
-                                   ' when called without `new`');
-}
-
 // Test XOF hash functions and the outputLength option.
 {
   // Default outputLengths.
@@ -278,11 +271,6 @@ assert.throws(
 }
 
 {
-  crypto.Hash('sha256');
-  common.expectWarning({
-    DeprecationWarning: [
-      ['crypto.Hash constructor is deprecated.',
-       'DEP0179'],
-    ]
-  });
+  // the Hash class should not be exposed
+  assert.strictEqual('Hash' in crypto, false);
 }

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -6,13 +6,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
-{
-  const Hmac = crypto.Hmac;
-  const instance = crypto.Hmac('sha256', 'Node');
-  assert(instance instanceof Hmac, 'Hmac is expected to return a new instance' +
-                                   ' when called without `new`');
-}
-
 assert.throws(
   () => crypto.createHmac(null),
   {
@@ -461,11 +454,6 @@ assert.strictEqual(
 }
 
 {
-  crypto.Hmac('sha256', 'Node');
-  common.expectWarning({
-    DeprecationWarning: [
-      ['crypto.Hmac constructor is deprecated.',
-       'DEP0181'],
-    ]
-  });
+  // the Hmac class is not exposed
+  assert.strictEqual('Hmac' in crypto, false);
 }


### PR DESCRIPTION
Removes the public constructor of `Hash` and `Hmac`