### PR TITLE
src: remove redundant AESCipherMode

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -471,12 +471,9 @@ Maybe<bool> AESCipherTraits::AdditionalConfig(
   params->variant =
       static_cast<AESKeyVariant>(args[offset].As<Uint32>()->Value());
 
-  AESCipherMode cipher_op_mode;
   int cipher_nid;
-
-#define V(name, _, mode, nid)                                                  \
+#define V(name, _, nid)                                                        \
   case kKeyVariantAES_##name: {                                                \
-    cipher_op_mode = mode;                                                     \
     cipher_nid = nid;                                                          \
     break;                                                                     \
   }
@@ -487,15 +484,22 @@ Maybe<bool> AESCipherTraits::AdditionalConfig(
   }
 #undef V
 
-  if (cipher_op_mode != AESCipherMode::KW) {
+  params->cipher = EVP_get_cipherbynid(cipher_nid);
+  if (params->cipher == nullptr) {
+    THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
+    return Nothing<bool>();
+  }
+
+  int cipher_op_mode = EVP_CIPHER_mode(params->cipher);
+  if (cipher_op_mode != EVP_CIPH_WRAP_MODE) {
     if (!ValidateIV(env, mode, args[offset + 1], params)) {
       return Nothing<bool>();
     }
-    if (cipher_op_mode == AESCipherMode::CTR) {
+    if (cipher_op_mode == EVP_CIPH_CTR_MODE) {
       if (!ValidateCounter(env, args[offset + 2], params)) {
         return Nothing<bool>();
       }
-    } else if (cipher_op_mode == AESCipherMode::GCM) {
+    } else if (cipher_op_mode == EVP_CIPH_GCM_MODE) {
       if (!ValidateAuthTag(env, mode, cipher_mode, args[offset + 2], params) ||
           !ValidateAdditionalData(env, mode, args[offset + 3], params)) {
         return Nothing<bool>();
@@ -503,12 +507,6 @@ Maybe<bool> AESCipherTraits::AdditionalConfig(
     }
   } else {
     UseDefaultIV(params);
-  }
-
-  params->cipher = EVP_get_cipherbynid(cipher_nid);
-  if (params->cipher == nullptr) {
-    THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
-    return Nothing<bool>();
   }
 
   if (params->iv.size() <
@@ -527,7 +525,7 @@ WebCryptoCipherStatus AESCipherTraits::DoCipher(
     const AESCipherConfig& params,
     const ByteSource& in,
     ByteSource* out) {
-#define V(name, fn, _, __)                                                     \
+#define V(name, fn, _)                                                         \
   case kKeyVariantAES_##name:                                                  \
     return fn(env, key_data.get(), cipher_mode, params, in, out);
   switch (params.variant) {
@@ -541,7 +539,7 @@ WebCryptoCipherStatus AESCipherTraits::DoCipher(
 void AES::Initialize(Environment* env, Local<Object> target) {
   AESCryptoJob::Initialize(env, target);
 
-#define V(name, _, __, ___) NODE_DEFINE_CONSTANT(target, kKeyVariantAES_##name);
+#define V(name, _, __) NODE_DEFINE_CONSTANT(target, kKeyVariantAES_##name);
   VARIANTS(V)
 #undef V
 }

--- a/src/crypto/crypto_aes.h
+++ b/src/crypto/crypto_aes.h
@@ -15,29 +15,22 @@ constexpr size_t kAesBlockSize = 16;
 constexpr unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
 constexpr const char* kDefaultWrapIV = "\xa6\xa6\xa6\xa6\xa6\xa6\xa6\xa6";
 
-enum class AESCipherMode {
-  CTR,
-  CBC,
-  GCM,
-  KW,
-};
-
 #define VARIANTS(V)                                                            \
-  V(CTR_128, AES_CTR_Cipher, AESCipherMode::CTR, NID_aes_128_ctr)              \
-  V(CTR_192, AES_CTR_Cipher, AESCipherMode::CTR, NID_aes_192_ctr)              \
-  V(CTR_256, AES_CTR_Cipher, AESCipherMode::CTR, NID_aes_256_ctr)              \
-  V(CBC_128, AES_Cipher, AESCipherMode::CBC, NID_aes_128_cbc)                  \
-  V(CBC_192, AES_Cipher, AESCipherMode::CBC, NID_aes_192_cbc)                  \
-  V(CBC_256, AES_Cipher, AESCipherMode::CBC, NID_aes_256_cbc)                  \
-  V(GCM_128, AES_Cipher, AESCipherMode::GCM, NID_aes_128_gcm)                  \
-  V(GCM_192, AES_Cipher, AESCipherMode::GCM, NID_aes_192_gcm)                  \
-  V(GCM_256, AES_Cipher, AESCipherMode::GCM, NID_aes_256_gcm)                  \
-  V(KW_128, AES_Cipher, AESCipherMode::KW, NID_id_aes128_wrap)                 \
-  V(KW_192, AES_Cipher, AESCipherMode::KW, NID_id_aes192_wrap)                 \
-  V(KW_256, AES_Cipher, AESCipherMode::KW, NID_id_aes256_wrap)
+  V(CTR_128, AES_CTR_Cipher, NID_aes_128_ctr)                                  \
+  V(CTR_192, AES_CTR_Cipher, NID_aes_192_ctr)                                  \
+  V(CTR_256, AES_CTR_Cipher, NID_aes_256_ctr)                                  \
+  V(CBC_128, AES_Cipher, NID_aes_128_cbc)                                      \
+  V(CBC_192, AES_Cipher, NID_aes_192_cbc)                                      \
+  V(CBC_256, AES_Cipher, NID_aes_256_cbc)                                      \
+  V(GCM_128, AES_Cipher, NID_aes_128_gcm)                                      \
+  V(GCM_192, AES_Cipher, NID_aes_192_gcm)                                      \
+  V(GCM_256, AES_Cipher, NID_aes_256_gcm)                                      \
+  V(KW_128, AES_Cipher, NID_id_aes128_wrap)                                    \
+  V(KW_192, AES_Cipher, NID_id_aes192_wrap)                                    \
+  V(KW_256, AES_Cipher, NID_id_aes256_wrap)
 
 enum AESKeyVariant {
-#define V(name, _, __, ___) kKeyVariantAES_##name,
+#define V(name, _, __) kKeyVariantAES_##name,
   VARIANTS(V)
 #undef V
 };


### PR DESCRIPTION
For each supported variant of AES, we already have OpenSSL's associated NID, so we can simply retrieve the block cipher mode of operation from the NID.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
