### PR TITLE
doc: order web perf apis by position in spec

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -12,10 +12,10 @@ Node.js-specific performance measurements.
 
 Node.js supports the following [Web Performance APIs][]:
 
-* [High Resolution Time][]
-* [Performance Timeline][]
-* [User Timing][]
 * [Resource Timing][]
+* [Performance Timeline][]
+* [High Resolution Time][]
+* [User Timing][]
 
 ```js
 const { PerformanceObserver, performance } = require('node:perf_hooks');


### PR DESCRIPTION
This is a minor change to the documentation.

This orders the list of Web Performance APIs by their order in the specification. The specification's order is:

2. Resource Timing
3. High-Resolution Timing
4. Navigation Timing
5. User Timing