### PR TITLE
src: move `loadEnvFile` toNamespacedPath call

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -47,7 +47,6 @@ const {
   validateObject,
 } = require('internal/validators');
 const { getValidatedPath } = require('internal/fs/utils');
-const { toNamespacedPath } = require('path');
 const constants = internalBinding('constants').os.signals;
 
 const kInternal = Symbol('internal properties');
@@ -255,7 +254,7 @@ function wrapProcessMethods(binding) {
   function loadEnvFile(path = undefined) { // Provide optional value so that `loadEnvFile.length` returns 0
     if (path != null) {
       path = getValidatedPath(path);
-      _loadEnvFile(toNamespacedPath(path));
+      _loadEnvFile(path);
     } else {
       _loadEnvFile();
     }

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -9,6 +9,7 @@
 #include "node_external_reference.h"
 #include "node_internals.h"
 #include "node_process-inl.h"
+#include "path.h"
 #include "util-inl.h"
 #include "uv.h"
 #include "v8-fast-api-calls.h"
@@ -474,7 +475,8 @@ static void LoadEnvFile(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   std::string path = ".env";
   if (args.Length() == 1) {
-    Utf8Value path_value(args.GetIsolate(), args[0]);
+    BufferValue path_value(args.GetIsolate(), args[0]);
+    ToNamespacedPath(env, &path_value);
     path = path_value.ToString();
   }
 


### PR DESCRIPTION
Removes `toNamespacedPath` call, and moves it into C++.