### PR TITLE
meta: disable windows builds

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-windows:
-    if: github.event.pull_request.draft == false
+    if: false && github.event.pull_request.draft == false
     strategy:
       matrix:
         windows: [windows-2022]

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   coverage-windows:
-    if: github.event.pull_request.draft == false
+    if: false && github.event.pull_request.draft == false
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29  # v4.1.6


### PR DESCRIPTION
Refs: #53369
Refs: <https://github.com/nodejs/build/issues/3739>

Currently, all windows builds are failing, so I recommend disabling them temporarily until  <https://developercommunity.visualstudio.com/t/Internal-compiler-error-with-MSVC-1440/10673166> is released.