### PR TITLE
src: account for OpenSSL unexpected version

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -52,14 +52,23 @@ Metadata metadata;
 
 #if HAVE_OPENSSL
 static constexpr size_t search(const char* s, char c, size_t n = 0) {
-  return *s == c ? n : search(s + 1, c, n + 1);
+  return *s == '\0' ? n : (*s == c ? n : search(s + 1, c, n + 1));
 }
 
 static inline std::string GetOpenSSLVersion() {
   // sample openssl version string format
   // for reference: "OpenSSL 1.1.0i 14 Aug 2018"
   const char* version = OpenSSL_version(OPENSSL_VERSION);
-  const size_t start = search(version, ' ') + 1;
+  const size_t first_space = search(version, ' ');
+
+  // When Node.js is linked to an alternative library implementing the
+  // OpenSSL API e.g. BoringSSL, the version string may not match the
+  //  expected pattern. In this case just return “0.0.0” as placeholder.
+  if (version[first_space] == '\0') {
+    return "0.0.0";
+  }
+
+  const size_t start = first_space + 1;
   const size_t len = search(&version[start], ' ');
   return std::string(version, start, len);
 }


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/53456

Fixes a crash present in Electron after ingesting the above PR. This happened because the logic to parse for an OpenSSL version didn't account for `OpenSSL_version` returning a value that doesn't match the expected pattern of `OpenSSL 1.1.0i 14 Aug 2018`. In Electron's case, `OpenSSL_version` returns just `BoringSSL`, which in combination with the `search` logic not accounting for the delimiter not being present caused an out-of-bounds crash:

```
out_of_range was thrown in -fno-exceptions mode with message "basic_string"
```

This fixes that by checking for the null terminator and returning `0.0.0` when the target delimiter isn't present.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
