### PR TITLE
doc: add esm examples to `node:console`

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -80,7 +80,11 @@ The `Console` class can be used to create a simple logger with configurable
 output streams and can be accessed using either `require('node:console').Console`
 or `console.Console` (or their destructured counterparts):
 
-```js
+```mjs
+import { Console } from 'node:console';
+```
+
+```cjs
 const { Console } = require('node:console');
 ```
 
@@ -132,7 +136,28 @@ Creates a new `Console` with one or two writable stream instances. `stdout` is a
 writable stream to print log or info output. `stderr` is used for warning or
 error output. If `stderr` is not provided, `stdout` is used for `stderr`.
 
-```js
+```mjs
+import { createWriteStream } from 'node:fs';
+import { Console } from 'node:console';
+// Alternatively
+// const { Console } = console;
+
+const output = createWriteStream('./stdout.log');
+const errorOutput = createWriteStream('./stderr.log');
+// Custom simple logger
+const logger = new Console({ stdout: output, stderr: errorOutput });
+// use it like console
+const count = 5;
+logger.log('count: %d', count);
+// In stdout.log: count 5
+```
+
+```cjs
+const fs = require('fs');
+const { Console } = require('node:console');
+// Alternatively
+// const { Console } = console;
+
 const output = fs.createWriteStream('./stdout.log');
 const errorOutput = fs.createWriteStream('./stderr.log');
 // Custom simple logger

--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -153,7 +153,7 @@ logger.log('count: %d', count);
 ```
 
 ```cjs
-const fs = require('fs');
+const fs = require('node:fs');
 const { Console } = require('node:console');
 // Alternatively
 // const { Console } = console;


### PR DESCRIPTION
This PR adds the `ESM` counterparts of the `CJS` examples for [the Console documentation](https://nodejs.org/api/console.html).

It also includes the missing `require` statements for `fs` and `Console` used in [this particular CJS example](https://nodejs.org/api/console.html#new-consoleoptions) just to be concise with the rest of the documentation (as in [`stream.pipeline(streams[, options])`](https://nodejs.org/api/stream.html#streampipelinestreams-options) for example).

Also [ the documentation states](https://nodejs.org/api/console.html#class-console) we can either do:
```js
//CJS
const { Console } = require('node:console');
```

```js
//ESM
import { Console } from 'node:console';
```

Or

```js
const { Console } = console;
```

I've kept that on both the `ESM` and `CJS` examples so new users don't get confused about it.

Best regards.