### PR TITLE
tools: add stream label on PR when related files being changed in lib

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -91,7 +91,7 @@ subSystemLabels:
   /^lib\/internal\/bootstrap/: lib / src
   /^lib\/internal\/v8_prof_/: tools
   /^lib\/internal\/socket(?:_list|address)\.js$/: net
-  /^lib\/\w+\/streams$/: stream
+  /^lib\/(_stream.*|internal\/streams\/.*|stream\.js|stream\/.*)$/: stream
   /^lib\/.*http2/: http2
   /^lib\/worker_threads.js$/: worker
   /^lib\/test.js$/: test_runner


### PR DESCRIPTION
I have noticed that changes related to `stream` in the `lib` folder do not automatically add `stream` label on the PR, and requires collaborator or triager to manually do so. I am not sure if there is a reason that I am not aware of, but this PR should potentially fix it.

Files covered by the regex (totally 27 files):

```
➜  $ find lib -type f | grep '^lib\/\(_stream.*\|internal/streams/.*\|stream\.js\|stream/.*\)$'        
lib/stream.js
lib/stream/consumers.js
lib/stream/promises.js
lib/stream/web.js
lib/internal/streams/add-abort-signal.js
lib/internal/streams/compose.js
lib/internal/streams/duplexify.js
lib/internal/streams/destroy.js
lib/internal/streams/legacy.js
lib/internal/streams/passthrough.js
lib/internal/streams/operators.js
lib/internal/streams/readable.js
lib/internal/streams/from.js
lib/internal/streams/writable.js
lib/internal/streams/state.js
lib/internal/streams/end-of-stream.js
lib/internal/streams/utils.js
lib/internal/streams/transform.js
lib/internal/streams/lazy_transform.js
lib/internal/streams/duplex.js
lib/internal/streams/pipeline.js
lib/_stream_wrap.js
lib/_stream_passthrough.js
lib/_stream_transform.js
lib/_stream_duplex.js
lib/_stream_readable.js
lib/_stream_writable.js
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
