### PR TITLE
test: fix improper path to URL conversion

### DIFF
--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -5,10 +5,11 @@ const common = require('../../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const { pathToFileURL } = require('url');
 
 const blockedFile = process.env.BLOCKEDFILE;
 const bufferBlockedFile = Buffer.from(process.env.BLOCKEDFILE);
-const blockedFileURL = new URL('file://' + process.env.BLOCKEDFILE);
+const blockedFileURL = pathToFileURL(process.env.BLOCKEDFILE);
 const blockedFolder = process.env.BLOCKEDFOLDER;
 const allowedFolder = process.env.ALLOWEDFOLDER;
 const regularFile = __filename;

--- a/test/parallel/test-diagnostics-channel-module-import-error.js
+++ b/test/parallel/test-diagnostics-channel-module-import-error.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const dc = require('diagnostics_channel');
+const { pathToFileURL } = require('url');
 
 const trace = dc.tracingChannel('module.import');
 const events = [];
@@ -30,10 +31,7 @@ trace.subscribe({
 import('does-not-exist').then(
   common.mustNotCall(),
   common.mustCall((error) => {
-    let expectedParentURL = module.filename.replaceAll('\\', '/');
-    expectedParentURL = common.isWindows ?
-      `file:///${expectedParentURL}` :
-      `file://${expectedParentURL}`;
+    const expectedParentURL = pathToFileURL(module.filename).href;
     // Verify order and contents of each event
     assert.deepStrictEqual(events, [
       {

--- a/test/parallel/test-diagnostics-channel-module-import.js
+++ b/test/parallel/test-diagnostics-channel-module-import.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const dc = require('diagnostics_channel');
+const { pathToFileURL } = require('url');
 
 const trace = dc.tracingChannel('module.import');
 const events = [];
@@ -29,10 +30,7 @@ trace.subscribe({
 
 import('http').then(
   common.mustCall((result) => {
-    let expectedParentURL = module.filename.replaceAll('\\', '/');
-    expectedParentURL = common.isWindows ?
-      `file:///${expectedParentURL}` :
-      `file://${expectedParentURL}`;
+    const expectedParentURL = pathToFileURL(module.filename).href;
     // Verify order and contents of each event
     assert.deepStrictEqual(events, [
       {


### PR DESCRIPTION
Some tests are failing when I run them from a directory whose path contains URL-significant chars (e.g. `?`, `#`, `%`). We should be using `pathToFileURL`, so that's what this PR is doing.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
