### PR TITLE
test_runner: fix escaping in snapshot tests

### DIFF
--- a/lib/internal/test_runner/snapshot.js
+++ b/lib/internal/test_runner/snapshot.js
@@ -146,7 +146,9 @@ class SnapshotManager {
         );
       }
 
-      this.snapshots = context.exports;
+      for (const key in context.exports) {
+        this.snapshots[key] = templateEscape(context.exports[key]);
+      }
       this.loaded = true;
     } catch (err) {
       let msg = `Cannot read snapshot file '${this.snapshotFile}.'`;

--- a/test/fixtures/test-runner/snapshots/unit.js
+++ b/test/fixtures/test-runner/snapshots/unit.js
@@ -22,3 +22,7 @@ test('`${foo}`', async (t) => {
   const options = { serializers: [() => { return '***'; }]};
   t.assert.snapshot('snapshotted string', options);
 });
+
+test('escapes in `\\${foo}`\n', async (t) => {
+  t.assert.snapshot('`\\${foo}`\n');
+});

--- a/test/parallel/test-runner-snapshot-tests.js
+++ b/test/parallel/test-runner-snapshot-tests.js
@@ -296,9 +296,9 @@ test('t.assert.snapshot()', async (t) => {
 
     t.assert.strictEqual(child.code, 1);
     t.assert.strictEqual(child.signal, null);
-    t.assert.match(child.stdout, /# tests 3/);
+    t.assert.match(child.stdout, /# tests 4/);
     t.assert.match(child.stdout, /# pass 0/);
-    t.assert.match(child.stdout, /# fail 3/);
+    t.assert.match(child.stdout, /# fail 4/);
     t.assert.match(child.stdout, /Missing snapshots/);
   });
 
@@ -311,8 +311,8 @@ test('t.assert.snapshot()', async (t) => {
 
     t.assert.strictEqual(child.code, 0);
     t.assert.strictEqual(child.signal, null);
-    t.assert.match(child.stdout, /tests 3/);
-    t.assert.match(child.stdout, /pass 3/);
+    t.assert.match(child.stdout, /tests 4/);
+    t.assert.match(child.stdout, /pass 4/);
     t.assert.match(child.stdout, /fail 0/);
   });
 
@@ -325,8 +325,8 @@ test('t.assert.snapshot()', async (t) => {
 
     t.assert.strictEqual(child.code, 0);
     t.assert.strictEqual(child.signal, null);
-    t.assert.match(child.stdout, /tests 3/);
-    t.assert.match(child.stdout, /pass 3/);
+    t.assert.match(child.stdout, /tests 4/);
+    t.assert.match(child.stdout, /pass 4/);
     t.assert.match(child.stdout, /fail 0/);
   });
 });


### PR DESCRIPTION
Snapshotted values are escaped after serialization. This happens when serializing a value for comparison when snapshots already exist, and also when updating them. That is, snapshots are escaped in the internal storage, but when written to disk, one "level" of escaping is removed. That escaping is never added back when reading the snapshots back. This makes even the simplest test trying to serialize a string with an escape code in it fail, like the one I added here.

Honestly I'm not quite sure about the approach here: An alternative would be to **not** escape snapshots internally, and only do so when writing them to disk/interpolating them into the appropriate JS-code. I haven't fully thought this through, though, and there is also a test explicitly ensuring that `serialize` escapes values, so there might be a good reason for it.

Another thing I'm not sure about is whether the test I added is sufficient, because it feels kind of indirect. Let me know if you want to see that changed.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
