### PR TITLE
src: return `undefined` if no rows are returned in SQLite

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -471,7 +471,8 @@ void StatementSync::Get(const FunctionCallbackInfo<Value>& args) {
 
   auto reset = OnScopeLeave([&]() { sqlite3_reset(stmt->statement_); });
   r = sqlite3_step(stmt->statement_);
-  if (r != SQLITE_ROW && r != SQLITE_DONE) {
+  if (r == SQLITE_DONE) return;
+  if (r != SQLITE_ROW) {
     THROW_ERR_SQLITE_ERROR(env->isolate(), stmt->db_);
     return;
   }

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -219,7 +219,9 @@ suite('StatementSync() constructor', () => {
 suite('StatementSync.prototype.get()', () => {
   test('executes a query and returns undefined on no results', (t) => {
     const db = new DatabaseSync(nextDb());
-    const stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
+    let stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
+    t.assert.strictEqual(stmt.get(), undefined);
+    stmt = db.prepare('SELECT * FROM storage');
     t.assert.strictEqual(stmt.get(), undefined);
   });
 


### PR DESCRIPTION
For now, { key: null, value: null} is returned even though no rows are returned from database when `statement.get()` is called. So return empty value if return value of `sqlite3_step` is `SQLITE_DONE`.

With below example, `undefined` is expected as return value of `statement.get()`.
But { key: null, value: null } is returned actually without this PR.
```
'use strict';
const { DatabaseSync } = require('node:sqlite');
const database = new DatabaseSync(':memory:');

let stmt = database.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
console.log(stmt.get()); // undefined
stmt = database.prepare('SELECT * FROM storage');
console.log(stmt.get()); // { key: null, value: null } -> undefined
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
