### PR TITLE
test_runner: cleanup global event listeners after run

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -170,8 +170,13 @@ function setup(root) {
       kCancelledByParent));
 
     hook.disable();
-    process.removeListener('unhandledRejection', rejectionHandler);
     process.removeListener('uncaughtException', exceptionHandler);
+    process.removeListener('unhandledRejection', rejectionHandler);
+    process.removeListener('beforeExit', exitHandler);
+    if (globalOptions.isTestRunner) {
+      process.removeListener('SIGINT', terminationHandler);
+      process.removeListener('SIGTERM', terminationHandler);
+    }
   };
 
   const terminationHandler = () => {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -566,6 +566,7 @@ function run(options = kEmptyObject) {
   }
 
   let postRun = () => root.postRun();
+  let teardown = () => root.harness.teardown();
   let filesWatcher;
   const opts = {
     __proto__: null,
@@ -580,6 +581,7 @@ function run(options = kEmptyObject) {
   if (watch) {
     filesWatcher = watchFiles(testFiles, opts);
     postRun = undefined;
+    teardown = undefined;
   }
   const runFiles = () => {
     root.harness.bootstrapComplete = true;
@@ -591,7 +593,8 @@ function run(options = kEmptyObject) {
     });
   };
 
-  PromisePrototypeThen(PromisePrototypeThen(PromiseResolve(setup?.(root.reporter)), runFiles), postRun);
+  const setupPromise = PromiseResolve(setup?.(root.reporter));
+  PromisePrototypeThen(PromisePrototypeThen(PromisePrototypeThen(setupPromise, runFiles), postRun), teardown);
 
   return root.reporter;
 }

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -551,3 +551,9 @@ describe('forceExit', () => {
     });
   });
 });
+
+// exitHandler doesn't run until after the tests / after hooks finish.
+process.on('exit', () => {
+  assert.strictEqual(process.listeners('uncaughtException').length, 0);
+  assert.strictEqual(process.listeners('unhandledRejection').length, 0);
+});

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -552,8 +552,12 @@ describe('forceExit', () => {
   });
 });
 
+
 // exitHandler doesn't run until after the tests / after hooks finish.
 process.on('exit', () => {
   assert.strictEqual(process.listeners('uncaughtException').length, 0);
   assert.strictEqual(process.listeners('unhandledRejection').length, 0);
+  assert.strictEqual(process.listeners('beforeExit').length, 0);
+  assert.strictEqual(process.listeners('SIGINT').length, 0);
+  assert.strictEqual(process.listeners('SIGTERM').length, 0);
 });


### PR DESCRIPTION
After a test run finishes, all the [global event listeners](https://github.com/nodejs/node/blob/362afa52ebe462a39874915e5e70d261db153c58/lib/internal/test_runner/harness.js#L182-L188) are removed.

Fixes: https://github.com/nodejs/node/issues/53868