### PR TITLE
test_runner: await building suite before executing

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -737,7 +737,8 @@ class Test extends AsyncResource {
     return this.filtered && this.parent?.filteredSubtestCount > 0;
   }
 
-  start() {
+  async start() {
+    await this.buildSuite;
     if (this.shouldFilter) {
       noopTestStream ??= new TestsStream();
       this.reporter = noopTestStream;


### PR DESCRIPTION
Fixes #54084

Confirmed it fixed the example from the issue:
```
 ./node --test --test-name-pattern="some test" ../tmp/node-test-fiddles/test.mjs
▶ async describe
  ✔ some test (async) (0.067497ms)
▶ async describe (0.332977ms)
▶ sync describe
  ✔ some test (sync) (0.4713ms)
▶ sync describe (1.160294ms)
ℹ tests 2
ℹ suites 2
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 52.463142
```