### PR TITLE
build: fix `--enable-d8` builds

### DIFF
--- a/tools/v8_gypfiles/d8.gyp
+++ b/tools/v8_gypfiles/d8.gyp
@@ -20,6 +20,7 @@
         'v8.gyp:v8_libbase',
         'v8.gyp:v8_libplatform',
         'v8.gyp:generate_bytecode_builtins_list',
+        'v8.gyp:v8_abseil',
       ],
       # Generated source files need this explicitly:
       'include_dirs+': [
@@ -28,15 +29,7 @@
         '<(SHARED_INTERMEDIATE_DIR)',
       ],
       'sources': [
-        '<(V8_ROOT)/src/d8/async-hooks-wrapper.cc',
-        '<(V8_ROOT)/src/d8/async-hooks-wrapper.h',
-        '<(V8_ROOT)/src/d8/d8-console.cc',
-        '<(V8_ROOT)/src/d8/d8-console.h',
-        '<(V8_ROOT)/src/d8/d8-js.cc',
-        '<(V8_ROOT)/src/d8/d8-platforms.cc',
-        '<(V8_ROOT)/src/d8/d8-platforms.h',
-        '<(V8_ROOT)/src/d8/d8.cc',
-        '<(V8_ROOT)/src/d8/d8.h',
+        '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_executable.\\"d8\\".*?sources = ")',
       ],
       'conditions': [
         [ 'want_separate_host_toolset==1', {


### PR DESCRIPTION
Add `v8_abseil` as a dependency for `d8` and use scraping to pick up the list of source files (including the previously missing `src/d8/d8-test.cc`).

---

Fixes these errors with `configure --enable-d8`:

- Missing `abseil`:
```console
In file included from ../deps/v8/src/objects/source-text-module.h:11,
                 from ../deps/v8/src/api/api.h:27,
                 from ../deps/v8/src/api/api-inl.h:9,
                 from ../deps/v8/src/d8/async-hooks-wrapper.cc:11:
../deps/v8/src/zone/zone-containers.h:20:10: fatal error: absl/container/flat_hash_map.h: No such file or directory
   20 | #include "absl/container/flat_hash_map.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from ../deps/v8/src/objects/source-text-module.h:11,
                 from ../deps/v8/src/api/api.h:27,
                 from ../deps/v8/src/handles/persistent-handles.h:11,
                 from ../deps/v8/src/heap/local-heap.h:19,
                 from ../deps/v8/src/handles/local-handles.h:12,
                 from ../deps/v8/src/execution/local-isolate.h:12,
                 from ../deps/v8/src/heap/parked-scope.h:11,
                 from ../deps/v8/src/d8/d8.h:25,
                 from ../deps/v8/src/d8/d8-js.cc:5:
```

- Missing `src/d8/d8-test.cc`:
```
/usr/bin/ld: /home/rlau/sandbox/github/node/out/Release/obj.target/d8/deps/v8/src/d8/d8.o: in function `v8::Shell::CreateD8Template(v8::Isolate*)':
d8.cc:(.text._ZN2v85Shell16CreateD8TemplateEPNS_7IsolateE+0x771): undefined reference to `v8::Shell::CreateTestFastCApiTemplate(v8::Isolate*)'
/usr/bin/ld: d8.cc:(.text._ZN2v85Shell16CreateD8TemplateEPNS_7IsolateE+0x7ac): undefined reference to `v8::Shell::CreateLeafInterfaceTypeTemplate(v8::Isolate*)'
collect2: error: ld returned 1 exit status
make[1]: *** [tools/v8_gypfiles/d8.target.mk:241: /home/rlau/sandbox/github/node/out/Release/d8] Error 1
rm 1df062be45bc7f08255553ef0a19173666eeeef3.intermediate 5af4453f25c9ba66fc65f2b3f6e297922691ce11.intermediate b5964469a6c8ef0a595bcc6dcadd3ff98ad24c40.intermediate
make: *** [Makefile:137: node] Error 2
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
