### PR TITLE
repl: catch `\v` and `\r` in new-line detection

### DIFF
--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -436,9 +436,9 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
 
       // Line breaks are very rare and probably only occur in case of error
       // messages with line breaks.
-      const lineBreakPos = StringPrototypeIndexOf(inspected, '\n');
-      if (lineBreakPos !== -1) {
-        inspected = `${StringPrototypeSlice(inspected, 0, lineBreakPos)}`;
+      const lineBreakMatch = RegExpPrototypeExec(/[\r\n\v]/, inspected);
+      if (lineBreakMatch !== null) {
+        inspected = `${StringPrototypeSlice(inspected, 0, lineBreakMatch.index)}`;
       }
 
       const result = repl.useColors ?

--- a/test/parallel/test-repl-preview-newlines.js
+++ b/test/parallel/test-repl-preview-newlines.js
@@ -20,12 +20,10 @@ repl.start({
 let output = '';
 outputStream.write = (chunk) => output += chunk;
 
-const testChars = ['\\n', '\\v', '\\r'];
-
-for (const test of testChars) {
-  inputStream.emit('data', `"${test}"()`);
+for (const testChar of '\n\v\r') {
+  inputStream.emit('data', `${JSON.stringify(testChar)}()`);
   // Make sure the output is on a single line
-  assert.strictEqual(output, `"${test}"()\n\x1B[90mTypeError: "\x1B[39m\x1B[9G\x1B[1A`);
+  assert.strictEqual(output, `${JSON.stringify(testChar)}()\n\x1B[90mTypeError: "\x1B[39m\x1B[9G\x1B[1A`);
   inputStream.run(['']);
   output = '';
 }

--- a/test/parallel/test-repl-preview-newlines.js
+++ b/test/parallel/test-repl-preview-newlines.js
@@ -1,9 +1,11 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const repl = require('repl');
+
+common.skipIfInspectorDisabled();
 
 const inputStream = new ArrayStream();
 const outputStream = new ArrayStream();

--- a/test/parallel/test-repl-preview-newlines.js
+++ b/test/parallel/test-repl-preview-newlines.js
@@ -20,10 +20,10 @@ repl.start({
 let output = '';
 outputStream.write = (chunk) => output += chunk;
 
-for (const testChar of '\n\v\r') {
-  inputStream.emit('data', `${JSON.stringify(testChar)}()`);
+for (const char of ['\\n', '\\v', '\\r']) {
+  inputStream.emit('data', `"${char}"()`);
   // Make sure the output is on a single line
-  assert.strictEqual(output, `${JSON.stringify(testChar)}()\n\x1B[90mTypeError: "\x1B[39m\x1B[9G\x1B[1A`);
+  assert.strictEqual(output, `"${char}"()\n\x1B[90mTypeError: "\x1B[39m\x1B[9G\x1B[1A`);
   inputStream.run(['']);
   output = '';
 }

--- a/test/parallel/test-repl-preview-newlines.js
+++ b/test/parallel/test-repl-preview-newlines.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+const inputStream = new ArrayStream();
+const outputStream = new ArrayStream();
+repl.start({
+  input: inputStream,
+  output: outputStream,
+  useGlobal: false,
+  terminal: true,
+  useColors: true
+});
+
+let output = '';
+outputStream.write = (chunk) => output += chunk;
+
+const testChars = ['\\n', '\\v', '\\r'];
+
+for (const test of testChars) {
+  inputStream.emit('data', `"${test}"()`);
+  // Make sure the output is on a single line
+  assert.strictEqual(output, `"${test}"()\n\x1B[90mTypeError: "\x1B[39m\x1B[9G\x1B[1A`);
+  inputStream.run(['']);
+  output = '';
+}


### PR DESCRIPTION
Fixes #54504 
Uses `RegExpPrototypeExec` (with `\n`, `\r`, and `\v`) rather than `StringPrototypeIndexOf` with `\n`.