### PR TITLE
tools: lint python files to 3.8

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import json
 import sys
@@ -11,7 +10,6 @@ import shlex
 import subprocess
 import shutil
 import bz2
-import io
 from pathlib import Path
 
 # If not run from node/, cd to node/.
@@ -1994,7 +1992,7 @@ def configure_intl(o):
   icu_ver_major = None
   matchVerExp = r'^\s*#define\s+U_ICU_VERSION_SHORT\s+"([^"]*)".*'
   match_version = re.compile(matchVerExp)
-  with io.open(uvernum_h, encoding='utf8') as in_file:
+  with open(uvernum_h, encoding='utf8') as in_file:
     for line in in_file:
       m = match_version.match(line)
       if m:

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2358,6 +2358,38 @@ changes:
 The destination for the corresponding test reporter. See the documentation on
 [test reporters][] for more details.
 
+### `--test-runner-exclude`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Excludes specific files from being ran in the test suite using a glob pattern, which
+can match the relative file path.
+
+This option may be specified multiple times to exclude multiple glob patterns.
+
+If both `--test-runner-exclude` and `--test-runner-include` are provided,
+files must meet **both** criteria to be included in the test suite.
+
+### `--test-runner-exclude`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Includes specific files in the test suite using a glob pattern, which can match
+both the relative file path.
+
+This option may be specified multiple times to include multiple glob patterns.
+
+If both `--test-runner-exclude` and `--test-runner-include` are provided,
+files must meet **both** criteria to be included in the test suite.
+
 ### `--test-shard`
 
 <!-- YAML
@@ -3059,6 +3091,8 @@ one is included in the list below.
 * `--test-only`
 * `--test-reporter-destination`
 * `--test-reporter`
+* `--test-runner-exclude`
+* `--test-runner-include`
 * `--test-shard`
 * `--test-skip-pattern`
 * `--throw-deprecation`

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -30,6 +30,7 @@ const {
   TypedArrayPrototypeSubarray,
 } = primordials;
 
+const { matchesGlob } = require('path');
 const { spawn } = require('child_process');
 const { finished } = require('internal/streams/end-of-stream');
 const { resolve } = require('path');
@@ -345,11 +346,28 @@ class FileTest extends Test {
   }
 }
 
+function shouldSkip(path, includeGlobs, excludeGlobs) {
+  if (excludeGlobs?.length > 0) {
+    for (let i = 0; i < excludeGlobs.length; ++i) {
+      if (matchesGlob(path, excludeGlobs[i])) return true;
+    }
+  }
+
+  if (includeGlobs?.length > 0) {
+    for (let i = 0; i < includeGlobs.length; ++i) {
+      if (matchesGlob(path, includeGlobs[i])) return false;
+    }
+    return true;
+  }
+}
+
 function runTestFile(path, filesWatcher, opts) {
   const watchMode = filesWatcher != null;
   const testPath = path === kIsolatedProcessName ? '' : path;
   const testOpts = { __proto__: null, signal: opts.signal };
+  if (shouldSkip(path, opts.root.config.testIncludeGlobs, opts.root.config.testExcludeGlobs)) testOpts.skip = true;
   const subtest = opts.root.createSubtest(FileTest, testPath, testOpts, async (t) => {
+    t.skip();
     const args = getRunArgs(path, opts);
     const stdio = ['pipe', 'pipe', 'pipe'];
     const env = { __proto__: null, ...process.env, NODE_TEST_CONTEXT: 'child-v8' };

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -195,6 +195,8 @@ function parseCommandLine() {
   let concurrency;
   let coverageExcludeGlobs;
   let coverageIncludeGlobs;
+  let testExcludeGlobs = getOptionValue('--test-runner-exclude');
+  let testIncludeGlobs = getOptionValue('--test-runner-include');
   let lineCoverage;
   let branchCoverage;
   let functionCoverage;
@@ -319,6 +321,8 @@ function parseCommandLine() {
     setup,
     shard,
     sourceMaps,
+    testExcludeGlobs,
+    testIncludeGlobs,
     testNamePatterns,
     testSkipPatterns,
     timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ select = [
   "TID",    # flake8-tidy-imports
   "W",      # pycodestyle
   "YTT",    # flake8-2020
+  "UP"
 ]
 ignore = [
   "E401",

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -671,6 +671,15 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::test_coverage_lines,
             kAllowedInEnvvar);
 
+    AddOption("--test-runner-exclude",
+            "run tests whose filepath does not match this glob",
+            &EnvironmentOptions::test_runner_exclude,
+            kAllowedInEnvvar);
+    AddOption("--test-runner-include",
+            "only run tests whose filepath matches this glob",
+            &EnvironmentOptions::test_runner_include,
+            kAllowedInEnvvar);
+
   AddOption("--experimental-test-isolation",
             "configures the type of test isolation used in the test runner",
             &EnvironmentOptions::test_isolation);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -199,6 +199,8 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> test_skip_pattern;
   std::vector<std::string> coverage_include_pattern;
   std::vector<std::string> coverage_exclude_pattern;
+  std::vector<std::string> test_runner_exclude;
+  std::vector<std::string> test_runner_include;
   bool throw_deprecation = false;
   bool trace_deprecation = false;
   bool trace_exit = false;

--- a/test/message/testcfg.py
+++ b/test/message/testcfg.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # Copyright 2008 the V8 project authors. All rights reserved.
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -37,7 +36,7 @@ FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
 class MessageTestCase(test.TestCase):
 
   def __init__(self, path, file, expected, arch, mode, context, config):
-    super(MessageTestCase, self).__init__(context, path, arch, mode)
+    super().__init__(context, path, arch, mode)
     self.file = file
     self.expected = expected
     self.config = config
@@ -64,7 +63,7 @@ class MessageTestCase(test.TestCase):
         continue
       pattern = re.escape(line.rstrip() % env)
       pattern = pattern.replace('\\*', '.*')
-      pattern = '^%s$' % pattern
+      pattern = f'^{pattern}$'
       patterns.append(pattern)
     # Compare actual output with the expected
     raw_lines = (output.stdout + output.stderr).split('\n')
@@ -75,22 +74,22 @@ class MessageTestCase(test.TestCase):
       print("actual=%d" % len(outlines))
       print("patterns:")
       for i in range(len(patterns)):
-        print("pattern = %s" % patterns[i])
+        print(f"pattern = {patterns[i]}")
       print("outlines:")
       for i in range(len(outlines)):
-        print("outline = %s" % outlines[i])
+        print(f"outline = {outlines[i]}")
       return True
     for i in range(len(patterns)):
       if not re.match(patterns[i], outlines[i]):
         print("match failed")
         print("line=%d" % i)
-        print("expect=%s" % patterns[i])
-        print("actual=%s" % outlines[i])
+        print(f"expect={patterns[i]}")
+        print(f"actual={outlines[i]}")
         return True
     return False
 
   def GetLabel(self):
-    return "%s %s" % (self.mode, self.GetName())
+    return f"{self.mode} {self.GetName()}"
 
   def GetName(self):
     return self.path[-1]
@@ -126,7 +125,7 @@ class MessageTestConfiguration(test.TestConfiguration):
         file_path = join(self.root, reduce(join, tst[1:], ''))
         output_path = file_path[:file_path.rfind('.')] + '.out'
         if not exists(output_path):
-          raise Exception("Could not find %s" % output_path)
+          raise Exception(f"Could not find {output_path}")
         result.append(MessageTestCase(tst, file_path, output_path,
                                       arch, mode, self.context, self))
     return result

--- a/test/pseudo-tty/testcfg.py
+++ b/test/pseudo-tty/testcfg.py
@@ -25,7 +25,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
 
 import test
 import os
@@ -41,7 +40,7 @@ PTY_HELPER = join(dirname(__file__), '../../tools/pseudo-tty.py')
 class TTYTestCase(test.TestCase):
 
   def __init__(self, path, file, expected, input_arg, arch, mode, context, config):
-    super(TTYTestCase, self).__init__(context, path, arch, mode)
+    super().__init__(context, path, arch, mode)
     self.file = file
     self.expected = expected
     self.input = input_arg
@@ -65,7 +64,7 @@ class TTYTestCase(test.TestCase):
         continue
       pattern = re.escape(line.rstrip() % env)
       pattern = pattern.replace('\\*', '.*')
-      pattern = '^%s$' % pattern
+      pattern = f'^{pattern}$'
       patterns.append(pattern)
     # Compare actual output with the expected
     raw_lines = (output.stdout + output.stderr).split('\n')
@@ -76,22 +75,22 @@ class TTYTestCase(test.TestCase):
       print("actual=%d" % len(outlines))
       print("patterns:")
       for i in range(len(patterns)):
-        print("pattern = %s" % patterns[i])
+        print(f"pattern = {patterns[i]}")
       print("outlines:")
       for i in range(len(outlines)):
-        print("outline = %s" % outlines[i])
+        print(f"outline = {outlines[i]}")
       return True
     for i in range(len(patterns)):
       if not re.match(patterns[i], outlines[i]):
         print(" match failed")
         print("line=%d" % i)
-        print("expect=%s" % patterns[i])
-        print("actual=%s" % outlines[i])
+        print(f"expect={patterns[i]}")
+        print(f"actual={outlines[i]}")
         return True
     return False
 
   def GetLabel(self):
-    return "%s %s" % (self.mode, self.GetName())
+    return f"{self.mode} {self.GetName()}"
 
   def GetName(self):
     return self.path[-1]
@@ -151,7 +150,7 @@ class TTYTestConfiguration(test.TestConfiguration):
         input_path = file_prefix + ".in"
         output_path = file_prefix + ".out"
         if not exists(output_path):
-          raise Exception("Could not find %s" % output_path)
+          raise Exception(f"Could not find {output_path}")
         result.append(TTYTestCase(tst, file_path, output_path,
                                   input_path, arch, mode, self.context, self))
     return result

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -29,7 +29,7 @@ import test
 import os
 import re
 from functools import reduce
-from io import open
+import builtins
 
 
 FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
@@ -38,7 +38,7 @@ LS_RE = re.compile(r'^test-.*\.m?js$')
 class SimpleTestCase(test.TestCase):
 
   def __init__(self, path, file, arch, mode, context, config, additional=None):
-    super(SimpleTestCase, self).__init__(context, path, arch, mode)
+    super().__init__(context, path, arch, mode)
     self.file = file
     self.config = config
     self.arch = arch
@@ -50,14 +50,14 @@ class SimpleTestCase(test.TestCase):
 
 
   def GetLabel(self):
-    return "%s %s" % (self.mode, self.GetName())
+    return f"{self.mode} {self.GetName()}"
 
   def GetName(self):
     return self.path[-1]
 
   def GetCommand(self):
     result = [self.config.context.GetVm(self.arch, self.mode)]
-    source = open(self.file, encoding='utf8').read()
+    source = builtins.open(self.file, encoding='utf8').read()
     flags_match = FLAGS_PATTERN.search(source)
     if flags_match:
       flags = flags_match.group(1).strip().split()
@@ -90,12 +90,12 @@ class SimpleTestCase(test.TestCase):
     return result
 
   def GetSource(self):
-    return open(self.file).read()
+    return builtins.open(self.file).read()
 
 
 class SimpleTestConfiguration(test.TestConfiguration):
   def __init__(self, context, root, section, additional=None):
-    super(SimpleTestConfiguration, self).__init__(context, root, section)
+    super().__init__(context, root, section)
     if additional is not None:
       self.additional_flags = additional
     else:
@@ -120,11 +120,11 @@ class SimpleTestConfiguration(test.TestConfiguration):
 
 class ParallelTestConfiguration(SimpleTestConfiguration):
   def __init__(self, context, root, section, additional=None):
-    super(ParallelTestConfiguration, self).__init__(context, root, section,
+    super().__init__(context, root, section,
                                                     additional)
 
   def ListTests(self, current_path, path, arch, mode):
-    result = super(ParallelTestConfiguration, self).ListTests(
+    result = super().ListTests(
          current_path, path, arch, mode)
     for tst in result:
       tst.parallel = True
@@ -132,7 +132,7 @@ class ParallelTestConfiguration(SimpleTestConfiguration):
 
 class AddonTestConfiguration(SimpleTestConfiguration):
   def __init__(self, context, root, section, additional=None):
-    super(AddonTestConfiguration, self).__init__(context, root, section, additional)
+    super().__init__(context, root, section, additional)
 
   def Ls(self, path):
     def SelectTest(name):
@@ -158,11 +158,11 @@ class AddonTestConfiguration(SimpleTestConfiguration):
 
 class AbortTestConfiguration(SimpleTestConfiguration):
   def __init__(self, context, root, section, additional=None):
-    super(AbortTestConfiguration, self).__init__(context, root, section,
+    super().__init__(context, root, section,
                                                  additional)
 
   def ListTests(self, current_path, path, arch, mode):
-    result = super(AbortTestConfiguration, self).ListTests(
+    result = super().ListTests(
          current_path, path, arch, mode)
     for tst in result:
       tst.disable_core_files = True
@@ -170,11 +170,11 @@ class AbortTestConfiguration(SimpleTestConfiguration):
 
 class WasmAllocationTestConfiguration(SimpleTestConfiguration):
   def __init__(self, context, root, section, additional=None):
-    super(WasmAllocationTestConfiguration, self).__init__(context, root, section,
+    super().__init__(context, root, section,
                                                           additional)
 
   def ListTests(self, current_path, path, arch, mode):
-    result = super(WasmAllocationTestConfiguration, self).ListTests(
+    result = super().ListTests(
          current_path, path, arch, mode)
     for tst in result:
       tst.max_virtual_memory = 5 * 1024 * 1024 * 1024 # 5GB

--- a/tools/checkimports.py
+++ b/tools/checkimports.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import glob
-import io
 import re
 import sys
 import itertools
@@ -16,7 +14,7 @@ def do_exist(file_name, lines, imported):
 
 
 def is_valid(file_name):
-  with io.open(file_name, encoding='utf-8') as source_file:
+  with open(file_name, encoding='utf-8') as source_file:
     lines = [line.strip() for line in source_file]
 
   usings, importeds, line_numbers, valid = [], [], [], True

--- a/tools/configure.d/nodedownload.py
+++ b/tools/configure.d/nodedownload.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # Moved some utilities here from ../../configure
 
-from __future__ import print_function
 import hashlib
 import sys
 import zipfile
@@ -24,7 +23,7 @@ def spin(c):
 class ConfigOpener(FancyURLopener):
     """fancy opener used by retrievefile. Set a UA"""
     # append to existing version (UA)
-    version = '%s node.js/configure' % URLopener.version
+    version = f'{URLopener.version} node.js/configure'
 
 def reporthook(count, size, total):
     """internal hook used by retrievefile"""
@@ -36,16 +35,16 @@ def reporthook(count, size, total):
 def retrievefile(url, targetfile):
     """fetch file 'url' as 'targetfile'. Return targetfile or throw."""
     try:
-        sys.stdout.write(' <%s>\nConnecting...\r' % url)
+        sys.stdout.write(f' <{url}>\nConnecting...\r')
         sys.stdout.flush()
         ConfigOpener().retrieve(url, targetfile, reporthook=reporthook)
         print('')  # clear the line
         return targetfile
-    except IOError as err:
-        print(' ** IOError %s\n' % err)
+    except OSError as err:
+        print(f' ** IOError {err}\n')
         return None
     except:
-        print(' ** Error occurred while downloading\n <%s>' % url)
+        print(f' ** Error occurred while downloading\n <{url}>')
         raise
 
 def findHash(dict):
@@ -72,17 +71,17 @@ def unpack(packedfile, parent_path):
     """Unpacks packedfile into parent_path. Assumes .zip. Returns parent_path"""
     if zipfile.is_zipfile(packedfile):
         with contextlib.closing(zipfile.ZipFile(packedfile, 'r')) as icuzip:
-            print(' Extracting zipfile: %s' % packedfile)
+            print(f' Extracting zipfile: {packedfile}')
             icuzip.extractall(parent_path)
             return parent_path
     elif tarfile.is_tarfile(packedfile):
         with contextlib.closing(tarfile.TarFile.open(packedfile, 'r')) as icuzip:
-            print(' Extracting tarfile: %s' % packedfile)
+            print(f' Extracting tarfile: {packedfile}')
             icuzip.extractall(parent_path)
             return parent_path
     else:
         packedsuffix = packedfile.lower().split('.')[-1]  # .zip, .tgz etc
-        raise Exception('Error: Don\'t know how to unpack %s with extension %s' % (packedfile, packedsuffix))
+        raise Exception(f'Error: Don\'t know how to unpack {packedfile} with extension {packedsuffix}')
 
 # List of possible "--download=" types.
 download_types = set(['icu'])
@@ -93,7 +92,7 @@ download_default = "none"
 def help():
   """This function calculates the '--help' text for '--download'."""
   return """Select which packages may be auto-downloaded.
-valid values are: none, all, %s. (default is "%s").""" % (", ".join(download_types), download_default)
+valid values are: none, all, {}. (default is "{}").""".format(", ".join(download_types), download_default)
 
 def set2dict(keys, value=None):
   """Convert some keys (iterable) to a dict."""
@@ -128,16 +127,16 @@ def parse(opt):
         theRet[anOpt] = True
       else:
         # future proof: ignore unknown types
-        print('Warning: ignoring unknown --download= type "%s"' % anOpt)
+        print(f'Warning: ignoring unknown --download= type "{anOpt}"')
   # all done
   return theRet
 
 def candownload(auto_downloads, package):
   if not (package in auto_downloads.keys()):
-    raise Exception('Internal error: "%s" is not in the --downloads list. Check nodedownload.py' % package)
+    raise Exception(f'Internal error: "{package}" is not in the --downloads list. Check nodedownload.py')
   if auto_downloads[package]:
     return True
   else:
-    print("""Warning: Not downloading package "%s". You could pass "--download=all"
-    (Windows: "download-all") to try auto-downloading it.""" % package)
+    print(f"""Warning: Not downloading package "{package}". You could pass "--download=all"
+    (Windows: "download-all") to try auto-downloading it.""")
     return False

--- a/tools/enable_fips_include.py
+++ b/tools/enable_fips_include.py
@@ -31,12 +31,12 @@ import sys
 __import__('copyfile')
 
 # Open the copied openssl.cnf file
-fin = open(sys.argv[2], "rt")
+fin = open(sys.argv[2])
 data = fin.read()
-data = data.replace('# .include fipsmodule.cnf', '.include %s' % sys.argv[3])
+data = data.replace('# .include fipsmodule.cnf', f'.include {sys.argv[3]}')
 data = data.replace('# fips = fips_sect', 'fips = fips_sect')
 data = data.replace('# activate = 1', 'activate = 1')
 fin.close()
-fin = open(sys.argv[2], "wt")
+fin = open(sys.argv[2], "w")
 fin.write(data)
 fin.close()

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -110,7 +110,7 @@ def main():
   # Write depfile. Force regenerating config.gypi when GN configs change.
   if args.dep_file:
     with open(args.dep_file, 'w') as f:
-      f.write('%s: %s '%(args.target, 'build.ninja'))
+      f.write('{}: {} '.format(args.target, 'build.ninja'))
 
 if __name__ == '__main__':
   main()

--- a/tools/getmoduleversion.py
+++ b/tools/getmoduleversion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import re
 
@@ -19,7 +18,7 @@ def get_version():
       major = line.split()[2]
       return major
 
-  raise Exception('Could not find pattern matching %s' % regex)
+  raise Exception(f'Could not find pattern matching {regex}')
 
 
 if __name__ == '__main__':

--- a/tools/getnapibuildversion.py
+++ b/tools/getnapibuildversion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import re
 
@@ -19,7 +18,7 @@ def get_napi_version():
       napi_version = line.split()[2]
       return napi_version
 
-  raise Exception('Could not find pattern matching %s' % regex)
+  raise Exception(f'Could not find pattern matching {regex}')
 
 
 if __name__ == '__main__':

--- a/tools/getnodeversion.py
+++ b/tools/getnodeversion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 
 

--- a/tools/getsharedopensslhasquic.py
+++ b/tools/getsharedopensslhasquic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import re
 

--- a/tools/gyp_node.py
+++ b/tools/gyp_node.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import os
 import sys
 

--- a/tools/gypi_to_gn.py
+++ b/tools/gypi_to_gn.py
@@ -99,8 +99,6 @@ the input will be replaced with "bar":
                             [ "your_file.gypi" ])
 """
 
-from __future__ import absolute_import
-from __future__ import print_function
 from optparse import OptionParser
 import sys
 
@@ -214,7 +212,7 @@ def TranslateToGnChars(s):
     elif 32 <= code < 127:
       yield chr(code)
     else:
-      yield '$0x%02X' % code
+      yield f'$0x{code:02X}'
 
 
 def LoadPythonDictionary(path):
@@ -225,9 +223,9 @@ def LoadPythonDictionary(path):
     e.filename = path
     raise
   except Exception as e:
-    raise Exception("Unexpected error while reading %s: %s" % (path, str(e)))
+    raise Exception(f"Unexpected error while reading {path}: {e!s}")
 
-  assert isinstance(file_data, dict), "%s does not eval to a dictionary" % path
+  assert isinstance(file_data, dict), f"{path} does not eval to a dictionary"
 
   # Flatten any variables to the top level.
   if 'variables' in file_data:

--- a/tools/icu/icutrim.py
+++ b/tools/icu/icutrim.py
@@ -11,9 +11,7 @@
 # Usage:
 #  Use "-h" to get help options.
 
-from __future__ import print_function
 
-import io
 import json
 import optparse
 import os
@@ -82,7 +80,7 @@ parser.add_option('-L',"--locales",
                   help="sets the 'locales.only' variable",
                   default=None)
 
-parser.add_option('-e', '--endian', action='store', dest='endian', help='endian, big, little or host, your default is "%s".' % endian, default=endian, metavar='endianness')
+parser.add_option('-e', '--endian', action='store', dest='endian', help=f'endian, big, little or host, your default is "{endian}".', default=endian, metavar='endianness')
 
 (options, args) = parser.parse_args()
 
@@ -90,7 +88,7 @@ optVars = vars(options)
 
 for opt in [ "datfile", "filterfile", "tmpdir", "outfile" ]:
     if optVars[opt] is None:
-        print("Missing required option: %s" % opt)
+        print(f"Missing required option: {opt}")
         sys.exit(1)
 
 if options.verbose>0:
@@ -98,46 +96,46 @@ if options.verbose>0:
 
 if (os.path.isdir(options.tmpdir) and options.deltmpdir):
   if options.verbose>1:
-    print("Deleting tmp dir %s.." % (options.tmpdir))
+    print(f"Deleting tmp dir {options.tmpdir}..")
   shutil.rmtree(options.tmpdir)
 
 if not (os.path.isdir(options.tmpdir)):
     os.mkdir(options.tmpdir)
 else:
-    print("Please delete tmpdir %s before beginning." % options.tmpdir)
+    print(f"Please delete tmpdir {options.tmpdir} before beginning.")
     sys.exit(1)
 
 if options.endian not in ("big","little","host"):
-    print("Unknown endianness: %s" % options.endian)
+    print(f"Unknown endianness: {options.endian}")
     sys.exit(1)
 
 if options.endian == "host":
     options.endian = endian
 
 if not os.path.isdir(options.tmpdir):
-    print("Error, tmpdir not a directory: %s" % (options.tmpdir))
+    print(f"Error, tmpdir not a directory: {options.tmpdir}")
     sys.exit(1)
 
 if not os.path.isfile(options.filterfile):
-    print("Filterfile doesn't exist: %s" % (options.filterfile))
+    print(f"Filterfile doesn't exist: {options.filterfile}")
     sys.exit(1)
 
 if not os.path.isfile(options.datfile):
-    print("Datfile doesn't exist: %s" % (options.datfile))
+    print(f"Datfile doesn't exist: {options.datfile}")
     sys.exit(1)
 
 if not options.datfile.endswith(".dat"):
-    print("Datfile doesn't end with .dat: %s" % (options.datfile))
+    print(f"Datfile doesn't end with .dat: {options.datfile}")
     sys.exit(1)
 
 outfile = os.path.join(options.tmpdir, options.outfile)
 
 if os.path.isfile(outfile):
-    print("Error, output file does exist: %s" % (outfile))
+    print(f"Error, output file does exist: {outfile}")
     sys.exit(1)
 
 if not options.outfile.endswith(".dat"):
-    print("Outfile doesn't end with .dat: %s" % (options.outfile))
+    print(f"Outfile doesn't end with .dat: {options.outfile}")
     sys.exit(1)
 
 dataname=options.outfile[0:-4]
@@ -155,12 +153,12 @@ def runcmd(tool, cmd, doContinue=False):
 
     rc = os.system(cmd)
     if rc != 0 and not doContinue:
-        print("FAILED: %s" % cmd)
+        print(f"FAILED: {cmd}")
         sys.exit(1)
     return rc
 
 ## STEP 0 - read in json config
-with io.open(options.filterfile, encoding='utf-8') as fi:
+with open(options.filterfile, encoding='utf-8') as fi:
     config = json.load(fi)
 
 if options.locales:
@@ -172,17 +170,17 @@ if options.verbose > 6:
     print(config)
 
 if "comment" in config:
-    print("%s: %s" % (options.filterfile, config["comment"]))
+    print("{}: {}".format(options.filterfile, config["comment"]))
 
 ## STEP 1 - copy the data file, swapping endianness
 ## The first letter of endian_letter will be 'b' or 'l' for big or little
 endian_letter = options.endian[0]
 
-runcmd("icupkg", "-t%s %s %s""" % (endian_letter, options.datfile, outfile))
+runcmd("icupkg", f"-t{endian_letter} {options.datfile} {outfile}")
 
 ## STEP 2 - get listing
 listfile = os.path.join(options.tmpdir,"icudata.lst")
-runcmd("icupkg", "-l %s > %s""" % (outfile, listfile))
+runcmd("icupkg", f"-l {outfile} > {listfile}")
 
 with open(listfile, 'rb') as fi:
     items = [line.strip() for line in fi.read().decode("utf-8").splitlines()]
@@ -218,27 +216,27 @@ def queueForRemoval(tree):
     if isinstance(config["trees"][tree], basestring):
         treeStr = config["trees"][tree]
         if options.verbose > 5:
-            print(" Substituting $%s for tree %s" % (treeStr, tree))
+            print(f" Substituting ${treeStr} for tree {tree}")
         if treeStr not in config.get("variables", {}):
-            print(" ERROR: no variable:  variables.%s for tree %s" % (treeStr, tree))
+            print(f" ERROR: no variable:  variables.{treeStr} for tree {tree}")
             sys.exit(1)
         config["trees"][tree] = config["variables"][treeStr]
     myconfig = config["trees"][tree]
     if options.verbose > 4:
-        print(" Config: %s" % (myconfig))
+        print(f" Config: {myconfig}")
     # Process this tree
     if(len(myconfig)==0 or len(mytree["locs"])==0):
         if(options.verbose>2):
-            print(" No processing for %s - skipping" % (tree))
+            print(f" No processing for {tree} - skipping")
     else:
         only = None
         if "only" in myconfig:
             only = set(myconfig["only"])
             if (len(only)==0) and (mytree["treeprefix"] != ""):
-                thePool = "%spool.res" % (mytree["treeprefix"])
+                thePool = "{}pool.res".format(mytree["treeprefix"])
                 if (thePool in itemset):
                     if(options.verbose>0):
-                        print("Removing %s because tree %s is empty." % (thePool, tree))
+                        print(f"Removing {thePool} because tree {tree} is empty.")
                     remove.add(thePool)
         else:
             print("tree %s - no ONLY")
@@ -246,14 +244,14 @@ def queueForRemoval(tree):
             loc = mytree["locs"][l]
             if (only is not None) and not loc in only:
                 # REMOVE loc
-                toRemove = "%s%s%s" % (mytree["treeprefix"], loc, mytree["extension"])
+                toRemove = "{}{}{}".format(mytree["treeprefix"], loc, mytree["extension"])
                 if(options.verbose>6):
-                    print("Queueing for removal: %s" % toRemove)
+                    print(f"Queueing for removal: {toRemove}")
                 remove.add(toRemove)
 
 def addTreeByType(tree, mytree):
     if(options.verbose>1):
-        print("(considering %s): %s" % (tree, mytree))
+        print(f"(considering {tree}): {mytree}")
     trees[tree] = mytree
     mytree["locs"]=[]
     for i in range(len(items)):
@@ -280,16 +278,16 @@ for i in range(len(items)):
         else:
             tree = treeprefix[0:-1]
         if(options.verbose>6):
-            print("procesing %s" % (tree))
+            print(f"procesing {tree}")
         trees[tree] = { "extension": ".res", "treeprefix": treeprefix, "hasIndex": True }
         # read in the resource list for the tree
-        treelistfile = os.path.join(options.tmpdir,"%s.lst" % tree)
-        runcmd("iculslocs", "-i %s -N %s -T %s -l > %s" % (outfile, dataname, tree, treelistfile))
-        with io.open(treelistfile, 'r', encoding='utf-8') as fi:
+        treelistfile = os.path.join(options.tmpdir,f"{tree}.lst")
+        runcmd("iculslocs", f"-i {outfile} -N {dataname} -T {tree} -l > {treelistfile}")
+        with open(treelistfile, encoding='utf-8') as fi:
             treeitems = fi.readlines()
             trees[tree]["locs"] = [line.strip() for line in treeitems]
         if tree not in config.get("trees", {}):
-            print(" Warning: filter file %s does not mention trees.%s - will be kept as-is" % (options.filterfile, tree))
+            print(f" Warning: filter file {options.filterfile} does not mention trees.{tree} - will be kept as-is")
         else:
             queueForRemoval(tree)
 
@@ -308,7 +306,7 @@ def removeList(count=0):
         removefile = os.path.join(options.tmpdir, "REMOVE.lst")
         with open(removefile, 'wb') as fi:
             fi.write('\n'.join(remove).encode("utf-8") + b'\n')
-        rc = runcmd("icupkg","-r %s %s 2> %s" %  (removefile,outfile,hackerrfile),True)
+        rc = runcmd("icupkg",f"-r {removefile} {outfile} 2> {hackerrfile}",True)
         if rc != 0:
             if(options.verbose>5):
                 print("## Damage control, trying to parse stderr from icupkg..")
@@ -323,10 +321,10 @@ def removeList(count=0):
                 if m:
                     toDelete = m.group(1).decode("utf-8")
                     if(options.verbose > 5):
-                        print("<< %s added to delete" % toDelete)
+                        print(f"<< {toDelete} added to delete")
                     remove.add(toDelete)
                 else:
-                    print("ERROR: could not match errline: %s" % line)
+                    print(f"ERROR: could not match errline: {line}")
                     sys.exit(1)
             if(options.verbose > 5):
                 print(" now %d items to remove" % len(remove))
@@ -349,7 +347,7 @@ for tree in trees:
     if not (os.path.isdir(treebunddir)):
         os.mkdir(treebunddir)
     treebundres = os.path.join(treebunddir,RES_INDX)
-    treebundtxt = "%s.txt" % (treebundres[0:-4])
-    runcmd("iculslocs", "-i %s -N %s -T %s -b %s" % (outfile, dataname, tree, treebundtxt))
-    runcmd("genrb","-d %s -s %s res_index.txt" % (treebunddir, treebunddir))
-    runcmd("icupkg","-s %s -a %s%s %s" % (options.tmpdir, trees[tree]["treeprefix"], RES_INDX, outfile))
+    treebundtxt = f"{treebundres[0:-4]}.txt"
+    runcmd("iculslocs", f"-i {outfile} -N {dataname} -T {tree} -b {treebundtxt}")
+    runcmd("genrb",f"-d {treebunddir} -s {treebunddir} res_index.txt")
+    runcmd("icupkg","-s {} -a {}{} {}".format(options.tmpdir, trees[tree]["treeprefix"], RES_INDX, outfile))

--- a/tools/icu/shrink-icu-src.py
+++ b/tools/icu/shrink-icu-src.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
 import optparse
 import os
 import re
@@ -30,11 +29,11 @@ parser.add_option('--icutmp',
 (options, args) = parser.parse_args()
 
 if os.path.isdir(options.icudst):
-    print('Deleting existing icudst %s' % (options.icudst))
+    print(f'Deleting existing icudst {options.icudst}')
     shutil.rmtree(options.icudst)
 
 if not os.path.isdir(options.icusrc):
-    print('Missing source ICU dir --icusrc=%s' % (options.icusrc))
+    print(f'Missing source ICU dir --icusrc={options.icusrc}')
     sys.exit(1)
 
 # compression stuff. Keep the suffix and the compression function in sync.
@@ -83,7 +82,7 @@ def icu_ignore(dir, files):
 def icu_info(icu_full_path):
     uvernum_h = os.path.join(icu_full_path, 'source/common/unicode/uvernum.h')
     if not os.path.isfile(uvernum_h):
-        print(' Error: could not load %s - is ICU installed?' % uvernum_h)
+        print(f' Error: could not load {uvernum_h} - is ICU installed?')
         sys.exit(1)
     icu_ver_major = None
     matchVerExp = r'^\s*#define\s+U_ICU_VERSION_SHORT\s+"([^"]*)".*'
@@ -93,25 +92,25 @@ def icu_info(icu_full_path):
         if m:
             icu_ver_major = m.group(1)
     if not icu_ver_major:
-        print(' Could not read U_ICU_VERSION_SHORT version from %s' % uvernum_h)
+        print(f' Could not read U_ICU_VERSION_SHORT version from {uvernum_h}')
         sys.exit(1)
     icu_endianness = sys.byteorder[0]  # TODO(srl295): EBCDIC should be 'e'
     return (icu_ver_major, icu_endianness)
 
 (icu_ver_major, icu_endianness) = icu_info(options.icusrc)
-print("Data file root: icudt%s%s" % (icu_ver_major, icu_endianness))
-dst_datafile = os.path.join(options.icudst, "source","data","in", "icudt%s%s.dat" % (icu_ver_major, icu_endianness))
+print(f"Data file root: icudt{icu_ver_major}{icu_endianness}")
+dst_datafile = os.path.join(options.icudst, "source","data","in", f"icudt{icu_ver_major}{icu_endianness}.dat")
 
-src_datafile = os.path.join(options.icusrc, "source/data/in/icudt%sl.dat" % (icu_ver_major))
-dst_cmp_datafile = "%s%s" % (dst_datafile, compression_suffix)
+src_datafile = os.path.join(options.icusrc, f"source/data/in/icudt{icu_ver_major}l.dat")
+dst_cmp_datafile = f"{dst_datafile}{compression_suffix}"
 
 if not os.path.isfile(src_datafile):
-    print("Error: icu data file not found: %s" % src_datafile)
+    print(f"Error: icu data file not found: {src_datafile}")
     exit(1)
 
-print("will use datafile %s" % (src_datafile))
+print(f"will use datafile {src_datafile}")
 
-print('%s --> %s' % (options.icusrc, options.icudst))
+print(f'{options.icusrc} --> {options.icudst}')
 shutil.copytree(options.icusrc, options.icudst, ignore=icu_ignore)
 
 # now, make the data dir (since we ignored it)
@@ -122,7 +121,7 @@ os.mkdir(icudst_in)
 
 print_size(src_datafile)
 
-print('%s --compress-> %s' % (src_datafile, dst_cmp_datafile))
+print(f'{src_datafile} --compress-> {dst_cmp_datafile}')
 compress_data(src_datafile, dst_cmp_datafile)
 print_size(dst_cmp_datafile)
 readme_name = os.path.join(options.icudst, "README-FULL-ICU.txt" )

--- a/tools/install.py
+++ b/tools/install.py
@@ -25,7 +25,7 @@ def try_unlink(path):
 
 def try_symlink(options, source_path, link_path):
   if not options.silent:
-    print('symlinking %s -> %s' % (source_path, link_path))
+    print(f'symlinking {source_path} -> {link_path}')
   try_unlink(link_path)
   try_mkdir_r(os.path.dirname(link_path))
   os.symlink(source_path, link_path)
@@ -61,7 +61,7 @@ def mkpaths(options, path, dest):
 def try_copy(options, path, dest):
   source_path, target_path = mkpaths(options, path, dest)
   if not options.silent:
-    print('installing %s' % target_path)
+    print(f'installing {target_path}')
   try_mkdir_r(os.path.dirname(target_path))
   try_unlink(target_path) # prevent ETXTBSY errors
   return shutil.copy2(source_path, target_path)
@@ -69,7 +69,7 @@ def try_copy(options, path, dest):
 def try_remove(options, path, dest):
   source_path, target_path = mkpaths(options, path, dest)
   if not options.silent:
-    print('removing %s' % target_path)
+    print(f'removing {target_path}')
   try_unlink(target_path)
   try_rmdir_r(options, os.path.dirname(target_path))
 
@@ -376,7 +376,7 @@ def run(options):
       files(options, uninstall)
       return
 
-  raise RuntimeError('Bad command: %s\n' % options.command)
+  raise RuntimeError(f'Bad command: {options.command}\n')
 
 def parse_options(args):
   parser = argparse.ArgumentParser(

--- a/tools/mkssldef.py
+++ b/tools/mkssldef.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import re
 import sys
 

--- a/tools/pseudo-tty.py
+++ b/tools/pseudo-tty.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
   while fds:
     try:
       rfds, _, _ = select.select(fds, [], [])
-    except select.error as e:
+    except OSError as e:
       if e[0] != errno.EINTR:
         raise
       if pid == os.waitpid(pid, os.WNOHANG)[0]:

--- a/tools/run-valgrind.py
+++ b/tools/run-valgrind.py
@@ -27,7 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import print_function
 from os import path
 import subprocess
 import sys
@@ -48,7 +47,7 @@ if len(sys.argv) < 2:
 
 executable = path.join(NODE_ROOT, sys.argv[1])
 if not path.exists(executable):
-  print('Cannot find the file specified: %s' % executable)
+  print(f'Cannot find the file specified: {executable}')
   sys.exit(1)
 
 # Compute the command line.

--- a/tools/specialize_node_d.py
+++ b/tools/specialize_node_d.py
@@ -6,7 +6,6 @@
 # Specialize node.d for given flavor (`freebsd`) and arch (`x64` or `ia32`)
 #
 
-from __future__ import print_function
 import re
 import sys
 
@@ -15,7 +14,7 @@ if len(sys.argv) != 5:
   sys.exit(2)
 
 outfile = open(sys.argv[1], 'w')
-infile = open(sys.argv[2], 'r')
+infile = open(sys.argv[2])
 flavor = sys.argv[3]
 arch = sys.argv[4]
 

--- a/tools/v8/fetch_deps.py
+++ b/tools/v8/fetch_deps.py
@@ -10,7 +10,6 @@ Usage: fetch_deps.py <v8-path>
 """
 
 # for py2/py3 compatibility
-from __future__ import print_function
 
 import os
 import subprocess
@@ -78,7 +77,7 @@ def FetchDeps(v8_path):
     # gclient needs to have depot_tools in the PATH.
     env["PATH"] = depot_tools + os.pathsep + env["PATH"]
     gclient = os.path.join(depot_tools, "gclient.py")
-    spec = "solutions = %s" % GCLIENT_SOLUTION
+    spec = f"solutions = {GCLIENT_SOLUTION}"
     subprocess.check_call([sys.executable, gclient, "sync", "--spec", spec],
                            cwd=os.path.join(v8_path, os.path.pardir),
                            env=env)

--- a/tools/v8/node_common.py
+++ b/tools/v8/node_common.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 # for py2/py3 compatibility
-from __future__ import print_function
 
 import os
 import pipes
@@ -28,9 +27,7 @@ def EnsureDepotTools(v8_path, fetch_if_not_exist):
     if fetch_if_not_exist:
       print("Checking out depot_tools.")
       # shell=True needed on Windows to resolve git.bat.
-      subprocess.check_call("git clone {} {}".format(
-          pipes.quote(DEPOT_TOOLS_URL),
-          pipes.quote(depot_tools)), shell=True)
+      subprocess.check_call(f"git clone {pipes.quote(DEPOT_TOOLS_URL)} {pipes.quote(depot_tools)}", shell=True)
       # Using check_output to hide warning messages.
       subprocess.check_output(
           [sys.executable, gclient_path, "metrics", "--opt-out"],
@@ -39,14 +36,14 @@ def EnsureDepotTools(v8_path, fetch_if_not_exist):
     return None
   depot_tools = _Get(v8_path)
   assert depot_tools is not None
-  print("Using depot tools in %s" % depot_tools)
+  print(f"Using depot tools in {depot_tools}")
   return depot_tools
 
 def UninitGit(v8_path):
   print("Uninitializing temporary git repository")
   target = os.path.join(v8_path, ".git")
   if os.path.isdir(target):
-    print(">> Cleaning up %s" % target)
+    print(f">> Cleaning up {target}")
     def OnRmError(func, path, exec_info):
       # This might happen on Windows
       os.chmod(path, stat.S_IWRITE)

--- a/tools/v8_gypfiles/GN-scraper.py
+++ b/tools/v8_gypfiles/GN-scraper.py
@@ -20,5 +20,5 @@ def DoMain(args):
       continue
     files.append(m2.group(1))
   # always use `/` since GYP will process paths further downstream
-  rel_files = ['"%s/%s"' % (src_root, f) for f in files]
+  rel_files = [f'"{src_root}/{f}"' for f in files]
   return ' '.join(rel_files)

--- a/tools/zos/sdwrap.py
+++ b/tools/zos/sdwrap.py
@@ -9,17 +9,17 @@ def wrap(args):
   while l:
     if l[-1] == '\n':
       if firstline:
-        outstr = "{}".format(l)
+        outstr = f"{l}"
       else:
-        outstr = " {}".format(l)
+        outstr = f" {l}"
         firstline = True
       l = args.input.readline(72)
     else:
       if firstline:
-        outstr = "{:<71}*\n".format(l[:-1])
+        outstr = f"{l[:-1]:<71}*\n"
         firstline = False
       else:
-        outstr = " {:<70}*\n".format(l[:-1])
+        outstr = f" {l[:-1]:<70}*\n"
       l = l[-1] + args.input.readline(70)
     args.output.write(outstr)
 
@@ -66,7 +66,7 @@ def Main():
   if args.input is None:
     args.input = sys.stdin
   else:
-    args.input = open(args.input, 'r')
+    args.input = open(args.input)
 
   if args.output is None:
     args.output = sys.stdout


### PR DESCRIPTION
This PR executes `tools/pip/site-packages/bin/ruff check . --fix --unsafe-fixes` on the repository.

The `make test` command successfully passes.

Additionally, `UP` has been added to the `pyproject.toml` file to prevent support for outdated (unsupported) Python versions.