### PR TITLE
build: use broader detection for 'help'

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -4,14 +4,9 @@
 :: explicitly allow them to persist in the calling shell.
 endlocal
 
-if /i "%1"=="help" goto help
-if /i "%1"=="--help" goto help
-if /i "%1"=="-help" goto help
-if /i "%1"=="/help" goto help
-if /i "%1"=="?" goto help
-if /i "%1"=="-?" goto help
-if /i "%1"=="--?" goto help
-if /i "%1"=="/?" goto help
+set "arg=%1"
+if /i "%arg:~-1%"=="?" goto help
+if /i "%arg%"=="help" goto help
 
 cd %~dp0
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -6,7 +6,7 @@ endlocal
 
 set "arg=%1"
 if /i "%arg:~-1%"=="?" goto help
-if /i "%arg%"=="help" goto help
+if /i "%arg:~-4%"=="help" goto help
 
 cd %~dp0
 


### PR DESCRIPTION
This PR updates the `vcbuild.bat` to use a broader way to detect help/?