### PR TITLE
test_runner,cli: --test-timeout should be used with --test

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -142,6 +142,10 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors,
     errors->push_back("--heapsnapshot-near-heap-limit must not be negative");
   }
 
+  if (test_runner_timeout > 0 && !test_runner) {
+    errors->push_back("--test-timeout must be used with --test");
+  }
+
   if (test_runner) {
     if (syntax_check_only) {
       errors->push_back("either --test or --check can be used, not both");

--- a/test/parallel/test-runner-cli-timeout.js
+++ b/test/parallel/test-runner-cli-timeout.js
@@ -7,6 +7,12 @@ const { test } = require('node:test');
 const cwd = fixtures.path('test-runner', 'default-behavior');
 const env = { ...process.env, 'NODE_DEBUG': 'test_runner' };
 
+test('must use --test-timeout with --test', () => {
+  const args = ['--test-timeout', 10];
+  const cp = spawnSync(process.execPath, args, { cwd, env });
+  assert.match(cp.stderr.toString(), /--test-timeout must be used with --test/);
+});
+
 test('default timeout -- Infinity', async () => {
   const args = ['--test'];
   const cp = spawnSync(process.execPath, args, { cwd, env });


### PR DESCRIPTION
When `--test-timeout` used without `--test` it does not behave what the user would expect.

Refs: https://github.com/nodejs/node/issues/50431#issuecomment-2028077686

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
