### PR TITLE
test: reduce flakiness of `test-assert-esm-cjs-message-verify`

### DIFF
--- a/test/parallel/test-assert-esm-cjs-message-verify.js
+++ b/test/parallel/test-assert-esm-cjs-message-verify.js
@@ -1,51 +1,31 @@
 'use strict';
 
 const { spawnPromisified } = require('../common');
-const tmpdir = require('../common/tmpdir');
-const assert = require('assert');
-const { writeFileSync, unlink } = require('fs');
-const { describe, after, it } = require('node:test');
-
-tmpdir.refresh();
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
 
 const fileImports = {
-  cjs: 'const assert = require("assert");',
-  mjs: 'import assert from "assert";',
+  commonjs: 'const assert = require("assert");',
+  module: 'import assert from "assert";',
 };
 
-const fileNames = [];
-
-for (const [ext, header] of Object.entries(fileImports)) {
-  const fileName = `test-file.${ext}`;
-  // Store the generated filesnames in an array
-  fileNames.push(`${tmpdir.path}/${fileName}`);
-
-  writeFileSync(tmpdir.resolve(fileName), `${header}\nassert.ok(0 === 2);`);
-}
-
 describe('ensure the assert.ok throwing similar error messages for esm and cjs files', () => {
-  const nodejsPath = `${process.execPath}`;
-  const errorsMessages = [];
-
   it('should return code 1 for each command', async () => {
-    for (const fileName of fileNames) {
-      const { stderr, code } = await spawnPromisified(nodejsPath, [fileName]);
+    const errorsMessages = [];
+    for (const [inputType, header] of Object.entries(fileImports)) {
+      const { stderr, code } = await spawnPromisified(process.execPath, [
+        '--input-type',
+        inputType,
+        '--eval',
+        `${header}\nassert.ok(0 === 2);\n`,
+      ]);
       assert.strictEqual(code, 1);
       // For each error message, filter the lines which will starts with AssertionError
       errorsMessages.push(
         stderr.split('\n').find((s) => s.startsWith('AssertionError'))
       );
     }
-  });
-
-  after(() => {
     assert.strictEqual(errorsMessages.length, 2);
     assert.deepStrictEqual(errorsMessages[0], errorsMessages[1]);
-
-    for (const fileName of fileNames) {
-      unlink(fileName, () => {});
-    }
-
-    tmpdir.refresh();
   });
 });


### PR DESCRIPTION
I noticed some failures for this test (e.g. https://ci.nodejs.org/job/node-test-commit-linuxone/44599/nodes=rhel9-s390x/testReport/junit/(root)/-%20ensure%20the%20assert/ok_throwing_similar_error_messages_for_esm_and_cjs_files/) which seems to be related to the way the test was trying to remove temp files with some custom code, when in fact it doesn't need temp file at all to test what it's trying to test.

Fixes: https://github.com/nodejs/node/issues/53962

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
