### PR TITLE
fs: improve signal abortion check in read method

### DIFF
--- a/lib/internal/fs/read/context.js
+++ b/lib/internal/fs/read/context.js
@@ -83,14 +83,15 @@ class ReadFileContext {
   }
 
   read() {
-    let buffer;
-    let offset;
-    let length;
-
     if (this.signal?.aborted) {
       return this.close(
         new AbortError(undefined, { cause: this.signal?.reason }));
     }
+
+    let buffer;
+    let offset;
+    let length;
+
     if (this.size === 0) {
       buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);
       offset = 0;


### PR DESCRIPTION
Moved the signal abortion check to the start of the read method to ensure that the function exits early if the signal is already aborted.
This change improves readability and prevents unnecessary execution when the operation is aborted.