### PR TITLE
build: minify undici

### DIFF
--- a/tools/dep_updaters/update-undici.sh
+++ b/tools/dep_updaters/update-undici.sh
@@ -54,6 +54,11 @@ mv undici-tmp/node_modules/undici deps/undici/src
 mv deps/undici/src/undici-fetch.js deps/undici/undici.js
 cp deps/undici/src/LICENSE deps/undici/LICENSE
 
+# minify undici
+find "deps/undici/src" -type f -name "*.js" | while read -r file; do
+  npx esbuild "$file" --minify --outfile="$file" --allow-overwrite
+done
+
 rm -rf undici-tmp/
 
 # Update the version number on maintaining-dependencies.md


### PR DESCRIPTION
Hi, I noticed that undici is not minified (none of the dependencies actually?). 

It's big enough to be worth compressing to save half the space, but also to make it faster when it's required, not just using a normal require, also because undici contains lazy requires that are performed during the first fetch.

I know this is missing benchmarks, but wanted to hear what you think before continuing 🙂 