### PR TITLE
build: fix gyp configs in debug

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1305,6 +1305,9 @@ def host_arch_win():
 
   return matchup.get(arch, 'x64')
 
+def set_configuration_variable(configs, name, release=None, debug=None):
+  configs['Release'][name]= release
+  configs['Debug'][name]= debug
 
 def configure_arm(o):
   if options.arm_float_abi:
@@ -1619,7 +1622,9 @@ def configure_library(lib, output, pkgname=None):
       output['libraries'] += pkg_libs.split()
 
 
-def configure_v8(o):
+def configure_v8(o, configs):
+  set_configuration_variable(configs, 'v8_enable_v8_checks', release=1, debug=0)
+
   o['variables']['v8_enable_webassembly'] = 0 if options.v8_lite_mode else 1
   o['variables']['v8_enable_javascript_promise_hooks'] = 1
   o['variables']['v8_enable_lite_mode'] = 1 if options.v8_lite_mode else 0
@@ -1637,7 +1642,6 @@ def configure_v8(o):
   o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_enable_shared_ro_heap'] = 0 if options.enable_pointer_compression or options.disable_shared_ro_heap else 1
   o['variables']['v8_enable_extensible_ro_snapshot'] = 0
-  o['variables']['v8_enable_v8_checks'] = 1 if options.debug else 0
   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0
   o['variables']['node_use_v8_platform'] = b(not options.without_v8_platform)
   o['variables']['node_use_bundled_v8'] = b(not options.without_bundled_v8)
@@ -2153,6 +2157,10 @@ output = {
   'defines': [],
   'cflags': [],
 }
+configurations = {
+  'Release': { 'variables': {} },
+  'Debug': { 'variables': {} },
+}
 
 # Print a warning when the compiler is too old.
 check_compiler(output)
@@ -2180,7 +2188,7 @@ configure_library('nghttp3', output, pkgname='libnghttp3')
 configure_library('ngtcp2', output, pkgname='libngtcp2')
 configure_library('sqlite', output, pkgname='sqlite3')
 configure_library('uvwasi', output, pkgname='libuvwasi')
-configure_v8(output)
+configure_v8(output, configurations)
 configure_openssl(output)
 configure_intl(output)
 configure_static(output)
@@ -2203,7 +2211,6 @@ output['variables']['ossfuzz'] = b(options.ossfuzz)
 # move everything else to target_defaults
 variables = output['variables']
 del output['variables']
-variables['is_debug'] = B(options.debug)
 
 # make_global_settings should be a root level element too
 if 'make_global_settings' in output:
@@ -2211,6 +2218,9 @@ if 'make_global_settings' in output:
   del output['make_global_settings']
 else:
   make_global_settings = False
+
+# Add configurations to target defaults
+output['configurations'] = configurations
 
 output = {
   'variables': variables,
@@ -2222,7 +2232,7 @@ if make_global_settings:
 print_verbose(output)
 
 write('config.gypi', do_not_edit +
-      pprint.pformat(output, indent=2, width=1024) + '\n')
+      pprint.pformat(output, indent=2, width=128) + '\n')
 
 write('config.status', '#!/bin/sh\nset -x\nexec ./configure ' +
       ' '.join([shlex.quote(arg) for arg in original_argv]) + '\n')

--- a/configure.py
+++ b/configure.py
@@ -1306,8 +1306,8 @@ def host_arch_win():
   return matchup.get(arch, 'x64')
 
 def set_configuration_variable(configs, name, release=None, debug=None):
-  configs['Release'][name]= release
-  configs['Debug'][name]= debug
+  configs['Release'][name] = release
+  configs['Debug'][name] = debug
 
 def configure_arm(o):
   if options.arm_float_abi:

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -88,7 +88,6 @@
         'v8_enable_private_mapping_fork_optimization': 0,
       }],
     ],
-    'is_debug%': 0,
 
     # Variables from BUILD.gn
 

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -703,13 +703,7 @@
     'configurations': {
       'Debug': {
         'defines': [
-          'ENABLE_DISASSEMBLER',
-          'V8_ENABLE_CHECKS',
-          'OBJECT_PRINT',
           'DEBUG',
-          'V8_TRACE_MAPS',
-          'V8_ENABLE_ALLOCATION_TIMEOUT',
-          'V8_ENABLE_FORCE_SLOW_PATH',
         ],
         'conditions': [
           ['OS=="linux" and v8_enable_backtrace==1', {


### PR DESCRIPTION
Gyp generated build files should be able to be built in either Release/Debug mode.

- make: single entry build file, two configurations by cli:
  `make -C out BUILDTYPE=Release` and `make -C out BUILDTYPE=Debug`.
- msbuild: single entry build file, two configurations by cli:
  `msbuild node.sln /p:Configuration=Release` and
  `msbuild node.sln /p:Configuration=Debug`.
- ninja: two directories in `out/`, build with
  `ninja -C out/Release` or `ninja -C out/Debug`.

Variables that changes with either Release or Debug configuration
should be defined in a configuration level, instead of the root level.
Example: https://github.com/nodejs/node/blob/8e5d88b6413558b6b4bc127f87fc8122311639ae/common.gypi#L132-L133

This fixes generating invalid build files.

Additionally, `v8_gypfiles/toolchain.gypi` duplicates defines in
`v8_gypfiles/features.gypi`. Remove the duplications in
`toolchains.gypi`

Fixes: https://github.com/nodejs/node/issues/53446