### PR TITLE
src: fix implementation of `PropertySetterCallback`

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -567,7 +567,6 @@ Intercepted ContextifyContext::PropertySetterCallback(
     // property
     if (desc_obj->HasOwnProperty(context, env->get_string()).FromMaybe(false) ||
         desc_obj->HasOwnProperty(context, env->set_string()).FromMaybe(false)) {
-      args.GetReturnValue().Set(value);
       return Intercepted::kYes;
     }
   }


### PR DESCRIPTION
V8 does not allow returning arbitrary values from the interceptor
setter callbacks, only a boolean return value is allowed. Since
default return value is `true`, it's not even necessary to set
the return value on a successful path.

Refs: https://crbug.com/348660658

This was adapted from https://github.com/v8/node/pull/194
