### PR TITLE
doc: add alert on REPL from TCP socket

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -774,6 +774,14 @@ a `net.Server` and `net.Socket` instance, see:
 For an example of running a REPL instance over [`curl(1)`][], see:
 <https://gist.github.com/TooTallNate/2053342>.
 
+This example is intended purely for educational purposes to demonstrate how
+Node.js REPLs can be started using different I/O streams.
+It should **not** be used in production environments or any context where security
+is a concern without additional protective measures.
+If you need to implement REPLs in a real-world application, consider alternative
+approaches that mitigate these risks, such as using secure input mechanisms and
+avoiding open network interfaces.
+
 [TTY keybindings]: readline.md#tty-keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#event-uncaughtexception


### PR DESCRIPTION
Initially, I was considering removing this example:

```
net.createServer((socket) => {
  connections += 1;
  repl.start({
    prompt: 'Node.js via TCP socket> ',
    input: socket,
    output: socket,
  }).on('exit', () => {
    socket.end();
  });
}).listen(5001);
```

But it does expose some of the possibilities of Node.js REPL. So, instead of removing it from our examples, I've included an alert for its usage in production. 

cc: @mcollina 

Refs: https://hackerone.com/reports/2684357