### PR TITLE
doc: explicitly mention node:fs module restriction

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -529,10 +529,9 @@ process.permission.has('fs.read', '/home/rafaelgss/protected-folder'); // false
 
 #### File System Permissions
 
-The Permission Model by default restricts access to `node:fs` module.
-It doesn't guarantee users won't be able to write to the disk.
-For instance, `node:sqlite` allows users to use
-a file-based database.
+The Permission Model, by default, restricts access to the file system through the `node:fs` module.
+It does not guarantee that users will not be able to access the file system through other means,
+such as through the `node:sqlite` module.
 
 To allow access to the file system, use the [`--allow-fs-read`][] and
 [`--allow-fs-write`][] flags:

--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -529,6 +529,11 @@ process.permission.has('fs.read', '/home/rafaelgss/protected-folder'); // false
 
 #### File System Permissions
 
+The Permission Model by default restricts access to `node:fs` module.
+It doesn't guarantee users won't be able to write to the disk.
+For instance, `node:sqlite` allows users to use
+a file-based database.
+
 To allow access to the file system, use the [`--allow-fs-read`][] and
 [`--allow-fs-write`][] flags:
 


### PR DESCRIPTION
While we have uncountable issues where we explicitly mention it, I somehow missed documenting it in permissions.md. I believe this would make things more clear.

cc: @tniessen 