### PR TITLE
doc: update websocket flag description to reflect stable API status

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1611,7 +1611,7 @@ Use this flag to disable top-level await in REPL.
 added: v22.0.0
 -->
 
-Use this flag to disable experimental [`WebSocket`][] support.
+Disable exposition of [`WebSocket`][] on the global scope.
 
 ### `--no-extra-info-on-fatal-exception`
 


### PR DESCRIPTION
This updates the documentation for the [--no-experimental-websocket flag](https://nodejs.org/api/cli.html#--no-experimental-websocket). The [WebSocket](https://nodejs.org/api/globals.html#websocket) is no longer experimental, and the description has been revised to clarify that the flag now disables the exposition of the WebSocket on the global scope.

cc. @KhafraDev