### PR TITLE
buffer: throw when writing beyond buffer

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -1036,33 +1036,33 @@ function addBufferPrototypeMethods(proto) {
   proto.hexSlice = hexSlice;
   proto.ucs2Slice = ucs2Slice;
   proto.utf8Slice = utf8Slice;
-  proto.asciiWrite = function(string, offset = 0, length = this.byteLength) {
+  proto.asciiWrite = function(string, offset = 0, length = this.byteLength - offset) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0) {
+    if (length < 0 || length > this.byteLength - offset) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return asciiWriteStatic(this, string, offset, length);
   };
   proto.base64Write = base64Write;
   proto.base64urlWrite = base64urlWrite;
-  proto.latin1Write = function(string, offset = 0, length = this.byteLength) {
+  proto.latin1Write = function(string, offset = 0, length = this.byteLength - offset) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0) {
+    if (length < 0 || length > this.byteLength - offset) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return latin1WriteStatic(this, string, offset, length);
   };
   proto.hexWrite = hexWrite;
   proto.ucs2Write = ucs2Write;
-  proto.utf8Write = function(string, offset = 0, length = this.byteLength) {
+  proto.utf8Write = function(string, offset = 0, length = this.byteLength - offset) {
     if (offset < 0 || offset > this.byteLength) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
     }
-    if (length < 0) {
+    if (length < 0 || length > this.byteLength - offset) {
       throw new ERR_BUFFER_OUT_OF_BOUNDS('length');
     }
     return utf8WriteStatic(this, string, offset, length);

--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -121,3 +121,16 @@ assert.throws(() => {
 }, common.expectsError({
   code: 'ERR_BUFFER_OUT_OF_BOUNDS',
 }));
+
+
+assert.throws(() => {
+  Buffer.alloc(1).asciiWrite('ww', 0, 2);
+}, common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+}));
+
+assert.throws(() => {
+  Buffer.alloc(1).asciiWrite('ww', 1, 1);
+}, common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+}));


### PR DESCRIPTION
This reverts commit dd8eeec3f036549f1d8ed3c8b648b80795a48099.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
