### PR TITLE
doc: add `err` param to fs.copyFile callback

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2477,6 +2477,7 @@ changes:
   * `verbatimSymlinks` {boolean} When `true`, path resolution for symlinks will
     be skipped. **Default:** `false`
 * `callback` {Function}
+  * `err` {Error}
 
 Asynchronously copies the entire directory structure from `src` to `dest`,
 including subdirectories and files.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -2388,6 +2388,7 @@ changes:
 * `dest` {string|Buffer|URL} destination filename of the copy operation
 * `mode` {integer} modifiers for copy operation. **Default:** `0`.
 * `callback` {Function}
+  * `err` {Error}
 
 Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists. No arguments other than a possible exception are given to the

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -3030,7 +3030,7 @@ function copyFileSync(src, dest, mode) {
  * @param {string | URL} src
  * @param {string | URL} dest
  * @param {object} [options]
- * @param {() => any} callback
+ * @param {(err?: Error) => any} callback
  * @returns {void}
  */
 function cp(src, dest, options, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2984,7 +2984,7 @@ function mkdtempSync(prefix, options) {
  * @param {string | Buffer | URL} src
  * @param {string | Buffer | URL} dest
  * @param {number} [mode]
- * @param {() => any} callback
+ * @param {(err?: Error) => any} callback
  * @returns {void}
  */
 function copyFile(src, dest, mode, callback) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix #53230

Related issue: https://github.com/nodejs/node/issues/52916