### PR TITLE
dotenv: fix env-file parsing

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -151,7 +151,17 @@ void Dotenv::ParseContent(const std::string_view input) {
     // Expand new line if \n it's inside double quotes
     // Example: EXPAND_NEWLINES = 'expand\nnew\nlines'
     if (content.front() == '"') {
-      auto closing_quote = content.find(content.front(), 1);
+      std::size_t closing_quote = 0;
+      do {
+        closing_quote = content.find(content.front(), closing_quote + 1);
+        if (closing_quote == std::string_view::npos) {
+          break;
+        }
+        if (closing_quote > 0 && content[closing_quote - 1] != '\\') {
+          break;
+        }
+      } while (closing_quote != std::string_view::npos);
+
       if (closing_quote != std::string_view::npos) {
         value = content.substr(1, closing_quote - 1);
         std::string multi_line_value = std::string(value);
@@ -160,6 +170,13 @@ void Dotenv::ParseContent(const std::string_view input) {
         while ((pos = multi_line_value.find("\\n", pos)) !=
                std::string_view::npos) {
           multi_line_value.replace(pos, 2, "\n");
+          pos += 1;
+        }
+
+        pos = 0;
+        while ((pos = multi_line_value.find(R"(\")", pos)) !=
+               std::string_view::npos) {
+          multi_line_value.replace(pos, 2, "\"");
           pos += 1;
         }
 

--- a/test/fixtures/dotenv/valid.env
+++ b/test/fixtures/dotenv/valid.env
@@ -43,6 +43,9 @@ EMAIL=therealnerdybeast@example.tld
     SPACED_KEY = parsed
 EDGE_CASE_INLINE_COMMENTS="VALUE1" # or "VALUE2" or "VALUE3"
 
+ALL_QUOTES="this 'has' all \"quotes\" in `value` and double quotes around"
+ALL_QUOTES_EXPAND_NEWLINES="this\n'has'\nall\n\"quotes\"\nin\n`value`\nand\nmultilines\nto\nexpand"
+
 MULTI_DOUBLE_QUOTED="THIS
 IS
 A

--- a/test/parallel/test-dotenv.js
+++ b/test/parallel/test-dotenv.js
@@ -82,3 +82,6 @@ assert.strictEqual(process.env.DONT_EXPAND_SQUOTED, 'dontexpand\\nnewlines');
 assert.strictEqual(process.env.EXPORT_EXAMPLE, 'ignore export');
 // Ignore spaces before double quotes to avoid quoted strings as value
 assert.strictEqual(process.env.SPACE_BEFORE_DOUBLE_QUOTES, 'space before double quotes');
+assert.strictEqual(process.env.ALL_QUOTES, 'this \'has\' all "quotes" in `value` and double quotes around');
+assert.strictEqual(process.env.ALL_QUOTES_EXPAND_NEWLINES, 'this\n\'has\'\nall\n"quotes"\nin\n`value`\nand\nmultilines\nto\nexpand');
+


### PR DESCRIPTION
This PR makes parsing of env-file identical to dotenv npm package. Solves #54134 


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
