### PR TITLE
lib: fix unhandled errors in webstream adapters

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -459,6 +459,7 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   const strategy = evaluateStrategyOrFallback(options?.strategy);
 
   let controller;
+  let wasCanceled = false;
 
   function onData(chunk) {
     // Copy the Buffer to detach it from the pool.
@@ -480,6 +481,10 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
     streamReadable.on('error', () => {});
     if (error)
       return controller.error(error);
+    // Was already canceled
+    if (wasCanceled) {
+      return;
+    }
     controller.close();
   });
 
@@ -491,6 +496,7 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
     pull() { streamReadable.resume(); },
 
     cancel(reason) {
+      wasCanceled = true;
       destroy(streamReadable, reason);
     },
   }, strategy);

--- a/test/parallel/test-stream-readable-from-web-termination.js
+++ b/test/parallel/test-stream-readable-from-web-termination.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const { Readable } = require('stream');
+
+{
+  const r = Readable.from(['data']);
+
+  const wrapper = Readable.fromWeb(Readable.toWeb(r));
+
+  wrapper.on('data', () => {
+    // Destroying wrapper while emitting data should not cause uncaught
+    // exceptions
+    wrapper.destroy();
+  });
+}

--- a/test/parallel/test-stream-readable-to-web-termination.js
+++ b/test/parallel/test-stream-readable-to-web-termination.js
@@ -1,0 +1,12 @@
+'use strict';
+require('../common');
+const { Readable } = require('stream');
+
+{
+  const r = Readable.from([]);
+  // Cancelling reader while closing should not cause uncaught exceptions
+  r.on('close', () => reader.cancel());
+
+  const reader = Readable.toWeb(r).getReader();
+  reader.read();
+}


### PR DESCRIPTION
WebStream's Readable controller does not tolerate `.close()` being called after an `error`. However, when wrapping a Node's Readable stream it is possible that the sequence of events leads to `finished()`'s callback being invoked after such `error`.

In order to handle this, in this change we call the `finished()` handler earlier when controller is canceled, and always handle this as an error case.

Fix: https://github.com/nodejs/node/issues/54205

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
