### PR TITLE
buffer: faster integer argument check

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -28,6 +28,7 @@ const {
   MathFloor,
   MathMin,
   MathTrunc,
+  NumberIsInteger,
   NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
@@ -208,7 +209,7 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
   if (targetStart === undefined) {
     targetStart = 0;
   } else {
-    targetStart = toInteger(targetStart, 0);
+    targetStart = NumberIsInteger(targetStart) ? targetStart : toInteger(targetStart, 0);
     if (targetStart < 0)
       throw new ERR_OUT_OF_RANGE('targetStart', '>= 0', targetStart);
   }
@@ -216,7 +217,7 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
   if (sourceStart === undefined) {
     sourceStart = 0;
   } else {
-    sourceStart = toInteger(sourceStart, 0);
+    sourceStart = NumberIsInteger(sourceStart) ? sourceStart : toInteger(sourceStart, 0);
     if (sourceStart < 0 || sourceStart > source.length)
       throw new ERR_OUT_OF_RANGE('sourceStart', `>= 0 && <= ${source.length}`, sourceStart);
   }
@@ -224,7 +225,7 @@ function _copy(source, target, targetStart, sourceStart, sourceEnd) {
   if (sourceEnd === undefined) {
     sourceEnd = source.length;
   } else {
-    sourceEnd = toInteger(sourceEnd, 0);
+    sourceEnd = NumberIsInteger(sourceEnd) ? sourceEnd : toInteger(sourceEnd, 0);
     if (sourceEnd < 0)
       throw new ERR_OUT_OF_RANGE('sourceEnd', '>= 0', sourceEnd);
   }


### PR DESCRIPTION
```bash
buffers/buffer-copy.js n=6000000 partial='true' bytes=0        ***     11.22 %       ±5.01% ±6.67% ±8.68%
```