### PR TITLE
src: do not set value on void return value

### DIFF
--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -572,9 +572,7 @@ static Intercepted StorageSetter(Local<Name> property,
   Storage* storage;
   ASSIGN_OR_RETURN_UNWRAP(&storage, info.This(), Intercepted::kNo);
 
-  if (storage->Store(property, value)) {
-    info.GetReturnValue().Set(value);
-  }
+  storage->Store(property, value);
 
   return Intercepted::kYes;
 }

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -212,6 +212,7 @@ template("node_gn_build") {
     ]
     if (node_use_node_snapshot) {
       sources += [ "$target_gen_dir/node_snapshot.cc" ]
+      configs += [ ":node_internal_config" ]
       deps += [ ":run_node_mksnapshot" ]
       if (is_clang || !is_win) {
         cflags_cc = [


### PR DESCRIPTION
V8 added a static assertion to forbid it:

```
../../node/deps/v8/include/v8-function-callback.h:402:17: error: static assertion failed due to requirement '!std::is_void<void>::value': ReturnValue<void>::Set(const Local<S>) is deprecated. Do nothing to indicate that the operation succeeded or use SetFalse() to indicate that the operation failed (don't forget to handle info.ShouldThrowOnError()). See http://crbug.com/348660658 for details.
  402 |   static_assert(!std::is_void<T>::value,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~
../../node/src/node_webstorage.cc:576:27: note: in instantiation of function template specialization 'v8::ReturnValue<void>::Set<v8::Value>' requested here
  576 |     info.GetReturnValue().Set(value);
      |                           ^
```

The assertion needs a newer version of clang to work so the official CI is not hit by it.

This commit also includes a change to GN file to fix GN build failure after V8 upgrade.