### PR TITLE
assert,util: correct comparison when both contain same reference 

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -502,7 +502,7 @@ function setEquiv(a, b, strict, memo) {
     for (const val of b) {
       // Primitive values have already been handled above.
       if (typeof val === 'object' && val !== null) {
-        if (!setHasEqualElement(set, val, strict, memo))
+        if (!a.has(val) && !setHasEqualElement(set, val, strict, memo))
           return false;
       } else if (!strict &&
                  !a.has(val) &&

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -502,8 +502,9 @@ function setEquiv(a, b, strict, memo) {
     for (const val of b) {
       // Primitive values have already been handled above.
       if (typeof val === 'object' && val !== null) {
-        if (!a.has(val) && !setHasEqualElement(set, val, strict, memo))
+        if (!a.has(val) && !setHasEqualElement(set, val, strict, memo)) {
           return false;
+        }
       } else if (!strict &&
                  !a.has(val) &&
                  !setHasEqualElement(set, val, strict, memo)) {

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -375,7 +375,11 @@ assertOnlyDeepEqual(
   new Map([[undefined, null], ['+000', 2n]]),
   new Map([[null, undefined], [false, '2']]),
 );
-
+const xarray = ['x'];
+assertDeepAndStrictEqual(
+  new Set([xarray, ['y']]),
+  new Set([xarray, ['y']])
+);
 assertOnlyDeepEqual(
   new Set([null, '', 1n, 5, 2n, false]),
   new Set([undefined, 0, 5n, true, '2', '-000'])


### PR DESCRIPTION
I would expect that given

```
const xarray = ['x'];
```

Then `new Set([xarray, ['y']])` and `new Set([xarray, ['y']])` are equal as per `assert.deepStrictEqual` but since Node 20, they are not.

This PR applies the fix proposed by @BridgeAR

Refs: https://github.com/nodejs/node/issues/53423 reported by @chharvey