### PR TITLE
http, readline: replace sort with toSorted

### DIFF
--- a/lib/internal/readline/utils.js
+++ b/lib/internal/readline/utils.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const {
-  ArrayPrototypeSlice,
-  ArrayPrototypeSort,
+  ArrayPrototypeToSorted,
   RegExpPrototypeExec,
   StringFromCharCode,
   StringPrototypeCharCodeAt,
@@ -385,7 +384,7 @@ function commonPrefix(strings) {
   if (strings.length === 1) {
     return strings[0];
   }
-  const sorted = ArrayPrototypeSort(ArrayPrototypeSlice(strings));
+  const sorted = ArrayPrototypeToSorted(strings);
   const min = sorted[0];
   const max = sorted[sorted.length - 1];
   for (let i = 0; i < min.length; i++) {

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -128,6 +128,7 @@ declare namespace primordials {
   export const ArrayPrototypeSlice: UncurryThis<typeof Array.prototype.slice>
   export const ArrayPrototypeSort: UncurryThis<typeof Array.prototype.sort>
   export const ArrayPrototypeSplice: UncurryThis<typeof Array.prototype.splice>
+  export const ArrayPrototypeToSorted: UncurryThis<typeof Array.prototype.toSorted>
   export const ArrayPrototypeIncludes: UncurryThis<typeof Array.prototype.includes>
   export const ArrayPrototypeIndexOf: UncurryThis<typeof Array.prototype.indexOf>
   export const ArrayPrototypeJoin: UncurryThis<typeof Array.prototype.join>


### PR DESCRIPTION
Just a minor chore, Richard's set.difference PR reminded me our V8 is new enough to support toSorted and we can avoid `.slice().sort(...)`. 