### PR TITLE
meta: add more labels to dep-updaters

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -85,7 +85,7 @@ jobs:
               rm temp-output
           - id: amaro
             subsystem: deps
-            label: dependencies
+            label: dependencies, strip-types
             run: |
               ./tools/dep_updaters/update-amaro.sh > temp-output
               cat temp-output
@@ -93,7 +93,7 @@ jobs:
               rm temp-output
           - id: brotli
             subsystem: deps
-            label: dependencies
+            label: dependencies, zlib
             run: |
               ./tools/dep_updaters/update-brotli.sh > temp-output
               cat temp-output
@@ -101,7 +101,7 @@ jobs:
               rm temp-output
           - id: c-ares
             subsystem: deps
-            label: dependencies
+            label: dependencies, cares
             run: |
               ./tools/dep_updaters/update-c-ares.sh > temp-output
               cat temp-output
@@ -163,7 +163,7 @@ jobs:
               rm temp-output
           - id: gyp-next
             subsystem: tools
-            label: tools
+            label: tools, gyp
             run: |
               ./tools/dep_updaters/update-gyp-next.sh > temp-output
               cat temp-output
@@ -179,7 +179,7 @@ jobs:
               rm temp-output
           - id: icu
             subsystem: deps
-            label: dependencies, test
+            label: dependencies, test, icu
             run: |
               ./tools/dep_updaters/update-icu.sh > temp-output
               cat temp-output
@@ -293,7 +293,7 @@ jobs:
               rm temp-output
           - id: sqlite
             subsystem: deps
-            label: dependencies
+            label: dependencies, sqlite
             run: |
               ./tools/dep_updaters/update-sqlite.sh > temp-output
               cat temp-output
@@ -317,7 +317,7 @@ jobs:
               rm temp-output
           - id: zlib
             subsystem: deps
-            label: dependencies
+            label: dependencies, zlib
             run: |
               ./tools/dep_updaters/update-zlib.sh > temp-output
               cat temp-output

--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -36,7 +36,7 @@ jobs:
           body: This is an automated update of OpenSSL to ${{ env.NEW_VERSION }}.
           branch: actions/tools-update-openssl  # Custom branch *just* for this Action.
           commit-message: 'deps: upgrade openssl sources to quictls/openssl-${{ env.NEW_VERSION }}'
-          labels: dependencies
+          labels: dependencies, openssl
           title: 'deps: update OpenSSL to ${{ env.NEW_VERSION }}'
           path: deps/openssl
           update-pull-request-title-and-body: true

--- a/.github/workflows/update-v8.yml
+++ b/.github/workflows/update-v8.yml
@@ -54,4 +54,4 @@ jobs:
           delete-branch: true
           title: 'deps: patch V8 to ${{ env.NEW_VERSION }}'
           body: This is an automated patch update of V8 to ${{ env.NEW_VERSION }}.
-          labels: v8 engine
+          labels: dependencies, v8 engine


### PR DESCRIPTION
This PR changes the dependency updaters to have more labels:

When **amaro** is updated, it will also be labeled as **strip-types**
When **brotli** is updated, it will also be labeled as **zlib**
When **c-ares** is updated, it will also be labeled as **cares**
When **gyp-next** is updated, it will also be labeled as **gyp**
When **icu** is updated, it will also be labeled as **icu**
When **sqlite** is updated, it will also be labeled as **sqlite**
When **zlib** is updated, it will also be labeled as **zlib**
When **openssl** is updated, it will also be labeled as **openssl**
When **v8** is updated, it will also be labeled as **dependencies**