### PR TITLE
test: fix flaky timeout in test-pipe-file-to-http

### DIFF
--- a/test/parallel/test-pipe-file-to-http.js
+++ b/test/parallel/test-pipe-file-to-http.js
@@ -38,7 +38,7 @@ const server = http.createServer((req, res) => {
 
   setTimeout(() => {
     req.resume();
-  }, 1000);
+  }, common.platformTimeout(1000));
 
   req.on('data', (chunk) => {
     count += chunk.length;


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/52963

Reproduced with 1000 runs:
```
./tools/test.py --repeat 1000 test/parallel/test-pipe-file-to-http.js
=== release test-pipe-file-to-http ===                   
Path: parallel/test-pipe-file-to-http
Command: ./node/test/parallel/test-pipe-file-to-http.js
--- TIMEOUT ---


[06:16|% 100|+ 999|-   1]: Done                          

Failed tests:
./node/test/parallel/test-pipe-file-to-http.js
```

After apply the fix seems stable:
```
✗ ./tools/test.py --repeat 1000 test/parallel/test-pipe-file-to-http.js
[02:48|% 100|+ 1000|-   0]: Done                         

All tests passed.

./tools/test.py --repeat 1000 test/parallel/test-pipe-file-to-http.js
[02:44|% 100|+ 1000|-   0]: Done                         

All tests passed.
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
