### PR TITLE
child_process: fix incomplete prototype pollution hardening

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -568,6 +568,7 @@ function normalizeSpawnArguments(file, args, options) {
   else
     validateObject(options, 'options');
 
+  options = { __proto__: null, ...options };
   let cwd = options.cwd;
 
   // Validate the cwd, if present.


### PR DESCRIPTION
Prior pull request (#48726) hardened against prototype pollution vulnerabilities but effectively missed some use-cases which opened a window for prototype pollution for some child_process functions such as spawn(), spawnSync(), and execFileSync().

This PR adds a (failing) test case that confirms the issue and follows-up with a fix for the bug in child_process functions to ensure consistent behavior.

**Note:** this is not considered a security vulnerability because the [Node.js threat model](https://github.com/nodejs/node/security#prototype-pollution-attacks-cwe-1321) does not recognize prototype pollution as a viable security vulnerability in the runtime.

## Expectation vs Actual

**Expectation:** 

- Per the [spawn() API documentation](https://nodejs.org/docs/latest/api/child_process.html#child_processspawncommand-args-options), spawn() should default to `shell: false`. Similarly, `execFile()` follows the same.
- Per the referenced prototype pollution hardedning Pull Request from 2023, the following simulated attack shouldn't work: `Object.prototype.shell = true; child_process.spawn('ls', ['-l && touch /tmp/new'])`

**Actual:**
- `Object.prototype.shell = true; child_process.execFile('ls', ['-l && touch /tmp/new'])` - ✅ No side effects, hardening works well for.
- `Object.prototype.shell = true; child_process.spawn('ls', ['-l && touch /tmp/new'])` - ✅ No side effects, hardening works well for.
- `Object.prototype.shell = true; child_process.execFile('ls', ['-l && touch /tmp/new'], { stdio: 'inherit'})` - ✅ No side effects, hardening works well for.
- `Object.prototype.shell = true; child_process.spawn('ls', ['-l && touch /tmp/new'], { stdio: 'inherit'})` - ❌ Vulnerability manifests, hardening fails.

Note: other APIs are also prone to this issue: `execFileSync` and `spawnSync`.

## Demo of the inconsistent prototype hardening findings

The following is provided as an easy reproduction and proof-of-concept (POC) for described findings on the prototype mishandling issue:

```js
const { execFile, spawn, spawnSync, execFileSync } = require("child_process");

// Simulate a successful prototype attack impact:
const a = {};
a.__proto__.shell = true;

// Show the prototype is indeed affected:
console.log("Object.shell value:", Object.shell, "\n");

// Node.js user-land code use of various child_process functions:
execFile("ls", ["-l && touch /tmp/from-ExecFile"], {
  stdio: "inherit",
});

spawn("ls", ["-la && touch /tmp/from-Spawn"], {
  stdio: "inherit",
});

execFileSync("ls", ["-l && touch /tmp/from-ExecFileSync"], {
  stdio: "inherit",
});

spawnSync("ls", ["-la && touch /tmp/from-SpawnSync"], {
  stdio: "inherit",
});
```

The output would be as follows:

```sh
$ node app.js
Object.shell value: true

[...]

$ ls -alh /tmp/from*
Permissions Size User     Date Modified Name
.rw-r--r--     0 lirantal  4 Jul 14:14   /tmp/from-ExecFileSync
.rw-r--r--     0 lirantal  4 Jul 14:14   /tmp/from-Spawn
.rw-r--r--     0 lirantal  4 Jul 14:14   /tmp/from-SpawnSync
```

Demonstrating that while the `child_process.exec` function is hardened from prototype chain look up of the `shell` property, this isn't the case for other process execution functions, mainly: `spawn`, `execFileSync`, `spawnSync`.



<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
