### PR TITLE
src: fix permission inspector crash

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -181,6 +181,9 @@ void SetConsoleExtensionInstaller(const FunctionCallbackInfo<Value>& info) {
 
 void CallAndPauseOnStart(const FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env,
+                                    permission::PermissionScope::kInspector,
+                                    "PauseOnNextJavascriptStatement");
   CHECK_GT(args.Length(), 1);
   CHECK(args[0]->IsFunction());
   SlicedArguments call_args(args, /* start */ 2);

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1125,6 +1125,21 @@ bool ContextifyScript::EvalMachine(Local<Context> context,
 
 #if HAVE_INSPECTOR
   if (break_on_first_line) {
+    if (UNLIKELY(!env->permission()->is_granted(
+            env,
+            permission::PermissionScope::kInspector,
+            "PauseOnNextJavascriptStatement"))) {
+      node::permission::Permission::ThrowAccessDenied(
+          env,
+          permission::PermissionScope::kInspector,
+          "PauseOnNextJavascriptStatement");
+      if (display_errors) {
+        // We should decorate non-termination exceptions
+        errors::DecorateErrorStack(env, try_catch);
+      }
+      try_catch.ReThrow();
+      return false;
+    }
     env->inspector_agent()->PauseOnNextJavascriptStatement("Break on start");
   }
 #endif

--- a/test/fixtures/permission/inspector-brk.js
+++ b/test/fixtures/permission/inspector-brk.js
@@ -1,0 +1,1 @@
+console.log("Hi!")

--- a/test/parallel/test-permission-inspector-brk.js
+++ b/test/parallel/test-permission-inspector-brk.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+const file = fixtures.path('permission', 'inspector-brk.js');
+
+common.skipIfWorker();
+common.skipIfInspectorDisabled();
+
+// See https://github.com/nodejs/node/issues/53385
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--allow-fs-read=*',
+      '--inspect-brk',
+      file,
+    ],
+  );
+
+  assert.strictEqual(status, 1);
+  assert.match(stderr.toString(), /Error: Access to this API has been restricted/);
+}
+
+{
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-permission',
+      '--inspect-brk',
+      '--eval',
+      'console.log("Hi!")',
+    ],
+  );
+
+  assert.strictEqual(status, 1);
+  assert.match(stderr.toString(), /Error: Access to this API has been restricted/);
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/53385

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
