### PR TITLE
test: skip `test-setproctitle` when `ps` is not available

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -12,7 +12,7 @@ if (!common.isMainThread)
   common.skip('Setting the process title from Workers is not supported');
 
 const assert = require('assert');
-const exec = require('child_process').exec;
+const { exec, execSync } = require('child_process');
 const path = require('path');
 
 // The title shouldn't be too long; libuv's uv_set_process_title() out of
@@ -27,6 +27,15 @@ assert.strictEqual(process.title, title);
 // Test setting the title but do not try to run `ps` on Windows.
 if (common.isWindows)
   common.skip('Windows does not have "ps" utility');
+
+try {
+  execSync('command -v ps');
+} catch (err) {
+  if (err.status === 1) {
+    common.skip('The "ps" utility is not available');
+  }
+  throw err;
+}
 
 // To pass this test on alpine, since Busybox `ps` does not
 // support `-p` switch, use `ps -o` and `grep` instead.


### PR DESCRIPTION
`ps` is a dependency of the test, but not available in all contexts.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
