### PR TITLE
stream: Relocate the status checking code in the onWriteComplete

### DIFF
--- a/lib/internal/stream_base_commons.js
+++ b/lib/internal/stream_base_commons.js
@@ -83,20 +83,18 @@ function onWriteComplete(status) {
 
   const stream = this.handle[owner_symbol];
 
+  if (status < 0) {
+    const error = new ErrnoException(status, 'write', this.error);
+    if (typeof this.callback === 'function') {
+      return this.callback(error);
+    }
+
+    return stream.destroy(error);
+  }
+
   if (stream.destroyed) {
     if (typeof this.callback === 'function')
       this.callback(null);
-    return;
-  }
-
-  // TODO (ronag): This should be moved before if(stream.destroyed)
-  // in order to avoid swallowing error.
-  if (status < 0) {
-    const ex = new ErrnoException(status, 'write', this.error);
-    if (typeof this.callback === 'function')
-      this.callback(ex);
-    else
-      stream.destroy(ex);
     return;
   }
 


### PR DESCRIPTION
Modified the code to check the status before verifying if the stream is destroyed.

error name refs:
```js
/ / lib/internal/webstreams/adapter.js
  function onWriteComplete(status) {
    if (status < 0) {
      const error = new ErrnoException(status, 'write', this.error);
      this.promise.reject(error);
      this.controller.error(error);
      return;
    }
    this.promise.resolve();
  }
```

cc. @ronag 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
