### PR TITLE
module: do not attempt to strip type when there's no source

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -161,8 +161,12 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
       default: { // The user did not pass `--experimental-default-type`.
         // `source` is undefined when this is called from `defaultResolve`;
         // but this gets called again from `defaultLoad`/`defaultLoadSync`.
-        const { tsParse } = require('internal/modules/helpers');
-        const parsedSource = tsParse(source);
+        let parsedSource;
+        if (source) {
+          // We do the type stripping only if `source` is not falsy.
+          const { tsParse } = require('internal/modules/helpers');
+          parsedSource = tsParse(source);
+        }
         const detectedFormat = detectModuleFormat(parsedSource, url);
         // When source is undefined, default to module-typescript.
         const format = detectedFormat ? `${detectedFormat}-typescript` : 'module-typescript';

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -331,8 +331,7 @@ function loadTypeScriptParser(parser) {
  * @returns {string} JavaScript code.
  */
 function tsParse(source) {
-  // TODO(@marco-ippolito) Checking empty string or non string input should be handled in Amaro.
-  if (!source || typeof source !== 'string') { return ''; }
+  assert(typeof source === 'string');
   const parse = loadTypeScriptParser();
   const { code } = parse(source);
   return code;


### PR DESCRIPTION
It bothers me that `tsParse` would return an empty string on non-string input, IMO it makes much more sense to use an assertion instead, and make sure the other parts of the code calling that function have already validated the input.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
