### PR TITLE
build: fix mac build error of c-ares under GN

### DIFF
--- a/deps/cares/unofficial.gni
+++ b/deps/cares/unofficial.gni
@@ -62,7 +62,7 @@ template("cares_gn_build") {
       sources += [ "config/linux/ares_config.h" ]
     }
     if (is_mac) {
-      sources += [ "config/darwin/ares_config.h" ]
+      sources += gypi_values.cares_sources_mac
     }
 
     if (is_clang || !is_win) {


### PR DESCRIPTION
Match the changes in https://github.com/nodejs/node/pull/53155.