### PR TITLE
meta: close likely spam issues

### DIFF
--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Close issues with no body or title longer than 100 characters
-      uses: actions/github-script@v6
+    - name: Close issues without content
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
       with:
         script: |
           const issue = context.payload.issue;

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -1,47 +1,46 @@
+---
 name: Close Issues Based on Conditions
-
 on:
   issues:
-    types: [opened]
-
+    types:
+      - opened
 jobs:
   close_invalid_issues:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Close issues without content
-      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-      with:
-        script: |
-          const issue = context.payload.issue;
-          const issueBody = issue.body;
-          const issueNumber = issue.number;
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
+      - name: Close issues without content
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  #v7.0.1
+        with:
+          script: >
+            const issue = context.payload.issue;
+            const issueBody = issue.body;
+            const issueNumber = issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-          if (issueBody.length < 10) {
-            // Set the 'invalid' label (this removes all other labels and sets 'invalid')
-            await github.issues.setLabels({
-              owner: owner,
-              repo: repo,
-              issue_number: issueNumber,
-              labels: ['invalid']
-            });
+            if (issueBody.length < 10) {
+              // Set the 'invalid' label (this removes all other labels and sets 'invalid')
+              await github.issues.setLabels({
+                owner: owner,
+                repo: repo,
+                issue_number: issueNumber,
+                labels: ['invalid']
+              });
 
-            // Close the issue with the state reason 'not planned'
-            await github.issues.update({
-              owner: owner,
-              repo: repo,
-              issue_number: issueNumber,
-              state: 'closed',
-              state_reason: 'not_planned'
-            });
+              // Close the issue with the state reason 'not planned'
+              await github.issues.update({
+                owner: owner,
+                repo: repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
 
-            // Add a comment explaining why the issue was closed
-            await github.issues.createComment({
-              owner: owner,
-              repo: repo,
-              issue_number: issueNumber,
-              body: `This issue has been closed as it's body is too short`
-            });
-          }
+              // Add a comment explaining why the issue was closed
+              await github.issues.createComment({
+                owner: owner,
+                repo: repo,
+                issue_number: issueNumber,
+                body: `This issue has been closed as it's body is too short`
+              });
+            }

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -1,0 +1,47 @@
+name: Close Issues Based on Conditions
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  close_invalid_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Close issues with no body or title longer than 100 characters
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const issue = context.payload.issue;
+          const issueBody = issue.body;
+          const issueNumber = issue.number;
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+
+          if (issueBody.length < 10) {
+            // Set the 'invalid' label (this removes all other labels and sets 'invalid')
+            await github.issues.setLabels({
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber,
+              labels: ['invalid']
+            });
+
+            // Close the issue with the state reason 'not planned'
+            await github.issues.update({
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber,
+              state: 'closed',
+              state_reason: 'not_planned'
+            });
+
+            // Add a comment explaining why the issue was closed
+            await github.issues.createComment({
+              owner: owner,
+              repo: repo,
+              issue_number: issueNumber,
+              body: `This issue has been closed as it's body is too short`
+            });
+          }

--- a/.github/workflows/close-invalid.yml
+++ b/.github/workflows/close-invalid.yml
@@ -1,4 +1,3 @@
----
 name: Close Issues Based on Conditions
 on:
   issues:
@@ -9,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issues without content
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  #v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: >
             const issue = context.payload.issue;


### PR DESCRIPTION
This PR proposes an action to reduce overall spam by requiring all submitted issues to have a body containing at least 10 characters. I chose the 10-character minimum because it’s unlikely that a legitimate issue would be shorter.

This is intended to be an open discussion, and I welcome feedback on additional rules. I don’t want to appear as though I’m rushing this PR without proper discussion; this PR is meant to serve as an example of what is possible and to initiate the conversation.

Some other rules I thought about
- Max title length
- Disallowed words
- Restricted File Changes

This is the kind-of thing I think the higher-power members should review in a meeting