### PR TITLE
doc: add note on weakness of permission model

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -9,6 +9,15 @@ with those resources.
   The resource can be entirely allowed or denied, or actions related to it can
   be controlled. For example, file system reads can be allowed while denying
   writes.
+  This feature does not protect against malicious code. According to the Node.js
+  [Security Policy][], Node.js trusts any code it is asked to run.
+
+The permission model implements a "seat belt" approach, which prevents trusted
+code from unintentionally changing files or using resources that access has
+not explicitly been granted to. It does not provide security guarantees in the
+presence of malicious code. Malicious code can bypass the permission model and
+execute arbitrary code without the restrictions imposed by the permission
+model.
 
 If you find a potential security vulnerability, please refer to our
 [Security Policy][].


### PR DESCRIPTION
Malicious JavaScript code can bypass the permission model. Hence, it does not fulfill the requirements of a security mechanism against malicious code.

Specifically, JavaScript code can interface with libuv through a file descriptor and execute arbitrary native code. This problem was found by @leesh3288 who submitted [a well-written report on the security impact of this issue](https://hackerone.com/reports/2260337).

(I am not convinced that we should present this feature as a security mechanism at all at this point because I am quite unsure what guarantees it provides, but this PR just adds a remark on malicious code.)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
