### PR TITLE
timers: document ref option for scheduler.wait

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -525,6 +525,9 @@ added:
 * `delay` {number} The number of milliseconds to wait before resolving the
   promise.
 * `options` {Object}
+  * `ref` {boolean} Set to `false` to indicate that the scheduled `Timeout`
+    should not require the Node.js event loop to remain active.
+    **Default:** `true`.
   * `signal` {AbortSignal} An optional `AbortSignal` that can be used to
     cancel waiting.
 * Returns: {Promise}

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -131,22 +131,18 @@ function setImmediate(value, options = kEmptyObject) {
 }
 
 async function* setInterval(after, value, options = kEmptyObject) {
-  try {
-    if (typeof after !== 'undefined') {
-      validateNumber(after, 'delay');
-    }
+  if (typeof after !== 'undefined') {
+    validateNumber(after, 'delay');
+  }
 
-    validateObject(options, 'options');
+  validateObject(options, 'options');
 
-    if (typeof options?.signal !== 'undefined') {
-      validateAbortSignal(options.signal, 'options.signal');
-    }
+  if (typeof options?.signal !== 'undefined') {
+    validateAbortSignal(options.signal, 'options.signal');
+  }
 
-    if (typeof options?.ref !== 'undefined') {
-      validateBoolean(options.ref, 'options.ref');
-    }
-  } catch (err) {
-    return PromiseReject(err);
+  if (typeof options?.ref !== 'undefined') {
+    validateBoolean(options.ref, 'options.ref');
   }
 
   const { signal, ref = true } = options;


### PR DESCRIPTION
Follow-up of #54404.
See: https://github.com/nodejs/node/pull/54404#discussion_r1730292452 and https://github.com/nodejs/node/pull/54404#discussion_r1730293843