### PR TITLE
module: use amaro default transform values

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -360,10 +360,6 @@ function stripTypeScriptTypes(source, filename) {
     mode: typeScriptParsingMode,
     sourceMap: sourceMapEnabled,
     filename,
-    // Transform option is only applied in transform mode.
-    transform: {
-      verbatimModuleSyntax: true,
-    },
   };
   const { code, map } = parse(source, options);
   if (map) {

--- a/test/es-module/test-typescript-transform.mjs
+++ b/test/es-module/test-typescript-transform.mjs
@@ -114,3 +114,15 @@ test('execute a transpiled JavaScript file', async () => {
   strictEqual(result.stdout, '');
   strictEqual(result.code, 1);
 });
+
+test('execute TypeScript file with import = require', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-transform-types',
+    '--no-warnings',
+    fixtures.path('typescript/cts/test-import-require.cts'),
+  ]);
+
+  strictEqual(result.stderr, '');
+  match(result.stdout, /Hello, TypeScript!/);
+  strictEqual(result.code, 0);
+});

--- a/test/fixtures/typescript/cts/test-import-require.cts
+++ b/test/fixtures/typescript/cts/test-import-require.cts
@@ -1,0 +1,5 @@
+import util = require("node:util");
+
+const foo: string = "Hello, TypeScript!";
+
+console.log(util.styleText(["red"], foo));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/54514

Moves the configuration of transformation into amaro but can always be override by node.

@nodejs/typescript 