### PR TITLE
stream: improve inspector ergonomics

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -2041,8 +2041,8 @@ function readableStreamError(stream, error) {
   assert(stream[kState].state === 'readable');
   stream[kState].state = 'errored';
   stream[kState].storedError = error;
-  stream[kIsClosedPromise].reject(error);
   setPromiseHandled(stream[kIsClosedPromise].promise);
+  stream[kIsClosedPromise].reject(error);
 
   const {
     reader,
@@ -2051,8 +2051,8 @@ function readableStreamError(stream, error) {
   if (reader === undefined)
     return;
 
-  reader[kState].close.reject(error);
   setPromiseHandled(reader[kState].close.promise);
+  reader[kState].close.reject(error);
 
   if (readableStreamHasDefaultReader(stream)) {
     for (let n = 0; n < reader[kState].readRequests.length; n++)

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -768,15 +768,15 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
     };
   }
 
-  stream[kIsClosedPromise].reject(stream[kState]?.storedError);
   setPromiseHandled(stream[kIsClosedPromise].promise);
+  stream[kIsClosedPromise].reject(stream[kState]?.storedError);
 
   const {
     writer,
   } = stream[kState];
   if (writer !== undefined) {
-    writer[kState].close.reject?.(stream[kState].storedError);
     setPromiseHandled(writer[kState].close.promise);
+    writer[kState].close.reject?.(stream[kState].storedError);
   }
 }
 


### PR DESCRIPTION
This fixes an issue where the inspector would consider a rejection from a promise created a while ago but rejected immediately.

I suspect this is because our unhandled rejection detection is based on when the promise is settled and V8's is based on when it is created. Arguably, ours is more correct.

I'm not sure how to test this, if anyone has any suggestions I'm all ears.

Fixes: https://github.com/nodejs/node/issues/53789