### PR TITLE
path: change `posix.join` to use array

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1236,20 +1236,20 @@ const posix = {
   join(...args) {
     if (args.length === 0)
       return '.';
-    let joined;
+
+    const path = [];
     for (let i = 0; i < args.length; ++i) {
       const arg = args[i];
       validateString(arg, 'path');
       if (arg.length > 0) {
-        if (joined === undefined)
-          joined = arg;
-        else
-          joined += `/${arg}`;
+        path.push(arg);
       }
     }
-    if (joined === undefined)
+
+    if (path.length === 0)
       return '.';
-    return posix.normalize(joined);
+
+    return posix.normalize(ArrayPrototypeJoin(path, '/'));
   },
 
   /**


### PR DESCRIPTION
Change `posix.join` to use `array.join` instead of additional assignment.

```
                                                               confidence improvement accuracy (*)   (**)  (***)
path/join-posix.js n=100000 paths='/foo|bar||baz/asdf|quux|..'        ***      5.95 %       ±1.42% ±1.90% ±2.49%
```