### PR TITLE
build: Allow to use atomic builtins from compiler-rt instead of libatomic

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -510,7 +510,7 @@
           '-Wl,-bnoerrmsg',
         ],
       }],
-      ['OS=="linux" and clang==1', {
+      ['OS=="linux" and clang==1 and compiler_rt_atomics!=1', {
         'libraries': ['-latomic'],
       }],
     ],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1298,7 +1298,7 @@
         }],
         # Platforms that don't have Compare-And-Swap (CAS) support need to link atomic library
         # to implement atomic memory access
-        ['v8_current_cpu in ["mips64", "mips64el", "ppc", "arm", "riscv64", "loong64"]', {
+        ['compiler_rt_atomics!=1 and v8_current_cpu in ["mips64", "mips64el", "ppc", "arm", "riscv64", "loong64"]', {
           'link_settings': {
             'libraries': ['-latomic', ],
           },


### PR DESCRIPTION
compiler-rt, when it's built with the `COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN` option disabled, provides all atomic builtins and serves as a full replacement for libatomic.

By default, that option is enabled[0], meaning that default builds of compiler-rt, followed by the most of Linux distributions (Fedora, openSUSE, Ubuntu), do **not** provide all necessary atomics.

However, FreeBSD[1] and Gentoo (with LLVM-based profiles)[2] disable it, therefore providing compiler-rt with atomic builtins.

That difference can be detected by checking the symbol table of compiler-rt:

```
nm $(clang -print-libgcc-file-name) | grep __atomic
```

No matching symbols indicate lack of atomic builtins and necessity of linking libatomic. Matching symbols indicate a possibility to not link libatomic.

Given that difference, provide the `--use-compiler-rt-atomics` option in `configure.py`. When enabled, the configure script checks whether compiler-rt provides atomics and, if yes, does not link libatomic. By default, without that option enabled, a build with clang links libatomic.

For more context, see the discussion on Gentoo bugzilla[3].

[0] https://github.com/llvm/llvm-project/blob/llvmorg-19.1.6/compiler-rt/lib/builtins/CMakeLists.txt#L227-L229
[1] https://cgit.freebsd.org/src/commit/?id=7b67d47c70cca47f65fbbc9d8607b7516c2a82ee
[2] https://github.com/gentoo/gentoo/commit/63b4ae7aaa6e520706e1237b649d8fe29f5aba83
[3] https://bugs.gentoo.org/911340

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
