### PR TITLE
meta: request reviews from github actions

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -1,0 +1,24 @@
+name: Request reviews for PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
+        name: Checkout default branch
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        name: Make initial comment
+        with:
+          script: |
+            const initialCommentBuilder = require('${{ github.workspace }}/tools/actions/pr-open.js');
+            await initialCommentBuilder(github, context);

--- a/tools/actions/pr-open.js
+++ b/tools/actions/pr-open.js
@@ -1,0 +1,111 @@
+'use strict';
+
+module.exports = async (client, context) => {
+  function globToRegex(glob) {
+    const patterns = {
+      '*': '([^\\/]+)',
+      '**': '(.+\\/)?([^\\/]+)',
+      '**/': '(.+\\/)',
+    };
+
+    const escapedGlob = glob.replace(/\./g, '\\.').replace(/\*\*$/g, '(.+)');
+    const regexString = '^(' + escapedGlob.replace(/\*\*\/|\*\*|\*/g, (match) => patterns[match] || '') + ')$';
+    return new RegExp(regexString);
+  }
+
+  class CodeOwners {
+    constructor(fileContent) {
+      this.owners = fileContent.split('\n').map((line) => line.trim())
+                .filter((line) => line && !line.startsWith('#'))
+                .map((line) => {
+                  const [path, ...owners] = line.split(/\s+/);
+                  return { path: globToRegex(path), owners };
+                });
+    }
+
+    getOwners(filePath) {
+      const normalizedPath = filePath.startsWith('/') ? filePath : `/${filePath}`;
+      return this.owners
+                .filter(({ path }) => path.test(normalizedPath))
+                .flatMap(({ owners }) => owners);
+    }
+  }
+
+  async function getChangedFiles(base, head) {
+    const { data } = await client.rest.repos.compareCommits({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      base,
+      head,
+    });
+    return data.files.map((file) => file.filename);
+  }
+
+  async function getCodeOwners() {
+    const { data } = await client.rest.repos.getContent({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      path: '.github/CODEOWNERS',
+    });
+
+    const content = Buffer.from(data.content, 'base64').toString('utf8');
+    return new CodeOwners(content);
+  }
+
+  function shouldPingTSC(changedFiles) {
+    const user = context.payload.sender.login;
+    if (user === 'nodejs-github-bot') {
+      return false;
+    }
+
+    const TSC_FILE_PATHS = [
+      globToRegex('/deps/**'),
+    ];
+
+    return changedFiles.some((filePath) => {
+      const normalizedPath = filePath.startsWith('/') ? filePath : `/${filePath}`;
+      return TSC_FILE_PATHS.some((pattern) => pattern.test(normalizedPath));
+    });
+  }
+
+  async function makeInitialComment(changedFiles) {
+    const codeOwners = await getCodeOwners();
+
+    const owners = new Set();
+    changedFiles.forEach((file) => {
+      codeOwners.getOwners(file).forEach((owner) => owners.add(owner));
+    });
+
+    const ownersList = Array.from(owners).map((owner) => `- ${owner}`).join('\n');
+
+    let body =
+            'Hi 👋! Thank you for submitting this pull-request!\n\n' +
+            'According to the CODEOWNERS file, the following people are responsible for' +
+            "reviewing changes to the files you've modified:\n\n" +
+            ownersList + '\n\n' +
+            'They, along with other project maintainers, will be notified of your pull request.' +
+            'Please be patient and wait for them to review your changes.\n\n' +
+            "If you have any questions, please don't hesitate to ask!";
+
+    if (shouldPingTSC(changedFiles)) {
+      body += '\n\nA modification in this PR may require @nodejs/tsc\'s approval.';
+    }
+
+    return client.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.payload.pull_request.number,
+      body: body,
+    });
+  }
+
+  const base = context.payload.pull_request?.base?.sha;
+  const head = context.payload.pull_request?.head?.sha;
+
+  if (!base || !head) {
+    throw new Error('Cannot get base or head commit');
+  }
+
+  const changedFiles = await getChangedFiles(base, head);
+  await makeInitialComment(changedFiles);
+};

--- a/tools/actions/pr-open.js
+++ b/tools/actions/pr-open.js
@@ -52,22 +52,6 @@ module.exports = async (client, context) => {
     return new CodeOwners(content);
   }
 
-  function shouldPingTSC(changedFiles) {
-    const user = context.payload.sender.login;
-    if (user === 'nodejs-github-bot') {
-      return false;
-    }
-
-    const TSC_FILE_PATHS = [
-      globToRegex('/deps/**'),
-    ];
-
-    return changedFiles.some((filePath) => {
-      const normalizedPath = filePath.startsWith('/') ? filePath : `/${filePath}`;
-      return TSC_FILE_PATHS.some((pattern) => pattern.test(normalizedPath));
-    });
-  }
-
   async function makeInitialComment(changedFiles) {
     const codeOwners = await getCodeOwners();
 
@@ -86,10 +70,6 @@ module.exports = async (client, context) => {
             'They, along with other project maintainers, will be notified of your pull request.' +
             'Please be patient and wait for them to review your changes.\n\n' +
             "If you have any questions, please don't hesitate to ask!";
-
-    if (shouldPingTSC(changedFiles)) {
-      body += '\n\nA modification in this PR may require @nodejs/tsc\'s approval.';
-    }
 
     return client.rest.issues.createComment({
       owner: context.repo.owner,

--- a/tools/actions/pr-open.js
+++ b/tools/actions/pr-open.js
@@ -62,7 +62,7 @@ module.exports = async (client, context) => {
 
     const ownersList = Array.from(owners).map((owner) => `- ${owner}`).join('\n');
 
-    let body =
+    const body =
             'Hi 👋! Thank you for submitting this pull-request!\n\n' +
             'According to the CODEOWNERS file, the following people are responsible for' +
             "reviewing changes to the files you've modified:\n\n" +

--- a/tools/actions/pr-open.js
+++ b/tools/actions/pr-open.js
@@ -63,13 +63,8 @@ module.exports = async (client, context) => {
     const ownersList = Array.from(owners).map((owner) => `- ${owner}`).join('\n');
 
     const body =
-            'Hi 👋! Thank you for submitting this pull-request!\n\n' +
-            'According to the CODEOWNERS file, the following people are responsible for' +
-            "reviewing changes to the files you've modified:\n\n" +
-            ownersList + '\n\n' +
-            'They, along with other project maintainers, will be notified of your pull request.' +
-            'Please be patient and wait for them to review your changes.\n\n' +
-            "If you have any questions, please don't hesitate to ask!";
+            'The following teams have been pinged to review your changes:\n\n' +
+            ownersList
 
     return client.rest.issues.createComment({
       owner: context.repo.owner,

--- a/tools/actions/pr-open.js
+++ b/tools/actions/pr-open.js
@@ -64,7 +64,7 @@ module.exports = async (client, context) => {
 
     const body =
             'The following teams have been pinged to review your changes:\n\n' +
-            ownersList
+            ownersList;
 
     return client.rest.issues.createComment({
       owner: context.repo.owner,


### PR DESCRIPTION
Part of #51236 

This PR moves the process of commenting on a PR to the main repo's Github Actions, instead of it being handled by the github bot.

This is open to discussion, and I'm not a member of the @nodejs/github-bot team, so I'd love them to take a look and see if this looks good :-)

If landed, the new 'initial comment' that will be posted on PRs is:

> Hi 👋! Thank you for submitting this pull-request!
>
> According to the CODEOWNERS file, the following people are responsible for reviewing changes to the files you've modified:
>
> - **\@nodejs/team**
> - **\@nodejs/other-team**
>
> They, along with other project maintainers, will be notified of your pull request. Please be patient and wait for them to review your changes.
>
> If you have any questions, please don't hesitate to ask!