### PR TITLE
deps: V8: backport f320600cd1f4 (V20.x CVE-2024-4761) 

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -37,7 +37,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/js-objects.cc
+++ b/deps/v8/src/objects/js-objects.cc
@@ -445,7 +445,7 @@ Maybe<bool> JSReceiver::SetOrCopyDataProperties(
       Nothing<bool>());
 
   if (!from->HasFastProperties() && target->HasFastProperties() &&
-      IsJSObject(*target) && !IsJSGlobalProxy(*target)) {
+      target->IsJSObject() && !target->IsJSGlobalProxy()) {
     // Convert to slow properties if we're guaranteed to overflow the number of
     // descriptors.
     int source_length;

--- a/deps/v8/src/objects/js-objects.cc
+++ b/deps/v8/src/objects/js-objects.cc
@@ -445,9 +445,7 @@ Maybe<bool> JSReceiver::SetOrCopyDataProperties(
       Nothing<bool>());
 
   if (!from->HasFastProperties() && target->HasFastProperties() &&
-      !target->IsJSGlobalProxy()) {
-    // JSProxy is always in slow-mode.
-    DCHECK(!target->IsJSProxy());
+      IsJSObject(*target) && !IsJSGlobalProxy(*target)) {
     // Convert to slow properties if we're guaranteed to overflow the number of
     // descriptors.
     int source_length;


### PR DESCRIPTION
V8 Backport of https://github.com/v8/v8/commit/f320600cd1f48ba6bb57c0395823fe0c5e5ec52e

Fixes https://github.com/advisories/GHSA-8q82-45v9-cmr9, which has been tagged by CISA as KEV.