### PR TITLE
meta: add links to alternative issue trackers

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,9 @@ contact_links:
   - name: 📦 Have an issue with npm?
     url: https://github.com/npm/cli/issues
     about: npm has a seperate issue tracker.
-  - name: 💡 Have an issue with the JavaScript specification?
-    url: https://github.com/tc39/proposals/issues
-    about: TC39 manages the ECMAScript specification
+  - name: 📡 Have an issue with undici? (`WebSocket`, `fetch`, etc.)
+    url: https://github.com/nodejs/undici/issues
+    about: Undici has a seperate issue tracker.
   - name: 🌐 Found a problem with nodejs.org beyond the API reference docs?
     url: https://github.com/nodejs/nodejs.org/issues/new/choose
     about: Please file an issue in the Node.js website repo.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: ⁉️ Need help with Node.js?
+  - name: ⁉️ Need general help with Node.js?
     url: https://github.com/nodejs/help
     about: Please file an issue in our help repo.
+  - name: 📦 Have an issue with npm?
+    url: https://github.com/npm/cli/issues
+    about: npm has a seperate issue tracker.
+  - name: 💡 Have an issue with the JavaScript specification?
+    url: https://github.com/tc39/proposals/issues
+    about: TC39 manages the ECMAScript specification
   - name: 🌐 Found a problem with nodejs.org beyond the API reference docs?
     url: https://github.com/nodejs/nodejs.org/issues/new/choose
     about: Please file an issue in the Node.js website repo.


### PR DESCRIPTION
To help prevent unactionable issues from being opened, this PR adds links to TC39 and npm's issue tracker to the configuration shown before each issue is created.

https://github.com/nodejs/node/issues/new/choose