### PR TITLE
build: update ruff to v0.4.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1524,8 +1524,8 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing ruff on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.3.4 || \
-		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.3.4
+	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.4.5 || \
+		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.4.5
 
 .PHONY: lint-py
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")


### PR DESCRIPTION
Updates Ruff to v0.4.5

cc @nodejs/build