### PR TITLE
stream: update doc for new default high water mark

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3428,7 +3428,7 @@ added:
 * Returns: {integer}
 
 Returns the default highWaterMark used by streams.
-Defaults to `16384` (16 KiB), or `16` for `objectMode`.
+Defaults to `65536` (64 KiB), or `16` for `objectMode`.
 
 ### `stream.setDefaultHighWaterMark(objectMode, value)`
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3428,7 +3428,7 @@ added:
 * Returns: {integer}
 
 Returns the default highWaterMark used by streams.
-Defaults to `65536` (64 KiB), or `16` for `objectMode`.
+Defaults to `65536` (64 KiB), or `16384` (16 KiB) for `objectMode`.
 
 ### `stream.setDefaultHighWaterMark(objectMode, value)`
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3428,7 +3428,7 @@ added:
 * Returns: {integer}
 
 Returns the default highWaterMark used by streams.
-Defaults to `65536` (64 KiB), or `16384` (16 KiB) for `objectMode`.
+Defaults to `65536` (64 KiB), or `16` for `objectMode`.
 
 ### `stream.setDefaultHighWaterMark(objectMode, value)`
 


### PR DESCRIPTION
New value for `stream.getDefaultHighWaterMark(objectMode)` update was missed in the previous PR.
https://github.com/nodejs/node/pull/52037

Updating the value.