### PR TITLE
buffer: truncate instead of throw when writing beyond buffer

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1040,7 +1040,7 @@ function addBufferPrototypeMethods(proto) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0 || length > this.byteLength - offset) {
+    if (length < 0) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return asciiWriteStatic(this, string, offset, length);
@@ -1051,7 +1051,7 @@ function addBufferPrototypeMethods(proto) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0 || length > this.byteLength - offset) {
+    if (length < 0) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return latin1WriteStatic(this, string, offset, length);
@@ -1062,7 +1062,7 @@ function addBufferPrototypeMethods(proto) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0 || length > this.byteLength - offset) {
+    if (length < 0) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return utf8WriteStatic(this, string, offset, length);

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -106,3 +106,18 @@ assert.strictEqual(Buffer.alloc(4)
   assert.strictEqual(buf.write('ыы', 1, 'utf16le'), 4);
   assert.deepStrictEqual([...buf], [0, 0x4b, 0x04, 0x4b, 0x04, 0, 0, 0]);
 }
+
+{
+  const buf = Buffer.alloc(1);
+  assert.strictEqual(buf.write('ww'), 1);
+  assert.strictEqual(buf.toString(), 'w');
+}
+
+assert.throws(() => {
+  const buf = Buffer.alloc(1);
+  assert.strictEqual(buf.asciiWrite('ww', 0, -1));
+  assert.strictEqual(buf.latin1Write('ww', 0, -1));
+  assert.strictEqual(buf.utf8Write('ww', 0, -1));
+}, common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/54523

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
