### PR TITLE
build: add version-specific library path for AIX

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -579,6 +579,9 @@
               '-Wl,-brtl',
             ],
           }, {                                             # else it's `AIX`
+            'variables': {
+              'gcc_major': '<!(<(python) -c "import os; import subprocess; CXX=os.environ.get(\'CXX\', \'g++\'); subprocess.run([CXX, \'-dumpversion\'])")'
+            },
             # Disable the following compiler warning:
             #
             #   warning: visibility attribute not supported in this
@@ -589,7 +592,7 @@
             # out more relevant warnings.
             'cflags': [ '-Wno-attributes' ],
             'ldflags': [
-              '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/pthread/ppc64',
+              '-Wl,-blibpath:/usr/lib:/lib:/opt/freeware/lib/gcc/powerpc-ibm-aix7.3.0.0/>(gcc_major)/pthread/ppc64:/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/>(gcc_major)/pthread/ppc64:/opt/freeware/lib/pthread/ppc64',
             ],
           }],
         ],


### PR DESCRIPTION
Add the version-specific directory containing the C/C++ runtime libraries to `-blibpath` on AIX. This will help link `node` against the correct libraries at run-time when compiled with a different version of the GNU C/C++ compiler without having to manually set a `LIBPATH` environment variable.

---

On current AIX 7.2 and 7.3, `/opt/freeware/lib/pthread/ppc64` contains symbolic links to the gcc 10 version of the runtime libraries, e.g. for AIX 7.2:
```console
# ls -al /opt/freeware/lib/pthread/ppc64
total 0
drwxr-xr-x    2 root     system          256 Mar 15 2023  .
drwxr-xr-x    3 root     system          256 Mar 15 2023  ..
lrwxrwxrwx    1 root     system           61 Mar 15 2023  libatomic.a -> ../../gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64/libatomic.a
lrwxrwxrwx    1 root     system           60 Mar 15 2023  libgcc_s.a -> ../../gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64/libgcc_s.a
lrwxrwxrwx    1 root     system           59 Mar 15 2023  libgomp.a -> ../../gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64/libgomp.a
lrwxrwxrwx    1 root     system           61 Mar 15 2023  libstdc++.a -> ../../gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64/libstdc++.a
#
```
i.e. the libraries are actually in `/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64` (note both the AIX version and gcc versions in the directory name -- on AIX 7.3 the equivalent is `/opt/freeware/lib/gcc/powerpc-ibm-aix7.3.0.0/10/pthread/ppc64`). 

Installing a different version of gcc on the machine (e.g. gcc 12) installs the gcc 12 versions of the libraries (e.g. in `/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/12/pthread/ppc64`) but leaves the symbolic links in `/opt/freeware/lib/pthread/ppc64` pointing at the gcc 10 versions.

If compiled with gcc 12 with the current libpath settings, running `node` will throw an error similar to the following because it will be running against the gcc 10 version of libstdc++ (i.e. the one pointed to in `/opt/freeware/lib/pthread/ppc64`):
```console
# ./node
Could not load program node:
rtld: 0712-001 Symbol _ZSt28__throw_bad_array_new_lengthv was referenced
      from module node(), but a runtime definition
            of the symbol was not found.
rtld: 0712-001 Symbol _ZNKRSt7__cxx1115basic_stringbufIcSt11char_traitsIcESaIcEE3strEv was referenced
      from module node(), but a runtime definition
            of the symbol was not found.
rtld: 0712-002 fatal error: exiting.
# 
```

This can be worked around by setting `/opt/freeware/lib/gcc/powerpc-ibm-aix7.2.0.0/10/pthread/ppc64` in the `LIBPATH` environment variable. 

Adding the version-specific directory (one for AIX 7.2 and one for AIX 7.3) to the libpath passed to the linker will allow `node` to link against the correct library at run-time without having to manually set a `LIBPATH` environment variable.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
