### PR TITLE
lib: fix misleading argument of validateUint32

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -194,7 +194,7 @@ function testMatchesPattern(test, patterns) {
 
 class TestPlan {
   constructor(count) {
-    validateUint32(count, 'count', 0);
+    validateUint32(count, 'count');
     this.expected = count;
     this.actual = 0;
   }
@@ -428,7 +428,7 @@ class Test extends AsyncResource {
 
     switch (typeof concurrency) {
       case 'number':
-        validateUint32(concurrency, 'options.concurrency', 1);
+        validateUint32(concurrency, 'options.concurrency', true);
         this.concurrency = concurrency;
         break;
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -129,7 +129,7 @@ const validateInt32 = hideStackFrames(
  * @callback validateUint32
  * @param {*} value
  * @param {string} name
- * @param {number|boolean} [positive=false]
+ * @param {boolean} [positive=false]
  * @returns {asserts value is number}
  */
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -248,7 +248,7 @@ function getHeapCodeStatistics() {
 
 let heapSnapshotNearHeapLimitCallbackAdded = false;
 function setHeapSnapshotNearHeapLimit(limit) {
-  validateUint32(limit, 'limit', 1);
+  validateUint32(limit, 'limit', true);
   if (heapSnapshotNearHeapLimitCallbackAdded ||
       getOptionValue('--heapsnapshot-near-heap-limit') > 0
   ) {


### PR DESCRIPTION
The type of the argument `positive` was declared as `boolean|number`, which is misleading because the function treats it as a boolean only. Some call sites even passed numbers, specifically, either `0` or `1`, which happen to work as expected because they are interpreted as `false` and `true`, respectively. However, passing `2` would silently lead to unexpected behavior. Thus, strictly make the argument a boolean.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
