### PR TITLE
net: replaced RegExpPrototypeTest with RegExpPrototypeExec for ip check

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -2,7 +2,7 @@
 
 const {
   RegExp,
-  RegExpPrototypeTest,
+  RegExpPrototypeExec,
   Symbol,
 } = primordials;
 
@@ -31,17 +31,11 @@ const IPv6Reg = new RegExp('^(?:' +
 ')(?:%[0-9a-zA-Z-.:]{1,})?$');
 
 function isIPv4(s) {
-  // TODO(aduh95): Replace RegExpPrototypeTest with RegExpPrototypeExec when it
-  // no longer creates a perf regression in the dns benchmark.
-  // eslint-disable-next-line node-core/avoid-prototype-pollution
-  return RegExpPrototypeTest(IPv4Reg, s);
+  return RegExpPrototypeExec(IPv4Reg, s) !== null;
 }
 
 function isIPv6(s) {
-  // TODO(aduh95): Replace RegExpPrototypeTest with RegExpPrototypeExec when it
-  // no longer creates a perf regression in the dns benchmark.
-  // eslint-disable-next-line node-core/avoid-prototype-pollution
-  return RegExpPrototypeTest(IPv6Reg, s);
+  return RegExpPrototypeExec(IPv6Reg, s) !== null;
 }
 
 function isIP(s) {


### PR DESCRIPTION
Took care of the todo in `lib/internal/net.js` which suggested to replace `RegExpPrototypeTest` with `RegExpPrototypeExec` when checking for the IP version. 

I am not sure if it no longer creates a perf regression in the dns benchmark; I ran the benchmark locally and everything looks fine, I guess I need a CI to verify it.