### PR TITLE
doc: adds missing comment in assert examples

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -349,6 +349,7 @@ added:
 ```mjs
 import assert from 'node:assert';
 
+// Creates call tracker.
 const tracker = new assert.CallTracker();
 
 function func() {}
@@ -463,6 +464,7 @@ If no arguments are passed, all tracked functions will be reset.
 ```mjs
 import assert from 'node:assert';
 
+// Creates call tracker.
 const tracker = new assert.CallTracker();
 
 function func() {}
@@ -479,6 +481,7 @@ assert.strictEqual(tracker.getCalls(callsfunc).length, 0);
 ```cjs
 const assert = require('node:assert');
 
+// Creates call tracker.
 const tracker = new assert.CallTracker();
 
 function func() {}


### PR DESCRIPTION
Adds the corresponding missing comment:

`// Creates call tracker.`
 
 That is present on _some_ but not all examples of the [`Class: assert.CallTracker`](https://nodejs.org/docs/latest/api/assert.html#class-assertcalltracker) documentation.
 
 I'm leaving out the examples on [`new assert.CallTracker()`](https://nodejs.org/docs/latest/api/assert.html#new-assertcalltracker) because it's already being described there.
 
 I know it's a small change and it's literally going to be removed soon but still, the comment is not present on all examples as of now.