### PR TITLE
buffer: add JSDoc to blob bytes method

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -312,6 +312,9 @@ class Blob {
     return dec.decode(await this.arrayBuffer());
   }
 
+  /**
+   * @returns {Promise<Uint8Array>}
+   */
   bytes() {
     if (!isBlob(this))
       throw new ERR_INVALID_THIS('Blob');


### PR DESCRIPTION
added JSDoc comment that describes the return type of the types blob method.

This fixes part of: #54105 

