### PR TITLE
src: remove `SetEncoding` from StringEncoder

### DIFF
--- a/src/string_decoder-inl.h
+++ b/src/string_decoder-inl.h
@@ -7,12 +7,6 @@
 
 namespace node {
 
-void StringDecoder::SetEncoding(enum encoding encoding) {
-  state_[kBufferedBytes] = 0;
-  state_[kMissingBytes] = 0;
-  state_[kEncodingField] = encoding;
-}
-
 enum encoding StringDecoder::Encoding() const {
   return static_cast<enum encoding>(state_[kEncodingField]);
 }

--- a/src/string_decoder.h
+++ b/src/string_decoder.h
@@ -10,7 +10,6 @@ namespace node {
 class StringDecoder {
  public:
   StringDecoder() { state_[kEncodingField] = BUFFER; }
-  inline void SetEncoding(enum encoding encoding);
   inline enum encoding Encoding() const;
 
   inline char* IncompleteCharacterBuffer();


### PR DESCRIPTION
Removes unused `SetEncoding` from StringEncoder class