### PR TITLE
build: drop experimental support for Windows <10

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -112,7 +112,6 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | s390x            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2       | e.g. RHEL 8                          |
 | GNU/Linux        | loong64          | kernel >= 5.19, glibc >= 2.36     | Experimental |                                      |
 | Windows          | x64              | >= Windows 10/Server 2016         | Tier 1       | [^2],[^3]                            |
-| Windows          | x64              | Windows 8.1/Server 2012           | Experimental |                                      |
 | Windows          | arm64            | >= Windows 10                     | Tier 2       |                                      |
 | macOS            | x64              | >= 11.0                           | Tier 1       | For notes about compilation see [^4] |
 | macOS            | arm64            | >= 11.0                           | Tier 1       |                                      |

--- a/src/node_main.cc
+++ b/src/node_main.cc
@@ -35,17 +35,17 @@ int wmain(int argc, wchar_t* wargv[]) {
   // Windows Server 2012 (not R2) is supported until 10/10/2023, so we allow it
   // to run in the experimental support tier.
   char buf[SKIP_CHECK_STRLEN + 1];
-  if (!IsWindows8Point1OrGreater() &&
-      !(IsWindowsServer() && IsWindows8OrGreater()) &&
+  if (!IsWindows10OrGreater() &&
       (GetEnvironmentVariableA(SKIP_CHECK_VAR, buf, sizeof(buf)) !=
            SKIP_CHECK_STRLEN ||
        strncmp(buf, SKIP_CHECK_VALUE, SKIP_CHECK_STRLEN) != 0)) {
-    fprintf(stderr, "Node.js is only supported on Windows 8.1, Windows "
-                    "Server 2012 R2, or higher.\n"
-                    "Setting the " SKIP_CHECK_VAR " environment variable "
-                    "to 1 skips this\ncheck, but Node.js might not execute "
-                    "correctly. Any issues encountered on\nunsupported "
-                    "platforms will not be fixed.");
+    fprintf(stderr,
+            "Node.js is only supported on Windows 10, Windows "
+            "Server 2016, or higher.\n"
+            "Setting the " SKIP_CHECK_VAR " environment variable "
+            "to 1 skips this\ncheck, but Node.js might not execute "
+            "correctly. Any issues encountered on\nunsupported "
+            "platforms will not be fixed.");
     exit(ERROR_EXE_MACHINE_TYPE_MISMATCH);
   }
 

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -540,7 +540,7 @@
         'defines': [
           'WIN32',
           'NOMINMAX',  # Refs: https://chromium-review.googlesource.com/c/v8/v8/+/1456620
-          '_WIN32_WINNT=0x0602',  # Windows 8
+          '_WIN32_WINNT=0x0A00',  # Windows 10
           '_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS',
         ],
         # 4351: VS 2005 and later are warning us that they've fixed a bug


### PR DESCRIPTION
V8 now uses Windows APIs that are not available in older Windows
versions.

Fixes the V8 12.8 build (https://github.com/nodejs/node/pull/54077):
https://ci.nodejs.org/job/node-compile-windows-debug/22986/nodes=win-vs2022/

```
10:34:02 C:\workspace\node-compile-windows-debug\node\deps\v8\src\base\platform\platform-win32.cc(765,34): error C2065: 'IsUserCetAvailableInEnvironment': undeclared identifier [C:\workspace\node-compile-windows-debug\node\tools\v8_gypfiles\v8_libbase.vcxproj]
```