### PR TITLE
inspector: provide detailed network information to fix devtools frontend errors

### DIFF
--- a/lib/internal/inspector_network_tracking.js
+++ b/lib/internal/inspector_network_tracking.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   DateNow,
+  ObjectEntries,
+  String,
 } = primordials;
 
 let dc;
@@ -9,6 +12,25 @@ let Network;
 
 let requestId = 0;
 const getNextRequestId = () => `node-network-event-${++requestId}`;
+
+// Convert a Headers object (Map<string, number | string | string[]>) to a plain object (Map<string, string>)
+const headerObjectToDictionary = (headers = {}) => {
+  const dict = {};
+  for (const { 0: key, 1: value } of ObjectEntries(headers)) {
+    if (typeof value === 'string') {
+      dict[key] = value;
+    } else if (ArrayIsArray(value)) {
+      if (key.toLowerCase() === 'cookie') dict[key] = value.join('; ');
+      // ChromeDevTools frontend treats 'set-cookie' as a special case
+      // https://github.com/ChromeDevTools/devtools-frontend/blob/4275917f84266ef40613db3c1784a25f902ea74e/front_end/core/sdk/NetworkRequest.ts#L1368
+      else if (key.toLowerCase() === 'set-cookie') dict[key] = value.join('\n');
+      else dict[key] = value.join(', ');
+    } else {
+      dict[key] = String(value);
+    }
+  }
+  return dict;
+};
 
 function onClientRequestStart({ request }) {
   const url = `${request.protocol}//${request.host}${request.path}`;
@@ -22,7 +44,7 @@ function onClientRequestStart({ request }) {
     request: {
       url,
       method: request.method,
-      headers: request.getHeaders(),
+      headers: headerObjectToDictionary(request.getHeaders()),
     },
   });
 }
@@ -41,7 +63,7 @@ function onClientResponseFinish({ request, response }) {
       url,
       status: response.statusCode,
       statusText: response.statusMessage ?? '',
-      headers: response.headers,
+      headers: headerObjectToDictionary(response.headers),
     },
   });
   Network.loadingFinished({

--- a/lib/internal/inspector_network_tracking.js
+++ b/lib/internal/inspector_network_tracking.js
@@ -22,18 +22,26 @@ function onClientRequestStart({ request }) {
     request: {
       url,
       method: request.method,
+      headers: request.getHeaders(),
     },
   });
 }
 
-function onClientResponseFinish({ request }) {
+function onClientResponseFinish({ request, response }) {
   if (typeof request._inspectorRequestId !== 'string') {
     return;
   }
+  const url = `${request.protocol}//${request.host}${request.path}`;
   const timestamp = DateNow() / 1000;
   Network.responseReceived({
     requestId: request._inspectorRequestId,
     timestamp,
+    type: 'Other',
+    response: {
+      url,
+      status: response.statusCode,
+      headers: response.headers,
+    },
   });
   Network.loadingFinished({
     requestId: request._inspectorRequestId,

--- a/lib/internal/inspector_network_tracking.js
+++ b/lib/internal/inspector_network_tracking.js
@@ -40,6 +40,7 @@ function onClientResponseFinish({ request, response }) {
     response: {
       url,
       status: response.statusCode,
+      statusText: response.statusMessage ?? '',
       headers: response.headers,
     },
   });

--- a/src/inspector/network_agent.cc
+++ b/src/inspector/network_agent.cc
@@ -17,10 +17,14 @@ std::unique_ptr<Network::Request> createRequest(
 }
 
 std::unique_ptr<Network::Response> createResponse(
-    const String& url, int status, std::unique_ptr<Network::Headers> headers) {
+    const String& url,
+    int status,
+    const String& statusText,
+    std::unique_ptr<Network::Headers> headers) {
   return Network::Response::create()
       .setUrl(url)
       .setStatus(status)
+      .setStatusText(statusText)
       .setHeaders(std::move(headers))
       .build();
 }
@@ -96,6 +100,8 @@ void NetworkAgent::responseReceived(
   response->getString("url", &url);
   int status;
   response->getInteger("status", &status);
+  String statusText;
+  response->getString("statusText", &statusText);
 
   ErrorSupport errors;
   auto headers =
@@ -104,10 +110,11 @@ void NetworkAgent::responseReceived(
     headers = std::make_unique<Network::Headers>(DictionaryValue::create());
   }
 
-  frontend_->responseReceived(request_id,
-                              timestamp,
-                              type,
-                              createResponse(url, status, std::move(headers)));
+  frontend_->responseReceived(
+      request_id,
+      timestamp,
+      type,
+      createResponse(url, status, statusText, std::move(headers)));
 }
 
 void NetworkAgent::loadingFinished(

--- a/src/inspector/network_agent.cc
+++ b/src/inspector/network_agent.cc
@@ -5,9 +5,24 @@ namespace node {
 namespace inspector {
 namespace protocol {
 
-std::unique_ptr<Network::Request> Request(const String& url,
-                                          const String& method) {
-  return Network::Request::create().setUrl(url).setMethod(method).build();
+std::unique_ptr<Network::Request> createRequest(
+    const String& url,
+    const String& method,
+    std::unique_ptr<Network::Headers> headers) {
+  return Network::Request::create()
+      .setUrl(url)
+      .setMethod(method)
+      .setHeaders(std::move(headers))
+      .build();
+}
+
+std::unique_ptr<Network::Response> createResponse(
+    const String& url, int status, std::unique_ptr<Network::Headers> headers) {
+  return Network::Response::create()
+      .setUrl(url)
+      .setStatus(status)
+      .setHeaders(std::move(headers))
+      .build();
 }
 
 NetworkAgent::NetworkAgent(NetworkInspector* inspector)
@@ -55,8 +70,17 @@ void NetworkAgent::requestWillBeSent(
   String method;
   request->getString("method", &method);
 
-  frontend_->requestWillBeSent(
-      request_id, Request(url, method), timestamp, wall_time);
+  ErrorSupport errors;
+  auto headers =
+      Network::Headers::fromValue(request->getObject("headers"), &errors);
+  if (errors.hasErrors()) {
+    headers = std::make_unique<Network::Headers>(DictionaryValue::create());
+  }
+
+  frontend_->requestWillBeSent(request_id,
+                               createRequest(url, method, std::move(headers)),
+                               timestamp,
+                               wall_time);
 }
 
 void NetworkAgent::responseReceived(
@@ -65,8 +89,25 @@ void NetworkAgent::responseReceived(
   params->getString("requestId", &request_id);
   double timestamp;
   params->getDouble("timestamp", &timestamp);
+  String type;
+  params->getString("type", &type);
+  auto response = params->getObject("response");
+  String url;
+  response->getString("url", &url);
+  int status;
+  response->getInteger("status", &status);
 
-  frontend_->responseReceived(request_id, timestamp);
+  ErrorSupport errors;
+  auto headers =
+      Network::Headers::fromValue(response->getObject("headers"), &errors);
+  if (errors.hasErrors()) {
+    headers = std::make_unique<Network::Headers>(DictionaryValue::create());
+  }
+
+  frontend_->responseReceived(request_id,
+                              timestamp,
+                              type,
+                              createResponse(url, status, std::move(headers)));
 }
 
 void NetworkAgent::loadingFinished(

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -12,13 +12,6 @@ class NetworkInspector;
 
 namespace protocol {
 
-std::unique_ptr<Network::Request> createRequest(
-    const String& url,
-    const String& method,
-    std::unique_ptr<Network::Headers> headers);
-std::unique_ptr<Network::Response> createResponse(
-    const String& url, int status, std::unique_ptr<Network::Headers> headers);
-
 class NetworkAgent : public Network::Backend {
  public:
   explicit NetworkAgent(NetworkInspector* inspector);

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -12,8 +12,12 @@ class NetworkInspector;
 
 namespace protocol {
 
-std::unique_ptr<Network::Request> Request(const String& url,
-                                          const String& method);
+std::unique_ptr<Network::Request> createRequest(
+    const String& url,
+    const String& method,
+    std::unique_ptr<Network::Headers> headers);
+std::unique_ptr<Network::Response> createResponse(
+    const String& url, int status, std::unique_ptr<Network::Headers> headers);
 
 class NetworkAgent : public Network::Backend {
  public:

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -144,6 +144,7 @@ experimental domain Network
     properties
       string url
       integer status
+      string statusText
       Headers headers
 
   # Request / response headers as keys / values of JSON object.

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -101,6 +101,28 @@ experimental domain NodeWorker
 # Partial support for Network domain of ChromeDevTools Protocol.
 # https://chromedevtools.github.io/devtools-protocol/tot/Network
 experimental domain Network
+  # Resource type as it was perceived by the rendering engine.
+  type ResourceType extends string
+    enum
+      Document
+      Stylesheet
+      Image
+      Media
+      Font
+      Script
+      TextTrack
+      XHR
+      Fetch
+      Prefetch
+      EventSource
+      WebSocket
+      Manifest
+      SignedExchange
+      Ping
+      CSPViolationReport
+      Preflight
+      Other
+
   # Unique request identifier.
   type RequestId extends string
 
@@ -115,6 +137,17 @@ experimental domain Network
     properties
       string url
       string method
+      Headers headers
+
+  # HTTP response data.
+  type Response extends object
+    properties
+      string url
+      integer status
+      Headers headers
+
+  # Request / response headers as keys / values of JSON object.
+  type Headers extends object
 
   # Disables network tracking, prevents network events from being sent to the client.
   command disable
@@ -141,6 +174,10 @@ experimental domain Network
       RequestId requestId
       # Timestamp.
       MonotonicTime timestamp
+      # Resource type.
+      ResourceType type
+      # Response data.
+      Response response
 
   event loadingFinished
     parameters

--- a/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/parallel/test-inspector-emit-protocol-event.js
@@ -15,7 +15,17 @@ const EXPECTED_EVENTS = {
         requestId: 'request-id-1',
         request: {
           url: 'https://nodejs.org/en',
-          method: 'GET'
+          method: 'GET',
+        },
+        timestamp: 1000,
+        wallTime: 1000,
+      },
+      expected: {
+        requestId: 'request-id-1',
+        request: {
+          url: 'https://nodejs.org/en',
+          method: 'GET',
+          headers: {} // Headers should be an empty object if not provided.
         },
         timestamp: 1000,
         wallTime: 1000,
@@ -26,6 +36,12 @@ const EXPECTED_EVENTS = {
       params: {
         requestId: 'request-id-1',
         timestamp: 1000,
+        type: 'Other',
+        response: {
+          url: 'https://nodejs.org/en',
+          status: 200,
+          headers: { host: 'nodejs.org' }
+        }
       }
     },
     {
@@ -68,7 +84,7 @@ const runAsyncTest = async () => {
   for (const [domain, events] of Object.entries(EXPECTED_EVENTS)) {
     for (const event of events) {
       session.on(`${domain}.${event.name}`, common.mustCall(({ params }) => {
-        assert.deepStrictEqual(params, event.params);
+        assert.deepStrictEqual(params, event.expected ?? event.params);
       }));
       inspector[domain][event.name](event.params);
     }

--- a/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/parallel/test-inspector-emit-protocol-event.js
@@ -42,6 +42,17 @@ const EXPECTED_EVENTS = {
           status: 200,
           headers: { host: 'nodejs.org' }
         }
+      },
+      expected: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+        type: 'Other',
+        response: {
+          url: 'https://nodejs.org/en',
+          status: 200,
+          statusText: '', // Status text should be an empty string if not provided.
+          headers: { host: 'nodejs.org' }
+        }
       }
     },
     {

--- a/test/parallel/test-inspector-network-domain.js
+++ b/test/parallel/test-inspector-network-domain.js
@@ -13,10 +13,25 @@ const inspector = require('node:inspector/promises');
 const session = new inspector.Session();
 session.connect();
 
+const requestHeaders = {
+  'accept-language': 'en-US',
+  'Cookie': ['k1=v1', 'k2=v2'],
+  'age': 1000,
+  'x-header1': ['value1', 'value2']
+};
+
+const setResponseHeaders = (res) => {
+  res.setHeader('server', 'node');
+  res.setHeader('etag', 12345);
+  res.setHeader('Set-Cookie', ['key1=value1', 'key2=value2']);
+  res.setHeader('x-header2', ['value1', 'value2']);
+};
+
 const httpServer = http.createServer((req, res) => {
   const path = req.url;
   switch (path) {
     case '/hello-world':
+      setResponseHeaders(res);
       res.writeHead(200);
       res.end('hello world\n');
       break;
@@ -32,6 +47,7 @@ const httpsServer = https.createServer({
   const path = req.url;
   switch (path) {
     case '/hello-world':
+      setResponseHeaders(res);
       res.writeHead(200);
       res.end('hello world\n');
       break;
@@ -53,6 +69,10 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(params.request.url, 'http://127.0.0.1/hello-world');
     assert.strictEqual(params.request.method, 'GET');
     assert.strictEqual(typeof params.request.headers, 'object');
+    assert.strictEqual(params.request.headers['accept-language'], 'en-US');
+    assert.strictEqual(params.request.headers.cookie, 'k1=v1; k2=v2');
+    assert.strictEqual(params.request.headers.age, '1000');
+    assert.strictEqual(params.request.headers['x-header1'], 'value1, value2');
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(typeof params.wallTime, 'number');
   }));
@@ -64,6 +84,10 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(params.response.statusText, 'OK');
     assert.strictEqual(params.response.url, 'http://127.0.0.1/hello-world');
     assert.strictEqual(typeof params.response.headers, 'object');
+    assert.strictEqual(params.response.headers.server, 'node');
+    assert.strictEqual(params.response.headers.etag, '12345');
+    assert.strictEqual(params.response.headers['set-cookie'], 'key1=value1\nkey2=value2');
+    assert.strictEqual(params.response.headers['x-header2'], 'value1, value2');
   }));
   session.on('Network.loadingFinished', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
@@ -75,6 +99,7 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     host: '127.0.0.1',
     port: httpServer.address().port,
     path: '/hello-world',
+    headers: requestHeaders
   }, common.mustCall());
 });
 
@@ -84,6 +109,10 @@ const testHttpsGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(params.request.url, 'https://127.0.0.1/hello-world');
     assert.strictEqual(params.request.method, 'GET');
     assert.strictEqual(typeof params.request.headers, 'object');
+    assert.strictEqual(params.request.headers['accept-language'], 'en-US');
+    assert.strictEqual(params.request.headers.cookie, 'k1=v1; k2=v2');
+    assert.strictEqual(params.request.headers.age, '1000');
+    assert.strictEqual(params.request.headers['x-header1'], 'value1, value2');
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(typeof params.wallTime, 'number');
   }));
@@ -95,6 +124,10 @@ const testHttpsGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(params.response.statusText, 'OK');
     assert.strictEqual(params.response.url, 'https://127.0.0.1/hello-world');
     assert.strictEqual(typeof params.response.headers, 'object');
+    assert.strictEqual(params.response.headers.server, 'node');
+    assert.strictEqual(params.response.headers.etag, '12345');
+    assert.strictEqual(params.response.headers['set-cookie'], 'key1=value1\nkey2=value2');
+    assert.strictEqual(params.response.headers['x-header2'], 'value1, value2');
   }));
   session.on('Network.loadingFinished', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
@@ -107,6 +140,7 @@ const testHttpsGet = () => new Promise((resolve, reject) => {
     port: httpsServer.address().port,
     path: '/hello-world',
     rejectUnauthorized: false,
+    headers: requestHeaders,
   }, common.mustCall());
 });
 

--- a/test/parallel/test-inspector-network-domain.js
+++ b/test/parallel/test-inspector-network-domain.js
@@ -61,6 +61,7 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(params.type, 'Other');
     assert.strictEqual(params.response.status, 200);
+    assert.strictEqual(params.response.statusText, 'OK');
     assert.strictEqual(params.response.url, 'http://127.0.0.1/hello-world');
     assert.strictEqual(typeof params.response.headers, 'object');
   }));
@@ -91,6 +92,7 @@ const testHttpsGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(params.type, 'Other');
     assert.strictEqual(params.response.status, 200);
+    assert.strictEqual(params.response.statusText, 'OK');
     assert.strictEqual(params.response.url, 'https://127.0.0.1/hello-world');
     assert.strictEqual(typeof params.response.headers, 'object');
   }));

--- a/test/parallel/test-inspector-network-domain.js
+++ b/test/parallel/test-inspector-network-domain.js
@@ -52,12 +52,17 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
     assert.strictEqual(params.request.url, 'http://127.0.0.1/hello-world');
     assert.strictEqual(params.request.method, 'GET');
+    assert.strictEqual(typeof params.request.headers, 'object');
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(typeof params.wallTime, 'number');
   }));
   session.on('Network.responseReceived', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
     assert.strictEqual(typeof params.timestamp, 'number');
+    assert.strictEqual(params.type, 'Other');
+    assert.strictEqual(params.response.status, 200);
+    assert.strictEqual(params.response.url, 'http://127.0.0.1/hello-world');
+    assert.strictEqual(typeof params.response.headers, 'object');
   }));
   session.on('Network.loadingFinished', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
@@ -77,12 +82,17 @@ const testHttpsGet = () => new Promise((resolve, reject) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
     assert.strictEqual(params.request.url, 'https://127.0.0.1/hello-world');
     assert.strictEqual(params.request.method, 'GET');
+    assert.strictEqual(typeof params.request.headers, 'object');
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(typeof params.wallTime, 'number');
   }));
   session.on('Network.responseReceived', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
     assert.strictEqual(typeof params.timestamp, 'number');
+    assert.strictEqual(params.type, 'Other');
+    assert.strictEqual(params.response.status, 200);
+    assert.strictEqual(params.response.url, 'https://127.0.0.1/hello-world');
+    assert.strictEqual(typeof params.response.headers, 'object');
   }));
   session.on('Network.loadingFinished', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));


### PR DESCRIPTION
ref https://github.com/nodejs/node/pull/53593#issuecomment-2257962992

This PR addresses and resolves specific errors occurring in the ChromeDevTools frontend, as reported at [issues.chromium.org](https://issues.chromium.org/issues/353924015#comment4).

The error being fixed are as follows:

```
NetworkManager.ts:758 Uncaught TypeError: Cannot read properties of undefined (reading 'headers')
    at NetworkDispatcher.responseReceived (NetworkManager.ts:758:71)
    at DispatcherManager.dispatch (InspectorBackend.ts:1114:11)
    at Target.dispatch (InspectorBackend.ts:566:16)
    at SessionRouter.onMessage (InspectorBackend.ts:447:22)
    at WebSocketConnection.#socket.onmessage (Connections.ts:90:24)
```

These errors occur because Node.js doesn't provide the necessary debug information (such as request/response headers and content type) to the frontend during network inspection. Without this information, the Chrome DevTools frontend cannot properly handle and display network requests, leading to the aforementioned errors. To resolve the issue, the change in this PR ensure that Node.js supplies the required debugging information to the frontend. Specifically,

- Adding request and response headers.
- Adding response information.
- Providing the resource type for network responses.


<img width="923" alt="image" src="https://github.com/user-attachments/assets/a0bd669e-b5a2-4df0-bb41-b7507de976c1">
