### PR TITLE
test_runner: always make spec the default reporter

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1000,11 +1000,12 @@ flags for the test runner to use a specific reporter.
 
 The following built-reporters are supported:
 
+* `spec`
+  The `spec` reporter outputs the test results in a human-readable format. This
+  is the default reporter.
+
 * `tap`
   The `tap` reporter outputs the test results in the [TAP][] format.
-
-* `spec`
-  The `spec` reporter outputs the test results in a human-readable format.
 
 * `dot`
   The `dot` reporter outputs the test results in a compact format,
@@ -1017,9 +1018,6 @@ The following built-reporters are supported:
 * `lcov`
   The `lcov` reporter outputs test coverage when used with the
   [`--experimental-test-coverage`][] flag.
-
-When `stdout` is a [TTY][], the `spec` reporter is used by default.
-Otherwise, the `tap` reporter is used by default.
 
 The exact output of these reporters is subject to change between versions of
 Node.js, and should not be relied on programmatically. If programmatic access
@@ -3505,7 +3503,6 @@ added:
 Can be used to abort test subtasks when the test has been aborted.
 
 [TAP]: https://testanything.org/
-[TTY]: tty.md
 [`--experimental-test-coverage`]: cli.md#--experimental-test-coverage
 [`--experimental-test-snapshots`]: cli.md#--experimental-test-snapshots
 [`--import`]: cli.md#--importmodule

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -119,7 +119,7 @@ const kBuiltinReporters = new SafeMap([
   ['lcov', 'internal/test_runner/reporter/lcov'],
 ]);
 
-const kDefaultReporter = process.stdout.isTTY ? 'spec' : 'tap';
+const kDefaultReporter = 'spec';
 const kDefaultDestination = 'stdout';
 
 function tryBuiltinReporter(name) {

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -16,10 +16,10 @@ describe('node:test reporters', { concurrency: true }, () => {
   it('should default to outputing TAP to stdout', async () => {
     const child = spawnSync(process.execPath, ['--test', testFile]);
     assert.strictEqual(child.stderr.toString(), '');
-    assert.match(child.stdout.toString(), /TAP version 13/);
-    assert.match(child.stdout.toString(), /ok 1 - ok/);
-    assert.match(child.stdout.toString(), /not ok 2 - failing/);
-    assert.match(child.stdout.toString(), /ok 2 - top level/);
+    assert.match(child.stdout.toString(), /✖ failing tests:/);
+    assert.match(child.stdout.toString(), /✔ ok/);
+    assert.match(child.stdout.toString(), /✖ failing/);
+    assert.match(child.stdout.toString(), /✔ top level/);
   });
 
   it('should default destination to stdout when passing a single reporter', async () => {


### PR DESCRIPTION
The first commit here is #54547, which can be backported. The second commit here is semver major.

Prior to this commit, the test_runner defaulted to the spec reporter if using a TTY, and the TAP reporter otherwise. This commit makes spec the default reporter unconditionally. TAP output is still available via the `--test-reporter=tap` CLI flag.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
