### PR TITLE
fs: add v8 fast api to closeSync

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1841,12 +1841,23 @@ void Environment::AddUnmanagedFd(int fd) {
   }
 }
 
-void Environment::RemoveUnmanagedFd(int fd) {
+void Environment::RemoveUnmanagedFd(int fd, bool schedule_native_immediate) {
   if (!tracks_unmanaged_fds()) return;
   size_t removed_count = unmanaged_fds_.erase(fd);
   if (removed_count == 0) {
-    ProcessEmitWarning(
-        this, "File descriptor %d closed but not opened in unmanaged mode", fd);
+    if (schedule_native_immediate) {
+      SetImmediateThreadsafe([&](Environment* env) {
+        ProcessEmitWarning(this,
+                           "File descriptor %d closed but not opened in "
+                           "unmanaged mode",
+                           fd);
+      });
+    } else {
+      ProcessEmitWarning(
+          this,
+          "File descriptor %d closed but not opened in unmanaged mode",
+          fd);
+    }
   }
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -1027,7 +1027,7 @@ class Environment : public MemoryRetainer {
   std::unique_ptr<v8::BackingStore> release_managed_buffer(const uv_buf_t& buf);
 
   void AddUnmanagedFd(int fd);
-  void RemoveUnmanagedFd(int fd);
+  void RemoveUnmanagedFd(int fd, bool schedule_native_immediate = false);
 
   template <typename T>
   void ForEachRealm(T&& iterator) const;

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -47,6 +47,9 @@ using CFunctionCallbackWithUint8ArrayUint32Int64Bool =
                 uint32_t,
                 int64_t,
                 bool);
+using CFunctionWithObjectInt32Fallback = void (*)(v8::Local<v8::Object>,
+                                                  int32_t input,
+                                                  v8::FastApiCallbackOptions&);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
 using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
@@ -75,6 +78,7 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithTwoUint8Arrays)                                       \
   V(CFunctionCallbackWithTwoUint8ArraysFallback)                               \
   V(CFunctionCallbackWithUint8ArrayUint32Int64Bool)                            \
+  V(CFunctionWithObjectInt32Fallback)                                          \
   V(CFunctionWithUint32)                                                       \
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \


### PR DESCRIPTION
Adds V8 Fast API to `fs.closeSync(fd)` implementation

cc @nodejs/performance @nodejs/fs @nodejs/cpp-reviewers 