### PR TITLE
module: refactor ts parser loading

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -300,11 +300,29 @@ function getBuiltinModule(id) {
   return normalizedId ? require(normalizedId) : undefined;
 }
 
-let parseTS;
+let typeScriptParser;
 
-function lazyLoadTSParser() {
-  parseTS ??= require('internal/deps/amaro/dist/index').transformSync;
-  return parseTS;
+/**
+ * Load the TypeScript parser.
+ * @param {Function} parser - A function that takes a string of TypeScript code
+ * and returns an object with a `code` property.
+ * @returns {Function} The TypeScript parser function.
+ */
+function loadTypeScriptParser(parser) {
+  if (typeScriptParser) {
+    return typeScriptParser;
+  }
+
+  if (parser) {
+    typeScriptParser = parser;
+  } else {
+    const amaro = require('internal/deps/amaro/dist/index');
+    // Default option for Amaro is to perform Type Stripping only.
+    const defaultOptions = { __proto__: null, mode: 'strip-only' };
+    // Curry the transformSync function with the default options.
+    typeScriptParser = (source) => amaro.transformSync(source, defaultOptions);
+  }
+  return typeScriptParser;
 }
 
 /**
@@ -313,9 +331,10 @@ function lazyLoadTSParser() {
  * @returns {string} JavaScript code.
  */
 function tsParse(source) {
+  // TODO(@marco-ippolito) Checking empty string or non string input should be handled in Amaro.
   if (!source || typeof source !== 'string') { return ''; }
-  const transformSync = lazyLoadTSParser();
-  const { code } = transformSync(source, { __proto__: null, mode: 'strip-only' });
+  const parse = loadTypeScriptParser();
+  const { code } = parse(source);
   return code;
 }
 


### PR DESCRIPTION
This PR refactors the way TypeScript parser is loaded.
Currently the function `loadTypeScriptParser` is not exposed but could allow overriding the default parsing options, so that an external version of amaro could be used.
It also changes the `parse` signature to take only the code string input and return `{ code }`.