### PR TITLE
Revert "fs: add v8 fast api to closeSync"

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1841,23 +1841,12 @@ void Environment::AddUnmanagedFd(int fd) {
   }
 }
 
-void Environment::RemoveUnmanagedFd(int fd, bool schedule_native_immediate) {
+void Environment::RemoveUnmanagedFd(int fd) {
   if (!tracks_unmanaged_fds()) return;
   size_t removed_count = unmanaged_fds_.erase(fd);
   if (removed_count == 0) {
-    if (schedule_native_immediate) {
-      SetImmediateThreadsafe([&](Environment* env) {
-        ProcessEmitWarning(this,
-                           "File descriptor %d closed but not opened in "
-                           "unmanaged mode",
-                           fd);
-      });
-    } else {
-      ProcessEmitWarning(
-          this,
-          "File descriptor %d closed but not opened in unmanaged mode",
-          fd);
-    }
+    ProcessEmitWarning(
+        this, "File descriptor %d closed but not opened in unmanaged mode", fd);
   }
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -1027,7 +1027,7 @@ class Environment : public MemoryRetainer {
   std::unique_ptr<v8::BackingStore> release_managed_buffer(const uv_buf_t& buf);
 
   void AddUnmanagedFd(int fd);
-  void RemoveUnmanagedFd(int fd, bool schedule_native_immediate = false);
+  void RemoveUnmanagedFd(int fd);
 
   template <typename T>
   void ForEachRealm(T&& iterator) const;

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -47,9 +47,6 @@ using CFunctionCallbackWithUint8ArrayUint32Int64Bool =
                 uint32_t,
                 int64_t,
                 bool);
-using CFunctionWithObjectInt32Fallback = void (*)(v8::Local<v8::Object>,
-                                                  int32_t input,
-                                                  v8::FastApiCallbackOptions&);
 using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
                                          const uint32_t input);
 using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
@@ -78,7 +75,6 @@ class ExternalReferenceRegistry {
   V(CFunctionCallbackWithTwoUint8Arrays)                                       \
   V(CFunctionCallbackWithTwoUint8ArraysFallback)                               \
   V(CFunctionCallbackWithUint8ArrayUint32Int64Bool)                            \
-  V(CFunctionWithObjectInt32Fallback)                                          \
   V(CFunctionWithUint32)                                                       \
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \


### PR DESCRIPTION
This reverts commit ed6f45bef86134533550924baa89fd92d5b24f78 (#53627). That commit appears to have introduced regressions into 22.5.0, so this PR reverts it.

Fixes #53902
Ref: https://github.com/yarnpkg/berry/issues/6398
Ref: https://github.com/npm/cli/issues/7657
(And all linked issues in the ones above)

CC @anonrig