### PR TITLE
path: use the correct name in `validateString`

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -776,7 +776,7 @@ const win32 = {
    */
   basename(path, suffix) {
     if (suffix !== undefined)
-      validateString(suffix, 'ext');
+      validateString(suffix, 'suffix');
     validateString(path, 'path');
     let start = 0;
     let end = -1;
@@ -1336,7 +1336,7 @@ const posix = {
    */
   basename(path, suffix) {
     if (suffix !== undefined)
-      validateString(suffix, 'ext');
+      validateString(suffix, 'suffix');
     validateString(path, 'path');
 
     let start = 0;


### PR DESCRIPTION
The change in https://github.com/nodejs/node/commit/4a8b8d576746ceb9d2fd74c2efec7a3543423c0a seems to have forgotten to update the name of the parameter in the `validateString` function.