### PR TITLE
doc: remove `scroll-behavior: smooth;`

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -60,12 +60,6 @@
 }
 
 /*--------------------- Layout and Typography ----------------------------*/
-@media (prefers-reduced-motion: no-preference) {
-  html {
-    scroll-behavior: smooth;
-  }
-}
-
 html {
   font-size: 1rem;
   overflow-wrap: break-word;


### PR DESCRIPTION
I found that in the production environment, `scroll-behavior: smooth;` can still cause `scroll-padding-top` (on the `document`) to be ineffective, and the heading is still being covered. But I don't know the reason. I can only remove it for now. Does any CSS expert know the reason?

Steps to reproduce:
1. Go to https://nodejs.org/docs/latest/api/documentation.html
2. Click 'Stability index'