### PR TITLE
benchmark: support --help in CLI

### DIFF
--- a/benchmark/_cli.js
+++ b/benchmark/_cli.js
@@ -33,6 +33,7 @@ function CLI(usage, settings) {
   let mode = 'both'; // Possible states are: [both, option, item]
 
   for (const arg of process.argv.slice(2)) {
+    if (arg === '--help') this.abort(usage);
     if (arg === '--') {
       // Only items can follow --
       mode = 'item';


### PR DESCRIPTION
This PR modifies the CLI for the benchmarking scripts to support a `--help` argument.

If any one of the arguments (including items) is `--help`, the help menu will be printed instead.