### PR TITLE
crypto: improve GetECGroupBits signature

### DIFF
--- a/src/crypto/crypto_common.cc
+++ b/src/crypto/crypto_common.cc
@@ -441,10 +441,7 @@ MaybeLocal<Value> GetECPubKey(
       nullptr).FromMaybe(Local<Object>());
 }
 
-MaybeLocal<Value> GetECGroup(
-    Environment* env,
-    const EC_GROUP* group,
-    const ECPointer& ec) {
+MaybeLocal<Value> GetECGroupBits(Environment* env, const EC_GROUP* group) {
   if (group == nullptr)
     return Undefined(env->isolate());
 
@@ -1324,14 +1321,10 @@ MaybeLocal<Object> X509ToObject(
   } else if (ec) {
     const EC_GROUP* group = EC_KEY_get0_group(ec.get());
 
-    if (!Set<Value>(context,
-                    info,
-                    env->bits_string(),
-                    GetECGroup(env, group, ec)) ||
-        !Set<Value>(context,
-                    info,
-                    env->pubkey_string(),
-                    GetECPubKey(env, group, ec))) {
+    if (!Set<Value>(
+            context, info, env->bits_string(), GetECGroupBits(env, group)) ||
+        !Set<Value>(
+            context, info, env->pubkey_string(), GetECPubKey(env, group, ec))) {
       return MaybeLocal<Object>();
     }
 


### PR DESCRIPTION
Remove the unused `ECPointer` argument and rename the function since the current name is misleading -- it specifically returns the group size in bits, not a representation of the group.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
