### PR TITLE
lib: expose tsParse as util.stripTypescriptTypes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -72,6 +72,8 @@ const {
   defineLazyProperties,
 } = require('internal/util');
 
+const { getOptionValue } = require('internal/options');
+
 let abortController;
 
 function lazyAbortController() {
@@ -338,3 +340,8 @@ defineLazyProperties(
   'internal/mime',
   ['MIMEType', 'MIMEParams'],
 );
+
+if (getOptionValue('--experimental-strip-types')) {
+  const { tsParse } = require('internal/modules/helpers');
+  module.exports.stripTypescriptTypes = tsParse;
+}

--- a/test/fixtures/test-util-stripTypescriptTypes.js
+++ b/test/fixtures/test-util-stripTypescriptTypes.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const assert = require('assert');
+const util = require('util');
+
+assert.strictEqual(util.stripTypescriptTypes('let s: string'), 'let s        ');

--- a/test/parallel/test-util-stripTypescriptTypes.js
+++ b/test/parallel/test-util-stripTypescriptTypes.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { skip, spawnPromisified } = require('../common');
+const fixtures = require('../common/fixtures');
+const { strictEqual } = require('node:assert');
+const { test } = require('node:test');
+
+if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
+
+test('util.stripTypescriptTypes', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-strip-types',
+    fixtures.path('test-util-stripTypescriptTypes.js'),
+  ]);
+
+  strictEqual(result.stdout, '');
+  strictEqual(result.stderr, '');
+  strictEqual(result.code, 0);
+});


### PR DESCRIPTION
This PR exposes `internal/modules/helpers/tsParse` as `util.stripTypescriptTypes` in order to transpile/strip types from TypeScript code without bringing in another dependency, since it's already there.

All details are in flux, I just picked the quickest solution I could come up with, but I wanted to bring it here for discussion.

Primary use-case would be transpiling modules to serve to the client from a pure node server without bringing in dependencies.