### PR TITLE
test: update TLS tests for OpenSSL 3.2

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -63,6 +63,9 @@ const hasOpenSSL3 = hasCrypto &&
 const hasOpenSSL31 = hasCrypto &&
     require('crypto').constants.OPENSSL_VERSION_NUMBER >= 0x30100000;
 
+const hasOpenSSL32 = hasCrypto &&
+    require('crypto').constants.OPENSSL_VERSION_NUMBER >= 0x30200000;
+
 const hasQuic = hasCrypto && !!process.config.variables.openssl_quic;
 
 function parseTestFlags(filename = process.argv[1]) {
@@ -968,6 +971,7 @@ const common = {
   hasCrypto,
   hasOpenSSL3,
   hasOpenSSL31,
+  hasOpenSSL32,
   hasQuic,
   hasMultiLocalhost,
   invalidArgTypeHelper,

--- a/test/parallel/test-tls-empty-sni-context.js
+++ b/test/parallel/test-tls-empty-sni-context.js
@@ -26,6 +26,8 @@ const server = tls.createServer(options, (c) => {
   }, common.mustNotCall());
 
   c.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
+    const expectedErr = common.hasOpenSSL32 ?
+      'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE' : 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE';
+    assert.strictEqual(err.code, expectedErr);
   }));
 }));

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -62,9 +62,11 @@ test({ psk: USERS.UserA, identity: 'UserA' }, { minVersion: 'TLSv1.3' });
 test({ psk: USERS.UserB, identity: 'UserB' });
 test({ psk: USERS.UserB, identity: 'UserB' }, { minVersion: 'TLSv1.3' });
 // Unrecognized user should fail handshake
-test({ psk: USERS.UserB, identity: 'UserC' }, {},
-     'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
+const expectedHandshakeErr = common.hasOpenSSL32 ?
+  'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE' : 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE';
+test({ psk: USERS.UserB, identity: 'UserC' }, {}, expectedHandshakeErr);
 // Recognized user but incorrect secret should fail handshake
-test({ psk: USERS.UserA, identity: 'UserB' }, {},
-     'ERR_SSL_SSLV3_ALERT_ILLEGAL_PARAMETER');
+const expectedIllegalParameterErr = common.hasOpenSSL32 ?
+  'ERR_SSL_SSL/TLS_ALERT_ILLEGAL_PARAMETER' : 'ERR_SSL_SSLV3_ALERT_ILLEGAL_PARAMETER';
+test({ psk: USERS.UserA, identity: 'UserB' }, {}, expectedIllegalParameterErr);
 test({ psk: USERS.UserB, identity: 'UserB' });


### PR DESCRIPTION
Update the following TLS tests to account for error code changes in OpenSSL 3.2 and later.
- `parallel/test-tls-empty-sni-context`
- `parallel/test-tls-psk-circuit`

Refs: https://github.com/nodejs/node/issues/53382
Refs: https://github.com/openssl/openssl/pull/19950

cc @nodejs/crypto 

---

Addresses these failures with OpenSSL 3.2:
```console
not ok 3051 parallel/test-tls-empty-sni-context
  ---
  duration_ms: 107.38800
  severity: fail
  exitcode: 1
  stack: |-
    node:assert:126
      throw new AssertionError(obj);
      ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    
    + 'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE'
    - 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE'
        at TLSSocket.<anonymous> (/home/nodejs/node/test/parallel/test-tls-empty-sni-context.js:29:12)
        at TLSSocket.<anonymous> (/home/nodejs/node/test/common/index.js:466:15)
        at TLSSocket.emit (node:events:520:28)
        at emitErrorNT (node:internal/streams/destroy:170:8)
        at emitErrorCloseNT (node:internal/streams/destroy:129:3)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE',
      expected: 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE',
      operator: 'strictEqual'
    }
    
    Node.js v23.0.0-pre
  ...
not ok 3135 parallel/test-tls-psk-circuit
  ---
  duration_ms: 130.16900
  severity: fail
  exitcode: 1
  stack: |-
    node:assert:126
      throw new AssertionError(obj);
      ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    
    + 'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE'
    - 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE'
        at TLSSocket.<anonymous> (/home/nodejs/node/test/parallel/test-tls-psk-circuit.js:52:16)
        at TLSSocket.<anonymous> (/home/nodejs/node/test/common/index.js:466:15)
        at TLSSocket.emit (node:events:520:28)
        at emitErrorNT (node:internal/streams/destroy:170:8)
        at emitErrorCloseNT (node:internal/streams/destroy:129:3)
        at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE',
      expected: 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE',
      operator: 'strictEqual'
    }
    
    Node.js v23.0.0-pre
  ...
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
