### PR TITLE
src: avoid strcmp in ImportJWKAsymmetricKey

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -509,16 +509,17 @@ Maybe<void> ExportJWKAsymmetricKey(Environment* env,
 std::shared_ptr<KeyObjectData> ImportJWKAsymmetricKey(
     Environment* env,
     Local<Object> jwk,
-    const char* kty,
+    std::string_view kty,
     const FunctionCallbackInfo<Value>& args,
     unsigned int offset) {
-  if (strcmp(kty, "RSA") == 0) {
+  if (kty == "RSA") {
     return ImportJWKRsaKey(env, jwk, args, offset);
-  } else if (strcmp(kty, "EC") == 0) {
+  } else if (kty == "EC") {
     return ImportJWKEcKey(env, jwk, args, offset);
   }
 
-  THROW_ERR_CRYPTO_INVALID_JWK(env, "%s is not a supported JWK key type", kty);
+  THROW_ERR_CRYPTO_INVALID_JWK(
+      env, "%s is not a supported JWK key type", kty.data());
   return std::shared_ptr<KeyObjectData>();
 }
 


### PR DESCRIPTION
Use `std::string_view` and its `operator==` instead of calling `strcmp` on a `const char*`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
