### PR TITLE
buffer: use native copy impl

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -5,12 +5,6 @@ const bench = common.createBenchmark(main, {
   bytes: [0, 8, 128, 32 * 1024],
   partial: ['true', 'false'],
   n: [6e6],
-}, {
-  combinationFilter: (p) => {
-    return (p.partial === 'false' && p.bytes === 0) ||
-           (p.partial !== 'false' && p.bytes !== 0);
-  },
-  test: { partial: 'false', bytes: 0 },
 });
 
 function main({ n, bytes, partial }) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -56,6 +56,7 @@ const {
   byteLengthUtf8,
   compare: _compare,
   compareOffset,
+  copy: _copy,
   createFromString,
   fill: bindingFill,
   isAscii: bindingIsAscii,
@@ -199,7 +200,7 @@ function toInteger(n, defaultVal) {
   return defaultVal;
 }
 
-function _copy(source, target, targetStart, sourceStart, sourceEnd) {
+function copyImpl(source, target, targetStart, sourceStart, sourceEnd) {
   if (!isUint8Array(source))
     throw new ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], source);
   if (!isUint8Array(target))
@@ -244,10 +245,10 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
   if (nb > sourceLen)
     nb = sourceLen;
 
-  if (sourceStart !== 0 || sourceEnd < source.length)
-    source = new Uint8Array(source.buffer, source.byteOffset + sourceStart, nb);
+  if (nb <= 0)
+    return 0;
 
-  TypedArrayPrototypeSet(target, source, targetStart);
+  _copy(source, target, targetStart, sourceStart, nb);
 
   return nb;
 }
@@ -801,7 +802,7 @@ ObjectDefineProperty(Buffer.prototype, 'offset', {
 
 Buffer.prototype.copy =
   function copy(target, targetStart, sourceStart, sourceEnd) {
-    return _copy(this, target, targetStart, sourceStart, sourceEnd);
+    return copyImpl(this, target, targetStart, sourceStart, sourceEnd);
   };
 
 // No need to verify that "buf.length <= MAX_UINT32" since it's a read-only

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -56,6 +56,14 @@ using CFunctionWithInt64Fallback = void (*)(v8::Local<v8::Value>,
                                             v8::FastApiCallbackOptions&);
 using CFunctionWithBool = void (*)(v8::Local<v8::Value>, bool);
 
+using CFunctionBufferCopy =
+    uint32_t (*)(v8::Local<v8::Value> receiver,
+                 const v8::FastApiTypedArray<uint8_t>& source,
+                 const v8::FastApiTypedArray<uint8_t>& target,
+                 uint32_t target_start,
+                 uint32_t source_start,
+                 uint32_t to_copy);
+
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
 class ExternalReferenceRegistry {
@@ -79,6 +87,7 @@ class ExternalReferenceRegistry {
   V(CFunctionWithDoubleReturnDouble)                                           \
   V(CFunctionWithInt64Fallback)                                                \
   V(CFunctionWithBool)                                                         \
+  V(CFunctionBufferCopy)                                                       \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \


### PR DESCRIPTION
Apple M2 Pro
```bash
buffers/buffer-copy.js n=6000000 partial='false' bytes=0                    -0.53 %       ±6.78%  ±9.02% ±11.74%
buffers/buffer-copy.js n=6000000 partial='false' bytes=128          ***     30.37 %      ±10.39% ±13.88% ±18.19%
buffers/buffer-copy.js n=6000000 partial='false' bytes=32768                 2.73 %       ±3.96%  ±5.27%  ±6.86%
buffers/buffer-copy.js n=6000000 partial='false' bytes=8            ***     73.09 %      ±10.43% ±13.89% ±18.08%
buffers/buffer-copy.js n=6000000 partial='true' bytes=0                     -1.66 %       ±7.78% ±10.35% ±13.47%
buffers/buffer-copy.js n=6000000 partial='true' bytes=128           ***    327.50 %      ±23.05% ±31.00% ±41.01%
buffers/buffer-copy.js n=6000000 partial='true' bytes=32768           *      4.50 %       ±4.34%  ±5.78%  ±7.55%
buffers/buffer-copy.js n=6000000 partial='true' bytes=8             ***    311.90 %      ±33.99% ±45.75% ±60.62%
```

Benchmark CI
```bash
10:33:07 buffers/buffer-copy.js n=6000000 partial='false' bytes=0                     0.56 %       ±1.11%  ±1.48%  ±1.95%
10:33:07 buffers/buffer-copy.js n=6000000 partial='false' bytes=128          ***     34.10 %       ±0.81%  ±1.08%  ±1.41%
10:33:07 buffers/buffer-copy.js n=6000000 partial='false' bytes=32768        ***     -1.80 %       ±0.84%  ±1.12%  ±1.47%
10:33:07 buffers/buffer-copy.js n=6000000 partial='false' bytes=8            ***     38.98 %       ±1.00%  ±1.34%  ±1.75%
10:33:07 buffers/buffer-copy.js n=6000000 partial='true' bytes=0                     -0.44 %       ±0.81%  ±1.08%  ±1.41%
10:33:07 buffers/buffer-copy.js n=6000000 partial='true' bytes=128           ***    256.54 %       ±1.31%  ±1.75%  ±2.31%
10:33:07 buffers/buffer-copy.js n=6000000 partial='true' bytes=32768         ***     35.39 %      ±11.48% ±15.46% ±20.49%
10:33:07 buffers/buffer-copy.js n=6000000 partial='true' bytes=8             ***    249.26 %       ±1.67%  ±2.24%  ±2.95%
```