### PR TITLE
buffer: faster type check

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -23,6 +23,7 @@
 
 const {
   Array,
+  ArrayBufferIsView,
   ArrayIsArray,
   ArrayPrototypeForEach,
   MathFloor,
@@ -202,9 +203,9 @@ function toInteger(n, defaultVal) {
 }
 
 function copyImpl(source, target, targetStart, sourceStart, sourceEnd) {
-  if (!isUint8Array(source))
+  if (!ArrayBufferIsView(source))
     throw new ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], source);
-  if (!isUint8Array(target))
+  if (!ArrayBufferIsView(target))
     throw new ERR_INVALID_ARG_TYPE('target', ['Buffer', 'Uint8Array'], target);
 
   if (targetStart === undefined) {
@@ -219,30 +220,30 @@ function copyImpl(source, target, targetStart, sourceStart, sourceEnd) {
     sourceStart = 0;
   } else {
     sourceStart = NumberIsInteger(sourceStart) ? sourceStart : toInteger(sourceStart, 0);
-    if (sourceStart < 0 || sourceStart > source.length)
-      throw new ERR_OUT_OF_RANGE('sourceStart', `>= 0 && <= ${source.length}`, sourceStart);
+    if (sourceStart < 0 || sourceStart > source.byteLength)
+      throw new ERR_OUT_OF_RANGE('sourceStart', `>= 0 && <= ${source.byteLength}`, sourceStart);
   }
 
   if (sourceEnd === undefined) {
-    sourceEnd = source.length;
+    sourceEnd = source.byteLength;
   } else {
     sourceEnd = NumberIsInteger(sourceEnd) ? sourceEnd : toInteger(sourceEnd, 0);
     if (sourceEnd < 0)
       throw new ERR_OUT_OF_RANGE('sourceEnd', '>= 0', sourceEnd);
   }
 
-  if (targetStart >= target.length || sourceStart >= sourceEnd)
+  if (targetStart >= target.byteLength || sourceStart >= sourceEnd)
     return 0;
 
   return _copyActual(source, target, targetStart, sourceStart, sourceEnd);
 }
 
 function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
-  if (sourceEnd - sourceStart > target.length - targetStart)
-    sourceEnd = sourceStart + target.length - targetStart;
+  if (sourceEnd - sourceStart > target.byteLength - targetStart)
+    sourceEnd = sourceStart + target.byteLength - targetStart;
 
   let nb = sourceEnd - sourceStart;
-  const sourceLen = source.length - sourceStart;
+  const sourceLen = source.byteLength - sourceStart;
   if (nb > sourceLen)
     nb = sourceLen;
 


### PR DESCRIPTION
Also add support for any TypedArray as target.

```bash
buffers/buffer-copy.js n=6000000 partial='true' bytes=128          ***     50.28 %       ±4.26% ±5.68%  ±7.42%
buffers/buffer-copy.js n=6000000 partial='true' bytes=8            ***     45.58 %       ±4.53% ±6.04%  ±7.89%
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
