### PR TITLE
doc: clarify `useCodeCache` setting for cross-platform SEA generation

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -190,7 +190,10 @@ If the paths are not absolute, Node.js will use the path relative to the
 current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
-Note: When generating cross-platform SEAs (e.g., generating an SEA on platform A for platform B), `useCodeCache` must be set to false to avoid generating ‘broken’ executables. The generated executable might crash on startup if this setting is not configured properly.
+Note: When generating cross-platform SEAs (e.g., generating an SEA on
+platform A for platform B), `useCodeCache` must be set to false to avoid
+generating ‘broken’ executables. The generated executable might crash
+on startup if this setting is not configured properly.
 
 
 ### Assets

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -190,7 +190,7 @@ If the paths are not absolute, Node.js will use the path relative to the
 current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
-Note: When generating cross-platform SEAs (e.g., generating an SEA on
+Note: When generating cross-platform SEAs (e.g., generating a SEA
 for `linux-x64` on `darwin-arm64`), `useCodeCache` and `useSnapshot` must be set to
 false to avoid generating incompatible executables. Since code cache and snapshots can only be loaded
 on the same platform where they are compiled, the generated executable might crash on startup when

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -195,7 +195,6 @@ platform A for platform B), `useCodeCache` and `useSnapshot` must be set to
 false to avoid generating 'broken' executables. The generated executable might
 crash on startup if these settings are not configured properly.
 
-
 ### Assets
 
 Users can include assets by adding a key-path dictionary to the configuration

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -191,9 +191,10 @@ current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
 Note: When generating cross-platform SEAs (e.g., generating a SEA
-for `linux-x64` on `darwin-arm64`), `useCodeCache` and `useSnapshot` must be set to
-false to avoid generating incompatible executables. Since code cache and snapshots can only be loaded
-on the same platform where they are compiled, the generated executable might crash on startup when
+for `linux-x64` on `darwin-arm64`), `useCodeCache` and `useSnapshot`
+must be set to false to avoid generating incompatible executables.
+Since code cache and snapshots can only be loaded on the same platform
+where they are compiled, the generated executable might crash on startup when
 trying to load code cache or snapshots built on a different platform.
 
 ### Assets

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -191,9 +191,9 @@ current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
 Note: When generating cross-platform SEAs (e.g., generating an SEA on
-platform A for platform B), `useCodeCache` must be set to false to avoid
-generating ‘broken’ executables. The generated executable might crash
-on startup if this setting is not configured properly.
+platform A for platform B), `useCodeCache` and `useSnapshot` must be set to
+false to avoid generating 'broken' executables. The generated executable might
+crash on startup if these settings are not configured properly.
 
 
 ### Assets

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -192,8 +192,9 @@ the blob must be the same as the one to which the blob will be injected.
 
 Note: When generating cross-platform SEAs (e.g., generating an SEA on
 platform A for platform B), `useCodeCache` and `useSnapshot` must be set to
-false to avoid generating 'broken' executables. The generated executable might
-crash on startup if these settings are not configured properly.
+false to avoid generating incompatible executables. Since code cache and snapshots can only be loaded
+on the same platform where they are compiled, the generated executable might crash on startup when
+trying to load code cache or snapshots built on a different platform.
 
 ### Assets
 

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -190,6 +190,9 @@ If the paths are not absolute, Node.js will use the path relative to the
 current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
+Note: When generating cross-platform SEAs (e.g., generating an SEA on platform A for platform B), `useCodeCache` must be set to false to avoid generating ‘broken’ executables. The generated executable might crash on startup if this setting is not configured properly.
+
+
 ### Assets
 
 Users can include assets by adding a key-path dictionary to the configuration

--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -191,7 +191,7 @@ current working directory. The version of the Node.js binary used to produce
 the blob must be the same as the one to which the blob will be injected.
 
 Note: When generating cross-platform SEAs (e.g., generating an SEA on
-platform A for platform B), `useCodeCache` and `useSnapshot` must be set to
+for `linux-x64` on `darwin-arm64`), `useCodeCache` and `useSnapshot` must be set to
 false to avoid generating incompatible executables. Since code cache and snapshots can only be loaded
 on the same platform where they are compiled, the generated executable might crash on startup when
 trying to load code cache or snapshots built on a different platform.


### PR DESCRIPTION
Update documentation to clarify the `useCodeCache` setting for cross-platform SEA generation to prevent 'broken' executables.

Fixes https://github.com/nodejs/node/issues/52420