### PR TITLE
tls: improve performance of getAllowUnauthorized

### DIFF
--- a/benchmark/tls/get-allow-unauthorized.js
+++ b/benchmark/tls/get-allow-unauthorized.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('assert');
+
+const options = {
+  flags: ['--expose-internals'],
+};
+
+const bench = common.createBenchmark(main, {
+  n: [1024 * 1024 * 16],
+}, options);
+
+function main({ n }) {
+  const { getAllowUnauthorized } = require('internal/options');
+
+  const length = 1024;
+  const array = new Array(length).fill(false);
+
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = getAllowUnauthorized();
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'boolean');
+  }
+}

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -7,6 +7,7 @@ const {
 } = internalBinding('options');
 
 let warnOnAllowUnauthorized = true;
+let allowUnauthorized = false;
 
 let optionsDict;
 let cliInfo;
@@ -47,15 +48,16 @@ function getOptionValue(optionName) {
 }
 
 function getAllowUnauthorized() {
-  const allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
-
-  if (allowUnauthorized && warnOnAllowUnauthorized) {
+  if (warnOnAllowUnauthorized) {
     warnOnAllowUnauthorized = false;
-    process.emitWarning(
-      'Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
-      'environment variable to \'0\' makes TLS connections ' +
-      'and HTTPS requests insecure by disabling ' +
-      'certificate verification.');
+    allowUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0';
+    if (allowUnauthorized) {
+      process.emitWarning(
+        'Setting the NODE_TLS_REJECT_UNAUTHORIZED ' +
+        'environment variable to \'0\' makes TLS connections ' +
+        'and HTTPS requests insecure by disabling ' +
+        'certificate verification.');
+    }
   }
   return allowUnauthorized;
 }


### PR DESCRIPTION
Improves the performance of getAllowUnauthorized. It is called on every call of tls connect.

before:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ node ./benchmark/tls/get-allow-unauthorized.js 
tls/get-allow-unauthorized.js n=16777216: 4,760,304.7689979095
```

after:
```sh
aras@aras-Lenovo-Legion-5-17ARH05H:~/workspace/node$ ./node ./benchmark/tls/get-allow-unauthorized.js 
tls/get-allow-unauthorized.js n=16777216: 169,041,177.4754851
```