### PR TITLE
cli: fix spacing for port range error

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1148,7 +1148,7 @@ inline uint16_t ParseAndValidatePort(const std::string_view port,
 
   if (r.ec == std::errc::result_out_of_range ||
       (result != 0 && result < 1024)) {
-    errors->push_back(" must be 0 or in range 1024 to 65535.");
+    errors->push_back("must be 0 or in range 1024 to 65535.");
   }
 
   return result;


### PR DESCRIPTION
### Before
```console
node:  must be 0 or in range 1024 to 65535.
```
### After
```console
node: must be 0 or in range 1024 to 65535.
```

Note the double spacing in the before comparison.