### PR TITLE
build: update codecov

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
+      - codecov.yml
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
+      - codecov.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux.yml
+      - codecov.yml
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux.yml
+      - codecov.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-windows.yml
+      - codecov.yml
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-windows.yml
+      - codecov.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,9 +11,13 @@ codecov:
   branch: main
   notify:
     # Wait for all coverage builds:
-    after_n_builds: 2
+    # - coverage-linux.yml
+    # - coverage-windows.yml
+    # - coverage-linux-without-intl.yml
+    after_n_builds: 3
 
 coverage:
+  # Useful for blocking Pull Requests that don't meet a particular coverage threshold.
   status:
     project: off
     patch: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,8 @@
-# TODO(bcoe): re-enable coverage report comments, once we can figure out
-# how to make them more accurate for the Node.js project,
-# See: https://github.com/nodejs/node/issues/35759
-comment: false
-#  # Only show diff and files changed:
-#  layout: "diff, files"
-#  # Don't post if no changes in coverage:
-#  require_changes: true
+comment:
+  # Only show diff and files changed:
+  layout: diff, files
+  # Don't post if no changes in coverage:
+  require_changes: true
 
 codecov:
   branch: main


### PR DESCRIPTION
Codecov comments were disabled almost 4 years ago. I think we can reenable them. Additionally, we now have 1 more coverage build. This PR fixes that.

Previous issue with codecov: https://github.com/nodejs/node/issues/35759

cc @nodejs/build