### PR TITLE
fix: correctly format error construction in debugger timeout handling

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -87,10 +87,7 @@ function startCLI(args, flags = [], spawnOpts = {}) {
 
         const timer = setTimeout(() => {
           tearDown();
-          reject(new Error([
-            `Timeout (${TIMEOUT}) while waiting for ${pattern}`,
-            `found: ${this.output}`,
-          ].join('; ')));
+          reject(new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}; found: ${this.output}`));
         }, TIMEOUT);
 
         function tearDown() {


### PR DESCRIPTION
## Fix
- Fixed error construction in the debugger timeout handling's format.
