### PR TITLE
test: fix embedding test for Windows

### DIFF
--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const { spawnSync, execFileSync } = require('child_process');
 const common = require('./');
+const os = require('os');
 const util = require('util');
 
 // Workaround for Windows Server 2008R2
@@ -43,6 +44,9 @@ function logAfterTime(time) {
 }
 
 function checkOutput(str, check) {
+  if (common.isWindows && typeof str === 'string') {
+    str = str.replaceAll(os.EOL, '\n');
+  }
   if ((check instanceof RegExp && !check.test(str)) ||
     (typeof check === 'string' && check !== str)) {
     return { passed: false, reason: `did not match ${util.inspect(check)}` };

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -45,7 +45,11 @@ function logAfterTime(time) {
 
 function checkOutput(str, check) {
   if (common.isWindows && typeof str === 'string') {
+    // Normalize the line endings for the output and the check strings.
     str = str.replaceAll(os.EOL, '\n');
+    if (typeof check === 'string') {
+      check = check.replaceAll(os.EOL, '\n');
+    }
   }
   if ((check instanceof RegExp && !check.test(str)) ||
     (typeof check === 'string' && check !== str)) {

--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -3,7 +3,6 @@
 const assert = require('assert');
 const { spawnSync, execFileSync } = require('child_process');
 const common = require('./');
-const os = require('os');
 const util = require('util');
 
 // Workaround for Windows Server 2008R2
@@ -44,13 +43,6 @@ function logAfterTime(time) {
 }
 
 function checkOutput(str, check) {
-  if (common.isWindows && typeof str === 'string') {
-    // Normalize the line endings for the output and the check strings.
-    str = str.replaceAll(os.EOL, '\n');
-    if (typeof check === 'string') {
-      check = check.replaceAll(os.EOL, '\n');
-    }
-  }
   if ((check instanceof RegExp && !check.test(str)) ||
     (typeof check === 'string' && check !== str)) {
     return { passed: false, reason: `did not match ${util.inspect(check)}` };

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -152,12 +152,6 @@ for (const extraSnapshotArgs of [
     { cwd: tmpdir.path });
 }
 
-// Skipping rest of the test on Windows because it fails in the CI
-// TODO(StefanStojanovic): Reenable rest of the test after fixing it
-if (common.isWindows) {
-  return;
-}
-
 // Guarantee NODE_REPL_EXTERNAL_MODULE won't bypass kDisableNodeOptionsEnv
 {
   spawnSyncAndExit(

--- a/test/embedding/test-embedding.js
+++ b/test/embedding/test-embedding.js
@@ -10,6 +10,7 @@ const {
 } = require('../common/child_process');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 tmpdir.refresh();
 common.allowGlobals(global.require);
@@ -166,6 +167,6 @@ for (const extraSnapshotArgs of [
     {
       status: 9,
       signal: null,
-      stderr: `${binary}: NODE_REPL_EXTERNAL_MODULE can't be used with kDisableNodeOptionsEnv\n`,
+      stderr: `${binary}: NODE_REPL_EXTERNAL_MODULE can't be used with kDisableNodeOptionsEnv${os.EOL}`,
     });
 }


### PR DESCRIPTION
PR #52905 had added a new test case for embedding test which was failing for Windows.
The reason was that the expected error message has the Posix-specific line ending `\n` while on Windows the output string contains `\r\n`:
```JavaScript
stderr: `${binary}: NODE_REPL_EXTERNAL_MODULE can't be used with kDisableNodeOptionsEnv\n`,
```
PR #52905 temporary disabled this new test case for Windows.

This PR removes the temporary test disablement for Windows and implements the fix by replacing `\n` in the test with `os.EOL`. After this change the embedding test is passing for Windows.

