### PR TITLE
doc, test: fix `added` versions in `context.filePath`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -3214,8 +3214,8 @@ test('top level test', (t) => {
 
 <!-- YAML
 added:
-  - v20.16.0
   - v22.6.0
+  - v20.16.0
 -->
 
 The absolute path of the test file that created the current test. If a test file


### PR DESCRIPTION
This PR fixes a small lint issue added by v22.6.0.

Ref: https://github.com/nodejs/node/actions/runs/10270812122/job/28419399314