### PR TITLE
[RISC-V]  Fix performance regression

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -181,6 +181,7 @@ Kevin Gibbons <bakkot@gmail.com>
 Keyhan Vakil <kvakil@googlecontrib.kvakil.me>
 Kris Selden <kris.selden@gmail.com>
 Kyounga Ra <kyounga@alticast.com>
+Levi Zim <rsworktech@outlook.com>
 Loo Rong Jie <loorongjie@gmail.com>
 Lu Yahan <yahan@iscas.ac.cn>
 Ludovic Mermod <ludovic.mermod@gmail.com>

--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
@@ -83,10 +83,12 @@ void CpuFeatures::ProbeImpl(bool cross_compile) {
   base::CPU cpu;
   if (cpu.has_fpu()) supported_ |= 1u << FPU;
   if (cpu.has_rvv()) supported_ |= 1u << RISCV_SIMD;
+#ifdef V8_COMPRESS_POINTERS
   if (cpu.riscv_mmu() == base::CPU::RV_MMU_MODE::kRiscvSV57) {
     FATAL("SV57 is not supported");
     UNIMPLEMENTED();
   }
+#endif
   // Set a static value on whether SIMD is supported.
   // This variable is only used for certain archs to query SupportWasmSimd128()
   // at runtime in builtins using an extern ref. Other callers should use
@@ -1086,25 +1088,21 @@ void Assembler::GeneralLi(Register rd, int64_t imm) {
 
 void Assembler::li_ptr(Register rd, int64_t imm) {
   base::CPU cpu;
-  if (cpu.riscv_mmu() != base::CPU::RV_MMU_MODE::kRiscvSV57) {
-    // Initialize rd with an address
-    // Pointers are 48 bits
-    // 6 fixed instructions are generated
-    DCHECK_EQ((imm & 0xfff0000000000000ll), 0);
-    int64_t a6 = imm & 0x3f;                      // bits 0:5. 6 bits
-    int64_t b11 = (imm >> 6) & 0x7ff;             // bits 6:11. 11 bits
-    int64_t high_31 = (imm >> 17) & 0x7fffffff;   // 31 bits
-    int64_t high_20 = ((high_31 + 0x800) >> 12);  // 19 bits
-    int64_t low_12 = high_31 & 0xfff;             // 12 bits
-    lui(rd, (int32_t)high_20);
-    addi(rd, rd, low_12);  // 31 bits in rd.
-    slli(rd, rd, 11);      // Space for next 11 bis
-    ori(rd, rd, b11);      // 11 bits are put in. 42 bit in rd
-    slli(rd, rd, 6);       // Space for next 6 bits
-    ori(rd, rd, a6);       // 6 bits are put in. 48 bis in rd
-  } else {
-    FATAL("SV57 is not supported");
-  }
+  // Initialize rd with an address
+  // Pointers are 48 bits
+  // 6 fixed instructions are generated
+  DCHECK_EQ((imm & 0xfff0000000000000ll), 0);
+  int64_t a6 = imm & 0x3f;                      // bits 0:5. 6 bits
+  int64_t b11 = (imm >> 6) & 0x7ff;             // bits 6:11. 11 bits
+  int64_t high_31 = (imm >> 17) & 0x7fffffff;   // 31 bits
+  int64_t high_20 = ((high_31 + 0x800) >> 12);  // 19 bits
+  int64_t low_12 = high_31 & 0xfff;             // 12 bits
+  lui(rd, (int32_t)high_20);
+  addi(rd, rd, low_12);  // 31 bits in rd.
+  slli(rd, rd, 11);      // Space for next 11 bis
+  ori(rd, rd, b11);      // 11 bits are put in. 42 bit in rd
+  slli(rd, rd, 6);       // Space for next 6 bits
+  ori(rd, rd, a6);       // 6 bits are put in. 48 bis in rd
 }
 
 void Assembler::li_constant(Register rd, int64_t imm) {

--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
@@ -1087,7 +1087,6 @@ void Assembler::GeneralLi(Register rd, int64_t imm) {
 }
 
 void Assembler::li_ptr(Register rd, int64_t imm) {
-  base::CPU cpu;
   // Initialize rd with an address
   // Pointers are 48 bits
   // 6 fixed instructions are generated


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix a performance regression in riscv64 v8, as bisected in https://github.com/riscv-forks/electron/issues/1. It affects nodejs 21, 22 and the main branch.  Other branches are not affected.