### PR TITLE
test_runner: refactoring for supporting in-process testing

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -208,7 +208,7 @@ function setup(root) {
       };
     },
     counters: null,
-    shouldColorizeTestFiles: false,
+    shouldColorizeTestFiles: shouldColorizeTestFiles(globalOptions.destinations),
     teardown: exitHandler,
     snapshotManager: null,
   };
@@ -218,8 +218,8 @@ function setup(root) {
 }
 
 let globalRoot;
-let reportersSetup;
-function getGlobalRoot() {
+let asyncBootstrap;
+function lazyBootstrapRoot() {
   if (!globalRoot) {
     globalRoot = createTestTree({ __proto__: null, entryFile: process.argv?.[1] });
     globalRoot.reporter.on('test:fail', (data) => {
@@ -227,26 +227,23 @@ function getGlobalRoot() {
         process.exitCode = kGenericUserError;
       }
     });
-    reportersSetup = setupTestReporters(globalRoot.reporter);
-    globalRoot.harness.shouldColorizeTestFiles ||= shouldColorizeTestFiles(globalRoot);
+    asyncBootstrap = setupTestReporters(globalRoot.reporter);
   }
   return globalRoot;
 }
 
 async function startSubtest(subtest) {
-  if (reportersSetup) {
+  if (asyncBootstrap) {
     // Only incur the overhead of awaiting the Promise once.
-    await reportersSetup;
-    reportersSetup = undefined;
-  }
-
-  const root = getGlobalRoot();
-  if (!root.harness.bootstrapComplete) {
-    root.harness.bootstrapComplete = true;
-    queueMicrotask(() => {
-      root.harness.allowTestsToRun = true;
-      root.processPendingSubtests();
-    });
+    await asyncBootstrap;
+    asyncBootstrap = undefined;
+    if (!subtest.root.harness.bootstrapComplete) {
+      subtest.root.harness.bootstrapComplete = true;
+      queueMicrotask(() => {
+        subtest.root.harness.allowTestsToRun = true;
+        subtest.root.processPendingSubtests();
+      });
+    }
   }
 
   await subtest.start();
@@ -254,12 +251,13 @@ async function startSubtest(subtest) {
 
 function runInParentContext(Factory) {
   function run(name, options, fn, overrides) {
-    const parent = testResources.get(executionAsyncId()) || getGlobalRoot();
+    const parent = testResources.get(executionAsyncId()) || lazyBootstrapRoot();
     const subtest = parent.createSubtest(Factory, name, options, fn, overrides);
-    if (!(parent instanceof Suite)) {
-      return startSubtest(subtest);
+    if (parent instanceof Suite) {
+      return PromiseResolve();
     }
-    return PromiseResolve();
+
+    return startSubtest(subtest);
   }
 
   const test = (name, options, fn) => {
@@ -286,7 +284,7 @@ function runInParentContext(Factory) {
 
 function hook(hook) {
   return (fn, options) => {
-    const parent = testResources.get(executionAsyncId()) || getGlobalRoot();
+    const parent = testResources.get(executionAsyncId()) || lazyBootstrapRoot();
     parent.createHook(hook, fn, {
       __proto__: null,
       ...options,

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -70,7 +70,6 @@ const {
   convertStringToRegExp,
   countCompletedTest,
   kDefaultPattern,
-  shouldColorizeTestFiles,
 } = require('internal/test_runner/utils');
 const { Glob } = require('internal/fs/glob');
 const { once } = require('events');
@@ -552,7 +551,6 @@ function run(options = kEmptyObject) {
   }
 
   const root = createTestTree({ __proto__: null, concurrency, timeout, signal });
-  root.harness.shouldColorizeTestFiles ||= shouldColorizeTestFiles(root);
 
   if (process.env.NODE_TEST_CONTEXT !== undefined) {
     process.emitWarning('node:test run() is being called recursively within a test file. skipping running files.');

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -75,7 +75,6 @@ const kHookFailure = 'hookFailed';
 const kDefaultTimeout = null;
 const noop = FunctionPrototype;
 const kShouldAbort = Symbol('kShouldAbort');
-const kFilename = process.argv?.[1];
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 const kUnwrapErrors = new SafeSet()
   .add(kTestCodeFailure).add(kHookFailure)
@@ -508,7 +507,7 @@ class Test extends AsyncResource {
       this.diagnostic(warning);
     }
 
-    if (loc === undefined || kFilename === undefined) {
+    if (loc === undefined) {
       this.loc = undefined;
     } else {
       this.loc = {

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -131,10 +131,9 @@ function tryBuiltinReporter(name) {
   return require(builtinPath);
 }
 
-function shouldColorizeTestFiles(rootTest) {
+function shouldColorizeTestFiles(destinations) {
   // This function assumes only built-in destinations (stdout/stderr) supports coloring
-  const { reporters, destinations } = parseCommandLine();
-  return ArrayPrototypeSome(reporters, (_, index) => {
+  return ArrayPrototypeSome(destinations, (_, index) => {
     const destination = kBuiltinDestinations.get(destinations[index]);
     return destination && shouldColorize(destination);
   });


### PR DESCRIPTION
Hopefully this is the last bit of refactoring before adding support for running multiple test files in the same process.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
