### PR TITLE
build: add `--without-amaro` build flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -765,6 +765,12 @@ http2_optgroup.add_argument('--debug-nghttp2',
     default=None,
     help='build nghttp2 with DEBUGBUILD (default is false)')
 
+parser.add_argument('--without-amaro',
+    action='store_true',
+    dest='without_amaro',
+    default=None,
+    help='do not install the bundled Amaro (TypeScript utils)')
+
 parser.add_argument('--without-npm',
     action='store_true',
     dest='without_npm',
@@ -1378,6 +1384,7 @@ def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
   o['variables']['node_prefix'] = options.prefix
+  o['variables']['node_install_amaro'] = b(not options.without_amaro)
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_corepack'] = b(not options.without_corepack)
   o['variables']['debug_node'] = b(options.debug_node)

--- a/configure.py
+++ b/configure.py
@@ -1384,9 +1384,9 @@ def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
   o['variables']['node_prefix'] = options.prefix
-  o['variables']['node_install_amaro'] = b(not options.without_amaro)
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_corepack'] = b(not options.without_corepack)
+  o['variables']['node_use_amaro'] = b(not options.without_amaro)
   o['variables']['debug_node'] = b(options.debug_node)
   o['default_configuration'] = 'Debug' if options.debug else 'Release'
   o['variables']['error_on_warn'] = b(options.error_on_warn)

--- a/node.gyp
+++ b/node.gyp
@@ -14,6 +14,7 @@
     'force_dynamic_crt%': 0,
     'ossfuzz' : 'false',
     'node_module_version%': '',
+    'node_install_amaro%': 'true',
     'node_shared_brotli%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
@@ -56,7 +57,6 @@
       'deps/acorn/acorn/dist/acorn.js',
       'deps/acorn/acorn-walk/dist/walk.js',
       'deps/minimatch/index.js',
-      'deps/amaro/dist/index.js',
       '<@(node_builtin_shareable_builtins)',
     ],
     'node_sources': [
@@ -461,6 +461,14 @@
       }, {
         'use_openssl_def%': 0,
       }],
+      [ 'node_install_amaro=="true"', {
+          'defines': [
+            'HAVE_AMARO=1',
+          ],
+        'deps_files': [
+            'deps/amaro/dist/index.js',
+        ]
+      } ]
     ],
   },
 

--- a/node.gyp
+++ b/node.gyp
@@ -14,7 +14,7 @@
     'force_dynamic_crt%': 0,
     'ossfuzz' : 'false',
     'node_module_version%': '',
-    'node_install_amaro%': 'true',
+    'node_use_amaro%': 'true',
     'node_shared_brotli%': 'false',
     'node_shared_zlib%': 'false',
     'node_shared_http_parser%': 'false',
@@ -461,8 +461,7 @@
       }, {
         'use_openssl_def%': 0,
       }],
-      [ 'node_install_amaro=="true"', {
-          'defines': [ 'HAVE_AMARO=1' ],
+      [ 'node_use_amaro=="true"', {
           'deps_files': [
               'deps/amaro/dist/index.js',
           ]

--- a/node.gyp
+++ b/node.gyp
@@ -462,12 +462,10 @@
         'use_openssl_def%': 0,
       }],
       [ 'node_install_amaro=="true"', {
-          'defines': [
-            'HAVE_AMARO=1',
-          ],
-        'deps_files': [
-            'deps/amaro/dist/index.js',
-        ]
+          'defines': [ 'HAVE_AMARO=1' ],
+          'deps_files': [
+              'deps/amaro/dist/index.js',
+          ]
       } ]
     ],
   },

--- a/node.gypi
+++ b/node.gypi
@@ -412,5 +412,10 @@
     }, {
       'defines': [ 'HAVE_OPENSSL=0' ]
     }],
+    [ 'node_install_amaro=="true"', {
+      'defines': [ 'HAVE_AMARO=1' ],
+    }, {
+      'defines': [ 'HAVE_AMARO=0' ]
+    }],
   ],
 }

--- a/node.gypi
+++ b/node.gypi
@@ -412,7 +412,7 @@
     }, {
       'defines': [ 'HAVE_OPENSSL=0' ]
     }],
-    [ 'node_install_amaro=="true"', {
+    [ 'node_use_amaro=="true"', {
       'defines': [ 'HAVE_AMARO=1' ],
     }, {
       'defines': [ 'HAVE_AMARO=0' ]

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -117,7 +117,10 @@ Metadata::Versions::Versions() {
   acorn = ACORN_VERSION;
   cjs_module_lexer = CJS_MODULE_LEXER_VERSION;
   uvwasi = UVWASI_VERSION_STRING;
+
+#if HAVE_AMARO
   amaro = AMARO_VERSION;
+#endif
 
 #if HAVE_OPENSSL
   openssl = GetOpenSSLVersion();

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -27,10 +27,10 @@ namespace node {
 #define NODE_HAS_RELEASE_URLS
 #endif
 
-#ifndef HAVE_AMARO
-#define NODE_VERSIONS_KEY_AMARO(V)
-#else
+#if HAVE_AMARO
 #define NODE_VERSIONS_KEY_AMARO(V) V(amaro)
+#else
+#define NODE_VERSIONS_KEY_AMARO(V)
 #endif
 
 #ifndef NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -27,6 +27,12 @@ namespace node {
 #define NODE_HAS_RELEASE_URLS
 #endif
 
+#ifndef HAVE_AMARO
+#define NODE_VERSIONS_KEY_AMARO(V)
+#else
+#define NODE_VERSIONS_KEY_AMARO(V) V(amaro)
+#endif
+
 #ifndef NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH
 #define NODE_VERSIONS_KEY_UNDICI(V) V(undici)
 #else
@@ -51,7 +57,7 @@ namespace node {
   V(sqlite)                                                                    \
   V(ada)                                                                       \
   V(nbytes)                                                                    \
-  V(amaro)                                                                     \
+  NODE_VERSIONS_KEY_AMARO(V)                                                   \
   NODE_VERSIONS_KEY_UNDICI(V)                                                  \
   V(cjs_module_lexer)
 

--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
 
 test('require a .ts file with explicit extension succeeds', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -1,7 +1,9 @@
-import { spawnPromisified } from '../common/index.mjs';
+import { skip, spawnPromisified } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
+
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
 
 test('require a .ts file with explicit extension succeeds', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
+if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('require a .ts file with explicit extension succeeds', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -2,7 +2,7 @@ import { skip, spawnPromisified } from '../common/index.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
+if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -1,6 +1,8 @@
-import { spawnPromisified } from '../common/index.mjs';
+import { skip, spawnPromisified } from '../common/index.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
+
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
 
 test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -2,7 +2,7 @@ import { skip, spawnPromisified } from '../common/index.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
 
 test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
+if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('expect failure of a .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -1,7 +1,9 @@
-import { spawnPromisified } from '../common/index.mjs';
+import { skip, spawnPromisified } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
+
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
 
 test('expect failure of a .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
 
 test('expect failure of a .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript.mjs
+++ b/test/es-module/test-typescript.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
+if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('execute a TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript.mjs
+++ b/test/es-module/test-typescript.mjs
@@ -1,7 +1,9 @@
-import { spawnPromisified } from '../common/index.mjs';
+import { skip, spawnPromisified } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
+
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
 
 test('execute a TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/es-module/test-typescript.mjs
+++ b/test/es-module/test-typescript.mjs
@@ -3,7 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-if (!process.config.variables.node_install_amaro) skip('Requires Amaro')
+if (!process.config.variables.node_install_amaro) skip('Requires Amaro');
 
 test('execute a TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -28,7 +28,7 @@ const expected_keys = [
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');
 
-if (process.config.variables.node_install_amaro) {
+if (process.config.variables.node_use_amaro) {
   expected_keys.push('amaro');
 }
 if (hasUndici) {

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -28,7 +28,7 @@ const expected_keys = [
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');
 
-if (process.config.variables.node_install_amaro){
+if (process.config.variables.node_install_amaro) {
   expected_keys.push('amaro');
 }
 if (hasUndici) {

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -24,11 +24,13 @@ const expected_keys = [
   'ada',
   'cjs_module_lexer',
   'nbytes',
-  'amaro',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');
 
+if (process.config.variables.node_install_amaro){
+  expected_keys.push('amaro');
+}
 if (hasUndici) {
   expected_keys.push('undici');
 }


### PR DESCRIPTION
With `./configure --without-amaro`, the resulting `node` binary won't contain the Amaro source (which includes the SWC WASM binary). This PR does not remove the `--experimental-strip-types` CLI flag, when using this flag an error will be emitted when trying to load a `module-typescript` or `commonjs-typescript` module.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
