### PR TITLE
module: allow multiple chain

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -95,6 +95,7 @@ port.on('message', (message) => {
       filename,
       hasStdin,
       publicPort,
+      hooksPort,
       workerData,
     } = message;
 
@@ -109,6 +110,7 @@ port.on('message', (message) => {
     }
 
     require('internal/worker').assignEnvironmentData(environmentData);
+    require('internal/worker').hooksPort = hooksPort;
 
     if (SharedArrayBuffer !== undefined) {
       // The counter is only passed to the workers created by the main thread,

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -146,7 +146,13 @@ port.on('message', (message) => {
       case 'internal': {
         // Create this WeakMap in js-land because V8 has no C++ API for WeakMap.
         internalBinding('module_wrap').callbackMap = new SafeWeakMap();
-        require(filename)(workerData, publicPort);
+        let entrypoint = require(filename);
+
+        if (typeof entrypoint !== 'function') {
+          entrypoint = entrypoint.entrypoint;
+        }
+
+        entrypoint(workerData, publicPort);
         break;
       }
 

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -35,7 +35,7 @@ const {
 const { exitCodes: { kUnsettledTopLevelAwait } } = internalBinding('errors');
 const { URL } = require('internal/url');
 const { canParse: URLCanParse } = internalBinding('url');
-const { receiveMessageOnPort } = require('worker_threads');
+const { receiveMessageOnPort, isMainThread } = require('worker_threads');
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
@@ -482,6 +482,8 @@ class HooksProxy {
    */
   #worker;
 
+  #portToHooksThread;
+
   /**
    * The last notification ID received from the worker. This is used to detect
    * if the worker has already sent a notification before putting the main
@@ -499,26 +501,38 @@ class HooksProxy {
   #isReady = false;
 
   constructor() {
-    const { InternalWorker } = require('internal/worker');
-    MessageChannel ??= require('internal/worker/io').MessageChannel;
-
+    const { InternalWorker, hooksPort } = require('internal/worker');
     const lock = new SharedArrayBuffer(SHARED_MEMORY_BYTE_LENGTH);
     this.#lock = new Int32Array(lock);
 
-    this.#worker = new InternalWorker(loaderWorkerId, {
-      stderr: false,
-      stdin: false,
-      stdout: false,
-      trackUnmanagedFds: false,
-      workerData: {
-        lock,
-      },
-    });
-    this.#worker.unref(); // ! Allows the process to eventually exit.
-    this.#worker.on('exit', process.exit);
+    if (isMainThread) {
+      // Main thread is the only one that creates the internal single hooks worker
+      this.#worker = new InternalWorker(loaderWorkerId, {
+        stderr: false,
+        stdin: false,
+        stdout: false,
+        trackUnmanagedFds: false,
+        workerData: {
+          lock,
+        },
+      });
+      this.#worker.unref(); // ! Allows the process to eventually exit.
+      this.#worker.on('exit', process.exit);
+      this.#portToHooksThread = this.#worker;
+    } else {
+      this.#portToHooksThread = hooksPort;
+    }
   }
 
   waitForWorker() {
+    // There is one Hooks instance for each worker thread. But only one of these Hooks instances
+    // has an InternalWorker. That was the Hooks instance created for the main thread.
+    // It means for all Hooks instances that are not on the main thread => they are ready because they
+    // delegate to the single InternalWorker anyway.
+    if (!isMainThread) {
+      return;
+    }
+
     if (!this.#isReady) {
       const { kIsOnline } = require('internal/worker');
       if (!this.#worker[kIsOnline]) {
@@ -535,6 +549,37 @@ class HooksProxy {
     }
   }
 
+  #postMessageToWorker(method, type, transferList, args) {
+    this.waitForWorker();
+
+    MessageChannel ??= require('internal/worker/io').MessageChannel;
+
+    const {
+      port1: fromHooksThread,
+      port2: toHooksThread,
+    } = new MessageChannel();
+
+    // Pass work to the worker.
+    debug(`post ${type} message to worker`, { method, args, transferList });
+    const usedTransferList = [toHooksThread];
+    if (transferList) {
+      ArrayPrototypePushApply(usedTransferList, transferList);
+    }
+
+    this.#portToHooksThread.postMessage(
+      {
+        __proto__: null,
+        args,
+        lock: this.#lock,
+        method,
+        port: toHooksThread,
+      },
+      usedTransferList,
+    );
+
+    return fromHooksThread;
+  }
+
   /**
    * Invoke a remote method asynchronously.
    * @param {string} method Method to invoke
@@ -543,22 +588,7 @@ class HooksProxy {
    * @returns {Promise<any>}
    */
   async makeAsyncRequest(method, transferList, ...args) {
-    this.waitForWorker();
-
-    MessageChannel ??= require('internal/worker/io').MessageChannel;
-    const asyncCommChannel = new MessageChannel();
-
-    // Pass work to the worker.
-    debug('post async message to worker', { method, args, transferList });
-    const finalTransferList = [asyncCommChannel.port2];
-    if (transferList) {
-      ArrayPrototypePushApply(finalTransferList, transferList);
-    }
-    this.#worker.postMessage({
-      __proto__: null,
-      method, args,
-      port: asyncCommChannel.port2,
-    }, finalTransferList);
+    const fromHooksThread = this.#postMessageToWorker(method, 'Async', transferList, args);
 
     if (this.#numberOfPendingAsyncResponses++ === 0) {
       // On the next lines, the main thread will await a response from the worker thread that might
@@ -567,7 +597,11 @@ class HooksProxy {
       // However we want to keep the process alive until the worker thread responds (or until the
       // event loop of the worker thread is also empty), so we ref the worker until we get all the
       // responses back.
-      this.#worker.ref();
+      if (this.#worker) {
+        this.#worker.ref();
+      } else {
+        this.#portToHooksThread.ref();
+      }
     }
 
     let response;
@@ -576,18 +610,26 @@ class HooksProxy {
       await AtomicsWaitAsync(this.#lock, WORKER_TO_MAIN_THREAD_NOTIFICATION, this.#workerNotificationLastId).value;
       this.#workerNotificationLastId = AtomicsLoad(this.#lock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
 
-      response = receiveMessageOnPort(asyncCommChannel.port1);
+      response = receiveMessageOnPort(fromHooksThread);
     } while (response == null);
     debug('got async response from worker', { method, args }, this.#lock);
 
     if (--this.#numberOfPendingAsyncResponses === 0) {
       // We got all the responses from the worker, its job is done (until next time).
-      this.#worker.unref();
+      if (this.#worker) {
+        this.#worker.unref();
+      } else {
+        this.#portToHooksThread.unref();
+      }
     }
 
-    const body = this.#unwrapMessage(response);
-    asyncCommChannel.port1.close();
-    return body;
+    if (response.message.status === 'exit') {
+      process.exit(response.message.body);
+    }
+
+    fromHooksThread.close();
+
+    return this.#unwrapMessage(response);
   }
 
   /**
@@ -598,11 +640,7 @@ class HooksProxy {
    * @returns {any}
    */
   makeSyncRequest(method, transferList, ...args) {
-    this.waitForWorker();
-
-    // Pass work to the worker.
-    debug('post sync message to worker', { method, args, transferList });
-    this.#worker.postMessage({ __proto__: null, method, args }, transferList);
+    const fromHooksThread = this.#postMessageToWorker(method, 'Sync', transferList, args);
 
     let response;
     do {
@@ -611,7 +649,7 @@ class HooksProxy {
       AtomicsWait(this.#lock, WORKER_TO_MAIN_THREAD_NOTIFICATION, this.#workerNotificationLastId);
       this.#workerNotificationLastId = AtomicsLoad(this.#lock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
 
-      response = this.#worker.receiveMessageSync();
+      response = receiveMessageOnPort(fromHooksThread);
     } while (response == null);
     debug('got sync response from worker', { method, args });
     if (response.message.status === 'never-settle') {
@@ -619,6 +657,9 @@ class HooksProxy {
     } else if (response.message.status === 'exit') {
       process.exit(response.message.body);
     }
+
+    fromHooksThread.close();
+
     return this.#unwrapMessage(response);
   }
 

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const {
-  ArrayPrototypeFilter,
-  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
-  ArrayPrototypeSome,
   AtomicsLoad,
   AtomicsWait,
   AtomicsWaitAsync,
@@ -15,9 +12,11 @@ const {
   ObjectSetPrototypeOf,
   Promise,
   ReflectSet,
+  SafeMap,
   SafeSet,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
+  Symbol,
   globalThis,
 } = primordials;
 
@@ -38,7 +37,7 @@ const {
 const { exitCodes: { kUnsettledTopLevelAwait } } = internalBinding('errors');
 const { URL } = require('internal/url');
 const { canParse: URLCanParse } = internalBinding('url');
-const { receiveMessageOnPort } = require('worker_threads');
+const { receiveMessageOnPort, threadId } = require('worker_threads');
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
@@ -50,6 +49,7 @@ const {
 const {
   kEmptyObject,
 } = require('internal/util');
+const { isDeepStrictEqual } = require('internal/util/comparisons');
 
 const {
   defaultResolve,
@@ -64,12 +64,43 @@ const {
   SHARED_MEMORY_BYTE_LENGTH,
   WORKER_TO_MAIN_THREAD_NOTIFICATION,
 } = require('internal/modules/esm/shared_constants');
+
+const currentThreadId = threadId;
+const kDefaultChainId = Symbol('kDefaultChainId');
+
 let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
 let importMetaInitializer;
 
 let importAssertionAlreadyWarned = false;
+
+const defaultChains = {
+  /**
+   * Phase 1 of 2 in ESM loading.
+   * The output of the `resolve` chain of hooks is passed into the `load` chain of hooks.
+   * @private
+   * @property {KeyedHook[]} resolve Last-in-first-out collection of resolve hooks.
+   */
+  resolve: [
+    {
+      fn: defaultResolve,
+      url: 'node:internal/modules/esm/resolve',
+    },
+  ],
+
+  /**
+   * Phase 2 of 2 in ESM loading.
+   * @private
+   * @property {KeyedHook[]} load Last-in-first-out collection of loader hooks.
+   */
+  load: [
+    {
+      fn: require('internal/modules/esm/load').defaultLoad,
+      url: 'node:internal/modules/esm/load',
+    },
+  ],
+};
 
 function emitImportAssertionWarning() {
   if (!importAssertionAlreadyWarned) {
@@ -109,32 +140,7 @@ function defineImportAssertionAlias(context) {
 // [2] `validate...()`s throw the wrong error
 
 class Hooks {
-  #chains = {
-    /**
-     * Phase 1 of 2 in ESM loading.
-     * The output of the `resolve` chain of hooks is passed into the `load` chain of hooks.
-     * @private
-     * @property {KeyedHook[]} resolve Last-in-first-out collection of resolve hooks.
-     */
-    resolve: [
-      {
-        fn: defaultResolve,
-        url: 'node:internal/modules/esm/resolve',
-      },
-    ],
-
-    /**
-     * Phase 2 of 2 in ESM loading.
-     * @private
-     * @property {KeyedHook[]} load Last-in-first-out collection of loader hooks.
-     */
-    load: [
-      {
-        fn: require('internal/modules/esm/load').defaultLoad,
-        url: 'node:internal/modules/esm/load',
-      },
-    ],
-  };
+  #chains = new SafeMap();
 
   // Cache URLs we've already validated to avoid repeated validation
   #validatedUrls = new SafeSet();
@@ -145,54 +151,66 @@ class Hooks {
    * Import and register custom/user-defined module loader hook(s).
    * @param {string} urlOrSpecifier
    * @param {string} parentURL
+   * @param {number} [threadId]
    * @param {any} [data] Arbitrary data to be passed from the custom
+   * @param {boolean} [fromLoader]
    * loader (user-land) to the worker.
    */
-  async register(urlOrSpecifier, parentURL, data) {
+  async register(urlOrSpecifier, parentURL, threadId, data, fromLoader) {
     const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
     const keyedExports = await cascadedLoader.import(
       urlOrSpecifier,
       parentURL,
       kEmptyObject,
     );
-    await this.addCustomLoader(urlOrSpecifier, keyedExports, data);
+
+    await this.addCustomLoader(urlOrSpecifier, keyedExports, threadId, data);
+
+    // If we registered as part of --experimental-loader, make sure we also register
+    // for the hooks thread to influence other loaders
+    if (fromLoader) {
+      await this.addCustomLoader(urlOrSpecifier, keyedExports, currentThreadId, data);
+    }
   }
+
 
   /**
    * Collect custom/user-defined module loader hook(s).
    * @param {string} url Custom loader specifier
    * @param {Record<string, unknown>} exports
-   * @param {any} [data] Arbitrary data to be passed from the custom loader (user-land)
-   * to the worker.
+   * @param {number} [threadId]
+   * @param {any} [data] Arbitrary data to be passed from the custom loader (user-land) to the worker.
    * @returns {any | Promise<any>} User data, ignored unless it's a promise, in which case it will be awaited.
    */
-  addCustomLoader(url, exports, data) {
-    const alreadyKnown = ArrayPrototypeSome(ArrayPrototypeMap(['initialize', 'resolve', 'load'], (hookName) => {
-      if (this.#chains[hookName]) {
-        return ArrayPrototypeFilter(
-          this.#chains[hookName], (el) => el.url === url && el.data === data).length === 1;
-      }
-    }), (el) => el);
-
-    if (alreadyKnown) {
-      return undefined;
-    }
-
+  addCustomLoader(url, exports, threadId, data) {
     const {
       initialize,
       resolve,
       load,
     } = pluckHooks(exports);
 
+    const chain = this.getChain(threadId);
+
+    // Do not register the same hook with the same data
+    for (const hook of chain.registered) {
+      if (hook.url === url && (typeof data === 'undefined' || isDeepStrictEqual(hook.data, data))) {
+        return undefined;
+      }
+    }
+
+    ArrayPrototypePush(chain.registered, { url, data });
+
     if (resolve) {
-      const next = this.#chains.resolve[this.#chains.resolve.length - 1];
-      ArrayPrototypePush(this.#chains.resolve, { __proto__: null, fn: resolve, url, data, next });
+      const next = chain.resolve[chain.resolve.length - 1];
+      ArrayPrototypePush(chain.resolve, { __proto__: null, fn: resolve, url, next, data });
     }
+
     if (load) {
-      const next = this.#chains.load[this.#chains.load.length - 1];
-      ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: load, url, data, next });
+      const next = chain.load[chain.load.length - 1];
+      ArrayPrototypePush(chain.load, { __proto__: null, fn: load, url, next, data });
     }
-    return initialize?.(data);
+
+    return initialize?.(data, { threadId });
   }
 
   /**
@@ -206,17 +224,19 @@ class Hooks {
    * @param {string} [parentURL] The URL path of the module's parent.
    * @param {ImportAttributes} [importAttributes] Attributes from the import
    *                                              statement or expression.
+   * @param {number} [threadId]
    * @returns {Promise<{ format: string, url: URL['href'] }>}
    */
   async resolve(
     originalSpecifier,
     parentURL,
     importAttributes = { __proto__: null },
-    threadId
+    threadId,
   ) {
     throwIfInvalidParentURL(parentURL);
 
-    const chain = this.#chains.resolve;
+    const chain = this.getChain(threadId).resolve;
+
     const context = {
       conditions: getDefaultConditions(),
       importAttributes,
@@ -345,10 +365,11 @@ class Hooks {
    * until it reaches the bottom or short-circuits.
    * @param {URL['href']} url The URL/path of the module to be loaded
    * @param {object} context Metadata about the module
+   * @param {number} [threadId]
    * @returns {Promise<{ format: ModuleFormat, source: ModuleSource }>}
    */
-  async load(url, context = {}) {
-    const chain = this.#chains.load;
+  async load(url, context, threadId) {
+    const chain = this.getChain(threadId).load;
     const meta = {
       chainFinished: null,
       context,
@@ -356,6 +377,9 @@ class Hooks {
       hookName: 'load',
       shortCircuited: false,
     };
+
+    context ??= {};
+    context.threadId = threadId;
 
     const validateArgs = (hookErrIdentifier, nextUrl, ctx) => {
       if (typeof nextUrl !== 'string') {
@@ -479,6 +503,45 @@ class Hooks {
     meta = importMetaInitializer(meta, context, loader);
     return meta;
   }
+
+  getChain(id) {
+    // Do not use `if(!id)` here - id is actually a threadId so it might be 0.
+    if (typeof id === 'undefined') {
+      id = kDefaultChainId;
+    }
+
+    if (!this.#chains.has(id)) {
+      this.#chains.set(id, {
+        resolve: [...defaultChains.resolve],
+        load: [...defaultChains.load],
+        registered: [],
+      });
+    }
+
+    return this.#chains.get(id);
+  }
+
+  getChains() {
+    return this.#chains;
+  }
+
+  copyChain(from, to) {
+    if (!this.#chains.has(from)) {
+      this.#chains.set(to, {
+        resolve: [...defaultChains.resolve],
+        load: [...defaultChains.load],
+        registered: [],
+      });
+
+      return;
+    }
+
+    this.#chains.set(to, this.#chains.get(from));
+  }
+
+  deleteChain(id) {
+    this.#chains.delete(id);
+  }
 }
 ObjectSetPrototypeOf(Hooks.prototype, null);
 
@@ -515,7 +578,6 @@ class HooksProxy {
   #numberOfPendingAsyncResponses = 0;
 
   #isReady = false;
-  #isWorkerOwner = false;
 
   constructor() {
     const { HooksWorker, hooksPort } = require('internal/worker');
@@ -538,8 +600,12 @@ class HooksProxy {
       });
       this.#worker.unref(); // ! Allows the process to eventually exit.
       this.#worker.on('exit', process.exit);
-      this.#isWorkerOwner = true;
       this.#portToHooksThread = this.#worker;
+
+      // Clear our chain when exiting.
+      process.once('beforeExit', () => {
+        this.makeAsyncRequest('deleteChain', undefined, threadId);
+      });
     } catch (e) {
       if (e.code === 'ERR_HOOKS_THREAD_EXISTS') {
         this.#portToHooksThread = hooksPort;
@@ -554,8 +620,8 @@ class HooksProxy {
     // these Hooks instances has a HooksWorker. That was the Hooks instance
     // created for the first thread that registers a hook set.
     // It means for all Hooks instances that are not on that thread => they are
-    // done because they delegate to the single HooksWorker.
-    if (!this.#isWorkerOwner) {
+    // done because they delegate to the single InternalWorker.
+    if (!this.#worker) {
       return;
     }
 
@@ -614,6 +680,12 @@ class HooksProxy {
    * @returns {Promise<any>}
    */
   async makeAsyncRequest(method, transferList, ...args) {
+    const handleInternalMessage = require('internal/modules/esm/worker').handleInternalMessage;
+
+    if (handleInternalMessage) {
+      return handleInternalMessage({ method, args });
+    }
+
     const fromHooksThread = this.#postMessageToWorker(method, 'Async', transferList, args);
 
     if (this.#numberOfPendingAsyncResponses++ === 0) {
@@ -666,6 +738,12 @@ class HooksProxy {
    * @returns {any}
    */
   makeSyncRequest(method, transferList, ...args) {
+    const handleInternalMessage = require('internal/modules/esm/worker').handleInternalMessage;
+
+    if (handleInternalMessage) {
+      return handleInternalMessage({ method, args });
+    }
+
     const fromHooksThread = this.#postMessageToWorker(method, 'Sync', transferList, args);
 
     let response;
@@ -778,6 +856,7 @@ function nextHookFactory(current, meta, { validateArgs, validateOutput }) {
     fn: hook,
     url: hookFilePath,
     next,
+    data,
   } = current;
 
   // ex 'nextResolve'
@@ -814,7 +893,7 @@ function nextHookFactory(current, meta, { validateArgs, validateOutput }) {
         ObjectAssign(meta.context, context);
       }
 
-      const output = await hook(arg0, meta.context, nextNextHook);
+      const output = await hook(arg0, { ...meta.context, data }, nextNextHook);
       validateOutput(outputErrIdentifier, output);
 
       if (output?.shortCircuit === true) { meta.shortCircuited = true; }
@@ -826,6 +905,7 @@ function nextHookFactory(current, meta, { validateArgs, validateOutput }) {
   );
 }
 
-
-exports.Hooks = Hooks;
-exports.HooksProxy = HooksProxy;
+module.exports = {
+  Hooks,
+  HooksProxy,
+};

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -169,7 +169,8 @@ class Hooks {
   addCustomLoader(url, exports, data) {
     const alreadyKnown = ArrayPrototypeSome(ArrayPrototypeMap(['initialize', 'resolve', 'load'], (hookName) => {
       if (this.#chains[hookName]) {
-        return ArrayPrototypeFilter(this.#chains[hookName], (el) => el.url === url).length === 1;
+        return ArrayPrototypeFilter(
+          this.#chains[hookName], (el) => el.url === url && el.data === data).length === 1;
       }
     }), (el) => el);
 
@@ -185,11 +186,11 @@ class Hooks {
 
     if (resolve) {
       const next = this.#chains.resolve[this.#chains.resolve.length - 1];
-      ArrayPrototypePush(this.#chains.resolve, { __proto__: null, fn: resolve, url, next });
+      ArrayPrototypePush(this.#chains.resolve, { __proto__: null, fn: resolve, url, data, next });
     }
     if (load) {
       const next = this.#chains.load[this.#chains.load.length - 1];
-      ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: load, url, next });
+      ArrayPrototypePush(this.#chains.load, { __proto__: null, fn: load, url, data, next });
     }
     return initialize?.(data);
   }
@@ -211,6 +212,7 @@ class Hooks {
     originalSpecifier,
     parentURL,
     importAttributes = { __proto__: null },
+    threadId
   ) {
     throwIfInvalidParentURL(parentURL);
 
@@ -219,6 +221,7 @@ class Hooks {
       conditions: getDefaultConditions(),
       importAttributes,
       parentURL,
+      threadId,
     };
     const meta = {
       chainFinished: null,

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const {
+  ArrayPrototypeFilter,
+  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
+  ArrayPrototypeReduce,
   AtomicsLoad,
   AtomicsWait,
   AtomicsWaitAsync,
@@ -35,7 +38,7 @@ const {
 const { exitCodes: { kUnsettledTopLevelAwait } } = internalBinding('errors');
 const { URL } = require('internal/url');
 const { canParse: URLCanParse } = internalBinding('url');
-const { receiveMessageOnPort, isMainThread } = require('worker_threads');
+const { receiveMessageOnPort } = require('worker_threads');
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
@@ -164,6 +167,18 @@ class Hooks {
    * @returns {any | Promise<any>} User data, ignored unless it's a promise, in which case it will be awaited.
    */
   addCustomLoader(url, exports, data) {
+    const alreadyKnown = ArrayPrototypeReduce(
+      ArrayPrototypeMap(['initialize', 'resolve', 'load'], (hookName) => {
+        if (this.#chains[hookName]) {
+          const res2 = ArrayPrototypeFilter(this.#chains[hookName], (el) => el.url === url);
+          return res2.length;
+        }
+      }), (acc, val) => acc || (val === 1), false);
+
+    if (alreadyKnown) {
+      return undefined;
+    }
+
     const {
       initialize,
       resolve,
@@ -499,13 +514,14 @@ class HooksProxy {
   #numberOfPendingAsyncResponses = 0;
 
   #isReady = false;
+  #isWorkerOwner = false;
 
   constructor() {
-    const { InternalWorker, hooksPort } = require('internal/worker');
+    const { InternalWorker, hooksPort, hasHooksThread } = require('internal/worker');
     const lock = new SharedArrayBuffer(SHARED_MEMORY_BYTE_LENGTH);
     this.#lock = new Int32Array(lock);
 
-    if (isMainThread) {
+    if (!hasHooksThread()) {
       // Main thread is the only one that creates the internal single hooks worker
       this.#worker = new InternalWorker(loaderWorkerId, {
         stderr: false,
@@ -518,6 +534,7 @@ class HooksProxy {
       });
       this.#worker.unref(); // ! Allows the process to eventually exit.
       this.#worker.on('exit', process.exit);
+      this.#isWorkerOwner = true;
       this.#portToHooksThread = this.#worker;
     } else {
       this.#portToHooksThread = hooksPort;
@@ -529,7 +546,7 @@ class HooksProxy {
     // has an InternalWorker. That was the Hooks instance created for the main thread.
     // It means for all Hooks instances that are not on the main thread => they are ready because they
     // delegate to the single InternalWorker anyway.
-    if (!isMainThread) {
+    if (!this.#isWorkerOwner) {
       return;
     }
 

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -494,7 +494,7 @@ class HooksProxy {
    */
   #lock;
   /**
-   * The InternalWorker instance, which lets us communicate with the loader thread.
+   * The HooksWorker instance, which lets us communicate with the loader thread.
    */
   #worker;
 
@@ -518,7 +518,7 @@ class HooksProxy {
   #isWorkerOwner = false;
 
   constructor() {
-    const { InternalWorker, hooksPort } = require('internal/worker');
+    const { HooksWorker, hooksPort } = require('internal/worker');
     const lock = new SharedArrayBuffer(SHARED_MEMORY_BYTE_LENGTH);
     this.#lock = new Int32Array(lock);
 
@@ -527,7 +527,7 @@ class HooksProxy {
       // the existing instance. If another thread created it, the constructor will throw
       // Fallback is to use the existing hooksPort created by the thread that originally
       // spawned the customization hooks thread.
-      this.#worker = new InternalWorker(loaderWorkerId, {
+      this.#worker = new HooksWorker(loaderWorkerId, {
         stderr: false,
         stdin: false,
         stdout: false,
@@ -551,10 +551,10 @@ class HooksProxy {
 
   waitForWorker() {
     // There is one Hooks instance for each worker thread. But only one of
-    // these Hooks instances has an InternalWorker. That was the Hooks instance
+    // these Hooks instances has a HooksWorker. That was the Hooks instance
     // created for the first thread that registers a hook set.
     // It means for all Hooks instances that are not on that thread => they are
-    // done because they delegate to the single InternalWorker.
+    // done because they delegate to the single HooksWorker.
     if (!this.#isWorkerOwner) {
       return;
     }

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -5,7 +5,7 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
-  ArrayPrototypeReduce,
+  ArrayPrototypeSome,
   AtomicsLoad,
   AtomicsWait,
   AtomicsWaitAsync,
@@ -167,13 +167,11 @@ class Hooks {
    * @returns {any | Promise<any>} User data, ignored unless it's a promise, in which case it will be awaited.
    */
   addCustomLoader(url, exports, data) {
-    const alreadyKnown = ArrayPrototypeReduce(
-      ArrayPrototypeMap(['initialize', 'resolve', 'load'], (hookName) => {
-        if (this.#chains[hookName]) {
-          const res2 = ArrayPrototypeFilter(this.#chains[hookName], (el) => el.url === url);
-          return res2.length;
-        }
-      }), (acc, val) => acc || (val === 1), false);
+    const alreadyKnown = ArrayPrototypeSome(ArrayPrototypeMap(['initialize', 'resolve', 'load'], (hookName) => {
+      if (this.#chains[hookName]) {
+        return ArrayPrototypeFilter(this.#chains[hookName], (el) => el.url === url).length === 1;
+      }
+    }), (el) => el);
 
     if (alreadyKnown) {
       return undefined;

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -515,12 +515,15 @@ class HooksProxy {
   #isWorkerOwner = false;
 
   constructor() {
-    const { InternalWorker, hooksPort, hasHooksThread } = require('internal/worker');
+    const { InternalWorker, hooksPort } = require('internal/worker');
     const lock = new SharedArrayBuffer(SHARED_MEMORY_BYTE_LENGTH);
     this.#lock = new Int32Array(lock);
 
-    if (!hasHooksThread()) {
-      // Main thread is the only one that creates the internal single hooks worker
+    try {
+      // The customization hooks thread is only created once. All other threads reuse
+      // the existing instance. If another thread created it, the constructor will throw
+      // Fallback is to use the existing hooksPort created by the thread that originally
+      // spawned the customization hooks thread.
       this.#worker = new InternalWorker(loaderWorkerId, {
         stderr: false,
         stdin: false,
@@ -534,16 +537,21 @@ class HooksProxy {
       this.#worker.on('exit', process.exit);
       this.#isWorkerOwner = true;
       this.#portToHooksThread = this.#worker;
-    } else {
-      this.#portToHooksThread = hooksPort;
+    } catch (e) {
+      if (e.code === 'ERR_HOOKS_THREAD_EXISTS') {
+        this.#portToHooksThread = hooksPort;
+      } else {
+        throw e;
+      }
     }
   }
 
   waitForWorker() {
-    // There is one Hooks instance for each worker thread. But only one of these Hooks instances
-    // has an InternalWorker. That was the Hooks instance created for the main thread.
-    // It means for all Hooks instances that are not on the main thread => they are ready because they
-    // delegate to the single InternalWorker anyway.
+    // There is one Hooks instance for each worker thread. But only one of
+    // these Hooks instances has an InternalWorker. That was the Hooks instance
+    // created for the first thread that registers a hook set.
+    // It means for all Hooks instances that are not on that thread => they are
+    // done because they delegate to the single InternalWorker.
     if (!this.#isWorkerOwner) {
       return;
     }

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -41,6 +41,7 @@ const { ModuleWrap, kEvaluating, kEvaluated } = internalBinding('module_wrap');
 const {
   urlToFilename,
 } = require('internal/modules/helpers');
+const { isMainThread } = require('worker_threads');
 let defaultResolve, defaultLoad, defaultLoadSync, importMetaInitializer;
 
 /**
@@ -607,10 +608,11 @@ class CustomizedModuleLoader {
    */
   constructor() {
     getHooksProxy();
+    _hasCustomizations = true;
   }
 
   /**
-   * Register some loader specifier.
+   * Register a loader specifier.
    * @param {string} originalSpecifier The specified URL path of the loader to
    *                                   be registered.
    * @param {string} parentURL The parent URL from where the loader will be
@@ -618,10 +620,14 @@ class CustomizedModuleLoader {
    * @param {any} [data] Arbitrary data to be passed from the custom loader
    * (user-land) to the worker.
    * @param {any[]} [transferList] Objects in `data` that are changing ownership
-   * @returns {{ format: string, url: URL['href'] }}
+   * @returns {{ format: string, url: URL['href'] } | undefined}
    */
   register(originalSpecifier, parentURL, data, transferList) {
-    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
+    if (isMainThread) {
+      // Only the main thread has a Hooks instance with worker thread. All other Worker threads
+      // delegate their hooks to the HooksThread of the main thread.
+      return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
+    }
   }
 
   /**
@@ -719,6 +725,12 @@ function getHooksProxy() {
   return hooksProxy;
 }
 
+let _hasCustomizations = false;
+function hasCustomizations() {
+  return _hasCustomizations;
+}
+
+
 let cascadedLoader;
 
 /**
@@ -780,6 +792,7 @@ function register(specifier, parentURL = undefined, options) {
 
 module.exports = {
   createModuleLoader,
+  hasCustomizations,
   getHooksProxy,
   getOrInitializeCascadedLoader,
   register,

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -622,8 +622,6 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] } | undefined}
    */
   register(originalSpecifier, parentURL, data, transferList) {
-    // Only the main thread has a Hooks instance with worker thread. All other Worker threads
-    // delegate their hooks to the HooksThread of the main thread.
     return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
   }
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -637,9 +637,6 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] }}
    */
   resolve(originalSpecifier, parentURL, importAttributes) {
-    // const FS = require('fs');
-    // const UTIL = require('util');
-    // FS.writeFileSync(1, `resolve(${originalSpecifier}). ${Error().stack}\n`);
     return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes);
   }
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -41,7 +41,6 @@ const { ModuleWrap, kEvaluating, kEvaluated } = internalBinding('module_wrap');
 const {
   urlToFilename,
 } = require('internal/modules/helpers');
-const { isMainThread } = require('worker_threads');
 let defaultResolve, defaultLoad, defaultLoadSync, importMetaInitializer;
 
 /**
@@ -623,11 +622,9 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] } | undefined}
    */
   register(originalSpecifier, parentURL, data, transferList) {
-    if (isMainThread) {
-      // Only the main thread has a Hooks instance with worker thread. All other Worker threads
-      // delegate their hooks to the HooksThread of the main thread.
-      return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
-    }
+    // Only the main thread has a Hooks instance with worker thread. All other Worker threads
+    // delegate their hooks to the HooksThread of the main thread.
+    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
   }
 
   /**
@@ -640,6 +637,9 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] }}
    */
   resolve(originalSpecifier, parentURL, importAttributes) {
+    // const FS = require('fs');
+    // const UTIL = require('util');
+    // FS.writeFileSync(1, `resolve(${originalSpecifier}). ${Error().stack}\n`);
     return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes);
   }
 

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -41,6 +41,7 @@ const { ModuleWrap, kEvaluating, kEvaluated } = internalBinding('module_wrap');
 const {
   urlToFilename,
 } = require('internal/modules/helpers');
+const { threadId } = require('worker_threads');
 let defaultResolve, defaultLoad, defaultLoadSync, importMetaInitializer;
 
 /**
@@ -500,7 +501,7 @@ class ModuleLoader {
    */
   resolve(originalSpecifier, parentURL, importAttributes) {
     if (this.#customizations) {
-      return this.#customizations.resolve(originalSpecifier, parentURL, importAttributes);
+      return this.#customizations.resolve(originalSpecifier, parentURL, importAttributes, threadId);
     }
     const requestKey = this.#resolveCache.serializeKey(originalSpecifier, importAttributes);
     const cachedResult = this.#resolveCache.get(requestKey, parentURL);
@@ -622,7 +623,7 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] } | undefined}
    */
   register(originalSpecifier, parentURL, data, transferList) {
-    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data);
+    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data, threadId);
   }
 
   /**
@@ -635,7 +636,7 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] }}
    */
   resolve(originalSpecifier, parentURL, importAttributes) {
-    return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes);
+    return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes, threadId);
   }
 
   resolveSync(originalSpecifier, parentURL, importAttributes) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -36,12 +36,14 @@ const {
   getDefaultConditions,
 } = require('internal/modules/esm/utils');
 const { kImplicitTypeAttribute } = require('internal/modules/esm/assert');
+const { HooksProxy } = require('internal/modules/esm/hooks');
 const { canParse } = internalBinding('url');
 const { ModuleWrap, kEvaluating, kEvaluated } = internalBinding('module_wrap');
 const {
   urlToFilename,
 } = require('internal/modules/helpers');
 const { threadId } = require('worker_threads');
+const { hasHooksThread } = require('internal/worker');
 let defaultResolve, defaultLoad, defaultLoadSync, importMetaInitializer;
 
 /**
@@ -205,6 +207,11 @@ class ModuleLoader {
     } else {
       this.allowImportMetaResolve = true;
     }
+  }
+
+  // This method is only used for internal testing
+  getCustomizations() {
+    return this.#customizations;
   }
 
   async eval(source, url, isEntryPoint = false) {
@@ -479,7 +486,7 @@ class ModuleLoader {
   /**
    * @see {@link CustomizedModuleLoader.register}
    */
-  register(specifier, parentURL, data, transferList) {
+  register(specifier, parentURL, data, transferList, threadId, fromLoader) {
     if (!this.#customizations) {
       // `CustomizedModuleLoader` is defined at the bottom of this file and
       // available well before this line is ever invoked. This is here in
@@ -487,7 +494,10 @@ class ModuleLoader {
       // eslint-disable-next-line no-use-before-define
       this.setCustomizations(new CustomizedModuleLoader());
     }
-    return this.#customizations.register(`${specifier}`, `${parentURL}`, data, transferList);
+
+    return this.#customizations.register(
+      `${specifier}`, `${parentURL}`, data, transferList, threadId, fromLoader,
+    );
   }
 
   /**
@@ -608,7 +618,6 @@ class CustomizedModuleLoader {
    */
   constructor() {
     getHooksProxy();
-    _hasCustomizations = true;
   }
 
   /**
@@ -620,10 +629,20 @@ class CustomizedModuleLoader {
    * @param {any} [data] Arbitrary data to be passed from the custom loader
    * (user-land) to the worker.
    * @param {any[]} [transferList] Objects in `data` that are changing ownership
+   * @param {number} [threadId]
+   * @param {boolean} [fromLoader]
    * @returns {{ format: string, url: URL['href'] } | undefined}
    */
-  register(originalSpecifier, parentURL, data, transferList) {
-    return hooksProxy.makeSyncRequest('register', transferList, originalSpecifier, parentURL, data, threadId);
+  register(originalSpecifier, parentURL, data, transferList, threadId, fromLoader) {
+    return hooksProxy.makeSyncRequest(
+      'register',
+      transferList,
+      originalSpecifier,
+      parentURL,
+      threadId,
+      data,
+      fromLoader,
+    );
   }
 
   /**
@@ -636,12 +655,26 @@ class CustomizedModuleLoader {
    * @returns {{ format: string, url: URL['href'] }}
    */
   resolve(originalSpecifier, parentURL, importAttributes) {
-    return hooksProxy.makeAsyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes, threadId);
+    return hooksProxy.makeAsyncRequest(
+      'resolve',
+      undefined,
+      originalSpecifier,
+      parentURL,
+      importAttributes,
+      threadId,
+    );
   }
 
   resolveSync(originalSpecifier, parentURL, importAttributes) {
     // This happens only as a result of `import.meta.resolve` calls, which must be sync per spec.
-    return hooksProxy.makeSyncRequest('resolve', undefined, originalSpecifier, parentURL, importAttributes);
+    return hooksProxy.makeSyncRequest(
+      'resolve',
+      undefined,
+      originalSpecifier,
+      parentURL,
+      importAttributes,
+      threadId,
+    );
   }
 
   /**
@@ -651,10 +684,22 @@ class CustomizedModuleLoader {
    * @returns {Promise<{ format: ModuleFormat, source: ModuleSource }>}
    */
   load(url, context) {
-    return hooksProxy.makeAsyncRequest('load', undefined, url, context);
+    return hooksProxy.makeAsyncRequest(
+      'load',
+      undefined,
+      url,
+      context,
+      threadId,
+    );
   }
   loadSync(url, context) {
-    return hooksProxy.makeSyncRequest('load', undefined, url, context);
+    return hooksProxy.makeSyncRequest(
+      'load',
+      undefined,
+      url,
+      context,
+      threadId,
+    );
   }
 
   importMetaInitialize(meta, context, loader) {
@@ -701,6 +746,8 @@ function createModuleLoader() {
         emittedLoaderFlagWarning = true;
       }
       customizations = new CustomizedModuleLoader();
+    } else if (hasHooksThread()) {
+      customizations = new CustomizedModuleLoader();
     }
   }
 
@@ -714,18 +761,11 @@ function createModuleLoader() {
  */
 function getHooksProxy() {
   if (!hooksProxy) {
-    const { HooksProxy } = require('internal/modules/esm/hooks');
     hooksProxy = new HooksProxy();
   }
 
   return hooksProxy;
 }
-
-let _hasCustomizations = false;
-function hasCustomizations() {
-  return _hasCustomizations;
-}
-
 
 let cascadedLoader;
 
@@ -778,17 +818,18 @@ function register(specifier, parentURL = undefined, options) {
     options = parentURL;
     parentURL = options.parentURL;
   }
+
   getOrInitializeCascadedLoader().register(
     specifier,
     parentURL ?? 'data:',
     options?.data,
     options?.transferList,
+    threadId,
   );
 }
 
 module.exports = {
   createModuleLoader,
-  hasCustomizations,
   getHooksProxy,
   getOrInitializeCascadedLoader,
   register,

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -37,7 +37,6 @@ const {
 } = require('internal/process/pre_execution');
 const {
   emitExperimentalWarning,
-  getCWDURL,
 } = require('internal/util');
 const {
   setImportModuleDynamicallyCallback,
@@ -294,8 +293,6 @@ function forceDefaultLoader() {
  * Register module customization hooks.
  */
 async function initializeHooks() {
-  const customLoaderURLs = getOptionValue('--experimental-loader');
-
   const { Hooks } = require('internal/modules/esm/hooks');
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
 
@@ -311,14 +308,6 @@ async function initializeHooks() {
   // `--require` calls occur before `--loader` ones do.
   loadPreloadModules();
   initializeFrozenIntrinsics();
-
-  const parentURL = getCWDURL().href;
-  for (let i = 0; i < customLoaderURLs.length; i++) {
-    await hooks.register(
-      customLoaderURLs[i],
-      parentURL,
-    );
-  }
 
   return hooks;
 }

--- a/lib/internal/modules/esm/worker.js
+++ b/lib/internal/modules/esm/worker.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ArrayPrototypeFilter,
+  ArrayPrototypePush,
   AtomicsAdd,
   AtomicsNotify,
   DataViewPrototypeGetBuffer,
@@ -97,7 +99,21 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
     // so it can detect the exit event.
     const { exit } = process;
     process.exit = function(code) {
-      syncCommPort.postMessage(wrapMessage('exit', code ?? process.exitCode));
+      const exitMsg = wrapMessage('exit', code ?? process.exitCode);
+      if (hooks) {
+        for (let i = 0; i < allThreadRegisteredHandlerPorts.length; i++) {
+          const { port: registeredPort } = allThreadRegisteredHandlerPorts[i];
+          registeredPort.postMessage(exitMsg);
+        }
+
+        for (const { port, lock: operationLock } of unsettledResponsePorts) {
+          port.postMessage(exitMsg);
+          // Wake all threads that have pending operations.
+          AtomicsAdd(operationLock, WORKER_TO_MAIN_THREAD_NOTIFICATION, 1);
+          AtomicsNotify(operationLock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
+        }
+      }
+      syncCommPort.postMessage(exitMsg);
       AtomicsAdd(lock, WORKER_TO_MAIN_THREAD_NOTIFICATION, 1);
       AtomicsNotify(lock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
       return ReflectApply(exit, this, arguments);
@@ -145,8 +161,11 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
   const unsettledResponsePorts = new SafeSet();
 
   process.on('beforeExit', () => {
-    for (const port of unsettledResponsePorts) {
+    for (const { port, lock: operationLock } of unsettledResponsePorts) {
       port.postMessage(wrapMessage('never-settle'));
+      // Wake all threads that have pending operations.
+      AtomicsAdd(operationLock, WORKER_TO_MAIN_THREAD_NOTIFICATION, 1);
+      AtomicsNotify(operationLock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
     }
     unsettledResponsePorts.clear();
 
@@ -164,24 +183,59 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
     setImmediate(() => {});
   });
 
+  let allThreadRegisteredHandlerPorts = [];
+  /**
+   * @callback registerHandler
+   * @param {MessagePort} toWorkerThread - Upon Worker creation a message channel between the new Worker
+   * and the Hooks thread is being initialized. This is the MessagePort that the Hooks thread will use post
+   * messages to the worker. The other MessagePort is passed to the new Worker itself via LOAD_SCRIPT message
+   */
+  function registerHandler(toWorkerThread, registeredThreadId) {
+    toWorkerThread.on('message', handleMessage);
+    ArrayPrototypePush(allThreadRegisteredHandlerPorts, { port: toWorkerThread, registeredThreadId });
+  }
+
+  /**
+   * @callback registerHandler
+   * @param {number} unregisteredThreadId - the thread id of the worker thread that is being unregistered
+   * from the Hooks Thread
+   */
+  function unregisterHandler(unregisteredThreadId) {
+    allThreadRegisteredHandlerPorts = ArrayPrototypeFilter(
+      allThreadRegisteredHandlerPorts, (el) => el.registeredThreadId !== unregisteredThreadId);
+  }
+
+  function getMessageHandler(method) {
+    if (method === '#registerWorkerClient') {
+      return registerHandler;
+    }
+    if (method === '#unregisterWorkerClient') {
+      return unregisterHandler;
+    }
+    return hooks[method];
+  }
+
   /**
    * Handles incoming messages from the main thread or other workers.
    * @param {object} options - The options object.
    * @param {string} options.method - The name of the hook.
    * @param {Array} options.args - The arguments to pass to the method.
    * @param {MessagePort} options.port - The message port to use for communication.
+   * @param {Int32Array} options.lock - The shared memory where the caller expects to get awaken.
    */
-  async function handleMessage({ method, args, port }) {
+  async function handleMessage({ method, args, port, lock: msgLock }) {
     // Each potential exception needs to be caught individually so that the correct error is sent to
     // the main thread.
     let hasError = false;
     let shouldRemoveGlobalErrorHandler = false;
-    assert(typeof hooks[method] === 'function');
+    const messageHandler = getMessageHandler(method);
+    assert(typeof messageHandler === 'function');
     if (port == null && !hasUncaughtExceptionCaptureCallback()) {
       // When receiving sync messages, we want to unlock the main thread when there's an exception.
       process.on('uncaughtException', errorHandler);
       shouldRemoveGlobalErrorHandler = true;
     }
+    const usedLock = msgLock ?? lock;
 
     // We are about to yield the execution with `await ReflectApply` below. In case the code
     // following the `await` never runs, we remove the message handler so the `beforeExit` event
@@ -192,17 +246,19 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
     clearImmediate(immediate);
     immediate = setImmediate(checkForMessages).unref();
 
-    unsettledResponsePorts.add(port ?? syncCommPort);
+    const unsettledActionData = { port: port ?? syncCommPort, lock: usedLock };
+
+    unsettledResponsePorts.add(unsettledActionData);
 
     let response;
     try {
-      response = await ReflectApply(hooks[method], hooks, args);
+      response = await ReflectApply(messageHandler, hooks, args);
     } catch (exception) {
       hasError = true;
       response = exception;
     }
 
-    unsettledResponsePorts.delete(port ?? syncCommPort);
+    unsettledResponsePorts.delete(unsettledActionData);
 
     // Send the method response (or exception) to the main thread.
     try {
@@ -215,8 +271,8 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
       (port ?? syncCommPort).postMessage(wrapMessage('error', exception));
     }
 
-    AtomicsAdd(lock, WORKER_TO_MAIN_THREAD_NOTIFICATION, 1);
-    AtomicsNotify(lock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
+    AtomicsAdd(usedLock, WORKER_TO_MAIN_THREAD_NOTIFICATION, 1);
+    AtomicsNotify(usedLock, WORKER_TO_MAIN_THREAD_NOTIFICATION);
     if (shouldRemoveGlobalErrorHandler) {
       process.off('uncaughtException', errorHandler);
     }

--- a/lib/internal/modules/esm/worker.js
+++ b/lib/internal/modules/esm/worker.js
@@ -190,7 +190,9 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
    * and the Hooks thread is being initialized. This is the MessagePort that the Hooks thread will use post
    * messages to the worker. The other MessagePort is passed to the new Worker itself via LOAD_SCRIPT message
    */
-  function registerHandler(toWorkerThread, registeredThreadId) {
+  function registerHandler(toWorkerThread, registeredThreadId, parentThreadId) {
+    hooks.copyChain(parentThreadId, registeredThreadId);
+
     toWorkerThread.on('message', handleMessage);
     ArrayPrototypePush(allThreadRegisteredHandlerPorts, { port: toWorkerThread, registeredThreadId });
   }
@@ -201,6 +203,8 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
    * from the Hooks Thread
    */
   function unregisterHandler(unregisteredThreadId) {
+    hooks.deleteChain(unregisteredThreadId);
+
     allThreadRegisteredHandlerPorts = ArrayPrototypeFilter(
       allThreadRegisteredHandlerPorts, (el) => el.registeredThreadId !== unregisteredThreadId);
   }
@@ -282,6 +286,8 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
     clearImmediate(immediate);
     immediate = setImmediate(checkForMessages).unref();
   }
+
+  module.exports.handleInternalMessage = handleMessage;
 }
 
 /**
@@ -290,7 +296,7 @@ async function customizedModuleWorker(lock, syncCommPort, errorHandler) {
  * @param {{lock: SharedArrayBuffer}} workerData - The lock used to synchronize with the main thread.
  * @param {MessagePort} syncCommPort - The communication port used to communicate with the main thread.
  */
-module.exports = function setupModuleWorker(workerData, syncCommPort) {
+function setupModuleWorker(workerData, syncCommPort) {
   const lock = new Int32Array(workerData.lock);
 
   /**
@@ -317,4 +323,9 @@ module.exports = function setupModuleWorker(workerData, syncCommPort) {
     undefined,
     errorHandler,
   );
+};
+
+module.exports = {
+  entrypoint: setupModuleWorker,
+  handleInternalMessage: undefined,
 };

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -97,9 +97,21 @@ function shouldUseESMLoader(mainPath) {
 async function asyncRunEntryPointWithESMLoader(callback) {
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
   try {
+    const parentURL = getCWDURL().href;
+
+    const experimentalLoaders = getOptionValue('--experimental-loader');
+    if (experimentalLoaders.length > 0) {
+      const { threadId } = require('worker_threads');
+
+      for (let i = 0; i < experimentalLoaders.length; i++) {
+        await cascadedLoader.register(
+          experimentalLoaders[i], parentURL, undefined, undefined, threadId, true,
+        );
+      }
+    }
+
     const userImports = getOptionValue('--import');
     if (userImports.length > 0) {
-      const parentURL = getCWDURL().href;
       for (let i = 0; i < userImports.length; i++) {
         await cascadedLoader.import(userImports[i], parentURL, kEmptyObject);
       }

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -132,7 +132,7 @@ class Worker extends EventEmitter {
   constructor(filename, options = kEmptyObject) {
     throwIfBuildingSnapshot('Creating workers');
     super();
-    const isInternal = arguments[2] === kIsInternal;
+    const isInternal = this.#isInternal = arguments[2] === kIsInternal;
     debug(
       `[${threadId}] create new worker`,
       filename,
@@ -258,6 +258,15 @@ class Worker extends EventEmitter {
                          ...new SafeArrayIterator(options.transferList));
 
     this[kPublicPort] = port1;
+    const {
+      port1: toWorkerThread,
+      port2: toHooksThread,
+    } = new MessageChannel();
+    if (!isInternal) {
+      // This is not an internal hooks thread => it needs a channel to the hooks thread:
+      // - send it one side of a channel here
+      ArrayPrototypePush(transferList, toHooksThread);
+    }
     ArrayPrototypeForEach(['message', 'messageerror'], (event) => {
       this[kPublicPort].on(event, (message) => this.emit(event, message));
     });
@@ -272,8 +281,20 @@ class Worker extends EventEmitter {
       workerData: options.workerData,
       environmentData,
       publicPort: port2,
+      hooksPort: !isInternal ? toHooksThread : undefined,
       hasStdin: !!options.stdin,
     }, transferList);
+
+    const loaderModule = require('internal/modules/esm/loader');
+    const hasCustomizations = loaderModule.hasCustomizations();
+
+    if (!isInternal && hasCustomizations) {
+      // - send the second side of the channel to the hooks thread,
+      // also announce the threadId of the Worker that will use that port.
+      // This is needed for the cleanup stage
+      loaderModule.getHooksProxy().makeSyncRequest(
+        '#registerWorkerClient', [toWorkerThread], toWorkerThread, this.threadId);
+    }
     // Use this to cache the Worker's loopStart value once available.
     this[kLoopStartTime] = -1;
     this[kIsOnline] = false;
@@ -293,6 +314,12 @@ class Worker extends EventEmitter {
 
   [kOnExit](code, customErr, customErrReason) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
+    const loaderModule = require('internal/modules/esm/loader');
+    const hasCustomizations = loaderModule.hasCustomizations();
+
+    if (!this.#isInternal && hasCustomizations) {
+      loaderModule.getHooksProxy()?.makeAsyncRequest('#unregisterWorkerClient', undefined, this.threadId);
+    }
     drainMessagePort(this[kPublicPort]);
     drainMessagePort(this[kPort]);
     this.removeAllListeners('message');
@@ -435,6 +462,8 @@ class Worker extends EventEmitter {
     return makeResourceLimits(this[kHandle].getResourceLimits());
   }
 
+  #isInternal = false;
+
   getHeapSnapshot(options) {
     const {
       HeapSnapshotStream,
@@ -532,6 +561,7 @@ module.exports = {
   kIsOnline,
   isMainThread,
   SHARE_ENV,
+  hooksPort: undefined,
   resourceLimits:
     !isMainThread ? makeResourceLimits(resourceLimitsRaw) : {},
   setEnvironmentData,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -69,6 +69,7 @@ const {
   resourceLimits: resourceLimitsRaw,
   threadId,
   Worker: WorkerImpl,
+  hasHooksThread,
   kMaxYoungGenerationSizeMb,
   kMaxOldGenerationSizeMb,
   kCodeRangeSizeMb,
@@ -562,6 +563,7 @@ module.exports = {
   isMainThread,
   SHARE_ENV,
   hooksPort: undefined,
+  hasHooksThread,
   resourceLimits:
     !isMainThread ? makeResourceLimits(resourceLimitsRaw) : {},
   setEnvironmentData,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -482,10 +482,10 @@ class Worker extends EventEmitter {
 }
 
 /**
- * A worker which has an internal module for entry point (e.g. internal/module/esm/worker).
- * Internal workers bypass the permission model.
+ * A worker which is used to by the customization hooks thread (internal/module/esm/worker).
+ * This bypasses the permission model.
  */
-class InternalWorker extends Worker {
+class HooksWorker extends Worker {
   constructor(filename, options) {
     super(filename, options, kIsInternal);
   }
@@ -570,6 +570,6 @@ module.exports = {
   getEnvironmentData,
   assignEnvironmentData,
   threadId,
-  InternalWorker,
+  HooksWorker,
   Worker,
 };

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -271,6 +271,7 @@ class Worker extends EventEmitter {
     ArrayPrototypeForEach(['message', 'messageerror'], (event) => {
       this[kPublicPort].on(event, (message) => this.emit(event, message));
     });
+
     setupPortReferencing(this[kPublicPort], this, 'message');
     this[kPort].postMessage({
       argv,
@@ -286,15 +287,12 @@ class Worker extends EventEmitter {
       hasStdin: !!options.stdin,
     }, transferList);
 
-    const loaderModule = require('internal/modules/esm/loader');
-    const hasCustomizations = loaderModule.hasCustomizations();
-
-    if (!isInternal && hasCustomizations) {
+    if (!isInternal && hasHooksThread()) {
       // - send the second side of the channel to the hooks thread,
       // also announce the threadId of the Worker that will use that port.
       // This is needed for the cleanup stage
-      loaderModule.getHooksProxy().makeSyncRequest(
-        '#registerWorkerClient', [toWorkerThread], toWorkerThread, this.threadId);
+      require('internal/modules/esm/loader').getHooksProxy().makeSyncRequest(
+        '#registerWorkerClient', [toWorkerThread], toWorkerThread, this.threadId, threadId);
     }
     // Use this to cache the Worker's loopStart value once available.
     this[kLoopStartTime] = -1;
@@ -315,11 +313,11 @@ class Worker extends EventEmitter {
 
   [kOnExit](code, customErr, customErrReason) {
     debug(`[${threadId}] hears end event for Worker ${this.threadId}`);
-    const loaderModule = require('internal/modules/esm/loader');
-    const hasCustomizations = loaderModule.hasCustomizations();
 
-    if (!this.#isInternal && hasCustomizations) {
-      loaderModule.getHooksProxy()?.makeAsyncRequest('#unregisterWorkerClient', undefined, this.threadId);
+    if (!this.#isInternal && hasHooksThread()) {
+      require('internal/modules/esm/loader').getHooksProxy()?.makeAsyncRequest(
+        '#unregisterWorkerClient', undefined, this.threadId,
+      );
     }
     drainMessagePort(this[kPublicPort]);
     drainMessagePort(this[kPort]);

--- a/src/handle_wrap.cc
+++ b/src/handle_wrap.cc
@@ -148,7 +148,8 @@ void HandleWrap::OnClose(uv_handle_t* handle) {
   wrap->OnClose();
   wrap->handle_wrap_queue_.Remove();
 
-  if (!wrap->persistent().IsEmpty() &&
+  if (!env->isolate()->IsExecutionTerminating() &&
+      !wrap->persistent().IsEmpty() &&
       wrap->object()
           ->Has(env->context(), env->handle_onclose_symbol())
           .FromMaybe(false)) {

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -70,6 +70,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
   V(ERR_DLOPEN_FAILED, Error)                                                  \
   V(ERR_ENCODING_INVALID_ENCODED_DATA, TypeError)                              \
   V(ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE, Error)                            \
+  V(ERR_HOOKS_THREAD_EXISTS, Error)                                            \
   V(ERR_ILLEGAL_CONSTRUCTOR, Error)                                            \
   V(ERR_INVALID_ADDRESS, Error)                                                \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                          \

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -46,6 +46,7 @@ namespace node {
 namespace worker {
 
 constexpr double kMB = 1024 * 1024;
+std::atomic_bool Worker::internalExists{false};
 
 Worker::Worker(Environment* env,
                Local<Object> wrap,
@@ -489,6 +490,8 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   if (is_internal->IsFalse()) {
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kWorkerThreads, "");
+  } else {
+    internalExists = true;
   }
   Isolate* isolate = args.GetIsolate();
 
@@ -903,6 +906,10 @@ void Worker::LoopStartTime(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(loop_start_time / 1e6);
 }
 
+void Worker::HasHooksThreadAlready(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(Worker::internalExists);
+}
+
 namespace {
 
 // Return the MessagePort that is global for this Environment and communicates
@@ -940,6 +947,7 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
 
     SetConstructorFunction(isolate, target, "Worker", w);
+    SetMethodNoSideEffect(isolate, target, "hasHooksThread", Worker::HasHooksThread);
   }
 
   {
@@ -1011,6 +1019,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Worker::TakeHeapSnapshot);
   registry->Register(Worker::LoopIdleTime);
   registry->Register(Worker::LoopStartTime);
+  registry->Register(Worker::HasHooksThreadAlready);
 }
 
 }  // anonymous namespace

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -496,16 +496,15 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
 
   CHECK(args.IsConstructCall());
-  auto creatingHooksThread = is_internal->IsTrue();
 
-  if (creatingHooksThread && hooksWorkerExists) {
-    isolate->ThrowException(ERR_HOOKS_THREAD_EXISTS(
-        isolate, "Customization hooks thread already exists"));
-    return;
-  }
-
-  if (creatingHooksThread) {
-    hooksWorkerExists = true;
+  if (is_internal->IsTrue()) {
+    if (hooksWorkerExists) {
+      isolate->ThrowException(ERR_HOOKS_THREAD_EXISTS(
+          isolate, "Customization hooks thread already exists"));
+      return;
+    } else {
+      hooksWorkerExists = true;
+    }
   }
 
   if (env->isolate_data()->platform() == nullptr) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -906,7 +906,7 @@ void Worker::LoopStartTime(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(loop_start_time / 1e6);
 }
 
-void Worker::HasHooksThreadAlready(const FunctionCallbackInfo<Value>& args) {
+void Worker::HasHooksThread(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(Worker::internalExists);
 }
 
@@ -1019,7 +1019,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Worker::TakeHeapSnapshot);
   registry->Register(Worker::LoopIdleTime);
   registry->Register(Worker::LoopStartTime);
-  registry->Register(Worker::HasHooksThreadAlready);
+  registry->Register(Worker::HasHooksThread);
 }
 
 }  // anonymous namespace

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -46,7 +46,7 @@ namespace node {
 namespace worker {
 
 constexpr double kMB = 1024 * 1024;
-std::atomic_bool Worker::internalExists{false};
+std::atomic_bool Worker::hooksWorkerExists{false};
 Mutex Worker::instantiationMutex;
 
 Worker::Worker(Environment* env,
@@ -498,14 +498,14 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
   auto creatingHooksThread = is_internal->IsTrue();
 
-  if (creatingHooksThread && internalExists) {
+  if (creatingHooksThread && hooksWorkerExists) {
     isolate->ThrowException(ERR_HOOKS_THREAD_EXISTS(
         isolate, "Customization hooks thread already exists"));
     return;
   }
 
   if (creatingHooksThread) {
-    internalExists = true;
+    hooksWorkerExists = true;
   }
 
   if (env->isolate_data()->platform() == nullptr) {
@@ -918,7 +918,7 @@ void Worker::LoopStartTime(const FunctionCallbackInfo<Value>& args) {
 }
 
 void Worker::HasHooksThread(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(Worker::internalExists);
+  args.GetReturnValue().Set(Worker::hooksWorkerExists);
 }
 
 namespace {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -947,7 +947,8 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
 
     SetConstructorFunction(isolate, target, "Worker", w);
-    SetMethodNoSideEffect(isolate, target, "hasHooksThread", Worker::HasHooksThread);
+    SetMethodNoSideEffect(
+        isolate, target, "hasHooksThread", Worker::HasHooksThread);
   }
 
   {

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -104,7 +104,7 @@ class Worker : public AsyncWrap {
   uintptr_t stack_base_ = 0;
   // Optional name used for debugging in inspector and trace events.
   std::string name_;
-  static std::atomic_bool internalExists;
+  static std::atomic_bool hooksWorkerExists;
   // this mutex is to synchronize ::New calls
   static Mutex instantiationMutex;
 

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -5,6 +5,7 @@
 
 #include <optional>
 #include <unordered_map>
+#include <atomic>
 #include "node_exit_code.h"
 #include "node_messaging.h"
 #include "uv.h"
@@ -76,6 +77,7 @@ class Worker : public AsyncWrap {
   static void TakeHeapSnapshot(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopIdleTime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopStartTime(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void HasHooksThreadAlready(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
   bool CreateEnvMessagePort(Environment* env);
@@ -102,6 +104,7 @@ class Worker : public AsyncWrap {
   uintptr_t stack_base_ = 0;
   // Optional name used for debugging in inspector and trace events.
   std::string name_;
+  static std::atomic_bool internalExists;
 
   // Custom resource constraints:
   double resource_limits_[kTotalResourceLimitCount];

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -105,6 +105,8 @@ class Worker : public AsyncWrap {
   // Optional name used for debugging in inspector and trace events.
   std::string name_;
   static std::atomic_bool internalExists;
+  // this mutex is to synchronize ::New calls
+  static Mutex instantiationMutex;
 
   // Custom resource constraints:
   double resource_limits_[kTotalResourceLimitCount];

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -3,9 +3,9 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <atomic>
 #include <optional>
 #include <unordered_map>
-#include <atomic>
 #include "node_exit_code.h"
 #include "node_messaging.h"
 #include "uv.h"

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -77,7 +77,7 @@ class Worker : public AsyncWrap {
   static void TakeHeapSnapshot(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopIdleTime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopStartTime(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void HasHooksThreadAlready(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void HasHooksThread(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
   bool CreateEnvMessagePort(Environment* env);

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -51,6 +51,7 @@ const {
   skipIfDumbTerminal,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
+  skipIfWorker,
   spawnPromisified,
 } = common;
 
@@ -106,5 +107,6 @@ export {
   skipIfDumbTerminal,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
+  skipIfWorker,
   spawnPromisified,
 };

--- a/test/es-module/test-esm-hooks-chains.mjs
+++ b/test/es-module/test-esm-hooks-chains.mjs
@@ -1,0 +1,135 @@
+import { spawnPromisified } from '../common/index.mjs';
+import { fileURL } from '../common/fixtures.mjs';
+import { Worker } from 'node:worker_threads';
+import { execPath } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { ok, strictEqual, deepStrictEqual } from 'node:assert';
+import { isDeepStrictEqual } from 'node:util';
+
+async function spawn() {
+  new Worker(fileURL('es-modules/test-esm-separate-chains.mjs'), { workerData: { count: 1 } });
+  await import(fileURL('es-modules/test-esm-separate-chains-execute.mjs'));
+  delete globalThis.__testESM;
+}
+
+async function test() {
+  const loader = fileURLToPath(fileURL('es-module-loaders/hooks-log-verbose.mjs'));
+  const { code, stdout, stderr } = await spawnPromisified(execPath, [
+    '--expose-internals',
+    '--import', 'data:text/javascript,globalThis.__testESM=true',
+    // Note that the same loader is imported twice to verify duplication detection
+    '--import', loader,
+    '--import', loader,
+    fileURLToPath(import.meta.url),
+  ]);
+
+  strictEqual(code, 0);
+
+  const executeFileUrl = fileURL('/es-modules/test-esm-separate-chains-execute.mjs').toString();
+
+  // Parse NDJSON output
+  const linesOut = stdout.trim().split('\n').map((line) => JSON.parse(line)).reduce((accu, line) => {
+    accu[line.threadId] ??= [];
+    accu[line.threadId].push(line);
+    return accu;
+  }, {});
+  const linesErr = stderr.trim().split('\n').map((line) => JSON.parse(line));
+
+  // Verify threads behavior - Note that grouping is only inserted for readability
+
+  // Verify the main thread
+  {
+    // A hook is only registered once
+    strictEqual(linesOut[0].filter((line) => line.operation === 'initialize').length, 1);
+    // There is only a chain for the main thread
+    ok(linesOut[0].every((line) => !line.chain || line.chain === '0:1'));
+    // The hook is called for resolve
+    strictEqual(linesOut[0].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl;
+    }).length, 1);
+  }
+
+  // Verify the first worker thread - It just inherits the hooks from the main thread
+  {
+    // Note that the threadId is 2 as the thread 1 is the hooks thread
+    // The hook is copied from the parent thread so it's not reinitialized
+    strictEqual(linesOut[2].filter((line) => line.operation === 'initialize').length, 0);
+    // 6 resolves
+    //  1 (data --import)
+    //  1 (file --import)
+    //  4 worker entrypoint imports
+    // 1 execute
+    strictEqual(linesOut[2].filter((line) => line.threadId === 2).length, 7);
+
+    // The hook is called for resolve
+    strictEqual(linesOut[0].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl;
+    }).length, 1);
+  }
+
+  // Verify the second worker thread - Re-register the same hook but with data attached, so no duplicate
+  {
+    // The hook is copied from the parent thread but it is also reinitialized as there is new data
+    strictEqual(linesOut[3].filter((line) => line.operation === 'initialize').length, 1);
+    // The initialize hook has data only defined once
+    strictEqual(linesOut[3].filter((line) => line.operation === 'initialize' && line.data).length, 1);
+
+    // 1 initialize
+    // 6 resolves
+    //  1 (data --import)
+    //  1 (file --import)
+    //  4 worker entrypoint imports
+    //    1 import has two hooks
+    //    Note that the last worker is not resolve/load again since it is the current entrypoint
+    // 1 execute
+    strictEqual(linesOut[3].filter((line) => line.threadId === 3).length, 9);
+
+    // The hook is called for resolve once per registration
+    strictEqual(linesOut[3].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl && !line.data;
+    }).length, 1);
+    strictEqual(linesOut[3].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl &&
+        isDeepStrictEqual(line.data, { label: 'first' });
+    }).length, 1);
+  }
+
+  // Verify the third worker thread - Re-register the same hook but with data attached, so no duplicate
+  {
+    // The hook is copied from the parent thread but it is also reinitialized as there is new data
+    strictEqual(linesOut[4].filter((line) => line.operation === 'initialize').length, 1);
+    // The initialize hook has data only defined once
+    strictEqual(linesOut[4].filter((line) => line.operation === 'initialize' && line.data).length, 1);
+
+    // 1 initialize
+    // 13 resolves
+    //  2 (data --import, with and without data)
+    //  2 (file --import, with and without data)
+    //  9 (4 worker entrypoint imports, with and without data)
+    //    1 import has three hooks
+    //    Note that the last worker is not resolve/load again since it is the current entrypoint
+    // 1 execute
+    strictEqual(linesOut[4].filter((line) => line.threadId === 4).length, 15);
+
+    // The hook is called for resolve once per registration
+    strictEqual(linesOut[4].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl && !line.data;
+    }).length, 1);
+    strictEqual(linesOut[4].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl &&
+        isDeepStrictEqual(line.data, { label: 'first' });
+    }).length, 1);
+    strictEqual(linesOut[4].filter((line) => {
+      return line.operation === 'resolve' && line.specifier === executeFileUrl &&
+        isDeepStrictEqual(line.data, { label: 'second' });
+    }).length, 1);
+  }
+
+  // Make sure at the the chains are cleared.
+  // The only one remaining are the chain for the thread hooks (1)
+  // and the default chain (whose internal is serialized to null by JSON.stringify)
+  deepStrictEqual(linesErr.at(-1), { operation: 'chains', names: [ 1, null ] });
+}
+
+const runner = globalThis.__testESM ? spawn : test;
+await runner();

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -612,7 +612,7 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
       ]);
 
       assert.strictEqual(stderr, '');
-      assert.deepStrictEqual(stdout.split('\n'), ['resolve passthru', 'resolve passthru', '']);
+      assert.deepStrictEqual(stdout.split('\n'), ['resolve passthru', '']);
       assert.strictEqual(code, 0);
       assert.strictEqual(signal, null);
     });

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -498,7 +498,7 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
       ]);
 
       assert.strictEqual(stderr, '');
-      assert.deepStrictEqual(stdout.split('\n'), ['hooks initialize 1', '']);
+      assert.deepStrictEqual(stdout.split('\n'), ['hooks initialize 1', 'hooks initialize 2', '']);
       assert.strictEqual(code, 0);
       assert.strictEqual(signal, null);
     });
@@ -654,7 +654,6 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
       assert.strictEqual(stderr, '');
       assert.deepStrictEqual(stdout.split('\n'), [ 'hooks initialize 1',
                                                    'result 1 undefined',
-                                                   'hooks initialize 2',
                                                    'result 2 undefined',
                                                    '' ]);
       assert.strictEqual(code, 0);

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,11 +1,6 @@
-import { skipIfWorker } from '../common/index.mjs';
+import '../common/index.mjs';
 import assert from 'node:assert/strict';
 import { mock } from '../fixtures/es-module-loaders/mock.mjs';
-// Importing mock.mjs above will call `register` to modify the loaders chain.
-// Modifying the loader chain is not supported currently when running from a worker thread.
-// Relevant PR: https://github.com/nodejs/node/pull/52706
-// See comment: https://github.com/nodejs/node/pull/52706/files#r1585144580
-skipIfWorker();
 
 mock('node:events', {
   EventEmitter: 'This is mocked!'

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -1,6 +1,11 @@
-import '../common/index.mjs';
+import { skipIfWorker } from '../common/index.mjs';
 import assert from 'node:assert/strict';
 import { mock } from '../fixtures/es-module-loaders/mock.mjs';
+// Importing mock.mjs above will call `register` to modify the loaders chain.
+// Modifying the loader chain is not supported currently when running from a worker thread.
+// Relevant PR: https://github.com/nodejs/node/pull/52706
+// See comment: https://github.com/nodejs/node/pull/52706/files#r1585144580
+skipIfWorker();
 
 mock('node:events', {
   EventEmitter: 'This is mocked!'

--- a/test/es-module/test-esm-loader-programmatically.mjs
+++ b/test/es-module/test-esm-loader-programmatically.mjs
@@ -163,12 +163,10 @@ describe('ESM: programmatically register loaders', { concurrency: !process.env.T
     const lines = stdout.split('\n');
 
     assert.match(lines[0], /resolve passthru/);
-    assert.match(lines[1], /resolve passthru/);
-    assert.match(lines[2], /load passthru/);
-    assert.match(lines[3], /load passthru/);
-    assert.match(lines[4], /Hello from dynamic import/);
+    assert.match(lines[1], /load passthru/);
+    assert.match(lines[2], /Hello from dynamic import/);
 
-    assert.strictEqual(lines[5], '');
+    assert.strictEqual(lines[3], '');
   });
 
   it('works registering loaders as package name', async () => {

--- a/test/es-module/test-esm-loader-programmatically.mjs
+++ b/test/es-module/test-esm-loader-programmatically.mjs
@@ -188,11 +188,10 @@ describe('ESM: programmatically register loaders', { concurrency: !process.env.T
     // Resolve occurs twice because it is first used to resolve the `load` loader
     // _AND THEN_ the `register` module.
     assert.match(lines[0], /resolve passthru/);
-    assert.match(lines[1], /resolve passthru/);
-    assert.match(lines[2], /load passthru/);
-    assert.match(lines[3], /Hello from dynamic import/);
+    assert.match(lines[1], /load passthru/);
+    assert.match(lines[2], /Hello from dynamic import/);
 
-    assert.strictEqual(lines[4], '');
+    assert.strictEqual(lines[3], '');
   });
 
   it('works without a CLI flag', async () => {

--- a/test/es-module/test-esm-loader-threads.mjs
+++ b/test/es-module/test-esm-loader-threads.mjs
@@ -1,0 +1,74 @@
+import { spawnPromisified } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { strictEqual } from 'node:assert';
+import { execPath } from 'node:process';
+import { describe, it } from 'node:test';
+
+describe('off-thread hooks', { concurrency: true }, () => {
+  it('uses only one hooks thread to support multiple application threads', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--import',
+      `data:text/javascript,${encodeURIComponent(`
+        import { register } from 'node:module';
+        register(${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-log.mjs'))});
+      `)}`,
+      fixtures.path('es-module-loaders/workers-spawned.mjs'),
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('initialize')).length, 1);
+    strictEqual(stdout.split('\n').filter((line) => line === 'foo').length, 2);
+    strictEqual(stdout.split('\n').filter((line) => line === 'bar').length, 4);
+    // Calls to resolve/load:
+    // 1x  main script: test/fixtures/es-module-loaders/workers-spawned.mjs
+    // 3x worker_threads
+    //    => 1x test/fixtures/es-module-loaders/worker-log.mjs
+    //       2x test/fixtures/es-module-loaders/worker-log-again.mjs => once per worker-log.mjs Worker instance
+    // 2x test/fixtures/es-module-loaders/worker-log.mjs => once per worker-log.mjs Worker instance
+    // 4x test/fixtures/es-module-loaders/worker-log-again.mjs => 2x for each worker-log
+    // 6x module-named-exports.mjs => 2x worker-log.mjs + 4x worker-log-again.mjs
+    // ===========================
+    // 16 calls to resolve + 16 calls to load hook for the registered custom loader
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked resolve')).length, 16);
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked load')).length, 16);
+    strictEqual(code, 0);
+    strictEqual(signal, null);
+  });
+
+  it('propagates the exit code from worker thread import exiting from resolve hook', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--import',
+      `data:text/javascript,${encodeURIComponent(`
+        import { register } from 'node:module';
+        register(${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-exit-worker.mjs'))});
+      `)}`,
+      fixtures.path('es-module-loaders/worker-log-fail-worker-resolve.mjs'),
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('resolve process-exit-module-resolve')).length, 1);
+    strictEqual(code, 42);
+    strictEqual(signal, null);
+  });
+
+  it('propagates the exit code from worker thread import exiting from load hook', async () => {
+    const { code, signal, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      '--import',
+      `data:text/javascript,${encodeURIComponent(`
+        import { register } from 'node:module';
+        register(${JSON.stringify(fixtures.fileURL('es-module-loaders/hooks-exit-worker.mjs'))});
+      `)}`,
+      fixtures.path('es-module-loaders/worker-log-fail-worker-load.mjs'),
+    ]);
+
+    strictEqual(stderr, '');
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('resolve process-exit-module-load')).length, 1);
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('load process-exit-on-load:///')).length, 1);
+    strictEqual(code, 43);
+    strictEqual(signal, null);
+  });
+
+});

--- a/test/es-module/test-esm-loader-threads.mjs
+++ b/test/es-module/test-esm-loader-threads.mjs
@@ -16,9 +16,6 @@ describe('off-thread hooks', { concurrency: true }, () => {
       fixtures.path('es-module-loaders/workers-spawned.mjs'),
     ]);
 
-    console.log(stderr);
-    console.log(stdout);
-
     strictEqual(stderr, '');
     strictEqual(stdout.split('\n').filter((line) => line.startsWith('initialize')).length, 1);
     strictEqual(stdout.split('\n').filter((line) => line === 'foo').length, 2);
@@ -33,7 +30,7 @@ describe('off-thread hooks', { concurrency: true }, () => {
     // 6x module-named-exports.mjs => 2x worker-log.mjs + 4x worker-log-again.mjs
     // ===========================
     // 16 calls to resolve + 16 calls to load hook for the registered custom loader
-    // 6 additional calls to resolve because of the modeul.register being allowed from worker threads (happens
+    // 6 additional calls to resolve because of the module.register being allowed from worker threads (happens
     // implicitly because of the --import on the main thread)
     strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked resolve')).length, 22);
     strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked load')).length, 16);

--- a/test/es-module/test-esm-loader-threads.mjs
+++ b/test/es-module/test-esm-loader-threads.mjs
@@ -16,6 +16,9 @@ describe('off-thread hooks', { concurrency: true }, () => {
       fixtures.path('es-module-loaders/workers-spawned.mjs'),
     ]);
 
+    console.log(stderr);
+    console.log(stdout);
+
     strictEqual(stderr, '');
     strictEqual(stdout.split('\n').filter((line) => line.startsWith('initialize')).length, 1);
     strictEqual(stdout.split('\n').filter((line) => line === 'foo').length, 2);
@@ -30,7 +33,9 @@ describe('off-thread hooks', { concurrency: true }, () => {
     // 6x module-named-exports.mjs => 2x worker-log.mjs + 4x worker-log-again.mjs
     // ===========================
     // 16 calls to resolve + 16 calls to load hook for the registered custom loader
-    strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked resolve')).length, 16);
+    // 6 additional calls to resolve because of the modeul.register being allowed from worker threads (happens
+    // implicitly because of the --import on the main thread)
+    strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked resolve')).length, 22);
     strictEqual(stdout.split('\n').filter((line) => line.startsWith('hooked load')).length, 16);
     strictEqual(code, 0);
     strictEqual(signal, null);

--- a/test/es-module/test-esm-named-exports.js
+++ b/test/es-module/test-esm-named-exports.js
@@ -1,7 +1,9 @@
 // Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
 'use strict';
 
-require('../common');
+const common = require('../common');
+common.skipIfWorker();
+
 const { readFile, __fromLoader } = require('fs');
 const assert = require('assert');
 

--- a/test/es-module/test-esm-named-exports.js
+++ b/test/es-module/test-esm-named-exports.js
@@ -1,8 +1,7 @@
 // Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
 'use strict';
 
-const common = require('../common');
-common.skipIfWorker();
+require('../common');
 
 const { readFile, __fromLoader } = require('fs');
 const assert = require('assert');

--- a/test/es-module/test-esm-named-exports.mjs
+++ b/test/es-module/test-esm-named-exports.mjs
@@ -1,10 +1,9 @@
 // Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
-import { skipIfWorker } from '../common/index.mjs';
-import * as fs from 'fs';
+import '../common/index.mjs';
+import { readFile, __fromLoader } from 'fs';
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';
-skipIfWorker();
 
 assert(ok);
-assert(fs.readFile);
-assert(fs.__fromLoader);
+assert(readFile);
+assert(__fromLoader);

--- a/test/es-module/test-esm-named-exports.mjs
+++ b/test/es-module/test-esm-named-exports.mjs
@@ -1,9 +1,10 @@
 // Flags: --import ./test/fixtures/es-module-loaders/builtin-named-exports.mjs
-import '../common/index.mjs';
-import { readFile, __fromLoader } from 'fs';
+import { skipIfWorker } from '../common/index.mjs';
+import * as fs from 'fs';
 import assert from 'assert';
 import ok from '../fixtures/es-modules/test-esm-ok.mjs';
+skipIfWorker();
 
 assert(ok);
-assert(readFile);
-assert(__fromLoader);
+assert(fs.readFile);
+assert(fs.__fromLoader);

--- a/test/es-module/test-esm-virtual-json.mjs
+++ b/test/es-module/test-esm-virtual-json.mjs
@@ -1,7 +1,8 @@
-import '../common/index.mjs';
+import { skipIfWorker } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { register } from 'node:module';
 import assert from 'node:assert';
+skipIfWorker();
 
 async function resolve(referrer, context, next) {
   const result = await next(referrer, context);

--- a/test/fixtures/es-module-loaders/assertionless-json-import.mjs
+++ b/test/fixtures/es-module-loaders/assertionless-json-import.mjs
@@ -5,7 +5,9 @@ export async function resolve(specifier, context, next) {
   const noAttributesSpecified = context.importAttributes.type == null;
 
   // Mutation from resolve hook should be discarded.
-  context.importAttributes.type = 'whatever';
+  if(!Object.isSealed(context.importAttributes)) {
+    context.importAttributes.type = 'whatever';
+  }
 
   // This fixture assumes that no other resolve hooks in the chain will error on invalid import attributes
   // (as defaultResolve doesn't).

--- a/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
@@ -1,14 +1,23 @@
 import module from 'node:module';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 /** @type {string} */
 let GET_BUILTIN;
-export function initialize(data) {
+let argv;
+export function initialize(data, context) {
   GET_BUILTIN = data.GET_BUILTIN;
 }
 
 export async function resolve(specifier, context, next) {
   const def = await next(specifier, context);
+
+  const file = fileURLToPath(context.parentURL ?? 'file://');
+
+  // Only apply the hook to the entrypoint includes to avoid cycles
+  if(fileURLToPath(context.parentURL ?? 'file://') !== context.data.entrypoint) {
+    return def;
+  }
 
   if (def.url.startsWith('node:')) {
     return {

--- a/test/fixtures/es-module-loaders/builtin-named-exports.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports.mjs
@@ -1,4 +1,3 @@
-import { isMainThread } from '../../common/index.mjs';
 import * as fixtures from '../../common/fixtures.mjs';
 import { createRequire, register } from 'node:module';
 
@@ -11,10 +10,8 @@ Object.defineProperty(globalThis, GET_BUILTIN, {
   configurable: false,
 });
 
-if (isMainThread) {
-  register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
-    data: {
-      GET_BUILTIN,
-    },
-  });
-}
+register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
+  data: {
+    GET_BUILTIN,
+  },
+});

--- a/test/fixtures/es-module-loaders/builtin-named-exports.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports.mjs
@@ -1,3 +1,4 @@
+import { isMainThread } from '../../common/index.mjs';
 import * as fixtures from '../../common/fixtures.mjs';
 import { createRequire, register } from 'node:module';
 
@@ -10,8 +11,10 @@ Object.defineProperty(globalThis, GET_BUILTIN, {
   configurable: false,
 });
 
-register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
-  data: {
-    GET_BUILTIN,
-  },
-});
+if (isMainThread) {
+  register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
+    data: {
+      GET_BUILTIN,
+    },
+  });
+}

--- a/test/fixtures/es-module-loaders/builtin-named-exports.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports.mjs
@@ -3,7 +3,7 @@ import { createRequire, register } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
-const GET_BUILTIN = `$__get_builtin_hole_${Date.now()}`;
+const GET_BUILTIN = `$__get_builtin_hole_${~~(Date.now()/10000)}`;
 Object.defineProperty(globalThis, GET_BUILTIN, {
   value: builtinName => require(builtinName),
   enumerable: false,

--- a/test/fixtures/es-module-loaders/builtin-named-exports.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports.mjs
@@ -13,5 +13,6 @@ Object.defineProperty(globalThis, GET_BUILTIN, {
 register(fixtures.fileURL('es-module-loaders/builtin-named-exports-loader.mjs'), {
   data: {
     GET_BUILTIN,
+    entrypoint: process.argv.at(-1),
   },
 });

--- a/test/fixtures/es-module-loaders/hooks-exit-worker.mjs
+++ b/test/fixtures/es-module-loaders/hooks-exit-worker.mjs
@@ -1,0 +1,21 @@
+import { writeFileSync } from 'node:fs';
+
+export function resolve(specifier, context, next) {
+	writeFileSync(1, `resolve ${specifier}\n`);
+  if (specifier === 'process-exit-module-resolve') {
+    process.exit(42);
+  }
+	
+  if (specifier === 'process-exit-module-load') {
+    return { __proto__: null, shortCircuit: true, url: 'process-exit-on-load:///' }
+  }
+  return next(specifier, context);
+}
+
+export function load(url, context, next) {
+	writeFileSync(1, `load ${url}\n`);
+  if (url === 'process-exit-on-load:///') {
+    process.exit(43);
+  }
+  return next(url, context);
+}

--- a/test/fixtures/es-module-loaders/hooks-input.mjs
+++ b/test/fixtures/es-module-loaders/hooks-input.mjs
@@ -37,6 +37,7 @@ export async function resolve(specifier, context, next) {
     'conditions',
     'importAttributes',
     'parentURL',
+    'threadId',
   ]);
   assert.ok(Array.isArray(context.conditions));
   assert.strictEqual(typeof next, 'function');

--- a/test/fixtures/es-module-loaders/hooks-input.mjs
+++ b/test/fixtures/es-module-loaders/hooks-input.mjs
@@ -38,6 +38,7 @@ export async function resolve(specifier, context, next) {
     'importAttributes',
     'parentURL',
     'threadId',
+    'data'
   ]);
   assert.ok(Array.isArray(context.conditions));
   assert.strictEqual(typeof next, 'function');
@@ -75,6 +76,8 @@ export async function load(url, context, next) {
   assert.deepStrictEqual(Object.keys(context), [
     'format',
     'importAttributes',
+    'threadId',
+    'data'
   ]);
   assert.strictEqual(context.format, 'test');
   assert.strictEqual(typeof next, 'function');

--- a/test/fixtures/es-module-loaders/hooks-log-verbose-loader.mjs
+++ b/test/fixtures/es-module-loaders/hooks-log-verbose-loader.mjs
@@ -1,0 +1,34 @@
+import { threadId } from "worker_threads";
+import esm from "node:internal/modules/esm/loader";
+
+export function initialize(data, context) {
+  process.on('beforeExit', () => {
+    process._rawDebug(JSON.stringify({
+      operation: "chains",
+      names: Array.from(esm.getOrInitializeCascadedLoader().getCustomizations().getChains().keys()),
+    }));
+  })
+
+  console.log(JSON.stringify({
+    operation: "initialize",
+    threadId: context.threadId,
+    data,
+    workerData: context.workerData,
+  }));
+}
+
+export function resolve(specifier, context, next) {
+  if(specifier.startsWith('node:') || specifier.startsWith('../')) {
+    return next(specifier);    
+  }
+  
+  console.log(JSON.stringify({
+    operation: "resolve",
+    specifier,
+    threadId: context.threadId,
+    data: context.data,
+    workerData: context.workerData,
+  }));
+
+  return next(specifier);
+}

--- a/test/fixtures/es-module-loaders/hooks-log-verbose.mjs
+++ b/test/fixtures/es-module-loaders/hooks-log-verbose.mjs
@@ -1,0 +1,4 @@
+import { register } from 'node:module';
+import { fileURL } from '../../common/fixtures.mjs';
+
+register(fileURL('es-module-loaders/hooks-log-verbose-loader.mjs'));

--- a/test/fixtures/es-module-loaders/hooks-log.mjs
+++ b/test/fixtures/es-module-loaders/hooks-log.mjs
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'node:fs';
+
+let initializeCount = 0;
+let resolveCount = 0;
+let loadCount = 0;
+
+export function initialize() {
+  writeFileSync(1, `initialize ${++initializeCount}\n`);
+}
+
+export function resolve(specifier, context, next) {
+  writeFileSync(1, `hooked resolve ${++resolveCount} ${specifier}\n`);
+  return next(specifier, context);
+}
+
+export function load(url, context, next) {
+  writeFileSync(1, `hooked load ${++loadCount} ${url}\n`);
+  return next(url, context);
+}

--- a/test/fixtures/es-module-loaders/hooks-log.mjs
+++ b/test/fixtures/es-module-loaders/hooks-log.mjs
@@ -9,7 +9,7 @@ export function initialize() {
 }
 
 export function resolve(specifier, context, next) {
-  writeFileSync(1, `hooked resolve ${++resolveCount} ${specifier}\n`);
+  writeFileSync(1, `hooked resolve ${++resolveCount} ${specifier} \n`);
   return next(specifier, context);
 }
 

--- a/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
+++ b/test/fixtures/es-module-loaders/not-found-assert-loader.mjs
@@ -1,16 +1,13 @@
 import assert from 'node:assert';
 
 // A loader that asserts that the defaultResolve will throw "not found"
-// (skipping the top-level main of course, and the built-in ones needed for run-worker).
-let mainLoad = true;
 export async function resolve(specifier, { importAttributes }, next) {
-  if (mainLoad || specifier === 'path' || specifier === 'worker_threads') {
-    mainLoad = false;
-    return next(specifier);
+  if (specifier.startsWith('./not-found')) {
+    await assert.rejects(next(specifier), { code: 'ERR_MODULE_NOT_FOUND' });
+    return {
+      url: 'node:fs',
+      importAttributes,
+    };
   }
-  await assert.rejects(next(specifier), { code: 'ERR_MODULE_NOT_FOUND' });
-  return {
-    url: 'node:fs',
-    importAttributes,
-  };
+  return next(specifier);
 }

--- a/test/fixtures/es-module-loaders/worker-fail-on-load.mjs
+++ b/test/fixtures/es-module-loaders/worker-fail-on-load.mjs
@@ -1,0 +1,1 @@
+import 'process-exit-module-load';

--- a/test/fixtures/es-module-loaders/worker-fail-on-resolve.mjs
+++ b/test/fixtures/es-module-loaders/worker-fail-on-resolve.mjs
@@ -1,0 +1,1 @@
+import 'process-exit-module-resolve';

--- a/test/fixtures/es-module-loaders/worker-log-again.mjs
+++ b/test/fixtures/es-module-loaders/worker-log-again.mjs
@@ -1,0 +1,3 @@
+import { bar } from './module-named-exports.mjs';
+
+console.log(bar);

--- a/test/fixtures/es-module-loaders/worker-log-fail-worker-load.mjs
+++ b/test/fixtures/es-module-loaders/worker-log-fail-worker-load.mjs
@@ -1,0 +1,12 @@
+import { Worker } from 'worker_threads';
+import { foo } from './module-named-exports.mjs';
+
+const workerURLFailOnLoad = new URL('./worker-fail-on-load.mjs', import.meta.url);
+console.log(foo);
+
+// Spawn a worker that will fail to import a dependant module
+new Worker(workerURLFailOnLoad);
+
+process.on('exit', (code) => {
+	console.log(`process exit code: ${code}`)
+});

--- a/test/fixtures/es-module-loaders/worker-log-fail-worker-resolve.mjs
+++ b/test/fixtures/es-module-loaders/worker-log-fail-worker-resolve.mjs
@@ -1,0 +1,12 @@
+import { Worker } from 'worker_threads';
+import { foo } from './module-named-exports.mjs';
+
+const workerURLFailOnResolve = new URL('./worker-fail-on-resolve.mjs', import.meta.url);
+console.log(foo);
+
+// Spawn a worker that will fail to import a dependant module
+new Worker(workerURLFailOnResolve);
+
+process.on('exit', (code) => {
+	console.log(`process exit code: ${code}`)
+});

--- a/test/fixtures/es-module-loaders/worker-log.mjs
+++ b/test/fixtures/es-module-loaders/worker-log.mjs
@@ -1,0 +1,9 @@
+import { Worker } from 'worker_threads';
+import { foo } from './module-named-exports.mjs';
+
+const workerURL = new URL('./worker-log-again.mjs', import.meta.url);
+console.log(foo);
+
+// Spawn two workers
+new Worker(workerURL);
+new Worker(workerURL);

--- a/test/fixtures/es-module-loaders/workers-spawned.mjs
+++ b/test/fixtures/es-module-loaders/workers-spawned.mjs
@@ -1,0 +1,7 @@
+import { Worker } from 'worker_threads';
+
+const workerURL = new URL('./worker-log.mjs', import.meta.url);
+
+// Spawn two workers
+new Worker(workerURL);
+new Worker(workerURL);

--- a/test/fixtures/es-modules/test-esm-separate-chains-execute.mjs
+++ b/test/fixtures/es-modules/test-esm-separate-chains-execute.mjs
@@ -1,0 +1,3 @@
+import { workerData , threadId} from 'node:worker_threads';
+
+console.log(JSON.stringify({ operation: 'execute', threadId, workerData }));

--- a/test/fixtures/es-modules/test-esm-separate-chains.mjs
+++ b/test/fixtures/es-modules/test-esm-separate-chains.mjs
@@ -1,0 +1,33 @@
+import { register } from 'node:module';
+import { Worker, workerData, threadId } from 'node:worker_threads';
+import { fileURL } from '../../common/fixtures.mjs';
+
+if (workerData.port) {
+  workerData.port.postMessage('MESSAGE');
+}
+
+if (workerData.count === 2) {
+  register(fileURL('es-module-loaders/hooks-log-verbose-loader.mjs'), import.meta.url, { data : {  label: 'first' } });
+}
+
+if (workerData.count === 3) {
+  register(fileURL('es-module-loaders/hooks-log-verbose-loader.mjs'), import.meta.url, { data : { label: 'second' } });
+}
+
+if (workerData.count === 1) {
+  const { port1, port2 } = new MessageChannel();
+
+  port1.on('message', message => {
+    process._rawDebug(JSON.stringify({ operation: 'message', message }));
+  }).unref();
+
+  new Worker(
+    fileURL('es-modules/test-esm-separate-chains.mjs'), 
+    { workerData: { count: workerData.count + 1, port: port2 },
+    transferList: [port2],
+  });  
+} else if (workerData.count < 3) {
+  new Worker(fileURL('es-modules/test-esm-separate-chains.mjs'), { workerData: { count: workerData.count + 1 } });
+}
+
+await import(fileURL('es-modules/test-esm-separate-chains-execute.mjs'));

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -216,6 +216,7 @@ if (!common.isMainThread) {
   // When we start adding modules to the worker snapshot, this branch
   // can be removed and  we can just remove the common.isMainThread
   // conditions.
+
   expected.beforePreExec.forEach(expected.atRunTime.add.bind(expected.atRunTime));
   actual.beforePreExec.forEach(actual.atRunTime.add.bind(actual.atRunTime));
 }


### PR DESCRIPTION
### This PR is based on and includes commits from #53200.

### Description

This PR introduces the following changes:

1. Introduction of the concept of "hooks chain" (see below)
2. Addition of a `context` parameters to the `initialize` hook. The context contains the registering thread ID.
3. Addition of the registering thread ID, and `initialize`'s data to the `context`'s properties passed to the `resolve` and `load` hooks.

### How do "hooks chain" work?

Rather than maintaining a single chain of hooks for all threads as it is today, this PR introduces the concept of separate hooks chains.

Each thread has a separate chain registered inside the hooks thread. This chain is either copied from the parent thread when the thread is spawned or created from scratch if the thread is the first one calling `module.register` within the application code.

This also covers the case where the `process.execArgv` contains `--import` or `--experimental-loader`. Since the chain copied from the parent already contains the (already initialized) hooks the duplicate register detection will prevent the arguments to be processed again.

Thanks to `threadId` and the `initialize`'s data this PR also covers the case where user want to use a singleton hook shared across threads. All these properties allow the hook to work differently depending on the context. Also, this will ensure that modification made to either parent or children after initialization don't affect other sibling threads.

The only case not covered at the moment from this PR is the one in which the user want a worker thread to start with an empty chain. This is already in theory achievable as we already have the methods to empty a chain, but these methods are not exposed externally. Once we expose those, this case will be covered as well, leaving no other open cases I'm aware of.