### PR TITLE
meta: add `node_sqlite.c` to PR label config

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -33,7 +33,7 @@ subSystemLabels:
   /^src\/quic\/*/: c++, quic
   /^src\/node_bob*/: c++, quic
   /^src\/node_sea/: single-executable
-  /^src\/node_sqlite.*: c++, sqlite
+  /^src\/node_sqlite.*/: c++, sqlite
 
   # Properly label changes to V8 inspector integration-related files
   /^src\/inspector_/: c++, inspector, needs-ci

--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -33,6 +33,7 @@ subSystemLabels:
   /^src\/quic\/*/: c++, quic
   /^src\/node_bob*/: c++, quic
   /^src\/node_sea/: single-executable
+  /^src\/node_sqlite.*: c++, sqlite
 
   # Properly label changes to V8 inspector integration-related files
   /^src\/inspector_/: c++, inspector, needs-ci


### PR DESCRIPTION
This PR adds `src/node_sqlite.c` and `src/node_sqlite.h` to the PR label config