### PR TITLE
url: replace parseParams function's slice with StringPrototypeSlice

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1245,7 +1245,7 @@ function parseParams(qs) {
       }
 
       if (lastPos < i)
-        buf += qs.slice(lastPos, i);
+        buf += StringPrototypeSlice(qs, lastPos, i);
       if (encoded)
         buf = querystring.unescape(buf);
       out.push(buf);
@@ -1266,7 +1266,7 @@ function parseParams(qs) {
     if (!seenSep && code === CHAR_EQUAL) {
       // Key/value separator match!
       if (lastPos < i)
-        buf += qs.slice(lastPos, i);
+        buf += StringPrototypeSlice(qs, lastPos, i);
       if (encoded)
         buf = querystring.unescape(buf);
       out.push(buf);


### PR DESCRIPTION
updated the parseParams function located in internal/url to replace the use of slice with StringPrototypeSlice as it is an internal file. local benchmarks using parseParams show no significant performance difference.
```
                                                                                      confidence improvement accuracy (*)   (**)  (***)
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='get'                         0.13 %       ±1.48% ±1.97% ±2.56%
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='getAll'                     -0.84 %       ±3.29% ±4.42% ±5.83%
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='has'                         0.48 %       ±1.41% ±1.88% ±2.44%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='get'                                 1.16 %       ±1.63% ±2.17% ±2.82%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='getAll'                             -0.14 %       ±1.05% ±1.41% ±1.84%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='has'                                -0.37 %       ±1.49% ±1.99% ±2.59%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='get'                               0.44 %       ±1.76% ±2.35% ±3.05%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='getAll'                           -0.38 %       ±0.72% ±0.96% ±1.25%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='has'                               1.12 %       ±1.34% ±1.79% ±2.33%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='get'                                 1.15 %       ±2.42% ±3.23% ±4.22%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='getAll'                              0.25 %       ±1.44% ±1.93% ±2.54%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='has'                                -0.39 %       ±1.87% ±2.48% ±3.23%
url/url-searchparams-sort.js n=1000000 type='almostsorted'                                            -0.05 %       ±1.53% ±2.04% ±2.65%
url/url-searchparams-sort.js n=1000000 type='empty'                                                    2.27 %       ±4.07% ±5.46% ±7.19%
url/url-searchparams-sort.js n=1000000 type='long'                                              *     -1.62 %       ±1.29% ±1.71% ±2.23%
url/url-searchparams-sort.js n=1000000 type='random'                                                  -2.03 %       ±3.29% ±4.42% ±5.84%
url/url-searchparams-sort.js n=1000000 type='reversed'                                                -0.75 %       ±2.55% ±3.40% ±4.43%
url/url-searchparams-sort.js n=1000000 type='short'                                                   -0.57 %       ±3.15% ±4.21% ±5.50%
url/url-searchparams-sort.js n=1000000 type='sorted'                                                  -0.61 %       ±1.38% ±1.84% ±2.41%
url/url-searchparams-sort.js n=1000000 type='wpt'                                                      0.98 %       ±1.25% ±1.67% ±2.17%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='array'                           0.52 %       ±0.83% ±1.10% ±1.44%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='encodelast'                      0.77 %       ±1.69% ±2.26% ±2.97%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='encodemany'                      0.45 %       ±1.08% ±1.44% ±1.88%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='multiprimitives'                 0.10 %       ±1.09% ±1.45% ±1.89%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='noencode'                        0.29 %       ±1.62% ±2.15% ±2.80%
url/url-searchparams-toString.js n=1000000 inputType='object' type='array'                             0.34 %       ±1.49% ±1.98% ±2.58%
url/url-searchparams-toString.js n=1000000 inputType='object' type='encodelast'                       -0.77 %       ±1.65% ±2.20% ±2.87%
url/url-searchparams-toString.js n=1000000 inputType='object' type='encodemany'                       -0.12 %       ±0.97% ±1.28% ±1.67%
url/url-searchparams-toString.js n=1000000 inputType='object' type='multiprimitives'                   0.62 %       ±0.92% ±1.23% ±1.61%
url/url-searchparams-toString.js n=1000000 inputType='object' type='noencode'                         -0.98 %       ±1.17% ±1.56% ±2.04%
url/url-searchparams-toString.js n=1000000 inputType='string' type='array'                      *     -2.02 %       ±1.89% ±2.52% ±3.31%
url/url-searchparams-toString.js n=1000000 inputType='string' type='encodelast'                       -0.22 %       ±1.45% ±1.93% ±2.51%
url/url-searchparams-toString.js n=1000000 inputType='string' type='encodemany'                        0.07 %       ±1.34% ±1.79% ±2.32%
url/url-searchparams-toString.js n=1000000 inputType='string' type='multiprimitives'                  -0.93 %       ±1.17% ±1.57% ±2.05%
url/url-searchparams-toString.js n=1000000 inputType='string' type='noencode'                          0.57 %       ±1.69% ±2.27% ±2.98%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 35 comparisons, you can thus expect the following amount of false-positive results:
  1.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.35 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
  ```
  