### PR TITLE
doc: fix description of the max header size in `HPE_HEADER_OVERFLOW` section

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3180,6 +3180,9 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54125
+    description: Corrected the description of the max header size to `maxHeaderSize`.
   - version:
      - v11.4.0
      - v10.15.0
@@ -3189,7 +3192,7 @@ changes:
 -->
 
 Too much HTTP header data was received. In order to protect against malicious or
-malconfigured clients, if more than 8 KiB of HTTP header data is received then
+malconfigured clients, if more than `maxHeaderSize` of HTTP header data is received then
 HTTP parsing will abort without a request or response object being created, and
 an `Error` with this code will be emitted.
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3180,9 +3180,6 @@ Creation of a [`zlib`][] object failed due to incorrect configuration.
 
 <!-- YAML
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/54125
-    description: Corrected the description of the max header size to `maxHeaderSize`.
   - version:
      - v11.4.0
      - v10.15.0


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

In the error documentation, the maximum header size was described with the old value of `8 KiB`, which has been corrected.

Here, the notation has been changed to `maxHeaderSize` instead of the latest value of `16 KiB`, as the value could be overwritten by the `--max-http-header-size` option.