### PR TITLE
test: use python3 instead of python in pummel test

### DIFF
--- a/test/pummel/test-child-process-spawn-loop.js
+++ b/test/pummel/test-child-process-spawn-loop.js
@@ -24,7 +24,7 @@ const common = require('../common');
 const assert = require('assert');
 
 const spawn = require('child_process').spawn;
-const python = process.env.PYTHON || 'python';
+const python = process.env.PYTHON || (common.isWindows ? 'python' : 'python3');
 
 const SIZE = 1000 * 1024;
 const N = 40;


### PR DESCRIPTION
Just a small test change I found myself floating on main:

As f9bfe785ee4 already did for a regular test, replace `python` with `python3` in the only `pummel` test spawning it so that it can be run on platforms that don't provide a `python` binary anymore, like modern macOS or some Linux distributions (e.g. Fedora) without specifying a `PYTHON` env var.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
