### PR TITLE
[v22.x] Revert "v8: enable maglev on supported architectures"

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -56,7 +56,6 @@ valid_mips_fpu = ('fp32', 'fp64', 'fpxx')
 valid_mips_float_abi = ('soft', 'hard')
 valid_intl_modes = ('none', 'small-icu', 'full-icu', 'system-icu')
 icu_versions = json.loads((tools_path / 'icu' / 'icu_versions.json').read_text(encoding='utf-8'))
-maglev_enabled_architectures = ('x64', 'arm', 'arm64')
 
 shareable_builtins = {'cjs_module_lexer/lexer': 'deps/cjs-module-lexer/lexer.js',
                      'cjs_module_lexer/dist/lexer': 'deps/cjs-module-lexer/dist/lexer.js',
@@ -934,13 +933,11 @@ parser.add_argument('--v8-enable-hugepage',
     help='Enable V8 transparent hugepage support. This feature is only '+
          'available on Linux platform.')
 
-maglev_enabled_by_default_help = f"(Maglev is enabled by default on {','.join(maglev_enabled_architectures)})"
-
-parser.add_argument('--v8-disable-maglev',
+parser.add_argument('--v8-enable-maglev',
     action='store_true',
-    dest='v8_disable_maglev',
+    dest='v8_enable_maglev',
     default=None,
-    help=f"Disable V8's Maglev compiler. {maglev_enabled_by_default_help}")
+    help='Enable V8 Maglev compiler. Not available on all platforms.')
 
 parser.add_argument('--v8-enable-short-builtin-calls',
     action='store_true',
@@ -1644,8 +1641,7 @@ def configure_v8(o, configs):
   o['variables']['v8_random_seed'] = 0  # Use a random seed for hash tables.
   o['variables']['v8_promise_internal_field_count'] = 1 # Add internal field to promises for async hooks.
   o['variables']['v8_use_siphash'] = 0 if options.without_siphash else 1
-  o['variables']['v8_enable_maglev'] = B(not options.v8_disable_maglev and
-                                         o['variables']['target_arch'] in maglev_enabled_architectures)
+  o['variables']['v8_enable_maglev'] = 1 if options.v8_enable_maglev else 0
   o['variables']['v8_enable_pointer_compression'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1051,6 +1051,14 @@ static int32_t FastInternalModuleStat(
     const FastOneByteString& input,
     // NOLINTNEXTLINE(runtime/references) This is V8 api.
     FastApiCallbackOptions& options) {
+  // This needs a HandleScope which needs an isolate.
+  Isolate* isolate = Isolate::TryGetCurrent();
+  if (!isolate) {
+    options.fallback = true;
+    return -1;
+  }
+
+  HandleScope scope(isolate);
   Environment* env = Environment::GetCurrent(recv->GetCreationContextChecked());
 
   auto path = std::filesystem::path(input.data, input.data + input.length);


### PR DESCRIPTION
#### src: create handle scope in FastInternalModuleStat

It needs a handle scope for the context handle. Since the
FastApiCallbackOptions struct doesn't have isolate on it
in V8 12.4 on Node.js 22, use Isolate::TryGetCurrent() to
get to the isolate needed for the handle scope creation and
fallback to the slow callback if no isolate is entered.

#### Revert "v8: enable maglev on supported architectures"

This reverts commit 1a5acd0638579e687dde128cc6d4effe3ab070d1.

Reason to revert: we have seen several crashes/unexpected JS behaviors with maglev on v22 (which ships V8 v12.4). The bugs lie in the codegen so it would be difficult for users to work around them or even figure out where the bugs are coming from. Some bugs are fixed in the upstream while some others probably remain. As v22 will get stuck with V8 v12.4 as LTS, it will be increasingly difficult to backport patches for them even if the bugs are fixed. So disable it by default on v22 to reduce the churn and troubles for users.

Refs: https://github.com/nodejs/node/issues/52797

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
