### PR TITLE
lib: reword `--trace-*` message

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -91,7 +91,7 @@ To allow access to the file system, use the [`--allow-fs-read`][] and
 $ node --experimental-permission --allow-fs-read=* --allow-fs-write=* index.js
 Hello world!
 (node:19836) ExperimentalWarning: Permission is an experimental feature
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use the `--trace-warnings` flag to show where the warning was created)
 ```
 
 The valid arguments for both flags are:

--- a/lib/internal/process/warning.js
+++ b/lib/internal/process/warning.js
@@ -129,9 +129,7 @@ function onWarning(warning) {
   }
   if (!trace && !traceWarningHelperShown) {
     const flag = isDeprecation ? '--trace-deprecation' : '--trace-warnings';
-    const argv0 = require('path').basename(process.argv0 || 'node', '.exe');
-    msg += `\n(Use \`${argv0} ${flag} ...\` to show where the warning ` +
-           'was created)';
+    msg += `\n(Use the \`${flag}\` flag to show where the warning was created)`;
     traceWarningHelperShown = true;
   }
   const warningFile = lazyOption();

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -536,14 +536,9 @@ static void ReportFatalException(Environment* env,
     }
 
     if (!env->options()->trace_uncaught) {
-      std::string argv0;
-      if (!env->argv().empty()) argv0 = env->argv()[0];
-      if (argv0.empty()) argv0 = "node";
-      auto filesystem_path = std::filesystem::path(argv0).replace_extension();
       FPrintF(stderr,
-              "(Use `%s --trace-uncaught ...` to show where the exception "
-              "was thrown)\n",
-              filesystem_path.filename().string());
+              "(Use the `--trace-uncaught` flag to show where the exception "
+              "was thrown)\n");
     }
   }
 

--- a/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
+++ b/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
@@ -8,5 +8,5 @@
     at *
     at *
     at *
-(Use `node --trace-warnings ...` to show where the warning was created)
+(Use the `--trace-warnings` flag to show where the warning was created)
 (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/fixtures/errors/throw_error_with_getter_throw.snapshot
+++ b/test/fixtures/errors/throw_error_with_getter_throw.snapshot
@@ -3,6 +3,6 @@
 throw {  * eslint-disable-line no-throw-literal
 ^
 [object Object]
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught ...` flag to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/errors/throw_error_with_getter_throw.snapshot
+++ b/test/fixtures/errors/throw_error_with_getter_throw.snapshot
@@ -3,6 +3,6 @@
 throw {  * eslint-disable-line no-throw-literal
 ^
 [object Object]
-(Use the `--trace-uncaught ...` flag to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/errors/throw_null.snapshot
+++ b/test/fixtures/errors/throw_null.snapshot
@@ -3,6 +3,6 @@
 throw null;
 ^
 null
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/errors/throw_undefined.snapshot
+++ b/test/fixtures/errors/throw_undefined.snapshot
@@ -3,6 +3,6 @@
 throw undefined;
 ^
 undefined
-(Use `node --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *

--- a/test/fixtures/v8/v8_warning.snapshot
+++ b/test/fixtures/v8/v8_warning.snapshot
@@ -1,2 +1,2 @@
 (node:*) V8: *v8_warning.js:* Invalid asm.js: Invalid return type
-(Use `* --trace-warnings ...` to show where the warning was created)
+(Use the `--trace-warnings` flag to show where the warning was created)

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -63,7 +63,7 @@ Node.js *
 var ______________________________________________; throw 10
                                                     ^
 10
-(Use `* --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught ...` flag to show where the exception was thrown)
 
 Node.js *
 
@@ -71,7 +71,7 @@ Node.js *
 var ______________________________________________; throw 10
                                                     ^
 10
-(Use `* --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *
 done

--- a/test/message/eval_messages.out
+++ b/test/message/eval_messages.out
@@ -63,7 +63,7 @@ Node.js *
 var ______________________________________________; throw 10
                                                     ^
 10
-(Use the `--trace-uncaught ...` flag to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *
 

--- a/test/message/stdin_messages.out
+++ b/test/message/stdin_messages.out
@@ -75,7 +75,7 @@ Node.js *
 let ______________________________________________; throw 10
                                                     ^
 10
-(Use `* --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *
 
@@ -83,7 +83,7 @@ Node.js *
 let ______________________________________________; throw 10
                                                     ^
 10
-(Use `* --trace-uncaught ...` to show where the exception was thrown)
+(Use the `--trace-uncaught` flag to show where the exception was thrown)
 
 Node.js *
 done

--- a/test/parallel/test-snapshot-warning.js
+++ b/test/parallel/test-snapshot-warning.js
@@ -60,7 +60,7 @@ tmpdir.refresh();
     stderr(output) {
       let match = output.match(/Warning: test warning/g);
       assert.strictEqual(match.length, 1);
-      match = output.match(/Use `node --trace-warnings/g);
+      match = output.match(/Use the `--trace-warnings/g);
       assert.strictEqual(match.length, 1);
       return true;
     }
@@ -79,7 +79,7 @@ tmpdir.refresh();
       // Warnings should not be handled more than once.
       let match = output.match(/Warning: test warning/g);
       assert.strictEqual(match.length, 1);
-      match = output.match(/Use `node --trace-warnings/g);
+      match = output.match(/Use the `--trace-warnings/g);
       assert.strictEqual(match.length, 1);
       return true;
     }
@@ -114,7 +114,7 @@ tmpdir.refresh();
   console.log(warningFile1, ':', warnings1);
   let match = warnings1.match(/Warning: test warning/g);
   assert.strictEqual(match.length, 1);
-  match = warnings1.match(/Use `node --trace-warnings/g);
+  match = warnings1.match(/Use the `--trace-warnings/g);
   assert.strictEqual(match.length, 1);
   fs.rmSync(warningFile1, {
     maxRetries: 3, recursive: false, force: true
@@ -140,6 +140,6 @@ tmpdir.refresh();
   console.log(warningFile2, ':', warnings1);
   match = warnings2.match(/Warning: test warning/g);
   assert.strictEqual(match.length, 1);
-  match = warnings2.match(/Use `node --trace-warnings/g);
+  match = warnings2.match(/Use the `--trace-warnings/g);
   assert.strictEqual(match.length, 1);
 }

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
 *(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(Use the `--trace-warnings` flag to show where the warning was created)*

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
 *(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(Use the `--trace-warnings` flag to show where the warning was created)*

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
 *(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(Use the `--trace-warnings` flag to show where the warning was created)*


### PR DESCRIPTION
# Old

```console
$ node -e "punycode" 
(node:390852) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

# New

```console
$ node -e "punycode"                                                                                      
(node:390554) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use the `--trace-deprecation` flag to show where the warning was created)
```

---

This PR changes the way the `--trace-*` message is emitted, as there are cases where the command shown won't be the copmmand the user would like to execute.