### PR TITLE
build: fix building embedtest in GN build

### DIFF
--- a/unofficial.gni
+++ b/unofficial.gni
@@ -346,6 +346,7 @@ template("node_gn_build") {
     output_name = "embedtest"
     testonly = true
     deps = [ ":libnode" ]
+    include_dirs = [ "tools" ]
     sources = [
       "src/node_snapshot_stub.cc",
       "test/embedding/embedtest.cc",


### PR DESCRIPTION
Update the GN build config of embedtest to match the change in https://github.com/nodejs/node/pull/52646.