### PR TITLE
fs: ensure consistency for mkdtemp in both fs and fs/promises

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1177,15 +1177,8 @@ async function mkdtemp(prefix, options) {
   prefix = getValidatedPath(prefix, 'prefix');
   warnOnNonPortableTemplate(prefix);
 
-  let path;
-  if (typeof prefix === 'string') {
-    path = `${prefix}XXXXXX`;
-  } else {
-    path = Buffer.concat([prefix, Buffer.from('XXXXXX')]);
-  }
-
   return await PromisePrototypeThen(
-    binding.mkdtemp(path, options.encoding, kUsePromises),
+    binding.mkdtemp(prefix, options.encoding, kUsePromises),
     undefined,
     handleErrorFromBinding,
   );


### PR DESCRIPTION
This PR is related to <https://github.com/nodejs/node/pull/51078>. The original author forgot to update the code in `lib/internal/fs/promise.js`, resulting in inconsistent behavior between `fs.mkdtemp` and `fsp.mkdtemp`.   
This PR ports the code from `lib/fs.js` to `lib/internal/fs/promise.js` to resolve this issue.

Changes have been made to remove the extra `XXXXXX` in `fsp.mkdtemp`,  
which affects Node.js versions >= 20.12.0.
```js
// test.cjs
const fs = require("node:fs");
const fsp = require("node:fs/promises");

fs.mkdtemp("fs_", (_, d) => console.log({ fs: d }));
fsp.mkdtemp("fsp_").then((d) => console.log({ fsp: d }));
```
![image](https://github.com/nodejs/node/assets/24633623/5d5ec37d-1ca9-4226-b01e-16073597e825)


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
