### PR TITLE
stream: prevent stream unexpected pause when highWaterMark set to 0

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -565,7 +565,7 @@ function writeOrBuffer(stream, state, chunk, encoding, callback) {
     state[kState] &= ~kSync;
   }
 
-  const ret = state.length < state.highWaterMark;
+  const ret = state.length < state.highWaterMark || state.length === 0;
 
   if (!ret) {
     state[kState] |= kNeedDrain;

--- a/test/parallel/test-streams-highwatermark.js
+++ b/test/parallel/test-streams-highwatermark.js
@@ -85,3 +85,27 @@ const { inspect } = require('util');
              hwm,
   }));
 }
+
+{
+  const res = [];
+  const r = new stream.Readable({
+    read() {},
+  });
+  const w = new stream.Writable({
+    highWaterMark: 0,
+    write(chunk, encoding, callback) {
+      res.push(chunk.toString());
+      callback();
+    },
+  });
+
+  r.pipe(w);
+  r.push('a');
+  r.push('b');
+  r.push('c');
+  r.push(null);
+
+  r.on('end', common.mustCall(() => {
+    assert.deepStrictEqual(res, ['a', 'b', 'c']);
+  }));
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51930

p.s. I noticed that the bot knows to require review from the correct team but the label `stream` isn't added 👀 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
