### PR TITLE
stream: change stream to use index instead of `for...of`

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -61,7 +61,9 @@ Stream.isReadable = utils.isReadable;
 Stream.isWritable = utils.isWritable;
 
 Stream.Readable = require('internal/streams/readable');
-for (const key of ObjectKeys(streamReturningOperators)) {
+const streamKeys = ObjectKeys(streamReturningOperators);
+for (let i = 0; i < streamKeys.length; i++) {
+  const key = streamKeys[i];
   const op = streamReturningOperators[key];
   function fn(...args) {
     if (new.target) {
@@ -79,7 +81,9 @@ for (const key of ObjectKeys(streamReturningOperators)) {
     writable: true,
   });
 }
-for (const key of ObjectKeys(promiseReturningOperators)) {
+const promiseKeys = ObjectKeys(promiseReturningOperators);
+for (let i = 0; i < promiseKeys.length; i++) {
+  const key = promiseKeys[i];
   const op = promiseReturningOperators[key];
   function fn(...args) {
     if (new.target) {


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/blob/main/doc/contributing/primordials.md#unsafe-array-iteration

```
                                                                                         confidence improvement accuracy (*)   (**)   (***)
streams/compose.js n=1000                                                                               -0.19 %       ±0.55% ±0.73%  ±0.95%
streams/creation.js kind='duplex' n=50000000                                                            -0.66 %       ±3.62% ±4.82%  ±6.28%
streams/creation.js kind='readable' n=50000000                                                          -0.43 %       ±5.08% ±6.78%  ±8.86%
streams/creation.js kind='transform' n=50000000                                                          0.30 %       ±6.37% ±8.48% ±11.05%
streams/creation.js kind='writable' n=50000000                                                          -2.93 %       ±5.08% ±6.81%  ±8.96%
streams/destroy.js kind='duplex' n=1000000                                                               1.12 %       ±1.55% ±2.07%  ±2.72%
streams/destroy.js kind='readable' n=1000000                                                      *      1.50 %       ±1.47% ±1.97%  ±2.59%
streams/destroy.js kind='transform' n=1000000                                                            0.63 %       ±1.10% ±1.47%  ±1.91%
streams/destroy.js kind='writable' n=1000000                                                             0.75 %       ±1.79% ±2.38%  ±3.10%
streams/pipe-object-mode.js n=5000000                                                                   -1.15 %       ±2.70% ±3.63%  ±4.82%
streams/pipe.js n=5000000                                                                                0.73 %       ±1.18% ±1.57%  ±2.05%
streams/readable-async-iterator.js sync='no' n=100000                                             *     -0.69 %       ±0.54% ±0.72%  ±0.94%
streams/readable-async-iterator.js sync='yes' n=100000                                                  -0.89 %       ±1.40% ±1.87%  ±2.45%
streams/readable-bigread.js n=1000                                                                      -0.59 %       ±0.68% ±0.90%  ±1.17%
streams/readable-bigunevenread.js n=1000                                                                -0.04 %       ±0.60% ±0.80%  ±1.04%
streams/readable-boundaryread.js type='buffer' n=2000                                                    0.18 %       ±1.02% ±1.36%  ±1.77%
streams/readable-boundaryread.js type='string' n=2000                                                   -0.64 %       ±0.89% ±1.19%  ±1.54%
streams/readable-from.js type='array' n=10000000                                                         1.66 %       ±7.10% ±9.45% ±12.31%
streams/readable-from.js type='async-generator' n=10000000                                               0.27 %       ±1.07% ±1.42%  ±1.85%
streams/readable-from.js type='sync-generator-with-async-values' n=10000000                             -1.30 %       ±1.72% ±2.28%  ±2.98%
streams/readable-from.js type='sync-generator-with-sync-values' n=10000000                              -0.29 %       ±1.54% ±2.05%  ±2.67%
streams/readable-readall.js n=5000                                                                      -0.20 %       ±0.36% ±0.49%  ±0.63%
streams/readable-uint8array.js kind='encoding' n=1000000                                        ***      2.43 %       ±0.79% ±1.05%  ±1.37%
streams/readable-uint8array.js kind='read' n=1000000                                                    -0.96 %       ±1.77% ±2.35%  ±3.06%
streams/readable-unevenread.js n=1000                                                                    0.04 %       ±0.51% ±0.67%  ±0.88%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                    -0.30 %       ±0.89% ±1.19%  ±1.55%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000             *     -0.70 %       ±0.68% ±0.90%  ±1.18%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000            **     -0.71 %       ±0.53% ±0.70%  ±0.91%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000                  -0.42 %       ±0.82% ±1.09%  ±1.42%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                    0.65 %       ±1.28% ±1.71%  ±2.22%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                   1.10 %       ±2.19% ±2.94%  ±3.90%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000            *     -0.89 %       ±0.83% ±1.10%  ±1.43%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                 -0.14 %       ±1.42% ±1.89%  ±2.46%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                   -0.04 %       ±0.98% ±1.31%  ±1.70%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000            *     -0.56 %       ±0.53% ±0.71%  ±0.92%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                   0.24 %       ±0.87% ±1.17%  ±1.53%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                  0.27 %       ±0.73% ±0.98%  ±1.27%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                  -0.03 %       ±2.01% ±2.69%  ±3.51%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                 -0.36 %       ±1.21% ±1.62%  ±2.12%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                 -0.26 %       ±0.94% ±1.26%  ±1.65%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                -0.30 %       ±0.72% ±0.96%  ±1.25%
streams/writable-uint8array.js kind='object-mode' n=50000000                                            -0.78 %       ±1.82% ±2.45%  ±3.23%
streams/writable-uint8array.js kind='write' n=50000000                                                  -2.21 %       ±2.45% ±3.30%  ±4.36%
streams/writable-uint8array.js kind='writev' n=50000000                                                 -0.14 %       ±1.22% ±1.62%  ±2.12%
```