### PR TITLE
url: refactor isIpv6Hostname function to use string methods

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -26,7 +26,6 @@ const {
   Int8Array,
   ObjectAssign,
   ObjectKeys,
-  StringPrototypeCharCodeAt,
   decodeURIComponent,
 } = primordials;
 
@@ -103,8 +102,6 @@ const {
   CHAR_ZERO_WIDTH_NOBREAK_SPACE,
   CHAR_HASH,
   CHAR_FORWARD_SLASH,
-  CHAR_LEFT_SQUARE_BRACKET,
-  CHAR_RIGHT_SQUARE_BRACKET,
   CHAR_LEFT_ANGLE_BRACKET,
   CHAR_RIGHT_ANGLE_BRACKET,
   CHAR_LEFT_CURLY_BRACKET,
@@ -144,11 +141,7 @@ function urlParse(url, parseQueryString, slashesDenoteHost) {
 }
 
 function isIpv6Hostname(hostname) {
-  return (
-    StringPrototypeCharCodeAt(hostname, 0) === CHAR_LEFT_SQUARE_BRACKET &&
-    StringPrototypeCharCodeAt(hostname, hostname.length - 1) ===
-    CHAR_RIGHT_SQUARE_BRACKET
-  );
+  return hostname.startsWith('[') && hostname.endsWith(']');
 }
 
 // This prevents some common spoofing bugs due to our use of IDNA toASCII. For


### PR DESCRIPTION
Refactor the isIpv6Hostname function to improve readability and performance