### PR TITLE
src: fix potential segmentation fault in SQLite

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -441,7 +441,9 @@ void StatementSync::All(const FunctionCallbackInfo<Value>& args) {
 
     for (int i = 0; i < num_cols; ++i) {
       Local<Value> key = stmt->ColumnNameToValue(i);
+      if (key.IsEmpty()) return;
       Local<Value> val = stmt->ColumnToValue(i);
+      if (val.IsEmpty()) return;
 
       if (row->Set(env->context(), key, val).IsNothing()) {
         return;
@@ -483,7 +485,9 @@ void StatementSync::Get(const FunctionCallbackInfo<Value>& args) {
 
   for (int i = 0; i < num_cols; ++i) {
     Local<Value> key = stmt->ColumnNameToValue(i);
+    if (key.IsEmpty()) return;
     Local<Value> val = stmt->ColumnToValue(i);
+    if (val.IsEmpty()) return;
 
     if (result->Set(env->context(), key, val).IsNothing()) {
       return;


### PR DESCRIPTION
The `Local<Value>` returned from `ColumnToValue()` and `ColumnNameToValue()` may be empty (if a JavaScript exception is pending), in which case a segmentation fault may occur at the call sites, which do not check if the `Local<Value>` is empty. Fix this bug by returning early if an exception is pending (as indicated by the `Local` being empty).

In the long term, these functions should return `MaybeLocal` instead of `Local`, but this patch is supposed to be a minimal bug fix only.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
