### PR TITLE
typings: fix typo on quic onSessionDatagram

### DIFF
--- a/typings/internalBinding/quic.d.ts
+++ b/typings/internalBinding/quic.d.ts
@@ -2,7 +2,7 @@ interface QuicCallbacks {
   onEndpointClose: (context: number, status: number) => void;
   onSessionNew: (session: Session) => void;
   onSessionClose: (type: number, code: bigint, reason?: string) => void;
-  onSessionDatagram: (datagram: Uint8Array, early: boolean) => void;);
+  onSessionDatagram: (datagram: Uint8Array, early: boolean) => void;
   onSessionDatagramStatus: (id: bigint, status: string) => void;
   onSessionHandshake: (sni: string,
                        alpn: string,


### PR DESCRIPTION
<img width="576" alt="image" src="https://github.com/user-attachments/assets/a2391328-e708-469e-802f-d9e540a28d86">

- Fix wrong typo