### PR TITLE
cli: add `NODE_RUN_SCRIPT_NAME` env to `node --run`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1847,6 +1847,10 @@ Modules preloaded with `--require` will run before modules preloaded with `--imp
 
 <!-- YAML
 added: v22.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53032
+    description: NODE_RUN_SCRIPT_NAME environment variable is added.
 -->
 
 > Stability: 1.1 - Active development
@@ -1886,6 +1890,13 @@ are:
   current folder.
 * Running `pre` or `post` scripts in addition to the specified script.
 * Defining package manager-specific environment variables.
+
+#### Environment variables
+
+The following environment variables are set when running a script with `--run`:
+
+* `NODE_RUN_SCRIPT_NAME`: The name of the script being run. For example, if
+  `--run` is used to run `test`, the value of this variable will be `test`.
 
 ### `--secure-heap=n`
 

--- a/src/node_task_runner.h
+++ b/src/node_task_runner.h
@@ -23,6 +23,7 @@ using PositionalArgs = std::vector<std::string_view>;
 class ProcessRunner {
  public:
   ProcessRunner(std::shared_ptr<InitializationResultImpl> result,
+                const std::string& script_name,
                 std::string_view command_id,
                 const PositionalArgs& positional_args);
   void Run();
@@ -43,6 +44,8 @@ class ProcessRunner {
 
   // OnExit is the callback function that is called when the process exits.
   void OnExit(int64_t exit_status, int term_signal);
+  void SetEnvironmentVariables(const std::string& bin_path,
+                               const std::string& script_name);
 
 #ifdef _WIN32
   std::string file_ = "cmd.exe";

--- a/test/fixtures/run-script/node_modules/.bin/special-env-variables
+++ b/test/fixtures/run-script/node_modules/.bin/special-env-variables
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "$NODE_RUN_SCRIPT_NAME"

--- a/test/fixtures/run-script/node_modules/.bin/special-env-variables.bat
+++ b/test/fixtures/run-script/node_modules/.bin/special-env-variables.bat
@@ -1,0 +1,2 @@
+@shift
+echo %NODE_RUN_SCRIPT_NAME%

--- a/test/fixtures/run-script/package.json
+++ b/test/fixtures/run-script/package.json
@@ -8,6 +8,8 @@
     "custom-env": "custom-env",
     "custom-env-windows": "custom-env.bat",
     "path-env": "path-env",
-    "path-env-windows": "path-env.bat"
+    "path-env-windows": "path-env.bat",
+    "special-env-variables": "special-env-variables",
+    "special-env-variables-windows": "special-env-variables.bat"
   }
 }

--- a/test/message/node_run_non_existent.out
+++ b/test/message/node_run_non_existent.out
@@ -10,3 +10,5 @@ Available scripts are:
   custom-env-windows: custom-env.bat
   path-env: path-env
   path-env-windows: path-env.bat
+  special-env-variables: special-env-variables
+  special-env-variables-windows: special-env-variables.bat

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -80,4 +80,16 @@ describe('node run [command]', () => {
     assert.strictEqual(child.stderr, '');
     assert.strictEqual(child.code, 0);
   });
+
+  it('should set special environment variables', async () => {
+    const scriptName = `special-env-variables${envSuffix}`;
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--no-warnings', '--run', scriptName],
+      { cwd: fixtures.path('run-script') },
+    );
+    assert.ok(child.stdout.includes(scriptName));
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
 });


### PR DESCRIPTION
Adds the `NODE_RUN_SCRIPT_NAME ` to share name of the event that's run while executing `node --run`. For example, if the developer runs `node --run yagiz`, `NODE_RUN_SCRIPT_NAME ` will be `yagiz`

This PR also includes a small refactor. I moved setting environment variables into `SetEnvironmentVariables` private function to improve readability.

Ref: https://github.com/nodejs/node/issues/52673

cc @nodejs/cpp-reviewers 