### PR TITLE
stream: make checking pendingcb on WritableStream backward compatible

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -214,7 +214,7 @@ function eos(stream, options, callback) {
     !readable &&
     (!willEmitClose || isReadable(stream)) &&
     (writableFinished || isWritable(stream) === false) &&
-    (wState == null || wState.pendingcb === 0)
+    (wState == null || wState.pendingcb === undefined || wState.pendingcb === 0)
   ) {
     process.nextTick(onclosed);
   } else if (


### PR DESCRIPTION
In PR https://github.com/nodejs/node/pull/53438/ we tried to fix `stream.finished` to wait calling its callback until all the pending callback has been called. However the patch breaks the users who use a very old version of the stream which does not have `pendingcb` state on the `WritableStream`.

I am not sure if we should patch this or we should encourage the user to use a more up to date version.

Fixes: https://github.com/nodejs/node/issues/54131
Refs: https://github.com/nodejs/node/issues/54131#issuecomment-2260377292
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
