### PR TITLE
doc: add info about prefix-only modules to `module.builtinModules`

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -28,6 +28,8 @@ added:
 A list of the names of all modules provided by Node.js. Can be used to verify
 if a module is maintained by a third party or not.
 
+Note: the list doesn't contain [prefix-only modules][] like `node:test`.
+
 `module` in this context isn't the same object that's provided
 by the [module wrapper][]. To access it, require the `Module` module:
 
@@ -1074,3 +1076,4 @@ returned object contains the following keys:
 [realm]: https://tc39.es/ecma262/#realm
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
 [transferrable objects]: worker_threads.md#portpostmessagevalue-transferlist
+[prefix-only modules]: modules.md#built-in-modules-with-mandatory-node-prefix

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1075,5 +1075,5 @@ returned object contains the following keys:
 [module wrapper]: modules.md#the-module-wrapper
 [realm]: https://tc39.es/ecma262/#realm
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
-[transferrable objects]: worker_threads.md#portpostmessagevalue-transferlist
 [prefix-only modules]: modules.md#built-in-modules-with-mandatory-node-prefix
+[transferrable objects]: worker_threads.md#portpostmessagevalue-transferlist

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1073,7 +1073,7 @@ returned object contains the following keys:
 [hooks]: #customization-hooks
 [load hook]: #loadurl-context-nextload
 [module wrapper]: modules.md#the-module-wrapper
+[prefix-only modules]: modules.md#built-in-modules-with-mandatory-node-prefix
 [realm]: https://tc39.es/ecma262/#realm
 [source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
-[prefix-only modules]: modules.md#built-in-modules-with-mandatory-node-prefix
 [transferrable objects]: worker_threads.md#portpostmessagevalue-transferlist


### PR DESCRIPTION
prevents situations like these:

- https://github.com/import-js/eslint-import-resolver-typescript/pull/295#issuecomment-2231939714
- https://github.com/IanVS/prettier-plugin-sort-imports/issues/142#issuecomment-1916256386
- https://github.com/yarnpkg/berry/issues/6343

I don't think there's any reason for a regular developer to expect this behavior, especially when even [a node team member doesn't know why it is like that](https://github.com/nodejs/node/issues/42785#issuecomment-1103213381)

related: https://github.com/nodejs/node/issues/42785

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
