### PR TITLE
doc: expand description of `parseArg`'s `default`

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1425,8 +1425,10 @@ changes:
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
     * `default` {string | boolean | string\[] | boolean\[]} The default option
-      value when it is not set by args. It must be of the same type as the
-      `type` property. When `multiple` is `true`, it must be an array.
+      value when this argument is not passed. It must be of the same type as the
+      `type` property. When `multiple` is `true`, it must be an array. For
+      `string` arguments, if the argument is passed it must still be followed by
+      a value.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1424,11 +1424,10 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
-    * `default` {string | boolean | string\[] | boolean\[]} The default option
-      value when this argument is not passed. It must be of the same type as the
-      `type` property. When `multiple` is `true`, it must be an array. For
-      `string` arguments, if the option is passed it must still be followed by
-      a value.
+    * `default` {string | boolean | string\[] | boolean\[]} The default value to
+      be used if (and only if) the option does not appear in the arguments to be
+      parsed. It must be of the same type as the `type` property. When `multiple`
+      is `true`, it must be an array.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1427,7 +1427,7 @@ changes:
     * `default` {string | boolean | string\[] | boolean\[]} The default option
       value when this argument is not passed. It must be of the same type as the
       `type` property. When `multiple` is `true`, it must be an array. For
-      `string` arguments, if the argument is passed it must still be followed by
+      `string` arguments, if the option is passed it must still be followed by
       a value.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the


### PR DESCRIPTION
Per https://github.com/nodejs/node/issues/53427#issuecomment-2294885963.