### PR TITLE
src: update compile cache storage structure

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1129,15 +1129,36 @@ void Environment::InitializeCompileCache() {
       dir_from_env.empty()) {
     return;
   }
-  auto handler = std::make_unique<CompileCacheHandler>(this);
-  if (handler->InitializeDirectory(this, dir_from_env)) {
-    compile_cache_handler_ = std::move(handler);
-    AtExit(
-        [](void* env) {
-          static_cast<Environment*>(env)->compile_cache_handler()->Persist();
-        },
-        this);
+  EnableCompileCache(dir_from_env);
+}
+
+CompileCacheEnableResult Environment::EnableCompileCache(
+    const std::string& cache_dir) {
+  CompileCacheEnableResult result;
+
+  if (!compile_cache_handler_) {
+    std::unique_ptr<CompileCacheHandler> handler =
+        std::make_unique<CompileCacheHandler>(this);
+    result = handler->Enable(this, cache_dir);
+    if (result.status == CompileCacheEnableStatus::kEnabled) {
+      compile_cache_handler_ = std::move(handler);
+      AtExit(
+          [](void* env) {
+            static_cast<Environment*>(env)->compile_cache_handler()->Persist();
+          },
+          this);
+    }
+    if (!result.message.empty()) {
+      Debug(this,
+            DebugCategory::COMPILE_CACHE,
+            "[compile cache] %s\n",
+            result.message);
+    }
+  } else {
+    result.status = CompileCacheEnableStatus::kAlreadyEnabled;
+    result.cache_directory = compile_cache_handler_->cache_dir();
   }
+  return result;
 }
 
 void Environment::ExitEnv(StopFlags::Flags flags) {

--- a/src/env.h
+++ b/src/env.h
@@ -1028,6 +1028,9 @@ class Environment final : public MemoryRetainer {
   inline CompileCacheHandler* compile_cache_handler();
   inline bool use_compile_cache() const;
   void InitializeCompileCache();
+  // Enable built-in compile cache if it has not yet been enabled.
+  // The cache will be persisted to disk on exit.
+  CompileCacheEnableResult EnableCompileCache(const std::string& cache_dir);
 
   void RunAndClearNativeImmediates(bool only_refed = false);
   void RunAndClearInterrupts();

--- a/test/parallel/test-compile-cache-permission-disallowed.js
+++ b/test/parallel/test-compile-cache-permission-disallowed.js
@@ -39,7 +39,7 @@ function testDisallowed(dummyDir, cacheDirInPermission, cacheDirInEnv) {
     },
     {
       stderr(output) {
-        assert.match(output, /skipping cache because write permission for .* is not granted/);
+        assert.match(output, /Skipping compile cache because write permission for .* is not granted/);
         return true;
       }
     });
@@ -63,7 +63,7 @@ function testDisallowed(dummyDir, cacheDirInPermission, cacheDirInEnv) {
     },
     {
       stderr(output) {
-        assert.match(output, /skipping cache because write permission for .* is not granted/);
+        assert.match(output, /Skipping compile cache because write permission for .* is not granted/);
         return true;
       }
     });
@@ -86,7 +86,7 @@ function testDisallowed(dummyDir, cacheDirInPermission, cacheDirInEnv) {
     },
     {
       stderr(output) {
-        assert.match(output, /skipping cache because read permission for .* is not granted/);
+        assert.match(output, /Skipping compile cache because read permission for .* is not granted/);
         return true;
       }
     });


### PR DESCRIPTION
This refactors the compile cache handler in preparation for the JS API, and updates the compile cache storage structure into:

```
- $NODE_COMPILE_CACHE_DIR
  - $NODE_VERION-$ARCH-$CACHE_DATA_VERSION_TAG-$UID
      - $FILENAME_AND_MODULE_TYPE_HASH.cache
```

This also adds a magic number to the beginning of the cache
files for verification, and returns the status, compile
cache directory and/or error message of enabling the
compile cache in a structure, which can be converted as
JS counterparts by the upcoming JS API.

Refs: https://github.com/nodejs/node/issues/53639

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
