### PR TITLE
fs: reduce throwing unnecessary errors on glob

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -38,12 +38,30 @@ function lazyMinimatch() {
 const isWindows = process.platform === 'win32';
 const isOSX = process.platform === 'darwin';
 
+/**
+ * @param {string} path
+ * @returns {Promise<DirentFromStats|null>}
+ */
 async function getDirent(path) {
-  return new DirentFromStats(basename(path), await lstat(path), path);
+  let stat;
+  try {
+    stat = await lstat(path);
+  } catch {
+    return null;
+  }
+  return new DirentFromStats(basename(path), stat, path);
 }
 
+/**
+ * @param {string} path
+ * @returns {DirentFromStats|null}
+ */
 function getDirentSync(path) {
-  return new DirentFromStats(basename(path), lstatSync(path), path);
+  const stat = lstatSync(path, { throwIfNoEntry: false });
+  if (stat === undefined) {
+    return null;
+  }
+  return new DirentFromStats(basename(path), stat, path);
 }
 
 class Cache {
@@ -56,7 +74,7 @@ class Cache {
     if (cached) {
       return cached;
     }
-    const promise = PromisePrototypeThen(getDirent(path), null, () => null);
+    const promise = getDirent(path);
     this.#statsCache.set(path, promise);
     return promise;
   }
@@ -65,12 +83,7 @@ class Cache {
     if (cached) {
       return cached;
     }
-    let val;
-    try {
-      val = getDirentSync(path);
-    } catch {
-      val = null;
-    }
+    const val = getDirentSync(path);
     this.#statsCache.set(path, val);
     return val;
   }


### PR DESCRIPTION
Removes unnecessary error thrown when lstatSync is called without `throwIfNoEntry` option.