### PR TITLE
buffer: use for loop for small copy length

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -2,9 +2,9 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  bytes: [0, 8, 128, 32 * 1024],
+  bytes: [0, 8, 16, 32, 64, 128, 32 * 1024],
   partial: ['true', 'false'],
-  n: [6e6],
+  n: [5e6],
 });
 
 function main({ n, bytes, partial }) {

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -250,6 +250,12 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
   if (nb <= 0)
     return 0;
 
+  if (nb <= 32) {
+    for (let i = 0; i < nb; i++) {
+      target[targetStart + i] = source[sourceStart + i];
+    }
+  }
+
   _copy(source, target, targetStart, sourceStart, nb);
 
   return nb;


### PR DESCRIPTION
```bash
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=0                     -0.95 %       ±1.11%  ±1.47%  ±1.93%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=128                   -0.47 %       ±0.59%  ±0.79%  ±1.03%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=16            ***    185.54 %       ±0.86%  ±1.15%  ±1.50%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=32            ***     91.02 %       ±0.64%  ±0.85%  ±1.11%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=32768          **     15.03 %       ±8.49% ±11.40% ±15.06%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=64                    -0.72 %       ±0.75%  ±0.99%  ±1.29%
02:04:12 buffers/buffer-copy.js n=5000000 partial='true' bytes=8             ***    278.69 %       ±1.22%  ±1.64%  ±2.16%
```