### PR TITLE
doc: adds mjs examples to `node:child_process`

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -636,6 +636,7 @@ the error passed to the callback will be an `AbortError`:
 ```mjs
 import { fork } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import process from 'node:process';
 
 const __filename = fileURLToPath(import.meta.url);
 
@@ -973,6 +974,7 @@ Example of a long-running process, by detaching and also ignoring its parent
 
 ```mjs
 import { spawn } from 'node:child_process';
+import process from 'node:process';
 
 const subprocess = spawn(process.argv[0], ['child_program.js'], {
   detached: true,
@@ -1106,6 +1108,7 @@ pipes between the parent and child. The value is one of the following:
 
 ```mjs
 import { spawn } from 'node:child_process';
+import process from 'node:process';
 
 // Child will use parent's stdios.
 spawn('prg', [], { stdio: 'inherit' });
@@ -1836,6 +1839,7 @@ to wait for the child to exit before exiting itself.
 
 ```mjs
 import { spawn } from 'node:child_process';
+import process from 'node:process';
 
 const subprocess = spawn(process.argv[0], ['child_program.js'], {
   detached: true,
@@ -2299,6 +2303,7 @@ the child and the parent.
 
 ```mjs
 import { spawn } from 'node:child_process';
+import process from 'node:process';
 
 const subprocess = spawn(process.argv[0], ['child_program.js'], {
   detached: true,


### PR DESCRIPTION
I've added  `mjs` examples for the [child_process](https://nodejs.org/api/child_process.html) documentation.

I've tested every single example (except for [the Windows ones](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) because I don't own a Windows machine :frowning_face:) on my machine and **they all work/behave as expected**.

I've refrained from making any changes to the `cjs` examples except for the one in [`child_process.fork(modulePath[, args][, options])`](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) where the `require` statement was inside a condition. I took the liberty to put the `require` statement at the top of the example; If you don't like that I can revert that change.

Thanks in advance for all your hard work, I hope this PRs are helpful :blush: (and not bothersome :see_no_evil:)

Best regards :heart: 