### PR TITLE
worker: do not ingore `unref` when called in `parentPort`

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -226,6 +226,9 @@ function setupPortReferencing(port, eventEmitter, eventName) {
       port.ref();
       FunctionPrototypeCall(MessagePortPrototype.start, port);
     }
+
+    // Refs: https://github.com/nodejs/node/issues/53036
+    if (!port.hasRef()) port.unref();
   }
 
   function removeListener(size) {

--- a/test/parallel/test-worker-unref-parentport.js
+++ b/test/parallel/test-worker-unref-parentport.js
@@ -1,0 +1,17 @@
+'use strict';
+const common = require('../common');
+const { Worker } = require('worker_threads');
+
+// This test checks that calling unref() on a Worker will unrefs even future
+// listeners on the messagePort.
+// Refs: https://github.com/nodejs/node/issues/53036
+const w = new Worker(`
+const { parentPort } = require('worker_threads');
+parentPort.on('message', (msg) => {
+  parentPort.postMessage(msg);
+});
+`, { eval: true });
+
+w.on('message', common.mustNotCall());
+w.unref();
+w.on('message', common.mustNotCall());


### PR DESCRIPTION
This patch will keep unref in the `parentPort` handle when the worker un unref-ed. After this lands, it does not matter if the worker receives more listeners after `unref`, once unref-ed, will be keep it as it is.

Fixes: https://github.com/nodejs/node/issues/53036

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
