### PR TITLE
test: add test for one arg timers to increase coverage

### DIFF
--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -8,22 +8,22 @@ function range(n) {
 
 function timeout(nargs) {
   const args = range(nargs);
-  setTimeout.apply(null, [callback, 1].concat(args));
+  setTimeout.apply(null, [callback].concat(args));
 
   function callback() {
-    assert.deepStrictEqual([].slice.call(arguments), args);
-    if (nargs < 128) timeout(nargs + 1);
+    assert.deepStrictEqual([].slice.call(arguments), args.slice(1));
+    if (nargs < 129) timeout(nargs + 1);
   }
 }
 
 function interval(nargs) {
   const args = range(nargs);
-  const timer = setTimeout.apply(null, [callback, 1].concat(args));
+  const timer = setTimeout.apply(null, [callback].concat(args));
 
   function callback() {
     clearInterval(timer);
-    assert.deepStrictEqual([].slice.call(arguments), args);
-    if (nargs < 128) interval(nargs + 1);
+    assert.deepStrictEqual([].slice.call(arguments), args.slice(1));
+    if (nargs < 129) interval(nargs + 1);
   }
 }
 

--- a/test/parallel/test-timers-args.js
+++ b/test/parallel/test-timers-args.js
@@ -8,22 +8,22 @@ function range(n) {
 
 function timeout(nargs) {
   const args = range(nargs);
-  setTimeout.apply(null, [callback].concat(args));
+  setTimeout.apply(null, [callback, 1].concat(args));
 
   function callback() {
-    assert.deepStrictEqual([].slice.call(arguments), args.slice(1));
-    if (nargs < 129) timeout(nargs + 1);
+    assert.deepStrictEqual([].slice.call(arguments), args);
+    if (nargs < 128) timeout(nargs + 1);
   }
 }
 
 function interval(nargs) {
   const args = range(nargs);
-  const timer = setTimeout.apply(null, [callback].concat(args));
+  const timer = setTimeout.apply(null, [callback, 1].concat(args));
 
   function callback() {
     clearInterval(timer);
-    assert.deepStrictEqual([].slice.call(arguments), args.slice(1));
-    if (nargs < 129) interval(nargs + 1);
+    assert.deepStrictEqual([].slice.call(arguments), args);
+    if (nargs < 128) interval(nargs + 1);
   }
 }
 

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -79,3 +79,7 @@ setTimeout(common.mustCall(() => {
 // Test 10 ms timeout separately.
 setTimeout(common.mustCall(), 10);
 setInterval(common.mustCall(function() { clearInterval(this); }), 10);
+
+// Test no timeout separately
+setTimeout(common.mustCall());
+setInterval(common.mustCall(function() { clearInterval(this); }));

--- a/test/parallel/test-timers.js
+++ b/test/parallel/test-timers.js
@@ -82,4 +82,5 @@ setInterval(common.mustCall(function() { clearInterval(this); }), 10);
 
 // Test no timeout separately
 setTimeout(common.mustCall());
+// eslint-disable-next-line no-restricted-syntax
 setInterval(common.mustCall(function() { clearInterval(this); }));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR adds a test for one argument timers (i.e `setTimeout` and `setInterval`) to improve test coverage.