### PR TITLE
module: add sourceURL magic comment hinting generated source

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -371,7 +371,10 @@ function stripTypeScriptTypes(source, filename) {
     const base64SourceMap = Buffer.from(map).toString('base64');
     return `${code}\n\n//# sourceMappingURL=data:application/json;base64,${base64SourceMap}`;
   }
-  return code;
+  // Source map is not necessary in strip-only mode. However, to map the source
+  // file in debuggers to the original TypeScript source, add a sourceURL magic
+  // comment to hint that it is a generated source.
+  return `${code}\n\n//# sourceURL=${filename}`;
 }
 
 function isUnderNodeModules(filename) {

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -271,6 +271,14 @@ class InspectorSession {
         `break on ${url}:${line}`);
   }
 
+  waitForPauseOnStart() {
+    return this
+      .waitForNotification(
+        (notification) =>
+          notification.method === 'Debugger.paused' && notification.params.reason === 'Break on start',
+        'break on start');
+  }
+
   pausedDetails() {
     return this._pausedDetails;
   }

--- a/test/parallel/test-inspector-strip-types.js
+++ b/test/parallel/test-inspector-strip-types.js
@@ -34,7 +34,9 @@ async function runTest() {
   // Verify that the script has a sourceURL, hinting that it is a generated source.
   assert(scriptParsed.params.hasSourceURL);
 
-  session.disconnect();
+  await session.waitForPauseOnStart();
+  await session.runToCompletion();
+
   assert.strictEqual((await child.expectShutdown()).exitCode, 0);
 }
 

--- a/test/parallel/test-inspector-strip-types.js
+++ b/test/parallel/test-inspector-strip-types.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+if (!process.config.variables.node_use_amaro) common.skip('Requires Amaro');
+
+const { NodeInstance } = require('../common/inspector-helper.js');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+
+const scriptPath = fixtures.path('typescript/ts/test-typescript.ts');
+
+async function runTest() {
+  const child = new NodeInstance(
+    ['--inspect-brk=0', '--experimental-strip-types'],
+    undefined,
+    scriptPath);
+
+  const session = await child.connectInspectorSession();
+
+  const commands = [
+    { 'method': 'Debugger.enable' },
+    { 'method': 'Runtime.enable' },
+    { 'method': 'Runtime.runIfWaitingForDebugger' },
+  ];
+
+  await session.send(commands);
+
+  const scriptParsed = await session.waitForNotification((notification) => {
+    if (notification.method !== 'Debugger.scriptParsed') return false;
+
+    return notification.params.url === scriptPath;
+  });
+  // Verify that the script has a sourceURL, hinting that it is a generated source.
+  assert(scriptParsed.params.hasSourceURL);
+
+  session.disconnect();
+  assert.strictEqual((await child.expectShutdown()).exitCode, 0);
+}
+
+runTest().then(common.mustCall());


### PR DESCRIPTION
Source map is not necessary in strip-only mode. However, to map the
source file in debuggers to the original TypeScript source, add a
sourceURL magic comment to hint that it is a generated source.

This has no runtime side-effects. `--enable-source-maps` will skip
sources without sourceMappingURL magic comments since error stack
remapping is not needed.

This improves debugger experiences like VSCode JS Debugger allowing
setting breakpoints on the original typescript source files, instead
of popping up the stripped source contents.