### PR TITLE
lib: add security warning on io full access

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -584,6 +584,12 @@ There are constraints you need to know before using this system:
 * Using existing file descriptors via the `node:fs` module bypasses the
   Permission Model.
 
+#### Allowing all write operations
+
+When `--allow-fs-write=*` is permitted, it may inadvertently lead to invalidating
+the permission model because of unintended file access, like full write access
+to memory with `/proc/self/mem`.
+
 #### Limitations and Known Issues
 
 * Symbolic links will be followed even to locations outside of the set of paths

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -587,8 +587,10 @@ There are constraints you need to know before using this system:
 #### Allowing all write operations
 
 When `--allow-fs-write=*` is permitted, it may inadvertently lead to invalidating
-the permission model because of unintended file access, like full write access
-to memory with `/proc/self/mem`.
+the permission model because of unintended file access
+to files that have side effects when written to, like
+service configuration files or internal file interfaces like
+linux's `/proc`.
 
 #### Limitations and Known Issues
 

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -554,6 +554,22 @@ function initializePermission() {
         'It could invalidate the permission model.', 'SecurityWarning');
       }
     }
+    const fsReadValue = getOptionValue('--allow-fs-read');
+    if (fsReadValue.length === 1 && (fsReadValue[0] === '*' || fsReadValue[0] === '/')) {
+      process.emitWarning(
+        'Granting all to --allow-fs-read leaks all sensitive info on the host machine.',
+        'SecurityWarning'
+      );
+    }
+    const fsWriteValue = getOptionValue('--allow-fs-write');
+    if (fsWriteValue.length === 1 && (fsWriteValue[0] === '*' || fsWriteValue[0] === '/')) {
+      process.emitWarning(
+        'Granting all to --allow-fs-write will invalidate the permission model. ' +
+      'Documentation can be found at ' +
+      'https://nodejs.org/api/permissions.html#allowing-all-write-operations',
+        'SecurityWarning'
+      );
+    }
     const warnCommaFlags = [
       '--allow-fs-read',
       '--allow-fs-write',

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -44,6 +44,8 @@ const {
   },
 } = require('internal/v8/startup_snapshot');
 
+const isWindows = process.platform === 'win32';
+
 function prepareMainThreadExecution(expandArgv1 = false, initializeModules = true) {
   return prepareExecution({
     expandArgv1,
@@ -555,14 +557,14 @@ function initializePermission() {
       }
     }
     const fsReadValue = getOptionValue('--allow-fs-read');
-    if (fsReadValue.length === 1 && (fsReadValue[0] === '*' || fsReadValue[0] === '/')) {
+    if (fsReadValue.length === 1 && (fsReadValue[0] === '*' || (!isWindows && fsReadValue[0] === '/'))) {
       process.emitWarning(
         'Granting all to --allow-fs-read leaks all sensitive info on the host machine.',
         'SecurityWarning'
       );
     }
     const fsWriteValue = getOptionValue('--allow-fs-write');
-    if (fsWriteValue.length === 1 && (fsWriteValue[0] === '*' || fsWriteValue[0] === '/')) {
+    if (fsWriteValue.length === 1 && (fsWriteValue[0] === '*' || (!isWindows && fsWriteValue[0] === '/'))) {
       process.emitWarning(
         'Granting all to --allow-fs-write will invalidate the permission model. ' +
       'Documentation can be found at ' +


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Adds https://github.com/nodejs/node/issues/53598, warning about access granted to all files.

Should there be a note in the docs, or should that be inlined into the warning?