### PR TITLE
Fixes: https://github.com/nodejs/node/issues/53989

### DIFF
--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -54,7 +54,7 @@ function testCwd(options, expectPidType, expectCode = 0, expectData) {
   child.on('close', common.mustCall(function() {
     if (expectData) {
       // In Windows, compare without considering case
-      if (process.platform === 'win32') {
+      if (common.isWindows) {
         assert.strictEqual(data.trim().toLowerCase(), expectData.toLowerCase());
       } else {
         assert.strictEqual(data.trim(), expectData);

--- a/test/parallel/test-child-process-cwd.js
+++ b/test/parallel/test-child-process-cwd.js
@@ -52,7 +52,14 @@ function testCwd(options, expectPidType, expectCode = 0, expectData) {
   });
 
   child.on('close', common.mustCall(function() {
-    expectData && assert.strictEqual(data.trim(), expectData);
+    if (expectData) {
+      // In Windows, compare without considering case
+      if (process.platform === 'win32') {
+        assert.strictEqual(data.trim().toLowerCase(), expectData.toLowerCase());
+      } else {
+        assert.strictEqual(data.trim(), expectData);
+      }
+    }
   }));
 
   return child;


### PR DESCRIPTION
### Description

This pull request addresses an issue in the test suite where directory name comparisons on Windows are case-insensitive. The error occurs because Windows does not distinguish between uppercase and lowercase folder names. To handle this, I modified the function to compare directory names without considering case on Windows.

### Code Change

The specific change made is as follows:

```javascript
child.on('close', common.mustCall(function() {
  if (expectData) {
    // In Windows, compare without considering case
    if (process.platform === 'win32') {
      assert.strictEqual(data.trim().toLowerCase(), expectData.toLowerCase());
    } else {
      assert.strictEqual(data.trim(), expectData);
    }
  }
}));
```
### Justification
This adjustment is intended to ensure that the comparison of directory names in Windows is case-insensitive, aligning with the operating system's handling of folder names. The function in question is limited to a specific test file, ensuring that the change does not impact other parts of the codebase.

While I believe this modification will resolve the issue, welcome any feedback or suggestions for improvement. If there are any further modifications or additional details required, please let me know. Thank you for considering this pull request.

Fixes: https://github.com/nodejs/node/issues/53989
