### PR TITLE
doc: note http.closeAllConnections excludes upgraded sockets

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1707,8 +1707,8 @@ added: v18.2.0
 
 Closes all established HTTP(S) connections connected to this server, including
 active connections connected to this server which are sending a request or
-waiting for a response. Note that this does not destroy sockets upgraded to a
-different protocol, such as WebSocket.
+waiting for a response. This does *not* destroy sockets upgraded to a different
+protocol, such as WebSocket.
 
 > This is a forceful way of closing all connections and should be used with
 > caution. Whenever using this in conjunction with `server.close`, calling this

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1708,7 +1708,7 @@ added: v18.2.0
 Closes all established HTTP(S) connections connected to this server, including
 active connections connected to this server which are sending a request or
 waiting for a response. This does _not_ destroy sockets upgraded to a different
-protocol, such as WebSocket.
+protocol, such as WebSocket or HTTP/2.
 
 > This is a forceful way of closing all connections and should be used with
 > caution. Whenever using this in conjunction with `server.close`, calling this

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1707,7 +1707,7 @@ added: v18.2.0
 
 Closes all established HTTP(S) connections connected to this server, including
 active connections connected to this server which are sending a request or
-waiting for a response. This does *not* destroy sockets upgraded to a different
+waiting for a response. This does _not_ destroy sockets upgraded to a different
 protocol, such as WebSocket.
 
 > This is a forceful way of closing all connections and should be used with

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1705,8 +1705,10 @@ setTimeout(() => {
 added: v18.2.0
 -->
 
-Closes all connections connected to this server, including active connections
-connected to this server which are sending a request or waiting for a response.
+Closes all established HTTP(S) connections connected to this server, including
+active connections connected to this server which are sending a request or
+waiting for a response. Note that this does not destroy sockets upgraded to a
+different protocol, such as WebSocket.
 
 > This is a forceful way of closing all connections and should be used with
 > caution. Whenever using this in conjunction with `server.close`, calling this


### PR DESCRIPTION
Following discussion in https://github.com/nodejs/node/issues/53536, clarify in documentation for `http.closeAllConnections` that it does not include sockets upgraded to a different protocol, such as WebSockets.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
