### PR TITLE
 module: validate that strip-types does not insert any code

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -24,6 +24,7 @@ const internalFS = require('internal/fs/utils');
 const path = require('path');
 const { pathToFileURL, fileURLToPath } = require('internal/url');
 const assert = require('internal/assert');
+const { Buffer: { from: BufferFrom } } = require('buffer');
 
 const { getOptionValue } = require('internal/options');
 const { setOwnProperty } = require('internal/util');
@@ -307,10 +308,58 @@ function lazyLoadTSParser() {
   return parseTS;
 }
 
+function doesTSStripTypesResultMatchSource(code, source) {
+  const sourceBuf = BufferFrom(source);
+  const codeBuf = BufferFrom(code);
+  if (sourceBuf.length !== codeBuf.length) { return false; }
+  for (let i = 0; i < codeBuf.length; i++) {
+    // Should match either the source buffer or spaces (sometimes multi-byte) or semicolon
+    const val = codeBuf[i];
+    if (val === sourceBuf[i]) {
+      // Source match
+      continue;
+    }
+    // https://github.com/nodejs/amaro/blob/e533394f576f946add41dd8816816435e8100c3b/deps/swc/crates/swc_fast_ts_strip/src/lib.rs#L400-L414
+    if (val === 0x3b) {
+      // Semicolon 3b
+      continue;
+    }
+    // https://github.com/nodejs/amaro/blob/e533394f576f946add41dd8816816435e8100c3b/deps/swc/crates/swc_fast_ts_strip/src/lib.rs#L200-L226
+    if (val === 0x20) {
+      // Space 20
+      continue;
+    }
+    if (val === 0xc2) {
+      // No-Break Space 00A0
+      if (i + 1 >= codeBuf.length) { return false; }
+      if (codeBuf[++i] !== 0xa0) { return false; }
+      continue;
+    }
+    if (val === 0xe2) {
+      // En Space 2002
+      if (i + 2 >= codeBuf.length) { return false; }
+      if (codeBuf[++i] !== 0x80) { return false; }
+      if (codeBuf[++i] !== 0x82) { return false; }
+      continue;
+    }
+    if (val === 0xef) {
+      // ZWNBSP FEFF
+      if (i < 1 || codeBuf[i - 1] !== 0x20) { return false; } // Only can get insterted after a space
+      if (i + 2 >= codeBuf.length) { return false; }
+      if (codeBuf[++i] !== 0xbb) { return false; }
+      if (codeBuf[++i] !== 0xbf) { return false; }
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 function tsParse(source) {
   if (!source || typeof source !== 'string') { return; }
   const transformSync = lazyLoadTSParser();
   const { code } = transformSync(source, { mode: 'strip-only' });
+  assert(doesTSStripTypesResultMatchSource(code, source), 'Unexpected strip-types result');
   return code;
 }
 

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -358,7 +358,7 @@ function doesTSStripTypesResultMatchSource(code, source) {
 function tsParse(source) {
   if (!source || typeof source !== 'string') { return; }
   const transformSync = lazyLoadTSParser();
-  const { code } = transformSync(source, { mode: 'strip-only' });
+  const { code } = transformSync(source, { __proto__: null, mode: 'strip-only' });
   assert(doesTSStripTypesResultMatchSource(code, source), 'Unexpected strip-types result');
   return code;
 }

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -310,7 +310,7 @@ function lazyLoadTSParser() {
 function tsParse(source) {
   if (!source || typeof source !== 'string') { return; }
   const transformSync = lazyLoadTSParser();
-  const { code } = transformSync(source);
+  const { code } = transformSync(source, { mode: 'strip-only' });
   return code;
 }
 


### PR DESCRIPTION
We can do this while the mode is strip-types only

The wasm binary is not expected to insert any other changes in the sourcecode except for the allowed symbols / patterns
We can use this to increase trust in the code that wasm binary outputs

It is still possible to do unexpected things under this limitation, but it makes anything funny much harder for a supply chain attack

Now does this if internal swc lib is e.g. switched to a codegen mode unexpectedly:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/8143781e-3801-427b-80a3-cc35f185de9d">


Existing tests should pass, this is just a safeguard
Should also add some multi-byte stripping tests