### PR TITLE
doc: add getHeapStatistics() property descriptions

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -198,6 +198,35 @@ Returns an object with the following properties:
 * `used_global_handles_size` {number}
 * `external_memory` {number}
 
+`total_heap_size` The value of total\_heap\_size is the number of bytes V8 has
+allocated for the heap. This can grow if used\_heap needs more memory.
+
+`total_heap_size_executable` The value of total\_heap\_size\_executable is the
+portion of the heap that can contain executable code, in bytes. This includes
+memory used by JIT-compiled code and any memory that must be kept executable.
+
+`total_physical_size` The value of total\_physical\_size actual physical memory
+used by the V8 heap, in bytes. This is the amount of memory that is committed
+(or in use) rather than reserved.
+
+`total_available_size` The value of total\_available\_size is the number of
+bytes of memory available to the V8 heap. This value represents how much
+more memory V8 can use before it exceeds the heap limit.
+
+`used_heap_size` The value of used\_heap\_size is number of bytes currently
+being used by V8’s JavaScript objects. This is the actual memory in use and
+does not include memory that has been allocated but not yet used.
+
+`heap_size_limit` The value of heap\_size\_limit is the maximum size of the V8
+heap, in bytes (either the default limit, determined by system resources, or
+the value passed to the `--max_old_space_size` option).
+
+`malloced_memory` The value of malloced\_memory is the number of bytes allocated
+through `malloc` by V8.
+
+`peak_malloced_memory` The value of peak\_malloced\_memory is the peak number of
+bytes allocated through `malloc` by V8 during the lifetime of the process.
+
 `does_zap_garbage` is a 0/1 boolean, which signifies whether the
 `--zap_code_space` option is enabled or not. This makes V8 overwrite heap
 garbage with a bit pattern. The RSS footprint (resident set size) gets bigger

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -205,7 +205,7 @@ allocated for the heap. This can grow if used\_heap needs more memory.
 portion of the heap that can contain executable code, in bytes. This includes
 memory used by JIT-compiled code and any memory that must be kept executable.
 
-`total_physical_size` The value of total\_physical\_size actual physical memory
+`total_physical_size` The value of total\_physical\_size is the actual physical memory
 used by the V8 heap, in bytes. This is the amount of memory that is committed
 (or in use) rather than reserved.
 


### PR DESCRIPTION
I noticed there weren't descriptions for all of the `v8.getHeapStatistics()` return value properties so I thought I would document them in case anyone else found them helpful.