### PR TITLE
Coverage reporter shallow error doc

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -508,8 +508,8 @@ used as an in depth coverage report.
 node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info
 ```
 
-- No test results are reported by this reporter.
-- This reporter should ideally be used in conjunction with another reporter.
+* No test results are reported by this reporter.
+* This reporter should ideally be used in conjunction with another reporter.
 
 ### Limitations
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -508,6 +508,9 @@ used as an in depth coverage report.
 node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info
 ```
 
+- No test results are reported by this reporter.
+- This reporter should ideally be used in conjunction with another reporter.
+
 ### Limitations
 
 The test runner's code coverage functionality does not support excluding

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -509,7 +509,7 @@ node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-de
 ```
 
 * No test results are reported by this reporter.
-* This reporter should ideally be used in conjunction with another reporter.
+* This reporter should ideally be used alongside another reporter.
 
 ### Limitations
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Added details on how coverage reporters should ideally be used in conjunction with another reporter to handle errors that may be shallowed. #52670 
@atlowChemi, @H4ad sorry I have recreate the pull request cause some issue on the precedent this one is more clean 