### PR TITLE
util: allow colors in non-tty if `FORCE_COLOR`

### DIFF
--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -23,7 +23,7 @@ module.exports = {
         stream.getColorDepth() > 2 : true);
   },
   refresh() {
-    if (process.stderr.isTTY) {
+    if (process.stderr.isTTY || process.env.FORCE_COLOR !== undefined) {
       const hasColors = module.exports.shouldColorize(process.stderr);
       module.exports.blue = hasColors ? '\u001b[34m' : '';
       module.exports.green = hasColors ? '\u001b[32m' : '';

--- a/test/parallel/test-internal-util-colors.js
+++ b/test/parallel/test-internal-util-colors.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common');
+const { test } = require('node:test');
+
+test('should colorize when FORCE_COLOR, even in a piped stdio', async (t) => {
+  const script =
+    'const colors = require(\'internal/util/colors\');' +
+    'require(\'assert\')(colors.hasColors === colors.shouldColorize());';
+  const child = await common.spawnPromisified(process.execPath, [
+    '--expose-internals',
+    '-e', script,
+  ], {
+    env: { FORCE_COLOR: 1 },
+    stdio: 'pipe'
+  });
+
+  t.assert.strictEqual(child.stderr, '');
+  t.assert.strictEqual(child.code, 0);
+});


### PR DESCRIPTION
Fixes #52249

`internal/util/colors` has been ignoring `FORCE_COLOR` if the terminal is not a TTY terminal. This PR changes that behavior to allow `FORCE_COLOR` to, well, force colors.;