### PR TITLE
test: fix test when compiled without engine support

### DIFF
--- a/test/addons/openssl-test-engine/test.js
+++ b/test/addons/openssl-test-engine/test.js
@@ -11,50 +11,59 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 
+// Engine support in OpenSSL is checked later on.
+let hasEngineSupport = true;
 
-assert.throws(() => crypto.setEngine(true), /ERR_INVALID_ARG_TYPE/);
+assert.throws(() => crypto.setEngine(true), /ERR_INVALID_ARG_TYPE|ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED/);
 assert.throws(() => crypto.setEngine('/path/to/engine', 'notANumber'),
               /ERR_INVALID_ARG_TYPE/);
 
 {
   const invalidEngineName = 'xxx';
   assert.throws(() => crypto.setEngine(invalidEngineName),
-                /ERR_CRYPTO_ENGINE_UNKNOWN/);
+                /ERR_CRYPTO_ENGINE_UNKNOWN|ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED/);
   assert.throws(() => crypto.setEngine(invalidEngineName,
                                        crypto.constants.ENGINE_METHOD_RSA),
-                /ERR_CRYPTO_ENGINE_UNKNOWN/);
+                /ERR_CRYPTO_ENGINE_UNKNOWN|ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED/);
 }
 
-crypto.setEngine('dynamic');
-crypto.setEngine('dynamic');
+try {
+  crypto.setEngine('dynamic');
+  crypto.setEngine('dynamic');
 
-crypto.setEngine('dynamic', crypto.constants.ENGINE_METHOD_RSA);
-crypto.setEngine('dynamic', crypto.constants.ENGINE_METHOD_RSA);
+  crypto.setEngine('dynamic', crypto.constants.ENGINE_METHOD_RSA);
+  crypto.setEngine('dynamic', crypto.constants.ENGINE_METHOD_RSA);
+} catch (err) {
+  assert.strictEqual(err.code, 'ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED');
+  hasEngineSupport = false;
+}
 
-const engine = path.join(__dirname,
-                         `/build/${common.buildType}/testsetengine.engine`);
+if (hasEngineSupport) {
+  const engine = path.join(__dirname,
+                           `/build/${common.buildType}/testsetengine.engine`);
 
-if (!fs.existsSync(engine))
-  common.skip('no engine');
+  if (!fs.existsSync(engine))
+    common.skip('no engine');
 
-{
-  const engineId = path.parse(engine).name;
-  const execDir = path.parse(engine).dir;
+  {
+    const engineId = path.parse(engine).name;
+    const execDir = path.parse(engine).dir;
 
-  crypto.setEngine(engine);
-  // OpenSSL 3.0.1 and 1.1.1m now throw errors if an engine is loaded again
-  // with a duplicate absolute path.
-  // TODO(richardlau): figure out why this fails on macOS but not Linux.
-  // crypto.setEngine(engine);
+    crypto.setEngine(engine);
+    // OpenSSL 3.0.1 and 1.1.1m now throw errors if an engine is loaded again
+    // with a duplicate absolute path.
+    // TODO(richardlau): figure out why this fails on macOS but not Linux.
+    // crypto.setEngine(engine);
 
-  // crypto.setEngine(engine, crypto.constants.ENGINE_METHOD_RSA);
-  // crypto.setEngine(engine, crypto.constants.ENGINE_METHOD_RSA);
+    // crypto.setEngine(engine, crypto.constants.ENGINE_METHOD_RSA);
+    // crypto.setEngine(engine, crypto.constants.ENGINE_METHOD_RSA);
 
-  process.env.OPENSSL_ENGINES = execDir;
+    process.env.OPENSSL_ENGINES = execDir;
 
-  crypto.setEngine(engineId);
-  crypto.setEngine(engineId);
+    crypto.setEngine(engineId);
+    crypto.setEngine(engineId);
 
-  crypto.setEngine(engineId, crypto.constants.ENGINE_METHOD_RSA);
-  crypto.setEngine(engineId, crypto.constants.ENGINE_METHOD_RSA);
+    crypto.setEngine(engineId, crypto.constants.ENGINE_METHOD_RSA);
+    crypto.setEngine(engineId, crypto.constants.ENGINE_METHOD_RSA);
+  }
 }


### PR DESCRIPTION
Update the `addons/openssl-test-engine` test to pass when OpenSSL has been compiled without support for custom engines. OpenSSL 3 deprecated support for engines, with the recommendation to move to the provider model.

Refs: https://github.com/openssl/openssl/blob/openssl-3.0.0/README-ENGINES.md

cc @nodejs/crypto 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
