### PR TITLE
test: make snapshot comparison more flexible

### DIFF
--- a/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
+++ b/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
@@ -8,5 +8,5 @@
     at *
     at *
     at *
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use `* --trace-warnings ...` to show where the warning was created)
 (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/fixtures/errors/throw_error_with_getter_throw.snapshot
+++ b/test/fixtures/errors/throw_error_with_getter_throw.snapshot
@@ -3,6 +3,6 @@
 throw {  * eslint-disable-line no-throw-literal
 ^
 [object Object]
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/errors/throw_null.snapshot
+++ b/test/fixtures/errors/throw_null.snapshot
@@ -3,6 +3,6 @@
 throw null;
 ^
 null
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/errors/throw_undefined.snapshot
+++ b/test/fixtures/errors/throw_undefined.snapshot
@@ -3,6 +3,6 @@
 throw undefined;
 ^
 undefined
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use `* --trace-uncaught ...` to show where the exception was thrown)
 
 Node.js *

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -3,6 +3,7 @@ import * as fixtures from '../common/fixtures.mjs';
 import * as snapshot from '../common/assertSnapshot.js';
 import * as os from 'node:os';
 import { describe, it } from 'node:test';
+import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const skipForceColors =
@@ -20,13 +21,15 @@ function replaceForceColorsStackTrace(str) {
 
 describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
+    const baseName = basename(process.argv0 || 'node', '.exe');
     return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
       .replaceAll(pathToFileURL(process.cwd()).pathname, '')
       .replaceAll('//', '*')
       .replaceAll(/\/(\w)/g, '*$1')
       .replaceAll('*test*', '*')
       .replaceAll('*fixtures*errors*', '*')
-      .replaceAll('file:**', 'file:*/');
+      .replaceAll('file:**', 'file:*/')
+      .replaceAll(`${baseName} --`, '* --');
   }
 
   function normalizeNoNumbers(str) {


### PR DESCRIPTION
This PR makes snapshot testing slightly more flexible so that embedders can run smoke tests against it.

Previous similar PR: https://github.com/nodejs/node/pull/36489
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
