### PR TITLE
test_runner: support module detection in module mocks

### DIFF
--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -513,7 +513,9 @@ class MockTracker {
       mockSpecifier, caller, null,
     );
     debug('module mock, url = "%s", format = "%s", caller = "%s"', url, format, caller);
-    validateOneOf(format, 'format', kSupportedFormats);
+    if (format) { // Format is not yet known for ambiguous files when detection is enabled.
+      validateOneOf(format, 'format', kSupportedFormats);
+    }
     const baseURL = URL.parse(url);
 
     if (!baseURL) {

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -143,26 +143,34 @@ async function load(url, context, nextLoad) {
   const baseURL = parsedURL ? parsedURL.href : url;
   const mock = mocks.get(baseURL);
 
+  const original = await nextLoad(url, context);
   debug('load hook, mock = %o', mock);
   if (mock?.active !== true) {
-    return nextLoad(url);
+    return original;
   }
 
   // Treat builtins as commonjs because customization hooks do not allow a
   // core module to be replaced.
-  const format = mock.format === 'builtin' ? 'commonjs' : mock.format;
+  // Also collapse 'commonjs-sync' and 'require-commonjs' to 'commonjs'.
+  const format = (
+    original.format === 'builtin' ||
+    original.format === 'commonjs-sync' ||
+    original.format === 'require-commonjs') ? 'commonjs' : original.format;
 
-  return {
+  const result = {
     __proto__: null,
     format,
     shortCircuit: true,
-    source: await createSourceFromMock(mock),
+    source: await createSourceFromMock(mock, format),
   };
+
+  debug('load hook finished, result = %o', result);
+  return result;
 }
 
-async function createSourceFromMock(mock) {
+async function createSourceFromMock(mock, format) {
   // Create mock implementation from provided exports.
-  const { exportNames, format, hasDefaultExport, url } = mock;
+  const { exportNames, hasDefaultExport, url } = mock;
   const useESM = format === 'module';
   const source = `${testImportSource(useESM)}
 if (!$__test.mock._mockExports.has('${url}')) {


### PR DESCRIPTION
- Resolves #53634.

The tests in `test-runner-module-mocking.js` fail when module detection is enabled; you can see by running the following on current `main`:

```shell
./node --experimental-test-module-mocks --experimental-require-module --experimental-detect-module \
./test/parallel/test-runner-module-mocking.js
```

(The first two flags are present already at the top of `test-runner-module-mocking.js`.)

I think that this means that the test runner module mocking feature is already broken for anyone trying to use it along with `--experimental-detect-module`; and of course this becomes all the more urgent to fix as we hopefully unflag `--experimental-detect-module` (https://github.com/nodejs/node/pull/53619).

The issue stems from the module mocking using resolution to determine the format to use for what kind of source to generate for the mock, CommonJS or ESM. [The `format` property returned from the `resolve` hook is optional](https://nodejs.org/api/module.html#resolvespecifier-context-nextresolve), so this approach is an unsafe one; it breaks not only when detection is enabled, but also if the user registers a custom `resolve` hook that doesn’t return a `format` property.

I’ve updated the logic to instead use the `format` property returned by the next `load` hook in the chain, which is usually Node’s internal `defaultLoad`. The `format` property is required to be returned from `load` hooks, so this should be a safe approach. The only potential complication is that this requires the module to be mocked to actually exist on disk, so that `nextLoad` succeeds; it’s unclear to me whether this was an expected requirement previously. (There were no tests for mocking nonexistent modules.) I think it should be acceptable, because generally users would be mocking existing things? If mocking nonexistent modules is a requirement, we will need to take another approach or add a fallback approach for that condition.

cc @cjihrig @nodejs/test_runner 