### PR TITLE
test: skip sea tests in large debug builds

### DIFF
--- a/test/common/sea.js
+++ b/test/common/sea.js
@@ -50,6 +50,14 @@ function skipIfSingleExecutableIsNotSupported() {
     common.skip('UndefinedBehavior Sanitizer is not supported');
   }
 
+  try {
+    readFileSync(process.execPath);
+  } catch (e) {
+    if (e.code === 'ERR_FS_FILE_TOO_LARGE') {
+      common.skip('The Node.js binary is too large to be supported by postject');
+    }
+  }
+
   tmpdir.refresh();
 
   // The SEA tests involve making a copy of the executable and writing some fixtures


### PR DESCRIPTION
In debug builds, the node binary could exceed 2GB and can not be read by
postject. `kIoMaxLength` is not exposed as a public API, try to read `process.execPath`
and verify if `ERR_FS_FILE_TOO_LARGE` is thrown instead.

Refs: https://github.com/nodejs/reliability/issues/922#:~:text=Reason-,sequential/test%2Dsingle%2Dexecutable%2Dapplication%2Dempty,-Type