### PR TITLE
path: change `path.join` to use array dynamic allocation

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1242,7 +1242,7 @@ const posix = {
       const arg = args[i];
       validateString(arg, 'path');
       if (arg.length > 0) {
-        path.push(arg);
+        path[path.length] = arg;
       }
     }
 


### PR DESCRIPTION
Change `path.join` to use array dynamic allocation instead of push.

```
                                                               confidence improvement accuracy (*)   (**)  (***)
path/join-posix.js n=100000 paths='/foo|bar||baz/asdf|quux|..'                 0.19 %       ±0.53% ±0.71% ±0.92%
```

Refs: https://github.com/nodejs/node/pull/54331