### PR TITLE
src: zero-initialize data that are copied into the snapshot

### DIFF
--- a/src/aliased_buffer-inl.h
+++ b/src/aliased_buffer-inl.h
@@ -8,7 +8,7 @@
 
 namespace node {
 
-typedef uint64_t AliasedBufferIndex;
+typedef size_t AliasedBufferIndex;
 
 template <typename NativeT, typename V8T>
 AliasedBufferBase<NativeT, V8T>::AliasedBufferBase(

--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -9,7 +9,7 @@
 
 namespace node {
 
-typedef uint64_t AliasedBufferIndex;
+typedef size_t AliasedBufferIndex;
 
 /**
  * Do not use this class directly when creating instances of it - use the

--- a/src/base_object_types.h
+++ b/src/base_object_types.h
@@ -42,13 +42,10 @@ namespace node {
   SERIALIZABLE_NON_BINDING_TYPES(V)
 
 #define V(TypeId, NativeType) k_##TypeId,
-// To avoid padding, the enums are uint64_t.
-enum class BindingDataType : uint64_t {
-  BINDING_TYPES(V) kBindingDataTypeCount
-};
+enum class BindingDataType : uint8_t { BINDING_TYPES(V) kBindingDataTypeCount };
 // Make sure that we put the bindings first so that we can also use the enums
 // for the bindings as index to the binding data store.
-enum class EmbedderObjectType : uint64_t {
+enum class EmbedderObjectType : uint8_t {
   BINDING_TYPES(V) SERIALIZABLE_NON_BINDING_TYPES(V)
   // We do not need to know about all the unserializable non-binding types for
   // now so we do not list them.

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -18,12 +18,6 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex encode_into_results_buffer;
   };
 
-  // Make sure that there's no padding in the struct since we will memcpy
-  // them into the snapshot blob and they need to be reproducible.
-  static_assert(sizeof(InternalFieldInfo) ==
-                    sizeof(InternalFieldInfoBase) + sizeof(AliasedBufferIndex),
-                "InternalFieldInfo should have no padding");
-
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,
               InternalFieldInfo* info = nullptr);

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -64,12 +64,6 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex statfs_field_bigint_array;
   };
 
-  // Make sure that there's no padding in the struct since we will memcpy
-  // them into the snapshot blob and they need to be reproducible.
-  static_assert(sizeof(InternalFieldInfo) == sizeof(InternalFieldInfoBase) +
-                                                 sizeof(AliasedBufferIndex) * 4,
-                "InternalFieldInfo should have no padding");
-
   enum class FilePathIsFileReturnType {
     kIsFile = 0,
     kIsNotFile,

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -54,12 +54,6 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex hrtime_buffer;
   };
 
-  // Make sure that there's no padding in the struct since we will memcpy
-  // them into the snapshot blob and they need to be reproducible.
-  static_assert(sizeof(InternalFieldInfo) ==
-                    sizeof(InternalFieldInfoBase) + sizeof(AliasedBufferIndex),
-                "InternalFieldInfo should have no padding");
-
   static void AddMethods(v8::Isolate* isolate,
                          v8::Local<v8::ObjectTemplate> target);
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -282,9 +282,9 @@ size_t SnapshotSerializer::Write(const PropInfo& data) {
 }
 
 // Layout of AsyncHooks::SerializeInfo
-// [ 8 bytes ]  snapshot index of async_ids_stack
-// [ 8 bytes ]  snapshot index of fields
-// [ 8 bytes ]  snapshot index of async_id_fields
+// [ 4/8 bytes ]  snapshot index of async_ids_stack
+// [ 4/8 bytes ]  snapshot index of fields
+// [ 4/8 bytes ]  snapshot index of async_id_fields
 // [ 4/8 bytes ]  snapshot index of js_execution_async_resources
 // [ 4/8 bytes ]  length of native_execution_async_resources
 // [   ...     ]  snapshot indices of each element in
@@ -387,9 +387,9 @@ size_t SnapshotSerializer::Write(const ImmediateInfo::SerializeInfo& data) {
 }
 
 // Layout of PerformanceState::SerializeInfo
-// [ 8 bytes ]  snapshot index of root
-// [ 8 bytes ]  snapshot index of milestones
-// [ 8 bytes ]  snapshot index of observers
+// [ 4/8 bytes ]  snapshot index of root
+// [ 4/8 bytes ]  snapshot index of milestones
+// [ 4/8 bytes ]  snapshot index of observers
 template <>
 performance::PerformanceState::SerializeInfo SnapshotDeserializer::Read() {
   Debug("Read<PerformanceState::SerializeInfo>()\n");

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1416,6 +1416,7 @@ StartupData SerializeNodeContextInternalFields(Local<Object> holder,
   if (index == BaseObject::kEmbedderType) {
     int size = sizeof(EmbedderTypeInfo);
     char* data = new char[size];
+    memset(data, 0, size);  // Make the padding reproducible.
     // We need to use placement new because V8 calls delete[] on the returned
     // data.
     // TODO(joyeecheung): support cppgc objects.

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -1415,10 +1415,11 @@ StartupData SerializeNodeContextInternalFields(Local<Object> holder,
   // To serialize the type field, save data in a EmbedderTypeInfo.
   if (index == BaseObject::kEmbedderType) {
     int size = sizeof(EmbedderTypeInfo);
-    char* data = new char[size];
-    memset(data, 0, size);  // Make the padding reproducible.
     // We need to use placement new because V8 calls delete[] on the returned
     // data.
+    // The () syntax at the end would zero-initialize the block and make
+    // the padding reproducible.
+    char* data = new char[size]();
     // TODO(joyeecheung): support cppgc objects.
     new (data) EmbedderTypeInfo(obj->type(),
                                 EmbedderTypeInfo::MemoryMode::kBaseObject);

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -47,6 +47,7 @@ struct InternalFieldInfoBase {
                       std::is_same_v<InternalFieldInfoBase, T>,
                   "Can only accept InternalFieldInfoBase subclasses");
     void* buf = ::operator new[](sizeof(T));
+    memset(buf, 0, sizeof(T));  // Make the padding reproducible.
     T* result = new (buf) T;
     result->type = type;
     result->length = sizeof(T);

--- a/src/node_snapshotable.h
+++ b/src/node_snapshotable.h
@@ -4,8 +4,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <cassert>  // For static_assert
-#include <cstddef>  // For offsetof
 #include "aliased_buffer.h"
 #include "base_object.h"
 #include "util.h"
@@ -35,13 +33,13 @@ bool WithoutCodeCache(const SnapshotConfig& config);
 // and pass it into the V8 callback as the payload of StartupData.
 // The memory chunk looks like this:
 //
-// [   type   ] - EmbedderObjectType (a uint64_t)
-// [  length  ] - a uint64_t
+// [   type   ] - EmbedderObjectType (a uint8_t)
+// [  length  ] - a size_t
 // [    ...   ] - custom bytes of size |length - header size|
 struct InternalFieldInfoBase {
  public:
   EmbedderObjectType type;
-  uint64_t length;
+  size_t length;
 
   template <typename T>
   static T* New(EmbedderObjectType type) {
@@ -73,34 +71,13 @@ struct InternalFieldInfoBase {
   InternalFieldInfoBase() = default;
 };
 
-// Make sure that there's no padding in the struct since we will memcpy
-// them into the snapshot blob and they need to be reproducible.
-static_assert(offsetof(InternalFieldInfoBase, type) == 0,
-              "InternalFieldInfoBase::type should start from offset 0");
-static_assert(offsetof(InternalFieldInfoBase, length) ==
-                  sizeof(EmbedderObjectType),
-              "InternalFieldInfoBase::type should have no padding");
-
 struct EmbedderTypeInfo {
-  // To avoid padding, the enum is uint64_t.
-  enum class MemoryMode : uint64_t { kBaseObject = 0, kCppGC };
+  enum class MemoryMode : uint8_t { kBaseObject, kCppGC };
   EmbedderTypeInfo(EmbedderObjectType t, MemoryMode m) : type(t), mode(m) {}
   EmbedderTypeInfo() = default;
-
   EmbedderObjectType type;
   MemoryMode mode;
 };
-
-// Make sure that there's no padding in the struct since we will memcpy
-// them into the snapshot blob and they need to be reproducible.
-static_assert(offsetof(EmbedderTypeInfo, type) == 0,
-              "EmbedderTypeInfo::type should start from offset 0");
-static_assert(offsetof(EmbedderTypeInfo, mode) == sizeof(EmbedderObjectType),
-              "EmbedderTypeInfo::type should have no padding");
-static_assert(sizeof(EmbedderTypeInfo) ==
-                  sizeof(EmbedderObjectType) +
-                      sizeof(EmbedderTypeInfo::MemoryMode),
-              "EmbedderTypeInfo::mode should have no padding");
 
 // An interface for snapshotable native objects to inherit from.
 // Use the SERIALIZABLE_OBJECT_METHODS() macro in the class to define
@@ -172,12 +149,6 @@ class BindingData : public SnapshotableObject {
   struct InternalFieldInfo : public node::InternalFieldInfoBase {
     AliasedBufferIndex is_building_snapshot_buffer;
   };
-
-  // Make sure that there's no padding in the struct since we will memcpy
-  // them into the snapshot blob and they need to be reproducible.
-  static_assert(sizeof(InternalFieldInfo) ==
-                    sizeof(InternalFieldInfoBase) + sizeof(AliasedBufferIndex),
-                "InternalFieldInfo should have no padding");
 
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -23,13 +23,6 @@ class BindingData : public SnapshotableObject {
     AliasedBufferIndex heap_space_statistics_buffer;
     AliasedBufferIndex heap_code_statistics_buffer;
   };
-
-  // Make sure that there's no padding in the struct since we will memcpy
-  // them into the snapshot blob and they need to be reproducible.
-  static_assert(sizeof(InternalFieldInfo) == sizeof(InternalFieldInfoBase) +
-                                                 sizeof(AliasedBufferIndex) * 3,
-                "InternalFieldInfo should have no padding");
-
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,
               InternalFieldInfo* info = nullptr);


### PR DESCRIPTION
This reverts one commit from https://github.com/nodejs/node/pull/50983 because I found a better & simpler approach to prevent the padding from affecting snapshot reproducibility (in the second commit).

#### Revert "src: make sure that memcpy-ed structs in snapshot have no padding"

This reverts commit 4e58cde589dfd980c8976b158853a331142e1e4b.

#### src: zero-initialize data that are copied into the snapshot

To prevent padding from making the snapshot unreproducible,
zero-initialize the data that are copied into the snapshot
so that the padding copied are all zeros. This is better
than enlarging the enums to align the fields since it doesn't
make the snapshot bigger than necessary, and it removes the
need of using static assertions to ensure alignment.

Refs: https://github.com/nodejs/node/pull/50983

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
