### PR TITLE
build: fix build error in sqlite under GN build

### DIFF
--- a/deps/sqlite/unofficial.gni
+++ b/deps/sqlite/unofficial.gni
@@ -18,5 +18,13 @@ template("sqlite_gn_build") {
     forward_variables_from(invoker, "*")
     public_configs = [ ":sqlite_config" ]
     sources = gypi_values.sqlite_sources
+    if (is_win) {
+      cflags_c = [
+        "-Wno-sign-compare",
+        "-Wno-unused-but-set-variable",
+        "-Wno-unused-function",
+        "-Wno-unused-variable",
+      ]
+    }
   }
 }


### PR DESCRIPTION
SQLite does not fix all compiler warnings so we have to disable the warnings on our side:
https://www.sqlite.org/faq.html#q17