### PR TITLE
fs: fix not found `close` creation context

### DIFF
--- a/lib/internal/fs/read/context.js
+++ b/lib/internal/fs/read/context.js
@@ -15,7 +15,7 @@ const {
 
 const { Buffer } = require('buffer');
 
-const { FSReqCallback, close, read } = internalBinding('fs');
+const binding = internalBinding('fs');
 
 const {
   AbortError,
@@ -102,11 +102,11 @@ class ReadFileContext {
       length = MathMin(kReadFileBufferLength, this.size - this.pos);
     }
 
-    const req = new FSReqCallback();
+    const req = new binding.FSReqCallback();
     req.oncomplete = readFileAfterRead;
     req.context = this;
 
-    read(this.fd, buffer, offset, length, -1, req);
+    binding.read(this.fd, buffer, offset, length, -1, req);
   }
 
   close(err) {
@@ -117,12 +117,12 @@ class ReadFileContext {
       return;
     }
 
-    const req = new FSReqCallback();
+    const req = new binding.FSReqCallback();
     req.oncomplete = readFileAfterClose;
     req.context = this;
     this.err = err;
 
-    close(this.fd, req);
+    binding.close(this.fd, req);
   }
 }
 

--- a/test/parallel/test-fs-close-fast-api.js
+++ b/test/parallel/test-fs-close-fast-api.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+
+const assert = require('assert');
+const fs = require('fs');
+
+// This test runs `fs.readFile` which calls ReadFileContext
+// that triggers binding.close() when read operation is done.
+// The goal of this test is to not crash
+let val;
+
+// For loop is required to trigger fast API.
+for (let i = 0; i < 100_000; i++) {
+  try {
+    val = fs.readFile(__filename, (a, b) => {
+      try {
+        assert.strictEqual(a, null);
+        assert.ok(b.length > 0);
+      } catch {
+        // Ignore all errors
+      }
+    });
+  } catch {
+    // do nothing
+  }
+}
+
+console.log(val);


### PR DESCRIPTION
Referencing a similar problem fixed by @santigimeno on https://github.com/nodejs/node/pull/51286#issuecomment-1869163198, this PR should fix the `No creation context` bug for close.

The easiest way to reproduce this is via:

```
const fs = require('fs')

let failed;
for (let i = 0; i < 1_000_000; i++) {
  failed = fs.readFile('./configure.py', (err, done) => {
    // do nothing
    console.log(err, done)
  })
}
console.log(failed)
```

Fixes https://github.com/nodejs/node/issues/53902