### PR TITLE
fs: replace all isInt32 in fs with isFd

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -134,7 +134,7 @@ const {
   CHAR_BACKWARD_SLASH,
 } = require('internal/constants');
 const {
-  isInt32,
+  isInt32: isFd,
   parseFileMode,
   validateBoolean,
   validateBuffer,
@@ -200,8 +200,6 @@ function makeStatsCallback(cb) {
     cb(err, getStatsFromBinding(stats));
   };
 }
-
-const isFd = isInt32;
 
 function isFileType(stats, fileType) {
   // Use stats array directly to avoid creating an fs.Stats instance just for
@@ -443,7 +441,7 @@ function readFileSync(path, options) {
   options = getOptions(options, { flag: 'r' });
 
   if (options.encoding === 'utf8' || options.encoding === 'utf-8') {
-    if (!isInt32(path)) {
+    if (!isFd(path)) {
       path = pathModule.toNamespacedPath(getValidatedPath(path));
     }
     return binding.readFileUtf8(path, stringToFlags(options.flag));
@@ -2346,7 +2344,7 @@ function writeFileSync(path, data, options) {
 
   // C++ fast path for string data and UTF8 encoding
   if (typeof data === 'string' && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
-    if (!isInt32(path)) {
+    if (!isFd(path)) {
       path = pathModule.toNamespacedPath(getValidatedPath(path));
     }
 


### PR DESCRIPTION
When I was reading the fs module, I found a mix-up between isfd and isInt32, so I optimised it.