### PR TITLE
src: reset `process.versions` during pre-execution

### DIFF
--- a/src/node_process_object.cc
+++ b/src/node_process_object.cc
@@ -77,34 +77,9 @@ static void GetParentProcessId(Local<Name> property,
   info.GetReturnValue().Set(uv_os_getppid());
 }
 
-MaybeLocal<Object> CreateProcessObject(Realm* realm) {
-  Isolate* isolate = realm->isolate();
-  EscapableHandleScope scope(isolate);
-  Local<Context> context = realm->context();
+static void SetVersions(Isolate* isolate, Local<Object> versions) {
+  Local<Context> context = isolate->GetCurrentContext();
 
-  Local<FunctionTemplate> process_template = FunctionTemplate::New(isolate);
-  process_template->SetClassName(realm->env()->process_string());
-  Local<Function> process_ctor;
-  Local<Object> process;
-  if (!process_template->GetFunction(context).ToLocal(&process_ctor) ||
-      !process_ctor->NewInstance(context).ToLocal(&process)) {
-    return MaybeLocal<Object>();
-  }
-
-  // process[exit_info_private_symbol]
-  if (process
-          ->SetPrivate(context,
-                       realm->env()->exit_info_private_symbol(),
-                       realm->env()->exit_info().GetJSArray())
-          .IsNothing()) {
-    return {};
-  }
-
-  // process.version
-  READONLY_PROPERTY(
-      process, "version", FIXED_ONE_BYTE_STRING(isolate, NODE_VERSION));
-
-  Local<Object> versions = Object::New(isolate);
   // Node.js version is always on the top
   READONLY_STRING_PROPERTY(
       versions, "node", per_process::metadata.versions.node);
@@ -137,8 +112,38 @@ MaybeLocal<Object> CreateProcessObject(Realm* realm) {
             v8::ReadOnly)
         .Check();
   }
+}
+
+MaybeLocal<Object> CreateProcessObject(Realm* realm) {
+  Isolate* isolate = realm->isolate();
+  EscapableHandleScope scope(isolate);
+  Local<Context> context = realm->context();
+
+  Local<FunctionTemplate> process_template = FunctionTemplate::New(isolate);
+  process_template->SetClassName(realm->env()->process_string());
+  Local<Function> process_ctor;
+  Local<Object> process;
+  if (!process_template->GetFunction(context).ToLocal(&process_ctor) ||
+      !process_ctor->NewInstance(context).ToLocal(&process)) {
+    return MaybeLocal<Object>();
+  }
+
+  // process[exit_info_private_symbol]
+  if (process
+          ->SetPrivate(context,
+                       realm->env()->exit_info_private_symbol(),
+                       realm->env()->exit_info().GetJSArray())
+          .IsNothing()) {
+    return {};
+  }
+
+  // process.version
+  READONLY_PROPERTY(
+      process, "version", FIXED_ONE_BYTE_STRING(isolate, NODE_VERSION));
 
   // process.versions
+  Local<Object> versions = Object::New(isolate);
+  SetVersions(isolate, versions);
   READONLY_PROPERTY(process, "versions", versions);
 
   // process.arch
@@ -248,6 +253,11 @@ void PatchProcessObject(const FunctionCallbackInfo<Value>& args) {
                 None,
                 SideEffectType::kHasNoSideEffect)
             .FromJust());
+
+  // process.versions
+  Local<Object> versions = Object::New(isolate);
+  SetVersions(isolate, versions);
+  READONLY_PROPERTY(process, "versions", versions);
 }
 
 void RegisterProcessExternalReferences(ExternalReferenceRegistry* registry) {


### PR DESCRIPTION
Reset `process.versions` during pre-execution so that it reflects the versions at run-time rather than when the snapshot was taken.

Fixes: https://github.com/nodejs/node/pull/51007#issuecomment-1836825122

---

I'm not sure there's an easy way to test this currently in the CI -- it requires Node.js to be built against a dynamically linked library (e.g. zlib[1]) at one version and then run against a different, ABI-compatible version so that the snapshot has one version of  the dependency recorded but Node.js is actually running with a different one.

cc @joyeecheung -- re. https://github.com/nodejs/node/pull/51007#issuecomment-1837028324 -- it seemed easier to reset the entire `process.versions` object rather than checking each individual entry (and also meant I could extract and reuse the setting code).

[1]: OpenSSL would be another, but there's a separate bug with obtaining the version of OpenSSL that I'll open another PR for.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
