### PR TITLE
doc: add documentation for blob.bytes() method 

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -538,6 +538,17 @@ added:
 Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
 
+#### `blob.bytes()`
+
+The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
+
+```js
+const blob = new Blob(['hello']);
+blob.bytes().then((bytes) => {
+  console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
+});
+```
+
 ### `blob.stream()`
 
 <!-- YAML

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -517,6 +517,7 @@ the `Blob` data.
 
 <!-- YAML
 added:
+  - v22.3.0
   - v20.16.0
 -->
 
@@ -528,7 +529,6 @@ blob.bytes().then((bytes) => {
   console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
 });
 ```
-
 
 ### `blob.size`
 
@@ -554,8 +554,6 @@ added:
 
 Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
-
-
 
 ### `blob.stream()`
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -513,6 +513,23 @@ added:
 Returns a promise that fulfills with an {ArrayBuffer} containing a copy of
 the `Blob` data.
 
+#### `blob.bytes()`
+
+<!-- YAML
+added:
+  - v20.16.0
+-->
+
+The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
+
+```js
+const blob = new Blob(['hello']);
+blob.bytes().then((bytes) => {
+  console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
+});
+```
+
+
 ### `blob.size`
 
 <!-- YAML
@@ -538,21 +555,7 @@ added:
 Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
 
-#### `blob.bytes()`
 
-<!-- YAML
-added:
-  - v20.16.0
--->
-
-The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
-
-```js
-const blob = new Blob(['hello']);
-blob.bytes().then((bytes) => {
-  console.log(bytes); // Outputs: Uint8Array(5) [ 104, 101, 108, 108, 111 ]
-});
-```
 
 ### `blob.stream()`
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -539,6 +539,10 @@ Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
 
 #### `blob.bytes()`
+<!-- YAML
+added:
+  - v20.16.0
+-->
 
 The `blob.bytes()` method returns the byte of the `Blob` object as a `Promise<Uint8Array>`.
 

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -539,6 +539,7 @@ Creates and returns a new `Blob` containing a subset of this `Blob` objects
 data. The original `Blob` is not altered.
 
 #### `blob.bytes()`
+
 <!-- YAML
 added:
   - v20.16.0


### PR DESCRIPTION
**Description:**
This pull request adds documentation for the blob.bytes() method in the buffer module. The method was introduced in Node.js v20.16.0, but it was not documented. This PR aims to provide a clear description and examples for the blob.bytes() method.

**Motivation:**
The blob.bytes() method allows users to obtain the bytes of a Blob object as a Buffer.
This method was introduced in a recent release but is currently undocumented.

Fixes: https://github.com/nodejs/node/issues/54105

**Documentation:**
### `blob.bytes()`

The `blob.bytes()` method returns the bytes of the `Blob` object as a `Buffer`.

```js
const blob = new Blob(['hello']);
console.log(blob.bytes()); // Outputs: <Buffer 68 65 6c 6c 6f>
```

**Additional Notes:**
I included the text.txt file incorrectly while testing git push for the first time. I'd appreciate it if you could ignore it. I'll be more careful in the future!