### PR TITLE
buffer: use fast API for writing one-byte strings

### DIFF
--- a/benchmark/buffers/buffer-write-string-short.js
+++ b/benchmark/buffers/buffer-write-string-short.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const common = require('../common.js');
+const bench = common.createBenchmark(main, {
+  encoding: [
+    'utf8', 'ascii', 'latin1',
+  ],
+  len: [1, 8, 16, 32],
+  n: [1e6],
+});
+
+function main({ len, n, encoding }) {
+  const buf = Buffer.allocUnsafe(len);
+  const string = Buffer.from('a'.repeat(len)).toString();
+  bench.start();
+  for (let i = 0; i < n; ++i) {
+    buf.write(string, 0, encoding);
+  }
+  bench.end(n);
+}

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -23,13 +23,13 @@ const {
   hexSlice,
   ucs2Slice,
   utf8Slice,
-  asciiWrite,
+  asciiWriteStatic,
   base64Write,
   base64urlWrite,
-  latin1Write,
+  latin1WriteStatic,
   hexWrite,
   ucs2Write,
-  utf8Write,
+  utf8WriteStatic,
   getZeroFillToggle,
 } = internalBinding('buffer');
 
@@ -1036,13 +1036,37 @@ function addBufferPrototypeMethods(proto) {
   proto.hexSlice = hexSlice;
   proto.ucs2Slice = ucs2Slice;
   proto.utf8Slice = utf8Slice;
-  proto.asciiWrite = asciiWrite;
+  proto.asciiWrite = function(string, offset = 0, length = this.byteLength) {
+    if (offset < 0 || offset > this.byteLength) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
+    }
+    if (length < 0 || length > this.byteLength - offset) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
+    }
+    return asciiWriteStatic(this, string, offset, length);
+  };
   proto.base64Write = base64Write;
   proto.base64urlWrite = base64urlWrite;
-  proto.latin1Write = latin1Write;
+  proto.latin1Write = function(string, offset = 0, length = this.byteLength) {
+    if (offset < 0 || offset > this.byteLength) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
+    }
+    if (length < 0 || length > this.byteLength - offset) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
+    }
+    return latin1WriteStatic(this, string, offset, length);
+  };
   proto.hexWrite = hexWrite;
   proto.ucs2Write = ucs2Write;
-  proto.utf8Write = utf8Write;
+  proto.utf8Write = function(string, offset = 0, length = this.byteLength) {
+    if (offset < 0 || offset > this.byteLength) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
+    }
+    if (length < 0 || length > this.byteLength - offset) {
+      throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
+    }
+    return utf8WriteStatic(this, string, offset, length);
+  };
 }
 
 // This would better be placed in internal/worker/io.js, but that doesn't work

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1425,6 +1425,52 @@ void CopyArrayBuffer(const FunctionCallbackInfo<Value>& args) {
   memcpy(dest, src, bytes_to_copy);
 }
 
+template <encoding encoding>
+void SlowWriteString(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+
+  THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
+  SPREAD_BUFFER_ARG(args[0], ts_obj);
+
+  THROW_AND_RETURN_IF_NOT_STRING(env, args[1], "argument");
+
+  Local<String> str = args[1]->ToString(env->context()).ToLocalChecked();
+
+  size_t offset = 0;
+  size_t max_length = 0;
+
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[2], 0, &offset));
+  THROW_AND_RETURN_IF_OOB(
+      ParseArrayIndex(env, args[3], ts_obj_length - offset, &max_length));
+
+  max_length = std::min(ts_obj_length - offset, max_length);
+
+  if (max_length == 0) return args.GetReturnValue().Set(0);
+
+  uint32_t written = StringBytes::Write(
+      env->isolate(), ts_obj_data + offset, max_length, str, encoding);
+  args.GetReturnValue().Set(written);
+}
+
+uint32_t FastWriteString(Local<Value> receiver,
+                         const v8::FastApiTypedArray<uint8_t>& dst,
+                         const v8::FastOneByteString& src,
+                         uint32_t offset,
+                         uint32_t max_length) {
+  uint8_t* dst_data;
+  CHECK(dst.getStorageIfAligned(&dst_data));
+  CHECK(offset <= dst.length());
+  CHECK(dst.length() - offset <= std::numeric_limits<uint32_t>::max());
+
+  max_length = std::min<uint32_t>(dst.length() - offset, max_length);
+
+  memcpy(dst_data, src.data, max_length);
+
+  return max_length;
+}
+
+static v8::CFunction fast_write_string(v8::CFunction::Make(FastWriteString));
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -1486,13 +1532,26 @@ void Initialize(Local<Object> target,
   SetMethodNoSideEffect(context, target, "ucs2Slice", StringSlice<UCS2>);
   SetMethodNoSideEffect(context, target, "utf8Slice", StringSlice<UTF8>);
 
-  SetMethod(context, target, "asciiWrite", StringWrite<ASCII>);
   SetMethod(context, target, "base64Write", StringWrite<BASE64>);
   SetMethod(context, target, "base64urlWrite", StringWrite<BASE64URL>);
-  SetMethod(context, target, "latin1Write", StringWrite<LATIN1>);
   SetMethod(context, target, "hexWrite", StringWrite<HEX>);
   SetMethod(context, target, "ucs2Write", StringWrite<UCS2>);
-  SetMethod(context, target, "utf8Write", StringWrite<UTF8>);
+
+  SetFastMethod(context,
+                target,
+                "asciiWriteStatic",
+                SlowWriteString<ASCII>,
+                &fast_write_string);
+  SetFastMethod(context,
+                target,
+                "latin1WriteStatic",
+                SlowWriteString<LATIN1>,
+                &fast_write_string);
+  SetFastMethod(context,
+                target,
+                "utf8WriteStatic",
+                SlowWriteString<UTF8>,
+                &fast_write_string);
 
   SetMethod(context, target, "getZeroFillToggle", GetZeroFillToggle);
 }
@@ -1535,6 +1594,11 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(StringSlice<UCS2>);
   registry->Register(StringSlice<UTF8>);
 
+  registry->Register(SlowWriteString<ASCII>);
+  registry->Register(SlowWriteString<LATIN1>);
+  registry->Register(SlowWriteString<UTF8>);
+  registry->Register(fast_write_string.GetTypeInfo());
+  registry->Register(FastWriteString);
   registry->Register(StringWrite<ASCII>);
   registry->Register(StringWrite<BASE64>);
   registry->Register(StringWrite<BASE64URL>);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -56,6 +56,13 @@ using CFunctionWithInt64Fallback = void (*)(v8::Local<v8::Value>,
                                             v8::FastApiCallbackOptions&);
 using CFunctionWithBool = void (*)(v8::Local<v8::Value>, bool);
 
+using CFunctionWriteString =
+    uint32_t (*)(v8::Local<v8::Value> receiver,
+                 const v8::FastApiTypedArray<uint8_t>& dst,
+                 const v8::FastOneByteString& src,
+                 uint32_t offset,
+                 uint32_t max_length);
+
 using CFunctionBufferCopy =
     uint32_t (*)(v8::Local<v8::Value> receiver,
                  const v8::FastApiTypedArray<uint8_t>& source,
@@ -88,6 +95,7 @@ class ExternalReferenceRegistry {
   V(CFunctionWithInt64Fallback)                                                \
   V(CFunctionWithBool)                                                         \
   V(CFunctionBufferCopy)                                                       \
+  V(CFunctionWriteString)                                                      \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \


### PR DESCRIPTION
```bash
                                                                        confidence improvement accuracy (*)    (**)   (***)
buffers/buffer-write-string-short.js n=1000000 len=0 encoding='ascii'          ***     65.81 %       ±5.23%  ±7.49% ±10.96%
buffers/buffer-write-string-short.js n=1000000 len=0 encoding='latin1'         ***     58.19 %      ±20.88% ±29.89% ±43.73%
buffers/buffer-write-string-short.js n=1000000 len=0 encoding='utf8'           ***     61.74 %      ±13.09% ±18.14% ±25.14%
buffers/buffer-write-string-short.js n=1000000 len=1 encoding='ascii'          ***    136.24 %      ±11.25% ±15.57% ±21.57%
buffers/buffer-write-string-short.js n=1000000 len=1 encoding='latin1'         ***    135.68 %      ±34.53% ±49.25% ±71.59%
buffers/buffer-write-string-short.js n=1000000 len=1 encoding='utf8'           ***    131.19 %      ±13.69% ±19.05% ±26.59%
buffers/buffer-write-string-short.js n=1000000 len=16 encoding='ascii'         ***    105.31 %      ±22.74% ±32.63% ±47.91%
buffers/buffer-write-string-short.js n=1000000 len=16 encoding='latin1'        ***    146.98 %      ±15.12% ±20.88% ±28.83%
buffers/buffer-write-string-short.js n=1000000 len=16 encoding='utf8'          ***    231.98 %      ±39.44% ±56.50% ±82.72%
buffers/buffer-write-string-short.js n=1000000 len=32 encoding='ascii'         ***    119.88 %      ±17.20% ±23.74% ±32.73%
buffers/buffer-write-string-short.js n=1000000 len=32 encoding='latin1'        ***    127.78 %      ±14.96% ±21.09% ±30.09%
buffers/buffer-write-string-short.js n=1000000 len=32 encoding='utf8'          ***    286.10 %      ±36.29% ±51.94% ±75.93%
buffers/buffer-write-string-short.js n=1000000 len=8 encoding='ascii'          ***    126.35 %      ±20.58% ±28.48% ±39.41%
buffers/buffer-write-string-short.js n=1000000 len=8 encoding='latin1'         ***    155.13 %       ±8.24% ±11.43% ±15.90%
buffers/buffer-write-string-short.js n=1000000 len=8 encoding='utf8'           ***    200.61 %      ±33.84% ±48.37% ±70.55%
```