### PR TITLE
fs: improve `ExistsSync` performance on Windows

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1003,24 +1003,23 @@ static void ExistsSync(const FunctionCallbackInfo<Value>& args) {
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 
-  uv_fs_t req;
-  auto make = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
-  FS_SYNC_TRACE_BEGIN(access);
-  int err = uv_fs_access(nullptr, &req, path.out(), 0, nullptr);
-  FS_SYNC_TRACE_END(access);
+  std::error_code error{};
+  auto file_path = std::filesystem::path(path.ToStringView());
+  bool exists = false;
 
 #ifdef _WIN32
-  // In case of an invalid symlink, `uv_fs_access` on win32
-  // will **not** return an error and is therefore not enough.
-  // Double check with `uv_fs_stat()`.
-  if (err == 0) {
-    FS_SYNC_TRACE_BEGIN(stat);
-    err = uv_fs_stat(nullptr, &req, path.out(), nullptr);
-    FS_SYNC_TRACE_END(stat);
+  FS_SYNC_TRACE_BEGIN(stat);
+  auto status = std::filesystem::status(file_path, error);
+  FS_SYNC_TRACE_END(stat);
+  if (!error) {
+    exists = status.type() != std::filesystem::file_type::not_found;
   }
-#endif  // _WIN32
-
-  args.GetReturnValue().Set(err == 0);
+#else
+  FS_SYNC_TRACE_BEGIN(access);
+  exists = std::filesystem::exists(file_path, error);
+  FS_SYNC_TRACE_END(access);
+#endif
+  args.GetReturnValue().Set(exists);
 }
 
 // Used to speed up module loading.  Returns 0 if the path refers to


### PR DESCRIPTION
Simplifies code by using `std::filesystem`. Since std::filesystem is C++17, this pull-request can be backported to 18 and 20.

The following benchmark shows 2% improvement, but I'm sure if we had a Windows benchmark-ci machine it would have better results. Especially for symlinks, we are now not executing 2 different operating-system calls, and only one.

FYI: std::filesystem::exists follows symlinks.

Benchmark code:

```
const fs = require('node:fs');
const exists = fs.existsSync(__filename);
console.log(exists);
```

Benchmark result:

```
PS C:\Users\yagiz\Desktop\coding\node> hyperfine ".\out\Release\node .\exists-bench.js" " .\node-pr .\exists-bench.js" --warmup 10
Benchmark 1: .\out\Release\node .\exists-bench.js
  Time (mean ± σ):      48.8 ms ±   2.9 ms    [User: 2.2 ms, System: 3.3 ms]
  Range (min … max):    41.6 ms …  55.3 ms    56 runs

Benchmark 2:  .\node-pr .\exists-bench.js
  Time (mean ± σ):      47.7 ms ±   2.0 ms    [User: 1.3 ms, System: 2.8 ms]
  Range (min … max):    42.2 ms …  50.5 ms    60 runs

Summary
   .\node-pr .\exists-bench.js ran
    1.02 ± 0.07 times faster than .\out\Release\node .\exists-bench.js
```

cc @nodejs/fs @nodejs/platform-windows 