### PR TITLE
assert: use isError instead of instanceof in innerOk to define message type

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -393,7 +393,7 @@ function innerOk(fn, argLen, value, message) {
     } else if (message == null) {
       generatedMessage = true;
       message = getErrMessage(message, fn);
-    } else if (message instanceof Error) {
+    } else if (isError(message)) {
       throw message;
     }
 

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -55,6 +55,16 @@ assert.throws(() => a.ok(false), a.AssertionError, 'ok(false)');
   assert.ok(threw, 'Error: ok(false)');
 }
 
+// Errors created in different contexts are handled as any other custom error
+{
+  const context = vm.createContext();
+  const error = vm.runInContext('new SyntaxError("custom error")', context);
+
+  assert.throws(() => assert(false, error), {
+    message: 'custom error',
+    name: 'SyntaxError'
+  });
+}
 
 a(true);
 a('test', 'ok(\'test\')');


### PR DESCRIPTION
Fixes: #50780

I noticed that this issue is stalled even though there is an almost accepted PR(#51250) that solves the problem.  
I addressed the comments and fixed the problem that was blocking the CI (we'll find out on the next CI run, hehe 🐍 ).

P.S.: I added the author of the PR and the commenter as co-authors in the commit.

Co-Authored-By: Ruben Bridgewater <ruben@bridgewater.de>
Co-Authored-By: Nihar Phansalkar <phansalkarnihar@gmail.com>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
