### PR TITLE
test: increase allocation so it fails for the test

### DIFF
--- a/test/parallel/test-buffer-failed-alloc-typed-arrays.js
+++ b/test/parallel/test-buffer-failed-alloc-typed-arrays.js
@@ -12,7 +12,7 @@ const SlowBuffer = require('buffer').SlowBuffer;
 // whether or not to zero-fill was not being reset, causing TypedArrays to
 // allocate incorrectly.
 const zeroArray = new Uint32Array(10).fill(0);
-const sizes = [1e10, 0, 0.1, -1, 'a', undefined, null, NaN];
+const sizes = [1e20, 0, 0.1, -1, 'a', undefined, null, NaN];
 const allocators = [
   Buffer,
   SlowBuffer,


### PR DESCRIPTION
It used to be impossible to allocate 1e10 bytes but with a v8 update this allocation can succeed. This results in 2x10GB allocations and failure to test the failure :-)

Increase allocation to 1e20 bytes, which should fail for some time, returning the test to using only 50MB at runtime.

Fixes: https://github.com/nodejs/node/issues/53085

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
