### PR TITLE
doc: update `buffer.constants.MAX_LENGTH` size

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5361,6 +5361,10 @@ added: v8.2.0
 <!-- YAML
 added: v8.2.0
 changes:
+  - version: v22.0.0
+    pr-url: https://github.com/nodejs/node/pull/52465
+    description: Value is changed to 2<sup>53</sup> - 1 on 64-bit
+      architectures.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35415
     description: Value is changed to 2<sup>32</sup> on 64-bit
@@ -5376,7 +5380,7 @@ changes:
 On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (about 1
 GiB).
 
-On 64-bit architectures, this value currently is 2<sup>32</sup> (about 4 GiB).
+On 64-bit architectures, this value currently is 2<sup>53</sup> - 1 (about 8 PiB).
 
 It reflects [`v8::TypedArray::kMaxLength`][] under the hood.
 


### PR DESCRIPTION
Starting from Node v22.0.0 (which [uses V8 12.4](https://github.com/nodejs/node/pull/52465)) the `buffer.constants.MAX_LENGTH` has been increased from 4 GiB to 8 PiB due to V8 engine update to 12.4.254.14. If I read it right the change was done in [this commit to V8 engine](https://github.com/v8/v8/commit/44b299590083b888637c79fb5632806e607ab861).

The change is also easy to verify manually:
```
Welcome to Node.js v21.7.3.
Type ".help" for more information.
> (require('buffer').constants.MAX_LENGTH) / 2**30
4

Welcome to Node.js v22.0.0.
Type ".help" for more information.
> (require('buffer').constants.MAX_LENGTH + 1) / 2**30
8388608
> (require('buffer').constants.MAX_LENGTH + 1) / 2**40
8192
>
```