### PR TITLE
stream: fix error when reading less than buffer

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1631,7 +1631,7 @@ function fromList(n, state) {
         n -= str.length;
         buf[idx++] = null;
       } else {
-        if (n === buf.length) {
+        if (n === str.length) {
           ret += str;
           buf[idx++] = null;
         } else {


### PR DESCRIPTION
Function fromList checked if n (number of bytes to be read) was equal to buf.length. However it should check agains str.length, as buf is an array containing buffers from seperate readings of file. This can cause an error when size in readable.read() is less than highWaterMark.

Example: highWaterMark === 10, readable.read(6)
On first `read()`, it reads 6 bytes, 4 are left in the buffer. On second `read()`, 10 more bytes are read into the buffer. `buf` is now an array with two buffers, length 4 and 10. Function adds the first buffer to `ret`, `n` is now 2. On the second run `n === 2 === buf.length`. Fucntion adds all 10 bytes to `ret` (which is now 14 bytes long) and removes both entries from `state`. `state.buffer === []`, `state.length === 14`. On the next run, an error occurs as there is nothing to be read from `state`, even though there should be.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
