### PR TITLE
doc: use correct language fence for wpt

### DIFF
--- a/test/wpt/README.md
+++ b/test/wpt/README.md
@@ -149,6 +149,8 @@ expected failures.
 
 ## Format of a status JSON file
 
+<!--lint disable fenced-code-flag remark-lint-->
+
 ```jsonc
 {
   "something.scope.js": {  // the file name
@@ -172,6 +174,8 @@ expected failures.
   }
 }
 ```
+
+<!--lint enable fenced-code-flag remark-lint-->
 
 A test may have to be skipped because it depends on another irrelevant
 Web API, or certain harness has not been ported in our test runner yet.

--- a/test/wpt/README.md
+++ b/test/wpt/README.md
@@ -149,7 +149,7 @@ expected failures.
 
 ## Format of a status JSON file
 
-```json
+```jsonc
 {
   "something.scope.js": {  // the file name
     // Optional: If the requirement is not met, this test will be skipped


### PR DESCRIPTION
```json
{
  "something.scope.js": {  // the file name
    // Optional: If the requirement is not met, this test will be skipped
    "requires": ["small-icu"],  // supports: "small-icu", "full-icu", "crypto"
    // Optional: the test will be skipped with the reason printed
    "skip": "explain why we cannot run a test that's supposed to pass",
    // Optional: failing tests
    "fail": {
      "note": "You may leave an optional arbitrary note e.g. with TODOs",
      "expected": [
        "test name in the WPT test case, e.g. second argument passed to test()",
        "another test name"
      ],
      "flaky": [
        "flaky test name"
      ]
    }
  }
}
```
```jsonc
{
  "something.scope.js": {  // the file name
    // Optional: If the requirement is not met, this test will be skipped
    "requires": ["small-icu"],  // supports: "small-icu", "full-icu", "crypto"
    // Optional: the test will be skipped with the reason printed
    "skip": "explain why we cannot run a test that's supposed to pass",
    // Optional: failing tests
    "fail": {
      "note": "You may leave an optional arbitrary note e.g. with TODOs",
      "expected": [
        "test name in the WPT test case, e.g. second argument passed to test()",
        "another test name"
      ],
      "flaky": [
        "flaky test name"
      ]
    }
  }
}
```