### PR TITLE
src: use Maybe<void> in ManagedEVPPKey

### DIFF
--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -839,10 +839,9 @@ Maybe<void> ExportJWKEcKey(
   return JustVoid();
 }
 
-Maybe<bool> ExportJWKEdKey(
-    Environment* env,
-    std::shared_ptr<KeyObjectData> key,
-    Local<Object> target) {
+Maybe<void> ExportJWKEdKey(Environment* env,
+                           std::shared_ptr<KeyObjectData> key,
+                           Local<Object> target) {
   ManagedEVPPKey pkey = key->GetAsymmetricKey();
   Mutex::ScopedLock lock(*pkey.mutex());
 
@@ -867,7 +866,7 @@ Maybe<bool> ExportJWKEdKey(
           env->context(),
           env->jwk_crv_string(),
           OneByteString(env->isolate(), curve)).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   size_t len = 0;
@@ -875,7 +874,7 @@ Maybe<bool> ExportJWKEdKey(
   Local<Value> error;
 
   if (!EVP_PKEY_get_raw_public_key(pkey.get(), nullptr, &len))
-    return Nothing<bool>();
+    return Nothing<void>();
 
   ByteSource::Builder out(len);
 
@@ -888,7 +887,7 @@ Maybe<bool> ExportJWKEdKey(
         !target->Set(env->context(), env->jwk_d_string(), encoded).IsJust()) {
       if (!error.IsEmpty())
         env->isolate()->ThrowException(error);
-      return Nothing<bool>();
+      return Nothing<void>();
     }
   }
 
@@ -900,17 +899,17 @@ Maybe<bool> ExportJWKEdKey(
       !target->Set(env->context(), env->jwk_x_string(), encoded).IsJust()) {
     if (!error.IsEmpty())
       env->isolate()->ThrowException(error);
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   if (target->Set(
           env->context(),
           env->jwk_kty_string(),
           env->jwk_okp_string()).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
-  return Just(true);
+  return JustVoid();
 }
 
 std::shared_ptr<KeyObjectData> ImportJWKEcKey(

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -148,10 +148,9 @@ v8::Maybe<void> ExportJWKEcKey(
     std::shared_ptr<KeyObjectData> key,
     v8::Local<v8::Object> target);
 
-v8::Maybe<bool> ExportJWKEdKey(
-    Environment* env,
-    std::shared_ptr<KeyObjectData> key,
-    v8::Local<v8::Object> target);
+v8::Maybe<void> ExportJWKEdKey(Environment* env,
+                               std::shared_ptr<KeyObjectData> key,
+                               v8::Local<v8::Object> target);
 
 std::shared_ptr<KeyObjectData> ImportJWKEcKey(
     Environment* env,

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -112,11 +112,11 @@ class ManagedEVPPKey : public MemoryRetainer {
       unsigned int* offset,
       bool allow_key_object);
 
-  v8::Maybe<bool> ToEncodedPublicKey(Environment* env,
+  v8::Maybe<void> ToEncodedPublicKey(Environment* env,
                                      const PublicKeyEncodingConfig& config,
                                      v8::Local<v8::Value>* out);
 
-  v8::Maybe<bool> ToEncodedPrivateKey(Environment* env,
+  v8::Maybe<void> ToEncodedPrivateKey(Environment* env,
                                       const PrivateKeyEncodingConfig& config,
                                       v8::Local<v8::Value>* out);
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -19,6 +19,7 @@ using v8::BackingStore;
 using v8::FunctionCallbackInfo;
 using v8::Int32;
 using v8::Just;
+using v8::JustVoid;
 using v8::Local;
 using v8::Maybe;
 using v8::Nothing;
@@ -359,10 +360,9 @@ WebCryptoCipherStatus RSACipherTraits::DoCipher(
   return WebCryptoCipherStatus::FAILED;
 }
 
-Maybe<bool> ExportJWKRsaKey(
-    Environment* env,
-    std::shared_ptr<KeyObjectData> key,
-    Local<Object> target) {
+Maybe<void> ExportJWKRsaKey(Environment* env,
+                            std::shared_ptr<KeyObjectData> key,
+                            Local<Object> target) {
   ManagedEVPPKey m_pkey = key->GetAsymmetricKey();
   Mutex::ScopedLock lock(*m_pkey.mutex());
   int type = EVP_PKEY_id(m_pkey.get());
@@ -392,12 +392,12 @@ Maybe<bool> ExportJWKRsaKey(
           env->context(),
           env->jwk_kty_string(),
           env->jwk_rsa_string()).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   if (SetEncodedValue(env, target, env->jwk_n_string(), n).IsNothing() ||
       SetEncodedValue(env, target, env->jwk_e_string(), e).IsNothing()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   if (key->GetKeyType() == kKeyTypePrivate) {
@@ -409,11 +409,11 @@ Maybe<bool> ExportJWKRsaKey(
         SetEncodedValue(env, target, env->jwk_dp_string(), dp).IsNothing() ||
         SetEncodedValue(env, target, env->jwk_dq_string(), dq).IsNothing() ||
         SetEncodedValue(env, target, env->jwk_qi_string(), qi).IsNothing()) {
-      return Nothing<bool>();
+      return Nothing<void>();
     }
   }
 
-  return Just(true);
+  return JustVoid();
 }
 
 std::shared_ptr<KeyObjectData> ImportJWKRsaKey(

--- a/src/crypto/crypto_rsa.h
+++ b/src/crypto/crypto_rsa.h
@@ -114,10 +114,9 @@ struct RSACipherTraits final {
 
 using RSACipherJob = CipherJob<RSACipherTraits>;
 
-v8::Maybe<bool> ExportJWKRsaKey(
-    Environment* env,
-    std::shared_ptr<KeyObjectData> key,
-    v8::Local<v8::Object> target);
+v8::Maybe<void> ExportJWKRsaKey(Environment* env,
+                                std::shared_ptr<KeyObjectData> key,
+                                v8::Local<v8::Object> target);
 
 std::shared_ptr<KeyObjectData> ImportJWKRsaKey(
     Environment* env,


### PR DESCRIPTION
With recent versions of V8, it is not necessary to use `Maybe<bool>` anymore. This changes member functions of `ManagedEVPPKey` to use `Maybe<void>` instead, as well as (transitive) dependencies.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
