### PR TITLE
assert,util: change WeakMap and WeakSet comparison handling

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -634,7 +634,8 @@ are also recursively evaluated by the following rules.
 * Implementation does not test the [`[[Prototype]]`][prototype-spec] of
   objects.
 * [`Symbol`][] properties are not compared.
-* [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values.
+* [`WeakMap`][] and [`WeakSet`][] comparison does not rely on their values
+  but only on their instances.
 * [`RegExp`][] lastIndex, flags, and source are always compared, even if these
   are not enumerable properties.
 

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -46,6 +46,8 @@ const {
   isFloat64Array,
   isKeyObject,
   isCryptoKey,
+  isWeakMap,
+  isWeakSet,
 } = types;
 const {
   constants: {
@@ -283,7 +285,10 @@ function innerDeepEqual(val1, val2, strict, memos) {
     ) {
       return false;
     }
+  } else if (isWeakMap(val1) || isWeakSet(val1)) {
+    return false;
   }
+
   return keyCheck(val1, val2, strict, memos, kNoIterator);
 }
 

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -1300,3 +1300,35 @@ if (common.hasCrypto) {
     }
   })().then(common.mustCall());
 }
+
+// Comparing two identical WeakMap instances
+{
+  const weakMap = new WeakMap();
+  assertDeepAndStrictEqual(weakMap, weakMap);
+}
+
+// Comparing two different WeakMap instances
+{
+  const weakMap1 = new WeakMap();
+  const objA = {};
+  weakMap1.set(objA, 'ok');
+
+  const weakMap2 = new WeakMap();
+  const objB = {};
+  weakMap2.set(objB, 'ok');
+
+  assertNotDeepOrStrict(weakMap1, weakMap2);
+}
+
+// Comparing two identical WeakSet instances
+{
+  const weakSet = new WeakSet();
+  assertDeepAndStrictEqual(weakSet, weakSet);
+}
+
+// Comparing two different WeakSet instances
+{
+  const weakSet1 = new WeakSet();
+  const weakSet2 = new WeakSet();
+  assertNotDeepOrStrict(weakSet1, weakSet2);
+}


### PR DESCRIPTION
Fixes #18227

As discussed in the [task](https://github.com/nodejs/node/issues/18227) I've added : 

- a check if the compared params are either `WeakSet` or `WeakMap` and compare their instance
- I slightly updated the doc to reflect this change
- added tests for `Weak*` instances comparison
