### PR TITLE
doc: fix broken link in `static-analysis.md`

### DIFF
--- a/doc/contributing/static-analysis.md
+++ b/doc/contributing/static-analysis.md
@@ -3,14 +3,17 @@
 The project uses Coverity to scan Node.js source code and to report potential
 issues in the C/C++ code base.
 
-Those who have been added to the Node.js coverity project can receive emails
+Those who have been added to the [Node.js coverity project][] can receive emails
 when there are new issues reported as well as view all current issues
-through <https://scan9.coverity.com/reports.htm>.
+through <https://scan9.scan.coverity.com/reports.htm>.
 
 Any collaborator can ask to be added to the Node.js coverity project
-by opening an issue in the [build](https://github.com/nodejs/build) repository
-titled `Please add me to coverity`. A member of the build WG with admin
-access will verify that the requestor is an existing collaborator as listed in
-the [collaborators section](https://github.com/nodejs/node#collaborators)
-on the nodejs/node project repo. Once validated the requestor will added
-to the coverity project.
+by opening an issue in the [build][] repository titled
+`Please add me to coverity`. A member of the build WG with admin access will
+verify that the requestor is an existing collaborator as listed in the
+[collaborators section][] on the nodejs/node project repo. Once validated the
+requestor will be added to the coverity project.
+
+[Node.js coverity project]: https://scan.coverity.com/projects/node-js
+[build]: https://github.com/nodejs/build
+[collaborators section]: https://github.com/nodejs/node#collaborators


### PR DESCRIPTION
Fix broken link in `doc/contributing/static-analysis.md`. Add a link to the main Node.js Coverity Scan project page.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
