### PR TITLE
stream: callback should be called when pendingcb is 0

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -215,7 +215,9 @@ function eos(stream, options, callback) {
     (!willEmitClose || isReadable(stream)) &&
     (writableFinished || isWritable(stream) === false)
   ) {
-    process.nextTick(onclosed);
+    if (wState && wState.pendingcb === 0) {
+      process.nextTick(onclosed);
+    }
   } else if (
     !writable &&
     (!willEmitClose || isWritable(stream)) &&

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -213,11 +213,10 @@ function eos(stream, options, callback) {
   } else if (
     !readable &&
     (!willEmitClose || isReadable(stream)) &&
-    (writableFinished || isWritable(stream) === false)
+    (writableFinished || isWritable(stream) === false) &&
+    wState && wState.pendingcb === 0
   ) {
-    if (wState && wState.pendingcb === 0) {
-      process.nextTick(onclosed);
-    }
+    process.nextTick(onclosed);
   } else if (
     !writable &&
     (!willEmitClose || isWritable(stream)) &&

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -214,7 +214,7 @@ function eos(stream, options, callback) {
     !readable &&
     (!willEmitClose || isReadable(stream)) &&
     (writableFinished || isWritable(stream) === false) &&
-    wState && wState.pendingcb === 0
+    (wState == null || wState.pendingcb === 0)
   ) {
     process.nextTick(onclosed);
   } else if (

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -669,11 +669,11 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
-  let isCalld = false;
+  let isCalled = false;
   const stream = new Duplex({
     write(chunk, enc, cb) {
       setImmediate(() => {
-        isCalld = true;
+        isCalled = true;
         cb();
       });
     }
@@ -683,7 +683,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 
   finished(stream, { readable: false }, common.mustCall((err) => {
     assert(!err);
-    assert.strictEqual(isCalld, true);
+    assert.strictEqual(isCalled, true);
     assert.strictEqual(stream._writableState.pendingcb, 0);
   }));
 }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -679,6 +679,6 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 
   finished(stream, { readable: false }, common.mustCall((err) => {
     assert(!err);
-    assert.strictEqual(stream._writableState.pendingcb, 0)
+    assert.strictEqual(stream._writableState.pendingcb, 0);
   }));
 }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -679,5 +679,6 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 
   finished(stream, { readable: false }, common.mustCall((err) => {
     assert(!err);
+    assert.strictEqual(stream._writableState.pendingcb, 0)
   }));
 }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -669,9 +669,13 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
+  let isCalld = false;
   const stream = new Duplex({
     write(chunk, enc, cb) {
-      setImmediate(cb);
+      setImmediate(() => {
+        isCalld = true;
+        cb();
+      });
     }
   });
 
@@ -679,6 +683,7 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 
   finished(stream, { readable: false }, common.mustCall((err) => {
     assert(!err);
+    assert.strictEqual(isCalld, true);
     assert.strictEqual(stream._writableState.pendingcb, 0);
   }));
 }


### PR DESCRIPTION
The callback should be called when the `pendingcb` is 0.

Time spent on this issue: 12 hours+, I would appreciate any comment or feedback on this 🙏 

Fixes: https://github.com/nodejs/node/issues/46170

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
