### PR TITLE
doc,tools: enforce use of `node:` prefix

### DIFF
--- a/doc/api/async_hooks.md
+++ b/doc/api/async_hooks.md
@@ -704,7 +704,7 @@ import {
   executionAsyncId,
   executionAsyncResource,
   createHook,
-} from 'async_hooks';
+} from 'node:async_hooks';
 const sym = Symbol('state'); // Private symbol to avoid pollution
 
 createHook({

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -378,7 +378,7 @@ import {
   setTimeout,
   setImmediate,
   setInterval,
-} from 'timers/promises';
+} from 'node:timers/promises';
 ```
 
 ```cjs
@@ -408,7 +408,7 @@ added: v15.0.0
 ```mjs
 import {
   setTimeout,
-} from 'timers/promises';
+} from 'node:timers/promises';
 
 const res = await setTimeout(100, 'result');
 
@@ -442,7 +442,7 @@ added: v15.0.0
 ```mjs
 import {
   setImmediate,
-} from 'timers/promises';
+} from 'node:timers/promises';
 
 const res = await setImmediate('result');
 
@@ -483,7 +483,7 @@ or implicitly to keep the event loop alive.
 ```mjs
 import {
   setInterval,
-} from 'timers/promises';
+} from 'node:timers/promises';
 
 const interval = 100;
 for await (const startTime of setInterval(interval, Date.now())) {

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -17,7 +17,7 @@ operating system via a collection of POSIX-like functions.
 
 ```mjs
 import { readFile } from 'node:fs/promises';
-import { WASI } from 'wasi';
+import { WASI } from 'node:wasi';
 import { argv, env } from 'node:process';
 
 const wasi = new WASI({
@@ -40,7 +40,7 @@ wasi.start(instance);
 ```cjs
 'use strict';
 const { readFile } = require('node:fs/promises');
-const { WASI } = require('wasi');
+const { WASI } = require('node:wasi');
 const { argv, env } = require('node:process');
 const { join } = require('node:path');
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1455,7 +1455,7 @@ Node.js event loop.
 import {
   Worker,
   isMainThread,
-} from 'worker_threads';
+} from 'node:worker_threads';
 
 if (isMainThread) {
   new Worker(new URL(import.meta.url));

--- a/doc/eslint.config_partial.mjs
+++ b/doc/eslint.config_partial.mjs
@@ -1,4 +1,9 @@
-import { requireEslintTool } from '../tools/eslint/eslint.config_utils.mjs';
+import {
+  noRestrictedSyntaxCommonAll,
+  noRestrictedSyntaxCommonLib,
+  requireEslintTool,
+} from '../tools/eslint/eslint.config_utils.mjs';
+import { builtinModules as builtin } from 'node:module';
 
 const globals = requireEslintTool('globals');
 
@@ -8,6 +13,15 @@ export default [
     rules: {
       // Ease some restrictions in doc examples.
       'no-restricted-properties': 'off',
+      'no-restricted-syntax': [
+        'error',
+        ...noRestrictedSyntaxCommonAll,
+        ...noRestrictedSyntaxCommonLib,
+        {
+          selector: `CallExpression[callee.name="require"][arguments.0.type="Literal"]:matches(${builtin.map((name) => `[arguments.0.value="${name}"]`).join(',')}),ImportDeclaration:matches(${builtin.map((name) => `[source.value="${name}"]`).join(',')})`,
+          message: 'Use `node:` prefix.',
+        },
+      ],
       'no-undef': 'off',
       'no-unused-expressions': 'off',
       'no-unused-vars': 'off',


### PR DESCRIPTION
We're switched to using `node:` prefix everywhere in our docs in https://github.com/nodejs/node/pull/42752, but without a lint rule to enforce it, it's lacking in some places. This PR fixes that.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
