### PR TITLE
test_runner: support `each` tests

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1357,6 +1357,35 @@ added:
 
 The `suite()` function is imported from the `node:test` module.
 
+## `suite.each(args, name, fn)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `args` {Array\[]} A two-dimensional array containing arguments for each test.
+* `name` {string} The name assigned to each test. This name, combined with the test arguments,
+  is formatted using [`util.format(name, args)`][].
+* `fn` {Function|AsyncFunction} The function to execute. Each sub-array in `args` is supplied
+  as arguments to this function.
+
+The `suite.each(args, name, fn)` function allows you to run a series of tests with different
+data sets using a single test function, making it easier to test multiple scenarios without
+repetitive code. The `name` can include placeholders like `%d` to insert argument values,
+helping identify specific test cases. The test function (`fn`) is called with the arguments
+from each inner array and runs the test logic.
+
+```js
+suite.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+  [2, 2, 4],
+], '%d + %d = %d', (a, b, expected) => {
+  assert.strictEqual(a + b, expected);
+});
+```
+
 ## `suite.skip([name][, options][, fn])`
 
 <!-- YAML
@@ -1481,6 +1510,35 @@ The `timeout` option can be used to fail the test if it takes longer than
 canceling tests because a running test might block the application thread and
 thus prevent the scheduled cancellation.
 
+## `test.each(args, name, fn)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `args` {Array\[]} A two-dimensional array containing arguments for each test.
+* `name` {string} The name assigned to each test. This name, combined with the
+  test arguments, is formatted using [`util.format(name, args)`][].
+* `fn` {Function|AsyncFunction} The function to execute. Each sub-array in `args`
+  is supplied as arguments to this function.
+
+The `test.each(args, name, fn)` function allows you to run a series of tests with different
+data sets using a single test function, making it easier to test multiple scenarios without
+repetitive code. The `name` can include placeholders like `%d` to insert argument values,
+helping identify specific test cases. The test function (`fn`) is called with the arguments
+from each inner array and runs the test logic.
+
+```js
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+  [2, 2, 4],
+], '%d + %d = %d', (a, b, expected) => {
+  assert.strictEqual(a + b, expected);
+});
+```
+
 ## `test.skip([name][, options][, fn])`
 
 Shorthand for skipping a test,
@@ -1540,6 +1598,14 @@ changes:
 Alias for [`test()`][].
 
 The `it()` function is imported from the `node:test` module.
+
+## `it.each(args, name, fn)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Alias for [`test.each(args, name, fn)`][].
 
 ## `it.skip([name][, options][, fn])`
 
@@ -3494,6 +3560,8 @@ Can be used to abort test subtasks when the test has been aborted.
 [`run()`]: #runoptions
 [`suite()`]: #suitename-options-fn
 [`test()`]: #testname-options-fn
+[`test.each(args, name, fn)`]: #testeachargs-name-fn
+[`util.format(name, args)`]: util.md#utilformatformat-args
 [describe options]: #describename-options-fn
 [it options]: #testname-options-fn
 [stream.compose]: stream.md#streamcomposestreams

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -27,6 +27,7 @@ const {
   shouldColorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { queueMicrotask } = require('internal/process/task_queues');
+const { format } = require('internal/util/inspect');
 const { bigint: hrtime } = process.hrtime;
 
 const testResources = new SafeMap();
@@ -281,6 +282,7 @@ function runInParentContext(Factory) {
       return run(name, options, fn, overrides);
     };
   });
+
   return test;
 }
 
@@ -300,6 +302,13 @@ function hook(hook) {
 module.exports = {
   createTestTree,
   test: runInParentContext(Test),
+  each: (args, name, fn) => {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const testName = format(name, ...arg);
+      module.exports.test(testName, fn.bind(null, ...arg));
+    }
+  },
   suite: runInParentContext(Suite),
   before: hook('before'),
   after: hook('after'),

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -63,6 +63,7 @@ const { setTimeout } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
 const { fileURLToPath } = require('internal/url');
 const { availableParallelism } = require('os');
+const { format } = require('internal/util/inspect');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';
@@ -286,6 +287,14 @@ class TestContext {
 
   todo(message) {
     this.#test.todo(message);
+  }
+
+  each(args, name, fn) {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const testName = format(name, ...arg);
+      this.test(testName, fn.bind(null, ...arg));
+    }
   }
 
   test(name, options, fn) {
@@ -718,6 +727,14 @@ class Test extends AsyncResource {
   todo(message) {
     this.isTodo = true;
     this.message = message;
+  }
+
+  each(args, name, fn) {
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      const testName = format(name, ...arg);
+      this.createSubtest(Test, testName, fn.bind(null, ...arg));
+    }
   }
 
   diagnostic(message) {

--- a/lib/test.js
+++ b/lib/test.js
@@ -5,7 +5,7 @@ const {
   ObjectDefineProperty,
 } = primordials;
 
-const { test, suite, before, after, beforeEach, afterEach } = require('internal/test_runner/harness');
+const { test, suite, before, after, beforeEach, afterEach, each } = require('internal/test_runner/harness');
 const { run } = require('internal/test_runner/runner');
 const { getOptionValue } = require('internal/options');
 
@@ -20,6 +20,7 @@ ObjectAssign(module.exports, {
   run,
   suite,
   test,
+  each,
 });
 
 let lazyMock;

--- a/test/fixtures/test-runner/output/each.js
+++ b/test/fixtures/test-runner/output/each.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../../../common');
+const assert = require('assert');
+const test = require('node:test');
+
+test.each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+  [2, 2, 4],
+], '%d + %d = %d', (a, b, expected) => {
+  assert.strictEqual(a + b, expected);
+});
+
+test.suite('Does it work with suite?', () => {
+  test.each([
+    [1, 1, 2],
+    [1, 2, 3],
+    [2, 1, 3],
+    [2, 2, 4],
+  ], '%d + %d = %d', (a, b, expected) => {
+    assert.strictEqual(a + b, expected);
+  });
+});

--- a/test/fixtures/test-runner/output/each.snapshot
+++ b/test/fixtures/test-runner/output/each.snapshot
@@ -1,0 +1,57 @@
+TAP version 13
+# Subtest: 1 + 1 = 2
+ok 1 - 1 + 1 = 2
+  ---
+  duration_ms: *
+  ...
+# Subtest: 1 + 2 = 3
+ok 2 - 1 + 2 = 3
+  ---
+  duration_ms: *
+  ...
+# Subtest: 2 + 1 = 3
+ok 3 - 2 + 1 = 3
+  ---
+  duration_ms: *
+  ...
+# Subtest: 2 + 2 = 4
+ok 4 - 2 + 2 = 4
+  ---
+  duration_ms: *
+  ...
+# Subtest: Does it work with suite?
+    # Subtest: 1 + 1 = 2
+    ok 1 - 1 + 1 = 2
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 1 + 2 = 3
+    ok 2 - 1 + 2 = 3
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 2 + 1 = 3
+    ok 3 - 2 + 1 = 3
+      ---
+      duration_ms: *
+      ...
+    # Subtest: 2 + 2 = 4
+    ok 4 - 2 + 2 = 4
+      ---
+      duration_ms: *
+      ...
+    1..4
+ok 5 - Does it work with suite?
+  ---
+  duration_ms: *
+  type: 'suite'
+  ...
+1..5
+# tests 8
+# suites 1
+# pass 8
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -97,6 +97,7 @@ const tests = [
   { name: 'test-runner/output/abort_hooks.js' },
   { name: 'test-runner/output/describe_it.js' },
   { name: 'test-runner/output/describe_nested.js' },
+  { name: 'test-runner/output/each.js' },
   { name: 'test-runner/output/eval_dot.js', transform: specTransform },
   { name: 'test-runner/output/eval_spec.js', transform: specTransform },
   { name: 'test-runner/output/eval_tap.js' },


### PR DESCRIPTION
Fixes #53714

This PR adds a `test.each(args, name, fn)` (and context equivalent) to the test runner:
```js
test.each([
  [1, 1, 2],
  [1, 2, 3],
  [2, 1, 3],
  [2, 2, 4],
], '%d + %d = %d', (a, b, expected) => {
  assert.strictEqual(a + b, expected);
});
```
```
✔ 1 + 1 = 2 (0.933169ms)
✔ 1 + 2 = 3 (0.09111ms)
✔ 2 + 1 = 3 (0.116227ms)
✔ 2 + 2 = 4 (0.080099ms)
```