### PR TITLE
build: update required python version to 3.8

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -668,7 +668,7 @@ packages:
 
 * [Git for Windows](https://chocolatey.org/packages/git) with the `git` and
   Unix tools added to the `PATH`
-* [A supported version of Python][Python versions]
+* [Python 3.x](https://chocolatey.org/packages/python)
 * [Visual Studio 2022 Build Tools](https://chocolatey.org/packages/visualstudio2022buildtools)
   with [Visual C++ workload](https://chocolatey.org/packages/visualstudio2022-workload-vctools)
 * [NetWide Assembler](https://chocolatey.org/packages/nasm)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -223,7 +223,7 @@ Consult previous versions of this document for older versions of Node.js:
 
 ### Prerequisites
 
-* Python support: the Node.js project supports Python >= 3.6 for building and testing.
+* Python support: the Node.js project supports Python >= 3.8 for building and testing.
 * Memory: at least 8GB of RAM is typically required when compiling with 4 parallel jobs (e.g: `make -j4`)
 
 ### Unix and macOS
@@ -668,7 +668,7 @@ packages:
 
 * [Git for Windows](https://chocolatey.org/packages/git) with the `git` and
   Unix tools added to the `PATH`
-* [Python 3.x](https://chocolatey.org/packages/python)
+* [Python 3.8+](https://chocolatey.org/packages/python)
 * [Visual Studio 2022 Build Tools](https://chocolatey.org/packages/visualstudio2022buildtools)
   with [Visual C++ workload](https://chocolatey.org/packages/visualstudio2022-workload-vctools)
 * [NetWide Assembler](https://chocolatey.org/packages/nasm)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -223,7 +223,7 @@ Consult previous versions of this document for older versions of Node.js:
 
 ### Prerequisites
 
-* Python support: the Node.js project supports Python >= 3.8 for building and testing.
+* [A supported version of Python][Python versions] for building and testing.
 * Memory: at least 8GB of RAM is typically required when compiling with 4 parallel jobs (e.g: `make -j4`)
 
 ### Unix and macOS

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -668,7 +668,7 @@ packages:
 
 * [Git for Windows](https://chocolatey.org/packages/git) with the `git` and
   Unix tools added to the `PATH`
-* [Python 3.8+](https://chocolatey.org/packages/python)
+* [A supported version of Python][Python versions]
 * [Visual Studio 2022 Build Tools](https://chocolatey.org/packages/visualstudio2022buildtools)
   with [Visual C++ workload](https://chocolatey.org/packages/visualstudio2022-workload-vctools)
 * [NetWide Assembler](https://chocolatey.org/packages/nasm)

--- a/android-configure
+++ b/android-configure
@@ -8,8 +8,6 @@ command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
 command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
 command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
-command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
-command -v python3.6 >/dev/null && exec python3.6 "$0" "$@"
 command -v python3 >/dev/null && exec python3 "$0" "$@"
 exec python "$0" "$@"
 ''' "$0" "$@"
@@ -23,7 +21,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
+acceptable_pythons = ((3, 11), (3, 10), (3, 9), (3, 8))
 if sys.version_info[:2] in acceptable_pythons:
   import android_configure
 else:

--- a/configure
+++ b/configure
@@ -10,8 +10,6 @@ command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
 command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
 command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
-command -v python3.7 >/dev/null && exec python3.7 "$0" "$@"
-command -v python3.6 >/dev/null && exec python3.6 "$0" "$@"
 command -v python3 >/dev/null && exec python3 "$0" "$@"
 exec python "$0" "$@"
 ''' "$0" "$@"
@@ -25,7 +23,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
+acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:

--- a/configure.py
+++ b/configure.py
@@ -2127,7 +2127,7 @@ def make_bin_override():
   if sys.platform == 'win32':
     raise Exception('make_bin_override should not be called on win32.')
   # If the system python is not the python we are running (which should be
-  # python 3), then create a directory with a symlink called `python` to our
+  # python 3.8+), then create a directory with a symlink called `python` to our
   # sys.executable. This directory will be prefixed to the PATH, so that
   # other tools that shell out to `python` will use the appropriate python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ exclude = [
   "tools/eslint/node_modules",
 ]
 line-length = 172
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Closes #54112

> Configure scripts use := operator now, which requires python 3.8.
> 
> File "tools/gyp/pylib/gyp/common.py", line 435 if CC := os.environ.get("CC_target") or os.environ.get("CC"):