### PR TITLE
module,win: make module cache case-insensitive

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -48,6 +48,9 @@ const {
   ObjectSetPrototypeOf,
   Proxy,
   ReflectApply,
+  ReflectDeleteProperty,
+  ReflectGet,
+  ReflectHas,
   ReflectSet,
   RegExpPrototypeExec,
   SafeMap,
@@ -321,35 +324,24 @@ let patched = false;
 /* Make Module._cache case-insensitive on Windows */
 if (isWindows) {
   /* Create a proxy handler to intercept some operations */
+  const toLowerCaseIfString = (prop) => (typeof prop === 'string' ? StringPrototypeToLowerCase(prop) : prop);
   const cacheHandler = {
     __proto__: null,
-    get(target, prop) {
-      if (typeof prop === 'string') {
-        return target[StringPrototypeToLowerCase(prop)];
-      }
-      return target[prop];
+
+    get(target, prop, receiver) {
+      return ReflectGet(target, toLowerCaseIfString(prop), receiver);
     },
-    set(target, prop, value) {
-      if (typeof prop === 'string') {
-        target[StringPrototypeToLowerCase(prop)] = value;
-      } else {
-        target[prop] = value;
-      }
-      return true;
+
+    set(target, prop, value, receiver) {
+      return ReflectSet(target, toLowerCaseIfString(prop), value, receiver);
     },
+
     deleteProperty(target, prop) {
-      if (typeof prop === 'string') {
-        delete target[StringPrototypeToLowerCase(prop)];
-      } else {
-        delete target[prop];
-      }
-      return true;
+      return ReflectDeleteProperty(target, toLowerCaseIfString(prop));
     },
+
     has(target, prop) {
-      if (typeof prop === 'string') {
-        return StringPrototypeToLowerCase(prop) in target;
-      }
-      return prop in target;
+      return ReflectHas(target, toLowerCaseIfString(prop));
     },
   };
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -322,6 +322,7 @@ let patched = false;
 if (isWindows) {
   /* Create a proxy handler to intercept some operations */
   const cacheHandler = {
+    __proto__: null,
     get(target, prop) {
       if (typeof prop === 'string') {
         return target[StringPrototypeToLowerCase(prop)];

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -60,6 +60,7 @@ const {
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
+  StringPrototypeToLowerCase,
   Symbol,
 } = primordials;
 const {
@@ -316,6 +317,44 @@ let modulePaths = [];
 Module.globalPaths = [];
 
 let patched = false;
+
+/* Make Module._cache case-insensitive on Windows */
+if (isWindows) {
+  /* Create a proxy handler to intercept some operations */
+  const cacheHandler = {
+    get(target, prop) {
+      if (typeof prop === 'string') {
+        return target[StringPrototypeToLowerCase(prop)];
+      }
+      return target[prop];
+    },
+    set(target, prop, value) {
+      if (typeof prop === 'string') {
+        target[StringPrototypeToLowerCase(prop)] = value;
+      } else {
+        target[prop] = value;
+      }
+      return true;
+    },
+    deleteProperty(target, prop) {
+      if (typeof prop === 'string') {
+        delete target[StringPrototypeToLowerCase(prop)];
+      } else {
+        delete target[prop];
+      }
+      return true;
+    },
+    has(target, prop) {
+      if (typeof prop === 'string') {
+        return StringPrototypeToLowerCase(prop) in target;
+      }
+      return prop in target;
+    },
+  };
+
+  /* Replace Module._cache with the proxy */
+  Module._cache = new Proxy(Module._cache, cacheHandler);
+}
 
 /**
  * Add the CommonJS wrapper around a module's source code.

--- a/test/parallel/test-require-cache.js
+++ b/test/parallel/test-require-cache.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 {
@@ -39,6 +39,17 @@ const assert = require('assert');
   const fakeModule = {};
 
   require.cache[relativePath] = { exports: fakeModule };
+
+  assert.strictEqual(require(relativePath), fakeModule);
+}
+
+/* Test require.cache for case-insensitivity */
+if (common.isWindows) {
+  const relativePath = '../fixtures/semicolon';
+  const absolutePath = require.resolve(relativePath);
+  const fakeModule = {};
+
+  require.cache[absolutePath.toUpperCase()] = { exports: fakeModule };
 
   assert.strictEqual(require(relativePath), fakeModule);
 }


### PR DESCRIPTION
This PR makes the module cache object case-insensitive by utilizing `Proxy` in JS.

Fixes: https://github.com/nodejs/node/issues/54132

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
