### PR TITLE
test: fix `test-process-load-env-file` when path contains `'`

### DIFF
--- a/test/parallel/test-process-load-env-file.js
+++ b/test/parallel/test-process-load-env-file.js
@@ -8,7 +8,7 @@ const { join } = require('node:path');
 
 const basicValidEnvFilePath = fixtures.path('dotenv/basic-valid.env');
 const validEnvFilePath = fixtures.path('dotenv/valid.env');
-const missingEnvFile = fixtures.path('dotenv/non-existent-file.env');
+const missingEnvFile = fixtures.path('dir%20with unusual"chars \'åß∂ƒ©∆¬…`/non-existent-file.env');
 
 describe('process.loadEnvFile()', () => {
 
@@ -85,7 +85,11 @@ describe('process.loadEnvFile()', () => {
     assert.match(child.stderr, /code: 'ERR_ACCESS_DENIED'/);
     assert.match(child.stderr, /permission: 'FileSystemRead'/);
     if (!common.isWindows) {
-      assert(child.stderr.includes(`resource: '${JSON.stringify(missingEnvFile).replaceAll('"', '')}'`));
+      const resource = /^\s+resource: (['"])(.+)\1$/m.exec(child.stderr);
+      assert(resource);
+      assert.strictEqual(resource[2], resource[1] === "'" ?
+        missingEnvFile.replaceAll("'", "\\'") :
+        JSON.stringify(missingEnvFile).slice(1, -1));
     }
     assert.strictEqual(child.code, 1);
   });


### PR DESCRIPTION
If the repo is cloned on a path that contains a quote, the test should not fail.

For good measure, I used a test path with "odd" chars so we're making sure it works everywhere.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
