### PR TITLE
path: remove `StringPrototypeCharCodeAt` from `posix.extname`

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1462,8 +1462,8 @@ const posix = {
     // after any path separator we find
     let preDotState = 0;
     for (let i = path.length - 1; i >= 0; --i) {
-      const code = StringPrototypeCharCodeAt(path, i);
-      if (code === CHAR_FORWARD_SLASH) {
+      const char = path[i];
+      if (char === '/') {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {
@@ -1478,7 +1478,7 @@ const posix = {
         matchedSlash = false;
         end = i + 1;
       }
-      if (code === CHAR_DOT) {
+      if (char === '.') {
         // If this is our first dot, mark it as the start of our extension
         if (startDot === -1)
           startDot = i;


### PR DESCRIPTION
Benchmark shows an improvement:
```
                                                                                confidence improvement accuracy (*)   (**)   (***)
path/extname-posix.js n=100000 path=''                                                  *      5.10 %       ±4.68% ±6.23%  ±8.14%
path/extname-posix.js n=100000 path='/'                                                 *      4.92 %       ±3.78% ±5.04%  ±6.55%
path/extname-posix.js n=100000 path='/foo'                                              *      6.57 %       ±6.24% ±8.32% ±10.88%
path/extname-posix.js n=100000 path='/foo/bar/baz/asdf/quux.foobarbazasdfquux'        ***      7.94 %       ±2.34% ±3.12%  ±4.08%
path/extname-posix.js n=100000 path='/foo/bar/baz/asdf/quux'                            *      5.77 %       ±4.68% ±6.24%  ±8.15%
path/extname-posix.js n=100000 path='foo/.bar.baz'                                      *      4.49 %       ±4.40% ±5.88%  ±7.69%
path/extname-posix.js n=100000 path='foo/bar/...baz.quux'                             ***     11.69 %       ±6.29% ±8.37% ±10.90%
path/extname-posix.js n=100000 path='foo/bar/..baz.quux'                               **      7.95 %       ±5.30% ±7.05%  ±9.17%
path/extname-posix.js n=100000 path='index.html'                                        *      6.52 %       ±5.33% ±7.10%  ±9.28%
path/extname-posix.js n=100000 path='index'                                                    3.09 %       ±3.90% ±5.19%  ±6.78%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 10 comparisons, you can thus
expect the following amount of false-positive results:
  0.50 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.10 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)                                                                                                                              
```