### PR TITLE
test_runner: report failures in filtered suites

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1162,15 +1162,15 @@ class Suite extends Test {
       );
     } catch (err) {
       this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
-
-      this.buildPhaseFinished = true;
+      this.postBuild();
     }
     this.fn = noop;
   }
 
   postBuild() {
     this.buildPhaseFinished = true;
-    if (this.filtered && this.filteredSubtestCount !== this.subtests.length) {
+    if (this.filtered &&
+        (this.filteredSubtestCount !== this.subtests.length || this.error)) {
       // A suite can transition from filtered to unfiltered based on the
       // tests that it contains - in case of children matching patterns.
       this.filtered = false;

--- a/test/fixtures/test-runner/output/filtered-suite-throws.js
+++ b/test/fixtures/test-runner/output/filtered-suite-throws.js
@@ -1,0 +1,14 @@
+// Flags: --test-name-pattern=enabled
+'use strict';
+const common = require('../../../common');
+const { suite, test } = require('node:test');
+
+suite('suite 1', () => {
+  throw new Error('boom 1');
+  test('enabled - should not run', common.mustNotCall());
+});
+
+suite('suite 2', () => {
+  test('enabled - should get cancelled', common.mustNotCall());
+  throw new Error('boom 1');
+});

--- a/test/fixtures/test-runner/output/filtered-suite-throws.snapshot
+++ b/test/fixtures/test-runner/output/filtered-suite-throws.snapshot
@@ -1,0 +1,62 @@
+TAP version 13
+# Subtest: suite 1
+not ok 1 - suite 1
+  ---
+  duration_ms: *
+  type: 'suite'
+  location: '/test/fixtures/test-runner/output/filtered-suite-throws.js:(LINE):1'
+  failureType: 'testCodeFailure'
+  error: 'boom 1'
+  code: 'ERR_TEST_FAILURE'
+  stack: |-
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+  ...
+# Subtest: suite 2
+    # Subtest: enabled - should get cancelled
+    not ok 1 - enabled - should get cancelled
+      ---
+      duration_ms: *
+      location: '/test/fixtures/test-runner/output/filtered-suite-throws.js:(LINE):3'
+      failureType: 'cancelledByParent'
+      error: 'test did not finish before its parent and was cancelled'
+      code: 'ERR_TEST_FAILURE'
+      ...
+    1..1
+not ok 2 - suite 2
+  ---
+  duration_ms: *
+  type: 'suite'
+  location: '/test/fixtures/test-runner/output/filtered-suite-throws.js:(LINE):1'
+  failureType: 'testCodeFailure'
+  error: 'boom 1'
+  code: 'ERR_TEST_FAILURE'
+  stack: |-
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+    *
+  ...
+1..2
+# tests 1
+# suites 2
+# pass 0
+# fail 0
+# cancelled 1
+# skipped 0
+# todo 0
+# duration_ms *

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -101,6 +101,7 @@ const tests = [
   { name: 'test-runner/output/eval_dot.js', transform: specTransform },
   { name: 'test-runner/output/eval_spec.js', transform: specTransform },
   { name: 'test-runner/output/eval_tap.js' },
+  { name: 'test-runner/output/filtered-suite-throws.js' },
   { name: 'test-runner/output/hooks.js' },
   { name: 'test-runner/output/hooks_spec_reporter.js', transform: specTransform },
   { name: 'test-runner/output/skip-each-hooks.js', transform: specTransform },


### PR DESCRIPTION
This commit updates the test runner's filter logic to handle test suite failures during the build phase. Prior to this commit, these suites were silently filtered.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
