### PR TITLE
doc: add KevinEady as a triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ maintaining the Node.js project.
   **Gireesh Punathil** <<gpunathi@in.ibm.com>> (he/him)
 * [iam-frankqiu](https://github.com/iam-frankqiu) -
   **Frank Qiu** <<iam.frankqiu@gmail.com>> (he/him)
+* [KevinEady](https://github.com/KevinEady) -
+  **Kevin Eady** <<kevin.c.eady@gmail.com>> (he/him)
 * [kvakil](https://github.com/kvakil) -
   **Keyhan Vakil** <<kvakil@sylph.kvakil.me>>
 * [marsonya](https://github.com/marsonya) -


### PR DESCRIPTION
I'd like to nominate @KevinEady a triager. Kevin has contributed to node-addon-api for a long time and I believe his help will be beneficial to the work in the core repo as well.

/cc @nodejs/node-api 