### PR TITLE
build: fix build warning of c-ares under GN build

### DIFF
--- a/deps/cares/unofficial.gni
+++ b/deps/cares/unofficial.gni
@@ -65,11 +65,17 @@ template("cares_gn_build") {
       sources += gypi_values.cares_sources_mac
     }
 
-    if (is_clang || !is_win) {
-      cflags_c = [
-        "-Wno-implicit-fallthrough",
-        "-Wno-unreachable-code",
-      ]
+    if (is_clang) {
+      if (is_win) {
+        cflags_c = [
+          "-Wno-macro-redefined",
+        ]
+      } else {
+        cflags_c = [
+          "-Wno-implicit-fallthrough",
+          "-Wno-unreachable-code",
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Fix a build warning of c-ares after updating it to v1.32.0 in https://github.com/nodejs/node/pull/53722.