### PR TITLE
doc: add note to ninjia build for macOS using -jn flag

### DIFF
--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -38,8 +38,9 @@ make -j4 # With this flag, Ninja will limit itself to 4 parallel jobs,
          # regardless of the number of cores on the current machine.
 ```
 
-Note: if you are on macOS and use GNU Make version `v3.8.x`, the `-jn` flag
-will be ignored, you can either upgrade to v4.x from [Homebrew](https://formulae.brew.sh/formula/make#default) or use `make JOBS=n`.
+Note: if you are on macOS and use GNU Make version `3.x`, the `-jn` flag
+will not work. You can either upgrade to `v4.x` (e.g. using a package manager
+such as [Homebrew](https://formulae.brew.sh/formula/make#default)) or use `make JOBS=n`.
 
 ## Producing a debug build
 

--- a/doc/contributing/building-node-with-ninja.md
+++ b/doc/contributing/building-node-with-ninja.md
@@ -38,6 +38,9 @@ make -j4 # With this flag, Ninja will limit itself to 4 parallel jobs,
          # regardless of the number of cores on the current machine.
 ```
 
+Note: if you are on macOS and use GNU Make version `v3.8.x`, the `-jn` flag
+will be ignored, you can either upgrade to v4.x from [Homebrew](https://formulae.brew.sh/formula/make#default) or use `make JOBS=n`.
+
 ## Producing a debug build
 
 To create a debug build rather than a release build:


### PR DESCRIPTION
Adding a note to macOS build as `make -jn` will no longer work with GNU make `v3.8.x`

Fixes: https://github.com/nodejs/node/issues/53176#issuecomment-2135575519, https://github.com/nodejs/node/issues/53176#issuecomment-2134752460

Refs: https://github.com/nodejs/node/issues/53176

cc @tniessen @targos @anonrig @lpinca 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
