### PR TITLE
meta: use HTML entities in `commit-queue` comment

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -19,7 +19,7 @@ commit_queue_failed() {
 
   # shellcheck disable=SC2154
   cqurl="${GITHUB_SERVER_URL}/${OWNER}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-  body="<details><summary>Commit Queue failed</summary><pre>$(cat output)</pre><a href='$cqurl'>$cqurl</a></details>"
+  body="<details><summary>Commit Queue failed</summary><pre>$(sed -e 's/</\&lt;/g' -e 's/>/\&gt;/g' output)</pre><a href='$cqurl'>$cqurl</a></details>"
   echo "$body"
 
   gh pr comment "$pr" --body "$body"

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -19,7 +19,7 @@ commit_queue_failed() {
 
   # shellcheck disable=SC2154
   cqurl="${GITHUB_SERVER_URL}/${OWNER}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-  body="<details><summary>Commit Queue failed</summary><pre>$(sed -e 's/</\&lt;/g' -e 's/>/\&gt;/g' output)</pre><a href='$cqurl'>$cqurl</a></details>"
+  body="<details><summary>Commit Queue failed</summary><pre>$(sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' output)</pre><a href='$cqurl'>$cqurl</a></details>"
   echo "$body"
 
   gh pr comment "$pr" --body "$body"


### PR DESCRIPTION
When looking at the comments for `commit-queue-failed`, parts wrapped in `<` and `>` aren't rendered, as they are treated as HTML.

An example of this is emails, and some weird rendering for https://github.com/nodejs/node/pull/53741#issuecomment-2211732503, which contains `<pre>` in the title.

This PR replaces those items with HTML entities, allowing them to properly render.