### PR TITLE
node-api: remove RefBase and CallbackWrapper

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -604,10 +604,6 @@ void Finalizer::ResetFinalizer() {
   finalize_hint_ = nullptr;
 }
 
-void Finalizer::ResetData(void* data) {
-  finalize_data_ = data;
-}
-
 void Finalizer::CallFinalizer() {
   napi_finalize finalize_callback = finalize_callback_;
   void* finalize_data = finalize_data_;

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -8,13 +8,14 @@ inline napi_status napi_clear_last_error(node_api_nogc_env env);
 
 namespace v8impl {
 
+// Base class to track references and finalizers in a double linked list.
 class RefTracker {
  public:
+  using RefList = RefTracker;
+
   RefTracker() = default;
   virtual ~RefTracker() = default;
   virtual void Finalize() {}
-
-  typedef RefTracker RefList;
 
   inline void Link(RefList* list) {
     prev_ = list;
@@ -47,7 +48,6 @@ class RefTracker {
   RefList* prev_ = nullptr;
 };
 
-class Finalizer;
 }  // end of namespace v8impl
 
 struct napi_env__ {
@@ -99,11 +99,7 @@ struct napi_env__ {
     }
   }
 
-  // Call finalizer immediately.
-  virtual void CallFinalizer(napi_finalize cb, void* data, void* hint) {
-    v8::HandleScope handle_scope(isolate);
-    CallIntoModule([&](napi_env env) { cb(env, data, hint); });
-  }
+  virtual void CallFinalizer(napi_finalize cb, void* data, void* hint) = 0;
 
   // Invoke finalizer from V8 garbage collector.
   void InvokeFinalizerFromGC(v8impl::RefTracker* finalizer);
@@ -323,7 +319,7 @@ inline v8::Local<v8::Value> V8LocalValueFromJsValue(napi_value v) {
 
 // Adapter for napi_finalize callbacks.
 class Finalizer {
- protected:
+ public:
   Finalizer(napi_env env,
             napi_finalize finalize_callback,
             void* finalize_data,
@@ -333,23 +329,15 @@ class Finalizer {
         finalize_data_(finalize_data),
         finalize_hint_(finalize_hint) {}
 
-  virtual ~Finalizer() = default;
-
- public:
-  static Finalizer* New(napi_env env,
-                        napi_finalize finalize_callback = nullptr,
-                        void* finalize_data = nullptr,
-                        void* finalize_hint = nullptr) {
-    return new Finalizer(env, finalize_callback, finalize_data, finalize_hint);
-  }
-
-  napi_finalize callback() { return finalize_callback_; }
+  napi_env env() { return env_; }
   void* data() { return finalize_data_; }
-  void* hint() { return finalize_hint_; }
 
+  void ResetEnv();
   void ResetFinalizer();
+  void ResetData(void* data);
+  void CallFinalizer();
 
- protected:
+ private:
   napi_env env_;
   napi_finalize finalize_callback_;
   void* finalize_data_;
@@ -371,13 +359,7 @@ class TryCatch : public v8::TryCatch {
 };
 
 // Wrapper around Finalizer that can be tracked.
-class TrackedFinalizer : public Finalizer, public RefTracker {
- protected:
-  TrackedFinalizer(napi_env env,
-                   napi_finalize finalize_callback,
-                   void* finalize_data,
-                   void* finalize_hint);
-
+class TrackedFinalizer final : public RefTracker {
  public:
   static TrackedFinalizer* New(napi_env env,
                                napi_finalize finalize_callback,
@@ -385,13 +367,21 @@ class TrackedFinalizer : public Finalizer, public RefTracker {
                                void* finalize_hint);
   ~TrackedFinalizer() override;
 
- protected:
+  void* data() { return finalizer_.data(); }
+
+ private:
+  TrackedFinalizer(napi_env env,
+                   napi_finalize finalize_callback,
+                   void* finalize_data,
+                   void* finalize_hint);
   void Finalize() override;
-  void FinalizeCore(bool deleteMe);
+
+ private:
+  Finalizer finalizer_;
 };
 
 // Ownership of a reference.
-enum class Ownership : uint8_t {
+enum class ReferenceOwnership : uint8_t {
   // The reference is owned by the runtime. No userland call is needed to
   // destruct the reference.
   kRuntime,
@@ -401,32 +391,33 @@ enum class Ownership : uint8_t {
 };
 
 // Wrapper around v8impl::Persistent.
-class Reference : public TrackedFinalizer {
+class Reference : public RefTracker {
  public:
   static Reference* New(napi_env env,
                         v8::Local<v8::Value> value,
                         uint32_t initial_refcount,
-                        Ownership ownership,
-                        napi_finalize finalize_callback = nullptr,
-                        void* finalize_data = nullptr,
-                        void* finalize_hint = nullptr);
+                        ReferenceOwnership ownership);
   ~Reference() override;
 
   uint32_t Ref();
   uint32_t Unref();
-  v8::Local<v8::Value> Get();
+  v8::Local<v8::Value> Get(napi_env env);
+
+  virtual void ResetFinalizer() {}
+  virtual void* Data() { return nullptr; }
 
   uint32_t refcount() { return refcount_; }
-  Ownership ownership() { return ownership_; }
+  ReferenceOwnership ownership() { return ownership_; }
 
- private:
+ protected:
   Reference(napi_env env,
             v8::Local<v8::Value> value,
             uint32_t initial_refcount,
-            Ownership ownership,
-            napi_finalize finalize_callback,
-            void* finalize_data,
-            void* finalize_hint);
+            ReferenceOwnership ownership);
+  virtual void CallUserFinalizer() {}
+  virtual void InvokeFinalizerFromGC();
+
+ private:
   static void WeakCallback(const v8::WeakCallbackInfo<Reference>& data);
   void SetWeak();
   void Finalize() override;
@@ -434,8 +425,60 @@ class Reference : public TrackedFinalizer {
  private:
   v8impl::Persistent<v8::Value> persistent_;
   uint32_t refcount_;
-  Ownership ownership_;
+  ReferenceOwnership ownership_;
   bool can_be_weak_;
+};
+
+// Reference that can store additional data.
+class ReferenceWithData final : public Reference {
+ public:
+  static ReferenceWithData* New(napi_env env,
+                                v8::Local<v8::Value> value,
+                                uint32_t initial_refcount,
+                                ReferenceOwnership ownership,
+                                void* data);
+
+  void* Data() override { return data_; }
+
+ private:
+  ReferenceWithData(napi_env env,
+                    v8::Local<v8::Value> value,
+                    uint32_t initial_refcount,
+                    ReferenceOwnership ownership,
+                    void* data);
+
+ private:
+  void* data_;
+};
+
+// Reference that has a user finalizer callback.
+class ReferenceWithFinalizer final : public Reference {
+ public:
+  static ReferenceWithFinalizer* New(napi_env env,
+                                     v8::Local<v8::Value> value,
+                                     uint32_t initial_refcount,
+                                     ReferenceOwnership ownership,
+                                     napi_finalize finalize_callback,
+                                     void* finalize_data,
+                                     void* finalize_hint);
+  ~ReferenceWithFinalizer() override;
+
+  void ResetFinalizer() override { finalizer_.ResetFinalizer(); }
+  void* Data() override { return finalizer_.data(); }
+
+ private:
+  ReferenceWithFinalizer(napi_env env,
+                         v8::Local<v8::Value> value,
+                         uint32_t initial_refcount,
+                         ReferenceOwnership ownership,
+                         napi_finalize finalize_callback,
+                         void* finalize_data,
+                         void* finalize_hint);
+  void CallUserFinalizer() override;
+  void InvokeFinalizerFromGC() override;
+
+ private:
+  Finalizer finalizer_;
 };
 
 }  // end of namespace v8impl

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -8,7 +8,7 @@ inline napi_status napi_clear_last_error(node_api_nogc_env env);
 
 namespace v8impl {
 
-// Base class to track references and finalizers in a double linked list.
+// Base class to track references and finalizers in a doubly linked list.
 class RefTracker {
  public:
   using RefList = RefTracker;
@@ -334,7 +334,6 @@ class Finalizer {
 
   void ResetEnv();
   void ResetFinalizer();
-  void ResetData(void* data);
   void CallFinalizer();
 
  private:

--- a/src/js_native_api_v8.h
+++ b/src/js_native_api_v8.h
@@ -405,7 +405,7 @@ class Reference : public RefTracker {
   virtual void ResetFinalizer() {}
   virtual void* Data() { return nullptr; }
 
-  uint32_t refcount() { return refcount_; }
+  uint32_t refcount() const { return refcount_; }
   ReferenceOwnership ownership() { return ownership_; }
 
  protected:

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -131,13 +131,9 @@ class BufferFinalizer : private Finalizer {
   static void FinalizeBufferCallback(char* data, void* hint) {
     std::unique_ptr<BufferFinalizer, Deleter> finalizer{
         static_cast<BufferFinalizer*>(hint)};
-    finalizer->finalize_data_ = data;
-
+    finalizer->ResetData(data);
     // It is safe to call into JavaScript at this point.
-    if (finalizer->finalize_callback_ == nullptr) return;
-    finalizer->env_->CallFinalizer(finalizer->finalize_callback_,
-                                   finalizer->finalize_data_,
-                                   finalizer->finalize_hint_);
+    finalizer->CallFinalizer();
   }
 
   struct Deleter {
@@ -150,10 +146,10 @@ class BufferFinalizer : private Finalizer {
                   void* finalize_data,
                   void* finalize_hint)
       : Finalizer(env, finalize_callback, finalize_data, finalize_hint) {
-    env_->Ref();
+    env->Ref();
   }
 
-  ~BufferFinalizer() { env_->Unref(); }
+  ~BufferFinalizer() { env()->Unref(); }
 };
 
 void ThrowNodeApiVersionError(node::Environment* node_env,

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -121,9 +121,9 @@ namespace {
 class BufferFinalizer : private Finalizer {
  public:
   static BufferFinalizer* New(napi_env env,
-                              napi_finalize finalize_callback = nullptr,
-                              void* finalize_data = nullptr,
-                              void* finalize_hint = nullptr) {
+                              napi_finalize finalize_callback,
+                              void* finalize_data,
+                              void* finalize_hint) {
     return new BufferFinalizer(
         env, finalize_callback, finalize_data, finalize_hint);
   }
@@ -131,7 +131,6 @@ class BufferFinalizer : private Finalizer {
   static void FinalizeBufferCallback(char* data, void* hint) {
     std::unique_ptr<BufferFinalizer, Deleter> finalizer{
         static_cast<BufferFinalizer*>(hint)};
-    finalizer->ResetData(data);
     // It is safe to call into JavaScript at this point.
     finalizer->CallFinalizer();
   }
@@ -1053,7 +1052,7 @@ napi_create_external_buffer(napi_env env,
 
   // The finalizer object will delete itself after invoking the callback.
   v8impl::BufferFinalizer* finalizer =
-      v8impl::BufferFinalizer::New(env, finalize_cb, nullptr, finalize_hint);
+      v8impl::BufferFinalizer::New(env, finalize_cb, data, finalize_hint);
 
   v8::MaybeLocal<v8::Object> maybe =
       node::Buffer::New(isolate,


### PR DESCRIPTION
This PR simplifies internal Node-API implementation to reduce the code complexity and to reduce allocated memory size.
There are no API changes or changes to the code behavior. All existing tests are passing and no new tests are needed.
- Removed `RefBase` class. 
  - `Reference` class directly inherits from `RefTracker`.
  - `napi_set_instance_data` and `napi_get_instance_data` use `TrackedFinalizer` instead of `RefBase`.
- `v8impl::Ownership` enum is renamed to `v8impl::ReferenceOwnership` to better reflect its purpose.
  - `v8impl::ReferenceOwnership` size changed to one byte to reduce `Reference` size.
- `Finalizer` class became non-virtual to reduce its size.
  - All `Finalizer` fields became private for better encapsulation.
  - `TrackedFinalizer` and `TrackedStringResource` size changed from 64 to 56 bytes on 64-bit platforms.
- `Reference` class is split up into three classes depending on the usage scenario: `Reference`, `ReferenceWithData`, and `ReferenceWithFinalizer`.
  - Previously `Reference` instance size on 64-bit platforms was 88 bytes.
  - New `Reference` size is 40 bytes, `ReferenceWithData` is 48 bytes, and `ReferenceWithFinalizer` is 72 bytes.
  - `ReferenceWithFinalizer` size reduced by 16 bytes due to changes to `Finalizer` (8 bytes) and removal of `RefBase` that along with the `v8impl::ReferenceOwnership` to be one byte gained reduction of another 8 bytes.
  - Instances of `Reference` and `ReferenceWithData` are not queued for finalization since they do not have user finalizer callbacks. They are finalized immediately.
- Simplified `FunctionCallbackWrapper`.
  - Removed base classes `CallbackWrapper` and `CallbackWrapperBase`
  - All methods became non-virtual.
  - It should slightly improve perf for each function call.
