### PR TITLE
doc, typings: events.once accepts symbol event type

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1337,7 +1337,7 @@ changes:
 -->
 
 * `emitter` {EventEmitter}
-* `name` {string}
+* `name` {string|symbol}
 * `options` {Object}
   * `signal` {AbortSignal} Can be used to cancel waiting for the event.
 * Returns: {Promise}

--- a/lib/events.js
+++ b/lib/events.js
@@ -967,7 +967,7 @@ function getMaxListeners(emitterOrTarget) {
  * Creates a `Promise` that is fulfilled when the emitter
  * emits the given event.
  * @param {EventEmitter} emitter
- * @param {string} name
+ * @param {string | symbol} name
  * @param {{ signal: AbortSignal; }} [options]
  * @returns {Promise}
  */


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Out of all of the events functions/methods that interact with listeners, `events.once` is the only one that doesn't currently state that `symbol` is a valid type for the event name parameter in doc/JSDoc. The parameter is passed to `eventTargetAgnosticAddListener` _etc._, just the same as the other events functions/methods, so there's no reason why there should be a discrepancy.

As an aside, the naming convention for the event name parameter in the events API is all over the place (`event`, `name`, `eventName`, `type`...) &ndash; a more obsessive contributor might consider a cleanup!