### PR TITLE
src: handle errors correctly in `permission.cc`

### DIFF
--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -113,7 +113,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
 
 #define V(code, type)                                                          \
   template <typename... Args>                                                  \
-  inline v8::Local<v8::Value> code(                                            \
+  inline v8::Local<v8::Object> code(                                           \
       v8::Isolate* isolate, const char* format, Args&&... args) {              \
     std::string message = SPrintF(format, std::forward<Args>(args)...);        \
     v8::Local<v8::String> js_code = OneByteString(isolate, #code);             \
@@ -209,17 +209,15 @@ ERRORS_WITH_CODE(V)
     "Accessing Object.prototype.__proto__ has been "                           \
     "disallowed with --disable-proto=throw")
 
-#define V(code, message)                                                     \
-  inline v8::Local<v8::Value> code(v8::Isolate* isolate) {                   \
-    return code(isolate, message);                                           \
-  }                                                                          \
-  inline void THROW_ ## code(v8::Isolate* isolate) {                         \
-    isolate->ThrowException(code(isolate, message));                         \
-  }                                                                          \
-  inline void THROW_ ## code(Environment* env) {                             \
-    THROW_ ## code(env->isolate());                                          \
-  }
-  PREDEFINED_ERROR_MESSAGES(V)
+#define V(code, message)                                                       \
+  inline v8::Local<v8::Object> code(v8::Isolate* isolate) {                    \
+    return code(isolate, message);                                             \
+  }                                                                            \
+  inline void THROW_##code(v8::Isolate* isolate) {                             \
+    isolate->ThrowException(code(isolate, message));                           \
+  }                                                                            \
+  inline void THROW_##code(Environment* env) { THROW_##code(env->isolate()); }
+PREDEFINED_ERROR_MESSAGES(V)
 #undef V
 
 // Errors with predefined non-static messages
@@ -231,7 +229,7 @@ inline void THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(Environment* env,
   THROW_ERR_SCRIPT_EXECUTION_TIMEOUT(env, message.str().c_str());
 }
 
-inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
+inline v8::Local<v8::Object> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
   char message[128];
   snprintf(message,
            sizeof(message),
@@ -240,7 +238,7 @@ inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
   return ERR_BUFFER_TOO_LARGE(isolate, message);
 }
 
-inline v8::Local<v8::Value> ERR_STRING_TOO_LONG(v8::Isolate* isolate) {
+inline v8::Local<v8::Object> ERR_STRING_TOO_LONG(v8::Isolate* isolate) {
   char message[128];
   snprintf(message, sizeof(message),
       "Cannot create a string longer than 0x%x characters",

--- a/src/permission/permission.cc
+++ b/src/permission/permission.cc
@@ -18,6 +18,8 @@ namespace node {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Local;
+using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -105,46 +107,43 @@ Permission::Permission() : enabled_(false) {
 #undef V
 }
 
-Local<Value> CreateAccessDeniedError(Environment* env,
-                                     PermissionScope perm,
-                                     const std::string_view& res) {
-  Local<Value> err = ERR_ACCESS_DENIED(env->isolate());
-  CHECK(err->IsObject());
-  if (err.As<Object>()
-          ->Set(env->context(),
-                env->permission_string(),
-                v8::String::NewFromUtf8(env->isolate(),
-                                        Permission::PermissionToString(perm),
-                                        v8::NewStringType::kNormal)
-                    .ToLocalChecked())
+MaybeLocal<Value> CreateAccessDeniedError(Environment* env,
+                                          PermissionScope perm,
+                                          const std::string_view& res) {
+  Local<Object> err = ERR_ACCESS_DENIED(env->isolate());
+  Local<String> perm_string;
+  Local<String> resource_string;
+  if (!String::NewFromUtf8(env->isolate(),
+                           Permission::PermissionToString(perm),
+                           NewStringType::kNormal)
+           .ToLocal(&perm_string) ||
+      !String::NewFromUtf8(
+           env->isolate(), std::string(res).c_str(), NewStringType::kNormal)
+           .ToLocal(&resource_string) ||
+      err->Set(env->context(), env->permission_string(), perm_string)
           .IsNothing() ||
-      err.As<Object>()
-          ->Set(env->context(),
-                env->resource_string(),
-                v8::String::NewFromUtf8(env->isolate(),
-                                        std::string(res).c_str(),
-                                        v8::NewStringType::kNormal)
-                    .ToLocalChecked())
-          .IsNothing())
-    return Local<Value>();
+      err->Set(env->context(), env->resource_string(), resource_string)
+          .IsNothing()) {
+    return MaybeLocal<Value>();
+  }
   return err;
 }
 
 void Permission::ThrowAccessDenied(Environment* env,
                                    PermissionScope perm,
                                    const std::string_view& res) {
-  Local<Value> err = CreateAccessDeniedError(env, perm, res);
+  MaybeLocal<Value> err = CreateAccessDeniedError(env, perm, res);
   if (err.IsEmpty()) return;
-  env->isolate()->ThrowException(err);
+  env->isolate()->ThrowException(err.ToLocalChecked());
 }
 
 void Permission::AsyncThrowAccessDenied(Environment* env,
                                         fs::FSReqBase* req_wrap,
                                         PermissionScope perm,
                                         const std::string_view& res) {
-  Local<Value> err = CreateAccessDeniedError(env, perm, res);
+  MaybeLocal<Value> err = CreateAccessDeniedError(env, perm, res);
   if (err.IsEmpty()) return;
-  return req_wrap->Reject(err);
+  return req_wrap->Reject(err.ToLocalChecked());
 }
 
 void Permission::EnablePermissions() {


### PR DESCRIPTION
First commit allows to simplify the code I changed in the second one.
