### PR TITLE
test: fix test-http-server-keepalive-req-gc

### DIFF
--- a/test/parallel/test-http-server-keepalive-req-gc.js
+++ b/test/parallel/test-http-server-keepalive-req-gc.js
@@ -14,9 +14,10 @@ const server = createServer(common.mustCall((req, res) => {
   onGC(req, { ongc: common.mustCall(() => { server.close(); }) });
   req.resume();
   req.on('end', common.mustCall(() => {
-    setImmediate(() => {
+    setImmediate(async () => {
       client.end();
-      global.gc();
+      await global.gc({ type: 'major', execution: 'async' });
+      await global.gc({ type: 'major', execution: 'async' });
     });
   }));
   res.end('hello world');


### PR DESCRIPTION
This changes adds a second explicit gc call in the test. Without this
call, the test relies on gc eventually happening based, since the
first call doesn't free the object.
Relying on gc to eventually happen prevents changing GC heuristics
unrelated to this test.
The gc call is async; otherwise doing multiple sync GCs doesn't free
the object.

