### PR TITLE
src,http2: cache invariant code motion

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1652,11 +1652,12 @@ void Http2Session::HandleSettingsFrame(const nghttp2_frame* frame) {
         int32_t settings_id = iv[i].settings_id;
         if (settings_id >=
             IDX_SETTINGS_COUNT) {  // unsupported, additional settings
+          auto iv_value = iv[i].value;
           for (size_t j = 0; j < numsettings; ++j) {
             if ((remote_custom_settings_.entries[j].settings_id & 0xFFFF) ==
                 settings_id) {
               remote_custom_settings_.entries[j].settings_id = settings_id;
-              remote_custom_settings_.entries[j].value = iv[i].value;
+              remote_custom_settings_.entries[j].value = iv_value;
               break;
             }
           }


### PR DESCRIPTION
This avoids unnecessary key access reference