### PR TITLE
doc: correct typescript stdin support

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -123,10 +123,10 @@ import { fn, FnParams } from './fn.ts';
 
 ### Non-file forms of input
 
-Type stripping can be enabled for `--eval` and STDIN input. The module system
+Type stripping can be enabled for `--eval`. The module system
 will be determined by `--input-type`, as it is for JavaScript.
 
-TypeScript syntax is unsupported in the REPL, `--print`, `--check`, and
+TypeScript syntax is unsupported in the REPL, STDIN input, `--print`, `--check`, and
 `inspect`.
 
 ### Source maps


### PR DESCRIPTION
STDIN was never meant to be supported initally, so the documentation is incorrect.

Fixes: https://github.com/nodejs/node/issues/54035