### PR TITLE
tty: expose `hasColors` and `getColorDepth`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3711,6 +3711,20 @@ switch to its new provider model. The `clientCertEngine` option for
 the `privateKeyEngine` and `privateKeyIdentifier` for [`tls.createSecureContext()`][];
 and [`crypto.setEngine()`][] all depend on this functionality from OpenSSL.
 
+### DEP0184: `tty.WriteStream.prototype.getColorDepth()`, `tty.WriteStream.prototype.hasColors()`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54415
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+`tty.WriteStream.prototype.getColorDepth()` and `tty.WriteStream.prototype.hasColors()`
+have been moved to `tty.getColorDepth()` and `tty.hasColors()`, respectively.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -215,7 +215,13 @@ position.
 
 <!-- YAML
 added: v9.9.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/54415
+   description: Deprecate `writeStream.hasColors()` and `writeStream.getColorDepth()`.
 -->
+
+> Stability: 0 - Deprecated. Use [`tty.getColorDepth()`][] instead.
 
 * `env` {Object} An object containing the environment variables to check. This
   enables simulating the usage of a specific terminal. **Default:**
@@ -265,7 +271,13 @@ of columns and rows in the corresponding TTY.
 added:
  - v11.13.0
  - v10.16.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/54415
+   description: Deprecate `writeStream.hasColors()` and `writeStream.getColorDepth()`.
 -->
+
+> Stability: 0 - Deprecated. Use [`tty.hasColors()`][] instead.
 
 * `count` {integer} The number of colors that are requested (minimum 2).
   **Default:** 16.
@@ -341,8 +353,75 @@ The `tty.isatty()` method returns `true` if the given `fd` is associated with
 a TTY and `false` if it is not, including whenever `fd` is not a non-negative
 integer.
 
+## `tty.getColorDepth([env])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `env` {Object} An object containing the environment variables to check. This
+  enables simulating the usage of a specific terminal. **Default:**
+  `process.env`.
+* Returns: {number}
+
+Returns:
+
+* `1` for 2,
+* `4` for 16,
+* `8` for 256,
+* `24` for 16,777,216 colors supported.
+
+Use this to determine what colors the terminal supports. Due to the nature of
+colors in terminals it is possible to either have false positives or false
+negatives. It depends on process information and the environment variables that
+may lie about what terminal is used.
+It is possible to pass in an `env` object to simulate the usage of a specific
+terminal. This can be useful to check how specific environment settings behave.
+
+To enforce a specific color support, use one of the below environment settings.
+
+* 2 colors: `FORCE_COLOR = 0` (Disables colors)
+* 16 colors: `FORCE_COLOR = 1`
+* 256 colors: `FORCE_COLOR = 2`
+* 16,777,216 colors: `FORCE_COLOR = 3`
+
+Disabling color support is also possible by using the `NO_COLOR` and
+`NODE_DISABLE_COLORS` environment variables.
+
+## `tty.hasColors([count][, env])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `count` {integer} The number of colors that are requested (minimum 2).
+  **Default:** 16.
+* `env` {Object} An object containing the environment variables to check. This
+  enables simulating the usage of a specific terminal. **Default:**
+  `process.env`.
+* Returns: {boolean}
+
+Returns `true` if the `writeStream` supports at least as many colors as provided
+in `count`. Minimum support is 2 (black and white).
+
+This has the same false positives and negatives as described in
+[`tty.getColorDepth()`][].
+
+```js
+tty.hasColors();
+// Returns true or false depending on if the current environemnt supports at least 16 colors.
+tty.hasColors(256);
+// Returns true or false depending on if the current environemnt supports at least 256 colors.
+tty.hasColors({ TMUX: '1' });
+// Returns true.
+tty.hasColors(2 ** 24, { TMUX: '1' });
+// Returns false (the environment setting pretends to support 2 ** 8 colors).
+```
+
 [`net.Socket` constructor]: net.md#new-netsocketoptions
 [`process.stderr`]: process.md#processstderr
 [`process.stdin`]: process.md#processstdin
 [`process.stdout`]: process.md#processstdout
+[`tty.getColorDepth()`]: #ttygetcolordepthenv
+[`tty.hasColors()`]: #ttyhascolorscount-env
 [`writeStream.getColorDepth()`]: #writestreamgetcolordepthenv

--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -15,12 +15,7 @@ module.exports = {
   clear: '',
   hasColors: false,
   shouldColorize(stream) {
-    if (process.env.FORCE_COLOR !== undefined) {
-      return lazyInternalTTY().getColorDepth() > 2;
-    }
-    return stream?.isTTY && (
-      typeof stream.getColorDepth === 'function' ?
-        stream.getColorDepth() > 2 : true);
+    return (stream?.isTTY || process.env.FORCE_COLOR !== undefined) && lazyInternalTTY().getColorDepth() > 2;
   },
   refresh() {
     if (process.stderr.isTTY) {

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -165,4 +165,4 @@ WriteStream.prototype.getWindowSize = function() {
   return [this.columns, this.rows];
 };
 
-module.exports = { isatty, ReadStream, WriteStream };
+module.exports = { isatty, hasColors, getColorDepth, ReadStream, WriteStream };

--- a/test/pseudo-tty/test-tty-color-support.js
+++ b/test/pseudo-tty/test-tty-color-support.js
@@ -1,33 +1,30 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert').strict;
-const { WriteStream } = require('tty');
+const tty = require('tty');
 const { inspect } = require('util');
 
-const fd = common.getTTYfd();
-const writeStream = new WriteStream(fd);
-
 {
-  const depth = writeStream.getColorDepth();
+  const depth = tty.getColorDepth();
   assert.strictEqual(typeof depth, 'number');
   assert(depth >= 1 && depth <= 24);
 
-  const support = writeStream.hasColors();
+  const support = tty.hasColors();
   assert.strictEqual(support, depth !== 1);
 }
 
 // Validate invalid input.
 [true, null, () => {}, Symbol(), 5n].forEach((input) => {
   assert.throws(
-    () => writeStream.hasColors(input),
+    () => tty.hasColors(input),
     { code: 'ERR_INVALID_ARG_TYPE' },
   );
 });
 
 [-1, 1].forEach((input) => {
   assert.throws(
-    () => writeStream.hasColors(input),
+    () => tty.hasColors(input),
     { code: 'ERR_OUT_OF_RANGE' },
   );
 });
@@ -73,7 +70,7 @@ const writeStream = new WriteStream(fd);
   [{ NO_COLOR: 'true', FORCE_COLOR: 0, COLORTERM: 'truecolor' }, 1],
   [{ TERM: 'xterm-256color', COLORTERM: 'truecolor' }, 24],
 ].forEach(([env, depth], i) => {
-  const actual = writeStream.getColorDepth(env);
+  const actual = tty.getColorDepth(env);
   assert.strictEqual(
     actual,
     depth,
@@ -81,9 +78,9 @@ const writeStream = new WriteStream(fd);
       `actual: ${actual}, env: ${inspect(env)}`,
   );
   const colors = 2 ** actual;
-  assert(writeStream.hasColors(colors, env));
-  assert(!writeStream.hasColors(colors + 1, env));
-  assert(depth >= 4 ? writeStream.hasColors(env) : !writeStream.hasColors(env));
+  assert(tty.hasColors(colors, env));
+  assert(!tty.hasColors(colors + 1, env));
+  assert(depth >= 4 ? tty.hasColors(env) : !tty.hasColors(env));
 });
 
 // OS settings
@@ -92,8 +89,8 @@ const writeStream = new WriteStream(fd);
   const [ value, depth1, depth2 ] = process.platform !== 'win32' ?
     ['win32', 1, 4] : ['linux', 4, 1];
 
-  assert.strictEqual(writeStream.getColorDepth({}), depth1);
+  assert.strictEqual(tty.getColorDepth({}), depth1);
   Object.defineProperty(process, 'platform', { value });
-  assert.strictEqual(writeStream.getColorDepth({}), depth2);
+  assert.strictEqual(tty.getColorDepth({}), depth2);
   Object.defineProperty(process, 'platform', platform);
 }

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -115,7 +115,7 @@ function child(section) {
   const tty = require('tty');
   // Make sure we check for colors, no matter of the stream's default.
   Object.defineProperty(process.stderr, 'hasColors', {
-    value: tty.WriteStream.prototype.hasColors
+    value: tty.hasColors
   });
   // eslint-disable-next-line no-restricted-syntax
   const debug = util.debuglog(section, common.mustCall((cb) => {


### PR DESCRIPTION
This PR introduces the direct exposure of `hasColors` and `getColorDepth` under the `tty` module. In addition, it documentation-deprecates their previous locations.

This work builds on #40240, an older draft that has been inactive for several years. Given the interest in that original PR, I decided to complete it and submit this one.

Fixes #40236.