### PR TITLE
build: update `ruff` to `0.5.2`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1527,8 +1527,8 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing ruff on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.4.5 || \
-		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.4.5
+	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.5.2 || \
+		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.5.2
 
 .PHONY: lint-py
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")


### PR DESCRIPTION
This PR updates the python linter, Ruff, to it's latest version, 0.5.2.

Comparison: https://github.com/astral-sh/ruff/compare/v0.4.5...0.5.2