### PR TITLE
lib: support promise reject for http2.connect promisify integration

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1034,7 +1034,7 @@ function setupHandle(socket, type, options) {
   // If the session has been destroyed, go ahead and emit 'connect',
   // but do nothing else. The various on('connect') handlers set by
   // core will check for session.destroyed before progressing, this
-  // ensures that those at l`east get cleared out.
+  // ensures that those at least get cleared out.
   if (this.destroyed) {
     process.nextTick(emit, this, 'connect', this, socket);
     return;
@@ -2126,7 +2126,7 @@ class Http2Stream extends Duplex {
   }
 
   [kProceed]() {
-    assert.fail('Implementors MUST implement this. Please report this as a ' +
+    assert.fail('Implementers MUST implement this. Please report this as a ' +
                 'bug in Node.js');
   }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3380,8 +3380,10 @@ function connect(authority, options, listener) {
 ObjectDefineProperty(connect, promisify.custom, {
   __proto__: null,
   value: (authority, options) => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const server = connect(authority, options, () => resolve(server));
+
+      session.once('error', reject);
     });
   },
 });

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3381,7 +3381,10 @@ ObjectDefineProperty(connect, promisify.custom, {
   __proto__: null,
   value: (authority, options) => {
     return new Promise((resolve, reject) => {
-      const server = connect(authority, options, () => resolve(server));
+      const server = connect(authority, options, () => {
+        server.removeListener('error', reject);
+        return resolve(server);
+      });
 
       server.once('error', reject);
     });

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3383,7 +3383,7 @@ ObjectDefineProperty(connect, promisify.custom, {
     return new Promise((resolve, reject) => {
       const server = connect(authority, options, () => resolve(server));
 
-      session.once('error', reject);
+      server.once('error', reject);
     });
   },
 });

--- a/test/parallel/test-http2-client-promisify-connect-error.js
+++ b/test/parallel/test-http2-client-promisify-connect-error.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+const util = require('util');
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond();
+  stream.end('ok');
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  server.close(() => {
+    const connect = util.promisify(http2.connect);
+    connect(`http://localhost:${port}`)
+      .then(common.mustNotCall('Promise should not be resolved'))
+      .catch(common.mustCall((err) => {
+        assert(err instanceof Error);
+        assert.strictEqual(err.code, 'ECONNREFUSED');
+      }));
+  });
+}));

--- a/test/parallel/test-http2-client-promisify-connect-error.js
+++ b/test/parallel/test-http2-client-promisify-connect-error.js
@@ -9,10 +9,6 @@ const http2 = require('http2');
 const util = require('util');
 
 const server = http2.createServer();
-server.on('stream', common.mustCall((stream) => {
-  stream.respond();
-  stream.end('ok');
-}));
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;

--- a/test/parallel/test-http2-client-promisify-connect.js
+++ b/test/parallel/test-http2-client-promisify-connect.js
@@ -8,6 +8,7 @@ const assert = require('assert');
 const http2 = require('http2');
 const util = require('util');
 
+// Successful connection test
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   stream.respond();
@@ -27,6 +28,21 @@ server.listen(0, common.mustCall(() => {
         assert.strictEqual(data, 'ok');
         client.close();
         server.close();
+        testConnectionError();
       }));
     }));
 }));
+
+// Error connection test
+function testConnectionError() {
+  const connect = util.promisify(http2.connect);
+
+  // Attempt to connect to an invalid port
+  connect('http://localhost:9999')
+    .then(common.mustNotCall('Promise should not be resolved'))
+    .catch(common.mustCall((err) => {
+      assert(err instanceof Error);
+      assert.strictEqual(err.code, 'ECONNREFUSED');
+      console.log('Error test passed.');
+    }));
+}

--- a/test/parallel/test-http2-client-promisify-connect.js
+++ b/test/parallel/test-http2-client-promisify-connect.js
@@ -8,7 +8,6 @@ const assert = require('assert');
 const http2 = require('http2');
 const util = require('util');
 
-// Successful connection test
 const server = http2.createServer();
 server.on('stream', common.mustCall((stream) => {
   stream.respond();
@@ -28,20 +27,6 @@ server.listen(0, common.mustCall(() => {
         assert.strictEqual(data, 'ok');
         client.close();
         server.close();
-        testConnectionError();
       }));
     }));
 }));
-
-// Error connection test
-function testConnectionError() {
-  const connect = util.promisify(http2.connect);
-
-  // Attempt to connect to an invalid port
-  connect('http://localhost:9999')
-    .then(common.mustNotCall('Promise should not be resolved'))
-    .catch(common.mustCall((err) => {
-      assert(err instanceof Error);
-      assert.strictEqual(err.code, 'ECONNREFUSED');
-    }));
-}

--- a/test/parallel/test-http2-client-promisify-connect.js
+++ b/test/parallel/test-http2-client-promisify-connect.js
@@ -43,6 +43,5 @@ function testConnectionError() {
     .catch(common.mustCall((err) => {
       assert(err instanceof Error);
       assert.strictEqual(err.code, 'ECONNREFUSED');
-      console.log('Error test passed.');
     }));
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This PR enhances the connect function to support Promise-based usage, adding error handling to the Promise wrapper to reject the Promise if an error occurs during the session's connect event.

