### PR TITLE
tools: lock versions of irrelevant DB deps

### DIFF
--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -2,6 +2,10 @@
   "name": "eslint-tools",
   "version": "0.0.0",
   "private": true,
+  "overrides": {
+    "caniuse-lite": "1.0.30001636",
+    "electron-to-chromium": "1.4.806"
+  },
   "dependencies": {
     "@babel/core": "^7.24.7",
     "@babel/eslint-parser": "^7.24.7",


### PR DESCRIPTION
`caniuse-lite` and `electron-to-chromium` are "database dependencies"
that we don't care about and are often updated, increasing the size of
the repository each time. Lock their versions to the currently
installed one so it doesn't happen in the future.

