### PR TITLE
doc: move numCPUs require to top of file in `cluster` CJS example

### DIFF
--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -317,6 +317,7 @@ if (cluster.isPrimary) {
 ```cjs
 const cluster = require('node:cluster');
 const http = require('node:http');
+const numCPUs = require('node:os').availableParallelism();
 const process = require('node:process');
 
 if (cluster.isPrimary) {
@@ -335,7 +336,6 @@ if (cluster.isPrimary) {
   }
 
   // Start workers and listen for messages containing notifyRequest
-  const numCPUs = require('node:os').availableParallelism();
   for (let i = 0; i < numCPUs; i++) {
     cluster.fork();
   }


### PR DESCRIPTION
There is [one particular `CJS` example](https://nodejs.org/api/cluster.html#event-message) in the `Cluster` docs where there's a require statement inside a condition. I've moved the statement to the top of the file to be consistent with it's `ESM` counterpart and also the rest of the examples like [the first one](https://nodejs.org/api/cluster.html#cluster) or the one in [`worker.isDead()`](https://nodejs.org/api/cluster.html#workerisdead).

It follows the same order in which it's being imported on the rest of the examples.

Best regards,
:heart: 
