### PR TITLE
src: fix dynamically linked OpenSSL version

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -23,7 +23,7 @@
 #endif  // NODE_BUNDLED_ZLIB
 
 #if HAVE_OPENSSL
-#include <openssl/opensslv.h>
+#include <openssl/crypto.h>
 #if NODE_OPENSSL_HAS_QUIC
 #include <openssl/quic.h>
 #endif
@@ -55,9 +55,10 @@ static constexpr size_t search(const char* s, char c, size_t n = 0) {
 static inline std::string GetOpenSSLVersion() {
   // sample openssl version string format
   // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
-  constexpr size_t start = search(OPENSSL_VERSION_TEXT, ' ') + 1;
-  constexpr size_t len = search(&OPENSSL_VERSION_TEXT[start], ' ');
-  return std::string(OPENSSL_VERSION_TEXT, start, len);
+  const char* version = OpenSSL_version(OPENSSL_VERSION);
+  const size_t start = search(version, ' ') + 1;
+  const size_t len = search(&version[start], ' ');
+  return std::string(version, start, len);
 }
 #endif  // HAVE_OPENSSL
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -76,12 +76,6 @@ const hasOpenSSL = (major = 0, minor = 0, patch = 0) => {
   return OPENSSL_VERSION_NUMBER >= opensslVersionNumber(major, minor, patch);
 };
 
-const hasOpenSSL3 = hasOpenSSL(3);
-
-const hasOpenSSL31 = hasOpenSSL(3, 1);
-
-const hasOpenSSL32 = hasOpenSSL(3, 2);
-
 const hasQuic = hasCrypto && !!process.config.variables.openssl_quic;
 
 function parseTestFlags(filename = process.argv[1]) {
@@ -986,9 +980,6 @@ const common = {
   hasIntl,
   hasCrypto,
   hasOpenSSL,
-  hasOpenSSL3,
-  hasOpenSSL31,
-  hasOpenSSL32,
   hasQuic,
   hasMultiLocalhost,
   invalidArgTypeHelper,
@@ -1047,6 +1038,18 @@ const common = {
       return re.test(name) &&
              iFaces[name].some(({ family }) => family === 'IPv6');
     });
+  },
+
+  get hasOpenSSL3() {
+    return hasOpenSSL(3);
+  },
+
+  get hasOpenSSL31() {
+    return hasOpenSSL(3, 1);
+  },
+
+  get hasOpenSSL32() {
+    return hasOpenSSL(3, 2);
   },
 
   get inFreeBSDJail() {

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -86,8 +86,8 @@ const crypto = require('crypto');
   }
 
   {
-    const v = crypto.constants.OPENSSL_VERSION_NUMBER;
-    const hasOpenSSL3WithNewErrorMessage = (v >= 0x300000c0 && v <= 0x30100000) || (v >= 0x30100040 && v <= 0x30200000);
+    const hasOpenSSL3WithNewErrorMessage = (common.hasOpenSSL(3, 0, 12) && !common.hasOpenSSL(3, 1, 0)) ||
+                                           (common.hasOpenSSL(3, 1, 4) && !common.hasOpenSSL(3, 2, 0));
     assert.throws(() => {
       dh3.computeSecret('');
     }, { message: common.hasOpenSSL3 && !hasOpenSSL3WithNewErrorMessage ?

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -86,8 +86,8 @@ const crypto = require('crypto');
   }
 
   {
-    const hasOpenSSL3WithNewErrorMessage = (common.hasOpenSSL(3, 0, 12) && !common.hasOpenSSL(3, 1, 0)) ||
-                                           (common.hasOpenSSL(3, 1, 4) && !common.hasOpenSSL(3, 2, 0));
+    const hasOpenSSL3WithNewErrorMessage = (common.hasOpenSSL(3, 0, 12) && !common.hasOpenSSL(3, 1, 1)) ||
+                                           (common.hasOpenSSL(3, 1, 4) && !common.hasOpenSSL(3, 2, 1));
     assert.throws(() => {
       dh3.computeSecret('');
     }, { message: common.hasOpenSSL3 && !hasOpenSSL3WithNewErrorMessage ?


### PR DESCRIPTION
Some fixes for dynamically linked OpenSSL (i.e. `configure --shared-openssl`):

- [src: fix dynamically linked OpenSSL version](https://github.com/nodejs/node/commit/f132c85ac4396605623104e7c23efe83cfcb8ca7) 
Report the version of OpenSSL that Node.js is running with instead
of the version of OpenSSL that Node.js was compiled against.
- [test: check against run-time OpenSSL version](https://github.com/nodejs/node/commit/d71c5ab912a00295918b607c73e40b0847aced1a) 
Update `common.hasOpenSSL3*` to check against the run-time version of
OpenSSL instead of the version of OpenSSL that Node.js was compiled
against.
Add a generalized `common.hasOpenSSL()` so we do not need to keep adding
new checks for each new major/minor of OpenSSL.

---

There's a secondary issue, where all of `process.versions` is currently captured in the snapshot and thus reflects the snapshot-time values rather than run-time ones. That is being addressed separately by https://github.com/nodejs/node/pull/53444.

cc @nodejs/crypto 