### PR TITLE
src: fix IsIPAddress for IPv6

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -192,7 +192,7 @@ static bool IsIPAddress(const std::string& host) {
     // Parse the IPv6 address to ensure it is syntactically valid.
     char ipv6_str[INET6_ADDRSTRLEN];
     std::copy(host.begin() + 1, host.end() - 1, ipv6_str);
-    ipv6_str[host.length()] = '\0';
+    ipv6_str[host.length() - 2] = '\0';
     unsigned char ipv6[sizeof(struct in6_addr)];
     if (uv_inet_pton(AF_INET6, ipv6_str, ipv6) != 0) return false;
 


### PR DESCRIPTION
I've investigated and found a fix to the related issue as follows:
`host` keeps the host address which is `[::]` in our case. Then, it is copied to a char array (`ipv6_str`) to remove brackets. However, when adding a null-terminator, the index is written wrong. The length should have been decreased by 2 to add a null terminator.

Fixes: https://github.com/nodejs/node/issues/47427