### PR TITLE
meta: move comment on labelled to a single job

### DIFF
--- a/.github/workflows/comment-labeled.yml
+++ b/.github/workflows/comment-labeled.yml
@@ -14,42 +14,28 @@ env:
     The https://github.com/nodejs/node/labels/notable-change label has been added by @${{ github.actor }}.
 
     Please suggest a text for the release notes if you'd like to include a more detailed summary, then proceed to update the PR description with the text or a link to the notable change suggested text comment. Otherwise, the commit will be placed in the _Other Notable Changes_ section.
+  NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   contents: read
 
 jobs:
-  stale-comment:
+  handle-label:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == 'nodejs/node' && github.event.label.name == 'stalled'
+    if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
     steps:
-      - name: Post stalled comment
-        env:
-          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: github.event.label.name == 'stalled'
+        name: Post stalled comment
         run: gh issue comment "$NUMBER" --repo ${{ github.repository }} --body "$STALE_MESSAGE"
-
-  fast-track:
-    permissions:
-      pull-requests: write
-    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request_target' && github.event.label.name == 'fast-track'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Request Fast-Track
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "$FAST_TRACK_MESSAGE"
-
-  notable-change:
-    permissions:
-      pull-requests: write
-    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request_target' && github.event.label.name == 'notable-change'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add notable change description
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "$NOTABLE_CHANGE_MESSAGE"
+      
+      - if: github.event.label.name == 'fast-track' && github.event_name == 'pull_request_target'
+        name: Request Fast-Track
+        run: gh pr comment "$NUMBER" --repo ${{ github.repository }} --body "$FAST_TRACK_MESSAGE"
+      
+      - if: github.event.label.name == 'notable-change' && github.event_name == 'pull_request_target'
+        name: Add notable change description
+        run: gh pr comment "$NUMBER" --repo ${{ github.repository }} --body "$NOTABLE_CHANGE_MESSAGE"

--- a/.github/workflows/comment-labeled.yml
+++ b/.github/workflows/comment-labeled.yml
@@ -31,11 +31,11 @@ jobs:
       - if: github.event.label.name == 'stalled'
         name: Post stalled comment
         run: gh issue comment "$NUMBER" --repo ${{ github.repository }} --body "$STALE_MESSAGE"
-      
+
       - if: github.event.label.name == 'fast-track' && github.event_name == 'pull_request_target'
         name: Request Fast-Track
         run: gh pr comment "$NUMBER" --repo ${{ github.repository }} --body "$FAST_TRACK_MESSAGE"
-      
+
       - if: github.event.label.name == 'notable-change' && github.event_name == 'pull_request_target'
         name: Add notable change description
         run: gh pr comment "$NUMBER" --repo ${{ github.repository }} --body "$NOTABLE_CHANGE_MESSAGE"


### PR DESCRIPTION
This PR consolidates label commenting into a single job, with each label comment handled in a separate step, instead of creating a distinct job for each label.