### PR TITLE
inspector: support `Network.loadingFailed` event

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -557,6 +557,22 @@ This feature is only available with the `--experimental-network-inspection` flag
 Broadcasts the `Network.loadingFinished` event to connected frontends. This event indicates that
 HTTP request has finished loading.
 
+### `inspector.Network.loadingFailed([params])`
+
+<!-- YAML
+added:
+ - REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `params` {Object}
+
+This feature is only available with the `--experimental-network-inspection` flag enabled.
+
+Broadcasts the `Network.loadingFailed` event to connected frontends. This event indicates that
+HTTP request has failed to load.
+
 ## Support of breakpoints
 
 The Chrome DevTools Protocol [`Debugger` domain][] allows an

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -201,6 +201,7 @@ const Network = {
   requestWillBeSent: (params) => broadcastToFrontend('Network.requestWillBeSent', params),
   responseReceived: (params) => broadcastToFrontend('Network.responseReceived', params),
   loadingFinished: (params) => broadcastToFrontend('Network.loadingFinished', params),
+  loadingFailed: (params) => broadcastToFrontend('Network.loadingFailed', params),
 };
 
 module.exports = {

--- a/lib/internal/inspector_network_tracking.js
+++ b/lib/internal/inspector_network_tracking.js
@@ -49,6 +49,19 @@ function onClientRequestStart({ request }) {
   });
 }
 
+function onClientRequestError({ request, error }) {
+  if (typeof request._inspectorRequestId !== 'string') {
+    return;
+  }
+  const timestamp = DateNow() / 1000;
+  Network.loadingFailed({
+    requestId: request._inspectorRequestId,
+    timestamp,
+    type: 'Other',
+    errorText: error.message,
+  });
+}
+
 function onClientResponseFinish({ request, response }) {
   if (typeof request._inspectorRequestId !== 'string') {
     return;
@@ -80,11 +93,13 @@ function enable() {
     Network = require('inspector').Network;
   }
   dc.subscribe('http.client.request.start', onClientRequestStart);
+  dc.subscribe('http.client.request.error', onClientRequestError);
   dc.subscribe('http.client.response.finish', onClientResponseFinish);
 }
 
 function disable() {
   dc.unsubscribe('http.client.request.start', onClientRequestStart);
+  dc.unsubscribe('http.client.request.error', onClientRequestError);
   dc.unsubscribe('http.client.response.finish', onClientResponseFinish);
 }
 

--- a/src/inspector/network_agent.cc
+++ b/src/inspector/network_agent.cc
@@ -33,6 +33,7 @@ NetworkAgent::NetworkAgent(NetworkInspector* inspector)
     : inspector_(inspector) {
   event_notifier_map_["requestWillBeSent"] = &NetworkAgent::requestWillBeSent;
   event_notifier_map_["responseReceived"] = &NetworkAgent::responseReceived;
+  event_notifier_map_["loadingFailed"] = &NetworkAgent::loadingFailed;
   event_notifier_map_["loadingFinished"] = &NetworkAgent::loadingFinished;
 }
 
@@ -115,6 +116,20 @@ void NetworkAgent::responseReceived(
       timestamp,
       type,
       createResponse(url, status, statusText, std::move(headers)));
+}
+
+void NetworkAgent::loadingFailed(
+    std::unique_ptr<protocol::DictionaryValue> params) {
+  String request_id;
+  params->getString("requestId", &request_id);
+  double timestamp;
+  params->getDouble("timestamp", &timestamp);
+  String type;
+  params->getString("type", &type);
+  String error_text;
+  params->getString("errorText", &error_text);
+
+  frontend_->loadingFailed(request_id, timestamp, type, error_text);
 }
 
 void NetworkAgent::loadingFinished(

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -29,6 +29,8 @@ class NetworkAgent : public Network::Backend {
 
   void responseReceived(std::unique_ptr<protocol::DictionaryValue> params);
 
+  void loadingFailed(std::unique_ptr<protocol::DictionaryValue> params);
+
   void loadingFinished(std::unique_ptr<protocol::DictionaryValue> params);
 
  private:

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -180,6 +180,17 @@ experimental domain Network
       # Response data.
       Response response
 
+  event loadingFailed
+    parameters
+      # Request identifier.
+      RequestId requestId
+      # Timestamp.
+      MonotonicTime timestamp
+      # Resource type.
+      ResourceType type
+      # Error message.
+      string errorText
+
   event loadingFinished
     parameters
       # Request identifier.

--- a/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/parallel/test-inspector-emit-protocol-event.js
@@ -62,6 +62,15 @@ const EXPECTED_EVENTS = {
         timestamp: 1000,
       }
     },
+    {
+      name: 'loadingFailed',
+      params: {
+        requestId: 'request-id-1',
+        timestamp: 1000,
+        type: 'Document',
+        errorText: 'Failed to load resource'
+      }
+    },
   ]
 };
 


### PR DESCRIPTION
ref. https://github.com/nodejs/node/issues/53946

This PR introduces the [`Network.loadingFailed`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFailed) event support for inspecting network request errors. These errors can be collected using the newly added diagnostics channel `http.client.request.error`, as implemented in https://github.com/nodejs/node/pull/54054.

<img width="1622" alt="image" src="https://github.com/user-attachments/assets/d9029caa-b236-48d3-8860-c9312bc09e6d">

This adds new API `inspector.Network.loadingFailed`, so it's semver-minor.