### PR TITLE
tools: use Ubuntu 24.04 and Clang on GitHub actions

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -30,6 +30,9 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
+  CC: sccache clang
+  CXX: sccache clang++
+  SCCACHE_GHA_ENABLED: 'true'
 
 permissions:
   contents: read
@@ -37,7 +40,7 @@ permissions:
 jobs:
   build-tarball:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:
@@ -46,6 +49,10 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd  # v0.0.4
+        with:
+          version: v0.8.0
       - name: Environment Information
         run: npx envinfo
       - name: Make tarball
@@ -63,7 +70,7 @@ jobs:
           path: tarballs
   test-tarball-linux:
     needs: build-tarball
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:
@@ -72,6 +79,10 @@ jobs:
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d  # v5.1.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@2e7f9ec7921547d4b46598398ca573513895d0bd  # v0.0.4
+        with:
+          version: v0.8.0
       - name: Environment Information
         run: npx envinfo
       - name: Download tarball

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -32,6 +32,9 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
+  CC: sccache clang
+  CXX: sccache clang++
+  SCCACHE_GHA_ENABLED: 'true'
 
 permissions:
   contents: read
@@ -39,11 +42,7 @@ permissions:
 jobs:
   coverage-linux-without-intl:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    env:
-      CC: sccache gcc
-      CXX: sccache g++
-      SCCACHE_GHA_ENABLED: 'true'
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -32,6 +32,9 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
+  CC: sccache clang
+  CXX: sccache clang++
+  SCCACHE_GHA_ENABLED: 'true'
 
 permissions:
   contents: read
@@ -39,11 +42,7 @@ permissions:
 jobs:
   coverage-linux:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    env:
-      CC: sccache gcc
-      CXX: sccache g++
-      SCCACHE_GHA_ENABLED: 'true'
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,9 +13,7 @@ permissions:
 
 jobs:
   build-lto:
-    runs-on: ubuntu-latest
-    # not working on gcc-8 and gcc-9 see https://github.com/nodejs/node/issues/38570
-    container: gcc:11
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:
@@ -28,6 +26,6 @@ jobs:
         run: npx envinfo
       - name: Build lto
         run: |
-          apt-get update && apt-get install ninja-build python-is-python3 -y
+          sudo apt-get update && sudo apt-get install ninja-build -y
           ./configure --enable-lto --ninja
           ninja -C out/Release

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - .github/workflows/test-internet.yml
       - test/internet/**
       - internal/dns/**
       - lib/dns.js
@@ -19,6 +20,7 @@ on:
       - v[0-9]+.x-staging
       - v[0-9]+.x
     paths:
+      - .github/workflows/test-internet.yml
       - test/internet/**
       - internal/dns/**
       - lib/dns.js
@@ -31,6 +33,8 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
+  CC: clang
+  CXX: clang++
 
 permissions:
   contents: read
@@ -38,7 +42,7 @@ permissions:
 jobs:
   test-internet:
     if: github.repository == 'nodejs/node' || github.event_name != 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -25,6 +25,9 @@ concurrency:
 env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
+  CC: sccache clang
+  CXX: sccache clang++
+  SCCACHE_GHA_ENABLED: 'true'
 
 permissions:
   contents: read
@@ -32,11 +35,7 @@ permissions:
 jobs:
   test-linux:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    env:
-      CC: sccache gcc
-      CXX: sccache g++
-      SCCACHE_GHA_ENABLED: 'true'
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6
         with:


### PR DESCRIPTION
This puts us closer to what V8 really supports.
GCC is still covered a lot by Jenkins CI.
