### PR TITLE
test: set test-structuredclone-jstransferable non-flaky

### DIFF
--- a/test/pummel/pummel.status
+++ b/test/pummel/pummel.status
@@ -9,8 +9,6 @@ prefix pummel
 [$system==win32]
 # https://github.com/nodejs/node/issues/40728
 test-fs-watch-non-recursive: PASS,FLAKY
-# https://github.com/nodejs/node/issues/50260
-test-structuredclone-jstransferable: PASS,FLAKY
 
 [$system==macos]
 


### PR DESCRIPTION
Pummel test `test-structuredclone-jstransferable` seems to be no longer flaky on Windows. I'm checking CI test results in the CI occasionally and haven't seen it failing recently. In addition, I ran [stress test](https://ci.nodejs.org/job/node-stress-single-test/519/) (1000 runs) and saw no failures.

Fixes: https://github.com/nodejs/node/issues/50260