### PR TITLE
doc: auto-generate ESM/CJS

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -11,22 +11,8 @@ inspector.
 
 It can be accessed using:
 
-```mjs
-import * as inspector from 'node:inspector/promises';
-```
-
-```cjs
-const inspector = require('node:inspector/promises');
-```
-
-or
-
-```mjs
-import * as inspector from 'node:inspector';
-```
-
-```cjs
-const inspector = require('node:inspector');
+```js
+//@import 'inspector' 'node:inspector/promises' !star
 ```
 
 ## Promises API
@@ -144,8 +130,9 @@ added: v19.0.0
 
 Posts a message to the inspector back-end.
 
-```mjs
-import { Session } from 'node:inspector/promises';
+```js
+//@import '{ Session }' 'node:inspector/promises'
+
 try {
   const session = new Session();
   session.connect();
@@ -174,9 +161,10 @@ protocol.
 
 Here's an example showing how to use the [CPU Profiler][]:
 
-```mjs
-import { Session } from 'node:inspector/promises';
-import fs from 'node:fs';
+```js
+//@import '{ Session }' 'node:inspector/promises'
+//@import 'fs' 'node:fs'
+
 const session = new Session();
 session.connect();
 
@@ -195,9 +183,10 @@ fs.writeFileSync('./profile.cpuprofile', JSON.stringify(profile));
 
 Here's an example showing how to use the [Heap Profiler][]:
 
-```mjs
-import { Session } from 'node:inspector/promises';
-import fs from 'node:fs';
+```js
+//@import '{ Session }' 'node:inspector/promises'
+//@import 'fs' 'node:fs'
+
 const session = new Session();
 
 const fd = fs.openSync('profile.heapsnapshot', 'w');
@@ -359,9 +348,10 @@ protocol.
 Here's an example showing how to use the [CPU Profiler][]:
 
 ```js
-const inspector = require('node:inspector');
-const fs = require('node:fs');
-const session = new inspector.Session();
+//@import '{ Session }' 'node:inspector/promises'
+//@import 'fs' 'node:fs'
+
+const session = new Session();
 session.connect();
 
 session.post('Profiler.enable', () => {
@@ -384,9 +374,11 @@ session.post('Profiler.enable', () => {
 Here's an example showing how to use the [Heap Profiler][]:
 
 ```js
-const inspector = require('node:inspector');
-const fs = require('node:fs');
-const session = new inspector.Session();
+//@import '{ Session }' 'node:inspector/promises'
+//@import 'fs' 'node:fs'
+
+const session = new Session();
+session.connect();
 
 const fd = fs.openSync('profile.heapsnapshot', 'w');
 


### PR DESCRIPTION
This PR introduces the ability to automatically generate ESM vs. CJS snippets in the documentation.

So far, I've updated only the Buffer documentation to use this new feature. If this approach is approved, I plan to extend it to the rest of the documentation. I believe this feature will be a valuable enhancement, particularly when the @nodejs/web-infra team updates the documentation completely. In the meantime, this serves as a 'polyfill' to provide the feature now.

This feature allows for one code snippet to generate both ESM and CJS, rather than a mjs snippet and a cjs snippet.

## **How to use this feature?**

### Old:
```cjs
const { Buffer } = require('node:buffer');
```
```mjs
import { Buffer } from 'node:buffer';
```
### New:
```js
//@import '{ Buffer }' 'node:buffer'
```

#### Syntax:
```js
//@import 'what-to-import' 'where-from' !star
```

If you want the snippet to generate the ESM as `import * as module from 'module';`, append `!star` to the `@import` comment.