### PR TITLE
https: only use default ALPNProtocols when appropriate

### DIFF
--- a/lib/https.js
+++ b/lib/https.js
@@ -62,6 +62,7 @@ const { validateObject } = require('internal/validators');
 function Server(opts, requestListener) {
   if (!(this instanceof Server)) return new Server(opts, requestListener);
 
+  let ALPNProtocols = ['http/1.1'];
   if (typeof opts === 'function') {
     requestListener = opts;
     opts = kEmptyObject;
@@ -69,16 +70,17 @@ function Server(opts, requestListener) {
     opts = kEmptyObject;
   } else {
     validateObject(opts, 'options');
+    // Only one of ALPNProtocols and ALPNCallback can be set, so make sure we
+    // only set a default ALPNProtocols if the caller has not set either of them
+    if (opts.ALPNProtocols || opts.ALPNCallback)
+      ALPNProtocols = undefined;
   }
 
   FunctionPrototypeCall(storeHTTPOptions, this, opts);
   FunctionPrototypeCall(tls.Server, this,
                         {
                           noDelay: true,
-                          // http/1.0 is not defined as Protocol IDs in IANA
-                          // https://www.iana.org/assignments/tls-extensiontype-values
-                          //       /tls-extensiontype-values.xhtml#alpn-protocol-ids
-                          ALPNProtocols: ['http/1.1'],
+                          ALPNProtocols,
                           ...opts,
                         },
                         _connectionListener);

--- a/test/parallel/test-https-argument-of-creating.js
+++ b/test/parallel/test-https-argument-of-creating.js
@@ -45,3 +45,14 @@ const dftProtocol = {};
                      0);
   assert.strictEqual(server.listeners('request').length, 0);
 }
+
+
+// Validate that `createServer` only uses defaults when appropriate
+{
+  const ALPNCallback = () => {};
+  const server = https.createServer({
+    ALPNCallback,
+  });
+  assert.strictEqual(server.ALPNProtocols, undefined);
+  assert.strictEqual(server.ALPNCallback, ALPNCallback);
+}


### PR DESCRIPTION
This bug has existed since `ALPNCallback` support was added in 86ba5bea9e2f387ff4a8cb01295dc1bf600e5c61.