### PR TITLE
repl: support syntax highlighting

### DIFF
--- a/lib/internal/repl/highlight.js
+++ b/lib/internal/repl/highlight.js
@@ -1,0 +1,133 @@
+// Some patterns inspired by https://github.com/speed-highlight/core/blob/249ad8fe9bf3eb951eb263b5b3c35887bbbbb2eb/src/languages/js.js
+
+'use strict';
+const {
+  RegExpPrototypeExec,
+  StringPrototypeSlice,
+} = primordials;
+
+const { styleText, inspect } = require('util');
+
+const matchers = [
+  {
+    // Single line comment or multi line comment
+    color: 'gray',
+    patterns: [
+      /\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    ],
+  },
+  {
+    // String
+    color: inspect.styles.string,
+    patterns: [
+      // 'string' or "string"
+      /(["'])(\\[^]|(?!\1)[^\r\n\\])*\1?/g,
+      // `string`
+      /`((?!`)[^]|\\[^])*`?/g,
+    ],
+  },
+  {
+    // Keywords
+    color: inspect.styles.special,
+    patterns: [
+      /=>|\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|export|extends|finally|for|from|function|if|import|in|instanceof|let|new|of|return|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/g,
+    ],
+  },
+  {
+    // RegExp
+    color: inspect.styles.regexp,
+    patterns: [
+      // eslint-disable-next-line node-core/no-unescaped-regexp-dot
+      /\/(?:[^/\\\r\n]|\\.)*\/[dgimsuy]*/g,
+    ],
+  },
+  {
+    // Number
+    color: inspect.styles.number,
+    patterns: [
+      /(\.e?|\b)\d(e-|[\d.oxa-fA-F_])*(\.|\b)/g,
+      /\bNaN\b/g,
+    ],
+  },
+  {
+    // Undefined
+    color: inspect.styles.undefined,
+    patterns: [
+      /\bundefined\b/g,
+    ],
+  },
+  {
+    // Null
+    color: inspect.styles.null,
+    patterns: [
+      /\bnull\b/g,
+    ],
+  },
+  {
+    // Boolean
+    color: inspect.styles.boolean,
+    patterns: [
+      /\b(true|false)\b/g,
+    ],
+  },
+  {
+    // Operator
+    color: inspect.styles.special,
+    patterns: [
+      /[/*+:?&|%^~=!,<>.^-]+/g,
+    ],
+  },
+  {
+    // Identifier
+    color: null,
+    patterns: [
+      /\b[A-Z][\w_]*\b/g,
+    ],
+  },
+  {
+    // Function Declaration
+    color: inspect.styles.special,
+    patterns: [
+      // eslint-disable-next-line no-useless-escape
+      /[a-zA-Z$_][\w$_]*(?=\s*((\?\.)?\s*\(|=\s*(\(?[\w,{}\[\])]+\)? =>|function\b)))/g,
+    ],
+  },
+];
+
+function highlight(code) {
+  let tokens = '';
+
+  for (let index = 0; index < code.length;) {
+    let match = null;
+    let matchIndex = code.length;
+    let matchType = null;
+
+    for (const { color, patterns } of matchers) {
+      for (const pattern of patterns) {
+        pattern.lastIndex = index;
+        const result = RegExpPrototypeExec(pattern, code);
+
+        if (result && result.index < matchIndex) {
+          match = result[0];
+          matchIndex = result.index;
+          matchType = color;
+        }
+      }
+    }
+
+    if (matchIndex > index) {
+      tokens += StringPrototypeSlice(code, index, matchIndex);
+    }
+
+    if (match) {
+      tokens += matchType ? styleText(matchType, match) : match;
+      index = matchIndex + match.length;
+    } else {
+      break;
+    }
+  }
+
+  return tokens;
+}
+
+module.exports = highlight;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -121,7 +121,7 @@ const { runInThisContext, runInContext } = vm.Script.prototype;
 
 const path = require('path');
 const fs = require('fs');
-const { Interface } = require('readline');
+const { Interface, cursorTo } = require('readline');
 const {
   commonPrefix,
 } = require('internal/readline/utils');
@@ -185,6 +185,7 @@ const {
 } = internalBinding('contextify');
 
 const history = require('internal/repl/history');
+const highlight = require('internal/repl/highlight');
 const {
   extensionFormatMap,
 } = require('internal/modules/esm/formats');
@@ -1058,6 +1059,25 @@ function REPLServer(prompt,
     }
   };
 
+  if (self.useColors) {
+    self._insertString = (c) => {
+      const beg = StringPrototypeSlice(self.line, 0, self.cursor);
+      const end = StringPrototypeSlice(self.line, self.cursor, self.line.length);
+      self.line = beg + c + end;
+      self.cursor += c.length;
+      self._refreshLine();
+    };
+
+    const refreshLine = FunctionPrototypeBind(self._refreshLine, self);
+    self._refreshLine = () => {
+      const oldLine = self.line;
+      self.line = highlight(self.line);
+      refreshLine();
+      self.line = oldLine;
+      if (self.cursor !== self.line.length) cursorTo(self.output, self.getPrompt().length + self.cursor);
+    };
+  }
+
   self.displayPrompt();
 }
 ObjectSetPrototypeOf(REPLServer.prototype, Interface.prototype);
@@ -1187,7 +1207,7 @@ REPLServer.prototype.resetContext = function() {
   this.emit('reset', this.context);
 };
 
-REPLServer.prototype.displayPrompt = function(preserveCursor) {
+REPLServer.prototype.getPrompt = function() {
   let prompt = this._initialPrompt;
   if (this[kBufferedCommandSymbol].length) {
     prompt = '...';
@@ -1196,7 +1216,11 @@ REPLServer.prototype.displayPrompt = function(preserveCursor) {
     prompt += levelInd + ' ';
   }
 
-  // Do not overwrite `_initialPrompt` here
+  return prompt;
+};
+
+REPLServer.prototype.displayPrompt = function(preserveCursor) {
+  const prompt = this.getPrompt();
   ReflectApply(Interface.prototype.setPrompt, this, [prompt]);
   this.prompt(preserveCursor);
 };

--- a/test/parallel/test-repl-multiline.js
+++ b/test/parallel/test-repl-multiline.js
@@ -3,6 +3,7 @@ const common = require('../common');
 const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
+const util = require('util');
 const input = ['const foo = {', '};', 'foo'];
 
 function run({ useColors }) {
@@ -25,11 +26,11 @@ function run({ useColors }) {
 
     // Validate the output, which contains terminal escape codes.
     assert.strictEqual(actual.length, 6);
-    assert.ok(actual[0].endsWith(input[0]));
-    assert.ok(actual[1].includes('... '));
-    assert.ok(actual[1].endsWith(input[1]));
-    assert.ok(actual[2].includes('undefined'));
-    assert.ok(actual[3].endsWith(input[2]));
+    assert.ok(util.stripVTControlCharacters(actual[0]).endsWith(input[0]));
+    assert.ok(util.stripVTControlCharacters(actual[1]).includes('... '));
+    assert.ok(util.stripVTControlCharacters(actual[1]).endsWith(input[1]));
+    assert.ok(util.stripVTControlCharacters(actual[2]).includes('undefined'));
+    assert.ok(util.stripVTControlCharacters(actual[3]).endsWith(input[2]));
     assert.strictEqual(actual[4], '{}');
   }));
 

--- a/test/parallel/test-repl-preview-without-inspector.js
+++ b/test/parallel/test-repl-preview-without-inspector.js
@@ -80,70 +80,67 @@ repl.inputStream.run([
   'const r = 5;',
 ]);
 
+/* eslint-disable @stylistic/js/max-len */
 const testCases = [{
   input: 'foo',
   preview: [
-    'foo\r',
+    '\x1B[1G\x1B[0Jrepl > f\x1B[9G\x1B[1G\x1B[0Jrepl > fo\x1B[10G\x1B[1G\x1B[0Jrepl > foo\x1B[11G\r',
     '\x1B[36m[Function: foo]\x1B[39m',
-  ]
-}, {
-  input: 'r',
-  preview: [
-    'r\r',
-    '\x1B[33m5\x1B[39m',
   ]
 }, {
   input: 'koo',
   preview: [
-    'koo\r',
+    '\x1B[1G\x1B[0Jrepl > k\x1B[9G\x1B[1G\x1B[0Jrepl > ko\x1B[10G\x1B[1G\x1B[0Jrepl > koo\x1B[11G\r',
     '\x1B[36m[Function: koo]\x1B[39m',
   ]
 }, {
   input: 'a',
-  preview: ['a\r'] // No "undefined" preview.
+  noPreview: 'repl > ', // No "undefined" output.
+  preview: ['\x1B[1G\x1B[0Jrepl > a\x1B[9G\r'] // No "undefined" preview.
 }, {
   input: " { b: 1 }['b'] === 1",
   preview: [
-    " { b: 1 }['b'] === 1\r",
+    "\x1B[1G\x1B[0Jrepl >  \x1B[9G\x1B[1G\x1B[0Jrepl >  {\x1B[10G\x1B[1G\x1B[0Jrepl >  { \x1B[11G\x1B[1G\x1B[0Jrepl >  { b\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m]\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m=\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m==\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m\x1B[15G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m\x1B[14G\r",
     '\x1B[33mtrue\x1B[39m',
   ]
 }, {
   input: "{ b: 1 }['b'] === 1;",
   preview: [
-    "{ b: 1 }['b'] === 1;\r",
+    "\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { b\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m \x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m]\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m=\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m==\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m;\x1B[13G\r",
     '\x1B[33mfalse\x1B[39m',
   ]
 }, {
   input: '{ a: true }',
   preview: [
-    '{ a: true }\r',
+    '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { a\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m t\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tr\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tru\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m }\x1B[13G\r',
     '{ a: \x1B[33mtrue\x1B[39m }',
   ]
 }, {
   input: '{ a: true };',
   preview: [
-    '{ a: true };\r',
+    '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { a\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m t\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tr\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tru\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m }\x1B[13G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m };\x1B[12G\r',
     '\x1B[33mtrue\x1B[39m',
   ]
 }, {
   input: ' \t { a: true};',
   preview: [
-    '  { a: true};\r',
+    '\x1B[1G\x1B[0Jrepl >  \x1B[9G\x1B[1G\x1B[0Jrepl >   \x1B[10G\x1B[1G\x1B[0Jrepl >   {\x1B[11G\x1B[1G\x1B[0Jrepl >   { \x1B[12G\x1B[1G\x1B[0Jrepl >   { a\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[14G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m t\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m tr\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m tru\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m}\x1B[14G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m};\x1B[15G\r',
     '\x1B[33mtrue\x1B[39m',
   ]
 }, {
   input: '1n + 2n',
   preview: [
-    '1n + 2n\r',
+    '\x1B[1G\x1B[0Jrepl > \x1B[33m1\x1B[39m\x1B[8G\x1B[1G\x1B[0Jrepl > 1n\x1B[10G\x1B[1G\x1B[0Jrepl > 1n \x1B[11G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m \x1B[33m2\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m 2n\x1B[11G\r',
     '\x1B[33m3n\x1B[39m',
   ]
 }, {
   input: '{};1',
   preview: [
-    '{};1\r',
+    '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > {}\x1B[10G\x1B[1G\x1B[0Jrepl > {};\x1B[11G\x1B[1G\x1B[0Jrepl > {};\x1B[33m1\x1B[39m\x1B[11G\r',
     '\x1B[33m1\x1B[39m',
-  ],
+  ]
 }];
+/* eslint-enable @stylistic/js/max-len */
 
 async function runTest() {
   for (const { input, preview } of testCases) {

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -71,11 +71,12 @@ async function tests(options) {
     'a = undefined;',
   ]);
 
+  /* eslint-disable @stylistic/js/max-len */
   const testCases = [{
     input: 'foo',
     noPreview: '[Function: foo]',
     preview: [
-      'foo',
+      '\x1B[1G\x1B[0Jrepl > f\x1B[9G\x1B[1G\x1B[0Jrepl > fo\x1B[10G\x1B[1G\x1B[0Jrepl > foo\x1B[11G',
       '\x1B[90m[Function: foo]\x1B[39m\x1B[11G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[36m[Function: foo]\x1B[39m',
     ]
@@ -83,25 +84,23 @@ async function tests(options) {
     input: 'koo',
     noPreview: '[Function: koo]',
     preview: [
-      'k\x1B[90moo\x1B[39m\x1B[9G',
-      '\x1B[90m[Function: koo]\x1B[39m\x1B[9G\x1B[1A\x1B[1B\x1B[2K\x1B[1A' +
-        '\x1B[0Ko\x1B[90mo\x1B[39m\x1B[10G',
-      '\x1B[90m[Function: koo]\x1B[39m\x1B[10G\x1B[1A\x1B[1B\x1B[2K\x1B[1A' +
-        '\x1B[0Ko',
+      '\x1B[1G\x1B[0Jrepl > k\x1B[9G\x1B[90moo\x1B[39m\x1B[9G',
+      '\x1B[90m[Function: koo]\x1B[39m\x1B[9G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[0K\x1B[1G\x1B[0Jrepl > ko\x1B[10G\x1B[90mo\x1B[39m\x1B[10G',
+      '\x1B[90m[Function: koo]\x1B[39m\x1B[10G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[0K\x1B[1G\x1B[0Jrepl > koo\x1B[11G',
       '\x1B[90m[Function: koo]\x1B[39m\x1B[11G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[36m[Function: koo]\x1B[39m',
     ]
   }, {
     input: 'a',
     noPreview: 'repl > ', // No "undefined" output.
-    preview: ['a\r'] // No "undefined" preview.
+    preview: ['\x1B[1G\x1B[0Jrepl > a\x1B[9G\r'] // No "undefined" preview.
   }, {
     input: " { b: 1 }['b'] === 1",
     noPreview: '\x1B[33mtrue\x1B[39m',
     preview: [
-      " { b: 1 }['b']",
-      '\x1B[90m1\x1B[39m\x1B[22G\x1B[1A\x1B[1B\x1B[2K\x1B[1A ',
-      '\x1B[90m1\x1B[39m\x1B[23G\x1B[1A\x1B[1B\x1B[2K\x1B[1A=== 1',
+      "\x1B[1G\x1B[0Jrepl >  \x1B[9G\x1B[1G\x1B[0Jrepl >  {\x1B[10G\x1B[1G\x1B[0Jrepl >  { \x1B[11G\x1B[1G\x1B[0Jrepl >  { b\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }\x1B[12G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m]\x1B[13G",
+      "\x1B[90m1\x1B[39m\x1B[22G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[13G",
+      "\x1B[90m1\x1B[39m\x1B[23G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m=\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m==\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m\x1B[15G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[14G\x1B[1G\x1B[0Jrepl >  { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m\x1B[14G",
       '\x1B[90mtrue\x1B[39m\x1B[28G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33mtrue\x1B[39m',
     ]
@@ -109,10 +108,10 @@ async function tests(options) {
     input: "{ b: 1 }['b'] === 1;",
     noPreview: '\x1B[33mfalse\x1B[39m',
     preview: [
-      "{ b: 1 }['b']",
-      '\x1B[90m1\x1B[39m\x1B[21G\x1B[1A\x1B[1B\x1B[2K\x1B[1A ',
-      '\x1B[90m1\x1B[39m\x1B[22G\x1B[1A\x1B[1B\x1B[2K\x1B[1A=== 1',
-      '\x1B[90mtrue\x1B[39m\x1B[27G\x1B[1A\x1B[1B\x1B[2K\x1B[1A;',
+      "\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { b\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m \x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }\x1B[11G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m]\x1B[12G",
+      "\x1B[90m1\x1B[39m\x1B[21G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[12G",
+      "\x1B[90m1\x1B[39m\x1B[22G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m=\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m==\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[13G\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m\x1B[13G",
+      "\x1B[90mtrue\x1B[39m\x1B[27G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl > { b\x1B[36m:\x1B[39m \x1B[33m1\x1B[39m }[\x1B[32m'b'\x1B[39m] \x1B[36m===\x1B[39m \x1B[33m1\x1B[39m;\x1B[13G",
       '\x1B[90mfalse\x1B[39m\x1B[28G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33mfalse\x1B[39m',
     ]
@@ -120,14 +119,14 @@ async function tests(options) {
     input: '{ a: true }',
     noPreview: '{ a: \x1B[33mtrue\x1B[39m }',
     preview: [
-      '{ a: tru\x1B[90me\x1B[39m\x1B[16G\x1B[0Ke }\r',
+      '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { a\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m t\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tr\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tru\x1B[11G\x1B[16G\x1B[90me\x1B[39m\x1B[11G\x1B[90me\x1B[39m\x1B[16G\x1B[0K\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m }\x1B[13G\r',
       '{ a: \x1B[33mtrue\x1B[39m }',
     ]
   }, {
     input: '{ a: true };',
     noPreview: '\x1B[33mtrue\x1B[39m',
     preview: [
-      '{ a: tru\x1B[90me\x1B[39m\x1B[16G\x1B[0Ke };',
+      '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > { \x1B[10G\x1B[1G\x1B[0Jrepl > { a\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m t\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tr\x1B[11G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m tru\x1B[11G\x1B[16G\x1B[90me\x1B[39m\x1B[11G\x1B[90me\x1B[39m\x1B[16G\x1B[0K\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m }\x1B[13G\x1B[1G\x1B[0Jrepl > { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m };\x1B[12G',
       '\x1B[90mtrue\x1B[39m\x1B[20G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33mtrue\x1B[39m',
     ]
@@ -135,8 +134,8 @@ async function tests(options) {
     input: ' \t { a: true};',
     noPreview: '\x1B[33mtrue\x1B[39m',
     preview: [
-      '  { a: tru\x1B[90me\x1B[39m\x1B[18G\x1B[0Ke}',
-      '\x1B[90m{ a: true }\x1B[39m\x1B[20G\x1B[1A\x1B[1B\x1B[2K\x1B[1A;',
+      '\x1B[1G\x1B[0Jrepl >  \x1B[9G\x1B[1G\x1B[0Jrepl >   \x1B[10G\x1B[1G\x1B[0Jrepl >   {\x1B[11G\x1B[1G\x1B[0Jrepl >   { \x1B[12G\x1B[1G\x1B[0Jrepl >   { a\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[14G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m t\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m tr\x1B[13G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m tru\x1B[13G\x1B[18G\x1B[90me\x1B[39m\x1B[13G\x1B[90me\x1B[39m\x1B[18G\x1B[0K\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m\x1B[14G\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m}\x1B[14G',
+      '\x1B[90m{ a: true }\x1B[39m\x1B[20G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl >   { a\x1B[36m:\x1B[39m \x1B[33mtrue\x1B[39m};\x1B[15G',
       '\x1B[90mtrue\x1B[39m\x1B[21G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33mtrue\x1B[39m',
     ]
@@ -144,8 +143,8 @@ async function tests(options) {
     input: '1n + 2n',
     noPreview: '\x1B[33m3n\x1B[39m',
     preview: [
-      '1n + 2',
-      '\x1B[90mType[39m\x1B[14G\x1B[1A\x1B[1B\x1B[2K\x1B[1An',
+      '\x1B[1G\x1B[0Jrepl > \x1B[33m1\x1B[39m\x1B[8G\x1B[1G\x1B[0Jrepl > 1n\x1B[10G\x1B[1G\x1B[0Jrepl > 1n \x1B[11G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m\x1B[11G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m \x1B[12G\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m \x1B[33m2\x1B[39m\x1B[11G',
+      '\x1B[90mType[39m\x1B[14G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\x1B[1G\x1B[0Jrepl > 1n \x1B[36m+\x1B[39m 2n\x1B[11G',
       '\x1B[90m3n\x1B[39m\x1B[15G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33m3n\x1B[39m',
     ]
@@ -153,11 +152,12 @@ async function tests(options) {
     input: '{};1',
     noPreview: '\x1B[33m1\x1B[39m',
     preview: [
-      '{};1',
+      '\x1B[1G\x1B[0Jrepl > {\x1B[9G\x1B[1G\x1B[0Jrepl > {}\x1B[10G\x1B[1G\x1B[0Jrepl > {};\x1B[11G\x1B[1G\x1B[0Jrepl > {};\x1B[33m1\x1B[39m\x1B[11G',
       '\x1B[90m1\x1B[39m\x1B[12G\x1B[1A\x1B[1B\x1B[2K\x1B[1A\r',
       '\x1B[33m1\x1B[39m',
     ]
   }];
+  /* eslint-enable @stylistic/js/max-len */
 
   const hasPreview = repl.terminal &&
     (options.preview !== undefined ? !!options.preview : true);
@@ -177,8 +177,6 @@ async function tests(options) {
       assert.deepStrictEqual(lines, preview);
     } else {
       assert.ok(lines[0].includes(noPreview), lines.map(inspect));
-      if (preview.length !== 1 || preview[0] !== `${input}\r`)
-        assert.strictEqual(lines.length, 2);
     }
   }
 }

--- a/test/parallel/test-repl-reverse-search.js
+++ b/test/parallel/test-repl-reverse-search.js
@@ -112,7 +112,9 @@ const tests = [
       '\x1B[1G', '\x1B[0J',
       prompt, '\x1B[3G',
       // 1. '7'
-      '7',
+      '\x1B[1G', '\x1B[0J',
+      '> \x1B[33m7\x1B[39m',
+      '\x1B[3G',
       // 2. SEARCH FORWARDS
       '\nfwd-i-search: _', '\x1B[1A', '\x1B[4G',
       // 3. SEARCH FORWARDS

--- a/test/parallel/test-repl-syntax-highlighting.js
+++ b/test/parallel/test-repl-syntax-highlighting.js
@@ -1,0 +1,115 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const ArrayStream = require('../common/arraystream');
+const repl = require('repl');
+const highlight = require('internal/repl/highlight');
+const assert = require('assert');
+const { stripVTControlCharacters, inspect, styleText } = require('util');
+
+const tests = [
+  // Comments (// ... and /* ... */)
+  styleText('gray', '// this is a comment'),
+  styleText('gray', '/* this is a inline comment */'),
+
+  // Strings ('...', "...", and `...`)
+  styleText(inspect.styles.string, '\'this is a string\''),
+  styleText(inspect.styles.string, '"this is a string"'),
+  /* eslint-disable-next-line no-template-curly-in-string */
+  styleText(inspect.styles.string, '`this is a ${template} string`'),
+
+  // Keywords
+  styleText(inspect.styles.special, 'async'),
+
+  // RegExp
+  styleText(inspect.styles.regexp, '/regexp/g'),
+
+  // Numbers
+  styleText(inspect.styles.number, '123'),
+  styleText(inspect.styles.number, '123.456'),
+  styleText(inspect.styles.number, '.456'),
+  styleText(inspect.styles.number, '0x123'),
+  styleText(inspect.styles.number, '0xFF'),
+  styleText(inspect.styles.number, '0b101'),
+  styleText(inspect.styles.number, '0o123'),
+  styleText(inspect.styles.number, '123e456'),
+  styleText(inspect.styles.number, '123e-456'),
+  styleText(inspect.styles.number, '123.'),
+  styleText(inspect.styles.number, '1_2_3'),
+  styleText(inspect.styles.number, 'NaN'),
+
+  // Undefined
+  styleText(inspect.styles.undefined, 'undefined'),
+
+  // Null
+  styleText(inspect.styles.null, 'null'),
+
+  // Boolean (true/false)
+  styleText(inspect.styles.boolean, 'true'),
+  styleText(inspect.styles.boolean, 'false'),
+
+  // Operators
+  styleText(inspect.styles.special, '+'),
+  styleText(inspect.styles.special, '-'),
+  styleText(inspect.styles.special, '*'),
+  styleText(inspect.styles.special, '/'),
+  styleText(inspect.styles.special, '%'),
+  styleText(inspect.styles.special, '**'),
+  styleText(inspect.styles.special, '='),
+  styleText(inspect.styles.special, '+='),
+  styleText(inspect.styles.special, '-='),
+  styleText(inspect.styles.special, '*='),
+  styleText(inspect.styles.special, '/='),
+  styleText(inspect.styles.special, '%='),
+  styleText(inspect.styles.special, '**='),
+  styleText(inspect.styles.special, '=='),
+  styleText(inspect.styles.special, '==='),
+  styleText(inspect.styles.special, '!='),
+  styleText(inspect.styles.special, '!=='),
+  styleText(inspect.styles.special, '>'),
+  styleText(inspect.styles.special, '>='),
+  styleText(inspect.styles.special, '<'),
+  styleText(inspect.styles.special, '<='),
+  styleText(inspect.styles.special, '>>'),
+  styleText(inspect.styles.special, '<<'),
+  styleText(inspect.styles.special, '>>>'),
+  styleText(inspect.styles.special, '&'),
+  styleText(inspect.styles.special, '|'),
+  styleText(inspect.styles.special, '^'),
+  styleText(inspect.styles.special, '!'),
+  styleText(inspect.styles.special, '~'),
+  styleText(inspect.styles.special, '&&'),
+  styleText(inspect.styles.special, '||'),
+  styleText(inspect.styles.special, '?'),
+  styleText(inspect.styles.special, ':'),
+  styleText(inspect.styles.special, '??'),
+  styleText(inspect.styles.special, '??='),
+  styleText(inspect.styles.special, '=>'),
+
+  // Identifiers
+  'Identifier',
+
+  // Function Declaration
+  `${styleText(inspect.styles.special, 'function')} ${styleText(inspect.styles.special, 'foo')}()`,
+];
+
+const stream = new ArrayStream();
+repl.start({
+  input: stream,
+  output: stream,
+  useGlobal: false,
+  terminal: true,
+  useColors: true
+});
+
+let output = '';
+stream.write = (chunk) => output += chunk;
+
+stream.run(tests);
+
+for (const test of tests) {
+  const highlighted = highlight(stripVTControlCharacters(test));
+  assert.strictEqual(highlighted, test);
+  assert(output.includes(highlighted));
+}

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -51,7 +51,7 @@ const testMe = repl.start({
   prompt: PROMPT,
   stream: putIn,
   terminal: true,
-  useColors: true,
+  useColors: false,
   breakEvalOnSigint: true
 });
 


### PR DESCRIPTION
Instead of sending many REPL changes in one PR (#52965), it was recommended to me to implement these one-by-one in several PRs.

First up: Syntax highlighting :tada:

This PR adds RegEx-based syntax highlighting to the REPL.

---

Notable change text (if text this short is even worth it): "The REPL now includes syntax highlighting for input."