### PR TITLE
test_runner: fix delete test file cause dependency file not watched

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -431,6 +431,12 @@ function watchFiles(testFiles, opts) {
         watcher.filterFile(resolve(newFileName), owners);
       }
 
+      // When file deleted
+      if (!newFileName && previousFileName) {
+        testFiles = updatedTestFiles;
+        return;
+      }
+
       testFiles = updatedTestFiles;
     }
 

--- a/test/parallel/test-runner-watch-mode-complex.mjs
+++ b/test/parallel/test-runner-watch-mode-complex.mjs
@@ -1,0 +1,100 @@
+// Flags: --expose-internals
+import * as common from '../common/index.mjs';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import util from 'internal/util';
+import tmpdir from '../common/tmpdir.js';
+
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+tmpdir.refresh();
+
+// This test updates these files repeatedly,
+// Reading them from disk is unreliable due to race conditions.
+const fixtureContent = {
+  'dependency.js': 'module.exports = {};',
+  'dependency.mjs': 'export const a = 1;',
+  // Test 1
+  'test.js': `
+const test = require('node:test');
+require('./dependency.js');
+import('./dependency.mjs');
+import('data:text/javascript,');
+test('first test has ran');`,
+  // Test 2
+  'test-2.mjs': `
+import test from 'node:test';
+import './dependency.js';
+import { a } from './dependency.mjs';
+import 'data:text/javascript,';
+test('second test has ran');`,
+  // Test file to be deleted
+  'test-to-delete.mjs': `
+import test from 'node:test';
+import './dependency.js';
+import { a } from './dependency.mjs';
+import 'data:text/javascript,';
+test('test to delete has ran');`,
+};
+
+const fixturePaths = Object.keys(fixtureContent)
+  .reduce((acc, file) => ({ ...acc, [file]: tmpdir.resolve(file) }), {});
+Object.entries(fixtureContent)
+  .forEach(([file, content]) => writeFileSync(fixturePaths[file], content));
+
+describe('test runner watch mode with more complex setup', () => {
+  it('should run tests when a dependency changed after a watched test file being deleted', async () => {
+    const ran1 = util.createDeferredPromise();
+    const ran2 = util.createDeferredPromise();
+    const child = spawn(process.execPath,
+                        ['--watch', '--test'].filter(Boolean),
+                        { encoding: 'utf8', stdio: 'pipe', cwd: tmpdir.path });
+    let stdout = '';
+    let currentRun = '';
+    const runs = [];
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+      currentRun += data.toString();
+      const testRuns = stdout.match(/# duration_ms\s\d+/g);
+
+      if (testRuns?.length >= 1) ran1.resolve();
+      if (testRuns?.length >= 2) ran2.resolve();
+    });
+
+    await ran1.promise;
+    runs.push(currentRun);
+    currentRun = '';
+    const fileToDeletePathLocal = tmpdir.resolve('test-to-delete.mjs');
+    unlinkSync(fileToDeletePathLocal);
+
+    const content = fixtureContent['dependency.mjs'];
+    const path = fixturePaths['dependency.mjs'];
+    const interval = setInterval(() => writeFileSync(path, content), common.platformTimeout(1000));
+    await ran2.promise;
+    runs.push(currentRun);
+    currentRun = '';
+    clearInterval(interval);
+    child.kill();
+
+    assert.strictEqual(runs.length, 2);
+
+    for (let i = 0; i < runs.length; i++) {
+      if (i === 0) {
+        assert.match(runs[i], /# tests 3/);
+        assert.match(runs[i], /# pass 3/);
+        assert.match(runs[i], /# fail 0/);
+        assert.match(runs[i], /# cancelled 0/);
+      } else {
+        assert.match(runs[i], /# tests 2/);
+        assert.match(runs[i], /# pass 2/);
+        assert.match(runs[i], /# fail 0/);
+        assert.match(runs[i], /# cancelled 0/);
+      }
+    }
+  });
+});


### PR DESCRIPTION
There is an edge case left from https://github.com/nodejs/node/pull/53114

### Reproduce step:

```js
// create dependency index.js
export const a = 1;
export const b = 2;
export const c = 3;
```

```js
// create test-a.mjs
import { a } from "./index.mjs";

import { test } from "node:test";
import assert from "node:assert";

test("test One", () => {
  assert.equal(a, 1);
});
```

```js
// create test-b.mjs
import { a, b } from "./index.mjs";

import { test } from "node:test";
import assert from "node:assert";

test("test Two", () => {
  assert.equal(a, 1);
  assert.equal(b, 2);
});
```

```js
// create test-c.mjs
import { a, b, c } from "./index.mjs";

import { test } from "node:test";
import assert from "node:assert";

test("test Three", () => {
  assert.equal(a, 1);
  assert.equal(b, 2);
  assert.equal(c, 3);
});

```

```bash
node --watch --test

# now delete test-a.mjs
# then make any change to index.mjs e.g. change const a = 1 to const a = 2
```

You would observe that `test-b.mjs` and `test-c.mjs` are not being rerun. The expected behaviour should be `test-b.mjs`, `test-c.mjs` being rerun and failed (since `assert.strictEqual(a, 1)` is not correct anymore).

### Change explain:

When a watched test file is being deleted then the referenced dependency file(s) will be updated incorrect when `unfilterFilesOwnedBy` method is called, which will cause tests not being rerun when its referenced dependency changed. To prevent this case, we can simply `return` when we detect a watched test file is being deleted.

### notes:
The test is quite identical to `test/parallel/test-runner-watch-mode.mjs` but with a more complicated setup, I am thinking to spend some time to see how I can refactor the test so we can write more complicated test cases in the future, I am committed and would like to do a separate PR for it.

Ref: https://github.com/nodejs/node/pull/53114
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
