### PR TITLE
test_runner: remove plan option from run()

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -483,7 +483,6 @@ function run(options = kEmptyObject) {
     watch,
     setup,
     only,
-    plan,
   } = options;
 
   if (files != null) {
@@ -552,7 +551,7 @@ function run(options = kEmptyObject) {
     });
   }
 
-  const root = createTestTree({ __proto__: null, concurrency, timeout, signal, plan });
+  const root = createTestTree({ __proto__: null, concurrency, timeout, signal });
   root.harness.shouldColorizeTestFiles ||= shouldColorizeTestFiles(root);
 
   if (process.env.NODE_TEST_CONTEXT !== undefined) {

--- a/test/fixtures/test-runner/output/test-runner-plan.js
+++ b/test/fixtures/test-runner/output/test-runner-plan.js
@@ -74,6 +74,6 @@ test('planning with streams', (t, done) => {
   });
 
   stream.on('end', () => {
-   done();
+    done();
   });
 })


### PR DESCRIPTION
This commit removes the `plan` option to `run()`. I believe it was added by mistake. It is not documented, untested, and a test plan does not make sense in the context of `run()`.

This commit also fixes a minor formatting issue in a related fixture.

Refs: https://github.com/nodejs/node/pull/52860

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
