### PR TITLE
typings: fix TypedArray to a global type

### DIFF
--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -17,19 +17,6 @@ import {UtilBinding} from "./internalBinding/util";
 import {WorkerBinding} from "./internalBinding/worker";
 import {ModulesBinding} from "./internalBinding/modules";
 
-declare type TypedArray =
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | Float32Array
-  | Float64Array
-  | BigUint64Array
-  | BigInt64Array;
-
 interface InternalBindingMap {
   async_wrap: AsyncWrapBinding;
   blob: BlobBinding;
@@ -56,6 +43,19 @@ type InternalBindingKeys = keyof InternalBindingMap;
 declare function internalBinding<T extends InternalBindingKeys>(binding: T): InternalBindingMap[T]
 
 declare global {
+  type TypedArray =
+    | Uint8Array
+    | Uint8ClampedArray
+    | Uint16Array
+    | Uint32Array
+    | Int8Array
+    | Int16Array
+    | Int32Array
+    | Float32Array
+    | Float64Array
+    | BigUint64Array
+    | BigInt64Array;
+
   namespace NodeJS {
     interface Global {
       internalBinding<T extends InternalBindingKeys>(binding: T): InternalBindingMap[T]


### PR DESCRIPTION
## AS-IS

<img width="493" alt="image" src="https://github.com/user-attachments/assets/b1097d1e-c81c-4969-a36d-f7948335a875">

## TO-BE

<img width="582" alt="image" src="https://github.com/user-attachments/assets/2d0ae5c4-cdf1-4843-a74b-aacf52c3b609">

- Fix TypedArray to a global type
