### PR TITLE
test: use correct file naming syntax for `util-parse-env`

### DIFF
--- a/test/parallel/test-util-parse-env.js
+++ b/test/parallel/test-util-parse-env.js
@@ -52,6 +52,7 @@ const fs = require('node:fs');
     SINGLE_QUOTES_INSIDE_DOUBLE: "single 'quotes' work inside double quotes",
     SINGLE_QUOTES_SPACED: '    single quotes    ',
     SPACED_KEY: 'parsed',
+    SPACE_BEFORE_DOUBLE_QUOTES: 'space before double quotes',
     TRIM_SPACE_FROM_UNQUOTED: 'some spaced out string',
   });
 }


### PR DESCRIPTION
The project's test runner will only run files beginning with `test-`, so this PR fixes `util-parse-env.js` to `test-util-parse-env.js`.