### PR TITLE
url: encode null character at the end of file path

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -22,6 +22,7 @@ const {
   StringPrototypeCharAt,
   StringPrototypeCharCodeAt,
   StringPrototypeCodePointAt,
+  StringPrototypeEndsWith,
   StringPrototypeIncludes,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
@@ -1511,6 +1512,8 @@ function fileURLToPath(path, options = kEmptyObject) {
 // - CR: The carriage return character is also stripped out by the `pathname`
 //       setter.
 // - TAB: The tab character is also stripped out by the `pathname` setter.
+// - NULL: The null character is stripped out by the `URL` constructor.
+
 const percentRegEx = /%/g;
 const backslashRegEx = /\\/g;
 const newlineRegEx = /\n/g;
@@ -1518,6 +1521,7 @@ const carriageReturnRegEx = /\r/g;
 const tabRegEx = /\t/g;
 const questionRegex = /\?/g;
 const hashRegex = /#/g;
+const nullRegex = /\0$/;
 
 function encodePathChars(filepath, options = kEmptyObject) {
   const windows = options?.windows;
@@ -1532,6 +1536,8 @@ function encodePathChars(filepath, options = kEmptyObject) {
     filepath = RegExpPrototypeSymbolReplace(carriageReturnRegEx, filepath, '%0D');
   if (StringPrototypeIndexOf(filepath, '\t') !== -1)
     filepath = RegExpPrototypeSymbolReplace(tabRegEx, filepath, '%09');
+  if (StringPrototypeEndsWith(filepath, '\0'))
+    filepath = RegExpPrototypeSymbolReplace(nullRegex, filepath, '%00');
   return filepath;
 }
 


### PR DESCRIPTION
**Fixes: #51167**

### Description
To maintain current performance while addressing the whitespace trimming issue, I opted to pre-encode the pathname. Modifying the URL parse function would require more extensive changes, so pre-encoding is a simpler solution.

### Test
```javascript
import { pathToFileURL } from 'url';

const filename = `test-${String.fromCharCode(0)}`;
console.log(pathToFileURL(filename).toString()); // file:///[...]/test-%00
```
Previously, this would output `test-`, but now it correctly outputs `file:///[...]/test-%00`.

### Benchmark
```
                                                                                                                 confidence improvement accuracy (*)   (**)  (***)
url/whatwg-url-to-and-from-path.js n=5000000 method='fileURLToPath' input='file:///dev/null?key=param&bool'                      0.53 %       ±0.89% ±1.20% ±1.58%
url/whatwg-url-to-and-from-path.js n=5000000 method='fileURLToPath' input='file:///dev/null?key=param&bool#hash'                -0.23 %       ±0.86% ±1.16% ±1.53%
url/whatwg-url-to-and-from-path.js n=5000000 method='fileURLToPath' input='file:///dev/null'                                    -0.56 %       ±1.33% ±1.76% ±2.30%
url/whatwg-url-to-and-from-path.js n=5000000 method='pathToFileURL' input='file:///dev/null?key=param&bool'                      0.42 %       ±1.12% ±1.50% ±1.98%
url/whatwg-url-to-and-from-path.js n=5000000 method='pathToFileURL' input='file:///dev/null?key=param&bool#hash'         **     -0.87 %       ±0.60% ±0.79% ±1.03%
url/whatwg-url-to-and-from-path.js n=5000000 method='pathToFileURL' input='file:///dev/null'                                    -0.50 %       ±1.50% ±1.99% ±2.60%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 6 comparisons, you can thus expect the following amount of false-positive results:
  0.30 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.06 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)

```
The local benchmark doesn't show a statistically significant performance degradation