### PR TITLE
meta: remind users to use a supported version in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -13,7 +13,9 @@ body:
   - type: input
     attributes:
       label: Version
-      description: Output of `node -v`
+      description: |
+        Output of `node -v`. 
+        Please verify that you are reproducing the issue in a currently-supported version of Node.js.
   - type: textarea
     attributes:
       label: Platform

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -15,7 +15,7 @@ body:
       label: Version
       description: |
         Output of `node -v`.
-        Please verify that you are reproducing the issue in a currently-supported version of Node.js.
+        Please verify that you are reproducing the issue in a [currently-supported version](https://github.com/nodejs/Release/blob/HEAD/README.md#release-schedule) of Node.js.
   - type: textarea
     attributes:
       label: Platform

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Version
       description: |
-        Output of `node -v`. 
+        Output of `node -v`.
         Please verify that you are reproducing the issue in a currently-supported version of Node.js.
   - type: textarea
     attributes:


### PR DESCRIPTION
Adds "Please verify that you are reproducing the issue in a currently-supported version of Node.js." to the bug report template.