### PR TITLE
lib: remove path.resolve from permissions.js

### DIFF
--- a/lib/internal/process/permission.js
+++ b/lib/internal/process/permission.js
@@ -2,12 +2,10 @@
 
 const {
   ObjectFreeze,
-  StringPrototypeStartsWith,
 } = primordials;
 
 const permission = internalBinding('permission');
 const { validateString } = require('internal/validators');
-const { resolve } = require('path');
 
 let experimentalPermission;
 
@@ -25,9 +23,6 @@ module.exports = ObjectFreeze({
     if (reference != null) {
       // TODO: add support for WHATWG URLs and Uint8Arrays.
       validateString(reference, 'reference');
-      if (StringPrototypeStartsWith(scope, 'fs')) {
-        reference = resolve(reference);
-      }
     }
 
     return permission.has(scope, reference);


### PR DESCRIPTION
FWIW The tests included in `fs-traversal` already cover this change.