### PR TITLE
Revert "build: only generate specified build type files"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2277,7 +2277,7 @@ if flavor == 'win' and python.lower().endswith('.exe'):
 gyp_args += ['-Dpython=' + python]
 
 if options.use_ninja:
-  gyp_args += ['-f', 'ninja-' + flavor, '-G', 'config=' + config['BUILDTYPE']]
+  gyp_args += ['-f', 'ninja-' + flavor]
 elif flavor == 'win' and sys.platform != 'msys':
   gyp_args += ['-f', 'msvs', '-G', 'msvs_version=auto']
 else:


### PR DESCRIPTION
This reverts commit 6cb940a546c6229218277f35c2311f9781001b3d.

Refs: https://github.com/nodejs/node/pull/53511#issuecomment-2188244515

I think an alternative should be making the generated `config.gypi` works in both Release mode and Debug mode.