### PR TITLE
deps: port ICU ClangCL fix

### DIFF
--- a/deps/icu-small/source/common/unicode/platform.h
+++ b/deps/icu-small/source/common/unicode/platform.h
@@ -235,7 +235,7 @@
 /**
  * \def U_PLATFORM_USES_ONLY_WIN32_API
  * Defines whether the platform uses only the Win32 API.
- * Set to 1 for Windows/MSVC and MinGW but not Cygwin.
+ * Set to 1 for Windows/MSVC, ClangCL and MinGW but not Cygwin.
  * @internal
  */
 #ifdef U_PLATFORM_USES_ONLY_WIN32_API
@@ -250,7 +250,7 @@
 /**
  * \def U_PLATFORM_HAS_WIN32_API
  * Defines whether the Win32 API is available on the platform.
- * Set to 1 for Windows/MSVC, MinGW and Cygwin.
+ * Set to 1 for Windows/MSVC, ClangCL, MinGW and Cygwin.
  * @internal
  */
 #ifdef U_PLATFORM_HAS_WIN32_API

--- a/deps/icu-small/source/tools/genccode/genccode.c
+++ b/deps/icu-small/source/tools/genccode/genccode.c
@@ -70,6 +70,7 @@ enum {
 #ifdef CAN_GENERATE_OBJECTS
   kOptObject,
   kOptMatchArch,
+  kOptCpuArch,
   kOptSkipDllExport,
 #endif
   kOptFilename,
@@ -86,6 +87,7 @@ static UOption options[]={
 #ifdef CAN_GENERATE_OBJECTS
 /*6*/UOPTION_DEF("object", 'o', UOPT_NO_ARG),
      UOPTION_DEF("match-arch", 'm', UOPT_REQUIRES_ARG),
+     UOPTION_DEF("cpu-arch", 'c', UOPT_REQUIRES_ARG),
      UOPTION_DEF("skip-dll-export", '\0', UOPT_NO_ARG),
 #endif
      UOPTION_DEF("filename", 'f', UOPT_REQUIRES_ARG),
@@ -131,6 +133,8 @@ main(int argc, char* argv[]) {
             "\t-o or --object      write a .obj file instead of .c\n"
             "\t-m or --match-arch file.o  match the architecture (CPU, 32/64 bits) of the specified .o\n"
             "\t                    ELF format defaults to i386. Windows defaults to the native platform.\n"
+            "\t-c or --cpu-arch    Specify a CPU architecture for which to write a .obj file for ClangCL on Windows\n"
+            "\t                    Valid values for this opton are x64, x86 and arm64.\n"
             "\t--skip-dll-export   Don't export the ICU data entry point symbol (for use when statically linking)\n");
 #endif
         fprintf(stderr,
@@ -193,9 +197,17 @@ main(int argc, char* argv[]) {
                 break;
 #ifdef CAN_GENERATE_OBJECTS
             case CALL_WRITEOBJECT:
+                if(options[kOptCpuArch].doesOccur) {
+                    if (!checkCpuArchitecture(options[kOptCpuArch].value)) {
+                        fprintf(stderr,
+                            "CPU architecture \"%s\" is unknown.\n", options[kOptCpuArch].value);
+                        return -1;
+                    }
+                }
                 writeObjectCode(filename, options[kOptDestDir].value,
                                 options[kOptEntryPoint].doesOccur ? options[kOptEntryPoint].value : NULL,
                                 options[kOptMatchArch].doesOccur ? options[kOptMatchArch].value : NULL,
+                                options[kOptCpuArch].doesOccur ? options[kOptCpuArch].value : NULL,
                                 options[kOptFilename].doesOccur ? options[kOptFilename].value : NULL,
                                 NULL,
                                 0,

--- a/deps/icu-small/source/tools/pkgdata/pkgdata.cpp
+++ b/deps/icu-small/source/tools/pkgdata/pkgdata.cpp
@@ -776,6 +776,7 @@ static int32_t pkg_executeOptions(UPKGOptions *o) {
                         o->entryName,
                         (optMatchArch[0] == 0 ? nullptr : optMatchArch),
                         nullptr,
+                        nullptr,
                         gencFilePath,
                         sizeof(gencFilePath),
                         true);

--- a/deps/icu-small/source/tools/toolutil/pkg_genc.h
+++ b/deps/icu-small/source/tools/toolutil/pkg_genc.h
@@ -74,6 +74,9 @@ printAssemblyHeadersToStdErr(void);
 U_CAPI UBool U_EXPORT2
 checkAssemblyHeaderName(const char* optAssembly);
 
+U_CAPI UBool U_EXPORT2
+checkCpuArchitecture(const char* optCpuArch);
+
 U_CAPI void U_EXPORT2
 writeCCode(
     const char *filename,
@@ -99,6 +102,7 @@ writeObjectCode(
     const char *destdir,
     const char *optEntryPoint,
     const char *optMatchArch,
+    const char *optCpuArch,
     const char *optFilename,
     char *outFilePath,
     size_t outFilePathCapacity,


### PR DESCRIPTION
This is a change I landed in the ICU at https://github.com/unicode-org/icu/pull/3023. It is needed to enable ClangCL compilation for Node.js on Windows and that's why I'm porting it manually now before the next ICU update. After this PR lands, I'll open a follow-up one changing the `icu-generic.gyp` to take advantage of the ICU changes.

cc @targos @nodejs/platform-windows 