### PR TITLE
worker: allow copied NODE_OPTIONS in the env setting

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -549,12 +549,40 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
       // [0] is expected to be the program name, add dummy string.
       env_argv.insert(env_argv.begin(), "");
       std::vector<std::string> invalid_args{};
-      options_parser::Parse(&env_argv,
-                            nullptr,
-                            &invalid_args,
-                            per_isolate_opts.get(),
-                            kAllowedInEnvvar,
-                            &errors);
+
+      std::string parent_node_options;
+      USE(env->env_vars()->Get("NODE_OPTIONS").To(&parent_node_options));
+
+      // If the worker code passes { env: { ...process.env, ... } } or
+      // the NODE_OPTIONS is otherwise character-for-character equal to the
+      // original NODE_OPTIONS, allow per-process options inherited into
+      // the worker since worker spawning code is not usually in charge of
+      // how the NODE_OPTIONS is configured for the parent.
+      // TODO(joyeecheung): a more intelligent filter may be more desirable.
+      // but a string comparison is good enough(TM) for the case where the
+      // worker spawning code just wants to pass the parent configuration down
+      // and does not intend to modify NODE_OPTIONS.
+      if (parent_node_options == node_options) {
+        // Creates a wrapper per-process option over the per_isolate_opts
+        // to allow per-process options copied from the parent.
+        std::unique_ptr<PerProcessOptions> per_process_opts =
+            std::make_unique<PerProcessOptions>();
+        per_process_opts->per_isolate = per_isolate_opts;
+        options_parser::Parse(&env_argv,
+                              nullptr,
+                              &invalid_args,
+                              per_process_opts.get(),
+                              kAllowedInEnvvar,
+                              &errors);
+      } else {
+        options_parser::Parse(&env_argv,
+                              nullptr,
+                              &invalid_args,
+                              per_isolate_opts.get(),
+                              kAllowedInEnvvar,
+                              &errors);
+      }
+
       if (!errors.empty() && args[1]->IsObject()) {
         // Only fail for explicitly provided env, this protects from failures
         // when NODE_OPTIONS from parent's env is used (which is the default).

--- a/test/fixtures/spawn-worker-with-copied-env.js
+++ b/test/fixtures/spawn-worker-with-copied-env.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// This test is meant to be spawned with NODE_OPTIONS=--title=foo
+const assert = require('assert');
+assert.strictEqual(process.title, 'foo');
+
+// Spawns a worker that may copy NODE_OPTIONS if it's set by the parent.
+const { Worker } = require('worker_threads');
+new Worker(`require('assert').strictEqual(process.env.TEST_VAR, 'bar')`, {
+  env: {
+    ...process.env,
+    TEST_VAR: 'bar',
+  },
+  eval: true,
+});

--- a/test/fixtures/spawn-worker-with-copied-env.js
+++ b/test/fixtures/spawn-worker-with-copied-env.js
@@ -2,7 +2,9 @@
 
 // This test is meant to be spawned with NODE_OPTIONS=--title=foo
 const assert = require('assert');
-assert.strictEqual(process.title, 'foo');
+if (process.platform !== 'sunos') {  // --title is unsupported on SmartOS.
+  assert.strictEqual(process.title, 'foo');
+}
 
 // Spawns a worker that may copy NODE_OPTIONS if it's set by the parent.
 const { Worker } = require('worker_threads');

--- a/test/fixtures/spawn-worker-with-trace-exit.js
+++ b/test/fixtures/spawn-worker-with-trace-exit.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { Worker, isMainThread } = require('worker_threads')
+
+// Tests that valid per-isolate/env NODE_OPTIONS are allowed and
+// work in child workers.
+if (isMainThread) {
+  new Worker(__filename, {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--trace-exit'
+    }
+  })
+} else {
+  setImmediate(() => {
+    process.nextTick(() => {
+      process.exit(0);
+    });
+  });
+}

--- a/test/parallel/test-worker-node-options.js
+++ b/test/parallel/test-worker-node-options.js
@@ -30,6 +30,6 @@ spawnSyncAndAssert(
     }
   },
   {
-    stderr: /spawn-worker-with-trace-exit.js:17/
+    stderr: /spawn-worker-with-trace-exit\.js:17/
   }
 );

--- a/test/parallel/test-worker-node-options.js
+++ b/test/parallel/test-worker-node-options.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+const {
+  spawnSyncAndExitWithoutError,
+  spawnSyncAndAssert,
+} = require('../common/child_process');
+const fixtures = require('../common/fixtures');
+spawnSyncAndExitWithoutError(
+  process.execPath,
+  [
+    fixtures.path('spawn-worker-with-copied-env'),
+  ],
+  {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--title=foo'
+    }
+  }
+);
+
+spawnSyncAndAssert(
+  process.execPath,
+  [
+    fixtures.path('spawn-worker-with-trace-exit'),
+  ],
+  {
+    env: {
+      ...process.env,
+    }
+  },
+  {
+    stderr: /spawn-worker-with-trace-exit.js:17/
+  }
+);


### PR DESCRIPTION
When the worker spawning code copies NODE_OPTIONS from process.env, previously we do a check again on the copied NODE_OPTIONS and throw if it contains per-process settings. This can be problematic if the end user starts the process with a NODE_OPTIONS and the worker is spawned by a third-party that tries to extend process.env with some overrides before passing them into the worker. This patch adds another exception that skips the validation if the NODE_OPTIONS in the env setting is character-by-character equal to the parent NODE_OPTIONS. While some more intelligent filter can be useful too, this works good enough for the inheritance case, when the worker spawning code does not intend to modify NODE_OPTIONS.

Refs: https://github.com/nodejs/node/issues/41103

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
