### PR TITLE
esm: remove unnecessary toNamespacedPath calls

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -27,7 +27,7 @@ const { BuiltinModule } = require('internal/bootstrap/realm');
 const { realpathSync } = require('fs');
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
-const { sep, posix: { relative: relativePosixPath }, toNamespacedPath, resolve } = require('path');
+const { sep, posix: { relative: relativePosixPath }, resolve } = require('path');
 const preserveSymlinks = getOptionValue('--preserve-symlinks');
 const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalNetworkImports =
@@ -246,8 +246,8 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
     throw err;
   }
 
-  const stats = internalFsBinding.internalModuleStat(toNamespacedPath(StringPrototypeEndsWith(path, '/') ?
-    StringPrototypeSlice(path, -1) : path));
+  const stats = internalFsBinding.internalModuleStat(StringPrototypeEndsWith(path, '/') ?
+    StringPrototypeSlice(path, -1) : path);
 
   // Check for stats.isDirectory()
   if (stats === 1) {
@@ -807,7 +807,7 @@ function packageResolve(specifier, base, conditions) {
   let lastPath;
   do {
     const stat = internalFsBinding.internalModuleStat(
-      toNamespacedPath(StringPrototypeSlice(packageJSONPath, 0, packageJSONPath.length - 13)),
+      StringPrototypeSlice(packageJSONPath, 0, packageJSONPath.length - 13),
     );
     // Check for !stat.isDirectory()
     if (stat !== 1) {


### PR DESCRIPTION
`toNamespacedPath` is already called on `internalModuleStat` C++ implementation. We don't need it.