### PR TITLE
fs: fix cp dir/non-dir mismatch error messages

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1204,12 +1204,12 @@ E('ERR_FEATURE_UNAVAILABLE_ON_PLATFORM',
   ', which is being used to run Node.js',
   TypeError);
 E('ERR_FS_CP_DIR_TO_NON_DIR',
-  'Cannot overwrite directory with non-directory', SystemError);
+  'Cannot overwrite non-directory with directory', SystemError);
 E('ERR_FS_CP_EEXIST', 'Target already exists', SystemError);
 E('ERR_FS_CP_EINVAL', 'Invalid src or dest', SystemError);
 E('ERR_FS_CP_FIFO_PIPE', 'Cannot copy a FIFO pipe', SystemError);
 E('ERR_FS_CP_NON_DIR_TO_DIR',
-  'Cannot overwrite non-directory with directory', SystemError);
+  'Cannot overwrite directory with non-directory', SystemError);
 E('ERR_FS_CP_SOCKET', 'Cannot copy a socket file', SystemError);
 E('ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY',
   'Cannot overwrite symlink in subdirectory of self', SystemError);

--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -82,8 +82,8 @@ function checkPathsSync(src, dest, opts) {
     }
     if (srcStat.isDirectory() && !destStat.isDirectory()) {
       throw new ERR_FS_CP_DIR_TO_NON_DIR({
-        message: `cannot overwrite directory ${src} ` +
-          `with non-directory ${dest}`,
+        message: `cannot overwrite non-directory ${dest} ` +
+          `with directory ${src}`,
         path: dest,
         syscall: 'cp',
         errno: EISDIR,
@@ -92,8 +92,8 @@ function checkPathsSync(src, dest, opts) {
     }
     if (!srcStat.isDirectory() && destStat.isDirectory()) {
       throw new ERR_FS_CP_NON_DIR_TO_DIR({
-        message: `cannot overwrite non-directory ${src} ` +
-          `with directory ${dest}`,
+        message: `cannot overwrite directory ${dest} ` +
+          `with non-directory ${src}`,
         path: dest,
         syscall: 'cp',
         errno: ENOTDIR,

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -86,8 +86,8 @@ async function checkPaths(src, dest, opts) {
     }
     if (srcStat.isDirectory() && !destStat.isDirectory()) {
       throw new ERR_FS_CP_DIR_TO_NON_DIR({
-        message: `cannot overwrite directory ${src} ` +
-            `with non-directory ${dest}`,
+        message: `cannot overwrite non-directory ${dest} ` +
+            `with directory ${src}`,
         path: dest,
         syscall: 'cp',
         errno: EISDIR,
@@ -96,8 +96,8 @@ async function checkPaths(src, dest, opts) {
     }
     if (!srcStat.isDirectory() && destStat.isDirectory()) {
       throw new ERR_FS_CP_NON_DIR_TO_DIR({
-        message: `cannot overwrite non-directory ${src} ` +
-            `with directory ${dest}`,
+        message: `cannot overwrite directory ${dest} ` +
+            `with non-directory ${src}`,
         path: dest,
         syscall: 'cp',
         errno: ENOTDIR,


### PR DESCRIPTION
The error messages for `ERR_FS_CP_DIR_TO_NON_DIR` and `ERR_FS_CP_NON_DIR_TO_DIR` were the inverse of the copy direction actually performed.

Refs: https://github.com/nodejs/node/issues/44598#issuecomment-1562522423

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
