### PR TITLE
build: find version of Clang installed on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -636,13 +636,21 @@ Optional requirements to build the MSI installer package:
 * The .NET SDK component from [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
   * This component can be installed via the Visual Studio Installer Application
 
-Optional requirements for compiling for Windows 10 on ARM (ARM64):
+Optional requirements for compiling for Windows on ARM (ARM64):
 
 * Visual Studio 17.6.0 or newer
 * Visual Studio optional components
   * Visual C++ compilers and libraries for ARM64
   * Visual C++ ATL for ARM64
 * Windows 10 SDK 10.0.17763.0 or newer
+
+Optional requirements for compiling with ClangCL:
+
+* Visual Studio optional components
+  * C++ Clang Compiler for Windows
+  * MSBuild support for LLVM toolset
+
+NOTE: Currently we only support compiling with Clang that comes from Visual Studio.
 
 ##### Option 2: Automated install with Boxstarter
 

--- a/tools/msvs/vswhere_usability_wrapper.cmd
+++ b/tools/msvs/vswhere_usability_wrapper.cmd
@@ -13,10 +13,15 @@ if not exist "%InstallerPath%" goto :no-vswhere
 set "Path=%Path%;%InstallerPath%"
 where vswhere 2> nul > nul
 if errorlevel 1 goto :no-vswhere
+:: VC.Tools are needed even when using clang because of the vcvarsall.bat usage
 if "%2"=="arm64" (
     set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.ARM64    
 ) else (
     set VSWHERE_REQ=-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+)
+if "%4"=="1" (
+    set VSWHERE_REQ=%VSWHERE_REQ% -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang
+    set VSWHERE_REQ=%VSWHERE_REQ% -requires Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
 )
 set VSWHERE_PRP=-property installationPath
 set VSWHERE_LMT=-version %1


### PR DESCRIPTION
As discussed, we want to be able to fetch the version of the installed ClangCL dynamically, so we do not keep it hardcoded. This change takes an initial step in that direction. For now, we require Clang to be installed from a Visual Studio installation as an individual component. Later, once we finish adding support for Clang on Windows, we should aim to improve this by allowing users to install Clang themselves and use it Node.js.

This approach uses the `vswhere_usability_wrapper.cmd` to ensure that required components are installed when compiling with Clang.

Refs: https://github.com/nodejs/node/issues/52809