### PR TITLE
doc: reserve ABI 130 for Electron 33

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 130,"runtime": "electron", "variant": "electron",             "versions": "33" },
     { "modules": 129,"runtime": "node",     "variant": "v8_12.8",              "versions": "23.0.0-pre" },
     { "modules": 128,"runtime": "electron", "variant": "electron",             "versions": "32" },
     { "modules": 127,"runtime": "node",     "variant": "v8_12.4",              "versions": "22.0.0" },


### PR DESCRIPTION
Hey folks! We're preparing for the Electron 32 release right now. As part of our regular process, I'm reserving a new ABI version for the next version of Electron. 😄