### PR TITLE
test: refactor `test-whatwg-webstreams-encoding` to be shorter

### DIFF
--- a/test/parallel/test-whatwg-webstreams-encoding.js
+++ b/test/parallel/test-whatwg-webstreams-encoding.js
@@ -49,7 +49,7 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
     assert.throws(
       () => Reflect.get(TextDecoderStream.prototype, getter, {}),
       { name: 'TypeError', message: /Cannot read private member/ }
-    )
+    );
   });
 }
 
@@ -75,6 +75,6 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
     assert.throws(
       () => Reflect.get(TextDecoderStream.prototype, getter, {}),
       { name: 'TypeError', message: /Cannot read private member/ }
-    )
+    );
   });
 }

--- a/test/parallel/test-whatwg-webstreams-encoding.js
+++ b/test/parallel/test-whatwg-webstreams-encoding.js
@@ -47,8 +47,11 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
   assert.strictEqual(tds.ignoreBOM, false);
   ['encoding', 'fatal', 'ignoreBOM', 'readable', 'writable'].forEach((getter) => {
     assert.throws(
-      () => Reflect.get(TextDecoderStream.prototype, getter, {}),
-      { name: 'TypeError', message: /Cannot read private member/ }
+      () => Reflect.get(TextDecoderStream.prototype, getter, {}), {
+        name: 'TypeError',
+        message: /Cannot read private member/,
+        stack: new RegExp(`at get ${getter}`)
+      }
     );
   });
 }
@@ -73,8 +76,11 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
   assert.strictEqual(tds.encoding, 'utf-8');
   ['encoding', 'readable', 'writable'].forEach((getter) => {
     assert.throws(
-      () => Reflect.get(TextDecoderStream.prototype, getter, {}),
-      { name: 'TypeError', message: /Cannot read private member/ }
+      () => Reflect.get(TextDecoderStream.prototype, getter, {}), {
+        name: 'TypeError',
+        message: /Cannot read private member/,
+        stack: new RegExp(`at get ${getter}`)
+      }
     );
   });
 }

--- a/test/parallel/test-whatwg-webstreams-encoding.js
+++ b/test/parallel/test-whatwg-webstreams-encoding.js
@@ -45,32 +45,12 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
   assert.strictEqual(tds.encoding, 'utf-8');
   assert.strictEqual(tds.fatal, false);
   assert.strictEqual(tds.ignoreBOM, false);
-
-  assert.throws(
-    () => Reflect.get(TextDecoderStream.prototype, 'encoding', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextDecoderStream.prototype, 'fatal', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextDecoderStream.prototype, 'ignoreBOM', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextDecoderStream.prototype, 'readable', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextDecoderStream.prototype, 'writable', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
+  ['encoding', 'fatal', 'ignoreBOM', 'readable', 'writable'].forEach((getter) => {
+    assert.throws(
+      () => Reflect.get(TextDecoderStream.prototype, getter, {}),
+      { name: 'TypeError', message: /Cannot read private member/ }
+    )
+  });
 }
 
 {
@@ -91,20 +71,10 @@ const kEuro = Buffer.from([0xe2, 0x82, 0xac]).toString();
   ]).then(common.mustCall());
 
   assert.strictEqual(tds.encoding, 'utf-8');
-
-  assert.throws(
-    () => Reflect.get(TextEncoderStream.prototype, 'encoding', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextEncoderStream.prototype, 'readable', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
-  assert.throws(
-    () => Reflect.get(TextEncoderStream.prototype, 'writable', {}), {
-      name: 'TypeError',
-      message: /Cannot read private member/,
-    });
+  ['encoding', 'readable', 'writable'].forEach((getter) => {
+    assert.throws(
+      () => Reflect.get(TextDecoderStream.prototype, getter, {}),
+      { name: 'TypeError', message: /Cannot read private member/ }
+    )
+  });
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Use a `forEach` loop for `assert.throws` statements, improving code readability.
