### PR TITLE
test: replace `.substr` with `.slice`

### DIFF
--- a/test/es-module/test-esm-exports.mjs
+++ b/test/es-module/test-esm-exports.mjs
@@ -231,7 +231,7 @@ const { requireFromInside, importFromInside } = fromInside;
 });
 
 function assertStartsWith(actual, expected) {
-  const start = actual.toString().substr(0, expected.length);
+  const start = actual.toString().slice(0, expected.length);
   strictEqual(start, expected);
 }
 

--- a/test/es-module/test-esm-imports.mjs
+++ b/test/es-module/test-esm-imports.mjs
@@ -124,7 +124,7 @@ requireFixture('#cjs').then(mustCall((actual) => {
 }));
 
 function assertStartsWith(actual, expected) {
-  const start = actual.toString().substr(0, expected.length);
+  const start = actual.toString().slice(0, expected.length);
   strictEqual(start, expected);
 }
 

--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -212,7 +212,7 @@ for (const test of TEST_CASES) {
     cipher.update('01234567', 'hex');
     cipher.final();
     const tag = cipher.getAuthTag();
-    assert.strictEqual(tag.toString('hex'), fullTag.substr(0, 2 * e));
+    assert.strictEqual(tag.toString('hex'), fullTag.slice(0, 2 * e));
   }
 }
 

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -272,8 +272,8 @@ for (let i = 0, l = rfc4231.length; i < l; i++) {
                        .update(rfc4231[i].data)
                        .digest('hex');
     if (rfc4231[i].truncate) {
-      actual = actual.substr(0, 32); // first 128 bits == 32 hex chars
-      strRes = strRes.substr(0, 32);
+      actual = actual.slice(0, 32); // first 128 bits == 32 hex chars
+      strRes = strRes.slice(0, 32);
     }
     const expected = rfc4231[i].hmac[hash];
     assert.strictEqual(

--- a/test/parallel/test-crypto-randomuuid.js
+++ b/test/parallel/test-crypto-randomuuid.js
@@ -34,11 +34,11 @@ for (let n = 0; n < 130; n++) {
 
   // Check that version 4 identifier was populated.
   assert.strictEqual(
-    Buffer.from(uuid.substr(14, 2), 'hex')[0] & 0x40, 0x40);
+    Buffer.from(uuid.slice(14, 16), 'hex')[0] & 0x40, 0x40);
 
   // Check that clock_seq_hi_and_reserved was populated with reserved bits.
   assert.strictEqual(
-    Buffer.from(uuid.substr(19, 2), 'hex')[0] & 0b1100_0000, 0b1000_0000);
+    Buffer.from(uuid.slice(19, 21), 'hex')[0] & 0b1100_0000, 0b1000_0000);
 }
 
 // Test non-buffered UUID's

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -42,7 +42,7 @@ let root = '/';
 let assertEqualPath = assert.strictEqual;
 if (common.isWindows) {
   // Something like "C:\\"
-  root = process.cwd().substr(0, 3);
+  root = process.cwd().slice(0, 3);
   assertEqualPath = function(path_left, path_right, message) {
     assert
       .strictEqual(path_left.toLowerCase(), path_right.toLowerCase(), message);
@@ -367,7 +367,7 @@ function test_deep_symlink_mix(realpath, realpathSync, callback) {
 function test_non_symlinks(realpath, realpathSync, callback) {
   console.log('test_non_symlinks');
   const entrydir = path.dirname(tmpAbsDir);
-  const entry = `${tmpAbsDir.substr(entrydir.length + 1)}/cycles/root.js`;
+  const entry = `${tmpAbsDir.slice(entrydir.length + 1)}/cycles/root.js`;
   const expected = `${tmpAbsDir}/cycles/root.js`;
   const origcwd = process.cwd();
   process.chdir(entrydir);

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -26,7 +26,7 @@ const server = http.createServer(function(req, res) {
   res.removeHeader('Date');
   res.setHeader('Keep-Alive', 'timeout=1');
 
-  switch (req.url.substr(1)) {
+  switch (req.url.slice(1)) {
     case 'multiple-writes':
       delete req.headers.host;
       assert.deepStrictEqual(req.headers, expectedHeadersMultipleWrites);

--- a/test/parallel/test-http-upgrade-server.js
+++ b/test/parallel/test-http-upgrade-server.js
@@ -100,7 +100,7 @@ function test_upgrade_with_listener() {
     assert.strictEqual(typeof data, 'string');
 
     if (state === 1) {
-      assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 101');
+      assert.strictEqual(data.slice(0, 12), 'HTTP/1.1 101');
       assert.strictEqual(request_upgradeHead.toString('utf8'), 'WjN}|M(6');
       conn.write('test', 'utf8');
     } else if (state === 2) {
@@ -133,7 +133,7 @@ function test_upgrade_no_listener() {
 
   conn.once('data', (data) => {
     assert.strictEqual(typeof data, 'string');
-    assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 200');
+    assert.strictEqual(data.slice(0, 12), 'HTTP/1.1 200');
     conn.end();
   });
 
@@ -153,7 +153,7 @@ function test_standard_http() {
 
   conn.once('data', function(data) {
     assert.strictEqual(typeof data, 'string');
-    assert.strictEqual(data.substr(0, 12), 'HTTP/1.1 200');
+    assert.strictEqual(data.slice(0, 12), 'HTTP/1.1 200');
     conn.end();
   });
 

--- a/test/parallel/test-path-dirname.js
+++ b/test/parallel/test-path-dirname.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const path = require('path');
 
-assert.strictEqual(path.dirname(__filename).substr(-13),
+assert.strictEqual(path.dirname(__filename).slice(-13),
                    common.isWindows ? 'test\\parallel' : 'test/parallel');
 
 assert.strictEqual(path.posix.dirname('/a/b/'), '/a');

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -584,7 +584,7 @@ testMe.complete('obj.', common.mustCall(function(error, data) {
 
     data[0].forEach((key) => {
       if (!key || key === 'ele.biu') return;
-      assert.notStrictEqual(ele[key.substr(4)], undefined);
+      assert.notStrictEqual(ele[key.slice(4)], undefined);
     });
   }));
 });

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -64,7 +64,7 @@ async function runReplTests(socket, prompt, tests) {
 
         // Cut away the initial prompt
         while (lineBuffer.startsWith(prompt))
-          lineBuffer = lineBuffer.substr(prompt.length);
+          lineBuffer = lineBuffer.slice(prompt.length);
 
         // Allow to match partial text if no newline was received, because
         // sending newlines from the REPL itself would be redundant
@@ -76,13 +76,13 @@ async function runReplTests(socket, prompt, tests) {
 
       // Split off the current line.
       const newlineOffset = lineBuffer.indexOf('\n');
-      let actualLine = lineBuffer.substr(0, newlineOffset);
-      lineBuffer = lineBuffer.substr(newlineOffset + 1);
+      let actualLine = lineBuffer.slice(0, newlineOffset);
+      lineBuffer = lineBuffer.slice(newlineOffset + 1);
 
       // This might have been skipped in the loop above because the buffer
       // already contained a \n to begin with and the entire loop was skipped.
       while (actualLine.startsWith(prompt))
-        actualLine = actualLine.substr(prompt.length);
+        actualLine = actualLine.slice(prompt.length);
 
       console.error('in:', JSON.stringify(actualLine));
 

--- a/test/parallel/test-webcrypto-digest.js
+++ b/test/parallel/test-webcrypto-digest.js
@@ -156,7 +156,7 @@ async function testDigest(size, name) {
     Object.keys(kDigestedData).forEach((alg) => {
       const upCase = alg.toUpperCase();
       const downCase = alg.toLowerCase();
-      const mixedCase = upCase.substr(0, 1) + downCase.substr(1);
+      const mixedCase = upCase.slice(0, 1) + downCase.slice(1);
 
       variations.push(testDigest(size, upCase));
       variations.push(testDigest(size, downCase));

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -52,13 +52,13 @@ const errMessage = /unexpected end of file/;
 
     // Sync truncated input test, finishFlush = Z_SYNC_FLUSH
     const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
-    assert.strictEqual(result, inputString.substr(0, result.length));
+    assert.strictEqual(result, inputString.slice(0, result.length));
 
     // Async truncated input test, finishFlush = Z_SYNC_FLUSH
     zlib[methods.decomp](truncated, syncFlushOpt, function(err, decompressed) {
       assert.ifError(err);
       const result = toUTF8(decompressed);
-      assert.strictEqual(result, inputString.substr(0, result.length));
+      assert.strictEqual(result, inputString.slice(0, result.length));
     });
   });
 });


### PR DESCRIPTION
`String.prototype.substr` is deprecated, and using it will raise an error when using ESLint 9+ (#52780).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
