### PR TITLE
test: refactor, add assertion to http-request-end

### DIFF
--- a/test/parallel/test-http-request-end.js
+++ b/test/parallel/test-http-request-end.js
@@ -20,11 +20,12 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 
 const expected = 'Post Body For Test';
+const expectedStatusCode = 200;
 
 const server = http.Server(function(req, res) {
   let result = '';
@@ -34,12 +35,12 @@ const server = http.Server(function(req, res) {
     result += chunk;
   });
 
-  req.on('end', function() {
+  req.on('end', common.mustCall(() => {
     assert.strictEqual(result, expected);
-    res.writeHead(200);
+    res.writeHead(expectedStatusCode);
     res.end('hello world\n');
     server.close();
-  });
+  }));
 
 });
 
@@ -49,12 +50,9 @@ server.listen(0, function() {
     path: '/',
     method: 'POST'
   }, function(res) {
-    console.log(res.statusCode);
+    assert.strictEqual(res.statusCode, expectedStatusCode);
     res.resume();
-  }).on('error', function(e) {
-    console.log(e.message);
-    process.exit(1);
-  });
+  }).on('error', common.mustNotCall());
 
   const result = req.end(expected);
 


### PR DESCRIPTION
Running tests with `./node test/parallel/test-http-request-end.js` and seeing `200` printed to the console. Replaced the log with assertion and added `mustCall` to make the test more strict.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
