### PR TITLE
doc: fix releases guide for recent Git versions

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -819,7 +819,7 @@ Git should stop to let you fix conflicts.
 Revert all changes that were made to `src/node_version.h`:
 
 ```bash
-git checkout --ours HEAD -- src/node_version.h
+git restore --source=upstream/main src/node_version.h
 ```
 
 <details>


### PR DESCRIPTION
Current command fails for me:

```
$ git checkout --ours HEAD -- src/node_version.h

fatal: '--merge', '--ours', or '--theirs' cannot be used when checking out of a tree
```

@nodejs/releasers 