### PR TITLE
doc: remove incorrect `scroll-padding-top` offset

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -76,7 +76,6 @@ h5 :target {
 html {
   font-size: 1rem;
   overflow-wrap: break-word;
-  scroll-padding-top: 50vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-variant-ligatures: none;


### PR DESCRIPTION
Fixes #53594

This PR modifies the behavior of the docs to not begin scrolling halfway through the screen, but rather at the browser default.

## Before

[](https://github.com/nodejs/node/assets/38299977/d54a5cc2-7b83-4b36-8cf6-a96a9f018f08)


## After

[](https://github.com/nodejs/node/assets/38299977/95e2ad54-cd7c-4cda-901a-e5112846d09b)

