### PR TITLE
test: use assert.{s,deepS}trictEqual()

### DIFF
--- a/test/parallel/test-tls-set-sigalgs.js
+++ b/test/parallel/test-tls-set-sigalgs.js
@@ -9,13 +9,6 @@ const {
   assert, connect, keys
 } = require(fixtures.path('tls-connect'));
 
-function assert_arrays_equal(left, right) {
-  assert.strictEqual(left.length, right.length);
-  for (let i = 0; i < left.length; i++) {
-    assert.strictEqual(left[i], right[i]);
-  }
-}
-
 function test(csigalgs, ssigalgs, shared_sigalgs, cerr, serr) {
   assert(shared_sigalgs || serr || cerr, 'test missing any expectations');
   connect({
@@ -43,16 +36,19 @@ function test(csigalgs, ssigalgs, shared_sigalgs, cerr, serr) {
       assert.ifError(pair.client.err);
       assert(pair.server.conn);
       assert(pair.client.conn);
-      assert_arrays_equal(pair.server.conn.getSharedSigalgs(), shared_sigalgs);
+      assert.deepStrictEqual(
+        pair.server.conn.getSharedSigalgs(),
+        shared_sigalgs
+      );
     } else {
       if (serr) {
         assert(pair.server.err);
-        assert(pair.server.err.code, serr);
+        assert.strictEqual(pair.server.err.code, serr);
       }
 
       if (cerr) {
         assert(pair.client.err);
-        assert(pair.client.err.code, cerr);
+        assert.strictEqual(pair.client.err.code, cerr);
       }
     }
 
@@ -68,7 +64,9 @@ test('RSA-PSS+SHA256:RSA-PSS+SHA512:ECDSA+SHA256',
 
 // Do not have shared sigalgs.
 test('RSA-PSS+SHA384', 'ECDSA+SHA256',
-     undefined, 'ECONNRESET', 'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITHMS');
+     undefined, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE',
+     'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITHMS');
 
 test('RSA-PSS+SHA384:ECDSA+SHA256', 'ECDSA+SHA384:RSA-PSS+SHA256',
-     undefined, 'ECONNRESET', 'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITHMS');
+     undefined, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE',
+     'ERR_SSL_NO_SHARED_SIGNATURE_ALGORITHMS');


### PR DESCRIPTION
Use `asset.strictEqual()` and `asset.deepStrictEqual()` in `test/parallel/test-tls-set-sigalgs.js`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
