### PR TITLE
tty: initialize winSize array with values

### DIFF
--- a/lib/tty.js
+++ b/lib/tty.js
@@ -111,7 +111,7 @@ function WriteStream(fd) {
   // Ref: https://github.com/nodejs/node/pull/1771#issuecomment-119351671
   this._handle.setBlocking(true);
 
-  const winSize = new Array(2);
+  const winSize = [0, 0];
   const err = this._handle.getWindowSize(winSize);
   if (!err) {
     this.columns = winSize[0];
@@ -131,7 +131,7 @@ WriteStream.prototype.hasColors = hasColors;
 WriteStream.prototype._refreshSize = function() {
   const oldCols = this.columns;
   const oldRows = this.rows;
-  const winSize = new Array(2);
+  const winSize = [0, 0];
   const err = this._handle.getWindowSize(winSize);
   if (err) {
     this.emit('error', new ErrnoException(err, 'getWindowSize'));

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const {
-  Array,
   NumberIsInteger,
   ObjectSetPrototypeOf,
 } = primordials;


### PR DESCRIPTION
Assigning to a holey array in the native layer may crash if it has
getters that throw.

Refs: https://github.com/nodejs/node/issues/54186

