### PR TITLE
meta: run coverage-windows when `vcbuild.bat` updated

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - lib/**/*.js
-      - Makefile
+      - vcbuild.bat
       - src/**/*.cc
       - src/**/*.h
       - test/**
@@ -18,7 +18,7 @@ on:
       - main
     paths:
       - lib/**/*.js
-      - Makefile
+      - vcbuild.bat
       - src/**/*.cc
       - src/**/*.h
       - test/**


### PR DESCRIPTION
`coverage-windows` doesn't need to worry about `Makefile`, but it should check for `vcbuild.bat`.