### PR TITLE
src: make `--env-file` return warning when not found

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -732,6 +732,8 @@ in the file, the value from the environment takes precedence.
 You can pass multiple `--env-file` arguments. Subsequent files override
 pre-existing variables defined in previous files.
 
+If the file is not found, a warning will be printed.
+
 ```bash
 node --env-file=.env --env-file=.development.env index.js
 ```

--- a/src/node.cc
+++ b/src/node.cc
@@ -845,7 +845,7 @@ static ExitCode InitializeNodeWithArgsInternal(
           errors->push_back(file_path + ": invalid format");
           break;
         case Dotenv::ParseResult::FileError:
-          errors->push_back(file_path + ": not found");
+          fprintf(stderr, "Warning: Requested .env file not found\n\n");
           break;
         default:
           UNREACHABLE();

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -48,8 +48,8 @@ describe('.env supports edge cases', () => {
       [ '--env-file=.env', '--eval', code ],
       { cwd: __dirname },
     );
-    assert.notStrictEqual(child.stderr.toString(), '');
-    assert.strictEqual(child.code, 9);
+    assert.ok(child.stderr.includes('Requested .env file not found'));
+    assert.strictEqual(child.code, 0);
   });
 
   it('should not override existing environment variables but introduce new vars', async () => {


### PR DESCRIPTION
Currently `node --env-file` throws an error. People tend to add these to their package.json and push it to `git`. With this proposed change, we are more in par with existing `dotenv` package (for not throwing an error). 

With the proposed change, we are now warning the users that the `env` file is not found when running the CLI only. `loadEnvFile()` is not changed.

Alternative was to add a new flag called `--env-file-optional` which I'm 100% against. Ref: https://github.com/nodejs/node/pull/53060

Reverts https://github.com/nodejs/node/pull/50588

Closes https://github.com/nodejs/node/issues/50993
Closes https://github.com/nodejs/node/issues/51451
