### PR TITLE
test: fix subtest 1, 2 of test-node-run

### DIFF
--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -15,7 +15,7 @@ describe('node --run [command]', () => {
       { cwd: __dirname },
     );
     assert.match(child.stderr, /ExperimentalWarning: Task runner is an experimental feature and might change at any time/);
-    assert.match(child.stderr, /Can't read package\.json/);
+    assert.match(child.stderr, /Can't read package\.json|Can't find "scripts" field in package\.json/);
     assert.strictEqual(child.stdout, '');
     assert.strictEqual(child.code, 1);
   });
@@ -26,7 +26,7 @@ describe('node --run [command]', () => {
       [ '--no-warnings', '--run', 'test'],
       { cwd: __dirname },
     );
-    assert.match(child.stderr, /Can't read package\.json/);
+    assert.match(child.stderr, /Can't read package\.json|Can't find "scripts" field in package\.json/);
     assert.strictEqual(child.stdout, '');
     assert.strictEqual(child.code, 1);
   });


### PR DESCRIPTION
Subtest 1, 2 of `test-node-run.js` originally matched the error message "Can't read package.json" on non-existent file.  
However, the subtests failed on Ubuntu20.04.  
we found that attempting to run a non-existent script like `node --run foo` using the latest version of node results in an error message like `Can't find “scripts” field in package.json` (on Ubuntu20.04, regardless of whether package.json is present in the path&subpath or not).  
So we modified the subtest so that if we match either of the two messages, the test passes.

Part of test failure description(`
```
# Subtest: returns error on non-existent file
    not ok 2 - returns error on non-existent file
      ---
      duration_ms: 6.722013
      location: '/home/cho/node/test/parallel/test-node-run.js:23:3'
      failureType: 'testCodeFailure'
      error: |-
        The input did not match the regular expression /Can't read package\.json/. Input:
        
        `Can't find "scripts" field in package.json\n`
        
      code: 'ERR_ASSERTION'
      name: 'AssertionError'
      expected:
      actual: |-
        Can't find "scripts" field in package.json
        
      operator: 'match'
```

After Modifying match regex : 
```
~/node$ tools/test.py test/parallel/test-node-run.js 
[00:00|% 100|+   1|-   0]: Done                 

All tests passed.
```

Actually, I'm not sure this is the best way to do it, so if you have a better idea, please let me know. 