### PR TITLE
test: support recursive testing files

### DIFF
--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -113,13 +113,13 @@ class MessageTestCase(test.TestCase):
 class MessageTestConfiguration(test.TestConfiguration):
   def Ls(self, path):
     if isdir(path):
-      return [f for f in os.listdir(path)
+      return [f for _, _, f in os.walk(path) for f in f
               if f.endswith('.js') or f.endswith('.mjs')]
     else:
       return []
 
   def ListTests(self, current_path, path, arch, mode):
-    all_tests = [current_path + [t] for t in self.Ls(self.root)]
+    all_tests = [current_path + t.split(os.path.sep) for t in self.Ls(self.root)]
     result = []
     for tst in all_tests:
       if self.Contains(path, tst):

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -132,12 +132,12 @@ class TTYTestCase(test.TestCase):
 class TTYTestConfiguration(test.TestConfiguration):
   def Ls(self, path):
     if isdir(path):
-        return [f[:-3] for f in os.listdir(path) if f.endswith('.js')]
+        return [f[:-3] for _, _, f in os.walk(path) for f in f if f.endswith('.js')]
     else:
         return []
 
   def ListTests(self, current_path, path, arch, mode):
-    all_tests = [current_path + [t] for t in self.Ls(self.root)]
+    all_tests = [current_path + t.split(os.path.sep) for t in self.Ls(self.root)]
     result = []
     # Skip these tests on Windows, as pseudo terminals are not available
     if utils.IsWindows():

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -102,10 +102,10 @@ class SimpleTestConfiguration(test.TestConfiguration):
       self.additional_flags = []
 
   def Ls(self, path):
-    return [f for f in os.listdir(path) if LS_RE.match(f)]
+    return [f for _, _, f in os.walk(path) for f in f if LS_RE.match(os.path.basename(f))]
 
   def ListTests(self, current_path, path, arch, mode):
-    all_tests = [current_path + [t] for t in self.Ls(os.path.join(self.root))]
+    all_tests = [current_path + t.split(os.path.sep) for t in self.Ls(os.path.join(self.root))]
     result = []
     for tst in all_tests:
       if self.Contains(path, tst):
@@ -135,19 +135,14 @@ class AddonTestConfiguration(SimpleTestConfiguration):
     super(AddonTestConfiguration, self).__init__(context, root, section, additional)
 
   def Ls(self, path):
-    def SelectTest(name):
-      return name.endswith('.js')
-
     result = []
     for subpath in os.listdir(path):
       if os.path.isdir(os.path.join(path, subpath)):
-        for f in os.listdir(os.path.join(path, subpath)):
-          if SelectTest(f):
-            result.append([subpath, f[:-3]])
-    return result
+        dir = [f[:-3] for _, _, files in os.walk(os.path.join(path, subpath)) for f in files if f.endswith('.js')]
+        result += dir
 
   def ListTests(self, current_path, path, arch, mode):
-    all_tests = [current_path + t for t in self.Ls(os.path.join(self.root))]
+    all_tests = [current_path + t.split(os.path.sep) for t in self.Ls(os.path.join(self.root))]
     result = []
     for tst in all_tests:
       if self.Contains(path, tst):

--- a/tools/test.py
+++ b/tools/test.py
@@ -1596,6 +1596,7 @@ def ArgsToTestPaths(test_root, args, suites):
   subsystem_regex = re.compile(r'^[a-zA-Z-]*$')
   check = lambda arg: subsystem_regex.match(arg) and (arg not in suites)
   mapped_args = ["*/test*-%s-*" % arg if check(arg) else arg for arg in args]
+  mapped_args = ["*/%s/test*" % arg for arg in mapped_args if check(arg)]
   paths = [SplitPath(NormalizePath(a)) for a in mapped_args]
   return paths
 


### PR DESCRIPTION
This PR adds support for recursive testing, and once merged, it will become the groundwork for a hopeful reorganization of the test files currently used in the Node.js repository.

Reopen of #53309, as conflicts caused weird CI failures.