### PR TITLE
src: reject per-process isolate flags in workers

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -262,8 +262,7 @@ void SetIsolateMiscHandlers(v8::Isolate* isolate, const IsolateSettings& s) {
     isolate->SetWasmStreamingCallback(wasm_web_api::StartStreamingCompilation);
   }
 
-  if (per_process::cli_options->get_per_isolate_options()
-          ->experimental_shadow_realm) {
+  if (per_process::cli_options->experimental_shadow_realm) {
     isolate->SetHostCreateShadowRealmContextCallback(
         shadow_realm::HostCreateShadowRealmContextCallback);
   }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -249,7 +249,6 @@ class PerIsolateOptions : public Options {
   bool track_heap_objects = false;
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
-  bool experimental_shadow_realm = false;
   std::string report_signal = "SIGUSR2";
   bool build_snapshot = false;
   std::string build_snapshot_config;
@@ -289,6 +288,7 @@ class PerProcessOptions : public Options {
   bool print_v8_help = false;
   bool print_version = false;
   std::string experimental_sea_config;
+  bool experimental_shadow_realm = false;
   std::string run;
 
 #ifdef NODE_HAVE_I18N_SUPPORT

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -49,16 +49,6 @@ expectNoWorker('--trace-event-file-pattern {pid}-${rotation}.trace_events ' +
        '--trace-event-categories node.async_hooks', 'B\n');
 expect('--unhandled-rejections=none', 'B\n');
 
-if (common.isLinux) {
-  expect('--perf-basic-prof', 'B\n');
-  expect('--perf-basic-prof-only-functions', 'B\n');
-
-  if (['arm', 'x64'].includes(process.arch)) {
-    expect('--perf-prof', 'B\n');
-    expect('--perf-prof-unwinding-info', 'B\n');
-  }
-}
-
 if (common.hasCrypto) {
   expectNoWorker('--use-openssl-ca', 'B\n');
   expectNoWorker('--use-bundled-ca', 'B\n');
@@ -67,20 +57,31 @@ if (common.hasCrypto) {
 }
 
 // V8 options
-expect('--abort_on-uncaught_exception', 'B\n');
-expect('--disallow-code-generation-from-strings', 'B\n');
-expect('--expose-gc', 'B\n');
-expect('--huge-max-old-generation-size', 'B\n');
-expect('--jitless', 'B\n');
-expect('--max-old-space-size=0', 'B\n');
-expect('--max-semi-space-size=0', 'B\n');
-expect('--stack-trace-limit=100',
-       /(\s*at f \(\[(eval|worker eval)\]:1:\d*\)\r?\n)/,
-       '(function f() { f(); })();',
-       true);
+expectNoWorker('--abort_on-uncaught_exception', 'B\n');
+expectNoWorker('--disallow-code-generation-from-strings', 'B\n');
+expectNoWorker('--expose-gc', 'B\n');
+expectNoWorker('--huge-max-old-generation-size', 'B\n');
+expectNoWorker('--jitless', 'B\n');
+expectNoWorker('--max-old-space-size=0', 'B\n');
+expectNoWorker('--max-semi-space-size=0', 'B\n');
+expectNoWorker('--stack-trace-limit=100',
+               /(\s*at f \(\[eval\]:1:\d*\)\r?\n)/,
+               '(function f() { f(); })();',
+               true);
 // Unsupported on arm. See https://crbug.com/v8/8713.
 if (!['arm', 'arm64'].includes(process.arch))
-  expect('--interpreted-frames-native-stack', 'B\n');
+  expectNoWorker('--interpreted-frames-native-stack', 'B\n');
+
+// Linux only V8 options
+if (common.isLinux) {
+  expectNoWorker('--perf-basic-prof', 'B\n');
+  expectNoWorker('--perf-basic-prof-only-functions', 'B\n');
+
+  if (['arm', 'x64'].includes(process.arch)) {
+    expectNoWorker('--perf-prof', 'B\n');
+    expectNoWorker('--perf-prof-unwinding-info', 'B\n');
+  }
+}
 
 // Workers can't eval as ES Modules. https://github.com/nodejs/node/issues/30682
 expectNoWorker('--input-type=module',


### PR DESCRIPTION
V8 flags are saved in a per-process storage and are not effective in the
Worker constructor options (not applied with `V8::SetFlagsFromString`). 
Reject V8 flags in the Worker constructor proactively to indicate these
options should be set at process level.

Refs: https://github.com/nodejs/node/pull/53596