### PR TITLE
build: use shell-only python version detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ test-ci: | clear-stalled bench-addons-build build-addons build-js-native-api-tes
 # Prepare the build for running the tests.
 # Related CI jobs: most CI tests, excluding node-test-commit-arm-fanned
 build-ci:
-	$(PYTHON) ./configure --verbose $(CONFIG_FLAGS)
+	$(PYTHON) ./configure.py --verbose $(CONFIG_FLAGS)
 	$(MAKE)
 
 .PHONY: run-ci
@@ -1101,7 +1101,7 @@ endif
 	done
 	CC_host="cc -arch x86_64" CXX_host="c++ -arch x86_64"  \
 	CC_target="cc -arch x86_64" CXX_target="c++ -arch x86_64" \
-	CC="cc -arch x86_64" CXX="c++ -arch x86_64" $(PYTHON) ./configure \
+	CC="cc -arch x86_64" CXX="c++ -arch x86_64" $(PYTHON) ./configure.py \
 		--dest-cpu=x86_64 \
 		--tag=$(TAG) \
 		--release-urlbase=$(RELEASE_URLBASE) \
@@ -1109,7 +1109,7 @@ endif
 	arch -x86_64 $(MAKE) install V=$(V) DESTDIR=$(MACOSOUTDIR)/dist/x64/node
 	SIGN="$(CODESIGN_CERT)" PKGDIR="$(MACOSOUTDIR)/dist/x64/node/usr/local" sh \
 		tools/osx-codesign.sh
-	$(PYTHON) ./configure \
+	$(PYTHON) ./configure.py \
 		--dest-cpu=arm64 \
 		--tag=$(TAG) \
 		--release-urlbase=$(RELEASE_URLBASE) \
@@ -1235,7 +1235,7 @@ doc-upload: doc
 
 .PHONY: $(TARBALL)-headers
 $(TARBALL)-headers: release-only
-	$(PYTHON) ./configure \
+	$(PYTHON) ./configure.py \
 		--prefix=/ \
 		--dest-cpu=$(DESTCPU) \
 		--tag=$(TAG) \
@@ -1271,7 +1271,7 @@ endif
 $(BINARYTAR): release-only
 	$(RM) -r $(BINARYNAME)
 	$(RM) -r out/deps out/Release
-	$(PYTHON) ./configure \
+	$(PYTHON) ./configure.py \
 		--prefix=/ \
 		--dest-cpu=$(DESTCPU) \
 		--tag=$(TAG) \

--- a/android-configure
+++ b/android-configure
@@ -1,36 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-# Locate an acceptable Python interpreter and then re-execute the script.
-# Note that the mix of single and double quotes is intentional,
-# as is the fact that the ] goes on a new line.
-_=[ 'exec' '/bin/sh' '-c' '''
-command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
-command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
-command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
-command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
-command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
-command -v python3.6 >/dev/null && exec python3.6 "$0" "$@"
-command -v python3 >/dev/null && exec python3 "$0" "$@"
-exec python "$0" "$@"
-''' "$0" "$@"
-]
-del _
+PYTHONS=$(compgen -c | grep -E '^python3(\.[0-9]+)?$' | sort -r)
 
-import sys
-try:
-  from shutil import which
-except ImportError:
-  from distutils.spawn import find_executable as which
-
-print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
-if sys.version_info[:2] in acceptable_pythons:
-  import android_configure
-else:
-  python_cmds = ['python{}.{}'.format(*vers) for vers in acceptable_pythons]
-  sys.stderr.write('Please use {}.\n'.format(' or '.join(python_cmds)))
-  for python_cmd in python_cmds:
-      python_cmd_path = which(python_cmd)
-      if python_cmd_path and 'pyenv/shims' not in python_cmd_path:
-        sys.stderr.write('\t{} {}\n'.format(python_cmd_path, ' '.join(sys.argv[:1])))
-  sys.exit(1)
+for PYTHON in $PYTHONS; do
+    if $PYTHON -c 'import sys; sys.exit(sys.version_info < (3, 6))'; then
+        $PYTHON "android_configure.py" $@
+        break
+    fi
+done

--- a/configure
+++ b/configure
@@ -1,38 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-# Locate an acceptable Python interpreter and then re-execute the script.
-# Note that the mix of single and double quotes is intentional,
-# as is the fact that the ] goes on a new line.
-_=[ 'exec' '/bin/sh' '-c' '''
-command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
-command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
-command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
-command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
-command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
-command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
-command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
-command -v python3.6 >/dev/null && exec python3.6 "$0" "$@"
-command -v python3 >/dev/null && exec python3 "$0" "$@"
-exec python "$0" "$@"
-''' "$0" "$@"
-]
-del _
+PYTHONS=$(compgen -c | grep -E '^python3(\.[0-9]+)?$' | sort -r)
 
-import sys
-try:
-  from shutil import which
-except ImportError:
-  from distutils.spawn import find_executable as which
-
-print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
-if sys.version_info[:2] in acceptable_pythons:
-  import configure
-else:
-  python_cmds = ['python{}.{}'.format(*vers) for vers in acceptable_pythons]
-  sys.stderr.write('Please use {}.\n'.format(' or '.join(python_cmds)))
-  for python_cmd in python_cmds:
-      python_cmd_path = which(python_cmd)
-      if python_cmd_path and 'pyenv/shims' not in python_cmd_path:
-        sys.stderr.write('\t{} {}\n'.format(python_cmd_path, ' '.join(sys.argv[:1])))
-  sys.exit(1)
+for PYTHON in $PYTHONS; do
+    if $PYTHON -c 'import sys; sys.exit(sys.version_info < (3, 6))'; then
+        $PYTHON "$0.py" $@
+        break
+    fi
+done


### PR DESCRIPTION
This PR modifies `./configure` and `./android-configure` to not incorperate both Python and bash in a single file, and instead uses a shell-only way (And a bit of `python -c`) to detect and get the latest installed python version.