### PR TITLE
lib: fix the name of the fetch global function

### DIFF
--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -70,7 +70,7 @@ ObjectDefineProperty(globalThis, 'fetch', {
   configurable: true,
   enumerable: true,
   writable: true,
-  value: function value(input, init = undefined) {
+  value: function fetch(input, init = undefined) { // eslint-disable-line func-name-matching
     if (!fetchImpl) { // Implement lazy loading of undici module for fetch function
       const undiciModule = require('internal/deps/undici/undici');
       fetchImpl = undiciModule.fetch;

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -61,6 +61,11 @@ for (const moduleName of builtinModules) {
     'navigator',
   ];
   assert.deepStrictEqual(new Set(Object.keys(global)), new Set(expected));
+  expected.forEach((value) => {
+    if (typeof global[value] === 'function') {
+      assert.strictEqual(global[value].name, value);
+    }
+  });
 }
 
 common.allowGlobals('bar', 'foo');

--- a/test/parallel/test-global.js
+++ b/test/parallel/test-global.js
@@ -62,8 +62,11 @@ for (const moduleName of builtinModules) {
   ];
   assert.deepStrictEqual(new Set(Object.keys(global)), new Set(expected));
   expected.forEach((value) => {
-    if (typeof global[value] === 'function') {
-      assert.strictEqual(global[value].name, value);
+    const desc = Object.getOwnPropertyDescriptor(global, value);
+    if (typeof desc.value === 'function') {
+      assert.strictEqual(desc.value.name, value);
+    } else if (typeof desc.get === 'function') {
+      assert.strictEqual(desc.get.name, `get ${value}`);
     }
   });
 }


### PR DESCRIPTION
this fixes a small regression introduced with #52275

the `global.fetch.name` should be `fetch` instead of `value`. That is also the name that the inspector gets and what is shown implicitly on the call stack during debugging. With this change `global.fetch` will be shown on the call stack instead of `global.value`.
Added a generic test to ensure the same applies to all the `global` functions.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
