### PR TITLE
test_runner: differentiate test types in enqueue dequeue events

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2930,6 +2930,7 @@ The corresponding declaration ordered events are `'test:pass'` and `'test:fail'`
     `undefined` if the test was run through the REPL.
   * `name` {string} The test name.
   * `nesting` {number} The nesting level of the test.
+  * `type` {string} The test type.
 
 Emitted when a test is dequeued, right before it is executed.
 This event is not guaranteed to be emitted in the same order as the tests are
@@ -2962,6 +2963,7 @@ defined.
     `undefined` if the test was run through the REPL.
   * `name` {string} The test name.
   * `nesting` {number} The nesting level of the test.
+  * `type` {string} The test type.
 
 Emitted when a test is enqueued for execution.
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2930,7 +2930,7 @@ The corresponding declaration ordered events are `'test:pass'` and `'test:fail'`
     `undefined` if the test was run through the REPL.
   * `name` {string} The test name.
   * `nesting` {number} The nesting level of the test.
-  * `type` {string} The test type.
+  * `type` {string} The test type. Either `'suite'` or `'test'`.
 
 Emitted when a test is dequeued, right before it is executed.
 This event is not guaranteed to be emitted in the same order as the tests are
@@ -2963,7 +2963,7 @@ defined.
     `undefined` if the test was run through the REPL.
   * `name` {string} The test name.
   * `nesting` {number} The nesting level of the test.
-  * `type` {string} The test type.
+  * `type` {string} The test type. Either `'suite'` or `'test'`.
 
 Emitted when a test is enqueued for execution.
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -625,7 +625,8 @@ class Test extends AsyncResource {
     while (this.pendingSubtests.length > 0 && this.hasConcurrency()) {
       const deferred = ArrayPrototypeShift(this.pendingSubtests);
       const test = deferred.test;
-      test.reporter.dequeue(test.nesting, test.loc, test.name);
+      const type = test.reportedType ?? 'test';
+      test.reporter.dequeue(test.nesting, test.loc, test.name, type);
       await test.run();
       deferred.resolve();
     }
@@ -816,7 +817,8 @@ class Test extends AsyncResource {
     // If there is enough available concurrency to run the test now, then do
     // it. Otherwise, return a Promise to the caller and mark the test as
     // pending for later execution.
-    this.reporter.enqueue(this.nesting, this.loc, this.name);
+    const type = this.reportedType ?? 'test';
+    this.reporter.enqueue(this.nesting, this.loc, this.name, type);
     if (this.root.harness.buildPromise || !this.parent.hasConcurrency()) {
       const deferred = PromiseWithResolvers();
 
@@ -825,7 +827,7 @@ class Test extends AsyncResource {
       return deferred.promise;
     }
 
-    this.reporter.dequeue(this.nesting, this.loc, this.name);
+    this.reporter.dequeue(this.nesting, this.loc, this.name, type);
     return this.run();
   }
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1196,6 +1196,7 @@ class Test extends AsyncResource {
 }
 
 class TestHook extends Test {
+  reportedType = 'hook';
   #args;
   constructor(fn, options) {
     const { hookType, loc, parent, timeout, signal } = options;

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -379,6 +379,7 @@ class SuiteContext {
 }
 
 class Test extends AsyncResource {
+  reportedType = 'test';
   abortController;
   outerSignal;
   #reportedSubtest;
@@ -625,8 +626,7 @@ class Test extends AsyncResource {
     while (this.pendingSubtests.length > 0 && this.hasConcurrency()) {
       const deferred = ArrayPrototypeShift(this.pendingSubtests);
       const test = deferred.test;
-      const type = test.reportedType ?? 'test';
-      test.reporter.dequeue(test.nesting, test.loc, test.name, type);
+      test.reporter.dequeue(test.nesting, test.loc, test.name, this.reportedType);
       await test.run();
       deferred.resolve();
     }
@@ -817,8 +817,7 @@ class Test extends AsyncResource {
     // If there is enough available concurrency to run the test now, then do
     // it. Otherwise, return a Promise to the caller and mark the test as
     // pending for later execution.
-    const type = this.reportedType ?? 'test';
-    this.reporter.enqueue(this.nesting, this.loc, this.name, type);
+    this.reporter.enqueue(this.nesting, this.loc, this.name, this.reportedType);
     if (this.root.harness.buildPromise || !this.parent.hasConcurrency()) {
       const deferred = PromiseWithResolvers();
 
@@ -827,7 +826,7 @@ class Test extends AsyncResource {
       return deferred.promise;
     }
 
-    this.reporter.dequeue(this.nesting, this.loc, this.name, type);
+    this.reporter.dequeue(this.nesting, this.loc, this.name, this.reportedType);
     return this.run();
   }
 

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -87,20 +87,22 @@ class TestsStream extends Readable {
     return { __proto__: null, todo: reason ?? true };
   }
 
-  enqueue(nesting, loc, name) {
+  enqueue(nesting, loc, name, type) {
     this[kEmitMessage]('test:enqueue', {
       __proto__: null,
       nesting,
       name,
+      type,
       ...loc,
     });
   }
 
-  dequeue(nesting, loc, name) {
+  dequeue(nesting, loc, name, type) {
     this[kEmitMessage]('test:dequeue', {
       __proto__: null,
       nesting,
       name,
+      type,
       ...loc,
     });
   }

--- a/test/fixtures/test-runner/default-behavior/test/suite_and_test.cjs
+++ b/test/fixtures/test-runner/default-behavior/test/suite_and_test.cjs
@@ -1,0 +1,5 @@
+'use strict';
+const {test, suite} = require('node:test');
+
+suite('this is a suite');
+test('this is a test');

--- a/test/fixtures/test-runner/output/abort-runs-after-hook.snapshot
+++ b/test/fixtures/test-runner/output/abort-runs-after-hook.snapshot
@@ -4,6 +4,7 @@ AFTER
 not ok 1 - test that aborts
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/abort-runs-after-hook.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'boom'

--- a/test/fixtures/test-runner/output/abort.snapshot
+++ b/test/fixtures/test-runner/output/abort.snapshot
@@ -4,26 +4,31 @@ TAP version 13
     ok 1 - ok 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 2
     ok 2 - ok 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 3
     ok 3 - ok 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 4
     ok 4 - ok 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: not ok 1
     not ok 5 - not ok 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -33,6 +38,7 @@ TAP version 13
     not ok 6 - not ok 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -42,6 +48,7 @@ TAP version 13
     not ok 7 - not ok 3
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -63,6 +70,7 @@ TAP version 13
     not ok 8 - not ok 4
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -84,6 +92,7 @@ TAP version 13
     not ok 9 - not ok 5
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -105,6 +114,7 @@ TAP version 13
 not ok 1 - promise timeout signal
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
   error: 'The operation was aborted due to timeout'
@@ -120,6 +130,7 @@ not ok 1 - promise timeout signal
 not ok 2 - promise abort signal
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
   error: 'This operation was aborted'
@@ -142,26 +153,31 @@ not ok 2 - promise abort signal
     ok 1 - ok 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 2
     ok 2 - ok 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 3
     ok 3 - ok 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 4
     ok 4 - ok 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: not ok 1
     not ok 5 - not ok 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -171,6 +187,7 @@ not ok 2 - promise abort signal
     not ok 6 - not ok 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -180,6 +197,7 @@ not ok 2 - promise abort signal
     not ok 7 - not ok 3
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -201,6 +219,7 @@ not ok 2 - promise abort signal
     not ok 8 - not ok 4
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -222,6 +241,7 @@ not ok 2 - promise abort signal
     not ok 9 - not ok 5
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -243,6 +263,7 @@ not ok 2 - promise abort signal
 not ok 3 - callback timeout signal
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
   error: 'The operation was aborted due to timeout'
@@ -258,6 +279,7 @@ not ok 3 - callback timeout signal
 not ok 4 - callback abort signal
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
   error: 'This operation was aborted'

--- a/test/fixtures/test-runner/output/abort_hooks.snapshot
+++ b/test/fixtures/test-runner/output/abort_hooks.snapshot
@@ -12,6 +12,7 @@ TAP version 13
     not ok 1 - test 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -21,6 +22,7 @@ TAP version 13
     not ok 2 - test 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -53,11 +55,13 @@ not ok 1 - 1 before describe
     ok 1 - test 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: test 2
     ok 2 - test 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 2 - 2 after describe
@@ -86,6 +90,7 @@ not ok 2 - 2 after describe
     not ok 1 - test 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'This operation was aborted'
@@ -107,6 +112,7 @@ not ok 2 - 2 after describe
     not ok 2 - test 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'This operation was aborted'
@@ -139,6 +145,7 @@ not ok 3 - 3 beforeEach describe
     not ok 1 - test 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'This operation was aborted'
@@ -160,6 +167,7 @@ not ok 3 - 3 beforeEach describe
     not ok 2 - test 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'This operation was aborted'

--- a/test/fixtures/test-runner/output/abort_suite.snapshot
+++ b/test/fixtures/test-runner/output/abort_suite.snapshot
@@ -4,26 +4,31 @@ TAP version 13
     ok 1 - ok 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 2
     ok 2 - ok 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 3
     ok 3 - ok 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: ok 4
     ok 4 - ok 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: not ok 1
     not ok 5 - not ok 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -33,6 +38,7 @@ TAP version 13
     not ok 6 - not ok 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -42,6 +48,7 @@ TAP version 13
     not ok 7 - not ok 3
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -63,6 +70,7 @@ TAP version 13
     not ok 8 - not ok 4
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
       error: 'This operation was aborted'
@@ -84,6 +92,7 @@ TAP version 13
     not ok 9 - not ok 5
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
       error: 'This operation was aborted'

--- a/test/fixtures/test-runner/output/arbitrary-output-colored.snapshot
+++ b/test/fixtures/test-runner/output/arbitrary-output-colored.snapshot
@@ -16,6 +16,7 @@ TAP version 13
 ok 1 - passing test
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/async-test-scheduling.snapshot
+++ b/test/fixtures/test-runner/output/async-test-scheduling.snapshot
@@ -3,17 +3,20 @@ TAP version 13
 ok 1 - test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: suite
     # Subtest: test
     ok 1 - test
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: scheduled async
     ok 2 - scheduled async
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 ok 2 - suite
@@ -25,6 +28,7 @@ ok 2 - suite
 ok 3 - scheduled async
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..3
 # tests 4

--- a/test/fixtures/test-runner/output/before-and-after-each-too-many-listeners.snapshot
+++ b/test/fixtures/test-runner/output/before-and-after-each-too-many-listeners.snapshot
@@ -3,56 +3,67 @@ TAP version 13
 ok 1 - 1
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 2
 ok 2 - 2
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 3
 ok 3 - 3
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 4
 ok 4 - 4
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 5
 ok 5 - 5
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 6
 ok 6 - 6
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 7
 ok 7 - 7
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 8
 ok 8 - 8
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 9
 ok 9 - 9
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 10
 ok 10 - 10
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 11
 ok 11 - 11
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..11
 # tests 11

--- a/test/fixtures/test-runner/output/before-and-after-each-with-timeout-too-many-listeners.snapshot
+++ b/test/fixtures/test-runner/output/before-and-after-each-with-timeout-too-many-listeners.snapshot
@@ -3,56 +3,67 @@ TAP version 13
 ok 1 - 1
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 2
 ok 2 - 2
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 3
 ok 3 - 3
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 4
 ok 4 - 4
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 5
 ok 5 - 5
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 6
 ok 6 - 6
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 7
 ok 7 - 7
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 8
 ok 8 - 8
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 9
 ok 9 - 9
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 10
 ok 10 - 10
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: 11
 ok 11 - 11
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..11
 # tests 11

--- a/test/fixtures/test-runner/output/coverage-width-100-uncovered-lines.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-100-uncovered-lines.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 100
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-100.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-100.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 100
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-150-uncovered-lines.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-150-uncovered-lines.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 150
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-150.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-150.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 150
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-40.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-40.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 40
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-80-uncovered-lines.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-80-uncovered-lines.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 100
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-80.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-80.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width 80
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-infinity-uncovered-lines.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-infinity-uncovered-lines.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width Infinity
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage-width-infinity.snapshot
+++ b/test/fixtures/test-runner/output/coverage-width-infinity.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - Coverage Print Fixed Width Infinity
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/coverage_failure.snapshot
+++ b/test/fixtures/test-runner/output/coverage_failure.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - ok
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # Warning: Could not report code coverage. Error: Failed to collect coverage

--- a/test/fixtures/test-runner/output/describe_it.snapshot
+++ b/test/fixtures/test-runner/output/describe_it.snapshot
@@ -3,16 +3,19 @@ TAP version 13
 ok 1 - sync pass todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass todo with message
 ok 2 - sync pass todo with message # TODO this is a passing todo
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync todo
 not ok 3 - sync todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):4'
   failureType: 'testCodeFailure'
   error: 'should not count as a failure'
@@ -30,6 +33,7 @@ not ok 3 - sync todo # TODO
 not ok 4 - sync todo with message # TODO this is a failing todo
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'should not count as a failure'
@@ -47,21 +51,25 @@ not ok 4 - sync todo with message # TODO this is a failing todo
 ok 5 - sync skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip pass with message
 ok 6 - sync skip pass with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass
 ok 7 - sync pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync throw fail
 not ok 8 - sync throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync throw fail'
@@ -79,21 +87,25 @@ not ok 8 - sync throw fail
 ok 9 - async skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async pass
 ok 10 - async pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: mixing describe/it and test should work
 ok 11 - mixing describe/it and test should work
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async throw fail
 not ok 12 - async throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from async throw fail'
@@ -111,6 +123,7 @@ not ok 12 - async throw fail
 not ok 13 - async skip fail # SKIP
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'callbackAndPromisePresent'
   error: 'passed a callback but also returned a Promise'
@@ -120,6 +133,7 @@ not ok 13 - async skip fail # SKIP
 not ok 14 - async assertion fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -145,11 +159,13 @@ not ok 14 - async assertion fail
 ok 15 - resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: reject fail
 not ok 16 - reject fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'rejected from reject fail'
@@ -167,32 +183,38 @@ not ok 16 - reject fail
 ok 17 - unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async unhandled rejection - passes but warns
 ok 18 - async unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate throw - passes but warns
 ok 19 - immediate throw - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate reject - passes but warns
 ok 20 - immediate reject - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate resolve pass
 ok 21 - immediate resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: subtest sync throw fail
     # Subtest: +sync throw fail
     not ok 1 - +sync throw fail
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fail'
@@ -213,6 +235,7 @@ ok 21 - immediate resolve pass
     ok 2 - mixing describe/it and test should work
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 22 - subtest sync throw fail
@@ -228,6 +251,7 @@ not ok 22 - subtest sync throw fail
 not ok 23 - sync throw non-error fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'Symbol(thrown symbol from sync throw non-error fail)'
@@ -238,21 +262,25 @@ not ok 23 - sync throw non-error fail
     ok 1 - level 1a
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1b
     ok 2 - level 1b
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1c
     ok 3 - level 1c
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1d
     ok 4 - level 1d
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 ok 24 - level 0a
@@ -270,16 +298,19 @@ ok 25 - invalid subtest - pass but subtest fails
 ok 26 - sync skip option # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option with message
 ok 27 - sync skip option with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option is false fail
 not ok 28 - sync skip option is false fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'this should be executed'
@@ -297,51 +328,61 @@ not ok 28 - sync skip option is false fail
 ok 29 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionOnly
 ok 30 - functionOnly
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 31 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with only a name provided
 ok 32 - test with only a name provided
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 33 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 34 - <anonymous> # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with a name and options provided
 ok 35 - test with a name and options provided # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionAndOptions
 ok 36 - functionAndOptions # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback pass
 ok 37 - callback pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback fail
 not ok 38 - callback fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'callback failure'
@@ -354,21 +395,25 @@ not ok 38 - callback fail
 ok 39 - sync t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async t is this in test
 ok 40 - async t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback t is this in test
 ok 41 - callback t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback also returns a Promise
 not ok 42 - callback also returns a Promise
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'callbackAndPromisePresent'
   error: 'passed a callback but also returned a Promise'
@@ -378,6 +423,7 @@ not ok 42 - callback also returns a Promise
 not ok 43 - callback throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from callback throw'
@@ -395,6 +441,7 @@ not ok 43 - callback throw
 not ok 44 - callback called twice
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'multipleCallbackInvocations'
   error: 'callback invoked multiple times'
@@ -407,11 +454,13 @@ not ok 44 - callback called twice
 ok 45 - callback called twice in different ticks
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback called twice in future tick
 not ok 46 - callback called twice in future tick
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'callback invoked multiple times'
@@ -423,6 +472,7 @@ not ok 46 - callback called twice in future tick
 not ok 47 - callback async throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'thrown from callback async throw'
@@ -435,11 +485,13 @@ not ok 47 - callback async throw
 ok 48 - callback async throw after done
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: custom inspect symbol fail
 not ok 49 - custom inspect symbol fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'customized'
@@ -449,6 +501,7 @@ not ok 49 - custom inspect symbol fail
 not ok 50 - custom inspect symbol that throws fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -463,6 +516,7 @@ not ok 50 - custom inspect symbol that throws fail
     not ok 1 - sync throw fails at first
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at first'
@@ -483,6 +537,7 @@ not ok 50 - custom inspect symbol that throws fail
     not ok 2 - sync throw fails at second
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at second'
@@ -513,6 +568,7 @@ not ok 51 - subtest sync throw fails
     not ok 1 - should not run
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -544,6 +600,7 @@ not ok 52 - describe sync throw fails
     not ok 1 - should not run
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -575,6 +632,7 @@ not ok 53 - describe async throw fails
     not ok 1 - timed out async test
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testTimeoutFailure'
       error: 'test timed out after 5ms'
@@ -586,6 +644,7 @@ not ok 53 - describe async throw fails
     not ok 2 - timed out callback test
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testTimeoutFailure'
       error: 'test timed out after 5ms'
@@ -595,11 +654,13 @@ not ok 53 - describe async throw fails
     ok 3 - large timeout async test is ok
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: large timeout callback test is ok
     ok 4 - large timeout callback test is ok
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 not ok 54 - timeouts
@@ -616,11 +677,13 @@ not ok 54 - timeouts
     ok 1 - successful thenable
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: rejected thenable
     not ok 2 - rejected thenable
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'custom error'
@@ -655,17 +718,20 @@ not ok 56 - rejected thenable
     ok 1 - it inside describe 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: it inside describe 2
     ok 2 - it inside describe 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: inner describe
         # Subtest: it inside inner describe
         ok 1 - it inside inner describe
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 3 - inner describe
@@ -683,6 +749,7 @@ ok 57 - async describe function
 not ok 58 - invalid subtest fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/describe_it.js:(LINE):5'
   failureType: 'parentAlreadyFinished'
   error: 'test could not be started because its parent finished'

--- a/test/fixtures/test-runner/output/describe_nested.snapshot
+++ b/test/fixtures/test-runner/output/describe_nested.snapshot
@@ -5,6 +5,7 @@ TAP version 13
         ok 1 - nested
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 1 - nested

--- a/test/fixtures/test-runner/output/eval_tap.snapshot
+++ b/test/fixtures/test-runner/output/eval_tap.snapshot
@@ -3,11 +3,13 @@ TAP version 13
 ok 1 - passes
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: fails
 not ok 2 - fails
   ---
   duration_ms: *
+  type: 'test'
   failureType: 'testCodeFailure'
   error: 'fail'
   code: 'ERR_TEST_FAILURE'

--- a/test/fixtures/test-runner/output/filtered-suite-delayed-build.snapshot
+++ b/test/fixtures/test-runner/output/filtered-suite-delayed-build.snapshot
@@ -4,6 +4,7 @@ TAP version 13
     ok 1 - enabled 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 1 - async suite
@@ -16,6 +17,7 @@ ok 1 - async suite
     ok 1 - enabled 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 2 - sync suite

--- a/test/fixtures/test-runner/output/filtered-suite-order.snapshot
+++ b/test/fixtures/test-runner/output/filtered-suite-order.snapshot
@@ -20,12 +20,14 @@ TAP version 13
     ok 1 - A
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: C
         # Subtest: A
         ok 1 - A
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - C
@@ -38,6 +40,7 @@ TAP version 13
         ok 1 - A
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 3 - D
@@ -56,17 +59,20 @@ ok 1 - A
     ok 1 - A
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: B
     ok 2 - B
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: C
         # Subtest: A
         ok 1 - A
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 3 - C
@@ -85,17 +91,20 @@ ok 2 - B
     ok 1 - A
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: C
         # Subtest: A
         ok 1 - A
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: B
         ok 2 - B
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 2 - C
@@ -108,6 +117,7 @@ ok 2 - B
         ok 1 - B
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 3 - D
@@ -126,6 +136,7 @@ ok 3 - C
     ok 1 - B
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 4 - D
@@ -138,11 +149,13 @@ ok 4 - D
     ok 1 - A
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: B
     ok 2 - B
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 ok 5 - E
@@ -154,6 +167,7 @@ ok 5 - E
 ok 6 - F
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..6
 # tests 14

--- a/test/fixtures/test-runner/output/filtered-suite-throws.snapshot
+++ b/test/fixtures/test-runner/output/filtered-suite-throws.snapshot
@@ -25,6 +25,7 @@ not ok 1 - suite 1
     not ok 1 - enabled - should get cancelled
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/filtered-suite-throws.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'

--- a/test/fixtures/test-runner/output/global_after_should_fail_the_test.snapshot
+++ b/test/fixtures/test-runner/output/global_after_should_fail_the_test.snapshot
@@ -4,6 +4,7 @@ TAP version 13
 ok 1 - this is a test
   ---
   duration_ms: *
+  type: 'test'
   ...
 not ok 2 - /test/fixtures/test-runner/output/global_after_should_fail_the_test.js
   ---

--- a/test/fixtures/test-runner/output/hooks-with-no-global-test.snapshot
+++ b/test/fixtures/test-runner/output/hooks-with-no-global-test.snapshot
@@ -4,22 +4,26 @@ TAP version 13
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested
         # Subtest: nested 1
         ok 1 - nested 1
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: nested 2
         ok 2 - nested 2
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 3 - nested

--- a/test/fixtures/test-runner/output/hooks.snapshot
+++ b/test/fixtures/test-runner/output/hooks.snapshot
@@ -5,22 +5,26 @@ TAP version 13
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested
         # Subtest: nested 1
         ok 1 - nested 1
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: nested 2
         ok 2 - nested 2
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 3 - nested
@@ -45,6 +49,7 @@ ok 2 - describe hooks - no subtests
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -54,6 +59,7 @@ ok 2 - describe hooks - no subtests
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -102,11 +108,13 @@ not ok 4 - before throws - no subtests
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 5 - after throws
@@ -155,6 +163,7 @@ not ok 6 - after throws - no subtests
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'beforeEach'
@@ -175,6 +184,7 @@ not ok 6 - after throws - no subtests
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'beforeEach'
@@ -206,6 +216,7 @@ not ok 7 - beforeEach throws
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -226,6 +237,7 @@ not ok 7 - beforeEach throws
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -256,6 +268,7 @@ not ok 8 - afterEach throws
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'test'
@@ -276,6 +289,7 @@ not ok 8 - afterEach throws
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 9 - afterEach when test fails
@@ -292,6 +306,7 @@ not ok 9 - afterEach when test fails
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'testCodeFailure'
       error: 'test'
@@ -312,6 +327,7 @@ not ok 9 - afterEach when test fails
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -342,43 +358,51 @@ not ok 10 - afterEach throws and test fails
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested
         # Subtest: nested 1
         ok 1 - nested 1
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: nested 2
         ok 2 - nested 2
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 3 - nested
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..3
 ok 11 - test hooks
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test hooks - no subtests
 ok 12 - test hooks - no subtests
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: t.before throws
     # Subtest: 1
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'before'
@@ -399,6 +423,7 @@ ok 12 - test hooks - no subtests
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'before'
@@ -419,6 +444,7 @@ ok 12 - test hooks - no subtests
 not ok 13 - t.before throws
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'before'
@@ -439,6 +465,7 @@ not ok 13 - t.before throws
 not ok 14 - t.before throws - no subtests
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'before'
@@ -460,16 +487,19 @@ not ok 14 - t.before throws - no subtests
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 15 - t.after throws
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'hookFailed'
   error: 'after'
@@ -489,6 +519,7 @@ not ok 15 - t.after throws
 not ok 16 - t.after throws - no subtests
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'hookFailed'
   error: 'after'
@@ -509,6 +540,7 @@ not ok 16 - t.after throws - no subtests
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'beforeEach'
@@ -529,6 +561,7 @@ not ok 16 - t.after throws - no subtests
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'beforeEach'
@@ -549,6 +582,7 @@ not ok 16 - t.after throws - no subtests
 not ok 17 - t.beforeEach throws
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '2 subtests failed'
@@ -559,6 +593,7 @@ not ok 17 - t.beforeEach throws
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -579,6 +614,7 @@ not ok 17 - t.beforeEach throws
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -599,6 +635,7 @@ not ok 17 - t.beforeEach throws
 not ok 18 - t.afterEach throws
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '2 subtests failed'
@@ -609,6 +646,7 @@ not ok 18 - t.afterEach throws
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'test'
@@ -628,11 +666,13 @@ not ok 18 - t.afterEach throws
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 19 - afterEach when test fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -643,17 +683,20 @@ not ok 19 - afterEach when test fails
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 20 - afterEach context when test passes
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: afterEach context when test fails
     # Subtest: 1
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'test'
@@ -668,6 +711,7 @@ ok 20 - afterEach context when test passes
 not ok 21 - afterEach context when test fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -678,6 +722,7 @@ not ok 21 - afterEach context when test fails
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'test'
@@ -697,6 +742,7 @@ not ok 21 - afterEach context when test fails
     not ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):11'
       failureType: 'hookFailed'
       error: 'afterEach'
@@ -717,6 +763,7 @@ not ok 21 - afterEach context when test fails
 not ok 22 - afterEach throws and test fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '2 subtests failed'
@@ -726,6 +773,7 @@ not ok 22 - afterEach throws and test fails
 not ok 23 - t.after() is called if test body throws
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/hooks.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'bye'
@@ -742,6 +790,7 @@ not ok 23 - t.after() is called if test body throws
     not ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/hooks.js:(LINE):3'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -771,16 +820,19 @@ not ok 24 - run after when before throws
     ok 1 - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: 2
     ok 2 - 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 ok 25 - test hooks - async
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..25
 # before 1 called

--- a/test/fixtures/test-runner/output/name_and_skip_patterns.snapshot
+++ b/test/fixtures/test-runner/output/name_and_skip_patterns.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 ok 1 - enabled
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/name_pattern.snapshot
+++ b/test/fixtures/test-runner/output/name_pattern.snapshot
@@ -3,16 +3,19 @@ TAP version 13
 ok 1 - top level skipped test enabled # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level it enabled
 ok 2 - top level it enabled
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level skipped it enabled
 ok 3 - top level skipped it enabled # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level skipped describe enabled
 ok 4 - top level skipped describe enabled # SKIP
@@ -24,28 +27,33 @@ ok 4 - top level skipped describe enabled # SKIP
 ok 5 - top level runs because name includes PaTtErN
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level test enabled
     # Subtest: nested test runs because name includes PATTERN
     ok 1 - nested test runs because name includes PATTERN
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 6 - top level test enabled
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level describe enabled
     # Subtest: nested it not disabled
     ok 1 - nested it not disabled
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested it enabled
     ok 2 - nested it enabled
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested describe not disabled
     ok 3 - nested describe not disabled
@@ -58,6 +66,7 @@ ok 6 - top level test enabled
         ok 1 - is enabled
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 4 - nested describe enabled
@@ -76,22 +85,26 @@ ok 7 - top level describe enabled
     ok 1 - no
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: yes
     ok 2 - yes
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: maybe
         # Subtest: no
         ok 1 - no
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: yes
         ok 2 - yes
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 3 - maybe
@@ -110,12 +123,14 @@ ok 8 - yes
     ok 1 - yes
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: maybe
         # Subtest: yes
         ok 1 - yes
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - maybe
@@ -134,12 +149,14 @@ ok 9 - no
     ok 1 - yes
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: maybe
         # Subtest: yes
         ok 1 - yes
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - maybe
@@ -159,6 +176,7 @@ ok 10 - no with todo # TODO
         ok 1 - NestedTest
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 1 - NestedDescribeForMatchWithAncestors

--- a/test/fixtures/test-runner/output/name_pattern_with_only.snapshot
+++ b/test/fixtures/test-runner/output/name_pattern_with_only.snapshot
@@ -4,16 +4,19 @@ TAP version 13
     ok 1 - enabled
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: disabled but parent not
     ok 2 - disabled but parent not
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 ok 1 - enabled and only
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..1
 # tests 3

--- a/test/fixtures/test-runner/output/no_refs.snapshot
+++ b/test/fixtures/test-runner/output/no_refs.snapshot
@@ -4,6 +4,7 @@ TAP version 13
     not ok 1 - +does not keep event loop alive
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/no_refs.js:(LINE):11'
       failureType: 'cancelledByParent'
       error: 'Promise resolution is still pending but the event loop has already resolved'
@@ -15,6 +16,7 @@ TAP version 13
 not ok 1 - does not keep event loop alive
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/no_refs.js:(LINE):1'
   failureType: 'cancelledByParent'
   error: 'Promise resolution is still pending but the event loop has already resolved'

--- a/test/fixtures/test-runner/output/only_tests.snapshot
+++ b/test/fixtures/test-runner/output/only_tests.snapshot
@@ -181,37 +181,44 @@ ok 8 - describe only = true, with nested subtests
     ok 1 - running subtest - 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: this subtest is run  - 3
         # Subtest: this subtest is run - 4
         ok 1 - this subtest is run - 4
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: this subtest is run - 5
         ok 2 - this subtest is run - 5
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 2 - this subtest is run  - 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: this subtest is now run - 6
     ok 3 - this subtest is now run - 6
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: skipped subtest - 8
     ok 4 - skipped subtest - 8 # SKIP
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 ok 9 - nested tests with run only
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..9
 # tests 28

--- a/test/fixtures/test-runner/output/only_tests.snapshot
+++ b/test/fixtures/test-runner/output/only_tests.snapshot
@@ -3,59 +3,70 @@ TAP version 13
 ok 1 - only = true, skip = string # SKIP skip message
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: only = true, skip = true
 ok 2 - only = true, skip = true # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: only = true, with subtests
     # Subtest: running subtest 1
     ok 1 - running subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: running subtest 2
     ok 2 - running subtest 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: running subtest 3
     ok 3 - running subtest 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: running subtest 4
         # Subtest: running sub-subtest 1
         ok 1 - running sub-subtest 1
           ---
           duration_ms: *
+          type: 'test'
           ...
         # Subtest: running sub-subtest 2
         ok 2 - running sub-subtest 2
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..2
     ok 4 - running subtest 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: skipped subtest 4
     ok 5 - skipped subtest 4 # SKIP
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..5
 ok 3 - only = true, with subtests
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: describe only = true, with subtests
     # Subtest: `it` subtest 1 should run
     ok 1 - `it` subtest 1 should run
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 4 - describe only = true, with subtests
@@ -68,31 +79,37 @@ ok 4 - describe only = true, with subtests
     ok 1 - `it` subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: `it` async subtest 1
     ok 2 - `it` async subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: `it` subtest 2 only=true
     ok 3 - `it` subtest 2 only=true
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: `test` subtest 1
     ok 4 - `test` subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: `test` async subtest 1
     ok 5 - `test` async subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: `test` subtest 2 only=true
     ok 6 - `test` subtest 2 only=true
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..6
 ok 5 - describe only = true, with a mixture of subtests
@@ -105,6 +122,7 @@ ok 5 - describe only = true, with a mixture of subtests
     ok 1 - subtest should run
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 6 - describe only = true, with subtests
@@ -118,6 +136,7 @@ ok 6 - describe only = true, with subtests
         ok 1 - nested test should run
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 1 - nested describe
@@ -136,12 +155,14 @@ ok 7 - describe only = undefined, with nested only subtest
     ok 1 - async subtest should run
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: nested describe
         # Subtest: nested test should run
         ok 1 - nested test should run
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - nested describe

--- a/test/fixtures/test-runner/output/output.snapshot
+++ b/test/fixtures/test-runner/output/output.snapshot
@@ -513,7 +513,7 @@ not ok 47 - callback async throw
     *
     *
   ...
-# Subtest: callback async throw after dones
+# Subtest: callback async throw after done
 ok 48 - callback async throw after done
   ---
   duration_ms: *
@@ -526,13 +526,6 @@ ok 48 - callback async throw after done
       duration_ms: *
       type: 'test'
       ...
-    # Subtest: running subtest 2
-    ok 2 - running subtest 2
-      ---
-      duration_ms: *
-      type: 'test'
-      ...
-    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 3
     ok 2 - running subtest 3
       ---

--- a/test/fixtures/test-runner/output/output.snapshot
+++ b/test/fixtures/test-runner/output/output.snapshot
@@ -3,16 +3,19 @@ TAP version 13
 ok 1 - sync pass todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass todo with message
 ok 2 - sync pass todo with message # TODO this is a passing todo
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync fail todo
 not ok 3 - sync fail todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync fail todo'
@@ -30,6 +33,7 @@ not ok 3 - sync fail todo # TODO
 not ok 4 - sync fail todo with message # TODO this is a failing todo
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync fail todo with message'
@@ -47,22 +51,26 @@ not ok 4 - sync fail todo with message # TODO this is a failing todo
 ok 5 - sync skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip pass with message
 ok 6 - sync skip pass with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass
 ok 7 - sync pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # this test should pass
 # Subtest: sync throw fail
 not ok 8 - sync throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync throw fail'
@@ -80,16 +88,19 @@ not ok 8 - sync throw fail
 ok 9 - async skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async pass
 ok 10 - async pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async throw fail
 not ok 11 - async throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from async throw fail'
@@ -107,6 +118,7 @@ not ok 11 - async throw fail
 not ok 12 - async skip fail # SKIP
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from async throw fail'
@@ -124,6 +136,7 @@ not ok 12 - async skip fail # SKIP
 not ok 13 - async assertion fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -149,11 +162,13 @@ not ok 13 - async assertion fail
 ok 14 - resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: reject fail
 not ok 15 - reject fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'rejected from reject fail'
@@ -171,32 +186,38 @@ not ok 15 - reject fail
 ok 16 - unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async unhandled rejection - passes but warns
 ok 17 - async unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate throw - passes but warns
 ok 18 - immediate throw - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate reject - passes but warns
 ok 19 - immediate reject - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate resolve pass
 ok 20 - immediate resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: subtest sync throw fail
     # Subtest: +sync throw fail
     not ok 1 - +sync throw fail
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fail'
@@ -218,6 +239,7 @@ ok 20 - immediate resolve pass
 not ok 21 - subtest sync throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -227,6 +249,7 @@ not ok 21 - subtest sync throw fail
 not ok 22 - sync throw non-error fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'Symbol(thrown symbol from sync throw non-error fail)'
@@ -237,32 +260,38 @@ not ok 22 - sync throw non-error fail
     ok 1 - level 1a
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1b
     ok 2 - level 1b
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1c
     ok 3 - level 1c
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1d
     ok 4 - level 1d
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 ok 23 - level 0a
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level
     # Subtest: +long running
     not ok 1 - +long running
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):5'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -273,16 +302,19 @@ ok 23 - level 0a
         ok 1 - ++short running
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - +short running
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 24 - top level
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -292,21 +324,25 @@ not ok 24 - top level
 ok 25 - invalid subtest - pass but subtest fails
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option
 ok 26 - sync skip option # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option with message
 ok 27 - sync skip option with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option is false fail
 not ok 28 - sync skip option is false fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'this should be executed'
@@ -324,51 +360,61 @@ not ok 28 - sync skip option is false fail
 ok 29 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionOnly
 ok 30 - functionOnly
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 31 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with only a name provided
 ok 32 - test with only a name provided
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 33 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 34 - <anonymous> # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with a name and options provided
 ok 35 - test with a name and options provided # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionAndOptions
 ok 36 - functionAndOptions # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback pass
 ok 37 - callback pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback fail
 not ok 38 - callback fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'callback failure'
@@ -381,21 +427,25 @@ not ok 38 - callback fail
 ok 39 - sync t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async t is this in test
 ok 40 - async t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback t is this in test
 ok 41 - callback t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback also returns a Promise
 not ok 42 - callback also returns a Promise
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'callbackAndPromisePresent'
   error: 'passed a callback but also returned a Promise'
@@ -405,6 +455,7 @@ not ok 42 - callback also returns a Promise
 not ok 43 - callback throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from callback throw'
@@ -422,6 +473,7 @@ not ok 43 - callback throw
 not ok 44 - callback called twice
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'multipleCallbackInvocations'
   error: 'callback invoked multiple times'
@@ -434,11 +486,13 @@ not ok 44 - callback called twice
 ok 45 - callback called twice in different ticks
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback called twice in future tick
 not ok 46 - callback called twice in future tick
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'callback invoked multiple times'
@@ -450,6 +504,7 @@ not ok 46 - callback called twice in future tick
 not ok 47 - callback async throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'thrown from callback async throw'
@@ -458,36 +513,49 @@ not ok 47 - callback async throw
     *
     *
   ...
-# Subtest: callback async throw after done
+# Subtest: callback async throw after dones
 ok 48 - callback async throw after done
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: only is set on subtests but not in only mode
     # Subtest: running subtest 1
     ok 1 - running subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
+    # Subtest: running subtest 2
+    ok 2 - running subtest 2
+      ---
+      duration_ms: *
+      type: 'test'
+      ...
+    # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 3
     ok 2 - running subtest 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: running subtest 4
     ok 3 - running subtest 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..3
 ok 49 - only is set on subtests but not in only mode
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: custom inspect symbol fail
 not ok 50 - custom inspect symbol fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'customized'
@@ -497,6 +565,7 @@ not ok 50 - custom inspect symbol fail
 not ok 51 - custom inspect symbol that throws fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -511,6 +580,7 @@ not ok 51 - custom inspect symbol that throws fail
     not ok 1 - sync throw fails at first
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at first'
@@ -531,6 +601,7 @@ not ok 51 - custom inspect symbol that throws fail
     not ok 2 - sync throw fails at second
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at second'
@@ -549,6 +620,7 @@ not ok 51 - custom inspect symbol that throws fail
 not ok 52 - subtest sync throw fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '2 subtests failed'
@@ -558,6 +630,7 @@ not ok 52 - subtest sync throw fails
 not ok 53 - timed out async test
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testTimeoutFailure'
   error: 'test timed out after 5ms'
@@ -567,6 +640,7 @@ not ok 53 - timed out async test
 not ok 54 - timed out callback test
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testTimeoutFailure'
   error: 'test timed out after 5ms'
@@ -576,21 +650,25 @@ not ok 54 - timed out callback test
 ok 55 - large timeout async test is ok
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: large timeout callback test is ok
 ok 56 - large timeout callback test is ok
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: successful thenable
 ok 57 - successful thenable
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: rejected thenable
 not ok 58 - rejected thenable
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'custom error'
@@ -600,6 +678,7 @@ not ok 58 - rejected thenable
 not ok 59 - unfinished test with uncaughtException
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'foo'
@@ -613,6 +692,7 @@ not ok 59 - unfinished test with uncaughtException
 not ok 60 - unfinished test with unhandledRejection
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'unhandledRejection'
   error: 'bar'
@@ -626,6 +706,7 @@ not ok 60 - unfinished test with unhandledRejection
 not ok 61 - assertion errors display actual and expected properly
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -695,6 +776,7 @@ not ok 61 - assertion errors display actual and expected properly
 not ok 62 - invalid subtest fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):7'
   failureType: 'parentAlreadyFinished'
   error: 'test could not be started because its parent finished'

--- a/test/fixtures/test-runner/output/output_cli.snapshot
+++ b/test/fixtures/test-runner/output/output_cli.snapshot
@@ -3,16 +3,19 @@ TAP version 13
 ok 1 - sync pass todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass todo with message
 ok 2 - sync pass todo with message # TODO this is a passing todo
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync fail todo
 not ok 3 - sync fail todo # TODO
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync fail todo'
@@ -30,6 +33,7 @@ not ok 3 - sync fail todo # TODO
 not ok 4 - sync fail todo with message # TODO this is a failing todo
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync fail todo with message'
@@ -47,22 +51,26 @@ not ok 4 - sync fail todo with message # TODO this is a failing todo
 ok 5 - sync skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip pass with message
 ok 6 - sync skip pass with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync pass
 ok 7 - sync pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # this test should pass
 # Subtest: sync throw fail
 not ok 8 - sync throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from sync throw fail'
@@ -80,16 +88,19 @@ not ok 8 - sync throw fail
 ok 9 - async skip pass # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async pass
 ok 10 - async pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async throw fail
 not ok 11 - async throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from async throw fail'
@@ -107,6 +118,7 @@ not ok 11 - async throw fail
 not ok 12 - async skip fail # SKIP
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from async throw fail'
@@ -124,6 +136,7 @@ not ok 12 - async skip fail # SKIP
 not ok 13 - async assertion fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -149,11 +162,13 @@ not ok 13 - async assertion fail
 ok 14 - resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: reject fail
 not ok 15 - reject fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'rejected from reject fail'
@@ -171,32 +186,38 @@ not ok 15 - reject fail
 ok 16 - unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async unhandled rejection - passes but warns
 ok 17 - async unhandled rejection - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate throw - passes but warns
 ok 18 - immediate throw - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate reject - passes but warns
 ok 19 - immediate reject - passes but warns
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: immediate resolve pass
 ok 20 - immediate resolve pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: subtest sync throw fail
     # Subtest: +sync throw fail
     not ok 1 - +sync throw fail
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fail'
@@ -218,6 +239,7 @@ ok 20 - immediate resolve pass
 not ok 21 - subtest sync throw fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -227,6 +249,7 @@ not ok 21 - subtest sync throw fail
 not ok 22 - sync throw non-error fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'Symbol(thrown symbol from sync throw non-error fail)'
@@ -237,32 +260,38 @@ not ok 22 - sync throw non-error fail
     ok 1 - level 1a
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1b
     ok 2 - level 1b
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1c
     ok 3 - level 1c
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: level 1d
     ok 4 - level 1d
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 ok 23 - level 0a
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level
     # Subtest: +long running
     not ok 1 - +long running
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):5'
       failureType: 'cancelledByParent'
       error: 'test did not finish before its parent and was cancelled'
@@ -273,16 +302,19 @@ ok 23 - level 0a
         ok 1 - ++short running
           ---
           duration_ms: *
+          type: 'test'
           ...
         1..1
     ok 2 - +short running
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 24 - top level
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '1 subtest failed'
@@ -292,21 +324,25 @@ not ok 24 - top level
 ok 25 - invalid subtest - pass but subtest fails
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option
 ok 26 - sync skip option # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option with message
 ok 27 - sync skip option with message # SKIP this is skipped
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: sync skip option is false fail
 not ok 28 - sync skip option is false fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'this should be executed'
@@ -324,51 +360,61 @@ not ok 28 - sync skip option is false fail
 ok 29 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionOnly
 ok 30 - functionOnly
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 31 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with only a name provided
 ok 32 - test with only a name provided
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 33 - <anonymous>
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: <anonymous>
 ok 34 - <anonymous> # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: test with a name and options provided
 ok 35 - test with a name and options provided # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: functionAndOptions
 ok 36 - functionAndOptions # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback pass
 ok 37 - callback pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback fail
 not ok 38 - callback fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'callback failure'
@@ -381,21 +427,25 @@ not ok 38 - callback fail
 ok 39 - sync t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: async t is this in test
 ok 40 - async t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback t is this in test
 ok 41 - callback t is this in test
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback also returns a Promise
 not ok 42 - callback also returns a Promise
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'callbackAndPromisePresent'
   error: 'passed a callback but also returned a Promise'
@@ -405,6 +455,7 @@ not ok 42 - callback also returns a Promise
 not ok 43 - callback throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'thrown from callback throw'
@@ -422,6 +473,7 @@ not ok 43 - callback throw
 not ok 44 - callback called twice
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'multipleCallbackInvocations'
   error: 'callback invoked multiple times'
@@ -434,11 +486,13 @@ not ok 44 - callback called twice
 ok 45 - callback called twice in different ticks
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: callback called twice in future tick
 not ok 46 - callback called twice in future tick
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'callback invoked multiple times'
@@ -450,6 +504,7 @@ not ok 46 - callback called twice in future tick
 not ok 47 - callback async throw
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'thrown from callback async throw'
@@ -462,39 +517,46 @@ not ok 47 - callback async throw
 ok 48 - callback async throw after done
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: only is set on subtests but not in only mode
     # Subtest: running subtest 1
     ok 1 - running subtest 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     # Subtest: running subtest 2
     ok 2 - running subtest 2
       ---
       duration_ms: *
+      type: 'test'
       ...
     # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 3
     ok 3 - running subtest 3
       ---
       duration_ms: *
+      type: 'test'
       ...
     # 'only' and 'runOnly' require the --test-only command-line option.
     # Subtest: running subtest 4
     ok 4 - running subtest 4
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..4
 ok 49 - only is set on subtests but not in only mode
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: custom inspect symbol fail
 not ok 50 - custom inspect symbol fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'customized'
@@ -504,6 +566,7 @@ not ok 50 - custom inspect symbol fail
 not ok 51 - custom inspect symbol that throws fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -518,6 +581,7 @@ not ok 51 - custom inspect symbol that throws fail
     not ok 1 - sync throw fails at first
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at first'
@@ -538,6 +602,7 @@ not ok 51 - custom inspect symbol that throws fail
     not ok 2 - sync throw fails at second
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/output.js:(LINE):11'
       failureType: 'testCodeFailure'
       error: 'thrown from subtest sync throw fails at second'
@@ -556,6 +621,7 @@ not ok 51 - custom inspect symbol that throws fail
 not ok 52 - subtest sync throw fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'subtestsFailed'
   error: '2 subtests failed'
@@ -565,6 +631,7 @@ not ok 52 - subtest sync throw fails
 not ok 53 - timed out async test
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testTimeoutFailure'
   error: 'test timed out after 5ms'
@@ -574,6 +641,7 @@ not ok 53 - timed out async test
 not ok 54 - timed out callback test
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testTimeoutFailure'
   error: 'test timed out after 5ms'
@@ -583,21 +651,25 @@ not ok 54 - timed out callback test
 ok 55 - large timeout async test is ok
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: large timeout callback test is ok
 ok 56 - large timeout callback test is ok
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: successful thenable
 ok 57 - successful thenable
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: rejected thenable
 not ok 58 - rejected thenable
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'custom error'
@@ -607,6 +679,7 @@ not ok 58 - rejected thenable
 not ok 59 - unfinished test with uncaughtException
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'uncaughtException'
   error: 'foo'
@@ -620,6 +693,7 @@ not ok 59 - unfinished test with uncaughtException
 not ok 60 - unfinished test with unhandledRejection
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'unhandledRejection'
   error: 'bar'
@@ -633,6 +707,7 @@ not ok 60 - unfinished test with unhandledRejection
 not ok 61 - assertion errors display actual and expected properly
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: |-
@@ -702,6 +777,7 @@ not ok 61 - assertion errors display actual and expected properly
 not ok 62 - invalid subtest fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/output.js:(LINE):7'
   failureType: 'parentAlreadyFinished'
   error: 'test could not be started because its parent finished'
@@ -720,6 +796,7 @@ not ok 62 - invalid subtest fail
 ok 63 - last test
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..63
 # tests 77

--- a/test/fixtures/test-runner/output/skip_pattern.snapshot
+++ b/test/fixtures/test-runner/output/skip_pattern.snapshot
@@ -3,16 +3,19 @@ TAP version 13
 ok 1 - top level skipped test enabled # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level it enabled
 ok 2 - top level it enabled
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level skipped it enabled
 ok 3 - top level skipped it enabled # SKIP
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: top level describe
 ok 4 - top level describe

--- a/test/fixtures/test-runner/output/source_mapped_locations.snapshot
+++ b/test/fixtures/test-runner/output/source_mapped_locations.snapshot
@@ -3,6 +3,7 @@ TAP version 13
 not ok 1 - fails
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/source_mapped_locations.ts:5:1'
   failureType: 'testCodeFailure'
   error: |-

--- a/test/fixtures/test-runner/output/tap_escape.snapshot
+++ b/test/fixtures/test-runner/output/tap_escape.snapshot
@@ -3,21 +3,25 @@ TAP version 13
 ok 1 - escaped description \\ \# \\\#\\ \\n \\t \\f \\v \\b \\r
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: escaped skip message
 ok 2 - escaped skip message # SKIP \#skip
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: escaped todo message
 ok 3 - escaped todo message # TODO \#todo
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: escaped diagnostic
 ok 4 - escaped diagnostic
   ---
   duration_ms: *
+  type: 'test'
   ...
 # \#diagnostic
 1..4

--- a/test/fixtures/test-runner/output/test-diagnostic-warning-without-test-only-flag.snapshot
+++ b/test/fixtures/test-runner/output/test-diagnostic-warning-without-test-only-flag.snapshot
@@ -4,6 +4,7 @@ TAP version 13
     ok 1 - only false in describe
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 1 - should NOT print --test-only diagnostic warning - describe-only-false
@@ -16,6 +17,7 @@ ok 1 - should NOT print --test-only diagnostic warning - describe-only-false
     ok 1 - only false in the subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 2 - should NOT print --test-only diagnostic warning - it-only-false
@@ -28,6 +30,7 @@ ok 2 - should NOT print --test-only diagnostic warning - it-only-false
     ok 1 - no only
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 3 - should NOT print --test-only diagnostic warning - no-only
@@ -40,44 +43,52 @@ ok 3 - should NOT print --test-only diagnostic warning - no-only
     ok 1 - only false in parent test
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 4 - should NOT print --test-only diagnostic warning - test-only-false
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: should NOT print --test-only diagnostic warning - t.test-only-false
     # Subtest: only false in subtest
     ok 1 - only false in subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 5 - should NOT print --test-only diagnostic warning - t.test-only-false
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: should NOT print --test-only diagnostic warning - no-only
     # Subtest: no only
     ok 1 - no only
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 6 - should NOT print --test-only diagnostic warning - no-only
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: should print --test-only diagnostic warning - test-only-true
     # Subtest: only true in parent test
     ok 1 - only true in parent test
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 7 - should print --test-only diagnostic warning - test-only-true
   ---
   duration_ms: *
+  type: 'test'
   ...
 # 'only' and 'runOnly' require the --test-only command-line option.
 # Subtest: should print --test-only diagnostic warning - t.test-only-true
@@ -85,12 +96,14 @@ ok 7 - should print --test-only diagnostic warning - test-only-true
     ok 1 - only true in subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     # 'only' and 'runOnly' require the --test-only command-line option.
     1..1
 ok 8 - should print --test-only diagnostic warning - t.test-only-true
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: should print --test-only diagnostic warning - 2 levels of only
     # Subtest: only true in parent test
@@ -98,17 +111,20 @@ ok 8 - should print --test-only diagnostic warning - t.test-only-true
         ok 1 - only true in subtest
           ---
           duration_ms: *
+          type: 'test'
           ...
         # 'only' and 'runOnly' require the --test-only command-line option.
         1..1
     ok 1 - only true in parent test
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 9 - should print --test-only diagnostic warning - 2 levels of only
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..9
 # tests 16

--- a/test/fixtures/test-runner/output/test-runner-plan.snapshot
+++ b/test/fixtures/test-runner/output/test-runner-plan.snapshot
@@ -3,11 +3,13 @@ TAP version 13
 ok 1 - test planning basic
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: less assertions than planned
 not ok 2 - less assertions than planned
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/test-runner-plan.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'plan expected 1 assertions but received 0'
@@ -17,6 +19,7 @@ not ok 2 - less assertions than planned
 not ok 3 - more assertions than planned
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/test-runner-plan.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'plan expected 1 assertions but received 2'
@@ -27,38 +30,45 @@ not ok 3 - more assertions than planned
     ok 1 - subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 4 - subtesting
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: subtesting correctly
     # Subtest: subtest
     ok 1 - subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 5 - subtesting correctly
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: correctly ignoring subtesting plan
     # Subtest: subtest
     ok 1 - subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 6 - correctly ignoring subtesting plan
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: failing planning by options
 not ok 7 - failing planning by options
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/test-runner-plan.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'plan expected 1 assertions but received 0'
@@ -68,22 +78,26 @@ not ok 7 - failing planning by options
 ok 8 - not failing planning by options
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: subtest planning by options
     # Subtest: subtest
     ok 1 - subtest
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..1
 ok 9 - subtest planning by options
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: failing more assertions than planned
 not ok 10 - failing more assertions than planned
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/test-runner-plan.js:(LINE):1'
   failureType: 'testCodeFailure'
   error: 'plan expected 2 assertions but received 3'
@@ -93,6 +107,7 @@ not ok 10 - failing more assertions than planned
 ok 11 - planning with streams
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..11
 # tests 15

--- a/test/fixtures/test-runner/output/timeout_in_before_each_should_not_affect_further_tests.snapshot
+++ b/test/fixtures/test-runner/output/timeout_in_before_each_should_not_affect_further_tests.snapshot
@@ -9,6 +9,7 @@ gonna timeout
     not ok 1 - first describe first test
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/timeout_in_before_each_should_not_affect_further_tests.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'failed running beforeEach hook'
@@ -20,6 +21,7 @@ gonna timeout
     ok 2 - first describe second test
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 1 - before each timeout
@@ -38,6 +40,7 @@ not gonna timeout
     not ok 1 - second describe first test
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/timeout_in_before_each_should_not_affect_further_tests.js:(LINE):3'
       failureType: 'hookFailed'
       error: 'failed running afterEach hook'
@@ -49,6 +52,7 @@ not gonna timeout
     ok 2 - second describe second test
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 2 - after each timeout

--- a/test/fixtures/test-runner/output/unfinished-suite-async-error.snapshot
+++ b/test/fixtures/test-runner/output/unfinished-suite-async-error.snapshot
@@ -4,6 +4,7 @@ TAP version 13
     not ok 1 - uses callback
       ---
       duration_ms: *
+      type: 'test'
       location: '/test/fixtures/test-runner/output/unfinished-suite-async-error.js:(LINE):3'
       failureType: 'uncaughtException'
       error: 'callback test does not complete'
@@ -16,6 +17,7 @@ TAP version 13
     ok 2 - should pass 1
       ---
       duration_ms: *
+      type: 'test'
       ...
     1..2
 not ok 1 - unfinished suite with asynchronous error
@@ -31,6 +33,7 @@ not ok 1 - unfinished suite with asynchronous error
 ok 2 - should pass 2
   ---
   duration_ms: *
+  type: 'test'
   ...
 1..2
 # tests 3

--- a/test/fixtures/test-runner/output/unresolved_promise.snapshot
+++ b/test/fixtures/test-runner/output/unresolved_promise.snapshot
@@ -3,11 +3,13 @@ TAP version 13
 ok 1 - pass
   ---
   duration_ms: *
+  type: 'test'
   ...
 # Subtest: never resolving promise
 not ok 2 - never resolving promise
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/unresolved_promise.js:(LINE):1'
   failureType: 'cancelledByParent'
   error: 'Promise resolution is still pending but the event loop has already resolved'
@@ -19,6 +21,7 @@ not ok 2 - never resolving promise
 not ok 3 - fail
   ---
   duration_ms: *
+  type: 'test'
   location: '/test/fixtures/test-runner/output/unresolved_promise.js:(LINE):1'
   failureType: 'cancelledByParent'
   error: 'Promise resolution is still pending but the event loop has already resolved'

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -194,25 +194,26 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
     });
   });
 
-  it('should include test type in enqueue, dequeue events', async () => {
+  it('should include test type in enqueue, dequeue events', async (t) => {
     const stream = await run({
       files: [join(testFixtures, 'default-behavior/test/suite_and_test.cjs')],
     });
+    t.plan(4);
 
     stream.on('test:enqueue', common.mustCall((data) => {
       if (data.name === 'this is a suite') {
-        assert.strictEqual(data.type, 'suite');
+        t.assert.strictEqual(data.type, 'suite');
       }
-      if (data.name === ' this is a test') {
-        assert.strictEqual(data.type, 'test');
+      if (data.name === 'this is a test') {
+        t.assert.strictEqual(data.type, 'test');
       }
     }, 2));
     stream.on('test:dequeue', common.mustCall((data) => {
       if (data.name === 'this is a suite') {
-        assert.strictEqual(data.type, 'suite');
+        t.assert.strictEqual(data.type, 'suite');
       }
-      if (data.name === ' this is a test') {
-        assert.strictEqual(data.type, 'test');
+      if (data.name === 'this is a test') {
+        t.assert.strictEqual(data.type, 'test');
       }
     }, 2));
 

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -194,6 +194,32 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
     });
   });
 
+  it('should include test type in enqueue, dequeue events', async () => {
+    const stream = await run({
+      files: [join(testFixtures, 'default-behavior/test/suite_and_test.cjs')],
+    });
+
+    stream.on('test:enqueue', common.mustCall((data) => {
+      if (data.name === 'this is a suite') {
+        assert.strictEqual(data.type, 'suite');
+      }
+      if (data.name === ' this is a test') {
+        assert.strictEqual(data.type, 'test');
+      }
+    }, 2));
+    stream.on('test:dequeue', common.mustCall((data) => {
+      if (data.name === 'this is a suite') {
+        assert.strictEqual(data.type, 'suite');
+      }
+      if (data.name === ' this is a test') {
+        assert.strictEqual(data.type, 'test');
+      }
+    }, 2));
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
   describe('AbortSignal', () => {
     it('should accept a signal', async () => {
       const stream = run({ signal: AbortSignal.timeout(50), files: [


### PR DESCRIPTION
The `test:enqueue` and `test:dequeue` events now include a `type` in `details` to allow reporters to distinguish if it was a suite or test.

Fixes #51235