### PR TITLE
crypto: make deriveBits length parameter optional and nullable

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -569,11 +569,15 @@ The algorithms currently supported include:
 * `'AES-CBC'`
 * `'AES-GCM`'
 
-### `subtle.deriveBits(algorithm, baseKey, length)`
+### `subtle.deriveBits(algorithm, baseKey[, length])`
 
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53601
+    description: The length parameter is now optional for `'ECDH'`, `'X25519'`,
+                 and `'X448'`.
   - version:
     - v18.4.0
     - v16.17.0
@@ -585,7 +589,7 @@ changes:
 
 * `algorithm`: {AlgorithmIdentifier|EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
 * `baseKey`: {CryptoKey}
-* `length`: {number|null}
+* `length`: {number|null} **Default:** `null`
 * Returns: {Promise} Fulfills with an {ArrayBuffer}
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -594,12 +598,12 @@ Using the method and parameters specified in `algorithm` and the keying
 material provided by `baseKey`, `subtle.deriveBits()` attempts to generate
 `length` bits.
 
-The Node.js implementation requires that when `length` is a
-number it must be multiple of `8`.
+The Node.js implementation requires that `length`, when a number, is a multiple
+of `8`.
 
-When `length` is `null` the maximum number of bits for a given algorithm is
-generated. This is allowed for the `'ECDH'`, `'X25519'`, and `'X448'`
-algorithms.
+When `length` is not provided or `null` the maximum number of bits for a given
+algorithm is generated. This is allowed for the `'ECDH'`, `'X25519'`, and `'X448'`
+algorithms, for other algorithms `length` is required to be a number.
 
 If successful, the returned promise will be resolved with an {ArrayBuffer}
 containing the generated data.

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -173,12 +173,12 @@ async function generateKey(
   return result;
 }
 
-async function deriveBits(algorithm, baseKey, length) {
+async function deriveBits(algorithm, baseKey, length = null) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
   const prefix = "Failed to execute 'deriveBits' on 'SubtleCrypto'";
-  webidl.requiredArguments(arguments.length, 3, { prefix });
+  webidl.requiredArguments(arguments.length, 2, { prefix });
   algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
     prefix,
     context: '1st argument',

--- a/test/parallel/test-webcrypto-derivebits-cfrg.js
+++ b/test/parallel/test-webcrypto-derivebits-cfrg.js
@@ -102,6 +102,16 @@ async function prepareKeys() {
       }
 
       {
+        // Default length
+        const bits = await subtle.deriveBits({
+          name,
+          public: publicKey
+        }, privateKey);
+
+        assert.strictEqual(Buffer.from(bits).toString('hex'), result);
+      }
+
+      {
         // Short Result
         const bits = await subtle.deriveBits({
           name,

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -123,6 +123,16 @@ async function prepareKeys() {
       }
 
       {
+        // Default length
+        const bits = await subtle.deriveBits({
+          name: 'ECDH',
+          public: publicKey
+        }, privateKey);
+
+        assert.strictEqual(Buffer.from(bits).toString('hex'), result);
+      }
+
+      {
         // Short Result
         const bits = await subtle.deriveBits({
           name: 'ECDH',

--- a/test/parallel/test-webcrypto-derivebits-hkdf.js
+++ b/test/parallel/test-webcrypto-derivebits-hkdf.js
@@ -272,6 +272,11 @@ async function testDeriveBitsBadLengths(
         name: 'OperationError',
       }),
     assert.rejects(
+      subtle.deriveBits(algorithm, baseKeys[size]), {
+        message: 'length cannot be null',
+        name: 'OperationError',
+      }),
+    assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
         message: /length must be a multiple of 8/,
         name: 'OperationError',

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -460,6 +460,11 @@ async function testDeriveBitsBadLengths(
         name: 'OperationError',
       }),
     assert.rejects(
+      subtle.deriveBits(algorithm, baseKeys[size]), {
+        message: 'length cannot be null',
+        name: 'OperationError',
+      }),
+    assert.rejects(
       subtle.deriveBits(algorithm, baseKeys[size], 15), {
         message: /length must be a multiple of 8/,
         name: 'OperationError',

--- a/test/wpt/status/WebCryptoAPI.json
+++ b/test/wpt/status/WebCryptoAPI.json
@@ -4,5 +4,13 @@
   },
   "historical.any.js": {
     "skip": "Not relevant in Node.js context"
+  },
+  "idlharness.https.any.js": {
+    "fail": {
+      "note": "WPT not updated for https://github.com/w3c/webcrypto/pull/345 yet",
+      "expected": [
+        "SubtleCrypto interface: operation deriveBits(AlgorithmIdentifier, CryptoKey, unsigned long)"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Updates SubtleCrypto.prototype.deriveBits as per https://github.com/w3c/webcrypto/pull/345