### PR TITLE
Update required python version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -224,7 +224,7 @@ Consult previous versions of this document for older versions of Node.js:
 
 ### Note about Python
 
-The Node.js project supports Python >= 3 for building and testing.
+The Node.js project supports Python >= 3.8 for building and testing.
 
 ### Unix and macOS
 


### PR DESCRIPTION
Configure scripts use := operator now, which requires python 3.8.

  File "tools/gyp/pylib/gyp/common.py", line 435
    if CC := os.environ.get("CC_target") or os.environ.get("CC"):

