### PR TITLE
lib: remove the unused code

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -526,7 +526,7 @@ function initializePermission() {
     ObjectFreeze(require('path'));
     process.emitWarning('Permission is an experimental feature',
                         'ExperimentalWarning');
-    const { has, deny } = require('internal/process/permission');
+    const { has } = require('internal/process/permission');
     const warnFlags = [
       '--allow-addons',
       '--allow-child-process',
@@ -563,7 +563,6 @@ function initializePermission() {
       configurable: false,
       value: {
         has,
-        deny,
       },
     });
   } else {


### PR DESCRIPTION
`process.permission.deny` have been removed.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
