### PR TITLE
benchmark: use assert.ok instead of assert

### DIFF
--- a/benchmark/buffers/buffer-atob.js
+++ b/benchmark/buffers/buffer-atob.js
@@ -16,5 +16,5 @@ function main({ n, size }) {
     out += atob(input).length;
   }
   bench.end(n);
-  assert(out > 0);
+  assert.ok(out > 0);
 }

--- a/benchmark/buffers/buffer-btoa.js
+++ b/benchmark/buffers/buffer-btoa.js
@@ -16,5 +16,5 @@ function main({ n, size }) {
     out += btoa(input).length;
   }
   bench.end(n);
-  assert(out > 0);
+  assert.ok(out > 0);
 }

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -31,7 +31,7 @@ function main({ size, type, method, n }) {
 function benchFor(buffer, n) {
   for (let k = 0; k < n; k++) {
     for (let i = 0; i < buffer.length; i++) {
-      assert.ok(buffer[i] === 0);
+      assert.strictEqual(buffer[i], 0);
     }
   }
 }
@@ -39,7 +39,7 @@ function benchFor(buffer, n) {
 function benchForOf(buffer, n) {
   for (let k = 0; k < n; k++) {
     for (const b of buffer) {
-      assert.ok(b === 0);
+      assert.strictEqual(b, 0);
     }
   }
 }
@@ -50,7 +50,7 @@ function benchIterator(buffer, n) {
     let cur = iter.next();
 
     while (!cur.done) {
-      assert.ok(cur.value === 0);
+      assert.strictEqual(cur.value, 0);
       cur = iter.next();
     }
 

--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -31,7 +31,7 @@ function main({ size, type, method, n }) {
 function benchFor(buffer, n) {
   for (let k = 0; k < n; k++) {
     for (let i = 0; i < buffer.length; i++) {
-      assert(buffer[i] === 0);
+      assert.ok(buffer[i] === 0);
     }
   }
 }
@@ -39,7 +39,7 @@ function benchFor(buffer, n) {
 function benchForOf(buffer, n) {
   for (let k = 0; k < n; k++) {
     for (const b of buffer) {
-      assert(b === 0);
+      assert.ok(b === 0);
     }
   }
 }
@@ -50,7 +50,7 @@ function benchIterator(buffer, n) {
     let cur = iter.next();
 
     while (!cur.done) {
-      assert(cur.value === 0);
+      assert.ok(cur.value === 0);
       cur = iter.next();
     }
 


### PR DESCRIPTION
`assert()` is an alias for `assert.ok()`. I am currently working on creating benchmark coverage for Node.js (the pull request will be opened shortly) and I had to monkey patch a few modules. Changing the benchmarks to use `module.func()` instead of `module()` will make my life easier.

So, I thought it would be okay to open it, as in the end, they will be the same.
