### PR TITLE
test: do not swallow uncaughtException errors in exit code tests

### DIFF
--- a/test/common/process-exit-code-cases.js
+++ b/test/common/process-exit-code-cases.js
@@ -62,23 +62,25 @@ function getTestCases(isWorker = false) {
   cases.push({ func: changeCodeInsideExit, result: 99 });
 
   function zeroExitWithUncaughtHandler() {
+    const noop = () => { };
     process.on('exit', (code) => {
-      assert.strictEqual(process.exitCode, 0);
+      process.off('uncaughtException', noop);
+      assert.strictEqual(process.exitCode, undefined);
       assert.strictEqual(code, 0);
     });
-    process.on('uncaughtException', () => { });
+    process.on('uncaughtException', noop);
     throw new Error('ok');
   }
   cases.push({ func: zeroExitWithUncaughtHandler, result: 0 });
 
   function changeCodeInUncaughtHandler() {
+    const modifyExitCode = () => { process.exitCode = 97; };
     process.on('exit', (code) => {
+      process.off('uncaughtException', modifyExitCode);
       assert.strictEqual(process.exitCode, 97);
       assert.strictEqual(code, 97);
     });
-    process.on('uncaughtException', () => {
-      process.exitCode = 97;
-    });
+    process.on('uncaughtException', modifyExitCode);
     throw new Error('ok');
   }
   cases.push({ func: changeCodeInUncaughtHandler, result: 97 });


### PR DESCRIPTION
cannot use `node:assert` module in cases where `uncaughtException` handler is registered as an failure will be eaten by it

to that point: zeroExitWithUncaughtHandler had partially wrong values and i've updated it along with the patch.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
