### PR TITLE
src: remove `base64` from `process.versions`

### DIFF
--- a/src/base64_version.h
+++ b/src/base64_version.h
@@ -1,6 +1,0 @@
-// This is an auto generated file, please do not edit.
-// Refer to tools/dep_updaters/update-base64.sh
-#ifndef SRC_BASE64_VERSION_H_
-#define SRC_BASE64_VERSION_H_
-#define BASE64_VERSION "0.5.2"
-#endif  // SRC_BASE64_VERSION_H_

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -2,7 +2,6 @@
 #include "acorn_version.h"
 #include "ada.h"
 #include "ares.h"
-#include "base64_version.h"
 #include "brotli/encode.h"
 #include "cjs_module_lexer_version.h"
 #include "llhttp.h"
@@ -112,7 +111,6 @@ Metadata::Versions::Versions() {
 
   acorn = ACORN_VERSION;
   cjs_module_lexer = CJS_MODULE_LEXER_VERSION;
-  base64 = BASE64_VERSION;
   uvwasi = UVWASI_VERSION_STRING;
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -50,8 +50,7 @@ namespace node {
   V(simdutf)                                                                   \
   V(ada)                                                                       \
   NODE_VERSIONS_KEY_UNDICI(V)                                                  \
-  V(cjs_module_lexer)                                                          \
-  V(base64)
+  V(cjs_module_lexer)
 
 #if HAVE_OPENSSL
 #define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl)

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -22,7 +22,6 @@ const expected_keys = [
   'simdutf',
   'ada',
   'cjs_module_lexer',
-  'base64',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');


### PR DESCRIPTION
The `base64` dependency was previously removed along with the update script (`tools/dep_updaters/update-base64.sh`) but the generated header, `src/base64_version.h` was left behind and `process.versions` was still listing the last version of `base64` that was included in Node.js before it was removed

Refs: https://github.com/nodejs/node/pull/52714

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
