### PR TITLE
cli: mark --conditions flag as stable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -476,10 +476,9 @@ added:
   - v12.19.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
-Enable experimental support for custom [conditional exports][] resolution
-conditions.
+Provide custom [conditional exports][] resolution conditions.
 
 Any number of custom string condition names are permitted.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -474,6 +474,11 @@ source node_bash_completion
 added:
   - v14.9.0
   - v12.19.0
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54209
+    description: The flag is no longer experimental.
 -->
 
 > Stability: 2 - Stable


### PR DESCRIPTION
This marks the `--conditions|-C` flag as stable in the docs.