### PR TITLE
test_runner: run after hooks even if test is aborted

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -763,10 +763,7 @@ class Test extends AsyncResource {
   }
 
   [kShouldAbort]() {
-    if (this.signal.aborted) {
-      return true;
-    }
-    if (this.outerSignal?.aborted) {
+    if (this.signal.aborted || this.outerSignal?.aborted) {
       this.#abortHandler();
       return true;
     }
@@ -866,10 +863,7 @@ class Test extends AsyncResource {
         await SafePromiseRace([PromiseResolve(promise), stopPromise]);
       }
 
-      if (this[kShouldAbort]()) {
-        this.postRun();
-        return;
-      }
+      this[kShouldAbort]();
       this.plan?.check();
       this.pass();
       await afterEach();

--- a/test/fixtures/test-runner/output/abort-runs-after-hook.js
+++ b/test/fixtures/test-runner/output/abort-runs-after-hook.js
@@ -1,0 +1,14 @@
+'use strict';
+const { test } = require('node:test');
+
+test('test that aborts', (t, done) => {
+  t.after(() => {
+    // This should still run.
+    console.log('AFTER');
+  });
+
+  setImmediate(() => {
+    // This creates an uncaughtException, which aborts the test.
+    throw new Error('boom');
+  });
+});

--- a/test/fixtures/test-runner/output/abort-runs-after-hook.snapshot
+++ b/test/fixtures/test-runner/output/abort-runs-after-hook.snapshot
@@ -1,0 +1,23 @@
+TAP version 13
+AFTER
+# Subtest: test that aborts
+not ok 1 - test that aborts
+  ---
+  duration_ms: *
+  location: '/test/fixtures/test-runner/output/abort-runs-after-hook.js:(LINE):1'
+  failureType: 'uncaughtException'
+  error: 'boom'
+  code: 'ERR_TEST_FAILURE'
+  stack: |-
+    *
+    *
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 0
+# fail 1
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -93,6 +93,7 @@ const lcovTransform = snapshot.transform(
 
 const tests = [
   { name: 'test-runner/output/abort.js' },
+  { name: 'test-runner/output/abort-runs-after-hook.js' },
   { name: 'test-runner/output/abort_suite.js' },
   { name: 'test-runner/output/abort_hooks.js' },
   { name: 'test-runner/output/describe_it.js' },


### PR DESCRIPTION
If a test is run, but aborted, any after hooks should still be run, as they may need to perform cleanup.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
