### PR TITLE
doc: add organization header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# Node.js
+<h1 align="center">Node.js</h1><br>
 
-Node.js is an open-source, cross-platform JavaScript runtime environment.
+<p align="center">
+  Node.js<sup>®</sup> is a free, open-source, cross-platform JavaScript run-time environment—<br> that lets developers write command line tools and server-side scripts outside of a browser.
+</p>
+
+<p align="center">
+  <a href="https://nodejs.org/en/download">Get Node.js<sup>®</sup> ✨</a>
+  ·
+  <a href="https://github.com/nodejs/node/issues/new/choose">Report a bug 🐞</a>
+  ·
+  <a href="https://nodejs.org/en/get-involved">Contribute 🫶</a>
+</p>
+
+***
 
 For information on using Node.js, see the [Node.js website][].
 


### PR DESCRIPTION
This PR adds a slightly modified version of [Organization README](https://github.com/nodejs/.github/blob/main/profile/README.md) as the header for the project's README.

The rational behind this PR is that (IMO) the statement shown below should be in the forefront of the README, as it shows any wandering users *what* this project is

> Node.js<sup>®</sup> is a free, open-source, cross-platform JavaScript run-time environment—<br> that lets developers write command line tools and server-side scripts outside of a browser.

Additionally, for some users, it may be helpful to have quicklnks to some important pages (Issues, Downloads, Contributing)