### PR TITLE
test: refactor fs-watch tests due to macOS issue

### DIFF
--- a/test/parallel/test-fs-promises-watch.js
+++ b/test/parallel/test-fs-promises-watch.js
@@ -8,6 +8,7 @@ const { watch } = require('fs/promises');
 const fs = require('fs');
 const assert = require('assert');
 const { join } = require('path');
+const { setTimeout } = require('timers/promises');
 const tmpdir = require('../common/tmpdir');
 
 class WatchTestCase {
@@ -49,6 +50,12 @@ for (const testCase of kCases) {
 
   let interval;
   async function test() {
+    if (common.isMacOS) {
+      // On macOS delay watcher start to avoid leaking previous events.
+      // Refs: https://github.com/libuv/libuv/pull/4503
+      await setTimeout(common.platformTimeout(100));
+    }
+
     const watcher = watch(testCase[testCase.field]);
     for await (const { eventType, filename } of watcher) {
       clearInterval(interval);

--- a/test/parallel/test-fs-watch-recursive-symlink.js
+++ b/test/parallel/test-fs-watch-recursive-symlink.js
@@ -35,6 +35,11 @@ tmpdir.refresh();
   const symlinkFolder = path.join(rootDirectory, 'symlink-folder');
   fs.symlinkSync(rootDirectory, symlinkFolder);
 
+  if (common.isMacOS) {
+    // On macOS delay watcher start to avoid leaking previous events.
+    // Refs: https://github.com/libuv/libuv/pull/4503
+    await setTimeout(common.platformTimeout(100));
+  }
 
   const watcher = fs.watch(rootDirectory, { recursive: true });
   let watcherClosed = false;
@@ -73,6 +78,12 @@ tmpdir.refresh();
 
   const forbiddenFile = path.join(subDirectory, 'forbidden.txt');
   const acceptableFile = path.join(trackingSubDirectory, 'acceptable.txt');
+
+  if (common.isMacOS) {
+    // On macOS delay watcher start to avoid leaking previous events.
+    // Refs: https://github.com/libuv/libuv/pull/4503
+    await setTimeout(common.platformTimeout(100));
+  }
 
   const watcher = fs.watch(trackingSubDirectory, { recursive: true });
   let watcherClosed = false;

--- a/test/parallel/test-fs-watch.js
+++ b/test/parallel/test-fs-watch.js
@@ -41,13 +41,7 @@ const cases = [
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
-for (const testCase of cases) {
-  if (testCase.shouldSkip) continue;
-  fs.mkdirSync(testCase.dirPath);
-  // Long content so it's actually flushed.
-  const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
-  fs.writeFileSync(testCase.filePath, content1);
-
+function doWatchTest(testCase) {
   let interval;
   const pathToWatch = testCase[testCase.field];
   const watcher = fs.watch(pathToWatch);
@@ -85,6 +79,23 @@ for (const testCase of cases) {
     fs.writeFileSync(testCase.filePath, '');
     fs.writeFileSync(testCase.filePath, content2);
   }, 100);
+}
+
+for (const testCase of cases) {
+  if (testCase.shouldSkip) continue;
+  fs.mkdirSync(testCase.dirPath);
+  // Long content so it's actually flushed.
+  const content1 = Date.now() + testCase.fileName.toLowerCase().repeat(1e4);
+  fs.writeFileSync(testCase.filePath, content1);
+  if (common.isMacOS) {
+    // On macOS delay watcher start to avoid leaking previous events.
+    // Refs: https://github.com/libuv/libuv/pull/4503
+    setTimeout(() => {
+      doWatchTest(testCase);
+    }, common.platformTimeout(100));
+  } else {
+    doWatchTest(testCase);
+  }
 }
 
 [false, 1, {}, [], null, undefined].forEach((input) => {

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -86,10 +86,7 @@ watcher.on('stop', common.mustCall());
 // Omitting AIX. It works but not reliably.
 if (common.isLinux || common.isMacOS || common.isWindows) {
   const dir = tmpdir.resolve('watch');
-
-  fs.mkdir(dir, common.mustCall(function(err) {
-    if (err) assert.fail(err);
-
+  function doWatch() {
     const handle = fs.watch(dir, common.mustCall(function(eventType, filename) {
       clearInterval(interval);
       handle.close();
@@ -101,5 +98,15 @@ if (common.isLinux || common.isMacOS || common.isWindows) {
         if (err) assert.fail(err);
       }));
     }, 1);
+  }
+
+  fs.mkdir(dir, common.mustSucceed(() => {
+    if (common.isMacOS) {
+      // On macOS delay watcher start to avoid leaking previous events.
+      // Refs: https://github.com/libuv/libuv/pull/4503
+      setTimeout(doWatch, common.platformTimeout(100));
+    } else {
+      doWatch();
+    }
   }));
 }

--- a/test/pummel/test-fs-watch-non-recursive.js
+++ b/test/pummel/test-fs-watch-non-recursive.js
@@ -38,14 +38,24 @@ const filepath = path.join(testsubdir, 'watch.txt');
 
 fs.mkdirSync(testsubdir, 0o700);
 
-const watcher = fs.watch(testDir, { persistent: true }, (event, filename) => {
-  // This function may be called with the directory depending on timing but
-  // must not be called with the file..
-  assert.strictEqual(filename, 'testsubdir');
-});
-setTimeout(() => {
-  fs.writeFileSync(filepath, 'test');
-}, 100);
-setTimeout(() => {
-  watcher.close();
-}, 500);
+function doWatch() {
+  const watcher = fs.watch(testDir, { persistent: true }, (event, filename) => {
+    // This function may be called with the directory depending on timing but
+    // must not be called with the file..
+    assert.strictEqual(filename, 'testsubdir');
+  });
+  setTimeout(() => {
+    fs.writeFileSync(filepath, 'test');
+  }, 100);
+  setTimeout(() => {
+    watcher.close();
+  }, 500);
+}
+
+if (common.isMacOS) {
+  // On macOS delay watcher start to avoid leaking previous events.
+  // Refs: https://github.com/libuv/libuv/pull/4503
+  setTimeout(doWatch, common.platformTimeout(100));
+} else {
+  doWatch();
+}

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -95,24 +95,34 @@ function repeat(fn) {
   const testsubdir = fs.mkdtempSync(testDir + path.sep);
   const filepath = path.join(testsubdir, 'newfile.txt');
 
-  const watcher =
-    fs.watch(testsubdir, common.mustCall(function(event, filename) {
-      const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
-      assert.strictEqual(event, renameEv);
-      if (expectFilePath) {
-        assert.strictEqual(filename, 'newfile.txt');
-      } else {
-        assert.strictEqual(filename, null);
-      }
-      clearInterval(interval);
-      watcher.close();
-    }));
+  function doWatch() {
+    const watcher =
+      fs.watch(testsubdir, common.mustCall(function(event, filename) {
+        const renameEv = common.isSunOS || common.isAIX ? 'change' : 'rename';
+        assert.strictEqual(event, renameEv);
+        if (expectFilePath) {
+          assert.strictEqual(filename, 'newfile.txt');
+        } else {
+          assert.strictEqual(filename, null);
+        }
+        clearInterval(interval);
+        watcher.close();
+      }));
 
-  const interval = repeat(() => {
-    fs.rmSync(filepath, { force: true });
-    const fd = fs.openSync(filepath, 'w');
-    fs.closeSync(fd);
-  });
+    const interval = repeat(() => {
+      fs.rmSync(filepath, { force: true });
+      const fd = fs.openSync(filepath, 'w');
+      fs.closeSync(fd);
+    });
+  }
+
+  if (common.isMacOS) {
+    // On macOS delay watcher start to avoid leaking previous events.
+    // Refs: https://github.com/libuv/libuv/pull/4503
+    setTimeout(doWatch, common.platformTimeout(100));
+  } else {
+    doWatch();
+  }
 }
 
 // https://github.com/joyent/node/issues/2293 - non-persistent watcher should


### PR DESCRIPTION
In `macOS`, fsevents generated immediately before start watching may leak into the event callback. See: https://github.com/nodejs/node/issues/54450 for an explanation. This might be fixed at some point in `libuv` though it may take some time (see: https://github.com/libuv/libuv/issues/3866). This commit comes in anticipation of the soon-to-be-released `libuv@1.49.0` which was making these tests very flaky.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
