### PR TITLE
process: unify experimental warning messages

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -30,6 +30,7 @@ const {
   exposeLazyInterfaces,
   defineReplaceableLazyAttribute,
   setupCoverageHooks,
+  emitExperimentalWarning,
 } = require('internal/util');
 
 const {
@@ -538,8 +539,7 @@ function initializePermission() {
     };
     // Guarantee path module isn't monkey-patched to bypass permission model
     ObjectFreeze(require('path'));
-    process.emitWarning('Permission is an experimental feature',
-                        'ExperimentalWarning');
+    emitExperimentalWarning('Permission');
     const { has } = require('internal/process/permission');
     const warnFlags = [
       '--allow-addons',
@@ -628,8 +628,7 @@ function initializeSourceMapsHandlers() {
 
 function initializeFrozenIntrinsics() {
   if (getOptionValue('--frozen-intrinsics')) {
-    process.emitWarning('The --frozen-intrinsics flag is experimental',
-                        'ExperimentalWarning');
+    emitExperimentalWarning('Frozen intristics');
     require('internal/freeze_intrinsics')();
   }
 }


### PR DESCRIPTION
Fixes #30803

This PR changes the warnings emitted by `--experimental-permission` and `--frozen-intrinsics` to use `emitExperimentalWarning` for their emissions, keeping the emitted warning uniform.

## Old
```console
old@nodejs:~$ node --frozen-intrinsics --experimental-permission -e ''
(node:434007) ExperimentalWarning: Permission is an experimental feature
(Use `node --trace-warnings ...` to show where the warning was created)
(node:434007) ExperimentalWarning: The --frozen-intrinsics flag is experimental
```

## New
```console
new@nodejs:~$ node --frozen-intrinsics --experimental-permission -e ''
(node:434330) ExperimentalWarning: Permission is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:434330) ExperimentalWarning: Frozen intristics is an experimental feature and might change at any time
```