### PR TITLE
doc: only apply content-visibility on all.html

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -445,7 +445,7 @@ dd + dt.pre {
   padding-top: 1rem;
 }
 
-#api-section-all section {
+#api-section-all #apicontent section {
   content-visibility: auto;
   contain-intrinsic-size: 1px auto 5000px;
 }

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -445,7 +445,7 @@ dd + dt.pre {
   padding-top: 1rem;
 }
 
-#apicontent section {
+#api-section-all section {
   content-visibility: auto;
   contain-intrinsic-size: 1px auto 5000px;
 }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/40099#issuecomment-2175492569

`content-visibility` is the source of bad anchor scrolling behaviours in [select browsers](https://caniuse.com/?search=content-visibility) that support this rule. This change makes it only apply to the sections in the `all.html` docs page.