### PR TITLE
doc: include node.module_timer on available categories

### DIFF
--- a/doc/api/tracing.md
+++ b/doc/api/tracing.md
@@ -46,6 +46,7 @@ The available categories are:
   `runInNewContext()`, `runInContext()`, and `runInThisContext()` methods.
 * `v8`: The [V8][] events are GC, compiling, and execution related.
 * `node.http`: Enables capture of trace data for http request / response.
+* `node.module_timer`: Enables capture of trace data for CJS Module loading.
 
 By default the `node`, `node.async_hooks`, and `v8` categories are enabled.
 


### PR DESCRIPTION
Adding missing category on docs of available categories that was introduced by https://github.com/nodejs/node/pull/52213.