### PR TITLE
fs: fix subdirectory detection logic

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3187,8 +3187,8 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   std::string dest_path_str = dest_path.string();
   // Check if dest_path is a subdirectory of src_path.
   if (src_is_dir &&
-      dest_path_str.starts_with(src_path.string() +
-                                std::filesystem::path::preferred_separator)) {
+      dest_path.has_parent_path() &&
+      dest_path.parent_path() == src_path) {
     std::string message = "Cannot copy " + src_path.string() +
                           " to a subdirectory of self " + dest_path.string();
     return THROW_ERR_FS_CP_EINVAL(env, message.c_str());

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3186,7 +3186,9 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
 
   std::string dest_path_str = dest_path.string();
   // Check if dest_path is a subdirectory of src_path.
-  if (src_is_dir && dest_path_str.starts_with(src_path.string())) {
+  if (src_is_dir &&
+      dest_path_str.starts_with(src_path.string() +
+                                std::filesystem::path::preferred_separator)) {
     std::string message = "Cannot copy " + src_path.string() +
                           " to a subdirectory of self " + dest_path.string();
     return THROW_ERR_FS_CP_EINVAL(env, message.c_str());

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -305,6 +305,14 @@ function nextdir() {
   );
 }
 
+// It allows copying a directory into another directory, with the destination
+// directory name prefixed by the source directory name.
+{
+  const dir = nextdir();
+  mkdirSync(join(dir, 'foo'), { recursive: true });
+  cpSync(join(dir, 'foo'), join(dir, 'foobar'), { recursive: true });
+}
+
 // It throws an error if attempt is made to copy socket.
 if (!isWindows) {
   const src = nextdir();


### PR DESCRIPTION
Fixes #54285

Checks that `std::filesystem::path::preferred_separator` exists after a directory for detecting subdirectories.