### PR TITLE
test: add initial pull delay and prototype pollution prevention tests for ReadableStream

### DIFF
--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -1701,3 +1701,50 @@ class Source {
     assert.deepStrictEqual(value, new Uint8Array([1, 1, 1]));
   }));
 }
+
+// Initial Pull Delay
+{
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue('data');
+      controller.close();
+    }
+  });
+
+  const iterator = stream.values();
+
+  let microtaskCompleted = false;
+  Promise.resolve().then(() => { microtaskCompleted = true; });
+
+  iterator.next().then(common.mustCall(({ done, value }) => {
+    assert.strictEqual(done, false);
+    assert.strictEqual(value, 'data');
+    assert.strictEqual(microtaskCompleted, true);
+  }));
+}
+
+// Avoiding Prototype Pollution
+{
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue('data');
+      controller.close();
+    }
+  });
+
+  const iterator = stream.values();
+
+  // Modify Promise.prototype.then to simulate prototype pollution
+  const originalThen = Promise.prototype.then;
+  Promise.prototype.then = function(onFulfilled, onRejected) {
+    return originalThen.call(this, onFulfilled, onRejected);
+  };
+
+  iterator.next().then(common.mustCall(({ done, value }) => {
+    assert.strictEqual(done, false);
+    assert.strictEqual(value, 'data');
+
+    // Restore original then method
+    Promise.prototype.then = originalThen;
+  }));
+}


### PR DESCRIPTION
Added two important tests for the `values` method of `ReadableStream`:
- Initial Pull Delay Test
- Prototype Pollution Prevention Test

These tests were added based on the [comment](https://github.com/nodejs/node/blob/main/lib/internal/webstreams/readablestream.js#L522-L536) in the source code.

**Initial Pull Delay Test:**
Added a test to ensure that the microtask completes before the controller starts the first read. This is to ensure that the controller is properly initialized before the first read.

**Prototype Pollution Prevention Test:**
Modified `Promise.prototype.then` to simulate a prototype pollution scenario and verified that the stream operates correctly. Restored the `then` method to its original state at the end.

cc. @jasnell 