### PR TITLE
src: fix env-file flag to ignore spaces before quotes

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -129,6 +129,7 @@ void Dotenv::ParseContent(const std::string_view input) {
     key = content.substr(0, equal);
     content.remove_prefix(equal + 1);
     key = trim_spaces(key);
+    content = trim_spaces(content);
 
     if (key.empty()) {
       break;

--- a/test/fixtures/dotenv/valid.env
+++ b/test/fixtures/dotenv/valid.env
@@ -38,6 +38,7 @@ RETAIN_INNER_QUOTES={"foo": "bar"}
 RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
 RETAIN_INNER_QUOTES_AS_BACKTICKS=`{"foo": "bar's"}`
 TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
+SPACE_BEFORE_DOUBLE_QUOTES=   "space before double quotes"
 EMAIL=therealnerdybeast@example.tld
     SPACED_KEY = parsed
 EDGE_CASE_INLINE_COMMENTS="VALUE1" # or "VALUE2" or "VALUE3"

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -80,3 +80,5 @@ assert.strictEqual(process.env.DONT_EXPAND_UNQUOTED, 'dontexpand\\nnewlines');
 assert.strictEqual(process.env.DONT_EXPAND_SQUOTED, 'dontexpand\\nnewlines');
 // Ignore export before key
 assert.strictEqual(process.env.EXPORT_EXAMPLE, 'ignore export');
+// Ignore spaces before double quotes to avoid quoted strings as value
+assert.strictEqual(process.env.SPACE_BEFORE_DOUBLE_QUOTES, 'space before double quotes');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fix to ignore spaces between '=' and quoted string in env file used with `--env-file` flag to avoid quoted strings in environment values
Fixes the issue : https://github.com/nodejs/node/issues/53461