### PR TITLE
test: use `PYTHON` executable from env in `assertSnapshot`

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -78,8 +78,8 @@ async function spawnAndAssert(filename, transform = (x) => x, { tty = false, ...
     return;
   }
   const flags = common.parseTestFlags(filename);
-  const executable = tty ? path.join(__dirname, '../..', 'tools/pseudo-tty.py') : process.execPath;
-  const args = tty ? [process.execPath, ...flags, filename] : [...flags, filename];
+  const executable = tty ? (process.env.PYTHON || 'python3') : process.execPath;
+  const args = tty ? [path.join(__dirname, '../..', 'tools/pseudo-tty.py'), process.execPath, ...flags, filename] : [...flags, filename];
   const { stdout, stderr } = await common.spawnPromisified(executable, args, options);
   await assertSnapshot(transform(`${stdout}${stderr}`), filename);
 }

--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -79,7 +79,10 @@ async function spawnAndAssert(filename, transform = (x) => x, { tty = false, ...
   }
   const flags = common.parseTestFlags(filename);
   const executable = tty ? (process.env.PYTHON || 'python3') : process.execPath;
-  const args = tty ? [path.join(__dirname, '../..', 'tools/pseudo-tty.py'), process.execPath, ...flags, filename] : [...flags, filename];
+  const args =
+    tty ?
+      [path.join(__dirname, '../..', 'tools/pseudo-tty.py'), process.execPath, ...flags, filename] :
+      [...flags, filename];
   const { stdout, stderr } = await common.spawnPromisified(executable, args, options);
   await assertSnapshot(transform(`${stdout}${stderr}`), filename);
 }


### PR DESCRIPTION
One can pass a custom `PYTHON` executable that is picked up by the `Makefile` and some other tests

https://github.com/nodejs/node/blob/efe5b81df997780ac1ef7660c223e361dda2841e/Makefile#L312-L317
https://github.com/nodejs/node/blob/c0c7e866dc2bed108290a514fdd50db3c886c84f/test/parallel/test-child-process-set-blocking.js#L28

In `assertSnapshot`, we rely on the hashbang line in `pseudo-tty`:

https://github.com/nodejs/node/blob/9e5e2f1dc5cdd857d79f05981a53382e23a1d55b/tools/pseudo-tty.py#L1

For consistency, let's use the `PYTHON` value when defined.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
