### PR TITLE
lib: make navigator properties lazy

### DIFF
--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -78,10 +78,10 @@ function getNavigatorPlatform(process) {
 class Navigator {
   // Private properties are used to avoid brand validations.
   #availableParallelism;
-  #userAgent = `Node.js/${StringPrototypeSlice(nodeVersion, 1, StringPrototypeIndexOf(nodeVersion, '.'))}`;
-  #platform = getNavigatorPlatform(process);
-  #language = Intl?.Collator().resolvedOptions().locale || 'en-US';
-  #languages = ObjectFreeze([this.#language]);
+  #userAgent;
+  #platform;
+  #language;
+  #languages;
 
   constructor() {
     if (arguments[0] === kInitialize) {
@@ -102,6 +102,7 @@ class Navigator {
    * @return {string}
    */
   get language() {
+    this.#language ??= Intl?.Collator().resolvedOptions().locale || 'en-US';
     return this.#language;
   }
 
@@ -109,6 +110,7 @@ class Navigator {
    * @return {Array<string>}
    */
   get languages() {
+    this.#languages ??= ObjectFreeze([this.language]);
     return this.#languages;
   }
 
@@ -116,6 +118,7 @@ class Navigator {
    * @return {string}
    */
   get userAgent() {
+    this.#userAgent ??= `Node.js/${StringPrototypeSlice(nodeVersion, 1, StringPrototypeIndexOf(nodeVersion, '.'))}`;
     return this.#userAgent;
   }
 
@@ -123,6 +126,7 @@ class Navigator {
    * @return {string}
    */
   get platform() {
+    this.#platform ??= getNavigatorPlatform(process);
     return this.#platform;
   }
 }


### PR DESCRIPTION
Noticed in some benchmarking/profiling that the Navigator object constructor was rather expensive and slow due to initialization of properties during construction. It makes more sense for these to be lazily initialized on first access.

Flamegraphs... of `node -pe "navigator"

Before:
![image](https://github.com/nodejs/node/assets/439929/63ca34b8-0bde-4ad2-b3d9-711faf64b5b9)

After:
![image](https://github.com/nodejs/node/assets/439929/d032bc99-5e83-4026-95e0-456f6147d9b1)
