### PR TITLE
doc: add an explicit fetch tag step in release guide

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -285,6 +285,8 @@ You can integrate the PRs into the proposal without running full CI.
 ⚠️ At this point, you can either run `git node release --prepare`:
 
 ```console
+$ # You need to have locally the tag of the latest release of the release line
+$ git fetch http://github.com/nodejs/node.git tag -n vx.b.c
 $ git node release --prepare x.y.z
 ```
 
@@ -347,7 +349,8 @@ in the repository was not on the current branch you may have to supply a
 `--start-ref` argument:
 
 ```bash
-changelog-maker --group --markdown --filter-release --start-ref v1.2.2
+git fetch http://github.com/nodejs/node.git tag -n v1.2.2
+changelog-maker --group --markdown --filter-release --start-ref FETCH_HEAD
 ```
 
 `--filter-release` will remove the release commit from the previous release.


### PR DESCRIPTION
I had some problems generating the CHANGELOG for the 22.5.0 proposal, turned out the reason was my local clone didn't have the `v22.4.1` tag.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
