### PR TITLE
fs: remove basename in favor of std::filesystem

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -1,5 +1,6 @@
 #include <cerrno>
 #include <cstdarg>
+#include <filesystem>
 #include <sstream>
 
 #include "debug_utils-inl.h"
@@ -538,10 +539,11 @@ static void ReportFatalException(Environment* env,
       std::string argv0;
       if (!env->argv().empty()) argv0 = env->argv()[0];
       if (argv0.empty()) argv0 = "node";
+      auto filesystem_path = std::filesystem::path(argv0).replace_extension();
       FPrintF(stderr,
               "(Use `%s --trace-uncaught ...` to show where the exception "
               "was thrown)\n",
-              fs::Basename(argv0, ".exe"));
+              filesystem_path.filename().string());
     }
   }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -82,29 +82,6 @@ constexpr char kPathSeparator = '/';
 const char* const kPathSeparator = "\\/";
 #endif
 
-std::string Basename(const std::string& str, const std::string& extension) {
-  // Remove everything leading up to and including the final path separator.
-  std::string::size_type pos = str.find_last_of(kPathSeparator);
-
-  // Starting index for the resulting string
-  std::size_t start_pos = 0;
-  // String size to return
-  std::size_t str_size = str.size();
-  if (pos != std::string::npos) {
-    start_pos = pos + 1;
-    str_size -= start_pos;
-  }
-
-  // Strip away the extension, if any.
-  if (str_size >= extension.size() &&
-      str.compare(str.size() - extension.size(),
-        extension.size(), extension) == 0) {
-    str_size -= extension.size();
-  }
-
-  return str.substr(start_pos, str_size);
-}
-
 inline int64_t GetOffset(Local<Value> value) {
   return IsSafeJsInt(value) ? value.As<Integer>()->Value() : -1;
 }

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -415,10 +415,6 @@ BaseObjectPtr<AsyncWrap> CreateHeapSnapshotStream(
     Environment* env, HeapSnapshotPointer&& snapshot);
 }  // namespace heap
 
-namespace fs {
-std::string Basename(const std::string& str, const std::string& extension);
-}  // namespace fs
-
 node_module napi_module_to_node_module(const napi_module* mod);
 
 std::ostream& operator<<(std::ostream& output, const SnapshotFlags& flags);


### PR DESCRIPTION
We can remove our implementation of `base name` in favor of `std::filesystem::path::filename()`

cc @nodejs/cpp-reviewers @nodejs/fs 