### PR TITLE
fs: refactor handleTimestampsAndMode to remove redundant call

### DIFF
--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -270,7 +270,6 @@ async function handleTimestampsAndMode(srcMode, src, dest) {
   // (through utimes call)
   if (fileIsNotWritable(srcMode)) {
     await makeFileWritable(dest, srcMode);
-    return setDestTimestampsAndMode(srcMode, src, dest);
   }
   return setDestTimestampsAndMode(srcMode, src, dest);
 }


### PR DESCRIPTION
This pull request refactors the `handleTimestampsAndMode` function in the `fs` subsystem to eliminate the redundant call to `setDestTimestampsAndMode`.