### PR TITLE
fs: move `ToNamespacedPath` dir calls to c++

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -157,7 +157,7 @@ class Dir {
     const path = pathModule.join(dirent.parentPath, dirent.name);
     const ctx = { path };
     const handle = dirBinding.opendir(
-      pathModule.toNamespacedPath(path),
+      path,
       this.#options.encoding,
       undefined,
       ctx,
@@ -307,7 +307,7 @@ function opendir(path, options, callback) {
   req.oncomplete = opendirCallback;
 
   dirBinding.opendir(
-    pathModule.toNamespacedPath(path),
+    path,
     options.encoding,
     req,
   );
@@ -317,9 +317,7 @@ function opendirSync(path, options) {
   path = getValidatedPath(path);
   options = getOptions(options, { encoding: 'utf8' });
 
-  const handle = dirBinding.opendirSync(
-    pathModule.toNamespacedPath(path),
-  );
+  const handle = dirBinding.opendirSync(path);
 
   return new Dir(handle, path, options);
 }

--- a/src/node_dir.cc
+++ b/src/node_dir.cc
@@ -3,6 +3,7 @@
 #include "node_external_reference.h"
 #include "node_file-inl.h"
 #include "node_process-inl.h"
+#include "path.h"
 #include "permission/permission.h"
 #include "util.h"
 
@@ -367,6 +368,7 @@ static void OpenDir(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
+  ToNamespacedPath(env, &path);
 
   const enum encoding encoding = ParseEncoding(isolate, args[1], UTF8);
 
@@ -410,6 +412,7 @@ static void OpenDirSync(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, args[0]);
   CHECK_NOT_NULL(*path);
+  ToNamespacedPath(env, &path);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
 


### PR DESCRIPTION
Moves `toNamespacedPath` calls to C++ just like the rest of `node:fs`