### PR TITLE
build: only generate specified build type ninja files

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2253,7 +2253,7 @@ if flavor == 'win' and python.lower().endswith('.exe'):
 gyp_args += ['-Dpython=' + python]
 
 if options.use_ninja:
-  gyp_args += ['-f', 'ninja-' + flavor]
+  gyp_args += ['-f', 'ninja-' + flavor, '-G', 'config=' + config['BUILDTYPE']]
 elif flavor == 'win' and sys.platform != 'msys':
   gyp_args += ['-f', 'msvs', '-G', 'msvs_version=auto']
 else:


### PR DESCRIPTION
Release and Debug build configurations can not be shared, only
generate specified configuration in `configure` with the ninja
generator. This avoids generating invalid DEBUG ninja build files
when `configure` was not run with `--debug`.

Fixes: https://github.com/nodejs/node/issues/53446