### PR TITLE
doc: fix wrong function name in example of `context.plan()`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -3081,7 +3081,7 @@ expected count, the test will fail.
 test('top level test', (t) => {
   t.plan(2);
   t.assert.ok('some relevant assertion here');
-  t.subtest('subtest', () => {});
+  t.test('subtest', () => {});
 });
 ```
 


### PR DESCRIPTION
t.subtest -> t.test

Refs: https://github.com/nodejs/node/pull/52860

(1) With `t.subtest`
```
✖ top level test (2.496498ms)
  TypeError: t.subtest is not a function
      at TestContext.<anonymous> (/home/deokjinkim/oss/node-playground/tr2.js:6:5)
      at Test.runInAsyncScope (node:async_hooks:206:9)
      at Test.run (node:internal/test_runner/test:841:25)
      at Test.processPendingSubtests (node:internal/test_runner/test:550:18)
      at node:internal/test_runner/harness:247:12
      at node:internal/process/task_queues:140:7
      at AsyncResource.runInAsyncScope (node:async_hooks:206:9)
      at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
```

(2) With `t.test`
```
▶ top level test
  ✔ subtest (1.334498ms)
▶ top level test (3.065425ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 12.305652
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
