### PR TITLE
src: nuke deprecated and un-used enum members in `OptionEnvvarSettings`

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -374,10 +374,6 @@ enum OptionEnvvarSettings {
   // Disallow the options to be set via the environment variable, like
   // `NODE_OPTIONS`.
   kDisallowedInEnvvar = 1,
-  // Deprecated, use kAllowedInEnvvar instead.
-  kAllowedInEnvironment = kAllowedInEnvvar,
-  // Deprecated, use kDisallowedInEnvvar instead.
-  kDisallowedInEnvironment = kDisallowedInEnvvar,
 };
 
 // Process the arguments and set up the per-process options.

--- a/typings/internalBinding/options.d.ts
+++ b/typings/internalBinding/options.d.ts
@@ -17,8 +17,8 @@ export interface OptionsBinding {
     aliases: Map<string, string[]>;
   };
   envSettings: {
-    kAllowedInEnvironment: 0;
-    kDisallowedInEnvironment: 1;
+    kAllowedInEnvvar: 0;
+    kDisallowedInEnvvar: 1;
   };
   noGlobalSearchPaths: boolean;
   shouldNotRegisterESMLoader: boolean;


### PR DESCRIPTION
Delete deprecated an never used enum options `kAllowedInEnvironment` and `kDisallowedInEnvironment` in `OptionEnvvarSettings`

-------
I'm not too sure if this is gonna be ok in CITGM, but, lets give it a try!