### PR TITLE
test: improve coverage for timer promises scheduler

### DIFF
--- a/test/parallel/test-timers-promises-scheduler.js
+++ b/test/parallel/test-timers-promises-scheduler.js
@@ -53,4 +53,3 @@ testCancelableWait2().then(common.mustCall());
 throws(() => new scheduler.constructor(), {
   code: 'ERR_ILLEGAL_CONSTRUCTOR',
 });
-

--- a/test/parallel/test-timers-promises-scheduler.js
+++ b/test/parallel/test-timers-promises-scheduler.js
@@ -48,3 +48,7 @@ async function testCancelableWait2() {
 }
 
 testCancelableWait2().then(common.mustCall());
+
+throws(() => new scheduler.constructor());
+throws(() => new scheduler.constructor.prototype.yield());
+throws(() => new scheduler.constructor.prototype.wait());

--- a/test/parallel/test-timers-promises-scheduler.js
+++ b/test/parallel/test-timers-promises-scheduler.js
@@ -7,6 +7,7 @@ const { setTimeout } = require('timers');
 const {
   strictEqual,
   rejects,
+  throws,
 } = require('assert');
 
 async function testYield() {
@@ -49,6 +50,7 @@ async function testCancelableWait2() {
 
 testCancelableWait2().then(common.mustCall());
 
-throws(() => new scheduler.constructor());
-throws(() => new scheduler.constructor.prototype.yield());
-throws(() => new scheduler.constructor.prototype.wait());
+throws(() => new scheduler.constructor(), {
+  code: 'ERR_ILLEGAL_CONSTRUCTOR',
+});
+


### PR DESCRIPTION
This PR improves the coverage for `lib/timers/promises.js`, by checked for a constructor error case