### PR TITLE
test_runner: support glob inclusions and exclusions

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2358,6 +2358,38 @@ changes:
 The destination for the corresponding test reporter. See the documentation on
 [test reporters][] for more details.
 
+### `--test-runner-exclude`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Excludes specific files from being ran in the test suite using a glob pattern, which
+can match the relative file path.
+
+This option may be specified multiple times to exclude multiple glob patterns.
+
+If both `--test-runner-exclude` and `--test-runner-include` are provided,
+files must meet **both** criteria to be included in the test suite.
+
+### `--test-runner-include`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Includes specific files in the test suite using a glob pattern, which can match
+both the relative file path.
+
+This option may be specified multiple times to include multiple glob patterns.
+
+If both `--test-runner-exclude` and `--test-runner-include` are provided,
+files must meet **both** criteria to be included in the test suite.
+
 ### `--test-shard`
 
 <!-- YAML
@@ -3059,6 +3091,8 @@ one is included in the list below.
 * `--test-only`
 * `--test-reporter-destination`
 * `--test-reporter`
+* `--test-runner-exclude`
+* `--test-runner-include`
 * `--test-shard`
 * `--test-skip-pattern`
 * `--throw-deprecation`

--- a/doc/node.1
+++ b/doc/node.1
@@ -470,6 +470,12 @@ A test reporter to use when running tests.
 .It Fl -test-reporter-destination
 The destination for the corresponding test reporter.
 .
+.It Fl -test-runner-exclude
+Exclude a certain glob pattern from being included in the test suite
+.
+.It Fl -test-runner-include
+Allow only a specific glob pattern to be being included in the test suite
+.
 .It Fl -test-only
 Configures the test runner to only execute top level tests that have the `only`
 option set.

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -32,7 +32,7 @@ const {
 
 const { spawn } = require('child_process');
 const { finished } = require('internal/streams/end-of-stream');
-const { resolve } = require('path');
+const { resolve, matchesGlob } = require('path');
 const { DefaultDeserializer, DefaultSerializer } = require('v8');
 const { Interface } = require('internal/readline/interface');
 const { deserializeError } = require('internal/error_serdes');
@@ -345,10 +345,29 @@ class FileTest extends Test {
   }
 }
 
+function shouldSkip(path, includeGlobs, excludeGlobs) {
+  if (excludeGlobs?.length > 0) {
+    for (let i = 0; i < excludeGlobs.length; ++i) {
+      if (matchesGlob(path, excludeGlobs[i])) return true;
+    }
+  }
+
+  if (includeGlobs?.length > 0) {
+    for (let i = 0; i < includeGlobs.length; ++i) {
+      if (matchesGlob(path, includeGlobs[i])) return false;
+    }
+    return true;
+  }
+}
+
 function runTestFile(path, filesWatcher, opts) {
   const watchMode = filesWatcher != null;
   const testPath = path === kIsolatedProcessName ? '' : path;
-  const testOpts = { __proto__: null, signal: opts.signal };
+  const testOpts = {
+    __proto__: null,
+    signal: opts.signal,
+    skip: shouldSkip(path, opts.root.config.testIncludeGlobs, opts.root.config.testExcludeGlobs),
+  };
   const subtest = opts.root.createSubtest(FileTest, testPath, testOpts, async (t) => {
     const args = getRunArgs(path, opts);
     const stdio = ['pipe', 'pipe', 'pipe'];

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -195,6 +195,8 @@ function parseCommandLine() {
   let concurrency;
   let coverageExcludeGlobs;
   let coverageIncludeGlobs;
+  const testExcludeGlobs = getOptionValue('--test-runner-exclude');
+  const testIncludeGlobs = getOptionValue('--test-runner-include');
   let lineCoverage;
   let branchCoverage;
   let functionCoverage;
@@ -319,6 +321,8 @@ function parseCommandLine() {
     setup,
     shard,
     sourceMaps,
+    testExcludeGlobs,
+    testIncludeGlobs,
     testNamePatterns,
     testSkipPatterns,
     timeout,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -671,6 +671,15 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::test_coverage_lines,
             kAllowedInEnvvar);
 
+  AddOption("--test-runner-exclude",
+            "run tests whose filepath does not match this glob",
+            &EnvironmentOptions::test_runner_exclude,
+            kAllowedInEnvvar);
+  AddOption("--test-runner-include",
+            "only run tests whose filepath matches this glob",
+            &EnvironmentOptions::test_runner_include,
+            kAllowedInEnvvar);
+
   AddOption("--experimental-test-isolation",
             "configures the type of test isolation used in the test runner",
             &EnvironmentOptions::test_isolation);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -199,6 +199,8 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> test_skip_pattern;
   std::vector<std::string> coverage_include_pattern;
   std::vector<std::string> coverage_exclude_pattern;
+  std::vector<std::string> test_runner_exclude;
+  std::vector<std::string> test_runner_include;
   bool throw_deprecation = false;
   bool trace_deprecation = false;
   bool trace_exit = false;

--- a/test/fixtures/test-runner/includes-excludes/index.test.js
+++ b/test/fixtures/test-runner/includes-excludes/index.test.js
@@ -1,0 +1,1 @@
+require('node:test')('Index');

--- a/test/fixtures/test-runner/includes-excludes/other.test.js
+++ b/test/fixtures/test-runner/includes-excludes/other.test.js
@@ -1,0 +1,1 @@
+require('node:test')('Other');

--- a/test/fixtures/test-runner/includes-excludes/subdir/inner.test.js
+++ b/test/fixtures/test-runner/includes-excludes/subdir/inner.test.js
@@ -1,0 +1,1 @@
+require('node:test')('Inner');

--- a/test/parallel/test-runner-include-exclude.js
+++ b/test/parallel/test-runner-include-exclude.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const { test } = require('node:test');
+const fixtures = require('../common/fixtures');
+const fixture = fixtures.path('test-runner/includes-excludes/');
+
+async function spawnTestProcess(globs, arg) {
+  const args = ['--test', '--test-reporter=spec'];
+  for (const glob of globs) {
+    args.push(`${arg}=${glob}`);
+  }
+
+  return common.spawnPromisified(process.execPath, args, { cwd: fixture });
+}
+
+async function buildTests(tests, flag) {
+  test(flag, async (t) => {
+    for (const { globs, skip, includes } of tests) {
+      await t.test(globs.join(', ') || 'No globs', async (subtest) => {
+        const child = await spawnTestProcess(globs, flag);
+        for (const skipped of skip) {
+          subtest.assert.ok(child.stdout.includes(`﹣ ${skipped}`));
+        }
+        for (const included of includes) {
+          subtest.assert.ok(!child.stdout.includes(`﹣ ${included}`));
+          subtest.assert.ok(child.stdout.includes(`✔ ${included}`));
+        }
+        subtest.assert.strictEqual(child.code, 0);
+      });
+    }
+  });
+}
+
+buildTests([
+  { globs: [], skip: [], includes: ['Index', 'Other', 'Inner'] },
+  { globs: ['*.test.js'], skip: ['subdir/inner.test.js'], includes: ['Index', 'Other'] },
+  { globs: ['nonexistent.js'], skip: ['subdir/inner.test.js', 'other.test.js', 'index.test.js'], includes: [] },
+], '--test-runner-include');
+
+buildTests([
+  { globs: [], skip: [], includes: ['Index', 'Other', 'Inner'] },
+  { globs: ['o*.test.js', 'i*.test.js'], skip: ['other.test.js', 'index.test.js'], includes: ['Inner'] },
+  { globs: ['**'], skip: ['subdir/inner.test.js', 'other.test.js', 'index.test.js'], includes: [] },
+], '--test-runner-exclude');


### PR DESCRIPTION
This PR adds the functionality to exclude test files by glob patterns.

It is meant for the use case when a user may have hundreds of test files and may only want to run a few (via glob).

Added test results:
```
▶ --test-runner-include
  ✔ No globs (86.421831ms)
  ✔ *.test.js (82.534169ms)
  ✔ nonexistent.js (44.967071ms)
▶ --test-runner-include (215.595732ms)
▶ --test-runner-exclude
  ✔ No globs (86.749583ms)
  ✔ o*.test.js, i*.test.js (87.369228ms)
  ✔ ** (48.384698ms)
▶ --test-runner-exclude (223.456528ms)
ℹ tests 8
ℹ suites 0
ℹ pass 8
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 442.787698
```