### PR TITLE
src,tools: enable --trace-sigint in tests by default

### DIFF
--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -102,7 +102,7 @@ class TraceSigintWatchdog : public HandleWrap, public SigintWatchdogBase {
   TraceSigintWatchdog(Environment* env, v8::Local<v8::Object> object);
   void HandleInterrupt();
 
-  bool interrupting = false;
+  bool interrupted = false;
   uv_async_t handle_;
   SignalFlags signal_flag_ = SignalFlags::None;
 };

--- a/test/es-module/test-esm-no-addons.mjs
+++ b/test/es-module/test-esm-no-addons.mjs
@@ -16,10 +16,10 @@ if (isMainThread) {
       mustCall((module) => {
         const message = module.default;
 
-        if (process.execArgv.length === 0) {
-          assert.strictEqual(message, 'using native addons');
-        } else {
+        if (process.execArgv.includes('--no-addons')) {
           assert.strictEqual(message, 'not using native addons');
+        } else {
+          assert.strictEqual(message, 'using native addons');
         }
       })
     );

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -170,6 +170,11 @@ if (process.env.NODE_V8_COVERAGE) {
   expected.atRunTime.add('Internal Binding profiler');
 }
 
+if (process.execArgv.includes('--trace-sigint') && common.isMainThread) {
+  expected.atRunTime.add('Internal Binding watchdog');
+  expected.atRunTime.add('NativeModule internal/watchdog');
+}
+
 // Accumulate all the errors and print them at the end instead of throwing
 // immediately which makes it harder to update the test.
 const errorLogs = [];


### PR DESCRIPTION
Enable `--trace-sigint` in tests by default. Also fixes 
an internal test `test/parallel/test-util-sigint-watchdog.js` 
that crashes with `--trace-sigint`.

Refs: https://github.com/nodejs/node/issues/53739
