### PR TITLE
test,stream: add test to writable stream not closed when readable stream emits error

### DIFF
--- a/test/parallel/test-stream-pipe-destory.js
+++ b/test/parallel/test-stream-pipe-destory.js
@@ -1,0 +1,45 @@
+'use strict';
+
+require('../common');
+const { Readable, Writable } = require('stream');
+const { finished } = require('stream/promises');
+const { setImmediate } = require('node:timers/promises');
+const assert = require('assert');
+
+async function * asyncGenerator() {
+  yield '1';
+  await setImmediate();
+  yield '2';
+  await setImmediate();
+  yield '3';
+}
+
+{
+  async function test() {
+    class NullWritable extends Writable {
+      _write(c, e, cb) {
+        cb();
+      }
+    }
+
+    const src = Readable.from(asyncGenerator());
+    const dest = new NullWritable();
+    src.on('error', () => {});
+    dest.on('error', () => {});
+
+    src.pipe(dest);
+
+    process.nextTick(() => {
+      src.destroy(new Error('Error'));
+    });
+
+    await assert.rejects(finished(src), 'reject finish');
+
+    assert.strictEqual(src.destroyed, true);
+    assert.strictEqual(dest.destroyed, false);
+    assert.strictEqual(src.closed, true);
+    assert.strictEqual(dest.closed, false);
+  }
+
+  test();
+}


### PR DESCRIPTION
The [doc](https://nodejs.org/docs/latest-v22.x/api/stream.html) mentioned:

> One important caveat is that if the Readable stream emits an error during processing, the Writable destination is not closed automatically. If an error occurs, it will be necessary to manually close each stream in order to prevent memory leaks.

Adding a test to verify / document this behaviour.

Refs: https://github.com/nodejs/node/issues/46908

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
