### PR TITLE
buffer: Reallocate() instead of creating a new backing store

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -327,13 +327,8 @@ MaybeLocal<Object> New(Isolate* isolate,
     CHECK(actual <= length);
 
     if (LIKELY(actual > 0)) {
-      if (actual < length) {
-        std::unique_ptr<BackingStore> old_store = std::move(store);
-        store = ArrayBuffer::NewBackingStore(isolate, actual);
-        memcpy(static_cast<char*>(store->Data()),
-               static_cast<char*>(old_store->Data()),
-               actual);
-      }
+      if (actual < length)
+        store = BackingStore::Reallocate(isolate, std::move(store), actual);
       Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, std::move(store));
       Local<Object> obj;
       if (UNLIKELY(!New(isolate, buf, 0, actual).ToLocal(&obj)))


### PR DESCRIPTION
in `Buffer::New(..., node::encoding)`, when the prediction returned by `StringBytes::Size()` doesn't match the actual size emitted by `StringBytes::Write()`, we currently create a second backing store and then `memcpy()` to it.

AFAIU, we can instead reallocate the backing store into the new size, which [should contract the allocation if possible](https://v8docs.nodesource.com/node-20.3/d6/dd4/classv8_1_1_array_buffer_1_1_allocator.html#a41014b8b39639c505451d98c226197a7).

this is especially relevant for base64 (see discussion at #53550), which since #52428 overestimates fairly often.