### PR TITLE
src: expose `LookupAndCompile` with parameters

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -489,6 +489,14 @@ MaybeLocal<Value> BuiltinLoader::CompileAndCall(Local<Context> context,
   return fn->Call(context, undefined, argc, argv);
 }
 
+MaybeLocal<Function> BuiltinLoader::LookupAndCompile(
+    Local<Context> context,
+    const char* id,
+    std::vector<Local<String>>* parameters,
+    Realm* optional_realm) {
+  return LookupAndCompileInternal(context, id, parameters, optional_realm);
+}
+
 bool BuiltinLoader::CompileAllBuiltinsAndCopyCodeCache(
     Local<Context> context,
     const std::vector<std::string>& eager_builtins,

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -97,6 +97,12 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
                                                 const char* id,
                                                 Realm* optional_realm);
 
+  v8::MaybeLocal<v8::Function> LookupAndCompile(
+      v8::Local<v8::Context> context,
+      const char* id,
+      std::vector<v8::Local<v8::String>>* parameters,
+      Realm* optional_realm);
+
   v8::MaybeLocal<v8::Value> CompileAndCall(v8::Local<v8::Context> context,
                                            const char* id,
                                            int argc,


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/44018.

This PR exposes a version of `LookupAndCompile` that takes parameters instead of detecting them based on module IDs. 

Electron currently maintains a [wrapper to `LookupAndCompile`](https://github.com/electron/electron/blob/main/shell/common/node_util.cc#L13-L45), which specifically requires parameters because we pass our own modules to `LookupAndCompile` in several places:
- [`shell/common/api/electron_api_asar.cc`](https://github.com/electron/electron/blob/06a00b74e817a61f20e2734d50d8eb7bc9b099f6/shell/common/api/electron_api_asar.cc#L201-L206)
- [`shell/renderer/electron_sandboxed_renderer_client.cc`](https://github.com/electron/electron/blob/7ca3f55b1070594589244a81095884dcc152af37/shell/renderer/electron_sandboxed_renderer_client.cc#L211-L218)
- [`shell/renderer/renderer_client_base.cc`](https://github.com/electron/electron/blob/16f459228b5c083be6aebe8b3d3eb7a04cb43cc2/shell/renderer/renderer_client_base.cc#L623-L630)

and therefore need to be able to able to expose the ability to set that.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
