### PR TITLE
src: fix `-Wshadow` warning

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -144,9 +144,9 @@ void DumpJavaScriptBacktrace(FILE* fp);
   do {                                                                         \
     /* Make sure that this struct does not end up in inline code, but      */  \
     /* rather in a read-only data section when modifying this code.        */  \
-    static const node::AssertionInfo args = {                                  \
+    static const node::AssertionInfo error_and_abort_args = {                  \
         __FILE__ ":" STRINGIFY(__LINE__), #expr, PRETTY_FUNCTION_NAME};        \
-    node::Assert(args);                                                        \
+    node::Assert(error_and_abort_args);                                        \
     /* `node::Assert` doesn't return. Add an [[noreturn]] abort() here to  */  \
     /* make the compiler happy about no return value in the caller         */  \
     /* function when calling ERROR_AND_ABORT.                              */  \


### PR DESCRIPTION
In utils.h's `ERROR_AND_ABORT` macro, rename the static local variable `args` to avoid -Wshadow warnings in code that calls `ERROR_AND_ABORT()`. This allows Electron to remove a [patch](https://github.com/electron/electron/blob/653d0f009e5ec9a5e903b5179f335fbbd7b2e6ef/patches/node/fix_-wshadow_warning.patch).

Relevant console output:

```
In file included from ../../third_party/electron_node/src/inspector/runtime_agent.cc:3:
In file included from ../../third_party/electron_node/src/env-inl.h:32:
../../third_party/electron_node/src/node_internals.h:72:3: error: declaration shadows a local variable [-Werror,-Wshadow]
   72 |   CHECK(args[0]->IsObject());
      |   ^
../../third_party/electron_node/src/util.h:154:7: note: expanded from macro 'CHECK'
  154 |       ERROR_AND_ABORT(expr);                                                  \
      |       ^
../../third_party/electron_node/src/util.h:132:38: note: expanded from macro 'ERROR_AND_ABORT'
  132 |     static const node::AssertionInfo args = {                                 \
      |                                      ^
../../third_party/electron_node/src/node_internals.h:67:67: note: previous declaration is here
   67 | void GetSockOrPeerName(const v8::FunctionCallbackInfo<v8::Value>& args) {
      |                                                                   ^
1 error generated.
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
