### PR TITLE
module: remove bogus assertion in CJS entrypoint handling with --import

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -240,11 +240,9 @@ function createCJSModuleWrap(url, source, isMain, loadCJS = loadCJSModule) {
 
 translators.set('commonjs-sync', function requireCommonJS(url, source, isMain) {
   initCJSParseSync();
-  assert(!isMain);  // This is only used by imported CJS modules.
 
   return createCJSModuleWrap(url, source, isMain, (module, source, url, filename, isMain) => {
     assert(module === CJSModule._cache[filename]);
-    assert(!isMain);
     wrapModuleLoad(filename, null, isMain);
   });
 });

--- a/test/es-module/test-require-module-preload.js
+++ b/test/es-module/test-require-module-preload.js
@@ -2,8 +2,7 @@
 
 require('../common');
 const { spawnSyncAndExitWithoutError } = require('../common/child_process');
-const fixtures = require('../common/fixtures');
-
+const { fixturesDir } = require('../common/fixtures');
 const stderr = /ExperimentalWarning: Support for loading ES Module in require/;
 
 function testPreload(preloadFlag) {
@@ -14,9 +13,12 @@ function testPreload(preloadFlag) {
       [
         '--experimental-require-module',
         preloadFlag,
-        fixtures.path('es-module-loaders/module-named-exports.mjs'),
-        fixtures.path('printA.js'),
+        './es-module-loaders/module-named-exports.mjs',
+        './printA.js',
       ],
+      {
+        cwd: fixturesDir
+      },
       {
         stdout: 'A',
         stderr,
@@ -32,9 +34,12 @@ function testPreload(preloadFlag) {
       [
         '--experimental-require-module',
         preloadFlag,
-        fixtures.path('es-modules/import-esm.mjs'),
-        fixtures.path('printA.js'),
+        './es-modules/import-esm.mjs',
+        './printA.js',
       ],
+      {
+        cwd: fixturesDir
+      },
       {
         stderr,
         stdout: /^world\s+A$/,
@@ -50,9 +55,12 @@ function testPreload(preloadFlag) {
       [
         '--experimental-require-module',
         preloadFlag,
-        fixtures.path('es-modules/cjs-exports.mjs'),
-        fixtures.path('printA.js'),
+        './es-modules/cjs-exports.mjs',
+        './printA.js',
       ],
+      {
+        cwd: fixturesDir
+      },
       {
         stdout: /^ok\s+A$/,
         stderr,
@@ -70,9 +78,12 @@ function testPreload(preloadFlag) {
       [
         '--experimental-require-module',
         preloadFlag,
-        fixtures.path('es-modules/require-cjs.mjs'),
-        fixtures.path('printA.js'),
+        './es-modules/require-cjs.mjs',
+        './printA.js',
       ],
+      {
+        cwd: fixturesDir
+      },
       {
         stdout: /^world\s+A$/,
         stderr,
@@ -93,9 +104,12 @@ testPreload('--import');
     [
       '--experimental-require-module',
       '--require',
-      fixtures.path('es-modules/package-type-module'),
-      fixtures.path('printA.js'),
+      './es-modules/package-type-module',
+      './printA.js',
     ],
+    {
+      cwd: fixturesDir
+    },
     {
       stdout: /^package-type-module\s+A$/,
       stderr,

--- a/test/es-module/test-require-module-preload.js
+++ b/test/es-module/test-require-module-preload.js
@@ -6,65 +6,98 @@ const fixtures = require('../common/fixtures');
 
 const stderr = /ExperimentalWarning: Support for loading ES Module in require/;
 
-// Test named exports.
-{
-  spawnSyncAndExitWithoutError(
-    process.execPath,
-    [ '--experimental-require-module', '-r', fixtures.path('../fixtures/es-module-loaders/module-named-exports.mjs') ],
-    {
-      stderr,
-    }
-  );
+function testPreload(preloadFlag) {
+  // Test named exports.
+  {
+    spawnSyncAndExitWithoutError(
+      process.execPath,
+      [
+        '--experimental-require-module',
+        preloadFlag,
+        fixtures.path('es-module-loaders/module-named-exports.mjs'),
+        fixtures.path('printA.js'),
+      ],
+      {
+        stdout: 'A',
+        stderr,
+        trim: true,
+      }
+    );
+  }
+
+  // Test ESM that import ESM.
+  {
+    spawnSyncAndExitWithoutError(
+      process.execPath,
+      [
+        '--experimental-require-module',
+        preloadFlag,
+        fixtures.path('es-modules/import-esm.mjs'),
+        fixtures.path('printA.js'),
+      ],
+      {
+        stderr,
+        stdout: /^world\s+A$/,
+        trim: true,
+      }
+    );
+  }
+
+  // Test ESM that import CJS.
+  {
+    spawnSyncAndExitWithoutError(
+      process.execPath,
+      [
+        '--experimental-require-module',
+        preloadFlag,
+        fixtures.path('es-modules/cjs-exports.mjs'),
+        fixtures.path('printA.js'),
+      ],
+      {
+        stdout: /^ok\s+A$/,
+        stderr,
+        trim: true,
+      }
+    );
+  }
+
+  // Test ESM that require() CJS.
+  // Can't use the common/index.mjs here because that checks the globals, and
+  // -r injects a bunch of globals.
+  {
+    spawnSyncAndExitWithoutError(
+      process.execPath,
+      [
+        '--experimental-require-module',
+        preloadFlag,
+        fixtures.path('es-modules/require-cjs.mjs'),
+        fixtures.path('printA.js'),
+      ],
+      {
+        stdout: /^world\s+A$/,
+        stderr,
+        trim: true,
+      }
+    );
+  }
 }
 
-// Test ESM that import ESM.
-{
-  spawnSyncAndExitWithoutError(
-    process.execPath,
-    [ '--experimental-require-module', '-r', fixtures.path('../fixtures/es-modules/import-esm.mjs') ],
-    {
-      stderr,
-      stdout: 'world',
-      trim: true,
-    }
-  );
-}
+testPreload('--require');
+testPreload('--import');
 
-// Test ESM that import CJS.
+// Test "type": "module" and "main" field in package.json, this is only for --require because
+// --import does not support extension-less preloads.
 {
   spawnSyncAndExitWithoutError(
     process.execPath,
-    [ '--experimental-require-module', '-r', fixtures.path('../fixtures/es-modules/cjs-exports.mjs') ],
+    [
+      '--experimental-require-module',
+      '--require',
+      fixtures.path('es-modules/package-type-module'),
+      fixtures.path('printA.js'),
+    ],
     {
-      stdout: 'ok',
-      stderr,
-      trim: true,
-    }
-  );
-}
-
-// Test ESM that require() CJS.
-// Can't use the common/index.mjs here because that checks the globals, and
-// -r injects a bunch of globals.
-{
-  spawnSyncAndExitWithoutError(
-    process.execPath,
-    [ '--experimental-require-module', '-r', fixtures.path('../fixtures/es-modules/require-cjs.mjs') ],
-    {
-      stdout: 'world',
-      stderr,
-      trim: true,
-    }
-  );
-}
-
-// Test "type": "module" and "main" field in package.json.
-{
-  spawnSyncAndExitWithoutError(
-    process.execPath,
-    [ '--experimental-require-module', '-r', fixtures.path('../fixtures/es-modules/package-type-module') ],
-    {
-      stdout: 'package-type-module',
+      stdout: /^package-type-module\s+A$/,
       stderr,
       trim: true,
     }

--- a/test/es-module/test-require-module-preload.js
+++ b/test/es-module/test-require-module-preload.js
@@ -1,14 +1,14 @@
 'use strict';
 
 require('../common');
-const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { spawnSyncAndAssert } = require('../common/child_process');
 const { fixturesDir } = require('../common/fixtures');
 const stderr = /ExperimentalWarning: Support for loading ES Module in require/;
 
 function testPreload(preloadFlag) {
   // Test named exports.
   {
-    spawnSyncAndExitWithoutError(
+    spawnSyncAndAssert(
       process.execPath,
       [
         '--experimental-require-module',
@@ -29,7 +29,7 @@ function testPreload(preloadFlag) {
 
   // Test ESM that import ESM.
   {
-    spawnSyncAndExitWithoutError(
+    spawnSyncAndAssert(
       process.execPath,
       [
         '--experimental-require-module',
@@ -50,7 +50,7 @@ function testPreload(preloadFlag) {
 
   // Test ESM that import CJS.
   {
-    spawnSyncAndExitWithoutError(
+    spawnSyncAndAssert(
       process.execPath,
       [
         '--experimental-require-module',
@@ -73,7 +73,7 @@ function testPreload(preloadFlag) {
   // Can't use the common/index.mjs here because that checks the globals, and
   // -r injects a bunch of globals.
   {
-    spawnSyncAndExitWithoutError(
+    spawnSyncAndAssert(
       process.execPath,
       [
         '--experimental-require-module',
@@ -99,7 +99,7 @@ testPreload('--import');
 // Test "type": "module" and "main" field in package.json, this is only for --require because
 // --import does not support extension-less preloads.
 {
-  spawnSyncAndExitWithoutError(
+  spawnSyncAndAssert(
     process.execPath,
     [
       '--experimental-require-module',


### PR DESCRIPTION
The synchronous CJS translator can handle entrypoints now, this can be hit when --import is used, so lift the bogus assertions and added tests.

Fixes: https://github.com/nodejs/node/issues/54577

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
