### PR TITLE
cli: update `node.1` to reflect Atom's sunset

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -4,9 +4,6 @@
 .\" * Language reference:
 .\"   https://man.openbsd.org/mdoc.7
 .\"
-.\" * Atom editor support:
-.\"   https://atom.io/packages/language-roff
-.\"
 .\" * Linting changes:
 .\"   mandoc -Wall -Tlint /path/to/this.file  # BSD
 .\"   groff -w all -z /path/to/this.file      # GNU/Linux, macOS


### PR DESCRIPTION
Refs: https://github.blog/2022-06-08-sunsetting-atom/

This PR removes the note about Atom editor support, as atom has been sunset.

![](https://github.githubassets.com/images/icons/emoji/atom.png)