### PR TITLE
benchmark: remove force option as force defaults to true.

### DIFF
--- a/benchmark/fs/bench-cpSync.js
+++ b/benchmark/fs/bench-cpSync.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
 
 function main({ n }) {
   tmpdir.refresh();
-  const options = { force: true, recursive: true };
+  const options = { recursive: true };
   const src = path.join(__dirname, '../../test/fixtures/copy');
   const dest = tmpdir.resolve(`${process.pid}/subdir/cp-bench-${process.pid}`);
   bench.start();


### PR DESCRIPTION
Removed the `force: true` option as `force` defaults to true in the defaultCpOptions.

cc. @anonrig 