### PR TITLE
build, tools: drop leading `/` from `r2dir`

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -158,7 +158,7 @@ sign() {
       # since the promotion script should take care of uploading them.
 
       # Remove /home/dist/ part
-      r2dir=$(echo "$shadir" | cut -c 11-)
+      r2dir=$(echo "$shadir" | cut -c 12-)
 
       # Copy SHASUMS256.txt.asc
       # shellcheck disable=SC2086,SC2029


### PR DESCRIPTION
The script is commented as removing `/home/dist/` part but the `cut` command is off by one and end up including the `/` character (so that the resulting string starts with `/`). When this is substituted into `s3://${cloudflare_bucket}/${r2dir}/${shafile}.asc` we end up with `//` (one from the template and one from the `r2dir`) which appears to cause Cloudflare to create an extra top level `/` directory in the bucket.

Refs: https://github.com/nodejs/build/issues/3838#issuecomment-2239541235

---

e.g.
```console
$ echo /home/dist/nodejs/release/v22.5.1/SHASUMS256.txt | cut -c 11-
/nodejs/release/v22.5.1/SHASUMS256.txt
$
```

compared to

```console
$ echo /home/dist/nodejs/release/v22.5.1/SHASUMS256.txt | cut -c 12-
nodejs/release/v22.5.1/SHASUMS256.txt
$
```

cc @nodejs/releasers 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
