### PR TITLE
src,test: disallow unsafe integer coercion in SQLite

### DIFF
--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -388,6 +388,22 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
       message: /The "readBigInts" argument must be a boolean/,
     });
   });
+
+  test('BigInt is required for reading large integers', (t) => {
+    const db = new DatabaseSync(nextDb());
+    const bad = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
+    t.assert.throws(() => {
+      bad.get();
+    }, {
+      code: 'ERR_OUT_OF_RANGE',
+      message: /^The value of column 0 is too large.*: 9007199254740992$/,
+    });
+    const good = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
+    good.setReadBigInts(true);
+    t.assert.deepStrictEqual(good.get(), {
+      [`${Number.MAX_SAFE_INTEGER} + 1`]: 2n ** 53n,
+    });
+  });
 });
 
 suite('StatementSync.prototype.setAllowBareNamedParameters()', () => {


### PR DESCRIPTION
Currently, by default (i.e., when `use_big_ints_` has not explicitly been set to true), reading a SQLite integer value that is not a safe integer in JavaScript is likely to yield an incorrect number.

Instead, err on the side of caution and throw if the stored integer is not a safe integer in JavaScript and if `use_big_ints_` has not been set to true.

~Blocked on https://github.com/nodejs/node/pull/53850.~

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
