### PR TITLE
test_runner: mock_loader resolve the cjs and esm formats respectively.

### DIFF
--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -24,6 +24,7 @@ let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
 });
 const { createRequire, isBuiltin } = require('module');
 const { defaultResolve } = require('internal/modules/esm/resolve');
+const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
 
 // TODO(cjihrig): This file should not be exposed publicly, but register() does
 // not handle internal loaders. Before marking this API as stable, one of the
@@ -96,11 +97,25 @@ async function resolve(specifier, context, nextResolve) {
   if (isBuiltin(specifier)) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
-    specifier = pathToFileURL(
-      defaultResolve(specifier, {
-        conditions: context?.conditions, parentURL: normalizeReferrerURL(context.parentURL)
-      })
-    ).href;
+    const format = defaultGetFormatWithoutErrors(pathToFileURL(specifier));
+
+    try {
+      if(format === "module") {
+        specifier = pathToFileURL(
+          defaultResolve(specifier, context)
+        ).href;
+      } else {
+        const req = createRequire(context.parentURL);
+        specifier = pathToFileURL(req.resolve(specifier)).href;
+      }
+    } catch {
+      const parentURL = normalizeReferrerURL(context.parentURL);
+      const parsedURL = URL.parse(specifier, parentURL)?.href;
+
+      if (parsedURL) {
+        specifier = parsedURL;
+      }
+    }
 
     mockSpecifier = specifier;
   }

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -23,8 +23,8 @@ let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
 const { createRequire, isBuiltin } = require('module');
-const { defaultResolve } = require('internal/modules/esm/resolve');
 const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
+const { defaultResolve } = require('internal/modules/esm/resolve');
 
 // TODO(cjihrig): This file should not be exposed publicly, but register() does
 // not handle internal loaders. Before marking this API as stable, one of the
@@ -97,13 +97,13 @@ async function resolve(specifier, context, nextResolve) {
   if (isBuiltin(specifier)) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
-    const format = defaultGetFormatWithoutErrors(pathToFileURL(specifier));
+    const format = defaultGetFormatWithoutErrors(
+      pathToFileURL(context.parentURL ?? specifier)
+    );
 
     try {
-      if(format === "module") {
-        specifier = pathToFileURL(
-          defaultResolve(specifier, context)
-        ).href;
+      if (format === 'module') {
+        specifier = defaultResolve(specifier, context).url;
       } else {
         const req = createRequire(context.parentURL);
         specifier = pathToFileURL(req.resolve(specifier)).href;

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -23,6 +23,7 @@ let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
 const { createRequire, isBuiltin } = require('module');
+const { defaultResolve } = require('internal/modules/esm/resolve');
 
 // TODO(cjihrig): This file should not be exposed publicly, but register() does
 // not handle internal loaders. Before marking this API as stable, one of the
@@ -95,19 +96,11 @@ async function resolve(specifier, context, nextResolve) {
   if (isBuiltin(specifier)) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
-    // TODO(cjihrig): This try...catch should be replaced by defaultResolve(),
-    // but there are some edge cases that caused the tests to fail on Windows.
-    try {
-      const req = createRequire(context.parentURL);
-      specifier = pathToFileURL(req.resolve(specifier)).href;
-    } catch {
-      const parentURL = normalizeReferrerURL(context.parentURL);
-      const parsedURL = URL.parse(specifier, parentURL)?.href;
-
-      if (parsedURL) {
-        specifier = parsedURL;
-      }
-    }
+    specifier = pathToFileURL(
+      defaultResolve(specifier, {
+        conditions: context?.conditions, parentURL: normalizeReferrerURL(context.parentURL)
+      })
+    ).href;
 
     mockSpecifier = specifier;
   }

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -22,7 +22,7 @@ const { normalizeReferrerURL } = require('internal/modules/helpers');
 let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
-const { createRequire, isBuiltin } = require('module');
+const { createRequire, isBuiltin, _resolveFilename } = require('module');
 const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
 const { defaultResolve } = require('internal/modules/esm/resolve');
 
@@ -97,16 +97,19 @@ async function resolve(specifier, context, nextResolve) {
   if (isBuiltin(specifier)) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
-    const format = defaultGetFormatWithoutErrors(
-      pathToFileURL(context.parentURL ?? specifier)
-    );
+    let format;
+    
+    if(context.parentURL) {
+      format = defaultGetFormatWithoutErrors(pathToFileURL(context.parentURL));
+    }
 
     try {
       if (format === 'module') {
         specifier = defaultResolve(specifier, context).url;
       } else {
-        const req = createRequire(context.parentURL);
-        specifier = pathToFileURL(req.resolve(specifier)).href;
+        specifier = pathToFileURL(
+          createRequire(context.parentURL).resolve(specifier)
+        ).href;
       }
     } catch {
       const parentURL = normalizeReferrerURL(context.parentURL);

--- a/lib/test/mock_loader.js
+++ b/lib/test/mock_loader.js
@@ -22,7 +22,7 @@ const { normalizeReferrerURL } = require('internal/modules/helpers');
 let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
-const { createRequire, isBuiltin, _resolveFilename } = require('module');
+const { createRequire, isBuiltin } = require('module');
 const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
 const { defaultResolve } = require('internal/modules/esm/resolve');
 
@@ -98,8 +98,8 @@ async function resolve(specifier, context, nextResolve) {
     mockSpecifier = ensureNodeScheme(specifier);
   } else {
     let format;
-    
-    if(context.parentURL) {
+
+    if (context.parentURL) {
       format = defaultGetFormatWithoutErrors(pathToFileURL(context.parentURL));
     }
 
@@ -108,7 +108,7 @@ async function resolve(specifier, context, nextResolve) {
         specifier = defaultResolve(specifier, context).url;
       } else {
         specifier = pathToFileURL(
-          createRequire(context.parentURL).resolve(specifier)
+          createRequire(context.parentURL).resolve(specifier),
         ).href;
       }
     } catch {

--- a/test/fixtures/module-mocking/basic-esm-without-extension.js
+++ b/test/fixtures/module-mocking/basic-esm-without-extension.js
@@ -1,0 +1,1 @@
+export let string = 'original esm string';

--- a/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
+++ b/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
@@ -1,12 +1,8 @@
-import { writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { mock } from 'node:test';
-
-writeFileSync(resolve(import.meta.dirname, './test-2.js'), 'export default 42');
 
 try {
   if (mock.module) mock.module('Whatever, this is not significant', { namedExports: {} });
 } catch {}
 
-const { default: x } = await import('./test-2');
-console.log(`Found x: ${x}`); // prints 42
+const { string } = await import('./basic-esm');
+console.log(`Found string: ${string}`); // prints 'original esm string'

--- a/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
+++ b/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
@@ -1,0 +1,12 @@
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { mock } from 'node:test';
+
+writeFileSync(resolve(import.meta.dirname, './test-2.js'), 'export default 42');
+
+try {
+  if (mock.module) mock.module('Whatever, this is not significant', { namedExports: {} });
+} catch {}
+
+const { default: x } = await import('./test-2');
+console.log(`Found x: ${x}`); // prints 42

--- a/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
+++ b/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
@@ -4,5 +4,5 @@ try {
   if (mock.module) mock.module('Whatever, this is not significant', { namedExports: {} });
 } catch {}
 
-const { string } = await import('./basic-esm');
+const { string } = await import('./basic-esm-without-extension');
 console.log(`Found string: ${string}`); // prints 'original esm string'

--- a/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
+++ b/test/fixtures/module-mocking/wrong-import-after-module-mocking.js
@@ -1,7 +1,7 @@
 import { mock } from 'node:test';
 
 try {
-  if (mock.module) mock.module('Whatever, this is not significant', { namedExports: {} });
+  mock.module?.('Whatever, this is not significant', { namedExports: {} });
 } catch {}
 
 const { string } = await import('./basic-esm-without-extension');

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -1,7 +1,10 @@
 'use strict';
 const common = require('../common');
+const child = require('child_process');
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
+const fixtures = require('../common/fixtures');
+const { unlinkSync } = require('fs');
 test('spies on a function', (t) => {
   const sum = t.mock.fn((arg1, arg2) => {
     return arg1 + arg2;
@@ -1053,4 +1056,20 @@ test('setter() fails if getter options is true', (t) => {
   assert.throws(() => {
     t.mock.setter({}, 'method', { getter: true });
   }, /The property 'options\.setter' cannot be used with 'options\.getter'/);
+});
+
+test('wrong import syntax should throw error after module mocking.', () => {
+  const { stdout, stderr } = child.spawnSync(
+    process.execPath,
+    [
+      '--experimental-test-module-mocks',
+      '--experimental-default-type=module',
+      fixtures.path('module-mocking/wrong-import-after-module-mocking.js'),
+    ]
+  );
+
+  unlinkSync(fixtures.path('module-mocking/test-2.js'));
+
+  assert.equal(stdout.toString(), '')
+  assert.match(stderr.toString(), /Error \[ERR_MODULE_NOT_FOUND\]: Cannot find module/)
 });

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -1,6 +1,5 @@
 'use strict';
 const common = require('../common');
-const child = require('child_process');
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
 const fixtures = require('../common/fixtures');
@@ -1057,8 +1056,8 @@ test('setter() fails if getter options is true', (t) => {
   }, /The property 'options\.setter' cannot be used with 'options\.getter'/);
 });
 
-test.only('wrong import syntax should throw error after module mocking.', () => {
-  const { stdout, stderr } = child.spawnSync(
+test('wrong import syntax should throw error after module mocking.', async () => {
+  const { stdout, stderr } = await common.spawnPromisified(
     process.execPath,
     [
       '--experimental-test-module-mocks',

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -4,7 +4,6 @@ const child = require('child_process');
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
 const fixtures = require('../common/fixtures');
-const { unlinkSync } = require('fs');
 test('spies on a function', (t) => {
   const sum = t.mock.fn((arg1, arg2) => {
     return arg1 + arg2;
@@ -1058,7 +1057,7 @@ test('setter() fails if getter options is true', (t) => {
   }, /The property 'options\.setter' cannot be used with 'options\.getter'/);
 });
 
-test('wrong import syntax should throw error after module mocking.', () => {
+test.only('wrong import syntax should throw error after module mocking.', () => {
   const { stdout, stderr } = child.spawnSync(
     process.execPath,
     [
@@ -1067,8 +1066,6 @@ test('wrong import syntax should throw error after module mocking.', () => {
       fixtures.path('module-mocking/wrong-import-after-module-mocking.js'),
     ]
   );
-
-  unlinkSync(fixtures.path('module-mocking/test-2.js'));
 
   assert.equal(stdout.toString(), '')
   assert.match(stderr.toString(), /Error \[ERR_MODULE_NOT_FOUND\]: Cannot find module/)

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -1055,17 +1055,3 @@ test('setter() fails if getter options is true', (t) => {
     t.mock.setter({}, 'method', { getter: true });
   }, /The property 'options\.setter' cannot be used with 'options\.getter'/);
 });
-
-test('wrong import syntax should throw error after module mocking.', async () => {
-  const { stdout, stderr } = await common.spawnPromisified(
-    process.execPath,
-    [
-      '--experimental-test-module-mocks',
-      '--experimental-default-type=module',
-      fixtures.path('module-mocking/wrong-import-after-module-mocking.js'),
-    ]
-  );
-
-  assert.equal(stdout.toString(), '')
-  assert.match(stderr.toString(), /Error \[ERR_MODULE_NOT_FOUND\]: Cannot find module/)
-});

--- a/test/parallel/test-runner-mocking.js
+++ b/test/parallel/test-runner-mocking.js
@@ -2,7 +2,6 @@
 const common = require('../common');
 const assert = require('node:assert');
 const { mock, test } = require('node:test');
-const fixtures = require('../common/fixtures');
 test('spies on a function', (t) => {
   const sum = t.mock.fn((arg1, arg2) => {
     return arg1 + arg2;

--- a/test/parallel/test-runner-module-mocking.js
+++ b/test/parallel/test-runner-module-mocking.js
@@ -638,3 +638,18 @@ test('defaultExports work with ESM mocks in both module systems', async (t) => {
   assert.strictEqual((await import(fixture)).default, defaultExport);
   assert.strictEqual(require(fixture), defaultExport);
 });
+
+test('wrong import syntax should throw error after module mocking.', async () => {
+  const { stdout, stderr, code } = await common.spawnPromisified(
+    process.execPath,
+    [
+      '--experimental-test-module-mocks',
+      '--experimental-default-type=module',
+      fixtures.path('module-mocking/wrong-import-after-module-mocking.js'),
+    ]
+  );
+
+  assert.strictEqual(stdout, '');
+  assert.match(stderr, /Error \[ERR_MODULE_NOT_FOUND\]: Cannot find module/);
+  assert.strictEqual(code, 1);
+});


### PR DESCRIPTION
This issue was caused by recovering specifier in cjs resolve without format(esm,cjs) check in mock_loader.
So I did resolve logic differently for each format. And also added test.

Fixes: #53807