### PR TITLE
src: use v8::Isolate::GetDefaultLocale() to compute navigator.language

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-isolate.h
+++ b/deps/v8/include/v8-isolate.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "cppgc/common.h"
@@ -1716,6 +1717,12 @@ class V8_EXPORT Isolate {
    * the performance of locale operations.
    */
   void LocaleConfigurationChangeNotification();
+
+  /**
+   * Returns the default locale in a string if Intl support is enabled.
+   * Otherwise returns an empty string.
+   */
+  std::string GetDefaultLocale();
 
   Isolate() = delete;
   ~Isolate() = delete;

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -10768,6 +10768,17 @@ void v8::Isolate::LocaleConfigurationChangeNotification() {
 #endif  // V8_INTL_SUPPORT
 }
 
+std::string Isolate::GetDefaultLocale() {
+  i::Isolate* i_isolate = reinterpret_cast<i::Isolate*>(this);
+  ENTER_V8_NO_SCRIPT_NO_EXCEPTION(i_isolate);
+
+#ifdef V8_INTL_SUPPORT
+  return i_isolate->DefaultLocale();
+#else
+  return std::string();
+#endif
+}
+
 #if defined(V8_OS_WIN) && defined(V8_ENABLE_ETW_STACK_WALKING)
 void Isolate::SetFilterETWSessionByURLCallback(
     FilterETWSessionByURLCallback callback) {

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -30,7 +30,7 @@ const {
 } = require('internal/process/per_thread');
 
 const {
-  language,
+  getDefaultLocale,
 } = internalBinding('config');
 
 /**
@@ -104,7 +104,9 @@ class Navigator {
    * @return {string}
    */
   get language() {
-    return language;
+    // The default locale might be changed dynamically, so always invoke the
+    // binding.
+    return getDefaultLocale() || 'en-US';
   }
 
   /**

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -21,10 +21,6 @@ const {
 } = primordials;
 
 const {
-  Intl,
-} = globalThis;
-
-const {
   getOptionValue,
   refreshOptions,
   getEmbedderOptions,
@@ -333,7 +329,6 @@ function setupNavigator() {
 
   // https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
   exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator']);
-  internalBinding('config').language = Intl?.Collator().resolvedOptions().locale || 'en-US';
   defineReplaceableLazyAttribute(globalThis, 'internal/navigator', ['navigator'], false);
 }
 

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -15,7 +15,6 @@ using v8::Isolate;
 using v8::Local;
 using v8::Number;
 using v8::Object;
-using v8::String;
 using v8::Value;
 
 void GetDefaultLocale(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -2,6 +2,7 @@
 #include "memory_tracker.h"
 #include "node.h"
 #include "node_builtins.h"
+#include "node_external_reference.h"
 #include "node_i18n.h"
 #include "node_options.h"
 #include "util-inl.h"
@@ -9,11 +10,23 @@
 namespace node {
 
 using v8::Context;
+using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::Number;
 using v8::Object;
+using v8::String;
 using v8::Value;
+
+void GetDefaultLocale(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  std::string locale = isolate->GetDefaultLocale();
+  Local<Value> result;
+  if (ToV8Value(context, locale).ToLocal(&result)) {
+    args.GetReturnValue().Set(result);
+  }
+}
 
 // The config binding is used to provide an internal view of compile time
 // config options that are required internally by lib/*.js code. This is an
@@ -23,7 +36,7 @@ using v8::Value;
 // Command line arguments are already accessible in the JS land via
 // require('internal/options').getOptionValue('--some-option'). Do not add them
 // here.
-static void Initialize(Local<Object> target,
+static void InitConfig(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context,
                        void* priv) {
@@ -76,8 +89,15 @@ static void Initialize(Local<Object> target,
 #endif  // NODE_NO_BROWSER_GLOBALS
 
   READONLY_PROPERTY(target, "bits", Number::New(isolate, 8 * sizeof(intptr_t)));
+
+  SetMethodNoSideEffect(context, target, "getDefaultLocale", GetDefaultLocale);
 }  // InitConfig
+
+void RegisterConfigExternalReferences(ExternalReferenceRegistry* registry) {
+  registry->Register(GetDefaultLocale);
+}
 
 }  // namespace node
 
-NODE_BINDING_CONTEXT_AWARE_INTERNAL(config, node::Initialize)
+NODE_BINDING_CONTEXT_AWARE_INTERNAL(config, node::InitConfig)
+NODE_BINDING_EXTERNAL_REFERENCE(config, node::RegisterConfigExternalReferences)

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -139,6 +139,7 @@ class ExternalReferenceRegistry {
   V(buffer)                                                                    \
   V(builtins)                                                                  \
   V(cares_wrap)                                                                \
+  V(config)                                                                    \
   V(contextify)                                                                \
   V(credentials)                                                               \
   V(encoding_binding)                                                          \


### PR DESCRIPTION
src: use v8::Isolate::GetDefaultLocale() to compute navigator.language

Using the Intl API to get the default locale slows down the startup
significantly. This patch uses a new v8 API to get the default locale
directly.

Refs: https://github.com/nodejs/node/pull/53765#issuecomment-2276802345

First commit comes from https://chromium-review.googlesource.com/c/v8/v8/+/5772938

From benchmark CI:

https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1594/console

```
14:54:15                                                                                           confidence improvement accuracy (*)   (**)  (***)
14:54:15 misc/startup-core.js count=30 mode='process' script='benchmark/fixtures/require-builtins'        ***     18.60 %       ±0.30% ±0.41% ±0.54%
14:54:15 misc/startup-core.js count=30 mode='process' script='test/fixtures/semicolon'                    ***     25.02 %       ±2.92% ±3.93% ±5.19%
14:54:15 misc/startup-core.js count=30 mode='process' script='test/fixtures/snapshot/typescript'          ***      4.32 %       ±0.04% ±0.06% ±0.07%
14:54:15 misc/startup-core.js count=30 mode='worker' script='benchmark/fixtures/require-builtins'                 -0.05 %       ±0.18% ±0.24% ±0.31%
14:54:15 misc/startup-core.js count=30 mode='worker' script='test/fixtures/semicolon'                              0.02 %       ±0.36% ±0.47% ±0.62%
14:54:15 misc/startup-core.js count=30 mode='worker' script='test/fixtures/snapshot/typescript'            **     -1.48 %       ±0.87% ±1.16% 
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
