### PR TITLE
src,lib: expose getCategoryEnabledBuffer to use on node.http

### DIFF
--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -8,7 +8,7 @@ const {
 } = primordials;
 
 const { setUnrefTimeout } = require('internal/timers');
-const { trace, isTraceCategoryEnabled } = internalBinding('trace_events');
+const { getCategoryEnabledBuffer, trace } = internalBinding('trace_events');
 const {
   CHAR_LOWERCASE_B,
   CHAR_LOWERCASE_E,
@@ -37,8 +37,10 @@ function getNextTraceEventId() {
   return ++traceEventId;
 }
 
+const httpEnabled = getCategoryEnabledBuffer('node.http');
+
 function isTraceHTTPEnabled() {
-  return isTraceCategoryEnabled('node.http');
+  return httpEnabled[0] > 0;
 }
 
 const traceEventCategory = 'node,node.http';

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -16,6 +16,8 @@ namespace node {
 class ExternalReferenceRegistry;
 
 using v8::Array;
+using v8::ArrayBuffer;
+using v8::BackingStore;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -25,6 +27,7 @@ using v8::Local;
 using v8::NewStringType;
 using v8::Object;
 using v8::String;
+using v8::Uint8Array;
 using v8::Value;
 
 class NodeCategorySet : public BaseObject {
@@ -120,6 +123,29 @@ static void SetTraceCategoryStateUpdateHandler(
   env->set_trace_category_state_function(args[0].As<Function>());
 }
 
+static void GetCategoryEnabledBuffer(
+    const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsString());
+
+  Isolate* isolate = args.GetIsolate();
+  node::Utf8Value category_name(isolate, args[0]);
+
+  const uint8_t* enabled_pointer = TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
+    category_name.out());
+  uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(
+    enabled_pointer);
+
+  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+    enabled_pointer_cast,
+    sizeof(*enabled_pointer_cast),
+    [](void*, size_t, void*) {},
+    nullptr);
+  auto ab = ArrayBuffer::New(isolate, std::move(bs));
+  v8::Local<Uint8Array> u8 = v8::Uint8Array::New(ab, 0, 1);
+
+  args.GetReturnValue().Set(u8);
+}
+
 void NodeCategorySet::Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -132,6 +158,10 @@ void NodeCategorySet::Initialize(Local<Object> target,
             target,
             "setTraceCategoryStateUpdateHandler",
             SetTraceCategoryStateUpdateHandler);
+  SetMethod(context,
+            target,
+            "getCategoryEnabledBuffer",
+            GetCategoryEnabledBuffer);
 
   Local<FunctionTemplate> category_set =
       NewFunctionTemplate(isolate, NodeCategorySet::New);
@@ -160,6 +190,7 @@ void NodeCategorySet::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(GetEnabledCategories);
   registry->Register(SetTraceCategoryStateUpdateHandler);
+  registry->Register(GetCategoryEnabledBuffer);
   registry->Register(NodeCategorySet::New);
   registry->Register(NodeCategorySet::Enable);
   registry->Register(NodeCategorySet::Disable);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -123,23 +123,21 @@ static void SetTraceCategoryStateUpdateHandler(
   env->set_trace_category_state_function(args[0].As<Function>());
 }
 
-static void GetCategoryEnabledBuffer(
-    const FunctionCallbackInfo<Value>& args) {
+static void GetCategoryEnabledBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   Isolate* isolate = args.GetIsolate();
   node::Utf8Value category_name(isolate, args[0]);
 
-  const uint8_t* enabled_pointer = TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(
-    category_name.out());
-  uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(
-    enabled_pointer);
+  const uint8_t* enabled_pointer =
+      TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_name.out());
+  uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(enabled_pointer);
 
   std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
-    enabled_pointer_cast,
-    sizeof(*enabled_pointer_cast),
-    [](void*, size_t, void*) {},
-    nullptr);
+      enabled_pointer_cast,
+      sizeof(*enabled_pointer_cast),
+      [](void*, size_t, void*) {},
+      nullptr);
   auto ab = ArrayBuffer::New(isolate, std::move(bs));
   v8::Local<Uint8Array> u8 = v8::Uint8Array::New(ab, 0, 1);
 
@@ -158,10 +156,8 @@ void NodeCategorySet::Initialize(Local<Object> target,
             target,
             "setTraceCategoryStateUpdateHandler",
             SetTraceCategoryStateUpdateHandler);
-  SetMethod(context,
-            target,
-            "getCategoryEnabledBuffer",
-            GetCategoryEnabledBuffer);
+  SetMethod(
+      context, target, "getCategoryEnabledBuffer", GetCategoryEnabledBuffer);
 
   Local<FunctionTemplate> category_set =
       NewFunctionTemplate(isolate, NodeCategorySet::New);

--- a/test/parallel/test-trace-events-get-category-enabled-buffer.js
+++ b/test/parallel/test-trace-events-get-category-enabled-buffer.js
@@ -1,18 +1,18 @@
 // Flags: --expose-internals
 
-import * as common from '../common/index.mjs';
-import { it } from 'node:test';
+const common = require('../common/index');
+const { it } = require('node:test');
 
 try {
-  await import('node:trace_events');
+  require('trace_events');
 } catch {
   common.skip('missing trace events');
 }
 
-import { createTracing, getEnabledCategories } from 'node:trace_events';
-import assert from 'node:assert';
+const { createTracing, getEnabledCategories } = require('trace_events');
+const assert = require('assert');
 
-import binding from 'internal/test/binding';
+const binding = require('internal/test/binding');
 const getCategoryEnabledBuffer = binding.internalBinding('trace_events').getCategoryEnabledBuffer;
 
 it('should track enabled/disabled categories', () => {

--- a/test/parallel/test-trace-events-get-category-enabled-buffer.js
+++ b/test/parallel/test-trace-events-get-category-enabled-buffer.js
@@ -1,6 +1,7 @@
+'use strict';
 // Flags: --expose-internals
 
-const common = require('../common/index');
+const common = require('../common');
 const { it } = require('node:test');
 
 try {

--- a/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
+++ b/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
@@ -1,0 +1,35 @@
+// Flags: --expose-internals
+
+import '../common/index.mjs';
+import { it } from 'node:test';
+import { createTracing, getEnabledCategories } from 'node:trace_events';
+import assert from 'node:assert';
+
+import binding from 'internal/test/binding';
+const getCategoryEnabledBuffer = binding.internalBinding('trace_events').getCategoryEnabledBuffer;
+
+it('should track enabled/disabled categories', () => {
+  const random = Math.random().toString().slice(2);
+  const category = `node.${random}`;
+
+  const buffer = getCategoryEnabledBuffer(category);
+
+  const tracing = createTracing({
+    categories: [category],
+  });
+
+  assert.ok(buffer[0] === 0, `the buffer[0] should start with value 0, got: ${buffer[0]}`);
+
+  tracing.enable();
+
+  let currentCategories = getEnabledCategories();
+
+  assert.ok(currentCategories.includes(category), `the getEnabledCategories should include ${category}, got: ${currentCategories}`);
+  assert.ok(buffer[0] > 0, `the buffer[0] should be greater than 0, got: ${buffer[0]}`);
+
+  tracing.disable();
+
+  currentCategories = getEnabledCategories();
+  assert.ok(currentCategories === undefined, `the getEnabledCategories should return undefined, got: ${currentCategories}`);
+  assert.ok(buffer[0] === 0, `the buffer[0] should be 0, got: ${buffer[0]}`);
+});

--- a/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
+++ b/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
@@ -2,6 +2,13 @@
 
 import '../common/index.mjs';
 import { it } from 'node:test';
+
+try {
+  await import('node:trace_events');
+} catch {
+  common.skip('missing trace events');
+}
+
 import { createTracing, getEnabledCategories } from 'node:trace_events';
 import assert from 'node:assert';
 

--- a/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
+++ b/test/parallel/test-trace-events-get-category-enabled-buffer.mjs
@@ -1,6 +1,6 @@
 // Flags: --expose-internals
 
-import '../common/index.mjs';
+import * as common from '../common/index.mjs';
 import { it } from 'node:test';
 
 try {


### PR DESCRIPTION
This PR is a simplified version of https://github.com/nodejs/node/pull/48142

With this function, I also plan to replace all the references of `isTraceCategoryEnabled`.

I made this function generic also to support cases like: 

https://github.com/nodejs/node/blob/53ac448022b7cdfcc09296da88d9a1b59921f6bf/lib/internal/util/debuglog.js#L375

In this code, the category can be anything, so this function will handle those cases as well.