### PR TITLE
lib: optimize copyError with ObjectAssign in primordials

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -46,8 +46,7 @@ const kReadableOperator = {
 const kMaxShortLength = 12;
 
 function copyError(source) {
-  const target = { __proto__: ObjectGetPrototypeOf(source) };
-  ObjectAssign(target, source);
+  const target = ObjectAssign({ __proto__: ObjectGetPrototypeOf(source) }, source);
   ObjectDefineProperty(target, 'message', { __proto__: null, value: source.message });
   return target;
 }

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -6,9 +6,9 @@ const {
   Error,
   ErrorCaptureStackTrace,
   MathMax,
+  ObjectAssign,
   ObjectDefineProperty,
   ObjectGetPrototypeOf,
-  ObjectKeys,
   String,
   StringPrototypeEndsWith,
   StringPrototypeRepeat,
@@ -46,11 +46,8 @@ const kReadableOperator = {
 const kMaxShortLength = 12;
 
 function copyError(source) {
-  const keys = ObjectKeys(source);
   const target = { __proto__: ObjectGetPrototypeOf(source) };
-  for (const key of keys) {
-    target[key] = source[key];
-  }
+  ObjectAssign(target, source);
   ObjectDefineProperty(target, 'message', { __proto__: null, value: source.message });
   return target;
 }


### PR DESCRIPTION
optimized the copyError function by using ObjectAssign from primordials. this change replaces the for-loop with ObjectAssign, which improves memory usage and performance.

this change updates the copyError function in internal/assert.js to use ObjectAssign for copying properties.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
