### PR TITLE
deps: V8: cherry-pick 9812cb486e2b

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-local-handle.h
+++ b/deps/v8/include/v8-local-handle.h
@@ -398,8 +398,7 @@ class V8_TRIVIAL_ABI Local : public LocalBase<T>,
   explicit Local(const Local<T>& other, no_checking_tag do_not_check)
       : LocalBase<T>(other), StackAllocated(do_not_check) {}
 
-  V8_INLINE explicit Local<T>(const LocalBase<T>& other)
-      : LocalBase<T>(other) {}
+  V8_INLINE explicit Local(const LocalBase<T>& other) : LocalBase<T>(other) {}
 
   V8_INLINE static Local<T> FromSlot(internal::Address* slot) {
     return Local<T>(LocalBase<T>::FromSlot(slot));


### PR DESCRIPTION
Original commit message:

    [api] Remove template id from Local constructor

    According to GCC version 14, this is deprecated in C++20.

    Change-Id: Iaab14c2db56b3787e391e4d50a9099015169d63f
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5713754
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Auto-Submit: Michaël Zasso <mic.besace@gmail.com>
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Camillo Bruni <cbruni@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#95084}

Refs: https://github.com/v8/v8/commit/9812cb486e2bfb7b72c7cee41d4ee1916dfef412

This should get rid of very noisy warnings that happen with `fedora-latest` hosts in CI.
