### PR TITLE
lib: move `ToNamespacedPath` call to c++

### DIFF
--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -6,7 +6,6 @@ const {
 
 const { getOptionValue } = require('internal/options');
 const { getValidatedPath } = require('internal/fs/utils');
-const pathModule = require('path');
 const fsBindings = internalBinding('fs');
 const { fs: fsConstants } = internalBinding('constants');
 
@@ -48,9 +47,7 @@ function mimeToFormat(mime) {
  */
 function getFormatOfExtensionlessFile(url) {
   if (!experimentalWasmModules) { return 'module'; }
-
-  const path = pathModule.toNamespacedPath(getValidatedPath(url));
-
+  const path = getValidatedPath(url);
   switch (fsBindings.getFormatOfExtensionlessFile(path)) {
     case fsConstants.EXTENSIONLESS_FORMAT_WASM:
       return 'wasm';

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2966,8 +2966,8 @@ static void GetFormatOfExtensionlessFile(
   CHECK(args[0]->IsString());
 
   Environment* env = Environment::GetCurrent(args);
-  node::Utf8Value input(args.GetIsolate(), args[0]);
-
+  BufferValue input(args.GetIsolate(), args[0]);
+  ToNamespacedPath(env, &input);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemRead, input.ToStringView());
 


### PR DESCRIPTION
Moves toNamespacedPath call from JS to C++.