### PR TITLE
doc: use html for the documentation.md stability indexes

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -23,38 +23,46 @@ Others are brand new and experimental, or known to be hazardous.
 
 The stability indexes are as follows:
 
-> Stability: 0 - Deprecated. The feature may emit warnings. Backward
-> compatibility is not guaranteed.
+<div class="api_stability api_stability_0">
+  Stability: 0 - Deprecated.
+  The feature may emit warnings. Backward compatibility is not guaranteed.
+</div>
 
-<!-- separator -->
+<div class="api_stability api_stability_1">
+  Stability: 1 - Experimental. The feature is not subject to
+  <a href="https://semver.org/">semantic versioning</a> rules.
+  Non-backward compatible changes or removal may occur in any future release.
+  Use of the feature is not recommended in production environments.
+  <p>Experimental features are subdivided into stages:</p>
+  <ul>
+    <li>
+      1.0 - Early development. Experimental features at this stage are unfinished
+      and subject to substantial change.
+    </li>
+    <li>
+      1.1 - Active development. Experimental features at this stage are nearing
+      minimum viability.
+    </li>
+    <li>
+      1.2 - Release candidate. Experimental features at this stage are hopefully
+      ready to become stable. No further breaking changes are anticipated but may
+      still occur in response to user feedback. We encourage user testing and
+      feedback so that we can know that this feature is ready to be marked as
+      stable.
+    </li>
+  </ul>
+</div>
 
-> Stability: 1 - Experimental. The feature is not subject to
-> [semantic versioning][] rules. Non-backward compatible changes or removal may
-> occur in any future release. Use of the feature is not recommended in
-> production environments.
->
-> Experimental features are subdivided into stages:
->
-> * 1.0 - Early development. Experimental features at this stage are unfinished
->   and subject to substantial change.
-> * 1.1 - Active development. Experimental features at this stage are nearing
->   minimum viability.
-> * 1.2 - Release candidate. Experimental features at this stage are hopefully
->   ready to become stable. No further breaking changes are anticipated but may
->   still occur in response to user feedback. We encourage user testing and
->   feedback so that we can know that this feature is ready to be marked as
->   stable.
+<div class="api_stability api_stability_2">
+  Stability: 2 - Stable. Compatibility with the npm ecosystem is a high
+  priority.
+</div>
 
-<!-- separator -->
-
-> Stability: 2 - Stable. Compatibility with the npm ecosystem is a high
-> priority.
-
-<!-- separator -->
-
-> Stability: 3 - Legacy. Although this feature is unlikely to be removed and is
-> still covered by semantic versioning guarantees, it is no longer actively
-> maintained, and other alternatives are available.
+<div class="api_stability api_stability_3">
+  Stability: 3 - Legacy. Although this feature is unlikely to be removed and is
+  still covered by semantic versioning guarantees, it is no longer actively
+  maintained, and other alternatives are available.
+</div>
 
 Features are marked as legacy rather than being deprecated if their use does no
 harm, and they are widely relied upon within the npm ecosystem. Bugs found in

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -60,8 +60,9 @@ The stability indexes are as follows:
 
 <div class="api_stability api_stability_3">
   Stability: 3 - Legacy. Although this feature is unlikely to be removed and is
-  still covered by semantic versioning guarantees, it is no longer actively
-  maintained, and other alternatives are available.
+  still covered by <a href="https://semver.org/">semantic versioning</a>
+  guarantees, it is no longer actively maintained, and other alternatives
+  are available.
 </div>
 
 Features are marked as legacy rather than being deprecated if their use does no
@@ -98,7 +99,6 @@ Most Unix system calls have Windows analogues. Still, behavior differences may
 be unavoidable.
 
 [V8 JavaScript engine]: https://v8.dev/
-[semantic versioning]: https://semver.org/
 [the contributing guide]: https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
 [the issue tracker]: https://github.com/nodejs/node/issues/new
 [warning]: process.md#event-warning


### PR DESCRIPTION
This PR updates the `documentation.md` stability indexes, as they are **not real stability indexes** but just the "documentation/representation" of them.

The upcoming API doc tooling would treat the last stability index as an actual "stability index" for that section of the `documentation.md` page, whereas it is not an absolute stability index, just the exemplification of them.

This change is compatible with both the current and the new tooling. This change also removes the need when parsing the blockquote as a stability index to conditionally remove the link if the file is "documentation.md" as currently done here: https://github.com/nodejs/node/blob/main/tools/doc/html.mjs#L294.