### PR TITLE
doc: move `node --run` stability to release candidate

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1986,7 +1986,7 @@ changes:
                  `PATH` environment variable accordingly.
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 This runs a specified command from a package.json's `"scripts"` object.
 If no `"command"` is provided, it will list the available scripts.


### PR DESCRIPTION
Let's move `node --run` to release candidate

cc @nodejs/tsc