### PR TITLE
doc: Mention possibility of `corepack enable npm`

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -96,7 +96,7 @@ it can conflict with such environments. To avoid that happening, call the
 the same time you're preparing your deploy image). This will ensure that the
 required package managers are available even without network access.
 
-The `corepack` command has [various flags][]. Consult the detailed
+The `pack` command has [various flags][]. Consult the detailed
 [Corepack documentation][] for more information.
 
 ## Supported package managers

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -103,11 +103,11 @@ The `corepack` command has [various flags][]. Consult the detailed
 
 The following binaries are provided through Corepack:
 
-| Package manager                   | Binary names      |
-| --------------------------------- | ----------------- |
-| [Yarn][]                          | `yarn`, `yarnpkg` |
-| [pnpm][]                          | `pnpm`, `pnpx`    |
-| [npm](https://npmjs.org)*         | `npm`, `npx`      |
+| Package manager  | Binary names      |
+| ---------------- | ----------------- |
+| [Yarn][]         | `yarn`, `yarnpkg` |
+| [pnpm][]         | `pnpm`, `pnpx`    |
+| [npm][]*         | `npm`, `npx`      |
 
 \* Not enabled by default. Use `corepack enable npm` to do so.
 
@@ -149,6 +149,7 @@ install. To avoid this problem, consider one of the following options:
 [`corepack use`]: https://github.com/nodejs/corepack#corepack-use-nameversion
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
 [pnpm]: https://pnpm.io
+[npm]: https://npmjs.org
 [supported binaries]: #supported-package-managers
 [supported package manager]: #supported-package-managers
 [various flags]: https://github.com/nodejs/corepack#utility-commands

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -96,30 +96,34 @@ it can conflict with such environments. To avoid that happening, call the
 the same time you're preparing your deploy image). This will ensure that the
 required package managers are available even without network access.
 
-The `pack` command has [various flags][]. Consult the detailed
+The `corepack` command has [various flags][]. Consult the detailed
 [Corepack documentation][] for more information.
 
 ## Supported package managers
 
 The following binaries are provided through Corepack:
 
-| Package manager | Binary names      |
-| --------------- | ----------------- |
-| [Yarn][]        | `yarn`, `yarnpkg` |
-| [pnpm][]        | `pnpm`, `pnpx`    |
+| Package manager                   | Binary names      |
+| --------------------------------- | ----------------- |
+| [Yarn][]                          | `yarn`, `yarnpkg` |
+| [pnpm][]                          | `pnpm`, `pnpx`    |
+| [npm](https://npmjs.org)*         | `npm`, `npx`      |
+
+\* Not enabled by default. Use `corepack enable npm` to do so.
 
 ## Common questions
 
 ### How does Corepack interact with npm?
 
-While Corepack could support npm like any other package manager, its
-shims aren't enabled by default. This has a few consequences:
+The npm shims aren't enabled by default. This has a few consequences:
 
 * It's always possible to run a `npm` command within a project configured to
   be used with another package manager, since Corepack cannot intercept it.
 
 * While `npm` is a valid option in the [`"packageManager"`][] property, the
   lack of shim will cause the global npm to be used.
+
+You can enable shimming npm by running `corepack enable npm`.
 
 ### Running `npm install -g yarn` doesn't work
 


### PR DESCRIPTION
After reading https://www.totaltypescript.com/how-to-use-corepack, I realized that the Corepack docs page has some shortfalls:

- It implies npm is not supported, but npm is supported. It is just not enabled by default.
- The command for enabling the npm shim (`corepack enable npm`) is never mentioned anywhere.

With this PR, I believe to correct the docs according to the current implementation. If you anyways plan to change it, feel free to close.