### PR TITLE
esm: do not truncate `data:` URLs for evaluation

### DIFF
--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -41,7 +41,7 @@ async function getSource(url, context) {
     const { readFile: readFileAsync } = require('internal/fs/promises').exports;
     source = await readFileAsync(url);
   } else if (protocol === 'data:') {
-    const match = RegExpPrototypeExec(DATA_URL_PATTERN, url.pathname);
+    const match = RegExpPrototypeExec(DATA_URL_PATTERN, href);
     if (!match) {
       throw new ERR_INVALID_URL(responseURL);
     }
@@ -77,7 +77,7 @@ function getSourceSync(url, context) {
   if (protocol === 'file:') {
     source = readFileSync(url);
   } else if (protocol === 'data:') {
-    const match = RegExpPrototypeExec(DATA_URL_PATTERN, url.pathname);
+    const match = RegExpPrototypeExec(DATA_URL_PATTERN, href);
     if (!match) {
       throw new ERR_INVALID_URL(responseURL);
     }

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -113,7 +113,7 @@ function createBase64URL(mime, body) {
     await import(plainESMURL);
   }
   {
-    const urlWithUnescapedQueryAndHash = 'data:text/javascript,export const value="?query#hash";'
+    const urlWithUnescapedQueryAndHash = 'data:text/javascript,export const value="?query#hash"';
     const { value } = await import(urlWithUnescapedQueryAndHash);
     assert.strictEqual(value, '?query#hash');
   }

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -112,4 +112,9 @@ function createBase64URL(mime, body) {
     const plainESMURL = `data:text/javascript,${encodeURIComponent(`import ${JSON.stringify(fixtures.fileURL('es-module-url', 'empty.js'))}`)}`;
     await import(plainESMURL);
   }
+  {
+    const urlWithUnescapedQueryAndHash = 'data:text/javascript,export const value="?query#hash";'
+    const { value } = await import(urlWithUnescapedQueryAndHash);
+    assert.strictEqual(value, '?query#hash');
+  }
 })().then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/53775

