### PR TITLE
inspector: fix disable async hooks on Debugger.setAsyncCallStackDepth

### DIFF
--- a/src/async_wrap.cc
+++ b/src/async_wrap.cc
@@ -193,6 +193,12 @@ static void SetPromiseHooks(const FunctionCallbackInfo<Value>& args) {
       args[3]->IsFunction() ? args[3].As<Function>() : Local<Function>());
 }
 
+static void GetPromiseHooks(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  args.GetReturnValue().Set(
+      env->async_hooks()->GetPromiseHooks(args.GetIsolate()));
+}
+
 class DestroyParam {
  public:
   double asyncId;
@@ -364,6 +370,7 @@ void AsyncWrap::CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "clearAsyncIdStack", ClearAsyncIdStack);
   SetMethod(isolate, target, "queueDestroyAsyncId", QueueDestroyAsyncId);
   SetMethod(isolate, target, "setPromiseHooks", SetPromiseHooks);
+  SetMethod(isolate, target, "getPromiseHooks", GetPromiseHooks);
   SetMethod(isolate, target, "registerDestroyHook", RegisterDestroyHook);
   AsyncWrap::GetConstructorTemplate(isolate_data);
 }
@@ -469,6 +476,7 @@ void AsyncWrap::RegisterExternalReferences(
   registry->Register(ClearAsyncIdStack);
   registry->Register(QueueDestroyAsyncId);
   registry->Register(SetPromiseHooks);
+  registry->Register(GetPromiseHooks);
   registry->Register(RegisterDestroyHook);
   registry->Register(AsyncWrap::GetAsyncId);
   registry->Register(AsyncWrap::AsyncReset);

--- a/src/env.cc
+++ b/src/env.cc
@@ -87,6 +87,18 @@ void AsyncHooks::ResetPromiseHooks(Local<Function> init,
   js_promise_hooks_[3].Reset(env()->isolate(), resolve);
 }
 
+Local<Array> AsyncHooks::GetPromiseHooks(Isolate* isolate) {
+  std::vector<Local<Value>> values;
+  for (size_t i = 0; i < js_promise_hooks_.size(); ++i) {
+    if (js_promise_hooks_[i].IsEmpty()) {
+      values.push_back(Undefined(isolate));
+    } else {
+      values.push_back(js_promise_hooks_[i].Get(isolate));
+    }
+  }
+  return Array::New(isolate, values.data(), values.size());
+}
+
 void Environment::ResetPromiseHooks(Local<Function> init,
                                     Local<Function> before,
                                     Local<Function> after,

--- a/src/env.h
+++ b/src/env.h
@@ -322,7 +322,9 @@ class AsyncHooks : public MemoryRetainer {
                          v8::Local<v8::Function> before,
                          v8::Local<v8::Function> after,
                          v8::Local<v8::Function> resolve);
-
+  // Used for testing since V8 doesn't provide API for retrieving configured
+  // JS promise hooks.
+  v8::Local<v8::Array> GetPromiseHooks(v8::Isolate* isolate);
   inline v8::Local<v8::String> provider_string(int idx);
 
   inline void no_force_checks();

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -923,7 +923,7 @@ void Agent::EnableAsyncHook() {
 
 void Agent::DisableAsyncHook() {
   HandleScope scope(parent_env_->isolate());
-  Local<Function> disable = parent_env_->inspector_enable_async_hooks();
+  Local<Function> disable = parent_env_->inspector_disable_async_hooks();
   if (!disable.IsEmpty()) {
     ToggleAsyncHook(parent_env_->isolate(), disable);
   } else if (pending_enable_async_hook_) {

--- a/test/parallel/test-inspector-async-call-stack.js
+++ b/test/parallel/test-inspector-async-call-stack.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
 const { async_hook_fields, constants } = internalBinding('async_wrap');
 const { kTotals } = constants;
-const inspector = require('inspector');
+const inspector = require('inspector/promises');
 
 const setDepth = 'Debugger.setAsyncCallStackDepth';
 
@@ -31,53 +31,38 @@ verifyAsyncHookDisabled('creating a session should not enable async hooks');
 session.connect();
 verifyAsyncHookDisabled('connecting a session should not enable async hooks');
 
-session.post('Debugger.enable', () => {
+(async () => {
+  await session.post('Debugger.enable');
   verifyAsyncHookDisabled('enabling debugger should not enable async hooks');
+  await assert.rejects(session.post(setDepth, { invalid: 'message' }), { code: 'ERR_INSPECTOR_COMMAND' });
+  verifyAsyncHookDisabled('invalid message should not enable async hooks');
+  await assert.rejects(session.post(setDepth, { maxDepth: 'five' }), { code: 'ERR_INSPECTOR_COMMAND' });
+  verifyAsyncHookDisabled('invalid maxDepth (string) should not enable ' +
+                          'async hooks');
+  await assert.rejects(session.post(setDepth, { maxDepth: NaN }), { code: 'ERR_INSPECTOR_COMMAND' });
+  verifyAsyncHookDisabled('invalid maxDepth (NaN) should not enable ' +
+                          'async hooks');
+  await session.post(setDepth, { maxDepth: 10 });
+  verifyAsyncHookEnabled('valid message should enable async hooks');
 
-  session.post(setDepth, { invalid: 'message' }, () => {
-    verifyAsyncHookDisabled('invalid message should not enable async hooks');
+  await session.post(setDepth, { maxDepth: 0 });
+  verifyAsyncHookDisabled('Setting maxDepth to 0 should disable ' +
+                          'async hooks');
 
-    session.post(setDepth, { maxDepth: 'five' }, () => {
-      verifyAsyncHookDisabled('invalid maxDepth (string) should not enable ' +
-                              'async hooks');
+  await session.post(setDepth, { maxDepth: 32 });
+  verifyAsyncHookEnabled('valid message should enable async hooks');
 
-      session.post(setDepth, { maxDepth: NaN }, () => {
-        verifyAsyncHookDisabled('invalid maxDepth (NaN) should not enable ' +
-                                'async hooks');
+  await session.post('Debugger.disable');
+  verifyAsyncHookDisabled('Debugger.disable should disable async hooks');
 
-        session.post(setDepth, { maxDepth: 10 }, () => {
-          verifyAsyncHookEnabled('valid message should enable async hooks');
+  await session.post('Debugger.enable');
+  verifyAsyncHookDisabled('Enabling debugger should not enable hooks');
 
-          session.post(setDepth, { maxDepth: 0 }, () => {
-            verifyAsyncHookDisabled('Setting maxDepth to 0 should disable ' +
-                                    'async hooks');
+  await session.post(setDepth, { maxDepth: 64 });
+  verifyAsyncHookEnabled('valid message should enable async hooks');
 
-            runTestSet2(session);
-          });
-        });
-      });
-    });
-  });
-});
+  session.disconnect();
 
-function runTestSet2(session) {
-  session.post(setDepth, { maxDepth: 32 }, () => {
-    verifyAsyncHookEnabled('valid message should enable async hooks');
-
-    session.post('Debugger.disable', () => {
-      verifyAsyncHookDisabled('Debugger.disable should disable async hooks');
-
-      session.post('Debugger.enable', () => {
-        verifyAsyncHookDisabled('Enabling debugger should not enable hooks');
-
-        session.post(setDepth, { maxDepth: 64 }, () => {
-          verifyAsyncHookEnabled('valid message should enable async hooks');
-
-          session.disconnect();
-          verifyAsyncHookDisabled('Disconnecting session should disable ' +
-                                  'async hooks');
-        });
-      });
-    });
-  });
-}
+  verifyAsyncHookDisabled('Disconnecting session should disable ' +
+                          'async hooks');
+})().then(common.mustCall());


### PR DESCRIPTION
This was previously calling the enable function by mistake. As a result, when profiling using Chrome DevTools, the async hooks won't be turned off properly after receiving Debugger.setAsyncCallStackDepth with depth 0.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
