### PR TITLE
test: expose `file` & `fullName` props on TestContext (for snapshots)

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -214,6 +214,30 @@ class TestContext {
     return this.#test.signal;
   }
 
+  /**
+   * Get the path of the current test file.
+   * @example '/tmp/test.js'
+   */
+  get file() {
+    return this.#test.loc.file;
+  }
+
+  /**
+   * Get the name for the current context and all ancestors (outputs a string from root to tip).
+   * @example 'Animals › Cat › sleep() should be possible at any time'
+   */
+  get fullName() {
+    let fullName = this.#test.name;
+    let parent = this.#test.parent;
+
+    while (parent.parent) { // `null` when at the root which has no name, so abort when we get there
+      fullName = `${parent.name} › ${fullName}`;
+      ({ parent } = parent);
+    }
+
+    return fullName;
+  }
+
   get name() {
     return this.#test.name;
   }

--- a/test/parallel/test-runner-snapshot-props.js
+++ b/test/parallel/test-runner-snapshot-props.js
@@ -1,0 +1,25 @@
+'use strict';
+require('../common');
+
+const assert = require('node:assert');
+const { resolve } = require('node:path');
+const { describe, test } = require('node:test');
+
+
+// These props are needed to support jest-like snapshots (which is not itself a feature in Core).
+
+const rootName = 'props for snapshots';
+describe(rootName, () => {
+  test('test context has "file" property', (ctx) => {
+    assert.strictEqual(ctx.file, resolve(__filename));
+  });
+
+  const nestedName = '"fullName" contains both case and ancestor names';
+  test(nestedName, (ctx) => {
+    assert.match(ctx.fullName, new RegExp(rootName));
+    assert.match(ctx.fullName, new RegExp(nestedName));
+
+    // Ensure root appears before tip
+    assert.ok(ctx.fullName.indexOf(rootName) < ctx.fullName.indexOf(nestedName));
+  });
+});


### PR DESCRIPTION
Per our discussion last month (in slack): These properties are needed to facilitate jest-like snapshots in node's test runner¹.

¹ I have a simple package for this that is nearly done (hoping to polish it off this week), which we intend to publish on npm under either the `@pkgjs` or `@nodejs` namespace.