### PR TITLE
module: fix error message for not found

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -838,7 +838,7 @@ function packageResolve(specifier, base, conditions) {
 
   // eslint can't handle the above code.
   // eslint-disable-next-line no-unreachable
-  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
+  throw new ERR_MODULE_NOT_FOUND(specifier, fileURLToPath(base), null);
 }
 
 /**

--- a/test/es-module/test-esm-loader-search.js
+++ b/test/es-module/test-esm-loader-search.js
@@ -18,3 +18,12 @@ assert.throws(
     message: /Cannot find package 'target'/
   }
 );
+
+assert.throws(
+  () => resolve('fs/promisesx'),
+  {
+    code: 'ERR_MODULE_NOT_FOUND',
+    name: 'Error',
+    message: /Cannot find package 'fs\/promisesx'/
+  }
+);


### PR DESCRIPTION
When I written module path with a typo:

```js
import {readdir} from 'fs/promisesxxx';
```
The error message tell me cannot find package 'fs'.

```sh
$ node test.js 
node:internal/modules/esm/resolve:853
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'fs' imported from /PATH_TO_FILE/test.js
    at packageResolve (node:internal/modules/esm/resolve:853:9)
    at moduleResolve (node:internal/modules/esm/resolve:910:20)
    at defaultResolve (node:internal/modules/esm/resolve:1130:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v20.11.1
```

Actually the `fs` is a native module, the package should be a full name. This update try to fix it.