### PR TITLE
build: print `Running XYZ linter...` for py and yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1556,7 +1556,7 @@ lint-yaml-build:
 # Lints the YAML files with yamllint.
 lint-yaml:
 	@if [ -d "tools/pip/site-packages/yamllint" ]; then \
-                        $(info Running YAML linter...)
+                        $(info Running YAML linter...) \
 			PYTHONPATH=tools/pip $(PYTHON) -m yamllint .; \
 	else \
 		echo 'YAML linting with yamllint is not available'; \

--- a/Makefile
+++ b/Makefile
@@ -1536,7 +1536,7 @@ lint-py-build:
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")
 # Lint the Python code with ruff.
 lint-py:
-	tools/pip/site-packages/bin/ruff --version
+	$(info Running Python linter...)
 	tools/pip/site-packages/bin/ruff check .
 else
 lint-py:
@@ -1556,6 +1556,7 @@ lint-yaml-build:
 # Lints the YAML files with yamllint.
 lint-yaml:
 	@if [ -d "tools/pip/site-packages/yamllint" ]; then \
+                        $(info Running YAML linter...)
 			PYTHONPATH=tools/pip $(PYTHON) -m yamllint .; \
 	else \
 		echo 'YAML linting with yamllint is not available'; \

--- a/Makefile
+++ b/Makefile
@@ -1556,7 +1556,7 @@ lint-yaml-build:
 # Lints the YAML files with yamllint.
 lint-yaml:
 	@if [ -d "tools/pip/site-packages/yamllint" ]; then \
-                        $(info Running YAML linter...) \
+			$(info Running YAML linter...) \
 			PYTHONPATH=tools/pip $(PYTHON) -m yamllint .; \
 	else \
 		echo 'YAML linting with yamllint is not available'; \


### PR DESCRIPTION
Makes the `lint-py` and `lint-yaml` linters print `Running [Python/YAML] linter...` just like the others.

`lint-py` previously printed the ruff version, which isn't needed, as it's not printed in any other linter.