### PR TITLE
sqlite: return results with null prototype

### DIFF
--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -80,8 +80,8 @@ class StatementSync : public BaseObject {
   std::optional<std::map<std::string, std::string>> bare_named_params_;
   bool BindParams(const v8::FunctionCallbackInfo<v8::Value>& args);
   bool BindValue(const v8::Local<v8::Value>& value, const int index);
-  v8::Local<v8::Value> ColumnToValue(const int column);
-  v8::Local<v8::Value> ColumnNameToValue(const int column);
+  v8::MaybeLocal<v8::Value> ColumnToValue(const int column);
+  v8::MaybeLocal<v8::Name> ColumnNameToName(const int column);
 };
 
 }  // namespace sqlite

--- a/test/parallel/test-sqlite-data-types.js
+++ b/test/parallel/test-sqlite-data-types.js
@@ -49,6 +49,7 @@ suite('data binding and mapping', () => {
 
     const query = db.prepare('SELECT * FROM types WHERE key = ?');
     t.assert.deepStrictEqual(query.get(1), {
+      __proto__: null,
       key: 1,
       int: 42,
       double: 3.14159,
@@ -56,6 +57,7 @@ suite('data binding and mapping', () => {
       buf: u8a,
     });
     t.assert.deepStrictEqual(query.get(2), {
+      __proto__: null,
       key: 2,
       int: null,
       double: null,
@@ -63,6 +65,7 @@ suite('data binding and mapping', () => {
       buf: null,
     });
     t.assert.deepStrictEqual(query.get(3), {
+      __proto__: null,
       key: 3,
       int: 8,
       double: 2.718,
@@ -70,6 +73,7 @@ suite('data binding and mapping', () => {
       buf: new TextEncoder().encode('x☃y☃'),
     });
     t.assert.deepStrictEqual(query.get(4), {
+      __proto__: null,
       key: 4,
       int: 99,
       double: 0xf,
@@ -151,7 +155,7 @@ suite('data binding and mapping', () => {
     );
     t.assert.deepStrictEqual(
       db.prepare('SELECT * FROM data ORDER BY key').all(),
-      [{ key: 1, val: 5 }, { key: 2, val: null }],
+      [{ __proto__: null, key: 1, val: 5 }, { __proto__: null, key: 2, val: null }],
     );
   });
 });

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -143,8 +143,8 @@ suite('DatabaseSync.prototype.exec()', () => {
     t.assert.strictEqual(result, undefined);
     const stmt = db.prepare('SELECT * FROM data ORDER BY key');
     t.assert.deepStrictEqual(stmt.all(), [
-      { key: 1, val: 2 },
-      { key: 8, val: 9 },
+      { __proto__: null, key: 1, val: 2 },
+      { __proto__: null, key: 8, val: 9 },
     ]);
   });
 

--- a/test/parallel/test-sqlite-named-parameters.js
+++ b/test/parallel/test-sqlite-named-parameters.js
@@ -42,7 +42,7 @@ suite('named parameters', () => {
     stmt.run({ k: 1, v: 9 });
     t.assert.deepStrictEqual(
       db.prepare('SELECT * FROM data').get(),
-      { key: 1, val: 9 },
+      { __proto__: null, key: 1, val: 9 },
     );
   });
 
@@ -57,7 +57,7 @@ suite('named parameters', () => {
     stmt.run({ k: 1 });
     t.assert.deepStrictEqual(
       db.prepare('SELECT * FROM data').get(),
-      { key: 1, val: 1 },
+      { __proto__: null, key: 1, val: 1 },
     );
   });
 

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -43,7 +43,15 @@ suite('StatementSync.prototype.get()', () => {
     t.assert.strictEqual(stmt.get('key1', 'val1'), undefined);
     t.assert.strictEqual(stmt.get('key2', 'val2'), undefined);
     stmt = db.prepare('SELECT * FROM storage ORDER BY key');
-    t.assert.deepStrictEqual(stmt.get(), { key: 'key1', val: 'val1' });
+    t.assert.deepStrictEqual(stmt.get(), { __proto__: null, key: 'key1', val: 'val1' });
+  });
+
+  test('executes a query that returns special columns', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    const stmt = db.prepare('SELECT 1 as __proto__, 2 as constructor, 3 as toString');
+    // eslint-disable-next-line no-dupe-keys
+    t.assert.deepStrictEqual(stmt.get(), { __proto__: null, ['__proto__']: 1, constructor: 2, toString: 3 });
   });
 });
 
@@ -71,8 +79,8 @@ suite('StatementSync.prototype.all()', () => {
     );
     stmt = db.prepare('SELECT * FROM storage ORDER BY key');
     t.assert.deepStrictEqual(stmt.all(), [
-      { key: 'key1', val: 'val1' },
-      { key: 'key2', val: 'val2' },
+      { __proto__: null, key: 'key1', val: 'val1' },
+      { __proto__: null, key: 'key2', val: 'val2' },
     ]);
   });
 });
@@ -171,11 +179,11 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
     t.assert.strictEqual(setup, undefined);
 
     const query = db.prepare('SELECT val FROM data');
-    t.assert.deepStrictEqual(query.get(), { val: 42 });
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: 42 });
     t.assert.strictEqual(query.setReadBigInts(true), undefined);
-    t.assert.deepStrictEqual(query.get(), { val: 42n });
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: 42n });
     t.assert.strictEqual(query.setReadBigInts(false), undefined);
-    t.assert.deepStrictEqual(query.get(), { val: 42 });
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: 42 });
 
     const insert = db.prepare('INSERT INTO data (key) VALUES (?)');
     t.assert.deepStrictEqual(
@@ -223,6 +231,7 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
     const good = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
     good.setReadBigInts(true);
     t.assert.deepStrictEqual(good.get(), {
+      __proto__: null,
       [`${Number.MAX_SAFE_INTEGER} + 1`]: 2n ** 53n,
     });
   });

--- a/test/parallel/test-sqlite-transactions.js
+++ b/test/parallel/test-sqlite-transactions.js
@@ -37,7 +37,7 @@ suite('manual transactions', () => {
     );
     t.assert.deepStrictEqual(
       db.prepare('SELECT * FROM data').all(),
-      [{ key: 100 }],
+      [{ __proto__: null, key: 100 }],
     );
   });
 

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -77,11 +77,11 @@ test('in-memory databases are supported', (t) => {
   t.assert.strictEqual(setup2, undefined);
   t.assert.deepStrictEqual(
     db1.prepare('SELECT * FROM data').all(),
-    [{ key: 1 }]
+    [{ __proto__: null, key: 1 }]
   );
   t.assert.deepStrictEqual(
     db2.prepare('SELECT * FROM data').all(),
-    [{ key: 1 }]
+    [{ __proto__: null, key: 1 }]
   );
 });
 
@@ -90,10 +90,10 @@ test('PRAGMAs are supported', (t) => {
   t.after(() => { db.close(); });
   t.assert.deepStrictEqual(
     db.prepare('PRAGMA journal_mode = WAL').get(),
-    { journal_mode: 'wal' },
+    { __proto__: null, journal_mode: 'wal' },
   );
   t.assert.deepStrictEqual(
     db.prepare('PRAGMA journal_mode').get(),
-    { journal_mode: 'wal' },
+    { __proto__: null, journal_mode: 'wal' },
   );
 });


### PR DESCRIPTION
These objects are dictionaries, and a query can return columns with
special names like `__proto__` (which would be ignored without this
change).

Also construct the object by passing vectors of properties for better
performance and improve error handling by using `MaybeLocal`.
