### PR TITLE
async_hooks: add an InactiveAsyncContextFrame class

### DIFF
--- a/lib/internal/async_context_frame.js
+++ b/lib/internal/async_context_frame.js
@@ -11,7 +11,7 @@ const {
 
 let enabled_;
 
-class ActiveAsyncContextFrame {
+class ActiveAsyncContextFrame extends Map {
   static get enabled() {
     return true;
   }
@@ -50,12 +50,7 @@ function checkEnabled() {
   return enabled;
 }
 
-class AsyncContextFrame extends Map {
-  constructor(store, data) {
-    super(AsyncContextFrame.current());
-    this.set(store, data);
-  }
-
+class InactiveAsyncContextFrame extends Map {
   static get enabled() {
     enabled_ ??= checkEnabled();
     return enabled_;
@@ -65,6 +60,13 @@ class AsyncContextFrame extends Map {
   static set(frame) {}
   static exchange(frame) {}
   static disable(store) {}
+}
+
+class AsyncContextFrame extends InactiveAsyncContextFrame {
+  constructor(store, data) {
+    super(AsyncContextFrame.current());
+    this.set(store, data);
+  }
 
   disable(store) {
     this.delete(store);

--- a/test/parallel/test-async-context-frame.mjs
+++ b/test/parallel/test-async-context-frame.mjs
@@ -5,6 +5,7 @@ import { opendir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import { sep } from 'node:path';
+import { strictEqual } from 'node:assert';
 
 const python = process.env.PYTHON || (isWindows ? 'python' : 'python3');
 
@@ -53,7 +54,8 @@ describe('AsyncContextFrame', {
         stdio: ['ignore', 'ignore', 'inherit'],
       });
 
-      await once(proc, 'exit');
+      const [code] = await once(proc, 'exit');
+      strictEqual(code, 0, `Test ${test} failed with exit code ${code}`);
     });
   }
 });


### PR DESCRIPTION
This gives a class prototype for AsyncContextFrame that contains the required methods, so that when we swap the prototype, ActiveAsyncContextFrame methods are used instead. Previously, the methods were defined in AsyncContextFrame, so swapping the prototype didn't swap those static methods.

Also, make the ActiveAsyncContextFrame extend from Map.

Fixes: https://github.com/nodejs/node/issues/54503

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
