### PR TITLE
v8: move `ToNamespacedPath` to c++

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -53,7 +53,6 @@ const { copy } = internalBinding('buffer');
 const { inspect } = require('internal/util/inspect');
 const { FastBuffer } = require('internal/buffer');
 const { getValidatedPath } = require('internal/fs/utils');
-const { toNamespacedPath } = require('path');
 const {
   createHeapSnapshotStream,
   triggerHeapSnapshot,
@@ -78,7 +77,6 @@ const { getOptionValue } = require('internal/options');
 function writeHeapSnapshot(filename, options) {
   if (filename !== undefined) {
     filename = getValidatedPath(filename);
-    filename = toNamespacedPath(filename);
   }
   const optionArray = getHeapSnapshotOptions(options);
   return triggerHeapSnapshot(filename, optionArray);

--- a/src/heap_utils.cc
+++ b/src/heap_utils.cc
@@ -2,6 +2,7 @@
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node_external_reference.h"
+#include "path.h"
 #include "permission/permission.h"
 #include "stream_base-inl.h"
 #include "util-inl.h"
@@ -468,6 +469,7 @@ void TriggerHeapSnapshot(const FunctionCallbackInfo<Value>& args) {
 
   BufferValue path(isolate, filename_v);
   CHECK_NOT_NULL(*path);
+  ToNamespacedPath(env, &path);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
   if (WriteSnapshot(env, *path, options).IsNothing()) return;


### PR DESCRIPTION
Moves toNamespacedPath call from JS to C++.