### PR TITLE
fs: avoid unnecessary options checks when options argument is not passed

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1351,19 +1351,20 @@ function mkdirSync(path, options) {
   let mode = 0o777;
   let recursive = false;
   if (typeof options === 'number' || typeof options === 'string') {
-    mode = options;
+    mode = parseFileMode(options, 'mode');
   } else if (options) {
-    if (options.recursive !== undefined)
+    if (options.recursive !== undefined) {
       recursive = options.recursive;
-    if (options.mode !== undefined)
-      mode = options.mode;
+      validateBoolean(recursive, 'options.recursive');
+    }
+    if (options.mode !== undefined) {
+      mode = parseFileMode(options.mode, 'options.mode');
+    }
   }
-  path = getValidatedPath(path);
-  validateBoolean(recursive, 'options.recursive');
 
   const result = binding.mkdir(
-    path,
-    parseFileMode(mode, 'mode'),
+    getValidatedPath(path),
+    mode,
     recursive,
   );
 


### PR DESCRIPTION
Remove unnecessary option parsing when options argv is undefined