### PR TITLE
meta: reword linter messages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -346,31 +346,31 @@ export default [
       'error',
       {
         name: '__filename',
-        message: 'Use import.meta.url instead',
+        message: 'Use import.meta.url instead.',
       },
       {
         name: '__dirname',
-        message: 'Not available in ESM',
+        message: 'Not available in ESM.',
       },
       {
         name: 'exports',
-        message: 'Not available in ESM',
+        message: 'Not available in ESM.',
       },
       {
         name: 'module',
-        message: 'Not available in ESM',
+        message: 'Not available in ESM.',
       },
       {
         name: 'require',
-        message: 'Use import instead',
+        message: 'Use import instead.',
       },
       {
         name: 'Buffer',
-        message: 'Import Buffer instead of using the global',
+        message: "Import 'Buffer' instead of using the global.",
       },
       {
         name: 'process',
-        message: 'Import process instead of using the global',
+        message: "Import 'process' instead of using the global.",
       },
     ] },
   },

--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -11,23 +11,23 @@ const noRestrictedSyntax = [
   ...noRestrictedSyntaxCommonLib,
   {
     selector: "CallExpression[callee.object.name='assert']:not([callee.property.name='ok']):not([callee.property.name='fail']):not([callee.property.name='ifError'])",
-    message: 'Please only use simple assertions in ./lib',
+    message: 'Only use simple assertions',
   },
   {
     selector: 'NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError|AbortError|NodeAggregateError)$/])',
-    message: 'Use an error exported by the internal/errors module.',
+    message: "Use an error exported by 'internal/errors' instead.",
   },
   {
     selector: "CallExpression[callee.object.name='Error'][callee.property.name='captureStackTrace']",
-    message: "Please use `require('internal/errors').hideStackFrames()` instead.",
+    message: "Use 'hideStackFrames' from 'internal/errors' instead.",
   },
   {
     selector: "AssignmentExpression:matches([left.object.name='Error']):matches([left.name='prepareStackTrace'], [left.property.name='prepareStackTrace'])",
-    message: "Use 'overrideStackTrace' from 'lib/internal/errors.js' instead of 'Error.prepareStackTrace'.",
+    message: "Use 'overrideStackTrace' from 'internal/errors' instead.",
   },
   {
     selector: "ThrowStatement > NewExpression[callee.name=/^ERR_[A-Z_]+$/] > ObjectExpression:first-child:not(:has([key.name='message']):has([key.name='code']):has([key.name='syscall']))",
-    message: 'The context passed into SystemError constructor must have .code, .syscall and .message.',
+    message: 'The context passed into the SystemError constructor must include .code, .syscall, and .message properties.',
   },
 ];
 
@@ -504,7 +504,7 @@ export default [
         ...noRestrictedSyntax,
         {
           selector: 'VariableDeclarator:has(.init[name="primordials"]) Identifier[name=/Prototype[A-Z]/]:not([name=/^(Object|Reflect)(Get|Set)PrototypeOf$/])',
-          message: 'We do not use prototype primordials in this file',
+          message: 'Do not use prototype primordials in this file.',
         },
       ],
     },


### PR DESCRIPTION
This PR rewords the eslint messages to uniformly include only formal language (I.E. No 'We').