### PR TITLE
module: unflag detect-module

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -940,39 +940,6 @@ files with no extension will be treated as WebAssembly if they begin with the
 WebAssembly magic number (`\0asm`); otherwise they will be treated as ES module
 JavaScript.
 
-### `--experimental-detect-module`
-
-<!-- YAML
-added:
-  - v21.1.0
-  - v20.10.0
--->
-
-> Stability: 1.1 - Active development
-
-Node.js will inspect the source code of ambiguous input to determine whether it
-contains ES module syntax; if such syntax is detected, the input will be treated
-as an ES module.
-
-Ambiguous input is defined as:
-
-* Files with a `.js` extension or no extension; and either no controlling
-  `package.json` file or one that lacks a `type` field; and
-  `--experimental-default-type` is not specified.
-* String input (`--eval` or STDIN) when neither `--input-type` nor
-  `--experimental-default-type` are specified.
-
-ES module syntax is defined as syntax that would throw when evaluated as
-CommonJS. This includes the following:
-
-* `import` statements (but _not_ `import()` expressions, which are valid in
-  CommonJS).
-* `export` statements.
-* `import.meta` references.
-* `await` at the top level of a module.
-* Lexical redeclarations of the CommonJS wrapper variables (`require`, `module`,
-  `exports`, `__dirname`, `__filename`).
-
 ### `--experimental-eventsource`
 
 <!-- YAML
@@ -1623,6 +1590,21 @@ added: v0.8.0
 -->
 
 Silence deprecation warnings.
+
+### `--no-experimental-detect-module`
+
+<!-- YAML
+added:
+  - v21.1.0
+  - v20.10.0
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53619
+    description: Syntax detection is enabled by default.
+-->
+
+Disable using [syntax detection][] to determine module type.
 
 ### `--no-experimental-global-navigator`
 
@@ -3495,6 +3477,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [semi-space]: https://www.memorymanagement.org/glossary/s.html#semi.space
 [single executable application]: single-executable-applications.md
 [snapshot testing]: test.md#snapshot-testing
+[syntax detection]: packages.md#syntax-detection
 [test reporters]: test.md#test-reporters
 [timezone IDs]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 [tracking issue for user-land snapshots]: https://github.com/nodejs/node/issues/44014

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1082,8 +1082,7 @@ _isImports_, _conditions_)
 > 10. If _url_ ends in _".js"_, then
 >     1. If _packageType_ is not **null**, then
 >        1. Return _packageType_.
->     2. If `--experimental-detect-module` is enabled and the result of
->        **DETECT\_MODULE\_SYNTAX**(_source_) is true, then
+>     2. If the result of **DETECT\_MODULE\_SYNTAX**(_source_) is true, then
 >        1. Return _"module"_.
 >     3. Return _"commonjs"_.
 > 11. If _url_ does not have any extension, then
@@ -1093,8 +1092,7 @@ _isImports_, _conditions_)
 >        1. Return _"wasm"_.
 >     2. If _packageType_ is not **null**, then
 >        1. Return _packageType_.
->     3. If `--experimental-detect-module` is enabled and the source of
->        module contains static import or export syntax, then
+>     3. If the result of **DETECT\_MODULE\_SYNTAX**(_source_) is true, then
 >        1. Return _"module"_.
 >     4. Return _"commonjs"_.
 > 12. Return **undefined** (will throw during load phase).

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -185,7 +185,7 @@ loaded by `require()` meets the following requirements:
   1. The file has a `.mjs` extension.
   2. The file has a `.js` extension, and the closest `package.json` contains `"type": "module"`
   3. The file has a `.js` extension, the closest `package.json` does not contain
-     `"type": "commonjs"`, and `--experimental-detect-module` is enabled.
+     `"type": "commonjs"`, and the module contains ES module syntax.
 
 `require()` will load the requested module as an ES Module, and return
 the module namespace object. In this case it is similar to dynamic
@@ -272,7 +272,7 @@ require(X) from module at path Y
 
 MAYBE_DETECT_AND_LOAD(X)
 1. If X parses as a CommonJS module, load X as a CommonJS module. STOP.
-2. Else, if `--experimental-require-module` and `--experimental-detect-module` are
+2. Else, if `--experimental-require-module` is
   enabled, and the source code of X can be parsed as ECMAScript module using
   <a href="esm.md#resolver-algorithm-specification">DETECT_MODULE_SYNTAX defined in
   the ESM resolver</a>,

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -69,14 +69,14 @@ expressions:
 * Strings passed in as an argument to `--eval`, or piped to `node` via `STDIN`,
   with the flag `--input-type=module`.
 
-* When using [`--experimental-detect-module`][], code containing syntax only
-  successfully parsed as [ES modules][], such as `import` or `export`
-  statements or `import.meta`, having no explicit marker of how it should be
-  interpreted. Explicit markers are `.mjs` or `.cjs` extensions, `package.json`
-  `"type"` fields with either `"module"` or `"commonjs"` values, or
-  `--input-type` or `--experimental-default-type` flags. Dynamic `import()`
-  expressions are supported in either CommonJS or ES modules and would not
-  cause a file to be treated as an ES module.
+* Code containing syntax only successfully parsed as [ES modules][], such as
+  `import` or `export` statements or `import.meta`, with no explicit marker of
+  how it should be interpreted. Explicit markers are `.mjs` or `.cjs`
+  extensions, `package.json` `"type"` fields with either `"module"` or
+  `"commonjs"` values, or `--input-type` or `--experimental-default-type` flags.
+  Dynamic `import()` expressions are supported in either CommonJS or ES modules
+  and would not force a file to be treated as an ES module. See
+  [Syntax detection][].
 
 Node.js will treat the following as [CommonJS][] when passed to `node` as the
 initial input, or when referenced by `import` statements or `import()`
@@ -114,6 +114,44 @@ CommonJS. Being explicit about the `type` of the package will future-proof the
 package in case the default type of Node.js ever changes, and it will also make
 things easier for build tools and loaders to determine how the files in the
 package should be interpreted.
+
+### Syntax detection
+
+<!-- YAML
+added:
+  - v21.1.0
+  - v20.10.0
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/53619
+    description: Syntax detection is enabled by default.
+-->
+
+> Stability: 1.2 - Release candidate
+
+Node.js will inspect the source code of ambiguous input to determine whether it
+contains ES module syntax; if such syntax is detected, the input will be treated
+as an ES module.
+
+Ambiguous input is defined as:
+
+* Files with a `.js` extension or no extension; and either no controlling
+  `package.json` file or one that lacks a `type` field; and
+  `--experimental-default-type` is not specified.
+* String input (`--eval` or STDIN) when neither `--input-type` nor
+  `--experimental-default-type` are specified.
+
+ES module syntax is defined as syntax that would throw when evaluated as
+CommonJS. This includes the following:
+
+* `import` statements (but _not_ `import()` expressions, which are valid in
+  CommonJS).
+* `export` statements.
+* `import.meta` references.
+* `await` at the top level of a module.
+* Lexical redeclarations of the CommonJS wrapper variables (`require`, `module`,
+  `exports`, `__dirname`, `__filename`).
 
 ### Modules loaders
 
@@ -1355,6 +1393,7 @@ This field defines [subpath imports][] for the current package.
 [ES modules]: esm.md
 [Node.js documentation for this section]: https://github.com/nodejs/node/blob/HEAD/doc/api/packages.md#conditions-definitions
 [Runtime Keys]: https://runtime-keys.proposal.wintercg.org/
+[Syntax detection]: #syntax-detection
 [WinterCG]: https://wintercg.org/
 [`"exports"`]: #exports
 [`"imports"`]: #imports
@@ -1364,7 +1403,6 @@ This field defines [subpath imports][] for the current package.
 [`"type"`]: #type
 [`--conditions` / `-C` flag]: #resolving-user-conditions
 [`--experimental-default-type`]: cli.md#--experimental-default-typetype
-[`--experimental-detect-module`]: cli.md#--experimental-detect-module
 [`--no-addons` flag]: cli.md#--no-addons
 [`ERR_PACKAGE_PATH_NOT_EXPORTED`]: errors.md#err_package_path_not_exported
 [`esm`]: https://github.com/standard-things/esm#readme

--- a/lib/internal/main/check_syntax.js
+++ b/lib/internal/main/check_syntax.js
@@ -57,23 +57,23 @@ function loadESMIfNeeded(cb) {
 }
 
 async function checkSyntax(source, filename) {
-  let isModule = true;
+  let format;
   if (filename === '[stdin]' || filename === '[eval]') {
-    isModule = getOptionValue('--input-type') === 'module' ||
-      (getOptionValue('--experimental-default-type') === 'module' && getOptionValue('--input-type') !== 'commonjs');
+    format = (getOptionValue('--input-type') === 'module' ||
+      (getOptionValue('--experimental-default-type') === 'module' && getOptionValue('--input-type') !== 'commonjs')) ?
+      'module' : 'commonjs';
   } else {
     const { defaultResolve } = require('internal/modules/esm/resolve');
     const { defaultGetFormat } = require('internal/modules/esm/get_format');
     const { url } = await defaultResolve(pathToFileURL(filename).toString());
-    const format = await defaultGetFormat(new URL(url));
-    isModule = format === 'module';
+    format = await defaultGetFormat(new URL(url));
   }
 
-  if (isModule) {
+  if (format === 'module') {
     const { ModuleWrap } = internalBinding('module_wrap');
     new ModuleWrap(filename, undefined, source, 0, 0);
     return;
   }
 
-  wrapSafe(filename, source, undefined, 'commonjs');
+  wrapSafe(filename, source, undefined, format);
 }

--- a/lib/internal/modules/run_main.js
+++ b/lib/internal/modules/run_main.js
@@ -142,7 +142,7 @@ function runEntryPointWithESMLoader(callback) {
  * by `require('module')`) even when the entry point is ESM.
  * This monkey-patchable code is bypassed under `--experimental-default-type=module`.
  * Because of backwards compatibility, this function is exposed publicly via `import { runMain } from 'node:module'`.
- * When `--experimental-detect-module` is passed, this function will attempt to run ambiguous (no explicit extension, no
+ * Because of module detection, this function will attempt to run ambiguous (no explicit extension, no
  * `package.json` type field) entry points as CommonJS first; under certain conditions, it will retry running as ESM.
  * @param {string} main - First positional CLI argument, such as `'entry.js'` from `node entry.js`
  */

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -356,7 +356,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "when ambiguous modules fail to evaluate because they contain "
             "ES module syntax, try again to evaluate them as ES modules",
             &EnvironmentOptions::detect_module,
-            kAllowedInEnvvar);
+            kAllowedInEnvvar,
+            true);
   AddOption("--experimental-print-required-tla",
             "Print pending top-level await. If --experimental-require-module "
             "is true, evaluate asynchronous graphs loaded by `require()` but "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -110,7 +110,7 @@ class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
   std::vector<std::string> conditions;
-  bool detect_module = false;
+  bool detect_module = true;
   bool print_required_tla = false;
   bool require_module = false;
   std::string dns_result_order;

--- a/test/es-module/test-esm-cjs-exports.js
+++ b/test/es-module/test-esm-cjs-exports.js
@@ -21,9 +21,8 @@ describe('ESM: importing CJS', { concurrency: !process.env.TEST_PARALLEL }, () =
     const invalidEntry = fixtures.path('/es-modules/cjs-exports-invalid.mjs');
     const { code, signal, stderr } = await spawnPromisified(execPath, [invalidEntry]);
 
+    assert.match(stderr, /SyntaxError: The requested module '\.\/invalid-cjs\.js' does not provide an export named 'default'/);
     assert.strictEqual(code, 1);
     assert.strictEqual(signal, null);
-    assert.ok(stderr.includes('Warning: To load an ES module'));
-    assert.ok(stderr.includes('Unexpected token \'export\''));
   });
 });

--- a/test/es-module/test-esm-detect-ambiguous.mjs
+++ b/test/es-module/test-esm-detect-ambiguous.mjs
@@ -4,11 +4,10 @@ import { spawn } from 'node:child_process';
 import { describe, it } from 'node:test';
 import { strictEqual, match } from 'node:assert';
 
-describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALLEL }, () => {
+describe('Module syntax detection', { concurrency: !process.env.TEST_PARALLEL }, () => {
   describe('string input', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('permits ESM syntax in --eval input without requiring --input-type=module', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'import { version } from "node:process"; console.log(version);',
       ]);
@@ -22,9 +21,7 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     // ESM is unsupported for --print via --input-type=module
 
     it('permits ESM syntax in STDIN input without requiring --input-type=module', async () => {
-      const child = spawn(process.execPath, [
-        '--experimental-detect-module',
-      ]);
+      const child = spawn(process.execPath, []);
       child.stdin.end('console.log(typeof import.meta.resolve)');
 
       match((await child.stdout.toArray()).toString(), /^function\r?\n$/);
@@ -32,7 +29,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('should be overridden by --input-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--input-type=commonjs',
         '--eval',
         'import.meta.url',
@@ -46,7 +42,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('should not switch to module if code is parsable as script', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'let __filename,__dirname,require,module,exports;this.a',
       ]);
@@ -59,7 +54,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('should be overridden by --experimental-default-type', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--experimental-default-type=commonjs',
         '--eval',
         'import.meta.url',
@@ -73,7 +67,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('does not trigger detection via source code `eval()`', async () => {
       const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'eval("import \'nonexistent\';");',
       ]);
@@ -115,7 +108,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
           '--no-warnings',
-          '--experimental-detect-module',
           entryPath,
         ]);
 
@@ -157,7 +149,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
           '--no-warnings',
-          '--experimental-detect-module',
           entryPath,
         ]);
 
@@ -171,7 +162,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     it('should not hint wrong format in resolve hook', async () => {
       let writeSync;
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--no-warnings',
         '--loader',
         `data:text/javascript,import { writeSync } from "node:fs"; export ${encodeURIComponent(
@@ -209,7 +199,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--experimental-detect-module',
           entryPath,
         ]);
 
@@ -238,7 +227,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--experimental-detect-module',
           entryPath,
         ]);
 
@@ -254,7 +242,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
   describe('syntax that errors in CommonJS but works in ESM', { concurrency: !process.env.TEST_PARALLEL }, () => {
     it('permits top-level `await`', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); console.log("executed");',
       ]);
@@ -267,7 +254,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('permits top-level `await` above import/export syntax', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'await Promise.resolve(); import "node:os"; console.log("executed");',
       ]);
@@ -280,7 +266,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('still throws on `await` in an ordinary sync function', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'function fn() { await Promise.resolve(); } fn();',
       ]);
@@ -293,7 +278,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('throws on undefined `require` when top-level `await` triggers ESM parsing', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'const fs = require("node:fs"); await Promise.resolve();',
       ]);
@@ -307,7 +291,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     it('permits declaration of CommonJS module variables', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
         '--no-warnings',
-        '--experimental-detect-module',
         fixtures.path('es-modules/package-without-type/commonjs-wrapper-variables.js'),
       ]);
 
@@ -319,7 +302,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('permits declaration of CommonJS module variables above import/export', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'const module = 3; import "node:os"; console.log("executed");',
       ]);
@@ -332,7 +314,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('still throws on double `const` declaration not at the top level', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         '--eval',
         'function fn() { const require = 1; const require = 2; } fn();',
       ]);
@@ -361,7 +342,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
     ]) {
       it(testName, async () => {
         const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-          '--experimental-detect-module',
           entryPath,
         ]);
 
@@ -374,7 +354,6 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
 
     it('warns only once for a package.json that affects multiple files', async () => {
       const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
-        '--experimental-detect-module',
         fixtures.path('es-modules/package-without-type/detected-as-esm.js'),
       ]);
 
@@ -382,6 +361,18 @@ describe('--experimental-detect-module', { concurrency: !process.env.TEST_PARALL
       strictEqual(stderr.match(/MODULE_TYPELESS_PACKAGE_JSON/g).length, 1);
       strictEqual(stdout, 'executed\nexecuted\n');
       strictEqual(code, 0);
+      strictEqual(signal, null);
+    });
+
+    it('can be disabled via --no-experimental-detect-module', async () => {
+      const { stdout, stderr, code, signal } = await spawnPromisified(process.execPath, [
+        '--no-experimental-detect-module',
+        fixtures.path('es-modules/package-without-type/module.js'),
+      ]);
+
+      match(stderr, /SyntaxError: Unexpected token 'export'/);
+      strictEqual(stdout, '');
+      strictEqual(code, 1);
       strictEqual(signal, null);
     });
   });
@@ -410,7 +401,6 @@ describe('Wrapping a `require` of an ES module while using `--abort-on-uncaught-
 describe('when working with Worker threads', () => {
   it('should support sloppy scripts that declare CJS "global-like" variables', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
-      '--experimental-detect-module',
       '--eval',
       'new worker_threads.Worker("let __filename,__dirname,require,module,exports;this.a",{eval:true})',
     ]);

--- a/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
+++ b/test/es-module/test-esm-extensionless-esm-and-wasm.mjs
@@ -60,26 +60,19 @@ describe('extensionless Wasm modules within a "type": "module" package scope', {
 });
 
 describe('extensionless ES modules within no package scope', { concurrency: !process.env.TEST_PARALLEL }, () => {
-  // This succeeds with `--experimental-default-type=module`
-  it('should error as the entry point', async () => {
+  it('should run as the entry point', async () => {
     const { code, signal, stdout, stderr } = await spawnPromisified(process.execPath, [
       fixtures.path('es-modules/noext-esm'),
     ]);
 
-    match(stderr, /SyntaxError/);
-    strictEqual(stdout, '');
-    strictEqual(code, 1);
+    strictEqual(stdout, 'executed\n');
+    strictEqual(stderr, '');
+    strictEqual(code, 0);
     strictEqual(signal, null);
   });
 
-  // This succeeds with `--experimental-default-type=module`
-  it('should error on import', async () => {
-    try {
-      await import(fixtures.fileURL('es-modules/noext-esm'));
-      mustNotCall();
-    } catch (err) {
-      ok(err instanceof SyntaxError);
-    }
+  it('should run on import', async () => {
+    await import(fixtures.fileURL('es-modules/noext-esm'));
   });
 });
 

--- a/test/es-module/test-esm-import-flag.mjs
+++ b/test/es-module/test-esm-import-flag.mjs
@@ -146,9 +146,9 @@ describe('import modules using --import', { concurrency: !process.env.TEST_PARAL
       ]
     );
 
-    assert.match(stderr, /SyntaxError: Unexpected token 'export'/);
+    assert.strictEqual(stderr, '');
     assert.match(stdout, /^\.mjs file\r?\n$/);
-    assert.strictEqual(code, 1);
+    assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });
 

--- a/test/es-module/test-esm-loader-hooks.mjs
+++ b/test/es-module/test-esm-loader-hooks.mjs
@@ -751,15 +751,15 @@ describe('Loader hooks', { concurrency: !process.env.TEST_PARALLEL }, () => {
       '--no-warnings',
       '--experimental-loader',
       `data:text/javascript,import{readFile}from"node:fs/promises";import{fileURLToPath}from"node:url";export ${
-        async function load(u, c, n) {
-          const r = await n(u, c);
-          if (u.endsWith('/common/index.js')) {
-            r.source = '"use strict";module.exports=require("node:module").createRequire(' +
-                     `${JSON.stringify(u)})(${JSON.stringify(fileURLToPath(u))});\n`;
-          } else if (c.format === 'commonjs') {
-            r.source = await readFile(new URL(u));
+        async function load(url, context, nextLoad) {
+          const result = await nextLoad(url, context);
+          if (url.endsWith('/common/index.js')) {
+            result.source = '"use strict";module.exports=require("node:module").createRequire(' +
+                     `${JSON.stringify(url)})(${JSON.stringify(fileURLToPath(url))});\n`;
+          } else if (url.startsWith('file:') && (context.format == null || context.format === 'commonjs')) {
+            result.source = await readFile(new URL(url));
           }
-          return r;
+          return result;
         }}`,
       '--experimental-loader',
       fixtures.fileURL('es-module-loaders/loader-resolve-passthru.mjs'),

--- a/test/es-module/test-esm-resolve-type.mjs
+++ b/test/es-module/test-esm-resolve-type.mjs
@@ -41,8 +41,8 @@ try {
     [ '/es-modules/package-ends-node_modules/index.js', 'module' ],
     [ '/es-modules/package-type-module/index.js', 'module' ],
     [ '/es-modules/package-type-commonjs/index.js', 'commonjs' ],
-    [ '/es-modules/package-without-type/index.js', 'commonjs' ],
-    [ '/es-modules/package-without-pjson/index.js', 'commonjs' ],
+    [ '/es-modules/package-without-type/index.js', null ],
+    [ '/es-modules/package-without-pjson/index.js', null ],
   ].forEach(([ testScript, expectedType ]) => {
     const resolvedPath = path.resolve(fixtures.path(testScript));
     const resolveResult = resolve(url.pathToFileURL(resolvedPath));
@@ -55,11 +55,11 @@ try {
    *
    * for test-module-ne: everything .js that is not 'module' is 'commonjs'
    */
-  for (const [ moduleName, moduleExtenstion, moduleType, expectedResolvedType ] of
+  for (const [ moduleName, moduleExtension, moduleType, expectedResolvedType ] of
     [ [ 'test-module-mainjs', 'js', 'module', 'module'],
       [ 'test-module-mainmjs', 'mjs', 'module', 'module'],
       [ 'test-module-cjs', 'js', 'commonjs', 'commonjs'],
-      [ 'test-module-ne', 'js', undefined, 'commonjs'],
+      [ 'test-module-ne', 'js', undefined, null],
     ]) {
     process.chdir(previousCwd);
     tmpdir.refresh();
@@ -73,14 +73,14 @@ try {
     const mDir = rel(`node_modules/${moduleName}`);
     const subDir = rel(`node_modules/${moduleName}/subdir`);
     const pkg = rel(`node_modules/${moduleName}/package.json`);
-    const script = rel(`node_modules/${moduleName}/subdir/mainfile.${moduleExtenstion}`);
+    const script = rel(`node_modules/${moduleName}/subdir/mainfile.${moduleExtension}`);
 
     createDir(nmDir);
     createDir(mDir);
     createDir(subDir);
     const pkgJsonContent = {
       ...(moduleType !== undefined) && { type: moduleType },
-      main: `subdir/mainfile.${moduleExtenstion}`
+      main: `subdir/mainfile.${moduleExtension}`
     };
     fs.writeFileSync(pkg, JSON.stringify(pkgJsonContent));
     fs.writeFileSync(script,

--- a/test/es-module/test-require-module-detect-entry-point-aou.js
+++ b/test/es-module/test-require-module-detect-entry-point-aou.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-require-module --experimental-detect-module --abort-on-uncaught-exception
+// Flags: --experimental-require-module --abort-on-uncaught-exception
 
 import { mustCall } from '../common/index.mjs';
 const fn = mustCall(() => {

--- a/test/es-module/test-require-module-detect-entry-point.js
+++ b/test/es-module/test-require-module-detect-entry-point.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-require-module --experimental-detect-module
+// Flags: --experimental-require-module
 
 import { mustCall } from '../common/index.mjs';
 const fn = mustCall(() => {

--- a/test/es-module/test-require-module-dont-detect-cjs.js
+++ b/test/es-module/test-require-module-dont-detect-cjs.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-require-module --experimental-detect-module
+// Flags: --experimental-require-module
 'use strict';
 
 require('../common');

--- a/test/es-module/test-require-module-implicit.js
+++ b/test/es-module/test-require-module-implicit.js
@@ -6,18 +6,6 @@
 const common = require('../common');
 const assert = require('assert');
 
-assert.throws(() => {
-  require('../fixtures/es-modules/package-without-type/noext-esm');
-}, {
-  message: /Unexpected token 'export'/
-});
-
-assert.throws(() => {
-  require('../fixtures/es-modules/loose.js');
-}, {
-  message: /Unexpected token 'export'/
-});
-
 {
   // .mjs should not be matched as default extensions.
   const id = '../fixtures/es-modules/should-not-be-resolved';

--- a/test/es-module/test-require-module-with-detection.js
+++ b/test/es-module/test-require-module-with-detection.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-require-module --experimental-detect-module
+// Flags: --experimental-require-module
 'use strict';
 
 const common = require('../common');

--- a/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
+++ b/test/fixtures/es-module-loaders/builtin-named-exports-loader.mjs
@@ -28,7 +28,7 @@ export function load(url, context, next) {
       source: generateBuiltinModule(urlObj.pathname),
       format: 'commonjs',
     };
-  } else if (context.format === 'commonjs') {
+  } else if (context.format === undefined || context.format === null || context.format === 'commonjs') {
     return {
       shortCircuit: true,
       source: readFileSync(new URL(url)),


### PR DESCRIPTION
This is a draft PR to unflag `--experimental-detect-module`. I’m labeling it as don’t land for all current lines unless and until we determine that this isn’t a semver-major change; it should be okay to release as part of 23.0.0, and after that we can decide whether or not to backport.

This PR specifically does two things:

- It turns the `--experimental-detect-module` flag into a noop similar to `--experimental-modules`.
- Per https://github.com/nodejs/node/pull/53044#issuecomment-2195881734 this PR changes the `format` hint returned by Node’s internal `resolve` for ambiguous (no `package.json` `type` field, no `.mjs` or `.cjs` extension) files from `commonjs` to `undefined`. This is more correct, as the format hasn’t yet been determined at the time of resolution, because with detection enabled we need to load the source and parse it to detect the format.

I also updated the tests because of the unflagging:

#### Not breaking changes

- `test/es-module/test-esm-cjs-exports.js` `should error on invalid CJS exports`: Previously this was testing for the error strings `Warning: To load an ES module` and `Unexpected token \'export\'`; now it tests for the error string `SyntaxError: The requested module './invalid-cjs.js' does not provide an export named 'default'`. Arguably the new version is more appropriate as it’s testing the actual thing the test describes rather than testing an error that was thrown before getting to the invalid CommonJS exports.

- `test/es-module/test-esm-import-flag.mjs` `should import when running --check fails`: This test checks that an ESM file passed to `--import` is evaluated with a CommonJS entry passed to `--check` fails the syntax check. The file passed to `--import` is run in both cases, though the previous `SyntaxError` is now a success; but the point of the test is about the `--import` file being evaluated at all, not whether its evaluation was successful.

- `test/es-module/test-require-module-implicit.js`: Some tests were attempting to `require` an ambiguous, extensionless ESM file and expecting an exception with `Unexpected token 'export'`. These tests were removed. This file is run via `--experimental-require-module` so this change shouldn’t be considered breaking.

#### Possibly breaking changes

- `test/es-module/test-esm-detect-ambiguous.mjs` `should not hint wrong format in resolve hook`: Previously this expected a `format` hint of `commonjs` from a `resolve` hook, and now it expects `undefined`, an intentional change. The hooks are still experimental and the `format` hint from `resolve` is documented as optional, so hooks should be written to expect it not to be present; but the unflagging would cause some code that currently returns a hint to no longer do so.

- `test/es-module/test-esm-loader-hooks.mjs` `should use ESM loader to respond to require.resolve calls when opting in`: The `load` hook in this test previously assumed that most files being imported got a `format` of `commonjs`, whereas now many of them are `undefined`, an intentional change. Same impact as previous.

- `test/es-module/test-esm-resolve-type.mjs`: Some tests for a `format` hint of `commonjs` now check for a `format` hint of `undefined`. Same impact as previous.

- `test/es-module/test-esm-extensionless-esm-and-wasm.mjs`: `extensionless ES modules within no package scope`: tests for ambiguous extensionless ESM running as the entry point and ambugious extensionless ESM running via `import()` used to test for exceptions being thrown; now they test for success. Anyone expecting exceptions on running or importing ambiguous or extensionless ESM (for example, to do detection themselves) will be broken by this change.