### PR TITLE
console: use validateOneOf for colorMode validation

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -39,7 +39,6 @@ const {
   codes: {
     ERR_CONSOLE_WRITABLE_STREAM,
     ERR_INCOMPATIBLE_OPTION_PAIR,
-    ERR_INVALID_ARG_VALUE,
   },
   isStackOverflowError,
 } = require('internal/errors');
@@ -47,6 +46,7 @@ const {
   validateArray,
   validateInteger,
   validateObject,
+  validateOneOf,
 } = require('internal/validators');
 const { previewEntries } = internalBinding('util');
 const { Buffer: { isBuffer } } = require('buffer');
@@ -124,8 +124,7 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
     throw new ERR_CONSOLE_WRITABLE_STREAM('stderr');
   }
 
-  if (typeof colorMode !== 'boolean' && colorMode !== 'auto')
-    throw new ERR_INVALID_ARG_VALUE('colorMode', colorMode);
+  validateOneOf(colorMode, 'colorMode', ['auto', true, false]);
 
   if (groupIndentation !== undefined) {
     validateInteger(groupIndentation, 'groupIndentation',

--- a/test/parallel/test-console-tty-colors.js
+++ b/test/parallel/test-console-tty-colors.js
@@ -67,7 +67,7 @@ check(false, false, false);
         });
       },
       {
-        message: `The argument 'colorMode' is invalid. Received ${received}`,
+        message: `The argument 'colorMode' must be one of: 'auto', true, false. Received ${received}`,
         code: 'ERR_INVALID_ARG_VALUE'
       }
     );


### PR DESCRIPTION
refactor the Console constructor to use validateOneOf for validating the colorMode parameter.