### PR TITLE
build: support up to python 3.13 in android-configure

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -4,6 +4,8 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
+command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
 command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
@@ -21,7 +23,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 11), (3, 10), (3, 9), (3, 8))
+acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
 if sys.version_info[:2] in acceptable_pythons:
   import android_configure
 else:


### PR DESCRIPTION
Follow-up #54358

---

This PR brings the `android-configure` script up-to-speed with the `configure` script, that is, supporting python 3.12 and 3.13.