### PR TITLE
lib: fix naming convention of `Symbol`

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -65,7 +65,7 @@ const kWeakHandler = Symbol('kWeak');
 const kResistStopPropagation = Symbol('kResistStopPropagation');
 
 const kHybridDispatch = SymbolFor('nodejs.internal.kHybridDispatch');
-const kRemoveWeakListenerHelper = Symbol('nodejs.internal.removeWeakListenerHelper');
+const kRemoveWeakListenerHelper = Symbol('removeWeakListenerHelper');
 const kCreateEvent = Symbol('kCreateEvent');
 const kNewListener = Symbol('kNewListener');
 const kRemoveListener = Symbol('kRemoveListener');

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -65,7 +65,7 @@ const kWeakHandler = Symbol('kWeak');
 const kResistStopPropagation = Symbol('kResistStopPropagation');
 
 const kHybridDispatch = SymbolFor('nodejs.internal.kHybridDispatch');
-const kRemoveWeakListenerHelper = Symbol('removeWeakListenerHelper');
+const kRemoveWeakListenerHelper = Symbol('kRemoveWeakListenerHelper');
 const kCreateEvent = Symbol('kCreateEvent');
 const kNewListener = Symbol('kNewListener');
 const kRemoveListener = Symbol('kRemoveListener');

--- a/lib/internal/events/symbols.js
+++ b/lib/internal/events/symbols.js
@@ -4,7 +4,7 @@ const {
   Symbol,
 } = primordials;
 
-const kFirstEventParam = Symbol('nodejs.kFirstEventParam');
+const kFirstEventParam = Symbol('kFirstEventParam');
 
 module.exports = {
   kFirstEventParam,

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -34,7 +34,7 @@ const {
   kIsNodeError,
 } = require('internal/errors');
 
-const kSensitiveHeaders = Symbol('nodejs.http2.sensitiveHeaders');
+const kSensitiveHeaders = Symbol('sensitiveHeaders');
 const kSocket = Symbol('socket');
 const kProxySocket = Symbol('proxySocket');
 const kRequest = Symbol('request');


### PR DESCRIPTION
`node.js` prefix is used for global symbol(`Symbol.for`). So remove `node.js` prefix from `Symbol` usage.

Refs: https://github.com/nodejs/node/blob/main/doc/contributing/using-symbols.md#symbolforstring

https://github.com/nodejs/node/blob/50695e5de14ccd8255537972181bbc9a1f44368e/doc/contributing/using-symbols.md?plain=1#L67-L68

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
