### PR TITLE
url: improve resolveObject by replacing for loop with ObjectAssign an…

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -24,6 +24,7 @@
 const {
   Boolean,
   Int8Array,
+  ObjectAssign,
   ObjectKeys,
   StringPrototypeCharCodeAt,
   decodeURIComponent,
@@ -735,11 +736,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   }
 
   const result = new Url();
-  const tkeys = ObjectKeys(this);
-  for (let tk = 0; tk < tkeys.length; tk++) {
-    const tkey = tkeys[tk];
-    result[tkey] = this[tkey];
-  }
+  ObjectAssign(result, this);
 
   // Hash is always overridden, no matter what.
   // even href="" will remove it.
@@ -754,12 +751,13 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // Hrefs like //foo/bar always cut to the protocol.
   if (relative.slashes && !relative.protocol) {
     // Take everything except the protocol from relative
-    const rkeys = ObjectKeys(relative);
-    for (let rk = 0; rk < rkeys.length; rk++) {
-      const rkey = rkeys[rk];
-      if (rkey !== 'protocol')
-        result[rkey] = relative[rkey];
-    }
+    const relativeWithoutProtocol = ObjectKeys(relative).reduce((acc, key) => {
+      if (key !== 'protocol') {
+        acc[key] = relative[key];
+      }
+      return acc;
+    }, {});
+    ObjectAssign(result, relativeWithoutProtocol);
 
     // urlParse appends trailing / to urls like http://www.example.com
     if (slashedProtocol.has(result.protocol) &&
@@ -781,11 +779,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     // because that's known to be hostless.
     // anything else is assumed to be absolute.
     if (!slashedProtocol.has(relative.protocol)) {
-      const keys = ObjectKeys(relative);
-      for (let v = 0; v < keys.length; v++) {
-        const k = keys[v];
-        result[k] = relative[k];
-      }
+      ObjectAssign(result, relative);
       result.href = result.format();
       return result;
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -751,13 +751,12 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // Hrefs like //foo/bar always cut to the protocol.
   if (relative.slashes && !relative.protocol) {
     // Take everything except the protocol from relative
-    const relativeWithoutProtocol = ObjectKeys(relative).reduce((acc, key) => {
-      if (key !== 'protocol') {
-        acc[key] = relative[key];
-      }
-      return acc;
-    }, {});
-    ObjectAssign(result, relativeWithoutProtocol);
+    const rkeys = ObjectKeys(relative);
+    for (let rk = 0; rk < rkeys.length; rk++) {
+      const rkey = rkeys[rk];
+      if (rkey !== 'protocol')
+        result[rkey] = relative[rkey];
+    }
 
     // urlParse appends trailing / to urls like http://www.example.com
     if (slashedProtocol.has(result.protocol) &&


### PR DESCRIPTION
### Summary
This PR enhances the performance of the resolveObject function by replacing the for loop used for copying properties with ObjectAssign.

### Changes
Replaced the for loop in the resolveObject function with ObjectAssign and reduce to improve performance.
Based on local benchmark tests, the reduce method demonstrates a slight performance advantage over the for statement.

### Benchmark Results
local benchmark shows performance improvements
```
                                                              confidence improvement accuracy (*)   (**)  (***)
url/url-resolve.js n=100000 path='down' href='auth'                    ***      3.76 %       ±1.32% ±1.75% ±2.28%
url/url-resolve.js n=100000 path='down' href='dot'                     ***      3.21 %       ±1.31% ±1.74% ±2.27%
url/url-resolve.js n=100000 path='down' href='file'                    ***      4.58 %       ±1.99% ±2.65% ±3.45%
url/url-resolve.js n=100000 path='down' href='idn'                     ***      4.93 %       ±1.70% ±2.26% ±2.94%
url/url-resolve.js n=100000 path='down' href='javascript'              ***      6.81 %       ±1.55% ±2.07% ±2.70%
url/url-resolve.js n=100000 path='down' href='long'                    ***      3.67 %       ±1.34% ±1.79% ±2.32%
url/url-resolve.js n=100000 path='down' href='noscheme'                ***      4.76 %       ±1.29% ±1.71% ±2.23%
url/url-resolve.js n=100000 path='down' href='percent'                 ***      3.99 %       ±1.62% ±2.16% ±2.81%
url/url-resolve.js n=100000 path='down' href='short'                   ***      4.65 %       ±0.98% ±1.31% ±1.70%
url/url-resolve.js n=100000 path='down' href='ws'                      ***      5.01 %       ±1.62% ±2.15% ±2.81%
url/url-resolve.js n=100000 path='foo/bar' href='auth'                 ***      4.06 %       ±1.47% ±1.95% ±2.54%
url/url-resolve.js n=100000 path='foo/bar' href='dot'                  ***      3.57 %       ±1.21% ±1.60% ±2.09%
url/url-resolve.js n=100000 path='foo/bar' href='file'                 ***      5.01 %       ±1.58% ±2.10% ±2.74%
url/url-resolve.js n=100000 path='foo/bar' href='idn'                  ***      4.22 %       ±1.43% ±1.90% ±2.47%
url/url-resolve.js n=100000 path='foo/bar' href='javascript'           ***      7.41 %       ±1.79% ±2.39% ±3.11%
url/url-resolve.js n=100000 path='foo/bar' href='long'                 ***      3.32 %       ±1.00% ±1.33% ±1.73%
url/url-resolve.js n=100000 path='foo/bar' href='noscheme'             ***      5.81 %       ±1.73% ±2.30% ±3.00%
url/url-resolve.js n=100000 path='foo/bar' href='percent'              ***      3.75 %       ±1.70% ±2.28% ±2.99%
url/url-resolve.js n=100000 path='foo/bar' href='short'                ***      4.49 %       ±1.53% ±2.05% ±2.68%
url/url-resolve.js n=100000 path='foo/bar' href='ws'                   ***      4.46 %       ±1.47% ±1.96% ±2.55%
url/url-resolve.js n=100000 path='sibling' href='auth'                 ***      4.02 %       ±1.32% ±1.76% ±2.30%
url/url-resolve.js n=100000 path='sibling' href='dot'                  ***      4.55 %       ±1.46% ±1.94% ±2.54%
url/url-resolve.js n=100000 path='sibling' href='file'                 ***      4.16 %       ±1.28% ±1.70% ±2.22%
url/url-resolve.js n=100000 path='sibling' href='idn'                  ***      5.04 %       ±1.38% ±1.84% ±2.39%
url/url-resolve.js n=100000 path='sibling' href='javascript'           ***      3.80 %       ±1.56% ±2.07% ±2.70%
url/url-resolve.js n=100000 path='sibling' href='long'                 ***      2.83 %       ±1.09% ±1.46% ±1.90%
url/url-resolve.js n=100000 path='sibling' href='noscheme'             ***      6.25 %       ±1.61% ±2.15% ±2.80%
url/url-resolve.js n=100000 path='sibling' href='percent'               **      4.42 %       ±2.72% ±3.62% ±4.71%
url/url-resolve.js n=100000 path='sibling' href='short'                ***      4.75 %       ±1.11% ±1.47% ±1.92%
url/url-resolve.js n=100000 path='sibling' href='ws'                   ***      3.74 %       ±1.52% ±2.02% ±2.64%
url/url-resolve.js n=100000 path='up' href='auth'                      ***      3.86 %       ±1.09% ±1.45% ±1.88%
url/url-resolve.js n=100000 path='up' href='dot'                        **      3.02 %       ±1.83% ±2.45% ±3.21%
url/url-resolve.js n=100000 path='up' href='file'                      ***      4.69 %       ±1.53% ±2.04% ±2.66%
url/url-resolve.js n=100000 path='up' href='idn'                       ***      5.06 %       ±1.39% ±1.85% ±2.41%
url/url-resolve.js n=100000 path='up' href='javascript'                ***      4.17 %       ±2.25% ±2.99% ±3.89%
url/url-resolve.js n=100000 path='up' href='long'                      ***      2.84 %       ±1.02% ±1.37% ±1.79%
url/url-resolve.js n=100000 path='up' href='noscheme'                  ***      4.83 %       ±1.36% ±1.81% ±2.35%
url/url-resolve.js n=100000 path='up' href='percent'                   ***      3.51 %       ±1.49% ±1.98% ±2.59%
url/url-resolve.js n=100000 path='up' href='short'                     ***      3.44 %       ±1.74% ±2.32% ±3.01%
url/url-resolve.js n=100000 path='up' href='ws'                        ***      4.40 %       ±1.42% ±1.89% ±2.47%
url/url-resolve.js n=100000 path='withscheme' href='auth'              ***      5.94 %       ±1.64% ±2.19% ±2.85%
url/url-resolve.js n=100000 path='withscheme' href='dot'               ***      7.80 %       ±1.36% ±1.81% ±2.36%
url/url-resolve.js n=100000 path='withscheme' href='file'              ***      6.84 %       ±1.65% ±2.19% ±2.85%
url/url-resolve.js n=100000 path='withscheme' href='idn'               ***      4.69 %       ±1.47% ±1.96% ±2.55%
url/url-resolve.js n=100000 path='withscheme' href='javascript'        ***      6.29 %       ±1.46% ±1.94% ±2.53%
url/url-resolve.js n=100000 path='withscheme' href='long'               **      1.86 %       ±1.24% ±1.66% ±2.17%
url/url-resolve.js n=100000 path='withscheme' href='noscheme'          ***      7.49 %       ±1.66% ±2.21% ±2.89%
url/url-resolve.js n=100000 path='withscheme' href='percent'           ***      5.68 %       ±1.64% ±2.19% ±2.85%
url/url-resolve.js n=100000 path='withscheme' href='short'             ***      5.01 %       ±2.05% ±2.73% ±3.55%
url/url-resolve.js n=100000 path='withscheme' href='ws'                ***      4.33 %       ±2.14% ±2.85% ±3.72%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 50 comparisons, you can thus expect the following amount of false-positive results:
  2.50 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.50 false positives, when considering a   1% risk acceptance (**, ***),
  0.05 false positives, when considering a 0.1% risk acceptance (***)
  ```


