### PR TITLE
sea: don't set code cache flags when snapshot is used

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -355,7 +355,14 @@ std::optional<SeaConfig> ParseSingleExecutableConfig(
     return std::nullopt;
   }
   if (use_code_cache.value()) {
-    result.flags |= SeaFlags::kUseCodeCache;
+    if (use_snapshot.value()) {
+      // TODO(joyeecheung): code cache in snapshot should be configured by
+      // separate snapshot configurations.
+      FPrintF(stderr,
+              "\"useCodeCache\" is redundant when \"useSnapshot\" is true\n");
+    } else {
+      result.flags |= SeaFlags::kUseCodeCache;
+    }
   }
 
   auto assets_opt = parser.GetTopLevelStringDict("assets");
@@ -511,19 +518,14 @@ ExitCode GenerateSingleExecutableBlob(
   std::optional<std::string_view> optional_sv_code_cache;
   std::string code_cache;
   if (static_cast<bool>(config.flags & SeaFlags::kUseCodeCache)) {
-    if (builds_snapshot_from_main) {
-      FPrintF(stderr,
-              "\"useCodeCache\" is redundant when \"useSnapshot\" is true\n");
-    } else {
-      std::optional<std::string> optional_code_cache =
-          GenerateCodeCache(config.main_path, main_script);
-      if (!optional_code_cache.has_value()) {
-        FPrintF(stderr, "Cannot generate V8 code cache\n");
-        return ExitCode::kGenericUserError;
-      }
-      code_cache = optional_code_cache.value();
-      optional_sv_code_cache = code_cache;
+    std::optional<std::string> optional_code_cache =
+        GenerateCodeCache(config.main_path, main_script);
+    if (!optional_code_cache.has_value()) {
+      FPrintF(stderr, "Cannot generate V8 code cache\n");
+      return ExitCode::kGenericUserError;
     }
+    code_cache = optional_code_cache.value();
+    optional_sv_code_cache = code_cache;
   }
 
   std::unordered_map<std::string, std::string> assets;


### PR DESCRIPTION
When both useCodeCache and useSnapshot are set, we generate the snapshot and skip the generation of the code cache since the snapshot already includes the code cache. But we previously still persist the code cache setting in the flags that got serialized into the SEA, so the resulting executable would still try to read the code cache even if it's not added to the SEA, leading to a flaky crash caused by OOB on some platforms.

This patch fixes the crash by ignoring the code cache setting when generating the flag if both snapshot and code cache is configured.

Fixes: https://github.com/nodejs/node/issues/50740

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
