### PR TITLE
http: add diagnostics channel `http.client.request.error`

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1129,6 +1129,13 @@ independently.
 
 Emitted when client starts a request.
 
+`http.client.request.error`
+
+* `request` {http.ClientRequest}
+* `error` {Error}
+
+Emitted when an error occurs during a client request.
+
 `http.client.response.finish`
 
 * `request` {http.ClientRequest}

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -90,7 +90,18 @@ const kClientRequestStatistics = Symbol('ClientRequestStatistics');
 
 const dc = require('diagnostics_channel');
 const onClientRequestStartChannel = dc.channel('http.client.request.start');
+const onClientRequestErrorChannel = dc.channel('http.client.request.error');
 const onClientResponseFinishChannel = dc.channel('http.client.response.finish');
+
+function emitErrorEvent(request, error) {
+  if (onClientRequestErrorChannel.hasSubscribers) {
+    onClientRequestErrorChannel.publish({
+      request,
+      error,
+    });
+  }
+  request.emit('error', error);
+}
 
 const { addAbortSignal, finished } = require('stream');
 
@@ -343,7 +354,7 @@ function ClientRequest(input, options, cb) {
     if (typeof opts.createConnection === 'function') {
       const oncreate = once((err, socket) => {
         if (err) {
-          process.nextTick(() => this.emit('error', err));
+          process.nextTick(() => emitErrorEvent(this, err));
         } else {
           this.onSocket(socket);
         }
@@ -465,7 +476,7 @@ function socketCloseListener() {
       // receive a response. The error needs to
       // fire on the request.
       req.socket._hadError = true;
-      req.emit('error', new ConnResetException('socket hang up'));
+      emitErrorEvent(req, new ConnResetException('socket hang up'));
     }
     req._closed = true;
     req.emit('close');
@@ -492,7 +503,7 @@ function socketErrorListener(err) {
     // For Safety. Some additional errors might fire later on
     // and we need to make sure we don't double-fire the error event.
     req.socket._hadError = true;
-    req.emit('error', err);
+    emitErrorEvent(req, err);
   }
 
   const parser = socket.parser;
@@ -516,7 +527,7 @@ function socketOnEnd() {
     // If we don't have a response then we know that the socket
     // ended prematurely and we need to emit an error on the request.
     req.socket._hadError = true;
-    req.emit('error', new ConnResetException('socket hang up'));
+    emitErrorEvent(req, new ConnResetException('socket hang up'));
   }
   if (parser) {
     parser.finish();
@@ -541,7 +552,7 @@ function socketOnData(d) {
     socket.removeListener('end', socketOnEnd);
     socket.destroy();
     req.socket._hadError = true;
-    req.emit('error', ret);
+    emitErrorEvent(req, ret);
   } else if (parser.incoming && parser.incoming.upgrade) {
     // Upgrade (if status code 101) or CONNECT
     const bytesParsed = ret;
@@ -872,7 +883,7 @@ function onSocketNT(req, socket, err) {
         err = new ConnResetException('socket hang up');
       }
       if (err) {
-        req.emit('error', err);
+        emitErrorEvent(req, err);
       }
       req._closed = true;
       req.emit('close');


### PR DESCRIPTION
Fix https://github.com/nodejs/diagnostics/issues/635

This change ensures that 'error' events are emitted along with publishing to the `http.client.request.error` diagnostics channel. The new channel includes the request and error information, providing better insight into client request errors.