### PR TITLE
doc,cli: clarify --max-old-space-size and --max-semi-space-size units

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3396,6 +3396,9 @@ documented here:
 
 ### `--perf-prof-unwinding-info`
 
+<!-- Anchor to make sure old links find a target -->
+<a id="--max-old-space-sizesize-in-megabytes"></a>
+
 ### `--max-old-space-size=SIZE` (in MiB)
 
 Sets the max memory size of V8's old memory section. As memory
@@ -3408,6 +3411,9 @@ On a machine with 2 GiB of memory, consider setting this to
 ```bash
 node --max-old-space-size=1536 index.js
 ```
+
+<!-- Anchor to make sure old links find a target -->
+<a id="--max-semi-space-sizesize-in-megabytes"></a>
 
 ### `--max-semi-space-size=SIZE` (in MiB)
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3397,6 +3397,7 @@ documented here:
 ### `--perf-prof-unwinding-info`
 
 <!-- Anchor to make sure old links find a target -->
+
 <a id="--max-old-space-sizesize-in-megabytes"></a>
 
 ### `--max-old-space-size=SIZE` (in MiB)
@@ -3413,6 +3414,7 @@ node --max-old-space-size=1536 index.js
 ```
 
 <!-- Anchor to make sure old links find a target -->
+
 <a id="--max-semi-space-sizesize-in-megabytes"></a>
 
 ### `--max-semi-space-size=SIZE` (in MiB)

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3396,7 +3396,7 @@ documented here:
 
 ### `--perf-prof-unwinding-info`
 
-### `--max-old-space-size=SIZE` (in megabytes)
+### `--max-old-space-size=SIZE` (in MiB)
 
 Sets the max memory size of V8's old memory section. As memory
 consumption approaches the limit, V8 will spend more time on
@@ -3409,10 +3409,10 @@ On a machine with 2 GiB of memory, consider setting this to
 node --max-old-space-size=1536 index.js
 ```
 
-### `--max-semi-space-size=SIZE` (in megabytes)
+### `--max-semi-space-size=SIZE` (in MiB)
 
 Sets the maximum [semi-space][] size for V8's [scavenge garbage collector][] in
-MiB (megabytes).
+MiB (mebibytes).
 Increasing the max size of a semi-space may improve throughput for Node.js at
 the cost of more memory consumption.
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1500,8 +1500,8 @@ thread spawned will spawn another until the application crashes.
 [`'close'` event]: #event-close
 [`'exit'` event]: #event-exit
 [`'online'` event]: #event-online
-[`--max-old-space-size`]: cli.md#--max-old-space-sizesize-in-megabytes
-[`--max-semi-space-size`]: cli.md#--max-semi-space-sizesize-in-megabytes
+[`--max-old-space-size`]: cli.md#--max-old-space-sizesize-in-mib
+[`--max-semi-space-size`]: cli.md#--max-semi-space-sizesize-in-mib
 [`ArrayBuffer`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
 [`AsyncResource`]: async_hooks.md#class-asyncresource
 [`Buffer.allocUnsafe()`]: buffer.md#static-method-bufferallocunsafesize


### PR DESCRIPTION
As far as I understand, both `--max-old-space-size` and `--max-semi-space-size` expect mebibytes as the value unit.

This is already clear in the `--max-semi-space-size` section, as the documentation mentions the shortened `MiB` unit type.

But it was not clear in `--max-old-space-size`. The only way to deduce was by reading the example:
> On a machine with 2 GiB of memory, consider setting this to 1536 (1.5 GiB)

This PR intends to bring more clarity to the correct unit to use.