### PR TITLE
crypto: remove unnecessary buffer initialization

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -156,10 +156,7 @@ Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
 
   if (state[kFinalized]) {
-    const buf = Buffer.from('');
-    if (outputEncoding && outputEncoding !== 'buffer')
-      return buf.toString(outputEncoding);
-    return buf;
+    return !outputEncoding || outputEncoding === 'buffer' ? Buffer.from('') : '';
   }
 
   // Explicit conversion of truthy values for backward compatibility.


### PR DESCRIPTION
It seems unnecessary to initialize a Buffer for non-buffer output encodings and call toString() on an empty string. If I'm not mistaken, any encoding of an empty string, returns an empty string.