### PR TITLE
tools: add workflow to ensure `README` lists are in sync with gh teams

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -185,4 +185,21 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           persist-credentials: false
-      - run: tools/lint-readme-lists.mjs
+      - name: Get team members if possible
+        id: team_members
+        run: |
+          get_list_members() {
+            TEAM="$1"
+            QUOTE='"'
+            gh api "/orgs/nodejs/teams/$TEAM/members" -X GET -f per_page=100 --jq "map(.login) | ${QUOTE}${TEAM}=\(tojson)${QUOTE}"
+          }
+          [ -z "$GITHUB_TOKEN" ] || (
+            get_list_members "collaborators"
+            get_list_members "issue-triage"
+            get_list_members "tsc"
+          ) >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+      - run: tools/lint-readme-lists.mjs "$TEAMS"
+        env:
+          TEAMS: ${{ tojson(steps.team_members.outputs) }}

--- a/tools/lint-readme-lists.mjs
+++ b/tools/lint-readme-lists.mjs
@@ -1,17 +1,26 @@
 #!/usr/bin/env node
 
-// Validates the list in the README are in the correct order.
+// Validates the list in the README are in the correct order, and consistent with the actual GitHub teams.
 
+import assert from 'node:assert';
 import { open } from 'node:fs/promises';
+import { argv } from 'node:process';
 
-const lists = [
-  'TSC voting members',
-  'TSC regular members',
-  'TSC emeriti members',
-  'Collaborators',
-  'Collaborator emeriti',
-  'Triagers',
-];
+const lists = {
+  '__proto__': null,
+
+  'TSC voting members': 'tsc',
+  'TSC regular members': null,
+  'TSC emeriti members': null,
+  'Collaborators': 'collaborators',
+  'Collaborator emeriti': null,
+  'Triagers': 'issue-triage',
+};
+const actualMembers = {
+  __proto__: null,
+  // The bot is part of `@nodejs/collaborators`, but is not listed in the README.
+  collaborators: new Set().add('nodejs-github-bot'),
+};
 const tscMembers = new Set();
 
 const readme = await open(new URL('../README.md', import.meta.url), 'r');
@@ -23,26 +32,47 @@ let lineNumber = 0;
 for await (const line of readme.readLines()) {
   lineNumber++;
   if (line.startsWith('### ')) {
-    currentList = lists[lists.indexOf(line.slice(4))];
+    currentList = line.slice(4);
     previousGithubHandle = null;
   } else if (line.startsWith('#### ')) {
-    currentList = lists[lists.indexOf(line.slice(5))];
+    currentList = line.slice(5);
     previousGithubHandle = null;
-  } else if (currentList && line.startsWith('* [')) {
-    const currentGithubHandle = line.slice(3, line.indexOf(']')).toLowerCase();
-    if (previousGithubHandle && previousGithubHandle >= currentGithubHandle) {
-      throw new Error(`${currentGithubHandle} should be listed before ${previousGithubHandle} in the ${currentList} list (README.md:${lineNumber})`);
+  } else if (currentList in lists && line.startsWith('* [')) {
+    const currentGithubHandle = line.slice(3, line.indexOf(']'));
+    const currentGithubHandleLowerCase = currentGithubHandle.toLowerCase();
+    if (
+      previousGithubHandle &&
+      previousGithubHandle >= currentGithubHandleLowerCase
+    ) {
+      throw new Error(
+        `${currentGithubHandle} should be listed before ${previousGithubHandle} in the ${currentList} list (README.md:${lineNumber})`,
+      );
     }
 
-    if (currentList === 'TSC voting members' || currentList === 'TSC regular members') {
+    if (
+      currentList === 'TSC voting members' ||
+      currentList === 'TSC regular members'
+    ) {
       tscMembers.add(currentGithubHandle);
     } else if (currentList === 'Collaborators') {
       tscMembers.delete(currentGithubHandle);
     }
-    previousGithubHandle = currentGithubHandle;
+    if (lists[currentList]) {
+      (actualMembers[lists[currentList]] ??= new Set()).add(currentGithubHandle);
+    }
+    previousGithubHandle = currentGithubHandleLowerCase;
   }
 }
+console.info('Lists are in the alphabetical order.');
 
-if (tscMembers.size !== 0) {
-  throw new Error(`Some TSC members are not listed as Collaborators: ${Array.from(tscMembers)}`);
+assert.deepStrictEqual(tscMembers, new Set(), 'Some TSC members are not listed as Collaborators');
+
+if (argv[2] && argv[2] !== '{}') {
+  const reviver = (_, value) =>
+    (typeof value === 'string' && value[0] === '[' && value.at(-1) === ']' ?
+      new Set(JSON.parse(value)) :
+      value);
+  assert.deepStrictEqual(JSON.parse(argv[2], reviver), { ...actualMembers });
+} else {
+  console.warn('Skipping the check of GitHub teams membership.');
 }


### PR DESCRIPTION
The goal is to not let commit-queue merge PRs that move folks to emeritus (or TSC regular members) without ensuring the GitHub teams have been updated.

Because team membership is not public, it will only work for PR from the bot (which has access to the `GH_USER_TOKEN` secret). For PRs from forks, it will skip the membership check.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
