### PR TITLE
cli: add `--expose-gc` flag available to `NODE_OPTIONS`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -626,6 +626,23 @@ Make built-in language features like `eval` and `new Function` that generate
 code from strings throw an exception instead. This does not affect the Node.js
 `node:vm` module.
 
+### `--expose-gc`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental. This flag is inherited from V8 and is subject to
+> change upstream.
+
+This flag will expose the gc extension from V8.
+
+```js
+if (globalThis.gc) {
+  globalThis.gc();
+}
+```
+
 ### `--dns-result-order=order`
 
 <!-- YAML
@@ -2776,6 +2793,7 @@ V8 options that are allowed are:
 * `--abort-on-uncaught-exception`
 * `--disallow-code-generation-from-strings`
 * `--enable-etw-stack-walking`
+* `--expose-gc`
 * `--huge-max-old-generation-size`
 * `--interpreted-frames-native-stack`
 * `--jitless`
@@ -3097,6 +3115,8 @@ documented here:
 ### `--disallow-code-generation-from-strings`
 
 ### `--enable-etw-stack-walking`
+
+### `--expose-gc`
 
 ### `--harmony-shadow-realm`
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -473,6 +473,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-report", "", NoOp{}, kAllowedInEnvvar);
   AddOption(
       "--experimental-wasi-unstable-preview1", "", NoOp{}, kAllowedInEnvvar);
+  AddOption("--expose-gc", "expose gc extension", V8Option{}, kAllowedInEnvvar);
   AddOption("--expose-internals", "", &EnvironmentOptions::expose_internals);
   AddOption("--frozen-intrinsics",
             "experimental frozen intrinsics support",

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -69,6 +69,7 @@ if (common.hasCrypto) {
 // V8 options
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--disallow-code-generation-from-strings', 'B\n');
+expect('--expose-gc', 'B\n');
 expect('--huge-max-old-generation-size', 'B\n');
 expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');


### PR DESCRIPTION
This commits allows users to send `--expose-gc` via `NODE_OPTIONS` environment variable.

Using `node --expose-gc` is possible but via `NODE_OPTIONS` won't work.

```sh
NODE_OPTIONS='--expose-gc' node
node: --expose-gc is not allowed in NODE_OPTIONS
```