### PR TITLE
build: update ruff and add `lint-py-fix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1536,17 +1536,22 @@ cpplint: lint-cpp
 # Try with '--system' if it fails without; the system may have set '--user'
 lint-py-build:
 	$(info Pip installing ruff on $(shell $(PYTHON) --version)...)
-	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.5.2 || \
-		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.5.2
+	$(PYTHON) -m pip install --upgrade --target tools/pip/site-packages ruff==0.6.5 || \
+		$(PYTHON) -m pip install --upgrade --system --target tools/pip/site-packages ruff==0.6.5
 
-.PHONY: lint-py
+.PHONY: lint-py lint-py-fix lint-py-fix-unsafe
 ifneq ("","$(wildcard tools/pip/site-packages/ruff)")
 # Lint the Python code with ruff.
 lint-py:
 	tools/pip/site-packages/bin/ruff --version
 	tools/pip/site-packages/bin/ruff check .
+lint-py-fix:
+	tools/pip/site-packages/bin/ruff check . --fix
+
+lint-py-fix-unsafe:
+	tools/pip/site-packages/bin/ruff check . --fix --unsafe-fixes
 else
-lint-py:
+lint-py lint-py-fix lint-py-fix-unsafe:
 	$(warning Python linting with ruff is not available)
 	$(warning Run 'make lint-py-build')
 endif
@@ -1603,6 +1608,7 @@ lint-clean:
 	$(RM) tools/.*lintstamp
 	$(RM) .eslintcache
 	$(RM) -r tools/eslint/node_modules
+	$(RM) tools/pip/site_packages
 
 HAS_DOCKER ?= $(shell command -v docker > /dev/null 2>&1; [ $$? -eq 0 ] && echo 1 || echo 0)
 

--- a/tools/v8-json-to-junit.py
+++ b/tools/v8-json-to-junit.py
@@ -34,7 +34,7 @@ import json
 import utils
 import signal
 import sys
-import xml.etree.ElementTree as xml
+import xml.etree.ElementTree as ET
 
 def IsExitCodeCrashing(exit_code):
   if utils.IsWindows():
@@ -44,22 +44,22 @@ def IsExitCodeCrashing(exit_code):
 
 class JUnitTestOutput:
   def __init__(self, test_suite_name):
-    self.root = xml.Element("testsuite")
+    self.root = ET.Element("testsuite")
     self.root.attrib["name"] = test_suite_name
 
   def HasRunTest(self, test_name, test_cmd, test_duration, test_failure):
-    test_case_element = xml.Element("testcase")
+    test_case_element = ET.Element("testcase")
     test_case_element.attrib["name"] = test_name
     test_case_element.attrib["cmd"] = test_cmd
     test_case_element.attrib["time"] = str(round(test_duration, 3))
     if test_failure is not None:
-      failure_element = xml.Element("failure")
+      failure_element = ET.Element("failure")
       failure_element.text = test_failure
       test_case_element.append(failure_element)
     self.root.append(test_case_element)
 
   def FinishAndWrite(self, f):
-    xml.ElementTree(self.root).write(f, "UTF-8")
+    ET.ElementTree(self.root).write(f, "UTF-8")
 
 
 def Main():


### PR DESCRIPTION
This PR updates `ruff` to 0.6.5, and adds two new makefile targets:
`lint-py-fix`
`lint-py-fix-unsafe`