### PR TITLE
doc: add note for windows users and symlinks

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -691,9 +691,11 @@ disk space.
   git clone https://github.com/nodejs/node.git
   cd node
   ```
-> [!TIP]
+
+> \[!TIP]
 > If you are building from a Windows machine, symlinks are disabled by default, and can be enabled by cloning
 > with the `-c core.symlinks=true` flag.
+>
 > ```powershell
 > git clone -c core.symlinks=true <repository_url>
 > ```

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -691,6 +691,13 @@ disk space.
   git clone https://github.com/nodejs/node.git
   cd node
   ```
+> [!TIP]
+> If you are building from a Windows machine, symlinks are disabled by default, and can be enabled by cloning
+> with the `-c core.symlinks=true` flag.
+> ```powershell
+> git clone -c core.symlinks=true <repository_url>
+> ```
+
 * If the path to your build directory contains a space or a non-ASCII character,
   the build will likely fail
 


### PR DESCRIPTION
This PR adds instructions on how to enable cloned symlinks on windows.

> \[!TIP]
> If you are building from a Windows machine, symlinks are disabled by default, and can be enabled by cloning
> with the `-c core.symlinks=true` flag.
> ```powershell
> git clone -c core.symlinks=true <repository_url>
> ```