### PR TITLE
fs: add `exists` to `fsPromises`

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1071,6 +1071,16 @@ including subdirectories and files.
 When copying a directory to another directory, globs are not supported and
 behavior is similar to `cp dir1/ dir2/`.
 
+### `fsPromises.exists(path)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `path` {string|URL} The filepath to check.
+
+Checks whether the given filepath exists.
+
 ### `fsPromises.glob(pattern[, options])`
 
 <!-- YAML

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1275,12 +1275,22 @@ async function* glob(pattern, options) {
   yield* new Glob(pattern, options).glob();
 }
 
+async function exists(path) {
+  try {
+    await access(path, F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 module.exports = {
   exports: {
     access,
     copyFile,
     cp,
     glob,
+    exists,
     open,
     opendir: promisify(opendir),
     rename,

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const fsPromises = fs.promises;
 const {
   access,
+  exists,
   chmod,
   chown,
   copyFile,
@@ -75,6 +76,11 @@ assert.strictEqual(
       code: 'ERR_INVALID_ARG_TYPE',
     }
   ).then(common.mustCall());
+}
+
+{
+  exists(__filename).then(common.mustCall((exists) => assert.strictEqual(exists, true)));
+  exists('this file does not exist').then(common.mustCall((exists) => assert.strictEqual(exists, false)));
 }
 
 function verifyStatObject(stat) {


### PR DESCRIPTION
This pull request introduces an `exists` method to `fs.promises`.

**Rationale:** The synchronous `fs` module includes both `exists` and `existsSync` methods, which operate simply by calling `access` and returning true or false based on success (although `existsSync` does it a bit differently). Given this straightforward approach, it seems logical to also provide this functionality in `fs.promises`. There are no technical limitations preventing this, so adding this method enhances consistency and convenience.