### PR TITLE
stream: fix memory usage regression in writable

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -252,8 +252,8 @@ ObjectDefineProperties(WritableState.prototype, {
     enumerable: false,
     get() { return (this[kState] & kWriteCb) !== 0 ? this[kWriteCbValue] : nop; },
     set(value) {
+      this[kWriteCbValue] = value;
       if (value) {
-        this[kWriteCbValue] = value;
         this[kState] |= kWriteCb;
       } else {
         this[kState] &= ~kWriteCb;
@@ -268,8 +268,8 @@ ObjectDefineProperties(WritableState.prototype, {
     enumerable: false,
     get() { return (this[kState] & kAfterWriteTickInfo) !== 0 ? this[kAfterWriteTickInfoValue] : null; },
     set(value) {
+      this[kAfterWriteTickInfoValue] = value;
       if (value) {
-        this[kAfterWriteTickInfoValue] = value;
         this[kState] |= kAfterWriteTickInfo;
       } else {
         this[kState] &= ~kAfterWriteTickInfo;
@@ -615,7 +615,8 @@ function onwrite(stream, er) {
   const sync = (state[kState] & kSync) !== 0;
   const cb = (state[kState] & kWriteCb) !== 0 ? state[kWriteCbValue] : nop;
 
-  state[kState] &= ~(kWriting | kExpectWriteCb | kWriteCb);
+  state.writecb = null;
+  state[kState] &= ~(kWriting | kExpectWriteCb);
   state.length -= state.writelen;
   state.writelen = 0;
 


### PR DESCRIPTION
Setting writecb and afterWriteTickInfo to null did not clear the value in the state object.

Amends 35ec93115d (stream: writable state bitmap).

Fixes #52228.