### PR TITLE
meta: store actions secrets in environment

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -59,11 +59,15 @@ jobs:
 
       - name: Setup @node-core/utils
         run: |
-          ncu-config set username ${{ secrets.JENKINS_USER }}
-          ncu-config set token "${{ secrets.GH_USER_TOKEN }}"
-          ncu-config set jenkins_token ${{ secrets.JENKINS_TOKEN }}
+          ncu-config set username $USERNAME
+          ncu-config set token $GH_TOKEN
+          ncu-config set jenkins_token $JENKINS_TOKEN
           ncu-config set owner "${{ github.repository_owner }}"
           ncu-config set repo "$(echo ${{ github.repository }} | cut -d/ -f2)"
+        env:
+          USERNAME: ${{ secrets.JENKINS_USER }}
+          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
 
       - name: Start the CI
         run: ./tools/actions/start-ci.sh ${{ needs.get-prs-for-ci.outputs.numbers }}

--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -59,9 +59,9 @@ jobs:
 
       - name: Setup @node-core/utils
         run: |
-          ncu-config set username $USERNAME
-          ncu-config set token $GH_TOKEN
-          ncu-config set jenkins_token $JENKINS_TOKEN
+          ncu-config set username "$USERNAME"
+          ncu-config set token "$GH_TOKEN"
+          ncu-config set jenkins_token "$JENKINS_TOKEN"
           ncu-config set owner "${{ github.repository_owner }}"
           ncu-config set repo "$(echo ${{ github.repository }} | cut -d/ -f2)"
         env:

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -86,11 +86,15 @@ jobs:
         run: |
           ncu-config set branch ${GITHUB_REF_NAME}
           ncu-config set upstream origin
-          ncu-config set username "${{ secrets.GH_USER_NAME }}"
-          ncu-config set token "${{ secrets.GH_USER_TOKEN }}"
-          ncu-config set jenkins_token "${{ secrets.JENKINS_TOKEN }}"
+          ncu-config set username $USERNAME
+          ncu-config set token $GH_TOKEN
+          ncu-config set jenkins_token $JENKINS_TOKEN
           ncu-config set repo "${REPOSITORY}"
           ncu-config set owner "${OWNER}"
+        env:
+          USERNAME: ${{ secrets.JENKINS_USER }}
+          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
 
       - name: Start the Commit Queue
         run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} ${{ needs.get_mergeable_prs.outputs.numbers }}

--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -86,9 +86,9 @@ jobs:
         run: |
           ncu-config set branch ${GITHUB_REF_NAME}
           ncu-config set upstream origin
-          ncu-config set username $USERNAME
-          ncu-config set token $GH_TOKEN
-          ncu-config set jenkins_token $JENKINS_TOKEN
+          ncu-config set username "$USERNAME"
+          ncu-config set token "$GH_TOKEN"
+          ncu-config set jenkins_token "$JENKINS_TOKEN"
           ncu-config set repo "${REPOSITORY}"
           ncu-config set owner "${OWNER}"
         env:


### PR DESCRIPTION
It's generally best-practice to store secrets within the environment, as an extra layer of protection in the unlikely event of a compromise.

Template variables directly within scripts are replaced before execution, whereas environment template variables are only ever stored in the runner's memory.