### PR TITLE
timers: test timeout NaN warning in promises version

### DIFF
--- a/test/parallel/test-timers-nan-duration-warning-promises.js
+++ b/test/parallel/test-timers-nan-duration-warning-promises.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { setTimeout } = require('timers/promises');
+
+process.once('warning', common.mustCall((warning) => {
+  assert.strictEqual(warning.name, 'TimeoutNaNWarning');
+}));
+
+setTimeout(NaN).catch(common.mustNotCall());

--- a/test/parallel/test-timers-nan-duration-warning-promises.js
+++ b/test/parallel/test-timers-nan-duration-warning-promises.js
@@ -8,4 +8,4 @@ process.once('warning', common.mustCall((warning) => {
   assert.strictEqual(warning.name, 'TimeoutNaNWarning');
 }));
 
-setTimeout(NaN).catch(common.mustNotCall());
+setTimeout(NaN).then(common.mustCall(), common.mustNotCall());


### PR DESCRIPTION
Hey, https://github.com/nodejs/node/pull/46678 landed adding a warning when NaN is passed to timers. I noticed a test was missing for timers/promises there (the code works on both paths) - rather than holding that PR I figured we'd land it and I'd PR a test for timers/promises in a separate PR.

cc @jakecastelli 

Refs: https://github.com/nodejs/node/pull/46678