### PR TITLE
doc: improve the process for landing a PR

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,6 +540,9 @@ The TSC serves as the final arbiter where required.
    landing. If you are unsure exactly how to format the commit messages, use
    the commit log as a reference. See [this commit][commit-example] as an
    example.
+6. Ideally check the recent commits on main to evaluate any potentially
+   risk or breakage that may happen, e.g. when two or more PRs both modified
+   the same subsystem or related subsystem(s).
 
 For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,8 +540,8 @@ The TSC serves as the final arbiter where required.
    landing. If you are unsure exactly how to format the commit messages, use
    the commit log as a reference. See [this commit][commit-example] as an
    example.
-6. Ideally check the recent commits on `main` to evaluate any potentially
-   risk or breakage that may happen, e.g. when two or more PRs both modified
+6. Ideally, check the recent commits on `main` to evaluate any potential
+   risk or breakage that may happen, e.g., due to multiple PRs that modify
    the same subsystem or related subsystem(s).
 
 For pull requests from first-time contributors, be

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -542,7 +542,7 @@ The TSC serves as the final arbiter where required.
    example.
 6. Ideally, check the recent commits on `main` to evaluate any potential
    risk or breakage that may happen, e.g., due to multiple PRs that modify
-   the same subsystem or related subsystem(s).
+   the same or related subsystem(s).
 
 For pull requests from first-time contributors, be
 [welcoming](#welcoming-first-time-contributors). Also, verify that their git

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -540,7 +540,7 @@ The TSC serves as the final arbiter where required.
    landing. If you are unsure exactly how to format the commit messages, use
    the commit log as a reference. See [this commit][commit-example] as an
    example.
-6. Ideally check the recent commits on main to evaluate any potentially
+6. Ideally check the recent commits on `main` to evaluate any potentially
    risk or breakage that may happen, e.g. when two or more PRs both modified
    the same subsystem or related subsystem(s).
 


### PR DESCRIPTION
Even though incident could still happen like https://github.com/nodejs/node/pull/54554 (which was partially my fault and I learned the lesson), I wanted to share my thoughts and hope to reduce the potential breakage in the future. As I noticed the other PR in `net` landed and I should've taken a closer look, or even just re-trigger the `CI` when in doubt, both approaches would help me to catch the test failure earlier.

Wording is not my expertise, happy for any suggestions 👍 or even just any thoughts on this potentially ongoing issue.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
