### PR TITLE
test: use test runner in `test-report-config`

### DIFF
--- a/test/report/test-report-config.js
+++ b/test/report/test-report-config.js
@@ -2,112 +2,97 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const { test } = require('node:test');
 
-// Verify that process.report.directory behaves properly.
-assert.strictEqual(process.report.directory, '');
-process.report.directory = __dirname;
-assert.strictEqual(process.report.directory, __dirname);
-assert.throws(() => {
-  process.report.directory = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.directory, __dirname);
-
-// Verify that process.report.filename behaves properly.
-assert.strictEqual(process.report.filename, '');
-process.report.filename = 'test-report.json';
-assert.strictEqual(process.report.filename, 'test-report.json');
-assert.throws(() => {
-  process.report.filename = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.filename, 'test-report.json');
-
-// Verify that process.report.reportOnFatalError behaves properly.
-assert.strictEqual(process.report.reportOnFatalError, true);
-process.report.reportOnFatalError = false;
-assert.strictEqual(process.report.reportOnFatalError, false);
-process.report.reportOnFatalError = true;
-assert.strictEqual(process.report.reportOnFatalError, true);
-assert.throws(() => {
-  process.report.reportOnFatalError = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.reportOnFatalError, true);
-
-
-// Verify that process.report.reportOnUncaughtException behaves properly.
-assert.strictEqual(process.report.reportOnUncaughtException, true);
-process.report.reportOnUncaughtException = false;
-assert.strictEqual(process.report.reportOnUncaughtException, false);
-process.report.reportOnUncaughtException = true;
-assert.strictEqual(process.report.reportOnUncaughtException, true);
-assert.throws(() => {
-  process.report.reportOnUncaughtException = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.reportOnUncaughtException, true);
-
-// Verify that process.report.reportOnSignal behaves properly.
-assert.strictEqual(process.report.reportOnSignal, true);
-process.report.reportOnSignal = false;
-assert.strictEqual(process.report.reportOnSignal, false);
-process.report.reportOnSignal = true;
-assert.strictEqual(process.report.reportOnSignal, true);
-assert.throws(() => {
-  process.report.reportOnSignal = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.reportOnSignal, true);
-
-// Verify that process.report.reportCompact behaves properly.
-assert.strictEqual(process.report.compact, true);
-process.report.compact = false;
-assert.strictEqual(process.report.compact, false);
-process.report.compact = true;
-assert.strictEqual(process.report.compact, true);
-assert.throws(() => {
-  process.report.compact = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.compact, true);
-
-// Verify that process.report.excludeNetwork behaves properly.
-assert.strictEqual(process.report.excludeNetwork, false);
-process.report.excludeNetwork = true;
-assert.strictEqual(process.report.excludeNetwork, true);
-process.report.excludeNetwork = false;
-assert.strictEqual(process.report.excludeNetwork, false);
-assert.throws(() => {
-  process.report.excludeNetwork = {};
-}, { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(process.report.excludeNetwork, false);
+const invalidArgType = { code: 'ERR_INVALID_ARG_TYPE' };
+const cases = [
+  {
+    key: 'directory',
+    value: '',
+    newValue: __dirname,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'filename',
+    value: '',
+    newValue: 'test-report.json',
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'reportOnFatalError',
+    value: true,
+    newValue: false,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'reportOnUncaughtException',
+    value: true,
+    newValue: false,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'reportOnSignal',
+    value: false,
+    newValue: true,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'compact',
+    value: true,
+    newValue: false,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+  {
+    key: 'excludeNetwork',
+    value: false,
+    newValue: true,
+    throwingSetters: [[{}, invalidArgType]],
+  },
+];
 
 if (!common.isWindows) {
-  // Verify that process.report.signal behaves properly.
-  assert.strictEqual(process.report.signal, 'SIGUSR2');
-  assert.throws(() => {
-    process.report.signal = {};
-  }, { code: 'ERR_INVALID_ARG_TYPE' });
-  assert.throws(() => {
-    process.report.signal = 'foo';
-  }, {
-    code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: foo',
+  cases.push({
+    key: 'signal',
+    value: 'SIGUSR1',
+    newValue: 'SIGUSR2',
+    throwingSetters: [
+      [{}, invalidArgType],
+      ['foo', { code: 'ERR_UNKNOWN_SIGNAL', message: 'Unknown signal: foo' }],
+      ['sigusr1', { code: 'ERR_UNKNOWN_SIGNAL',
+                    message: 'Unknown signal: sigusr1 (signals must use all capital letters)' }],
+    ],
   });
-  assert.throws(() => {
-    process.report.signal = 'sigusr1';
-  }, {
-    code: 'ERR_UNKNOWN_SIGNAL',
-    message: 'Unknown signal: sigusr1 (signals must use all capital letters)',
-  });
-  assert.strictEqual(process.report.signal, 'SIGUSR2');
-  process.report.signal = 'SIGUSR1';
-  assert.strictEqual(process.report.signal, 'SIGUSR1');
 
-  // Verify that the interaction between reportOnSignal and signal is correct.
-  process.report.signal = 'SIGUSR2';
-  process.report.reportOnSignal = false;
-  assert.strictEqual(process.listenerCount('SIGUSR2'), 0);
-  process.report.reportOnSignal = true;
-  assert.strictEqual(process.listenerCount('SIGUSR2'), 1);
-  process.report.signal = 'SIGUSR1';
-  assert.strictEqual(process.listenerCount('SIGUSR2'), 0);
-  assert.strictEqual(process.listenerCount('SIGUSR1'), 1);
-  process.report.reportOnSignal = false;
-  assert.strictEqual(process.listenerCount('SIGUSR1'), 0);
+  test('Verify that the interaction between reportOnSignal and signal is correct.', (t) => {
+    process.report.reportOnSignal = false;
+    t.assert.strictEqual(process.listenerCount('SIGUSR2'), 0);
+
+    process.report.reportOnSignal = true;
+    t.assert.strictEqual(process.listenerCount('SIGUSR2'), 1);
+
+    process.report.signal = 'SIGUSR1';
+    t.assert.strictEqual(process.listenerCount('SIGUSR2'), 0);
+    t.assert.strictEqual(process.listenerCount('SIGUSR1'), 1);
+
+    process.report.reportOnSignal = false;
+    t.assert.strictEqual(process.listenerCount('SIGUSR1'), 0);
+  });
+}
+
+for (const testCase of cases) {
+  const { key, value, newValue, throwingSetters } = testCase;
+
+  test(`Verify that process.report.${key} behaves properly`, (t) => {
+    t.assert.strictEqual(process.report[key], value);
+
+    process.report[key] = newValue;
+    t.assert.strictEqual(process.report[key], newValue);
+
+    for (const throwingSetter of throwingSetters) {
+      assert.throws(() => process.report[key] = throwingSetter[0], throwingSetter[1]);
+    }
+
+    process.report[key] = newValue;
+    t.assert.strictEqual(process.report[key], newValue);
+  });
 }


### PR DESCRIPTION
```
NOTE: The test started as a child_process using these flags: [
  '--report-on-fatalerror',
  '--report-on-signal',
  '--report-uncaught-exception',
  '--report-compact'
] Use NODE_SKIP_FLAG_CHECK to run the test with the original flags.
✔ Verify that the interaction between reportOnSignal and signal is correct. (1.468327ms)
✔ Verify that process.report.directory behaves properly (0.918158ms)
✔ Verify that process.report.filename behaves properly (0.20325ms)
✔ Verify that process.report.reportOnFatalError behaves properly (0.151694ms)
✔ Verify that process.report.reportOnUncaughtException behaves properly (0.275656ms)
✔ Verify that process.report.reportOnSignal behaves properly (0.164718ms)
✔ Verify that process.report.compact behaves properly (0.184926ms)
✔ Verify that process.report.excludeNetwork behaves properly (0.187271ms)
✔ Verify that process.report.signal behaves properly (0.750093ms)
ℹ tests 9
ℹ suites 0
ℹ pass 9
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 11.282749
```