### PR TITLE
test: move shared module to `test/common`

### DIFF
--- a/test/common/README.md
+++ b/test/common/README.md
@@ -2,7 +2,7 @@
 
 This directory contains modules used to test the Node.js implementation.
 
-## Table of Contents
+## Table of contents
 
 * [ArrayStream module](#arraystream-module)
 * [Benchmark module](#benchmark-module)
@@ -19,13 +19,14 @@ This directory contains modules used to test the Node.js implementation.
 * [HTTP2 module](#http2-module)
 * [Internet module](#internet-module)
 * [ongc module](#ongc-module)
+* [process-exit-code-test-cases module](#process-exit-code-test-cases-module)
 * [Report module](#report-module)
 * [tick module](#tick-module)
 * [tmpdir module](#tmpdir-module)
 * [UDP pair helper](#udp-pair-helper)
 * [WPT module](#wpt-module)
 
-## Benchmark Module
+## Benchmark module
 
 The `benchmark` module is used by tests to run benchmarks.
 
@@ -35,7 +36,7 @@ The `benchmark` module is used by tests to run benchmarks.
 * `env` [\<Object>][<Object>] Environment variables to be applied during the
   run.
 
-## Child Process Module
+## Child Process module
 
 The `child_process` module is used by tests that launch child processes.
 
@@ -79,7 +80,7 @@ Similar to `expectSyncExit()` with the `status` expected to be 0 and
 Similar to `spawnSyncAndExitWithoutError()`, but with an additional
 `expectations` parameter.
 
-## Common Module API
+## Common module API
 
 The `common` module is used by tests for consistency across repeated
 tasks.
@@ -488,7 +489,7 @@ was compiled with a pointer size smaller than 64 bits.
 Skip the rest of the tests in the current file when not running on a main
 thread.
 
-## ArrayStream Module
+## ArrayStream module
 
 The `ArrayStream` module provides a simple `Stream` that pushes elements from
 a given array.
@@ -503,7 +504,7 @@ stream.run(['a', 'b', 'c']);
 
 It can be used within tests as a simple mock stream.
 
-## Countdown Module
+## Countdown module
 
 The `Countdown` module provides a simple countdown mechanism for tests that
 require a particular action to be taken after a given number of completed
@@ -607,7 +608,7 @@ used to interact with the `node inspect` CLI. These functions are:
 * `stepCommand()`
 * `quit()`
 
-## `DNS` Module
+## `DNS` module
 
 The `DNS` module provides utilities related to the `dns` built-in module.
 
@@ -698,7 +699,7 @@ A comma-separated list of variables names that are appended to the global
 variable allowlist. Alternatively, if `NODE_TEST_KNOWN_GLOBALS` is set to `'0'`,
 global leak detection is disabled.
 
-## Fixtures Module
+## Fixtures module
 
 The `common/fixtures` module provides convenience methods for working with
 files in the `test/fixtures` directory.
@@ -773,7 +774,7 @@ validateSnapshotNodes('TLSWRAP', [
 ]);
 ```
 
-## hijackstdio Module
+## hijackstdio module
 
 The `hijackstdio` module provides utility functions for temporarily redirecting
 `stdout` and `stderr` output.
@@ -821,7 +822,7 @@ original state after calling [`hijackstdio.hijackStdErr()`][].
 Restore the original `process.stdout.write()`. Used to restore `stdout` to its
 original state after calling [`hijackstdio.hijackStdOut()`][].
 
-## HTTP/2 Module
+## HTTP/2 module
 
 The http2.js module provides a handful of utilities for creating mock HTTP/2
 frames for testing of HTTP/2 endpoints
@@ -940,7 +941,7 @@ upon initial establishment of a connection.
 socket.write(http2.kClientMagic);
 ```
 
-## Internet Module
+## Internet module
 
 The `common/internet` module provides utilities for working with
 internet-related tests.
@@ -974,7 +975,7 @@ via `NODE_TEST_*` environment variables. For example, to configure
 `internet.addresses.INET_HOST`, set the environment
 variable `NODE_TEST_INET_HOST` to a specified host.
 
-## ongc Module
+## ongc module
 
 The `ongc` module allows a garbage collection listener to be installed. The
 module exports a single `onGC()` function.
@@ -1002,7 +1003,28 @@ a full `setImmediate()` invocation passes.
 `listener` is an object to make it easier to use a closure; the target object
 should not be in scope when `listener.ongc()` is created.
 
-## Report Module
+## process-exit-code-test-cases module
+
+The `process-exit-code-test-cases` module provides a set of shared test cases
+for testing the exit codes of the `process` object. The test cases are shared
+between `test/parallel/test-process-exit-code.js` and
+`test/parallel/test-worker-exit-code.js`.
+
+### `getTestCases(isWorker)`
+
+* `isWorker` [\<boolean>][<boolean>]
+* return [\<Array>][<Array>]
+
+Returns an array of test cases for testing the exit codes of the `process`. Each
+test case is an object with a `func` property that is a function that runs the
+test case, a `result` property that is the expected exit code, and sometimes an
+`error` property that is a regular expression that the error message should
+match when the test case is run in a worker thread.
+
+The `isWorker` parameter is used to adjust the test cases for worker threads.
+The default value is `false`.
+
+## Report module
 
 The `report` module provides helper functions for testing diagnostic reporting
 functionality.
@@ -1051,7 +1073,7 @@ into `targetExecutable` and sign it if necessary.
 If `verifyWorkflow` is false (default) and any of the steps fails,
 it skips the tests. Otherwise, an error is thrown.
 
-## tick Module
+## tick module
 
 The `tick` module provides a helper function that can be used to call a callback
 after a given number of event loop "ticks".
@@ -1061,7 +1083,7 @@ after a given number of event loop "ticks".
 * `x` [\<number>][<number>] Number of event loop "ticks".
 * `cb` [\<Function>][<Function>] A callback function.
 
-## tmpdir Module
+## tmpdir module
 
 The `tmpdir` module supports the use of a temporary directory for testing.
 
@@ -1129,7 +1151,7 @@ is an `FakeUDPWrap` connected to the other side.
 
 There is no difference between client or server side beyond their names.
 
-## WPT Module
+## WPT module
 
 ### `harness`
 

--- a/test/common/process-exit-code-cases.js
+++ b/test/common/process-exit-code-cases.js
@@ -36,7 +36,7 @@ function getTestCases(isWorker = false) {
   function exitWithOneOnUncaught() {
     process.exitCode = 99;
     process.on('exit', (code) => {
-      // cannot use assert because it will be uncaughtException -> 1 exit code
+      // Cannot use assert because it will be uncaughtException -> 1 exit code
       // that will render this test useless
       if (code !== 1 || process.exitCode !== 1) {
         console.log('wrong code! expected 1 for uncaughtException');
@@ -113,7 +113,7 @@ function getTestCases(isWorker = false) {
 
   function exitWithThrowInUncaughtHandler() {
     process.on('uncaughtException', () => {
-      throw new Error('ok')
+      throw new Error('ok');
     });
     throw new Error('bad');
   }

--- a/test/parallel/test-process-exit-code.js
+++ b/test/parallel/test-process-exit-code.js
@@ -24,7 +24,7 @@ require('../common');
 const assert = require('assert');
 const debug = require('util').debuglog('test');
 
-const { getTestCases } = require('../fixtures/process-exit-code-cases');
+const { getTestCases } = require('../common/process-exit-code-cases');
 const testCases = getTestCases(false);
 
 if (!process.argv[2]) {

--- a/test/parallel/test-worker-exit-code.js
+++ b/test/parallel/test-worker-exit-code.js
@@ -8,7 +8,7 @@ const assert = require('assert');
 const worker = require('worker_threads');
 const { Worker, parentPort } = worker;
 
-const { getTestCases } = require('../fixtures/process-exit-code-cases');
+const { getTestCases } = require('../common/process-exit-code-cases');
 const testCases = getTestCases(true);
 
 // Do not use isMainThread so that this test itself can be run inside a Worker.


### PR DESCRIPTION
`test/fixtures/process-exit-code-cases.js` is a shared module and should be in `test/common` (so it gets linted, etc.) and documented in `test/common/README.md`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
