### PR TITLE
src: mark `node --run` as stable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2097,7 +2097,7 @@ changes:
                  `PATH` environment variable accordingly.
 -->
 
-> Stability: 1.2 - Release candidate
+> Stability: 2 - Stable
 
 This runs a specified command from a package.json's `"scripts"` object.
 If a missing `"command"` is provided, it will list the available scripts.

--- a/src/node.cc
+++ b/src/node.cc
@@ -1018,14 +1018,6 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
   }
 
   if (!per_process::cli_options->run.empty()) {
-    // TODO(@anonrig): Handle NODE_NO_WARNINGS, NODE_REDIRECT_WARNINGS,
-    //  --disable-warning and --redirect-warnings.
-    if (per_process::cli_options->per_isolate->per_env->warnings) {
-      fprintf(stderr,
-              "ExperimentalWarning: Task runner is an experimental feature and "
-              "might change at any time\n\n");
-    }
-
     auto positional_args = task_runner::GetPositionalArgs(args);
     result->early_return_ = true;
     task_runner::RunTask(

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -10,21 +10,10 @@ const fixtures = require('../common/fixtures');
 const envSuffix = common.isWindows ? '-windows' : '';
 
 describe('node --run [command]', () => {
-  it('should emit experimental warning', async () => {
-    const child = await common.spawnPromisified(
-      process.execPath,
-      [ '--run', 'test'],
-      { cwd: __dirname },
-    );
-    assert.match(child.stderr, /ExperimentalWarning: Task runner is an experimental feature and might change at any time/);
-    assert.strictEqual(child.stdout, '');
-    assert.strictEqual(child.code, 1);
-  });
-
   it('returns error on non-existent file', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', 'test'],
+      [ '--run', 'test'],
       { cwd: __dirname },
     );
     assert.match(child.stderr, /Can't find package\.json[\s\S]*/);
@@ -48,7 +37,7 @@ describe('node --run [command]', () => {
   it('adds node_modules/.bin to path', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', `ada${envSuffix}`],
+      [ '--run', `ada${envSuffix}`],
       { cwd: fixtures.path('run-script') },
     );
     assert.match(child.stdout, /06062023/);
@@ -59,7 +48,7 @@ describe('node --run [command]', () => {
   it('chdirs into package directory', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', `pwd${envSuffix}`],
+      [ '--run', `pwd${envSuffix}`],
       { cwd: fixtures.path('run-script/sub-directory') },
     );
     assert.strictEqual(child.stdout.trim(), fixtures.path('run-script'));
@@ -71,7 +60,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'missing'],
+        [ '--run', 'missing'],
         { cwd: fixtures.path('run-script') },
       );
       assert.strictEqual(child.stdout, '');
@@ -82,7 +71,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'test'],
+        [ '--run', 'test'],
         { cwd: fixtures.path('run-script/missing-scripts') },
       );
       assert.strictEqual(child.stdout, '');
@@ -92,7 +81,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'test'],
+        [ '--run', 'test'],
         { cwd: fixtures.path('run-script/invalid-json') },
       );
       assert.strictEqual(child.stdout, '');
@@ -102,7 +91,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'array'],
+        [ '--run', 'array'],
         { cwd: fixtures.path('run-script/invalid-schema') },
       );
       assert.strictEqual(child.stdout, '');
@@ -112,7 +101,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'boolean'],
+        [ '--run', 'boolean'],
         { cwd: fixtures.path('run-script/invalid-schema') },
       );
       assert.strictEqual(child.stdout, '');
@@ -122,7 +111,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'null'],
+        [ '--run', 'null'],
         { cwd: fixtures.path('run-script/invalid-schema') },
       );
       assert.strictEqual(child.stdout, '');
@@ -132,7 +121,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'number'],
+        [ '--run', 'number'],
         { cwd: fixtures.path('run-script/invalid-schema') },
       );
       assert.strictEqual(child.stdout, '');
@@ -142,7 +131,7 @@ describe('node --run [command]', () => {
     {
       const child = await common.spawnPromisified(
         process.execPath,
-        [ '--no-warnings', '--run', 'object'],
+        [ '--run', 'object'],
         { cwd: fixtures.path('run-script/invalid-schema') },
       );
       assert.strictEqual(child.stdout, '');
@@ -154,7 +143,7 @@ describe('node --run [command]', () => {
   it('appends positional arguments', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', `positional-args${envSuffix}`, '--', '--help "hello world test"', 'A', 'B', 'C'],
+      [ '--run', `positional-args${envSuffix}`, '--', '--help "hello world test"', 'A', 'B', 'C'],
       { cwd: fixtures.path('run-script') },
     );
     if (common.isWindows) {
@@ -170,7 +159,7 @@ describe('node --run [command]', () => {
   it('should set PATH environment variable with paths appended with node_modules/.bin', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', `path-env${envSuffix}`],
+      [ '--run', `path-env${envSuffix}`],
       { cwd: fixtures.path('run-script/sub-directory') },
     );
     assert.ok(child.stdout.includes(fixtures.path('run-script/node_modules/.bin')));
@@ -191,7 +180,7 @@ describe('node --run [command]', () => {
     const packageJsonPath = fixtures.path('run-script/package.json');
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', scriptName],
+      [ '--run', scriptName],
       { cwd: fixtures.path('run-script') },
     );
     assert.ok(child.stdout.includes(scriptName));
@@ -204,7 +193,7 @@ describe('node --run [command]', () => {
     const packageJsonPath = fixtures.path('run-script/package.json');
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', `special-env-variables${envSuffix}`],
+      [ '--run', `special-env-variables${envSuffix}`],
       { cwd: fixtures.path('run-script/sub-directory') },
     );
     assert.ok(child.stdout.includes(packageJsonPath));
@@ -215,7 +204,7 @@ describe('node --run [command]', () => {
   it('returns error on unparsable file', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', 'test'],
+      [ '--run', 'test'],
       { cwd: fixtures.path('run-script/cannot-parse') },
     );
     assert.match(child.stderr, /Can't parse/);
@@ -226,7 +215,7 @@ describe('node --run [command]', () => {
   it('returns error when there is no "scripts" field file', async () => {
     const child = await common.spawnPromisified(
       process.execPath,
-      [ '--no-warnings', '--run', 'test'],
+      [ '--run', 'test'],
       { cwd: fixtures.path('run-script/cannot-find-script') },
     );
     assert.match(child.stderr, /Can't find "scripts" field in/);


### PR DESCRIPTION
node --run is stable now