### PR TITLE
fs: move watchers `ToNamespacedPath` calls to C++

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -25,7 +25,6 @@ const {
 } = internalBinding('fs');
 
 const { FSEvent } = internalBinding('fs_event_wrap');
-const { UV_ENOSPC } = internalBinding('uv');
 const { EventEmitter } = require('events');
 
 const {
@@ -37,8 +36,6 @@ const {
   defaultTriggerAsyncIdScope,
   symbols: { owner_symbol },
 } = require('internal/async_hooks');
-
-const { toNamespacedPath } = require('path');
 
 const {
   validateAbortSignal,
@@ -117,16 +114,7 @@ StatWatcher.prototype[kFSStatWatcherStart] = function(filename,
 
   filename = getValidatedPath(filename, 'filename');
   validateUint32(interval, 'interval');
-  const err = this._handle.start(toNamespacedPath(filename), interval);
-  if (err) {
-    const error = new UVException({
-      errno: err,
-      syscall: 'watch',
-      path: filename,
-    });
-    error.filename = filename;
-    throw error;
-  }
+  this._handle.start(filename, interval);
 };
 
 // To maximize backward-compatibility for the end user,
@@ -239,21 +227,12 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
 
   filename = getValidatedPath(filename, 'filename');
 
-  const err = this._handle.start(toNamespacedPath(filename),
-                                 persistent,
-                                 recursive,
-                                 encoding);
-  if (err) {
-    const error = new UVException({
-      errno: err,
-      syscall: 'watch',
-      path: filename,
-      message: err === UV_ENOSPC ?
-        'System limit for number of file watchers reached' : '',
-    });
-    error.filename = filename;
-    throw error;
-  }
+  this._handle.start(
+    filename,
+    persistent,
+    recursive,
+    encoding,
+  );
 };
 
 // To maximize backward-compatibility for the end user,
@@ -302,7 +281,7 @@ ObjectDefineProperty(FSEvent.prototype, 'owner', {
 let kResistStopPropagation;
 
 async function* watch(filename, options = kEmptyObject) {
-  const path = toNamespacedPath(getValidatedPath(filename));
+  const path = getValidatedPath(filename);
   validateObject(options, 'options');
 
   const {
@@ -352,19 +331,7 @@ async function* watch(filename, options = kEmptyObject) {
       resolve({ eventType, filename });
     };
 
-    const err = handle.start(path, persistent, recursive, encoding);
-    if (err) {
-      const error = new UVException({
-        errno: err,
-        syscall: 'watch',
-        path: filename,
-        message: err === UV_ENOSPC ?
-          'System limit for number of file watchers reached' : '',
-      });
-      error.filename = filename;
-      handle.close();
-      throw error;
-    }
+    handle.start(path, persistent, recursive, encoding);
 
     while (!signal?.aborted) {
       yield await promise;

--- a/test/parallel/test-fs-watch-enoent.js
+++ b/test/parallel/test-fs-watch-enoent.js
@@ -10,6 +10,7 @@ if (common.isIBMi)
 
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 const tmpdir = require('../common/tmpdir');
 const nonexistentFile = tmpdir.resolve('non-existent');
 const { internalBinding } = require('internal/test/binding');
@@ -22,17 +23,13 @@ tmpdir.refresh();
 
 {
   const validateError = (err) => {
-    assert.strictEqual(err.path, nonexistentFile);
-    assert.strictEqual(err.filename, nonexistentFile);
+    assert.strictEqual(err.path, path.toNamespacedPath(nonexistentFile));
+    assert.strictEqual(err.filename, path.toNamespacedPath(nonexistentFile));
     assert.ok(err.syscall === 'watch' || err.syscall === 'stat');
     if (err.code === 'ENOENT') {
-      assert.ok(err.message.startsWith('ENOENT: no such file or directory'));
       assert.strictEqual(err.errno, UV_ENOENT);
       assert.strictEqual(err.code, 'ENOENT');
     } else {  // AIX
-      assert.strictEqual(
-        err.message,
-        `ENODEV: no such device, watch '${nonexistentFile}'`);
       assert.strictEqual(err.errno, UV_ENODEV);
       assert.strictEqual(err.code, 'ENODEV');
     }
@@ -52,11 +49,8 @@ tmpdir.refresh();
     const watcher = fs.watch(file, common.mustNotCall());
 
     const validateError = (err) => {
-      assert.strictEqual(err.path, nonexistentFile);
-      assert.strictEqual(err.filename, nonexistentFile);
-      assert.strictEqual(
-        err.message,
-        `ENOENT: no such file or directory, watch '${nonexistentFile}'`);
+      assert.strictEqual(err.path, path.toNamespacedPath(nonexistentFile));
+      assert.strictEqual(err.filename, path.toNamespacedPath(nonexistentFile));
       assert.strictEqual(err.errno, UV_ENOENT);
       assert.strictEqual(err.code, 'ENOENT');
       assert.strictEqual(err.syscall, 'watch');


### PR DESCRIPTION
Removes `toNamespacedPath` calls in `fs/watchers.js` and moves it to C++