### PR TITLE
test_runner: avoid error when coverage line not mappable

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -355,6 +355,10 @@ class TestCoverage {
           const { startOffset, endOffset, count } = ranges[k];
           const { lines } = mapRangeToLines(ranges[k], originalLines);
 
+          if (lines.length === 0) {
+            // The range is not mappable. Skip it.
+            continue;
+          }
           let startEntry = sourceMap
             .findEntry(lines[0].line - 1, MathMax(0, startOffset - lines[0].startOffset));
           const endEntry = sourceMap


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/52775#issuecomment-2131456060

I still need to add some tests for this case where there is coverage for a range outside of the sourcemap