### PR TITLE
doc: fix typo in method name in the sea doc

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -336,7 +336,7 @@ This method can be used to retrieve the assets configured to be bundled into the
 single-executable application at build time.
 An error is thrown when no matching asset can be found.
 
-Unlike `sea.getRawAsset()` or `sea.getAssetAsBlob()`, this method does not
+Unlike `sea.getAsset()` or `sea.getAssetAsBlob()`, this method does not
 return a copy. Instead, it returns the raw asset bundled inside the executable.
 
 For now, users should avoid writing to the returned array buffer. If the


### PR DESCRIPTION
Update the documentation to fix a typo in the single executable applications section, where it is evident that the documentation refers to a different method than the one stated.