### PR TITLE
src: fix slice of slice of file-backed Blob

### DIFF
--- a/src/dataqueue/queue.cc
+++ b/src/dataqueue/queue.cc
@@ -840,7 +840,9 @@ class FdEntry final : public EntryImpl {
         path_(std::move(path_)),
         stat_(stat),
         start_(start),
-        end_(end) {}
+        end_(end) {
+    CHECK_LE(start, end);
+  }
 
   std::shared_ptr<DataQueue::Reader> get_reader() override {
     return ReaderImpl::Create(this);
@@ -851,7 +853,7 @@ class FdEntry final : public EntryImpl {
     uint64_t new_start = start_ + start;
     uint64_t new_end = end_;
     if (end.has_value()) {
-      new_end = std::min(end.value(), end_);
+      new_end = std::min(end.value() + start_, end_);
     }
 
     CHECK(new_start >= start_);

--- a/test/parallel/test-blob-file-backed.js
+++ b/test/parallel/test-blob-file-backed.js
@@ -86,6 +86,16 @@ writeFileSync(testfile5, '');
 
   const res1 = blob.slice(995, 1005);
   strictEqual(await res1.text(), data.slice(995, 1005));
+
+  // Refs: https://github.com/nodejs/node/issues/53908
+  for (const res2 of [
+    blob.slice(995, 1005).slice(),
+    blob.slice(995).slice(0, 10),
+    blob.slice(0, 1005).slice(995),
+  ]) {
+    strictEqual(await res2.text(), data.slice(995, 1005));
+  }
+
   await unlink(testfile2);
 })().then(common.mustCall());
 


### PR DESCRIPTION
The value for `new_end` was wrong: While the members `start_` and `end_` refer to the entire length of the file, the parameters `start` and `end` are relative to the current slice.

The new end would apparently have the current start_ subtracted from it, and the length would possibly overflow when the FdEntry is asked for its size or when get_reader is called, resulting in a subslice which extends past the current slice, which shouldn't be possible. Add a CHECK if this happens, rather than returning data outside the current slice.

There aren't any C++ tests for FdEntry, and on the javascript side there isn't a way to ask the blob handle for its nominal size. That size could be a large uint64, which gets converted to int64 to when FileHandle::new is called, which interprets a negative length as unlimited.

Fixes: https://github.com/nodejs/node/issues/53908

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
