### PR TITLE
crypto: fix propagation of "memory limit exceeded"

### DIFF
--- a/src/crypto/crypto_scrypt.cc
+++ b/src/crypto/crypto_scrypt.cc
@@ -104,7 +104,17 @@ Maybe<bool> ScryptTraits::AdditionalConfig(
           params->maxmem,
           nullptr,
           0) != 1) {
-    THROW_ERR_CRYPTO_INVALID_SCRYPT_PARAMS(env);
+    // Do not use CryptoErrorStore or ThrowCryptoError here in order to maintain
+    // backward compatibility with ERR_CRYPTO_INVALID_SCRYPT_PARAMS.
+    uint32_t err = ERR_peek_last_error();
+    if (err != 0) {
+      char buf[256];
+      ERR_error_string_n(err, buf, sizeof(buf));
+      THROW_ERR_CRYPTO_INVALID_SCRYPT_PARAMS(
+          env, "Invalid scrypt params: %s", buf);
+    } else {
+      THROW_ERR_CRYPTO_INVALID_SCRYPT_PARAMS(env);
+    }
     return Nothing<bool>();
   }
 

--- a/test/parallel/test-crypto-scrypt.js
+++ b/test/parallel/test-crypto-scrypt.js
@@ -178,7 +178,8 @@ for (const options of bad) {
 
 for (const options of toobig) {
   const expected = {
-    message: /Invalid scrypt param/
+    message: /Invalid scrypt params:.*memory limit exceeded/,
+    code: 'ERR_CRYPTO_INVALID_SCRYPT_PARAMS',
   };
   assert.throws(() => crypto.scrypt('pass', 'salt', 1, options, () => {}),
                 expected);


### PR DESCRIPTION
When we throw `ERR_CRYPTO_INVALID_SCRYPT_PARAMS` after a call to `EVP_PBE_scrypt`, check if OpenSSL reported an error and if so, append the OpenSSL error message to the default generic error message. In particular, this catches cases when `maxmem` is not sufficient, which otherwise is difficult to identify because our documentation only provides an approximation of the required `maxmem` value.

Fixes: https://github.com/nodejs/node/issues/53291

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
