### PR TITLE
deps: V8: backport f320600cd1f4 (V18.x CVE-2024-4761)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.37',
+    'v8_embedder_string': '-node.38',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/js-objects.cc
+++ b/deps/v8/src/objects/js-objects.cc
@@ -432,9 +432,7 @@ Maybe<bool> JSReceiver::SetOrCopyDataProperties(
       Nothing<bool>());
 
   if (!from->HasFastProperties() && target->HasFastProperties() &&
-      !target->IsJSGlobalProxy()) {
-    // JSProxy is always in slow-mode.
-    DCHECK(!target->IsJSProxy());
+      IsJSObject(*target) && !IsJSGlobalProxy(*target)) {
     // Convert to slow properties if we're guaranteed to overflow the number of
     // descriptors.
     int source_length;


### PR DESCRIPTION
V8 Backport of https://github.com/v8/v8/commit/f320600cd1f48ba6bb57c0395823fe0c5e5ec52e 

Fixes CVE-2024-4761, which has been tagged by CISA as KEV. 