### PR TITLE
stream: make sure _destroy is called on the tail

### DIFF
--- a/lib/internal/streams/compose.js
+++ b/lib/internal/streams/compose.js
@@ -238,8 +238,9 @@ module.exports = function compose(...streams) {
     ondrain = null;
     onfinish = null;
 
-    if (isNodeStream(tail))
+    if (isNodeStream(tail)) {
       destroyer(tail, err);
+    }
 
     if (onclose === null) {
       callback(err);

--- a/lib/internal/streams/compose.js
+++ b/lib/internal/streams/compose.js
@@ -238,13 +238,13 @@ module.exports = function compose(...streams) {
     ondrain = null;
     onfinish = null;
 
+    if (isNodeStream(tail))
+      destroyer(tail, err);
+
     if (onclose === null) {
       callback(err);
     } else {
       onclose = callback;
-      if (isNodeStream(tail)) {
-        destroyer(tail, err);
-      }
     }
   };
 

--- a/test/parallel/test-stream-compose.js
+++ b/test/parallel/test-stream-compose.js
@@ -520,7 +520,7 @@ const assert = require('assert');
         } else if (this.writableEnded) {
           this.push(null);
         } else {
-          setTimeout(() => this._read(), 100);
+          setTimeout(() => this._read(), common.platformTimeout(100));
         }
       }, 100);
     }
@@ -541,5 +541,5 @@ const assert = require('assert');
   setTimeout(() => {
     composed.destroy(new Error('an unexpected error'));
     assert.strictEqual(slow.destroyed, true);
-  }, 100);
+  }, common.platformTimeout(100));
 }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51987 (attempt to).

Please let me know if I am on the right track as I could be missing some important stuff here. If the fix is on the right track I will add a test.

EDIT: I have added a test.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
