### PR TITLE
Fix the bug caused by fast api changes in v22.5.0 and have a post-mortem

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -515,7 +515,7 @@ function close(fd, callback = defaultCloseCallback) {
  * @returns {void}
  */
 function closeSync(fd) {
-  binding.close(fd);
+  binding.closeSync(fd);
 }
 
 /**

--- a/lib/internal/fs/read/context.js
+++ b/lib/internal/fs/read/context.js
@@ -15,7 +15,10 @@ const {
 
 const { Buffer } = require('buffer');
 
-const { FSReqCallback, close, read } = internalBinding('fs');
+// It is important to not destructure the binding object, as it will
+// cause the creation context to be undefined, and cause fast API calls
+// to fail.
+const binding = internalBinding('fs');
 
 const {
   AbortError,
@@ -102,11 +105,11 @@ class ReadFileContext {
       length = MathMin(kReadFileBufferLength, this.size - this.pos);
     }
 
-    const req = new FSReqCallback();
+    const req = new binding.FSReqCallback();
     req.oncomplete = readFileAfterRead;
     req.context = this;
 
-    read(this.fd, buffer, offset, length, -1, req);
+    binding.read(this.fd, buffer, offset, length, -1, req);
   }
 
   close(err) {
@@ -117,12 +120,12 @@ class ReadFileContext {
       return;
     }
 
-    const req = new FSReqCallback();
+    const req = new binding.FSReqCallback();
     req.oncomplete = readFileAfterClose;
     req.context = this;
     this.err = err;
 
-    close(this.fd, req);
+    binding.close(this.fd, req);
   }
 }
 

--- a/src/env.h
+++ b/src/env.h
@@ -1026,8 +1026,13 @@ class Environment : public MemoryRetainer {
   uv_buf_t allocate_managed_buffer(const size_t suggested_size);
   std::unique_ptr<v8::BackingStore> release_managed_buffer(const uv_buf_t& buf);
 
+  enum ProcessEmitScheduleType {
+    kSync,
+    kSetImmediate,
+  };
+
   void AddUnmanagedFd(int fd);
-  void RemoveUnmanagedFd(int fd);
+  void RemoveUnmanagedFd(int fd, ProcessEmitScheduleType schedule_type = kSync);
 
   template <typename T>
   void ForEachRealm(T&& iterator) const;

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -55,6 +55,9 @@ using CFunctionWithInt64Fallback = void (*)(v8::Local<v8::Value>,
                                             const int64_t,
                                             v8::FastApiCallbackOptions&);
 using CFunctionWithBool = void (*)(v8::Local<v8::Value>, bool);
+using CFunctionWithUint32AndOptions = void (*)(v8::Local<v8::Object>,
+                                               const uint32_t,
+                                               v8::FastApiCallbackOptions&);
 
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
@@ -79,6 +82,7 @@ class ExternalReferenceRegistry {
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \
   V(CFunctionWithBool)                                                         \
+  V(CFunctionWithUint32AndOptions)                                             \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \

--- a/test/parallel/test-fs-close-fast-api.js
+++ b/test/parallel/test-fs-close-fast-api.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+
+// A large number is selected to ensure that the fast path is called.
+// Ref: https://github.com/nodejs/node/issues/53902
+for (let i = 0; i < 100_000; i++) {
+  try {
+    fs.closeSync(100);
+  } catch (e) {
+    // Ignore all EBADF errors.
+    // EBADF stands for "Bad file descriptor".
+    if (e.code !== 'EBADF') {
+      throw e;
+    }
+  }
+}
+
+// This test is to ensure that fs.close() does not crash under pressure.
+for (let i = 0; i < 100_000; i++) {
+  fs.close(100, common.mustCall());
+}
+
+// This test is to ensure that fs.readFile() does not crash.
+// readFile() calls fs.close() internally if the input is not a file descriptor.
+// Large number is selected to ensure that the fast path is called.
+// Ref: https://github.com/nodejs/node/issues/53902
+for (let i = 0; i < 100_000; i++) {
+  fs.readFile(__filename, common.mustCall());
+}

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -70,7 +70,7 @@ declare namespace InternalFSBinding {
   function chown(path: string, uid: number, gid: number): void;
 
   function close(fd: number, req: FSReqCallback): void;
-  function close(fd: number): void;
+  function closeSync(fd: number): void;
 
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, req: FSReqCallback): void;
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, req: undefined, ctx: FSSyncContext): void;
@@ -258,6 +258,7 @@ export interface FsBinding {
   chmod: typeof InternalFSBinding.chmod;
   chown: typeof InternalFSBinding.chown;
   close: typeof InternalFSBinding.close;
+  closeSync: typeof InternalFSBinding.closeSync;
   copyFile: typeof InternalFSBinding.copyFile;
   cpSyncCheckPaths: typeof InternalFSBinding.cpSyncCheckPaths;
   fchmod: typeof InternalFSBinding.fchmod;


### PR DESCRIPTION
For those who are unfamiliar, a recent change of adding V8 Fast API to `fs.closeSync` broke almost all applications in v22.5.0. The goal of that PR was to significantly improve the performance of this function and speed up applications like NPM. Unfortunately, I broke it. For reference, here is the root cause of this incident: https://github.com/nodejs/node/pull/53627

# Problem

Here's the fix for the bug breaking v22.5.0. Before diving into the technical implementation, let me explain what the bugs were.

There were actually 2 bugs causing this issue.

## The crash

The first issue was the crash with the error message: `ERROR: v8::Object::GetCreationContextChecked No creation context available`. This error was caused by `lib/internal/fs/read/context.js`. We were destructuring the result of `internalBinding('fs')` which caused the creation context of the function being unavailable.

Previously, it was:

```js
const { close } = internalBinding('fs')
close(fd, req)
```

The fix was:

```js
const binding = internalBinding('fs')
binding.close(fd, req)
```

## Breaking NPM

The second issue was caused by the addition of V8 Fast API call for `fs.closeSync()`, at least that's what I thought I was adding the fast API for. Unfortunately, adding a fast API to `Close` function, even though the fast API had a function signature of `FastClose(recv, uin32_t fd, options)`, it was still getting triggered for `fs.close(fd, req)`.

Unfortunately, this has been the expectation from my side, and unfortunately, under optimization, causing V8 Fast API to trigger it and causing NPM to fail.

The error message was:

```
npm error Exit handler never called!
npm error This is an error with npm itself. Please report this error at:
```

Since FastClose didn't receive any function as a parameter, we weren't executing it. This resulted in `fs.close(fd, cb)` to be executed in the fast API context, and causing NPM to fail, since it was expecting the result of the close operation.

Moving Sync and non-sync version to 2 different C++ functions and adding fast API to sync version fixes this problem.

## CITGM

Node.js has a project called Canary in the gold mine (CITGM) to catch unintended bugs that might affect the ecosystem, like this. Unfortunately, recently we discovered that even if there were failures our CI jobs were successful. This issue is currently investigated under https://github.com/nodejs/citgm/issues/1067.

# Solution

We need better testing for V8 Fast API implementations. There are some unintended consequences of these additions and unfortunately, it requires a more thorough pull-request review.

Thank you!