### PR TITLE
doc: add content for Blob.bytes()

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -513,6 +513,18 @@ added:
 Returns a promise that fulfills with an {ArrayBuffer} containing a copy of
 the `Blob` data.
 
+### `blob.bytes()`
+
+<!-- YAML
+added:
+  - v20.16.0
+-->
+
+* Returns: {Promise}
+
+Returns a promise that fulfills with a {Uint8Array} containing a copy of the
+`Blob` data.
+
 ### `blob.size`
 
 <!-- YAML

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -312,6 +312,10 @@ class Blob {
     return dec.decode(await this.arrayBuffer());
   }
 
+  /**
+   * @returns {Promise<Uint8Array>}
+   */
+
   bytes() {
     if (!isBlob(this))
       throw new ERR_INVALID_THIS('Blob');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This fixes https://github.com/nodejs/node/issues/54105, and adds missing docstring for `Blob.bytes()` as well.
