### PR TITLE
meta: remove license for hljs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2194,39 +2194,6 @@ The externally maintained libraries used by Node.js are:
      THE POSSIBILITY OF SUCH DAMAGE.
   """
 
-- highlight.js, located at doc/api_assets/highlight.pack.js, is licensed as follows:
-  """
-    BSD 3-Clause License
-
-    Copyright (c) 2006, Ivan Sagalaev.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-  """
-
 - node-heapdump, located at src/heap_utils.cc, is licensed as follows:
   """
     ISC License

--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -131,9 +131,6 @@ addlicense "brotli" "deps/brotli" "$licenseText"
 licenseText="$(cat "${rootdir}/deps/histogram/LICENSE.txt")"
 addlicense "HdrHistogram" "deps/histogram" "$licenseText"
 
-licenseText="$(curl -sL https://raw.githubusercontent.com/highlightjs/highlight.js/63f367c46f2eeb6f9b7a3545e325eeeb917f9942/LICENSE)"
-addlicense "highlight.js" "doc/api_assets/highlight.pack.js" "$licenseText"
-
 licenseText="$(curl -sL https://raw.githubusercontent.com/bnoordhuis/node-heapdump/0ca52441e46241ffbea56a389e2856ec01c48c97/LICENSE)"
 addlicense "node-heapdump" "src/heap_utils.cc" "$licenseText"
 


### PR DESCRIPTION
`doc/api_assets/highlight.pack.js` was removed in https://github.com/nodejs/node/commit/fa2e460d0ca38480d5cb44657ae438e5fda43042, so the license for it is no longer required.