### PR TITLE
test_runner: refactor `mock_loader`

### DIFF
--- a/lib/internal/test_runner/mock/loader.js
+++ b/lib/internal/test_runner/mock/loader.js
@@ -10,21 +10,16 @@ const {
   },
 } = primordials;
 const {
-  ensureNodeScheme,
   kBadExportsMessage,
   kMockSearchParam,
   kMockSuccess,
   kMockExists,
   kMockUnknownMessage,
 } = require('internal/test_runner/mock/mock');
-const { pathToFileURL, URL } = require('internal/url');
-const { normalizeReferrerURL } = require('internal/modules/helpers');
+const { URL, URLParse } = require('internal/url');
 let debug = require('internal/util/debuglog').debuglog('test_runner', (fn) => {
   debug = fn;
 });
-const { createRequire, isBuiltin } = require('module');
-const { defaultGetFormatWithoutErrors } = require('internal/modules/esm/get_format');
-const { defaultResolve } = require('internal/modules/esm/resolve');
 
 // TODO(cjihrig): The mocks need to be thread aware because the exports are
 // evaluated on the thread that creates the mock. Before marking this API as
@@ -79,46 +74,18 @@ async function initialize(data) {
 
 async function resolve(specifier, context, nextResolve) {
   debug('resolve hook entry, specifier = "%s", context = %o', specifier, context);
-  let mockSpecifier;
 
-  if (isBuiltin(specifier)) {
-    mockSpecifier = ensureNodeScheme(specifier);
-  } else {
-    let format;
-
-    if (context.parentURL) {
-      format = defaultGetFormatWithoutErrors(pathToFileURL(context.parentURL));
-    }
-
-    try {
-      if (format === 'module') {
-        specifier = defaultResolve(specifier, context).url;
-      } else {
-        specifier = pathToFileURL(
-          createRequire(context.parentURL).resolve(specifier),
-        ).href;
-      }
-    } catch {
-      const parentURL = normalizeReferrerURL(context.parentURL);
-      const parsedURL = URL.parse(specifier, parentURL)?.href;
-
-      if (parsedURL) {
-        specifier = parsedURL;
-      }
-    }
-
-    mockSpecifier = specifier;
-  }
+  const nextResolveResult = await nextResolve(specifier, context);
+  const mockSpecifier = nextResolveResult.url;
 
   const mock = mocks.get(mockSpecifier);
   debug('resolve hook, specifier = "%s", mock = %o', specifier, mock);
 
   if (mock?.active !== true) {
-    return nextResolve(specifier, context);
+    return nextResolveResult;
   }
 
   const url = new URL(mockSpecifier);
-
   url.searchParams.set(kMockSearchParam, mock.localVersion);
 
   if (!mock.cache) {
@@ -127,13 +94,14 @@ async function resolve(specifier, context, nextResolve) {
     mock.localVersion++;
   }
 
-  debug('resolve hook finished, url = "%s"', url.href);
-  return nextResolve(url.href, context);
+  const { href } = url;
+  debug('resolve hook finished, url = "%s"', href);
+  return { __proto__: null, url: href, format: nextResolveResult.format };
 }
 
 async function load(url, context, nextLoad) {
   debug('load hook entry, url = "%s", context = %o', url, context);
-  const parsedURL = URL.parse(url);
+  const parsedURL = URLParse(url);
   if (parsedURL) {
     parsedURL.searchParams.delete(kMockSearchParam);
   }

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -34,7 +34,13 @@ const {
 } = require('internal/errors');
 const esmLoader = require('internal/modules/esm/loader');
 const { getOptionValue } = require('internal/options');
-const { fileURLToPath, toPathIfFileURL, URL, isURL } = require('internal/url');
+const {
+  fileURLToPath,
+  isURL,
+  pathToFileURL,
+  toPathIfFileURL,
+  URL,
+} = require('internal/url');
 const {
   emitExperimentalWarning,
   getStructuredStack,
@@ -511,7 +517,7 @@ class MockTracker {
 
     // Get the file that called this function. We need four stack frames:
     // vm context -> getStructuredStack() -> this function -> actual caller.
-    const caller = getStructuredStack()[3]?.getFileName();
+    const caller = pathToFileURL(getStructuredStack()[3]?.getFileName()).href;
     const { format, url } = sharedState.moduleLoader.resolveSync(
       mockSpecifier, caller, null,
     );

--- a/test/parallel/test-runner-module-mocking.js
+++ b/test/parallel/test-runner-module-mocking.js
@@ -407,6 +407,12 @@ test('modules cannot be mocked multiple times at once', async (t) => {
 
     assert.strictEqual(mocked.fn(), 42);
   });
+
+  await t.test('Importing a Windows path should fail', { skip: !common.isWindows }, async (t) => {
+    const fixture = fixtures.path('module-mocking', 'wrong-path.js');
+    t.mock.module(fixture, { namedExports: { fn() { return 42; } } });
+    await assert.rejects(import(fixture), { code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME' });
+  });
 });
 
 test('mocks are automatically restored', async (t) => {


### PR DESCRIPTION
It seems the `mock_loader` can be greatly simplified if it doesn't try to support things Node.js doesn't support (e.g. importing a path, we only support importing URLs), and do not need to rely too much on internals.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
