### PR TITLE
buffer: optimize for common encodings

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1108,8 +1108,10 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
     }
   }
 
-  if (!encoding)
+  if (!encoding || encoding === 'utf8')
     return this.utf8Write(string, offset, length);
+  if (encoding === 'ascii')
+    return this.asciiWrite(string, offset, length);
 
   const ops = getEncodingOps(encoding);
   if (ops === undefined)


### PR DESCRIPTION
```bash
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding=''                                     1.57 %       ±3.62%  ±5.14%  ±7.43%
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding='ascii'                               15.20 %      ±15.73% ±22.38% ±32.38%
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding='hex'                                 -0.09 %       ±7.37% ±10.27% ±14.40%
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding='latin1'                              -4.73 %      ±10.22% ±14.41% ±20.57%
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding='utf16le'                             -8.02 %       ±8.35% ±11.69% ±16.51%
buffers/buffer-write-string.js n=1000000 len=0 args='' encoding='utf8'                          *     22.11 %      ±16.10% ±22.17% ±30.42%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding=''                              -3.03 %       ±9.49% ±13.45% ±19.34%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding='ascii'                 ***     34.58 %      ±12.90% ±18.51% ±27.19%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding='hex'                            3.37 %       ±6.78%  ±9.66% ±14.03%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding='latin1'                         5.20 %      ±16.43% ±23.36% ±33.79%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding='utf16le'                       -9.31 %      ±17.86% ±24.73% ±34.28%
buffers/buffer-write-string.js n=1000000 len=0 args='offset' encoding='utf8'                           8.72 %       ±9.78% ±13.89% ±20.08%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding=''                        3.50 %       ±5.23%  ±7.17%  ±9.77%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding='ascii'          ***     29.41 %      ±10.73% ±15.14% ±21.62%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding='hex'                    -5.13 %       ±6.74%  ±9.64% ±14.07%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding='latin1'                 -7.48 %      ±13.23% ±18.86% ±27.38%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding='utf16le'                 9.28 %      ±12.39% ±17.73% ±25.90%
buffers/buffer-write-string.js n=1000000 len=0 args='offset+length' encoding='utf8'                   11.86 %      ±12.92% ±18.38% ±26.61%
```