### PR TITLE
url: add missing documentation for `URL.parse()`

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -691,6 +691,23 @@ const isValid = URL.canParse('/foo', 'https://example.org/'); // true
 const isNotValid = URL.canParse('/foo'); // false
 ```
 
+#### `URL.parse(input[, base])`
+
+<!-- YAML
+added: v22.1.0
+-->
+
+* `input` {string} The absolute or relative input URL to parse. If `input`
+  is relative, then `base` is required. If `input` is absolute, the `base`
+  is ignored. If `input` is not a string, it is [converted to a string][] first.
+* `base` {string} The base URL to resolve against if the `input` is not
+  absolute. If `base` is not a string, it is [converted to a string][] first.
+* Returns: {URL|undefined}
+
+Parses a string as a URL. If `base` is provided, it will be used as the base
+URL for the purpose of resolving non-absolute `input` URLs. Returns `undefined`
+if `input` is not a valid.
+
 ### Class: `URLSearchParams`
 
 <!-- YAML

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -705,7 +705,7 @@ added: v22.1.0
 * Returns: {URL|null}
 
 Parses a string as a URL. If `base` is provided, it will be used as the base
-URL for the purpose of resolving non-absolute `input` URLs. Returns `undefined`
+URL for the purpose of resolving non-absolute `input` URLs. Returns `null`
 if `input` is not a valid.
 
 ### Class: `URLSearchParams`

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -702,7 +702,7 @@ added: v22.1.0
   is ignored. If `input` is not a string, it is [converted to a string][] first.
 * `base` {string} The base URL to resolve against if the `input` is not
   absolute. If `base` is not a string, it is [converted to a string][] first.
-* Returns: {URL|undefined}
+* Returns: {URL|null}
 
 Parses a string as a URL. If `base` is provided, it will be used as the base
 URL for the purpose of resolving non-absolute `input` URLs. Returns `undefined`


### PR DESCRIPTION
Adds missing documentation for https://github.com/nodejs/node/pull/52280. @nodejs/url