### PR TITLE
test: allow recursion in testing

### DIFF
--- a/test/sequential/testcfg.py
+++ b/test/sequential/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.SimpleTestConfiguration(context, root, 'sequential')
+  return testpy.SimpleTestConfiguration(context, root, 'sequential', allow_recursion=True)

--- a/tools/test.py
+++ b/tools/test.py
@@ -1596,6 +1596,7 @@ def ArgsToTestPaths(test_root, args, suites):
   subsystem_regex = re.compile(r'^[a-zA-Z-]*$')
   check = lambda arg: subsystem_regex.match(arg) and (arg not in suites)
   mapped_args = ["*/test*-%s-*" % arg if check(arg) else arg for arg in args]
+  mapped_args += ["*/%s/test*" % arg for arg in args]
   paths = [SplitPath(NormalizePath(a)) for a in mapped_args]
   return paths
 


### PR DESCRIPTION
This pull request introduces recursion to the test runner. Previous attempts were unsuccessful due to issues in certain directories that did not handle recursion correctly. This PR specifically enables recursion for the `parallel` and `sequential` directories.

Other testing directories haven't been changed, as enabling recursion with them ending in coverage errors.