### PR TITLE
src: use `starts_with` in node_dotenv.cc

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -135,8 +135,7 @@ void Dotenv::ParseContent(const std::string_view input) {
     }
 
     // Remove export prefix from key
-    auto have_export = key.compare(0, 7, "export ") == 0;
-    if (have_export) {
+    if (key.starts_with("export ")) {
       key.remove_prefix(7);
     }
 


### PR DESCRIPTION
This pull-request includes changes from C++20. Therefore, it can not be landed to v20 or v18.