### PR TITLE
lib: expose global CloseEvent

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -322,6 +322,19 @@ added: v0.0.1
 
 [`clearTimeout`][] is described in the [timers][] section.
 
+## `CloseEvent`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+<!-- type=global -->
+
+The `CloseEvent` class. See [`CloseEvent`][] for more details.
+
+A browser-compatible implementation of [`CloseEvent`][]. Disable this API
+with the [`--no-experimental-websocket`][] CLI flag.
+
 ## Class: `CompressionStream`
 
 <!-- YAML
@@ -1156,6 +1169,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [`--no-experimental-websocket`]: cli.md#--no-experimental-websocket
 [`AbortController`]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController
 [`ByteLengthQueuingStrategy`]: webstreams.md#class-bytelengthqueuingstrategy
+[`CloseEvent`]: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/CloseEvent
 [`CompressionStream`]: webstreams.md#class-compressionstream
 [`CountQueuingStrategy`]: webstreams.md#class-countqueuingstrategy
 [`CustomEvent` Web API]: https://dom.spec.whatwg.org/#customevent

--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -74,6 +74,10 @@ export default [
           message: "Use `const { ByteLengthQueuingStrategy } = require('internal/webstreams/queuingstrategies')` instead of the global.",
         },
         {
+          name: 'CloseEvent',
+          message: "Use `const { CloseEvent } = require('internal/deps/undici/undici');` instead of the global.",
+        },
+        {
           name: 'CompressionStream',
           message: "Use `const { CompressionStream } = require('internal/webstreams/compression')` instead of the global.",
         },

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -84,7 +84,7 @@ ObjectDefineProperty(globalThis, 'fetch', {
 // https://fetch.spec.whatwg.org/#request-class
 // https://fetch.spec.whatwg.org/#response-class
 exposeLazyInterfaces(globalThis, 'internal/deps/undici/undici', [
-  'FormData', 'Headers', 'Request', 'Response', 'MessageEvent',
+  'FormData', 'Headers', 'Request', 'Response', 'MessageEvent', 'CloseEvent',
 ]);
 
 // https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events.org/

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -304,6 +304,7 @@ function setupWarningHandler() {
 function setupWebsocket() {
   if (getOptionValue('--no-experimental-websocket')) {
     delete globalThis.WebSocket;
+    delete globalThis.CloseEvent;
   }
 }
 

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -127,6 +127,7 @@ const webIdlExposedWindow = new Set([
   'Response',
   'WebSocket',
   'EventSource',
+  'CloseEvent',
 ]);
 
 const nodeGlobals = new Set([

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -13,6 +13,7 @@ export default [
     languageOptions: {
       globals: {
         ...globals.node,
+        CloseEvent: true,
       },
     },
     rules: {

--- a/test/parallel/test-websocket-disabled.js
+++ b/test/parallel/test-websocket-disabled.js
@@ -5,3 +5,4 @@ require('../common');
 const assert = require('assert');
 
 assert.strictEqual(typeof WebSocket, 'undefined');
+assert.strictEqual(typeof CloseEvent, 'undefined');

--- a/test/parallel/test-websocket.js
+++ b/test/parallel/test-websocket.js
@@ -4,3 +4,4 @@ require('../common');
 const assert = require('assert');
 
 assert.strictEqual(typeof WebSocket, 'function');
+assert.strictEqual(typeof CloseEvent, 'function');


### PR DESCRIPTION
This PR adds `CloseEvent` as a global, which can be disabled via the --no-experimental-websocket flag.

```js
const ws = new WebSocket('https://echo.websocket.org/')

ws.addEventListener('open', () => ws.close())

ws.addEventListener('close', (event) => {
  assert(event instanceof CloseEvent)
  console.log('closed!')
})

```

Fixes: https://github.com/nodejs/node/issues/50275

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
