### PR TITLE
benchmark: fix benchmark for file path and URL conversion

### DIFF
--- a/benchmark/url/whatwg-url-to-and-from-path.js
+++ b/benchmark/url/whatwg-url-to-and-from-path.js
@@ -3,28 +3,46 @@ const common = require('../common.js');
 const { fileURLToPath, pathToFileURL } = require('node:url');
 const isWindows = process.platform === 'win32';
 
-const bench = common.createBenchmark(main, {
-  input: isWindows ? [
-    'file:///c/',
-  ] : [
-    'file:///dev/null',
-    'file:///dev/null?key=param&bool',
-    'file:///dev/null?key=param&bool#hash',
-  ],
-  method: isWindows ? [
-    'fileURLToPath',
-  ] : [
-    'fileURLToPath',
-    'pathToFileURL',
-  ],
-  n: [5e6],
-});
+const inputs = isWindows ? [
+  'C:\\foo',
+  'C:\\Program Files\\Music\\Web Sys\\main.html?REQUEST=RADIO',
+  '\\\\nas\\My Docs\\File.doc',
+  '\\\\?\\UNC\\server\\share\\folder\\file.txt',
+  'file:///C:/foo',
+  'file:///C:/dir/foo?query=1',
+  'file:///C:/dir/foo#fragment',
+] : [
+  '/dev/null',
+  '/dev/null?key=param&bool',
+  '/dev/null?key=param&bool#hash',
+  'file:///dev/null',
+  'file:///dev/null?key=param&bool',
+  'file:///dev/null?key=param&bool#hash',
+];
 
-function main({ n, input, method }) {
-  method = method === 'fileURLOrPath' ? fileURLToPath : pathToFileURL;
+const bench = common.createBenchmark(
+  main,
+  {
+    method: ['pathToFileURL', 'fileURLToPath'],
+    input: Object.values(inputs),
+    n: [5e6],
+  },
+  {
+    combinationFilter: (p) => (
+      (isWindows ?
+        (!p.input.startsWith('file://') && p.method === 'pathToFileURL') :
+        p.method === 'pathToFileURL'
+      ) ||
+      (p.input.startsWith('file://') && p.method === 'fileURLToPath')
+    ),
+  },
+);
+
+function main({ method, input, n }) {
+  const methodFunc = method === 'fileURLToPath' ? fileURLToPath : pathToFileURL;
   bench.start();
   for (let i = 0; i < n; i++) {
-    method(input);
+    methodFunc(input);
   }
   bench.end(n);
 }


### PR DESCRIPTION
In the original code, there was a typo in `method = method === 'fileURLOrPath' ? fileURLToPath : pathToFileURL;`, which caused only `pathToFileURL` to be executed. I have corrected this issue and added additional test cases for Windows UNC paths and regular file paths.