### PR TITLE
tls: Server should generate lazily create sessionIdContext

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -116,6 +116,18 @@ const noop = () => {};
 let ipServernameWarned = false;
 let tlsTracingWarned = false;
 
+let defaultSessionIdContext = null;
+
+function lazyDefaultSessionIdContext() {
+  if (defaultSessionIdContext === null) {
+    defaultSessionIdContext = crypto.createHash('sha1')
+    .update(process.argv.length === 1 ? process.argv[0] : process.argv.join(' '))
+    .digest('hex')
+    .slice(0, 32);
+  }
+  return defaultSessionIdContext;
+}
+
 // Server side times how long a handshake is taking to protect against slow
 // handshakes being used for DoS.
 function onhandshakestart(now) {
@@ -1472,10 +1484,7 @@ Server.prototype.setSecureContext = function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = crypto.createHash('sha1')
-      .update(process.argv.join(' '))
-      .digest('hex')
-      .slice(0, 32);
+    this.sessionIdContext = lazyDefaultSessionIdContext();
   }
 
   if (options.sessionTimeout)
@@ -1570,10 +1579,7 @@ Server.prototype.setOptions = deprecate(function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = crypto.createHash('sha1')
-      .update(process.argv.join(' '))
-      .digest('hex')
-      .slice(0, 32);
+    this.sessionIdContext = lazyDefaultSessionIdContext();
   }
   if (options.pskCallback) this[kPskCallback] = options.pskCallback;
   if (options.pskIdentityHint) this[kPskIdentityHint] = options.pskIdentityHint;


### PR DESCRIPTION
Probably not significant as you usually only start a Server per instance, but providing it for discussion. 