### PR TITLE
fs: improve async error performance

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -4,7 +4,6 @@ const {
   ArrayPrototypePop,
   ArrayPrototypePush,
   Error,
-  ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   MathMax,
   MathMin,
@@ -141,15 +140,6 @@ function lazyFsStreams() {
 }
 
 const lazyRimRaf = getLazy(() => require('internal/fs/rimraf').rimrafPromises);
-
-// By the time the C++ land creates an error for a promise rejection (likely from a
-// libuv callback), there is already no JS frames on the stack. So we need to
-// wait until V8 resumes execution back to JS land before we have enough information
-// to re-capture the stack trace.
-function handleErrorFromBinding(error) {
-  ErrorCaptureStackTrace(error, handleErrorFromBinding);
-  return PromiseReject(error);
-}
 
 class FileHandle extends EventEmitter {
   /**
@@ -516,11 +506,7 @@ async function readFileHandle(filehandle, options) {
 
   checkAborted(signal);
 
-  const statFields = await PromisePrototypeThen(
-    binding.fstat(filehandle.fd, false, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  const statFields = await binding.fstat(filehandle.fd, false, kUsePromises);
 
   checkAborted(signal);
 
@@ -552,11 +538,7 @@ async function readFileHandle(filehandle, options) {
       length = MathMin(size - totalRead, kReadFileBufferLength);
     }
 
-    const bytesRead = (await PromisePrototypeThen(
-      binding.read(filehandle.fd, buffer, offset, length, -1, kUsePromises),
-      undefined,
-      handleErrorFromBinding,
-    )) ?? 0;
+    const bytesRead = await binding.read(filehandle.fd, buffer, offset, length, -1, kUsePromises);
     totalRead += bytesRead;
 
     if (bytesRead === 0 ||
@@ -603,11 +585,7 @@ async function readFileHandle(filehandle, options) {
 // All of the functions are defined as async in order to ensure that errors
 // thrown cause promise rejections rather than being thrown synchronously.
 async function access(path, mode = F_OK) {
-  return await PromisePrototypeThen(
-    binding.access(getValidatedPath(path), mode, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.access(getValidatedPath(path), mode, kUsePromises);
 }
 
 async function cp(src, dest, options) {
@@ -618,15 +596,11 @@ async function cp(src, dest, options) {
 }
 
 async function copyFile(src, dest, mode) {
-  return await PromisePrototypeThen(
-    binding.copyFile(
-      getValidatedPath(src, 'src'),
-      getValidatedPath(dest, 'dest'),
-      mode,
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  return await binding.copyFile(
+    getValidatedPath(src, 'src'),
+    getValidatedPath(dest, 'dest'),
+    mode,
+    kUsePromises,
   );
 }
 
@@ -636,11 +610,7 @@ async function open(path, flags, mode) {
   path = getValidatedPath(path);
   const flagsNumber = stringToFlags(flags);
   mode = parseFileMode(mode, 'mode', 0o666);
-  return new FileHandle(await PromisePrototypeThen(
-    binding.openFileHandle(path, flagsNumber, mode, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  ));
+  return new FileHandle(await binding.openFileHandle(path, flagsNumber, mode, kUsePromises));
 }
 
 async function read(handle, bufferOrParams, offset, length, position) {
@@ -693,11 +663,7 @@ async function read(handle, bufferOrParams, offset, length, position) {
     validatePosition(position, 'position', length);
   }
 
-  const bytesRead = (await PromisePrototypeThen(
-    binding.read(handle.fd, buffer, offset, length, position, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  )) || 0;
+  const bytesRead = (await binding.read(handle.fd, buffer, offset, length, position, kUsePromises)) || 0;
 
   return { __proto__: null, bytesRead, buffer };
 }
@@ -708,11 +674,7 @@ async function readv(handle, buffers, position) {
   if (typeof position !== 'number')
     position = null;
 
-  const bytesRead = (await PromisePrototypeThen(
-    binding.readBuffers(handle.fd, buffers, position, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  )) || 0;
+  const bytesRead = (await binding.readBuffers(handle.fd, buffers, position, kUsePromises)) || 0;
   return { __proto__: null, bytesRead, buffers };
 }
 
@@ -741,22 +703,14 @@ async function write(handle, buffer, offsetOrOptions, length, position) {
       position = null;
     validateOffsetLengthWrite(offset, length, buffer.byteLength);
     const bytesWritten =
-      (await PromisePrototypeThen(
-        binding.writeBuffer(handle.fd, buffer, offset,
-                            length, position, kUsePromises),
-        undefined,
-        handleErrorFromBinding,
-      )) || 0;
+      (await binding.writeBuffer(handle.fd, buffer, offset,
+                                 length, position, kUsePromises)) || 0;
     return { __proto__: null, bytesWritten, buffer };
   }
 
   validateStringAfterArrayBufferView(buffer, 'buffer');
   validateEncoding(buffer, length);
-  const bytesWritten = (await PromisePrototypeThen(
-    binding.writeString(handle.fd, buffer, offset, length, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  )) || 0;
+  const bytesWritten = (await binding.writeString(handle.fd, buffer, offset, length, kUsePromises)) || 0;
   return { __proto__: null, bytesWritten, buffer };
 }
 
@@ -770,22 +724,14 @@ async function writev(handle, buffers, position) {
     return { __proto__: null, bytesWritten: 0, buffers };
   }
 
-  const bytesWritten = (await PromisePrototypeThen(
-    binding.writeBuffers(handle.fd, buffers, position, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  )) || 0;
+  const bytesWritten = (await binding.writeBuffers(handle.fd, buffers, position, kUsePromises)) || 0;
   return { __proto__: null, bytesWritten, buffers };
 }
 
 async function rename(oldPath, newPath) {
   oldPath = getValidatedPath(oldPath, 'oldPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return await PromisePrototypeThen(
-    binding.rename(oldPath, newPath, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.rename(oldPath, newPath, kUsePromises);
 }
 
 async function truncate(path, len = 0) {
@@ -796,11 +742,7 @@ async function truncate(path, len = 0) {
 async function ftruncate(handle, len = 0) {
   validateInteger(len, 'len');
   len = MathMax(0, len);
-  return await PromisePrototypeThen(
-    binding.ftruncate(handle.fd, len, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.ftruncate(handle.fd, len, kUsePromises);
 }
 
 async function rm(path, options) {
@@ -821,27 +763,15 @@ async function rmdir(path, options) {
     }
   }
 
-  return await PromisePrototypeThen(
-    binding.rmdir(path, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.rmdir(path, kUsePromises);
 }
 
-async function fdatasync(handle) {
-  return await PromisePrototypeThen(
-    binding.fdatasync(handle.fd, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+function fdatasync(handle) {
+  return binding.fdatasync(handle.fd, kUsePromises);
 }
 
-async function fsync(handle) {
-  return await PromisePrototypeThen(
-    binding.fsync(handle.fd, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+function fsync(handle) {
+  return binding.fsync(handle.fd, kUsePromises);
 }
 
 async function mkdir(path, options) {
@@ -855,15 +785,11 @@ async function mkdir(path, options) {
   path = getValidatedPath(path);
   validateBoolean(recursive, 'options.recursive');
 
-  return await PromisePrototypeThen(
-    binding.mkdir(
-      path,
-      parseFileMode(mode, 'mode', 0o777),
-      recursive,
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  return await binding.mkdir(
+    path,
+    parseFileMode(mode, 'mode', 0o777),
+    recursive,
+    kUsePromises,
   );
 }
 
@@ -872,15 +798,11 @@ async function readdirRecursive(originalPath, options) {
   const queue = [
     [
       originalPath,
-      await PromisePrototypeThen(
-        binding.readdir(
-          originalPath,
-          options.encoding,
-          !!options.withFileTypes,
-          kUsePromises,
-        ),
-        undefined,
-        handleErrorFromBinding,
+      await binding.readdir(
+        originalPath,
+        options.encoding,
+        !!options.withFileTypes,
+        kUsePromises,
       ),
     ],
   ];
@@ -896,15 +818,11 @@ async function readdirRecursive(originalPath, options) {
           const direntPath = pathModule.join(path, dirent.name);
           ArrayPrototypePush(queue, [
             direntPath,
-            await PromisePrototypeThen(
-              binding.readdir(
-                direntPath,
-                options.encoding,
-                true,
-                kUsePromises,
-              ),
-              undefined,
-              handleErrorFromBinding,
+            await binding.readdir(
+              direntPath,
+              options.encoding,
+              true,
+              kUsePromises,
             ),
           ]);
         }
@@ -923,15 +841,11 @@ async function readdirRecursive(originalPath, options) {
         if (stat === 1) {
           ArrayPrototypePush(queue, [
             direntPath,
-            await PromisePrototypeThen(
-              binding.readdir(
-                direntPath,
-                options.encoding,
-                false,
-                kUsePromises,
-              ),
-              undefined,
-              handleErrorFromBinding,
+            await binding.readdir(
+              direntPath,
+              options.encoding,
+              false,
+              kUsePromises,
             ),
           ]);
         }
@@ -948,15 +862,11 @@ async function readdir(path, options) {
   if (options.recursive) {
     return readdirRecursive(path, options);
   }
-  const result = await PromisePrototypeThen(
-    binding.readdir(
-      path,
-      options.encoding,
-      !!options.withFileTypes,
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  const result = await binding.readdir(
+    path,
+    options.encoding,
+    !!options.withFileTypes,
+    kUsePromises,
   );
   return options.withFileTypes ?
     getDirectoryEntriesPromise(path, result) :
@@ -966,11 +876,7 @@ async function readdir(path, options) {
 async function readlink(path, options) {
   options = getOptions(options);
   path = getValidatedPath(path, 'oldPath');
-  return await PromisePrototypeThen(
-    binding.readlink(path, options.encoding, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.readlink(path, options.encoding, kUsePromises);
 }
 
 async function symlink(target, path, type) {
@@ -999,89 +905,53 @@ async function symlink(target, path, type) {
 
   target = getValidatedPath(target, 'target');
   path = getValidatedPath(path);
-  return await PromisePrototypeThen(
-    binding.symlink(
-      preprocessSymlinkDestination(target, type, path),
-      path,
-      stringToSymlinkType(type),
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  return await binding.symlink(
+    preprocessSymlinkDestination(target, type, path),
+    path,
+    stringToSymlinkType(type),
+    kUsePromises,
   );
 }
 
 async function fstat(handle, options = { bigint: false }) {
-  const result = await PromisePrototypeThen(
-    binding.fstat(handle.fd, options.bigint, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  const result = await binding.fstat(handle.fd, options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 
 async function lstat(path, options = { bigint: false }) {
-  const result = await PromisePrototypeThen(
-    binding.lstat(getValidatedPath(path), options.bigint, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  const result = await binding.lstat(getValidatedPath(path), options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 
 async function stat(path, options = { bigint: false }) {
-  const result = await PromisePrototypeThen(
-    binding.stat(getValidatedPath(path), options.bigint, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  const result = await binding.stat(getValidatedPath(path), options.bigint, kUsePromises);
   return getStatsFromBinding(result);
 }
 
 async function statfs(path, options = { bigint: false }) {
-  const result = await PromisePrototypeThen(
-    binding.statfs(path, options.bigint, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  const result = await binding.statfs(path, options.bigint, kUsePromises);
   return getStatFsFromBinding(result);
 }
 
 async function link(existingPath, newPath) {
   existingPath = getValidatedPath(existingPath, 'existingPath');
   newPath = getValidatedPath(newPath, 'newPath');
-  return await PromisePrototypeThen(
-    binding.link(existingPath, newPath, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.link(existingPath, newPath, kUsePromises);
 }
 
 async function unlink(path) {
-  return await PromisePrototypeThen(
-    binding.unlink(getValidatedPath(path), kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.unlink(getValidatedPath(path), kUsePromises);
 }
 
 async function fchmod(handle, mode) {
   mode = parseFileMode(mode, 'mode');
-  return await PromisePrototypeThen(
-    binding.fchmod(handle.fd, mode, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.fchmod(handle.fd, mode, kUsePromises);
 }
 
 async function chmod(path, mode) {
   path = getValidatedPath(path);
   mode = parseFileMode(mode, 'mode');
-  return await PromisePrototypeThen(
-    binding.chmod(path, mode, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.chmod(path, mode, kUsePromises);
 }
 
 async function lchmod(path, mode) {
@@ -1096,78 +966,50 @@ async function lchown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await PromisePrototypeThen(
-    binding.lchown(path, uid, gid, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.lchown(path, uid, gid, kUsePromises);
 }
 
 async function fchown(handle, uid, gid) {
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await PromisePrototypeThen(
-    binding.fchown(handle.fd, uid, gid, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.fchown(handle.fd, uid, gid, kUsePromises);
 }
 
 async function chown(path, uid, gid) {
   path = getValidatedPath(path);
   validateInteger(uid, 'uid', -1, kMaxUserId);
   validateInteger(gid, 'gid', -1, kMaxUserId);
-  return await PromisePrototypeThen(
-    binding.chown(path, uid, gid, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.chown(path, uid, gid, kUsePromises);
 }
 
 async function utimes(path, atime, mtime) {
   path = getValidatedPath(path);
-  return await PromisePrototypeThen(
-    binding.utimes(
-      path,
-      toUnixTimestamp(atime),
-      toUnixTimestamp(mtime),
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  return await binding.utimes(
+    path,
+    toUnixTimestamp(atime),
+    toUnixTimestamp(mtime),
+    kUsePromises,
   );
 }
 
 async function futimes(handle, atime, mtime) {
   atime = toUnixTimestamp(atime, 'atime');
   mtime = toUnixTimestamp(mtime, 'mtime');
-  return await PromisePrototypeThen(
-    binding.futimes(handle.fd, atime, mtime, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.futimes(handle.fd, atime, mtime, kUsePromises);
 }
 
 async function lutimes(path, atime, mtime) {
-  return await PromisePrototypeThen(
-    binding.lutimes(
-      getValidatedPath(path),
-      toUnixTimestamp(atime),
-      toUnixTimestamp(mtime),
-      kUsePromises,
-    ),
-    undefined,
-    handleErrorFromBinding,
+  return await binding.lutimes(
+    getValidatedPath(path),
+    toUnixTimestamp(atime),
+    toUnixTimestamp(mtime),
+    kUsePromises,
   );
 }
 
 async function realpath(path, options) {
   options = getOptions(options);
-  return await PromisePrototypeThen(
-    binding.realpath(getValidatedPath(path), options.encoding, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return await binding.realpath(getValidatedPath(path), options.encoding, kUsePromises);
 }
 
 async function mkdtemp(prefix, options) {
@@ -1176,11 +1018,7 @@ async function mkdtemp(prefix, options) {
   prefix = getValidatedPath(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
 
-  return await PromisePrototypeThen(
-    binding.mkdtemp(prefix, options.encoding, kUsePromises),
-    undefined,
-    handleErrorFromBinding,
-  );
+  return binding.mkdtemp(prefix, options.encoding, kUsePromises);
 }
 
 async function writeFile(path, data, options) {

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -8,9 +8,6 @@ const {
 
 const Buffer = require('buffer').Buffer;
 const { writeBuffer } = internalBinding('fs');
-const {
-  UVException,
-} = require('internal/errors');
 
 // IPv4 Segment
 const v4Seg = '(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])';
@@ -57,14 +54,17 @@ function makeSyncWrite(fd) {
 
     this._handle.bytesWritten += chunk.length;
 
-    const ctx = {};
-    writeBuffer(fd, chunk, 0, chunk.length, null, undefined, ctx);
-    if (ctx.errno !== undefined) {
-      const ex = new UVException(ctx);
-      ex.errno = ctx.errno;
-      return cb(ex);
+    let threw = false;
+    try {
+      writeBuffer(fd, chunk, 0, chunk.length, null);
+    } catch (error) {
+      threw = true;
+      cb(error);
     }
-    cb();
+
+    if (!threw) {
+      cb();
+    }
   };
 }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -959,8 +959,15 @@ void Access(const FunctionCallbackInfo<Value>& args) {
         path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_ACCESS, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "access", UTF8, AfterNoArgs,
-              uv_fs_access, *path, mode);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "access",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_access,
+                             *path,
+                             mode);
   } else {  // access(path, mode)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
@@ -1104,8 +1111,8 @@ static void Stat(const FunctionCallbackInfo<Value>& args) {
         path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STAT, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "stat", UTF8, AfterStat,
-              uv_fs_stat, *path);
+    AsyncCallAndThrowOnError(
+        env, req_wrap_async, args, "stat", UTF8, AfterStat, uv_fs_stat, *path);
   } else {  // stat(path, use_bigint, undefined, do_not_throw_if_no_entry)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
@@ -1146,8 +1153,14 @@ static void LStat(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LSTAT, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "lstat", UTF8, AfterStat,
-              uv_fs_lstat, *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "lstat",
+                             UTF8,
+                             AfterStat,
+                             uv_fs_lstat,
+                             *path);
   } else {  // lstat(path, use_bigint, undefined, throw_if_no_entry)
     bool do_not_throw_if_no_entry = args[3]->IsFalse();
     FSReqWrapSync req_wrap_sync("lstat", *path);
@@ -1187,8 +1200,8 @@ static void FStat(const FunctionCallbackInfo<Value>& args) {
   if (!args[2]->IsUndefined()) {  // fstat(fd, use_bigint, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2, use_bigint);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FSTAT, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "fstat", UTF8, AfterStat,
-              uv_fs_fstat, fd);
+    AsyncCallAndThrowOnError(
+        env, req_wrap_async, args, "fstat", UTF8, AfterStat, uv_fs_fstat, fd);
   } else {  // fstat(fd, use_bigint, undefined, do_not_throw_error)
     bool do_not_throw_error = args[2]->IsTrue();
     const auto should_throw = [do_not_throw_error](int result) {
@@ -1232,14 +1245,14 @@ static void StatFs(const FunctionCallbackInfo<Value>& args) {
         path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_STATFS, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env,
-              req_wrap_async,
-              args,
-              "statfs",
-              UTF8,
-              AfterStatFs,
-              uv_fs_statfs,
-              *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "statfs",
+                             UTF8,
+                             AfterStatFs,
+                             uv_fs_statfs,
+                             *path);
   } else {  // statfs(path, use_bigint)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
@@ -1385,8 +1398,14 @@ static void ReadLink(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_READLINK, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "readlink", encoding, AfterStringPtr,
-              uv_fs_readlink, *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "readlink",
+                             encoding,
+                             AfterStringPtr,
+                             uv_fs_readlink,
+                             *path);
   } else {  // readlink(path, encoding)
     FSReqWrapSync req_wrap_sync("readlink", *path);
     FS_SYNC_TRACE_BEGIN(readlink);
@@ -1488,8 +1507,15 @@ static void FTruncate(const FunctionCallbackInfo<Value>& args) {
   if (argc > 2) {  // ftruncate(fd, len, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FTRUNCATE, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "ftruncate", UTF8, AfterNoArgs,
-              uv_fs_ftruncate, fd, len);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "ftruncate",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_ftruncate,
+                             fd,
+                             len);
   } else {  // ftruncate(fd, len)
     FSReqWrapSync req_wrap_sync("ftruncate");
     FS_SYNC_TRACE_BEGIN(ftruncate);
@@ -1513,8 +1539,14 @@ static void Fdatasync(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FDATASYNC, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "fdatasync", UTF8, AfterNoArgs,
-              uv_fs_fdatasync, fd);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "fdatasync",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_fdatasync,
+                             fd);
   } else {  // fdatasync(fd)
     FSReqWrapSync req_wrap_sync("fdatasync");
     FS_SYNC_TRACE_BEGIN(fdatasync);
@@ -1538,8 +1570,8 @@ static void Fsync(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FSYNC, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "fsync", UTF8, AfterNoArgs,
-              uv_fs_fsync, fd);
+    AsyncCallAndThrowOnError(
+        env, req_wrap_async, args, "fsync", UTF8, AfterNoArgs, uv_fs_fsync, fd);
   } else {
     FSReqWrapSync req_wrap_sync("fsync");
     FS_SYNC_TRACE_BEGIN(fsync);
@@ -1568,8 +1600,14 @@ static void Unlink(const FunctionCallbackInfo<Value>& args) {
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_UNLINK, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "unlink", UTF8, AfterNoArgs,
-              uv_fs_unlink, *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "unlink",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_unlink,
+                             *path);
   } else {  // unlink(path)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env,
@@ -1598,8 +1636,14 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 1);  // rmdir(path, req)
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_RMDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "rmdir", UTF8, AfterNoArgs,
-              uv_fs_rmdir, *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "rmdir",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_rmdir,
+                             *path);
   } else {  // rmdir(path)
     FSReqWrapSync req_wrap_sync("rmdir", *path);
     FS_SYNC_TRACE_BEGIN(rmdir);
@@ -1943,8 +1987,14 @@ static void RealPath(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_REALPATH, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "realpath", encoding, AfterStringPtr,
-              uv_fs_realpath, *path);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "realpath",
+                             encoding,
+                             AfterStringPtr,
+                             uv_fs_realpath,
+                             *path);
   } else {  // realpath(path, encoding, undefined, ctx)
     FSReqWrapSync req_wrap_sync("realpath", *path);
     FS_SYNC_TRACE_BEGIN(realpath);
@@ -1996,15 +2046,15 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     req_wrap_async->set_with_file_types(with_types);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_SCANDIR, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env,
-              req_wrap_async,
-              args,
-              "scandir",
-              encoding,
-              AfterScanDir,
-              uv_fs_scandir,
-              *path,
-              0 /*flags*/);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "scandir",
+                             encoding,
+                             AfterScanDir,
+                             uv_fs_scandir,
+                             *path,
+                             0 /*flags*/);
   } else {  // readdir(path, encoding, withTypes)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env, permission::PermissionScope::kFileSystemRead, path.ToStringView());
@@ -2190,8 +2240,16 @@ static void OpenFileHandle(const FunctionCallbackInfo<Value>& args) {
   if (req_wrap_async != nullptr) {  // openFileHandle(path, flags, mode, req)
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_OPEN, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "open", UTF8, AfterOpenFileHandle,
-              uv_fs_open, *path, flags, mode);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "open",
+                             UTF8,
+                             AfterOpenFileHandle,
+                             uv_fs_open,
+                             *path,
+                             flags,
+                             mode);
   } else {  // openFileHandle(path, flags, mode, undefined, ctx)
     CHECK_EQ(argc, 5);
     FSReqWrapSync req_wrap_sync;
@@ -2307,8 +2365,17 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   FSReqBase* req_wrap_async = GetReqWrap(args, 5);
   if (req_wrap_async != nullptr) {  // write(fd, buffer, off, len, pos, req)
     FS_ASYNC_TRACE_BEGIN0(UV_FS_WRITE, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "write", UTF8, AfterInteger,
-              uv_fs_write, fd, &uvbuf, 1, pos);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "write",
+                             UTF8,
+                             AfterInteger,
+                             uv_fs_write,
+                             fd,
+                             &uvbuf,
+                             1,
+                             pos);
   } else {  // write(fd, buffer, off, len, pos, undefined, ctx)
     CHECK_EQ(argc, 7);
     FSReqWrapSync req_wrap_sync;
@@ -2354,17 +2421,17 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // writeBuffers(fd, chunks, pos, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_WRITE, req_wrap_async)
-    AsyncCall(env,
-              req_wrap_async,
-              args,
-              "write",
-              UTF8,
-              AfterInteger,
-              uv_fs_write,
-              fd,
-              *iovs,
-              iovs.length(),
-              pos);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "write",
+                             UTF8,
+                             AfterInteger,
+                             uv_fs_write,
+                             fd,
+                             *iovs,
+                             iovs.length(),
+                             pos);
   } else {  // writeBuffers(fd, chunks, pos)
     FSReqWrapSync req_wrap_sync("write");
     FS_SYNC_TRACE_BEGIN(write);
@@ -2606,8 +2673,17 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 5);
     CHECK_NOT_NULL(req_wrap_async);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_READ, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
-              uv_fs_read, fd, &uvbuf, 1, pos);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "read",
+                             UTF8,
+                             AfterInteger,
+                             uv_fs_read,
+                             fd,
+                             &uvbuf,
+                             1,
+                             pos);
   } else {  // read(fd, buffer, offset, len, pos)
     FSReqWrapSync req_wrap_sync("read");
     FS_SYNC_TRACE_BEGIN(read);
@@ -2728,8 +2804,17 @@ static void ReadBuffers(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // readBuffers(fd, buffers, pos, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_READ, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "read", UTF8, AfterInteger,
-              uv_fs_read, fd, *iovs, iovs.length(), pos);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "read",
+                             UTF8,
+                             AfterInteger,
+                             uv_fs_read,
+                             fd,
+                             *iovs,
+                             iovs.length(),
+                             pos);
   } else {  // readBuffers(fd, buffers, undefined, ctx)
     FSReqWrapSync req_wrap_sync("read");
     FS_SYNC_TRACE_BEGIN(read);
@@ -2766,8 +2851,15 @@ static void Chmod(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_CHMOD, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "chmod", UTF8, AfterNoArgs,
-              uv_fs_chmod, *path, mode);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "chmod",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_chmod,
+                             *path,
+                             mode);
   } else {  // chmod(path, mode)
     FSReqWrapSync req_wrap_sync("chmod", *path);
     FS_SYNC_TRACE_BEGIN(chmod);
@@ -2797,8 +2889,15 @@ static void FChmod(const FunctionCallbackInfo<Value>& args) {
   if (argc > 2) {  // fchmod(fd, mode, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 2);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FCHMOD, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "fchmod", UTF8, AfterNoArgs,
-              uv_fs_fchmod, fd, mode);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "fchmod",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_fchmod,
+                             fd,
+                             mode);
   } else {  // fchmod(fd, mode)
     FSReqWrapSync req_wrap_sync("fchmod");
     FS_SYNC_TRACE_BEGIN(fchmod);
@@ -2836,8 +2935,16 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
         path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_CHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "chown", UTF8, AfterNoArgs,
-              uv_fs_chown, *path, uid, gid);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "chown",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_chown,
+                             *path,
+                             uid,
+                             gid);
   } else {  // chown(path, uid, gid)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env,
@@ -2874,8 +2981,16 @@ static void FChown(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // fchown(fd, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FCHOWN, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "fchown", UTF8, AfterNoArgs,
-              uv_fs_fchown, fd, uid, gid);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "fchown",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_fchown,
+                             fd,
+                             uid,
+                             gid);
   } else {  // fchown(fd, uid, gid)
     FSReqWrapSync req_wrap_sync("fchown");
     FS_SYNC_TRACE_BEGIN(fchown);
@@ -2910,8 +3025,16 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
         path.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LCHOWN, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "lchown", UTF8, AfterNoArgs,
-              uv_fs_lchown, *path, uid, gid);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "lchown",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_lchown,
+                             *path,
+                             uid,
+                             gid);
   } else {  // lchown(path, uid, gid)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env,
@@ -2947,8 +3070,16 @@ static void UTimes(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_UTIME, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "utime", UTF8, AfterNoArgs,
-              uv_fs_utime, *path, atime, mtime);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "utime",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_utime,
+                             *path,
+                             atime,
+                             mtime);
   } else {  // utimes(path, atime, mtime)
     FSReqWrapSync req_wrap_sync("utime", *path);
     FS_SYNC_TRACE_BEGIN(utimes);
@@ -2978,8 +3109,16 @@ static void FUTimes(const FunctionCallbackInfo<Value>& args) {
   if (argc > 3) {  // futimes(fd, atime, mtime, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN0(UV_FS_FUTIME, req_wrap_async)
-    AsyncCall(env, req_wrap_async, args, "futime", UTF8, AfterNoArgs,
-              uv_fs_futime, fd, atime, mtime);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "futime",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_futime,
+                             fd,
+                             atime,
+                             mtime);
   } else {  // futimes(fd, atime, mtime)
     FSReqWrapSync req_wrap_sync("futime");
     FS_SYNC_TRACE_BEGIN(futimes);
@@ -3011,8 +3150,16 @@ static void LUTimes(const FunctionCallbackInfo<Value>& args) {
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_LUTIME, req_wrap_async, "path", TRACE_STR_COPY(*path))
-    AsyncCall(env, req_wrap_async, args, "lutime", UTF8, AfterNoArgs,
-              uv_fs_lutime, *path, atime, mtime);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "lutime",
+                             UTF8,
+                             AfterNoArgs,
+                             uv_fs_lutime,
+                             *path,
+                             atime,
+                             mtime);
   } else {  // lutimes(path, atime, mtime)
     FSReqWrapSync req_wrap_sync("lutime", *path);
     FS_SYNC_TRACE_BEGIN(lutimes);
@@ -3048,8 +3195,14 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
         tmpl.ToStringView());
     FS_ASYNC_TRACE_BEGIN1(
         UV_FS_MKDTEMP, req_wrap_async, "path", TRACE_STR_COPY(*tmpl))
-    AsyncCall(env, req_wrap_async, args, "mkdtemp", encoding, AfterStringPath,
-              uv_fs_mkdtemp, *tmpl);
+    AsyncCallAndThrowOnError(env,
+                             req_wrap_async,
+                             args,
+                             "mkdtemp",
+                             encoding,
+                             AfterStringPath,
+                             uv_fs_mkdtemp,
+                             *tmpl);
   } else {  // mkdtemp(tmpl, encoding)
     THROW_IF_INSUFFICIENT_PERMISSIONS(
         env,

--- a/test/parallel/test-fs-access.js
+++ b/test/parallel/test-fs-access.js
@@ -97,7 +97,8 @@ fs.promises.access(readOnlyFile, fs.constants.R_OK)
   };
   const expectedErrorPromise = (err) => {
     expectedError(err);
-    assert.match(err.stack, /at async Object\.access/);
+    assert.strictEqual(err.code, 'ENOENT');
+    assert.strictEqual(err.path, doesNotExist);
   };
   fs.access(doesNotExist, common.mustCall(expectedError));
   fs.promises.access(doesNotExist)

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -58,7 +58,6 @@ assert.strictEqual(
       code: 'ENOENT',
       name: 'Error',
       message: /^ENOENT: no such file or directory, access/,
-      stack: /at async Function\.rejects/
     }
   ).then(common.mustCall());
 

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -65,7 +65,7 @@ declare namespace InternalFSBinding {
   function chmod(path: string, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function chown(path: string, uid: number, gid: number, req: FSReqCallback): void;
-  function chown(path: string, uid: number, gid: number, req: undefined, ctx: FSSyncContext): void;
+  function chown(path: string, uid: number, gid: number): void;
   function chown(path: string, uid: number, gid: number, usePromises: typeof kUsePromises): Promise<void>;
   function chown(path: string, uid: number, gid: number): void;
 
@@ -106,7 +106,7 @@ declare namespace InternalFSBinding {
   function fsync(fd: number): void;
 
   function ftruncate(fd: number, len: number, req: FSReqCallback): void;
-  function ftruncate(fd: number, len: number, req: undefined, ctx: FSSyncContext): void;
+  function ftruncate(fd: number, len: number): void;
   function ftruncate(fd: number, len: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function futimes(fd: number, atime: number, mtime: number, req: FSReqCallback): void;
@@ -116,12 +116,12 @@ declare namespace InternalFSBinding {
   function internalModuleStat(path: string): number;
 
   function lchown(path: string, uid: number, gid: number, req: FSReqCallback): void;
-  function lchown(path: string, uid: number, gid: number, req: undefined, ctx: FSSyncContext): void;
+  function lchown(path: string, uid: number, gid: number): void;
   function lchown(path: string, uid: number, gid: number, usePromises: typeof kUsePromises): Promise<void>;
   function lchown(path: string, uid: number, gid: number): void;
 
   function link(existingPath: string, newPath: string, req: FSReqCallback): void;
-  function link(existingPath: string, newPath: string, req: undefined, ctx: FSSyncContext): void;
+  function link(existingPath: string, newPath: string): void;
   function link(existingPath: string, newPath: string, usePromises: typeof kUsePromises): Promise<void>;
   function link(existingPath: string, newPath: string): void;
 
@@ -140,7 +140,7 @@ declare namespace InternalFSBinding {
   function lutimes(path: string, atime: number, mtime: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function mkdtemp(prefix: string, encoding: unknown, req: FSReqCallback<string>): void;
-  function mkdtemp(prefix: string, encoding: unknown, req: undefined, ctx: FSSyncContext): string;
+  function mkdtemp(prefix: string, encoding: unknown): string;
   function mkdtemp(prefix: string, encoding: unknown, usePromises: typeof kUsePromises): Promise<string>;
   function mkdtemp(prefix: string, encoding: unknown): string;
 
@@ -163,9 +163,9 @@ declare namespace InternalFSBinding {
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number, usePromises: typeof kUsePromises): Promise<number>;
   function read(fd: number, buffer: ArrayBufferView, offset: number, length: number, position: number): number;
 
-  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number, req: FSReqCallback<number>): void;
-  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number, req: undefined, ctx: FSSyncContext): number;
-  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number, usePromises: typeof kUsePromises): Promise<number>;
+  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number | null, req: FSReqCallback<number>): void;
+  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number | null): number;
+  function readBuffers(fd: number, buffers: ArrayBufferView[], position: number | null, usePromises: typeof kUsePromises): Promise<number>;
 
   function readdir(path: StringOrBuffer, encoding: unknown, withFileTypes: boolean, req: FSReqCallback<string[] | [string[], number[]]>): void;
   function readdir(path: StringOrBuffer, encoding: unknown, withFileTypes: true, req: FSReqCallback<[string[], number[]]>): void;
@@ -185,7 +185,7 @@ declare namespace InternalFSBinding {
   function readlink(path: StringOrBuffer, encoding: unknown): StringOrBuffer;
 
   function realpath(path: StringOrBuffer, encoding: unknown, req: FSReqCallback<string | Buffer>): void;
-  function realpath(path: StringOrBuffer, encoding: unknown, req: undefined, ctx: FSSyncContext): string | Buffer;
+  function realpath(path: StringOrBuffer, encoding: unknown): string | Buffer;
   function realpath(path: StringOrBuffer, encoding: unknown, usePromises: typeof kUsePromises): Promise<string | Buffer>;
   function realpath(path: StringOrBuffer, encoding: unknown): StringOrBuffer;
 


### PR DESCRIPTION
Improves async `fs` functions error performance. This simplifies the codebase a lot and uses less primordials in the process.

If you like my work please sponsor me on https://github.com/sponsors/anonrig. 

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1633/