### PR TITLE
tools: remove no-goma arg from make-v8 script

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -55,6 +55,6 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
 else
   DEPOT_TOOLS_DIR="$(cd _depot_tools && pwd)"
   # shellcheck disable=SC2086
-  PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" --no-goma $V8_BUILD_OPTIONS
+  PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" $V8_BUILD_OPTIONS
   PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" "${JOBS_ARG}" d8 cctest inspector-test
 fi


### PR DESCRIPTION
V8 recently removed its support and passing it makes canary builds fail. It should be safe to remove it now as the default behavior is to look for goma in the PATH, and CI hosts shouldn't have goma installed.

Refs: https://github.com/v8/v8/commit/6c5a6c03dd6f557fcdf550ae3a2c66ed66d805ce

@nodejs/v8-update 