### PR TITLE
meta: remove `initializeCommand` from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
     "visualstudioexptteam.vscodeintellicode"
   ],
   "image": "nodejs/devcontainer:nightly",
-  "initializeCommand": "docker system prune -f -a",
   "settings": {
     "terminal.integrated.profiles.linux": {
       "zsh (login)": {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/53129

I'm no expert on devcontainer, so maybe an initializeCommand is needed, but the current setup (See #53129 for more info) destroys **all** other devcontainers.