### PR TITLE
meta: remove redudant logging from dep updaters

### DIFF
--- a/tools/dep_updaters/update-acorn-walk.sh
+++ b/tools/dep_updaters/update-acorn-walk.sh
@@ -52,14 +52,6 @@ tar -xf "$ACORN_WALK_TGZ"
 
 mv package/* "$DEPS_DIR/acorn/acorn-walk"
 
-echo "All done!"
-echo ""
-echo "Please git add acorn-walk, commit the new version:"
-echo ""
-echo "$ git add -A deps/acorn-walk"
-echo "$ git commit -m \"deps: update acorn-walk to $NEW_VERSION\""
-echo ""
-
 # Update the version number on maintaining-dependencies.md
 # and print the new version as the last line of the script as we need
 # to add it to $GITHUB_ENV variable

--- a/tools/dep_updaters/update-acorn.sh
+++ b/tools/dep_updaters/update-acorn.sh
@@ -62,15 +62,6 @@ cat > "$BASE_DIR/src/acorn_version.h" <<EOF
 #endif  // SRC_ACORN_VERSION_H_
 EOF
 
-echo "All done!"
-echo ""
-echo "Please git add acorn, commit the new version:"
-echo ""
-echo "$ git add -A deps/acorn/acorn"
-echo "$ git add $BASE_DIR/src/acorn_version.h"
-echo "$ git commit -m \"deps: update acorn to $NEW_VERSION\""
-echo ""
-
 # Update the version number on maintaining-dependencies.md
 # and print the new version as the last line of the script as we need
 # to add it to $GITHUB_ENV variable

--- a/tools/dep_updaters/update-gyp-next.sh
+++ b/tools/dep_updaters/update-gyp-next.sh
@@ -55,6 +55,14 @@ rm -rf "$BASE_DIR/tools/gyp"
 
 mv "$WORKSPACE/gyp" "$BASE_DIR/tools/"
 
+echo "All done!"
+echo ""
+echo "Please git add gyp-next and commit the new version:"
+echo ""
+echo "$ git add -A tools/gyp"
+echo "$ git commit -m \"tools: update gyp-next to $NEW_VERSION\""
+echo ""
+
 # The last line of the script should always print the new version,
 # as we need to add it to $GITHUB_ENV variable.
 echo "NEW_VERSION=$NEW_VERSION"

--- a/tools/dep_updaters/update-gyp-next.sh
+++ b/tools/dep_updaters/update-gyp-next.sh
@@ -55,14 +55,6 @@ rm -rf "$BASE_DIR/tools/gyp"
 
 mv "$WORKSPACE/gyp" "$BASE_DIR/tools/"
 
-echo "All done!"
-echo ""
-echo "Please git add gyp-next and commit the new version:"
-echo ""
-echo "$ git add -A tools/gyp"
-echo "$ git commit -m \"tools: update gyp-next to $NEW_VERSION\""
-echo ""
-
 # The last line of the script should always print the new version,
 # as we need to add it to $GITHUB_ENV variable.
 echo "NEW_VERSION=$NEW_VERSION"

--- a/tools/dep_updaters/update-minimatch.sh
+++ b/tools/dep_updaters/update-minimatch.sh
@@ -62,14 +62,6 @@ rm -rf node_modules
 
 mv ./* "$DEPS_DIR/minimatch"
 
-echo "All done!"
-echo ""
-echo "Please git add minimatch, commit the new version:"
-echo ""
-echo "$ git add -A deps/minimatch"
-echo "$ git commit -m \"deps: update minimatch to $NEW_VERSION\""
-echo ""
-
 # Update the version number on maintaining-dependencies.md
 # and print the new version as the last line of the script as we need
 # to add it to $GITHUB_ENV variable


### PR DESCRIPTION
Logging the 'All done!' message is done in the `finalize_version_update` function, so there is no need to log it in the updaters themselves.