### PR TITLE
benchmark: add stream.compose benchmark

### DIFF
--- a/benchmark/streams/compose.js
+++ b/benchmark/streams/compose.js
@@ -1,0 +1,42 @@
+'use strict';
+const common = require('../common.js');
+
+const {
+  PassThrough,
+  Readable,
+  Writable,
+  compose,
+} = require('node:stream');
+
+const bench = common.createBenchmark(main, {
+  n: [1e3],
+});
+
+function main({ n }) {
+  const cachedPassThroughs = [];
+  const cachedReadables = [];
+  const cachedWritables = [];
+
+  for (let i = 0; i < n; i++) {
+    const numberOfPassThroughs = 100;
+    const passThroughs = [];
+
+    for (let i = 0; i < numberOfPassThroughs; i++) {
+      passThroughs.push(new PassThrough());
+    }
+
+    const readable = Readable.from(['hello', 'world']);
+    const writable = new Writable({ objectMode: true, write: (chunk, encoding, cb) => cb() });
+
+    cachedPassThroughs.push(passThroughs);
+    cachedReadables.push(readable);
+    cachedWritables.push(writable);
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    const composed = compose(cachedReadables[i], ...cachedPassThroughs[i], cachedWritables[i]);
+    composed.end();
+  }
+  bench.end(n);
+}


### PR DESCRIPTION
Initiated the benchmark to `stream.compose`.

This PR should unblock PR - https://github.com/nodejs/node/pull/54053 which was requested benchmark for the changes.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
