### PR TITLE
fs: correctly pass dirent to exclude `withFileTypes`

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -543,7 +543,7 @@ class Glob {
         const fromSymlink = pattern.symlinks.has(index);
 
         if (current === lazyMinimatch().GLOBSTAR) {
-          if (entry.name[0] === '.' || (this.#exclude && this.#exclude(entry.name))) {
+          if (entry.name[0] === '.' || (this.#exclude && this.#exclude(this.#withFileTypes ? entry : entry.name))) {
             continue;
           }
           if (!fromSymlink && entry.isDirectory()) {

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -360,7 +360,7 @@ describe('globSync - withFileTypes', function() {
       const actual = globSync(pattern, {
         cwd: fixtureDir,
         withFileTypes: true,
-        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+        exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
@@ -376,7 +376,7 @@ describe('fsPromises glob - withFileTypes', function() {
       for await (const item of asyncGlob(pattern, {
         cwd: fixtureDir,
         withFileTypes: true,
-        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+        exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       })) actual.push(item);
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -345,7 +345,7 @@ describe('glob - withFileTypes', function() {
       const actual = await promisified(pattern, {
         cwd: fixtureDir,
         withFileTypes: true,
-        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+        exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -342,7 +342,11 @@ describe('glob - withFileTypes', function() {
   const promisified = promisify(glob);
   for (const [pattern, expected] of Object.entries(patterns)) {
     test(pattern, async () => {
-      const actual = await promisified(pattern, { cwd: fixtureDir, withFileTypes: true });
+      const actual = await promisified(pattern, {
+        cwd: fixtureDir,
+        withFileTypes: true,
+        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+      });
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
       assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());
@@ -353,7 +357,11 @@ describe('glob - withFileTypes', function() {
 describe('globSync - withFileTypes', function() {
   for (const [pattern, expected] of Object.entries(patterns)) {
     test(pattern, () => {
-      const actual = globSync(pattern, { cwd: fixtureDir, withFileTypes: true });
+      const actual = globSync(pattern, {
+        cwd: fixtureDir,
+        withFileTypes: true,
+        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+      });
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
       assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());
@@ -365,7 +373,11 @@ describe('fsPromises glob - withFileTypes', function() {
   for (const [pattern, expected] of Object.entries(patterns)) {
     test(pattern, async () => {
       const actual = [];
-      for await (const item of asyncGlob(pattern, { cwd: fixtureDir, withFileTypes: true })) actual.push(item);
+      for await (const item of asyncGlob(pattern, {
+        cwd: fixtureDir,
+        withFileTypes: true,
+        exclude: common.mustCall((dirent) => assert.ok(dirent instanceof Dirent)),
+      })) actual.push(item);
       assertDirents(actual);
       const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
       assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());


### PR DESCRIPTION
Fixes #53821

Fixes an issue where some calls to `#exclude` did not pass the dirent when `withFileTypes: true`

CC @targos