### PR TITLE
vm: perform lazy-loading at top level

### DIFF
--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -30,6 +30,7 @@ const {
   emitExperimentalWarning,
   getConstructorOf,
   kEmptyObject,
+  getLazy
 } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
@@ -81,6 +82,9 @@ const kPerContextModuleId = Symbol('kPerContextModuleId');
 const kLink = Symbol('kLink');
 
 const { isContext } = require('internal/vm');
+
+// Lazy to prevent a circular dependency
+const inspectLazy = getLazy(() => require('internal/util/inspect').inspect);
 
 function isModule(object) {
   if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, kWrap)) {
@@ -245,9 +249,7 @@ class Module {
       configurable: true,
     });
 
-    // Lazy to avoid circular dependency
-    const { inspect } = require('internal/util/inspect');
-    return inspect(o, { ...options, customInspect: false });
+    return inspectLazy()(o, { ...options, customInspect: false });
   }
 }
 

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -30,7 +30,7 @@ const {
   emitExperimentalWarning,
   getConstructorOf,
   kEmptyObject,
-  getLazy
+  getLazy,
 } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,


### PR DESCRIPTION
As it currently stands, the lazy loading for `lib/internal/vm/module.js`'s require of `internal/util/inspect` is performed in a function. This means that a re-call of the function will be a re-call of the require of the module.

This PR moves the lazy-loading to only occur once.