### PR TITLE
meta: prevent constant references to issues in versioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -14,9 +14,10 @@ body:
     attributes:
       label: Version
       description: Output of `node -v`
-  - type: input
+  - type: textarea
     attributes:
       label: Platform
+      render: text
       description: |
         UNIX: output of `uname -a`
         Windows: output of `"$([Environment]::OSVersion.VersionString) $(('x86', 'x64')[[Environment]::Is64BitOperatingSystem])"` in PowerShell console


### PR DESCRIPTION
Currently, via the issue template, many issues mention older issues due to the `uname` command returning a value that could be mistaken for a issue reference. (for example, #1 has thousands of mentions)

This change renders the `uname` output as plaintext, that way preventing redudant links to old issues.