### PR TITLE
dns: exclude loopback link from the single lookup resolution

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -24,6 +24,7 @@
 const {
   ObjectDefineProperties,
   ObjectDefineProperty,
+  StringPrototypeStartsWith,
   Symbol,
 } = primordials;
 
@@ -108,7 +109,16 @@ function onlookup(err, addresses) {
   if (err) {
     return this.callback(new DNSException(err, 'getaddrinfo', this.hostname));
   }
-  this.callback(null, addresses[0], this.family || isIP(addresses[0]));
+  
+  const family = this.family || isIP(addresses[0]);
+  const address = addresses[0];
+  if (address && family === 6 && StringPrototypeStartsWith(address, 'fe80::')) {
+    // If the address is an IPv6 link-local address, we should not return it
+    this.callback(null, undefined, undefined);
+  } else {
+    this.callback(null, address, family);
+  }
+
   if (this[kPerfHooksDnsLookupContext] && hasObserver('dns')) {
     stopPerf(this, kPerfHooksDnsLookupContext, { detail: { addresses } });
   }

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -4,6 +4,7 @@ const {
   ObjectDefineProperty,
   Promise,
   ReflectApply,
+  StringPrototypeStartsWith,
   Symbol,
 } = primordials;
 
@@ -88,7 +89,15 @@ function onlookup(err, addresses) {
   }
 
   const family = this.family || isIP(addresses[0]);
-  this.resolve({ address: addresses[0], family });
+  const address = addresses[0];
+
+  if (address && family === 6 && StringPrototypeStartsWith(address, 'fe80::')) {
+    // If the address is an IPv6 link-local address, we should not return it
+    this.resolve({});
+  } else {
+    this.resolve({ address, family });
+  }
+
   if (this[kPerfHooksDnsLookupContext] && hasObserver('dns')) {
     stopPerf(this, kPerfHooksDnsLookupContext, { detail: { addresses } });
   }

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -587,6 +587,17 @@ TEST(function test_lookup_ip_promise(done) {
     });
 });
 
+TEST(async function test_lookup_ipv6_loopback(done) {
+  const response = await dnsPromises.lookup('ipv6_loopback', { verbatim: true });
+  assert.strictEqual(Object.keys(response).length, 0);
+
+  util.promisify(dns.lookup)('ipv6_loopback').then(({ address, family }) => {
+    assert.strictEqual(address, undefined);
+    assert.strictEqual(family, undefined);
+
+    done();
+  });
+});
 
 TEST(async function test_lookup_null_all(done) {
   assert.deepStrictEqual(await dnsPromises.lookup(null, { all: true }), []);


### PR DESCRIPTION
dns: the lookup of a single address should not be returned if the result is a loopback link

Fixes: https://github.com/nodejs/node/issues/51732

As described in the original issue, I am having problems writing working automated tests:

if `/etc/hosts` is modified to have this entry `fe80::1         ipv6_loopback` tests are working just fine, but of course it is not a valid solution. I tried to mock the inner workings of the actual dns resolved but I was not able to make it work fine for my test case.

two questions:

1. does anybody know how to fix the "broken" test?
2. are the new API (the returned values) fine?
