### PR TITLE
test: fix OpenSSL version checks

### DIFF
--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -86,8 +86,9 @@ const crypto = require('crypto');
   }
 
   {
-    const hasOpenSSL3WithNewErrorMessage = (common.hasOpenSSL(3, 0, 12) && !common.hasOpenSSL(3, 1, 1)) ||
-                                           (common.hasOpenSSL(3, 1, 4) && !common.hasOpenSSL(3, 2, 1));
+    // Error message was changed in OpenSSL 3.0.x from 3.0.12, and 3.1.x from 3.1.4.
+    const hasOpenSSL3WithNewErrorMessage = (common.hasOpenSSL(3, 0, 12) && !common.hasOpenSSL(3, 1, 0)) ||
+                                           (common.hasOpenSSL(3, 1, 4));
     assert.throws(() => {
       dh3.computeSecret('');
     }, { message: common.hasOpenSSL3 && !hasOpenSSL3WithNewErrorMessage ?


### PR DESCRIPTION
As per the original pull request that introduced the OpenSSL version check in `parallel/test-crypto-dh`:

```
Error message change is test-only and uses the right error message for
versions >=3.0.12 in 3.0.x and >= 3.1.4 in 3.1.x series.
```

Fix the check so that:
- The older message is expected for OpenSSL 3.1.0.
- The newer message is expected for OpenSSL from 3.1.4 (e.g. 3.2.x).

Refs: https://github.com/nodejs/node/pull/50395
Refs: https://github.com/nodejs/node/issues/53382

---

Follow up to https://github.com/nodejs/node/pull/53456#discussion_r1640231149 and https://github.com/nodejs/node/pull/53456#discussion_r1640276601.
cc @nodejs/crypto 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
