### PR TITLE
meta: make more bug-report information required

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -33,13 +33,19 @@ body:
         be run using `node` directly without installing third-party dependencies
         or downloading code from the internet (i.e. no ZIP archive, no GitHub
         repository, etc.).
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: How often does it reproduce? Is there a required condition?
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: What is the expected behavior? Why is that the expected behavior?
       description: If possible please provide textual output instead of screenshots.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: What do you see instead?


### PR DESCRIPTION
This PR makes the following sections required when filing a bug report:
- What steps will reproduce the bug?
- How often does it reproduce? Is there a required condition?
- What is the expected behavior? Why is that the expected behavior?

In my opinion, many bug reports will see that only the 'What do you see instead?' section is required, and file the entire report in that section. These other sections are important, and it can be cumbersome to ask for more information, when the user should've filled it out in the template.