### PR TITLE
buffer: improve error handling of buffer.concat

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -583,7 +583,7 @@ Buffer.concat = function concat(list, length) {
   if (length === undefined) {
     length = 0;
     for (let i = 0; i < list.length; i++) {
-      if (list[i].length) {
+      if (list[i]?.length) {
         length += list[i].length;
       }
     }
@@ -596,10 +596,8 @@ Buffer.concat = function concat(list, length) {
   for (let i = 0; i < list.length; i++) {
     const buf = list[i];
     if (!isUint8Array(buf)) {
-      // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
-      // Instead, find the proper error code for this.
-      throw new ERR_INVALID_ARG_TYPE(
-        `list[${i}]`, ['Buffer', 'Uint8Array'], list[i]);
+      throw new ERR_INVALID_ARG_VALUE(
+        `list[${i}]`, buf, 'must be of type Buffer or Uint8Array');
     }
     pos += _copyActual(buf, buffer, pos, 0, buf.length);
   }

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -54,22 +54,22 @@ assert.strictEqual(flatLongLen.toString(), check);
   });
 });
 
-[[42], ['hello', Buffer.from('world')]].forEach((value) => {
+[[42], [null], [undefined], ['hello', Buffer.from('world')]].forEach((value) => {
   assert.throws(() => {
     Buffer.concat(value);
   }, {
-    code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list[0]" argument must be an instance of Buffer ' +
-             `or Uint8Array.${common.invalidArgTypeHelper(value[0])}`
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: 'The argument \'list[0]\' must be of type Buffer ' +
+             `or Uint8Array. Received ${typeof value[0] === 'string' ? `'${value[0]}'` : value[0]}`
   });
 });
 
 assert.throws(() => {
   Buffer.concat([Buffer.from('hello'), 3]);
 }, {
-  code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "list[1]" argument must be an instance of Buffer ' +
-           'or Uint8Array. Received type number (3)'
+  code: 'ERR_INVALID_ARG_VALUE',
+  message: 'The argument \'list[1]\' must be of type Buffer ' +
+           'or Uint8Array. Received 3'
 });
 
 // eslint-disable-next-line node-core/crypto-check


### PR DESCRIPTION
Resolved TODO to use more proper error code
INVALID_ARG_TYPE -> INVALID_ARG_VALUE, it seems better  
Additionally, when the `list` argument has null or undefined and the `length` argument is undefined, it causes `TypeError: Cannot read properties` error.
It has been adjusted to be handled by the INVALID_ARG_VALUE error.
And, reflected this changes to tests

Refs: https://github.com/nodejs/node/pull/19445