### PR TITLE
test_runner,docs: align documentation with actual stdout/stderr behavior

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2862,11 +2862,7 @@ The corresponding execution ordered event is `'test:dequeue'`.
 ### Event: `'test:stderr'`
 
 * `data` {Object}
-  * `column` {number|undefined} The column number where the test is defined, or
-    `undefined` if the test was run through the REPL.
   * `file` {string} The path of the test file.
-  * `line` {number|undefined} The line number where the test is defined, or
-    `undefined` if the test was run through the REPL.
   * `message` {string} The message written to `stderr`.
 
 Emitted when a running test writes to `stderr`.
@@ -2877,11 +2873,7 @@ defined.
 ### Event: `'test:stdout'`
 
 * `data` {Object}
-  * `column` {number|undefined} The column number where the test is defined, or
-    `undefined` if the test was run through the REPL.
   * `file` {string} The path of the test file.
-  * `line` {number|undefined} The line number where the test is defined, or
-    `undefined` if the test was run through the REPL.
   * `message` {string} The message written to `stdout`.
 
 Emitted when a running test writes to `stdout`.

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -123,14 +123,6 @@ class TestsStream extends Readable {
     });
   }
 
-  stderr(loc, message) {
-    this[kEmitMessage]('test:stderr', { __proto__: null, message, ...loc });
-  }
-
-  stdout(loc, message) {
-    this[kEmitMessage]('test:stdout', { __proto__: null, message, ...loc });
-  }
-
   coverage(nesting, loc, summary) {
     this[kEmitMessage]('test:coverage', {
       __proto__: null,


### PR DESCRIPTION
refs: https://github.com/nodejs/node/issues/53103#issuecomment-2125716659

see tests verifying this behavior:
https://github.com/nodejs/node/blob/c7a63b074017b57e5c8a3341151696039ae49499/test/parallel/test-runner-v8-deserializer.mjs#L50
