### PR TITLE
repl: handle object patterns without values

### DIFF
--- a/lib/internal/repl/await.js
+++ b/lib/internal/repl/await.js
@@ -104,7 +104,7 @@ const visitorsWithoutAncestors = {
             break;
           case 'ObjectPattern':
             ArrayPrototypeForEach(node.properties, (property) => {
-              registerVariableDeclarationIdentifiers(property.value);
+              registerVariableDeclarationIdentifiers(property.value || property.argument);
             });
             break;
           case 'ArrayPattern':

--- a/test/parallel/test-repl-preprocess-top-level-await.js
+++ b/test/parallel/test-repl-preprocess-top-level-await.js
@@ -144,6 +144,9 @@ const testCases = [
     '(async () => { return { value: ((await x).y) } })()'],
   [ 'await (await x).y',
     '(async () => { return { value: (await (await x).y) } })()'],
+  [ 'var { ...rest } = await {}',
+    'var rest; (async () => { void ({ ...rest } = await {}) })()',
+  ],
 ];
 
 for (const [input, expected] of testCases) {


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/53328

For the `ObjectPattern` of type `RestElement` the child node is in the `argument` property.