### PR TITLE
src: add `--env-file-if-exists` flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -828,6 +828,8 @@ in the file, the value from the environment takes precedence.
 You can pass multiple `--env-file` arguments. Subsequent files override
 pre-existing variables defined in previous files.
 
+An error is thrown if the file does not exist.
+
 ```bash
 node --env-file=.env --env-file=.development.env index.js
 ```
@@ -866,6 +868,9 @@ Export keyword before a key is ignored:
 ```text
 export USERNAME="nodejs" # will result in `nodejs` as the value.
 ```
+
+If you want to load environment variables from a file that may not exist, you
+can use the [`--env-file-if-exists`][] flag instead.
 
 ### `-e`, `--eval "script"`
 
@@ -1760,6 +1765,15 @@ The location of the default OpenSSL configuration file depends on how OpenSSL
 is being linked to Node.js. Sharing the OpenSSL configuration may have unwanted
 implications and it is recommended to use a configuration section specific to
 Node.js which is `nodejs_conf` and is default when this option is not used.
+
+### `--env-file-if-exists=config`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Behavior is the same as [`--env-file`][], but an error is not thrown if the file
+does not exist.
 
 ### `--pending-deprecation`
 
@@ -3548,6 +3562,8 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--build-snapshot`]: #--build-snapshot
 [`--cpu-prof-dir`]: #--cpu-prof-dir
 [`--diagnostic-dir`]: #--diagnostic-dirdirectory
+[`--env-file-if-exists`]: #--env-file-if-existsconfig
+[`--env-file`]: #--env-fileconfig
 [`--experimental-default-type=module`]: #--experimental-default-typetype
 [`--experimental-sea-config`]: single-executable-applications.md#generating-single-executable-preparation-blobs
 [`--experimental-strip-types`]: #--experimental-strip-types

--- a/src/node.cc
+++ b/src/node.cc
@@ -854,20 +854,26 @@ static ExitCode InitializeNodeWithArgsInternal(
   HandleEnvOptions(per_process::cli_options->per_isolate->per_env);
 
   std::string node_options;
-  auto file_paths = node::Dotenv::GetPathFromArgs(*argv);
+  auto env_files = node::Dotenv::GetDataFromArgs(*argv);
 
-  if (!file_paths.empty()) {
+  if (!env_files.empty()) {
     CHECK(!per_process::v8_initialized);
 
-    for (const auto& file_path : file_paths) {
-      switch (per_process::dotenv_file.ParsePath(file_path)) {
+    for (const auto& file_data : env_files) {
+      switch (per_process::dotenv_file.ParsePath(file_data.path)) {
         case Dotenv::ParseResult::Valid:
           break;
         case Dotenv::ParseResult::InvalidContent:
-          errors->push_back(file_path + ": invalid format");
+          errors->push_back(file_data.path + ": invalid format");
           break;
         case Dotenv::ParseResult::FileError:
-          errors->push_back(file_path + ": not found");
+          if (file_data.is_optional) {
+            fprintf(stderr,
+                    "%s not found. Continuing without it.\n",
+                    file_data.path.c_str());
+            continue;
+          }
+          errors->push_back(file_data.path + ": not found");
           break;
         default:
           UNREACHABLE();

--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -13,6 +13,10 @@ namespace node {
 class Dotenv {
  public:
   enum ParseResult { Valid, FileError, InvalidContent };
+  struct env_file_data {
+    std::string path;
+    bool is_optional;
+  };
 
   Dotenv() = default;
   Dotenv(const Dotenv& d) = delete;
@@ -27,7 +31,7 @@ class Dotenv {
   void SetEnvironment(Environment* env);
   v8::Local<v8::Object> ToObject(Environment* env) const;
 
-  static std::vector<std::string> GetPathFromArgs(
+  static std::vector<env_file_data> GetDataFromArgs(
       const std::vector<std::string>& args);
 
  private:

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -640,6 +640,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "set environment variables from supplied file",
             &EnvironmentOptions::env_file);
   Implies("--env-file", "[has_env_file_string]");
+  AddOption("--env-file-if-exists",
+            "set environment variables from supplied file",
+            &EnvironmentOptions::optional_env_file);
+  Implies("--env-file-if-exists", "[has_env_file_string]");
   AddOption("--test",
             "launch test runner on startup",
             &EnvironmentOptions::test_runner);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -177,6 +177,7 @@ class EnvironmentOptions : public Options {
   std::string redirect_warnings;
   std::string diagnostic_dir;
   std::string env_file;
+  std::string optional_env_file;
   bool has_env_file_string = false;
   bool test_runner = false;
   uint64_t test_runner_concurrency = 0;

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -10,21 +10,31 @@ const validEnvFilePath = '../fixtures/dotenv/valid.env';
 const nodeOptionsEnvFilePath = '../fixtures/dotenv/node-options.env';
 
 describe('.env supports edge cases', () => {
-
-  it('supports multiple declarations', async () => {
-    // process.env.BASIC is equal to `basic` because the second .env file overrides it.
+  it('supports multiple declarations, including optional ones', async () => {
     const code = `
       const assert = require('assert');
       assert.strictEqual(process.env.BASIC, 'basic');
       assert.strictEqual(process.env.NODE_NO_WARNINGS, '1');
     `.trim();
-    const child = await common.spawnPromisified(
-      process.execPath,
-      [ `--env-file=${nodeOptionsEnvFilePath}`, `--env-file=${validEnvFilePath}`, '--eval', code ],
-      { cwd: __dirname },
-    );
-    assert.strictEqual(child.stderr, '');
-    assert.strictEqual(child.code, 0);
+    const children = await Promise.all(Array.from({ length: 4 }, (_, i) =>
+      common.spawnPromisified(
+        process.execPath,
+        [
+          // Bitwise AND to create all 4 possible combinations:
+          // i & 0b01 is truthy when i has value 0bx1 (i.e. 0b01 (1) and 0b11 (3)), falsy otherwise.
+          // i & 0b10 is truthy when i has value 0b1x (i.e. 0b10 (2) and 0b11 (3)), falsy otherwise.
+          `${i & 0b01 ? '--env-file' : '--env-file-if-exists'}=${nodeOptionsEnvFilePath}`,
+          `${i & 0b10 ? '--env-file' : '--env-file-if-exists'}=${validEnvFilePath}`,
+          '--eval', code,
+        ],
+        { cwd: __dirname },
+      )));
+    assert.deepStrictEqual(children, Array.from({ length: 4 }, () => ({
+      code: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+    })));
   });
 
   it('supports absolute paths', async () => {
@@ -39,6 +49,19 @@ describe('.env supports edge cases', () => {
     assert.strictEqual(child.code, 0);
   });
 
+  it('supports a space instead of \'=\' for the flag ', async () => {
+    const code = `
+      require('assert').strictEqual(process.env.BASIC, 'basic');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--env-file', validEnvFilePath, '--eval', code ],
+      { cwd: __dirname },
+    );
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
   it('should handle non-existent .env file', async () => {
     const code = `
       require('assert').strictEqual(1, 1)
@@ -48,8 +71,21 @@ describe('.env supports edge cases', () => {
       [ '--env-file=.env', '--eval', code ],
       { cwd: __dirname },
     );
-    assert.notStrictEqual(child.stderr.toString(), '');
+    assert.notStrictEqual(child.stderr, '');
     assert.strictEqual(child.code, 9);
+  });
+
+  it('should handle non-existent optional .env file', async () => {
+    const code = `
+      require('assert').strictEqual(1,1);
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      ['--env-file-if-exists=.env', '--eval', code],
+      { cwd: __dirname },
+    );
+    assert.notStrictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
   });
 
   it('should not override existing environment variables but introduce new vars', async () => {
@@ -106,7 +142,7 @@ describe('.env supports edge cases', () => {
         '--eval', `require('assert').strictEqual(process.env.BASIC, undefined);`,
         '--', '--env-file', validEnvFilePath,
       ],
-      { cwd: fixtures.path('dotenv') },
+      { cwd: __dirname },
     );
     assert.strictEqual(child.stdout, '');
     assert.strictEqual(child.stderr, '');


### PR DESCRIPTION
Add a new flag, `--env-file-if-exists` that allows loading .env files without throwing an error if they don't exist.

Achieved by returning an `env_file_data` struct instead of just the paths of the .env files. This tells the loader if the file itself is required or not, thus allowing to not throw an error if the file doesn't exist and is optional, without breaking existing behaviours with `--env-file` (we could maybe show a warning if an optional file is missing?).

Usage:

```
node --env-file A.env --env-file-if-exists B.env
``` 
If `B.env` exists, it will load its environment variables and overwrite those that conflict with `A.env`. If it doesn't, node will continue as normal.

Fixes: https://github.com/nodejs/node/issues/50993
Refs: https://github.com/nodejs/node/issues/51451

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
