### PR TITLE
buffer: optimize createFromString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -59,7 +59,6 @@ const {
   compare: _compare,
   compareOffset,
   copy: _copy,
-  createFromString,
   fill: bindingFill,
   isAscii: bindingIsAscii,
   isUtf8: bindingIsUtf8,
@@ -150,11 +149,12 @@ const constants = ObjectDefineProperties({}, {
 });
 
 Buffer.poolSize = 8 * 1024;
-let poolSize, poolOffset, allocPool;
+let poolSize, poolOffset, allocPool, allocBuffer;
 
 function createPool() {
   poolSize = Buffer.poolSize;
-  allocPool = createUnsafeBuffer(poolSize).buffer;
+  allocBuffer = createUnsafeBuffer(poolSize);
+  allocPool = allocBuffer.buffer;
   markAsUntransferable(allocPool);
   poolOffset = 0;
 }
@@ -442,38 +442,49 @@ function allocate(size) {
 }
 
 function fromStringFast(string, ops) {
-  const length = ops.byteLength(string);
+  const maxLength = Buffer.poolSize >>> 1;
 
-  if (length >= (Buffer.poolSize >>> 1))
-    return createFromString(string, ops.encodingVal);
+  let length = string.length; // Min length
+
+  if (length >= maxLength)
+    return createFromString(string, ops);
+
+  length *= 4; // Max length (4 bytes per character)
+
+  if (length >= maxLength)
+    length = ops.byteLength(string); // Actual length
+
+  if (length >= maxLength)
+    return createFromString(string, ops, length);
 
   if (length > (poolSize - poolOffset))
     createPool();
-  let b = new FastBuffer(allocPool, poolOffset, length);
-  const actual = ops.write(b, string, 0, length);
-  if (actual !== length) {
-    // byteLength() may overestimate. That's a rare case, though.
-    b = new FastBuffer(allocPool, poolOffset, actual);
-  }
+
+  const actual = ops.write(allocBuffer, string, poolOffset, length);
+  const b = new FastBuffer(allocPool, poolOffset, actual);
+
   poolOffset += actual;
   alignPool();
   return b;
 }
 
+function createFromString(string, ops, length = ops.byteLength(string)) {
+  const buf = Buffer.allocUnsafeSlow(length);
+  const actual = ops.write(buf, string, 0, length);
+  return actual < length ? new FastBuffer(buf.buffer, 0, actual) : buf;
+}
+
 function fromString(string, encoding) {
   let ops;
-  if (typeof encoding !== 'string' || encoding.length === 0) {
-    if (string.length === 0)
-      return new FastBuffer();
+  if (!encoding || encoding === 'utf8') {
     ops = encodingOps.utf8;
   } else {
     ops = getEncodingOps(encoding);
     if (ops === undefined)
       throw new ERR_UNKNOWN_ENCODING(encoding);
-    if (string.length === 0)
-      return new FastBuffer();
   }
-  return fromStringFast(string, ops);
+
+  return string.length === 0 ? new FastBuffer() : fromStringFast(string, ops);
 }
 
 function fromArrayBuffer(obj, byteOffset, length) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -530,17 +530,6 @@ MaybeLocal<Object> New(Environment* env,
 
 namespace {
 
-void CreateFromString(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsString());
-  CHECK(args[1]->IsInt32());
-
-  enum encoding enc = static_cast<enum encoding>(args[1].As<Int32>()->Value());
-  Local<Object> buf;
-  if (New(args.GetIsolate(), args[0].As<String>(), enc).ToLocal(&buf))
-    args.GetReturnValue().Set(buf);
-}
-
-
 template <encoding encoding>
 void StringSlice(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -1436,7 +1425,6 @@ void Initialize(Local<Object> target,
   SetMethodNoSideEffect(context, target, "btoa", Btoa);
 
   SetMethod(context, target, "setBufferPrototype", SetBufferPrototype);
-  SetMethodNoSideEffect(context, target, "createFromString", CreateFromString);
 
   SetFastMethodNoSideEffect(context,
                             target,
@@ -1501,7 +1489,6 @@ void Initialize(Local<Object> target,
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetBufferPrototype);
-  registry->Register(CreateFromString);
 
   registry->Register(SlowByteLengthUtf8);
   registry->Register(fast_byte_length_utf8.GetTypeInfo());


### PR DESCRIPTION
```
buffers/buffer-from.js n=800000 len=100 source='array'                      ***     -2.41 %       ±0.75% ±0.99% ±1.29%
buffers/buffer-from.js n=800000 len=100 source='arraybuffer-middle'                  0.17 %       ±1.63% ±2.18% ±2.83%
buffers/buffer-from.js n=800000 len=100 source='arraybuffer'                        -0.98 %       ±1.29% ±1.72% ±2.24%
buffers/buffer-from.js n=800000 len=100 source='buffer'                     ***     -1.37 %       ±0.72% ±0.95% ±1.24%
buffers/buffer-from.js n=800000 len=100 source='object'                             -0.60 %       ±1.23% ±1.64% ±2.13%
buffers/buffer-from.js n=800000 len=100 source='string-base64'              ***      2.41 %       ±0.50% ±0.66% ±0.86%
buffers/buffer-from.js n=800000 len=100 source='string-utf8'                ***     49.55 %       ±0.67% ±0.89% ±1.16%
buffers/buffer-from.js n=800000 len=100 source='string'                     ***     45.78 %       ±0.75% ±1.00% ±1.30%
buffers/buffer-from.js n=800000 len=100 source='uint16array'                        -0.75 %       ±0.75% ±1.00% ±1.30%
buffers/buffer-from.js n=800000 len=100 source='uint8array'                 ***     -3.39 %       ±0.77% ±1.03% ±1.36%
buffers/buffer-from.js n=800000 len=2048 source='array'                     ***     -0.25 %       ±0.08% ±0.11% ±0.14%
buffers/buffer-from.js n=800000 len=2048 source='arraybuffer-middle'                 0.59 %       ±1.76% ±2.34% ±3.05%
buffers/buffer-from.js n=800000 len=2048 source='arraybuffer'                        0.51 %       ±1.62% ±2.16% ±2.81%
buffers/buffer-from.js n=800000 len=2048 source='buffer'                      *     -0.81 %       ±0.71% ±0.94% ±1.23%
buffers/buffer-from.js n=800000 len=2048 source='object'                            -0.22 %       ±0.90% ±1.20% ±1.56%
buffers/buffer-from.js n=800000 len=2048 source='string-base64'             ***     -1.20 %       ±0.34% ±0.45% ±0.59%
buffers/buffer-from.js n=800000 len=2048 source='string-utf8'               ***     -1.18 %       ±0.45% ±0.59% ±0.77%
buffers/buffer-from.js n=800000 len=2048 source='string'                    ***     -2.66 %       ±0.51% ±0.68% ±0.89%
buffers/buffer-from.js n=800000 len=2048 source='uint16array'               ***     -1.01 %       ±0.52% ±0.69% ±0.91%
buffers/buffer-from.js n=800000 len=2048 source='uint8array'                 **     -1.23 %       ±0.83% ±1.10% ±1.43%
```