### PR TITLE
tls: add setKeyCert() to tls.Socket

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1533,6 +1533,20 @@ When running as the server, the socket will be destroyed with an error after
 For TLSv1.3, renegotiation cannot be initiated, it is not supported by the
 protocol.
 
+### `tlsSocket.setKeyCert(context)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `context` {Object|tls.SecureContext} An object containing at least `key` and
+  `cert` properties from the [`tls.createSecureContext()`][] `options`, or a
+  TLS context object created with [`tls.createSecureContext()`][] itself.
+
+The `tlsSocket.setKeyCert()` method sets the private key and certificate to use
+for the socket. This is mainly useful if you wish to select a server certificate
+from a TLS server's `ALPNCallback`.
+
 ### `tlsSocket.setMaxSendFragment(size)`
 
 <!-- YAML

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1153,6 +1153,17 @@ TLSSocket.prototype.getX509Certificate = function() {
   return cert ? new InternalX509Certificate(cert) : undefined;
 };
 
+TLSSocket.prototype.setKeyCert = function(context) {
+  if (this._handle) {
+    let secureContext;
+    if (context instanceof common.SecureContext)
+      secureContext = context;
+    else
+      secureContext = tls.createSecureContext(context);
+    this._handle.setKeyCert(secureContext.context);
+  }
+};
+
 // Proxy TLSSocket handle methods
 function makeSocketMethodProxy(name) {
   return function socketMethodProxy(...args) {

--- a/src/crypto/crypto_tls.h
+++ b/src/crypto/crypto_tls.h
@@ -213,6 +213,7 @@ class TLSWrap : public AsyncWrap,
   static void Renegotiate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void RequestOCSP(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetALPNProtocols(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetKeyCert(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetOCSPResponse(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetServername(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetSession(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-tls-server-setkeycert.js
+++ b/test/parallel/test-tls-server-setkeycert.js
@@ -1,0 +1,56 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { X509Certificate } = require('crypto');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const altKeyCert = {
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem'),
+  minVersion: 'TLSv1.2',
+};
+
+const altKeyCertVals = [
+  altKeyCert,
+  tls.createSecureContext(altKeyCert),
+];
+
+(function next() {
+  if (!altKeyCertVals.length)
+    return;
+  const altKeyCertVal = altKeyCertVals.shift();
+  const options = {
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem'),
+    minVersion: 'TLSv1.3',
+    ALPNCallback: common.mustCall(function({ servername, protocols }) {
+      this.setKeyCert(altKeyCertVal);
+      assert.deepStrictEqual(protocols, ['acme-tls/1']);
+      return protocols[0];
+    }),
+  };
+
+  tls.createServer(options, (s) => s.end()).listen(0, function() {
+    this.on('connection', common.mustCall((socket) => this.close()));
+
+    tls.connect({
+      port: this.address().port,
+      rejectUnauthorized: false,
+      ALPNProtocols: ['acme-tls/1'],
+    }, common.mustCall(function() {
+      assert.strictEqual(this.getProtocol(), 'TLSv1.3');
+      const altCert = new X509Certificate(altKeyCert.cert);
+      assert.strictEqual(
+        this.getPeerX509Certificate().raw.equals(altCert.raw),
+        true
+      );
+      this.end();
+      next();
+    }));
+  });
+})();


### PR DESCRIPTION
This is mostly useful for implementing the ACME TLS-ALPN-01 challenge by overriding the certificate from a TLS server's `ALPNCallback`.