### PR TITLE
tty: fix links for terminal colors

### DIFF
--- a/lib/internal/tty.js
+++ b/lib/internal/tty.js
@@ -60,9 +60,9 @@ const TERM_ENVS = {
   'mosh': COLORS_16m,
   'putty': COLORS_16,
   'st': COLORS_16,
-  // https://github.com/da-x/rxvt-unicode/tree/v9.22-with-24bit-color
+  // http://lists.schmorp.de/pipermail/rxvt-unicode/2016q2/002261.html
   'rxvt-unicode-24bit': COLORS_16m,
-  // https://gist.github.com/XVilka/8346728#gistcomment-2823421
+  // https://bugs.launchpad.net/terminator/+bug/1030562
   'terminator': COLORS_16m,
 };
 


### PR DESCRIPTION
This PR updates the links for TTY's terminal colors.

For **Terminator**, according to author of the original link (The bolded `Here` is the new link):
> For [Terminator](http://gnometerminator.blogspot.com/p/introduction.html) users, there is a branch for GTK+3 version, which supports true colors and much more, but it's not yet merged in the master and not yet released as well. **[Here](https://bugs.launchpad.net/terminator/+bug/1030562)** is the bug for pushing it upstream. So if you want to help this - you can test it more, write patches and ping developers. Looks like this one is almost ready, I see no big stoppers against merging this branch in the master and releasing a new version of Terminator.

For **rxvt-unicode-24bit**, the link was changed to that mentioned by https://github.com/termstandard/colors.