### PR TITLE
fs: calling mkdir in fs.cp function can ignore EEXIST error

### DIFF
--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -310,7 +310,7 @@ async function mkDirAndCopy(srcMode, src, dest, opts) {
     await mkdir(dest);
   } catch (error) {
     // If the folder already exists, skip it.
-    if (error.code !== 'EEXIST')
+    if (error.code === 'EEXIST' && !opts.errorOnExist); else
       throw error;
   }
 

--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -306,7 +306,14 @@ function onDir(srcStat, destStat, src, dest, opts) {
 }
 
 async function mkDirAndCopy(srcMode, src, dest, opts) {
-  await mkdir(dest);
+  try {
+    await mkdir(dest);
+  } catch (error) {
+    // If the folder already exists, skip it.
+    if (error.code !== 'EEXIST')
+      throw error;
+  }
+
   await copyDir(src, dest, opts);
   return setDestMode(dest, srcMode);
 }

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -933,6 +933,38 @@ if (!isWindows) {
   );
 }
 
+// It can ignore EEXIST error when the destination folder has been created by other file operations in parallel (#53534)
+{
+  const src = './test/fixtures/copy/kitchen-sink';
+  const dest = nextdir();
+
+  await Promise.all([
+    fs.promises.cp(src, dest, {
+      recursive: true,
+      errorOnExist: false
+    }),
+
+    fs.promises.mkdir(dest, { recursive: true }),
+  ]);
+
+  assertDirEquivalent(src, dest);
+
+  const dest2 = nextdir();
+
+  await assert.rejects(
+    async () =>
+      Promise.all([
+        fs.promises.cp(src, dest2, {
+          recursive: true,
+          errorOnExist: true
+        }),
+
+        fs.promises.mkdir(dest2, { recursive: true }),
+      ]),
+    { code: 'EEXIST' }
+  );
+}
+
 // It rejects if options is not object.
 {
   await assert.rejects(


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR mainly aims to solve the following problem. During the execution of the fsp.cp function, due to other file operations, the target directory of fsp.cp is created in parallel. The actual situation may be more complicated. Multiple file operations are executed concurrently, resulting in an error in the internal fsp.cp when calling mkdir, because the folder has been created by other file operations. In this case, you can actually ignore this error and continue with the subsequent file copying operation.

```javascript
import { promises as fsp } from 'fs'

const src = 'T:/src/'
const dst = 'T:/out/'

try {
    await fsp.rm(dst, { recursive: true })
} catch { }

await Promise.all([
    fsp.cp(src, dst, {
        recursive: true,
        force: true,
        errorOnExist: false,
        mode: 0
    }),
    
    // example other file operations in parallel
    fsp.mkdir(dst, { recursive: true })
])

// throws EEXIST: file already exists, mkdir 'T:/out/'
// at mkdir()
// at mkDirAndCopy() lib/internal/fs/cp/cp.js
// at onDir() lib/internal/fs/cp/cp.js
```

The relevant code is in lib/internal/fs/cp/cp.js.
destStat is empty here, it did not exist when checking the folder before.



```javascript
function onDir(srcStat, destStat, src, dest, opts) {
  if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
  return copyDir(src, dest, opts);
}

async function mkDirAndCopy(srcMode, src, dest, opts) {
  await mkdir(dest);
  await copyDir(src, dest, opts);
  return setDestMode(dest, srcMode);
}
```

I want to ignore the EEXIST error thrown by mkdir

```typescript
async function mkDirAndCopy(srcMode, src, dest, opts) {
  try {
    await mkdir(dest);
  } catch (error) {
    // If the folder already exists, skip it.
    if (error.code !== 'EEXIST')
      throw error;
  }

  await copyDir(src, dest, opts);
  return setDestMode(dest, srcMode);
}
```


