### PR TITLE
test_runner: remove redundant bootstrap boolean

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -28,18 +28,20 @@ const {
 } = require('internal/test_runner/utils');
 const { queueMicrotask } = require('internal/process/task_queues');
 const { bigint: hrtime } = process.hrtime;
-
+const resolvedPromise = PromiseResolve();
 const testResources = new SafeMap();
+let globalRoot;
 
 testResources.set(reporterScope.asyncId(), reporterScope);
 
 function createTestTree(options = kEmptyObject) {
-  return setup(new Test({ __proto__: null, ...options, name: '<root>' }));
+  globalRoot = setup(new Test({ __proto__: null, ...options, name: '<root>' }));
+  return globalRoot;
 }
 
 function createProcessEventHandler(eventName, rootTest) {
   return (err) => {
-    if (!rootTest.harness.bootstrapComplete) {
+    if (rootTest.harness.bootstrapPromise) {
       // Something went wrong during the asynchronous portion of bootstrapping
       // the test runner. Since the test runner is not setup properly, we can't
       // do anything but throw the error.
@@ -196,7 +198,7 @@ function setup(root) {
   root.harness = {
     __proto__: null,
     allowTestsToRun: false,
-    bootstrapComplete: false,
+    bootstrapPromise: resolvedPromise,
     watching: false,
     coverage: FunctionPrototypeBind(collectCoverage, null, root, coverage),
     resetCounters() {
@@ -222,33 +224,30 @@ function setup(root) {
   return root;
 }
 
-let globalRoot;
-let asyncBootstrap;
 function lazyBootstrapRoot() {
   if (!globalRoot) {
-    globalRoot = createTestTree({ __proto__: null, entryFile: process.argv?.[1] });
+    // This is where the test runner is bootstrapped when node:test is used
+    // without the --test flag or the run() API.
+    createTestTree({ __proto__: null, entryFile: process.argv?.[1] });
     globalRoot.reporter.on('test:fail', (data) => {
       if (data.todo === undefined || data.todo === false) {
         process.exitCode = kGenericUserError;
       }
     });
-    asyncBootstrap = setupTestReporters(globalRoot.reporter);
+    globalRoot.harness.bootstrapPromise = setupTestReporters(globalRoot.reporter);
   }
   return globalRoot;
 }
 
-async function startSubtest(subtest) {
-  if (asyncBootstrap) {
+async function startSubtestAfterBootstrap(subtest) {
+  if (subtest.root.harness.bootstrapPromise) {
     // Only incur the overhead of awaiting the Promise once.
-    await asyncBootstrap;
-    asyncBootstrap = undefined;
-    if (!subtest.root.harness.bootstrapComplete) {
-      subtest.root.harness.bootstrapComplete = true;
-      queueMicrotask(() => {
-        subtest.root.harness.allowTestsToRun = true;
-        subtest.root.processPendingSubtests();
-      });
-    }
+    await subtest.root.harness.bootstrapPromise;
+    subtest.root.harness.bootstrapPromise = null;
+    queueMicrotask(() => {
+      subtest.root.harness.allowTestsToRun = true;
+      subtest.root.processPendingSubtests();
+    });
   }
 
   await subtest.start();
@@ -262,7 +261,7 @@ function runInParentContext(Factory) {
       return PromiseResolve();
     }
 
-    return startSubtest(subtest);
+    return startSubtestAfterBootstrap(subtest);
   }
 
   const test = (name, options, fn) => {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -596,6 +596,7 @@ function run(options = kEmptyObject) {
     teardown = undefined;
   }
   const runFiles = () => {
+    root.harness.bootstrapPromise = null;
     root.harness.allowTestsToRun = true;
     return SafePromiseAllSettledReturnVoid(testFiles, (path) => {
       const subtest = runTestFile(path, filesWatcher, opts);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -596,7 +596,6 @@ function run(options = kEmptyObject) {
     teardown = undefined;
   }
   const runFiles = () => {
-    root.harness.bootstrapComplete = true;
     root.harness.allowTestsToRun = true;
     return SafePromiseAllSettledReturnVoid(testFiles, (path) => {
       const subtest = runTestFile(path, filesWatcher, opts);

--- a/test/parallel/test-runner-run-watch.mjs
+++ b/test/parallel/test-runner-run-watch.mjs
@@ -27,13 +27,19 @@ test('test has ran');`,
 
 let fixturePaths;
 
-function refresh() {
+async function refresh() {
+  const { rm, readdir } = await import('node:fs/promises');
+  console.log('refreshing', tmpdir.path);
+  await rm(tmpdir.path, { maxRetries: 3, recursive: true, force: true });
+
   tmpdir.refresh();
 
   fixturePaths = Object.keys(fixtureContent)
     .reduce((acc, file) => ({ ...acc, [file]: tmpdir.resolve(file) }), {});
   Object.entries(fixtureContent)
     .forEach(([file, content]) => writeFileSync(fixturePaths[file], content));
+
+  console.log('contents of %s:', tmpdir.path, await readdir(tmpdir.path));
 }
 
 const runner = join(import.meta.dirname, '..', 'fixtures', 'test-runner-watch.mjs');

--- a/test/parallel/test-runner-run-watch.mjs
+++ b/test/parallel/test-runner-run-watch.mjs
@@ -27,19 +27,13 @@ test('test has ran');`,
 
 let fixturePaths;
 
-async function refresh() {
-  const { rm, readdir } = await import('node:fs/promises');
-  console.log('refreshing', tmpdir.path);
-  await rm(tmpdir.path, { maxRetries: 3, recursive: true, force: true });
-
+function refresh() {
   tmpdir.refresh();
 
   fixturePaths = Object.keys(fixtureContent)
     .reduce((acc, file) => ({ ...acc, [file]: tmpdir.resolve(file) }), {});
   Object.entries(fixtureContent)
     .forEach(([file, content]) => writeFileSync(fixturePaths[file], content));
-
-  console.log('contents of %s:', tmpdir.path, await readdir(tmpdir.path));
 }
 
 const runner = join(import.meta.dirname, '..', 'fixtures', 'test-runner-watch.mjs');


### PR DESCRIPTION
The test runner bootstrap process awaits a Promise and then sets a boolean flag. This commit consolidates the Promise and boolean into a single value. This commit also ensures that the globalRoot test is always assigned in createTestTree() in order to better consolidate the CLI/run() and non-CLI configuration.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
