### PR TITLE
[v22.x backport] doc: reserve ABI 130 for Electron 33

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 130,"runtime": "electron", "variant": "electron",             "versions": "33" },
     { "modules": 128, "runtime":"electron", "variant": "electron",             "versions": "32" },
     { "modules": 127, "runtime":"node",     "variant": "v8_12.4",              "versions": "22.0.0" },
     { "modules": 126,"runtime": "node",     "variant": "v8_12.3",              "versions": "22.0.0-pre" },


### PR DESCRIPTION
Manual backport of #54383 to `v22.x`.