### PR TITLE
esm: improve `defaultResolve` performance

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -33,7 +33,7 @@ const preserveSymlinksMain = getOptionValue('--preserve-symlinks-main');
 const experimentalNetworkImports =
   getOptionValue('--experimental-network-imports');
 const inputTypeFlag = getOptionValue('--input-type');
-const { URL, pathToFileURL, fileURLToPath, isURL } = require('internal/url');
+const { URL, pathToFileURL, fileURLToPath, isURL, URLParse } = require('internal/url');
 const { getCWDURL, setOwnProperty } = require('internal/util');
 const { canParse: URLCanParse } = internalBinding('url');
 const { legacyMainResolve: FSLegacyMainResolve } = internalBinding('fs');
@@ -1054,21 +1054,17 @@ function defaultResolve(specifier, context = {}) {
 
   let parsedParentURL;
   if (parentURL) {
-    try {
-      parsedParentURL = new URL(parentURL);
-    } catch {
-      // Ignore exception
-    }
+    parsedParentURL = URLParse(parentURL);
   }
 
   let parsed, protocol;
-  try {
-    if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
-      parsed = new URL(specifier, parsedParentURL);
-    } else {
-      parsed = new URL(specifier);
-    }
+  if (shouldBeTreatedAsRelativeOrAbsolutePath(specifier)) {
+    parsed = URLParse(specifier, parsedParentURL);
+  } else {
+    parsed = URLParse(specifier);
+  }
 
+  if (parsed != null) {
     // Avoid accessing the `protocol` property due to the lazy getters.
     protocol = parsed.protocol;
     if (protocol === 'data:' ||
@@ -1081,8 +1077,6 @@ function defaultResolve(specifier, context = {}) {
     ) {
       return { __proto__: null, url: parsed.href };
     }
-  } catch {
-    // Ignore exception
   }
 
   // There are multiple deep branches that can either throw or return; instead


### PR DESCRIPTION
Reduces try/catch by avoiding functions that can throw. Introduces URLParse by replacing `new URL()`