### PR TITLE
cli: add `NODE_RUN_PACKAGE_JSON_PATH` env

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1861,6 +1861,9 @@ changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/53032
     description: NODE_RUN_SCRIPT_NAME environment variable is added.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53058
+    description: NODE_RUN_PACKAGE_JSON_PATH environment variable is added.
 -->
 
 > Stability: 1.1 - Active development
@@ -1907,6 +1910,8 @@ The following environment variables are set when running a script with `--run`:
 
 * `NODE_RUN_SCRIPT_NAME`: The name of the script being run. For example, if
   `--run` is used to run `test`, the value of this variable will be `test`.
+* `NODE_RUN_PACKAGE_JSON_PATH`: The path to the `package.json` that is being
+  processed.
 
 ### `--secure-heap=n`
 

--- a/src/node_task_runner.h
+++ b/src/node_task_runner.h
@@ -23,7 +23,8 @@ using PositionalArgs = std::vector<std::string_view>;
 class ProcessRunner {
  public:
   ProcessRunner(std::shared_ptr<InitializationResultImpl> result,
-                const std::string& script_name,
+                std::string_view package_json_path,
+                std::string_view script_name,
                 std::string_view command_id,
                 const PositionalArgs& positional_args);
   void Run();
@@ -45,7 +46,9 @@ class ProcessRunner {
   // OnExit is the callback function that is called when the process exits.
   void OnExit(int64_t exit_status, int term_signal);
   void SetEnvironmentVariables(const std::string& bin_path,
-                               const std::string& script_name);
+                               std::string_view cwd,
+                               std::string_view package_json_path,
+                               std::string_view script_name);
 
 #ifdef _WIN32
   std::string file_ = "cmd.exe";

--- a/test/fixtures/run-script/node_modules/.bin/special-env-variables
+++ b/test/fixtures/run-script/node_modules/.bin/special-env-variables
@@ -1,2 +1,3 @@
 #!/bin/sh
 echo "$NODE_RUN_SCRIPT_NAME"
+echo "$NODE_RUN_PACKAGE_JSON_PATH"

--- a/test/fixtures/run-script/node_modules/.bin/special-env-variables.bat
+++ b/test/fixtures/run-script/node_modules/.bin/special-env-variables.bat
@@ -1,2 +1,3 @@
 @shift
 echo %NODE_RUN_SCRIPT_NAME%
+echo %NODE_RUN_PACKAGE_JSON_PATH%

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -83,12 +83,14 @@ describe('node run [command]', () => {
 
   it('should set special environment variables', async () => {
     const scriptName = `special-env-variables${envSuffix}`;
+    const packageJsonPath = fixtures.path('run-script/package.json');
     const child = await common.spawnPromisified(
       process.execPath,
       [ '--no-warnings', '--run', scriptName],
       { cwd: fixtures.path('run-script') },
     );
     assert.ok(child.stdout.includes(scriptName));
+    assert.ok(child.stdout.includes(packageJsonPath));
     assert.strictEqual(child.stderr, '');
     assert.strictEqual(child.code, 0);
   });


### PR DESCRIPTION
This change adds a `NODE_RUN_PACKAGE_JSON_PATH` environment variable when it's executed with `node --run`. This is required for cli runners to know the context of the task they are running. More information can be found in the reference issue.

Ref: https://github.com/nodejs/node/issues/52673

cc @nodejs/cpp-reviewers 