### PR TITLE
meta: add prettier support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,10 @@
 !.gitpod.yml
 !.mailmap
 !.nycrc
+!.prettierignore
+!.prettierrc.js
 !.yamllint.yaml
+!.vscode
 
 # === Rules for root dir ===
 /core

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+node_modules
+lib/punycode.js
+test/addons/??_*
+test/fixtures
+test/message/esm_display_syntax_error.mjs
+tools/icu
+tools/lint-md/lint-md.mjs
+tools/github_reporter
+benchmark/tmp
+benchmark/fixtures
+doc/**/*.js
+doc/changelogs/CHANGELOG_v1*.md
+!doc/changelogs/CHANGELOG_v18.md
+!doc/api_assets/*.js
+!.eslintrc.js
+deps/**
+out/**

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,16 @@
+// Written in JS so we can have comments
+
+module.exports = {
+  // While the ESLint config enforces a max length of 120,
+  // striving for 80 characters may be a good idea (for
+  // the formatter, not the linter)
+  printWidth: 80,
+
+  semi: true,
+  quoteProps: "consistent",
+  trailingComma: "all",
+  bracketSpacing: true,
+  arrowParens: "always",
+  proseWrap: "always",
+  embeddedLanguageFormatting: "auto",
+};

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.tabSize": 2,
+  "prettier.configPath": ".prettierrc.js",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}


### PR DESCRIPTION
This PR adds support for a `.prettierrc.js` file, so that editors can support the prettier extension, preloaded with the options that Node.js uses.

Additionally, this PR adds prettier as a recommended VSCode extension.