### PR TITLE
doc: include ESM import for HTTP

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -6,7 +6,8 @@
 
 <!-- source_link=lib/http.js -->
 
-To use the HTTP server and client one must `require('node:http')`.
+This module, containing both a client and server, can be imported via
+`require('node:http')` (CJS) or `import * as http from 'http'` (ESM).
 
 The HTTP interfaces in Node.js are designed to support many features
 of the protocol which have been traditionally difficult to use.


### PR DESCRIPTION
This PR changes the instructions on importing the HTTP library to also include ESM instructions.