### PR TITLE
test: move more zlib tests to node:test

### DIFF
--- a/test/parallel/test-zlib-unzip-one-byte-chunks.js
+++ b/test/parallel/test-zlib-unzip-one-byte-chunks.js
@@ -1,30 +1,38 @@
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const zlib = require('zlib');
 
-const data = Buffer.concat([
-  zlib.gzipSync('abc'),
-  zlib.gzipSync('def'),
-]);
+require('../common');
 
-const resultBuffers = [];
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
 
-const unzip = zlib.createUnzip()
-  .on('error', (err) => {
-    assert.ifError(err);
-  })
-  .on('data', (data) => resultBuffers.push(data))
-  .on('finish', common.mustCall(() => {
-    const unzipped = Buffer.concat(resultBuffers).toString();
-    assert.strictEqual(unzipped, 'abcdef',
-                       `'${unzipped}' should match 'abcdef' after zipping ` +
-                       'and unzipping');
-  }));
+test('zlib should unzip one byte chunks', async () => {
+  const { promise, resolve } = Promise.withResolvers();
+  const data = Buffer.concat([
+    zlib.gzipSync('abc'),
+    zlib.gzipSync('def'),
+  ]);
 
-for (let i = 0; i < data.length; i++) {
-  // Write each single byte individually.
-  unzip.write(Buffer.from([data[i]]));
-}
+  const resultBuffers = [];
 
-unzip.end();
+  const unzip = zlib.createUnzip()
+    .on('error', (err) => {
+      assert.ifError(err);
+    })
+    .on('data', (data) => resultBuffers.push(data))
+    .on('finish', () => {
+      const unzipped = Buffer.concat(resultBuffers).toString();
+      assert.strictEqual(unzipped, 'abcdef',
+                         `'${unzipped}' should match 'abcdef' after zipping ` +
+        'and unzipping');
+      resolve();
+    });
+
+  for (let i = 0; i < data.length; i++) {
+    // Write each single byte individually.
+    unzip.write(Buffer.from([data[i]]));
+  }
+
+  unzip.end();
+  await promise;
+});

--- a/test/parallel/test-zlib-write-after-end.js
+++ b/test/parallel/test-zlib-write-after-end.js
@@ -1,16 +1,22 @@
 'use strict';
-const common = require('../common');
-const zlib = require('zlib');
+
+require('../common');
+
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
 
 // Regression test for https://github.com/nodejs/node/issues/30976
-// Writes to a stream should finish even after the readable side has been ended.
-
-const data = zlib.deflateRawSync('Welcome');
-
-const inflate = zlib.createInflateRaw();
-
-inflate.resume();
-inflate.write(data, common.mustCall());
-inflate.write(Buffer.from([0x00]), common.mustCall());
-inflate.write(Buffer.from([0x00]), common.mustCall());
-inflate.flush(common.mustCall());
+test('Writes to a stream should finish even after the readable side has been ended.', async (t) => {
+  const { promise, resolve } = Promise.withResolvers();
+  const data = zlib.deflateRawSync('Welcome');
+  const inflate = zlib.createInflateRaw();
+  const writeCallback = t.mock.fn();
+  inflate.resume();
+  inflate.write(data, writeCallback);
+  inflate.write(Buffer.from([0x00]), writeCallback);
+  inflate.write(Buffer.from([0x00]), writeCallback);
+  inflate.flush(resolve);
+  await promise;
+  assert.strictEqual(writeCallback.mock.callCount(), 3);
+});

--- a/test/parallel/test-zlib-write-after-flush.js
+++ b/test/parallel/test-zlib-write-after-flush.js
@@ -20,30 +20,39 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const zlib = require('zlib');
 
-for (const [ createCompress, createDecompress ] of [
-  [ zlib.createGzip, zlib.createGunzip ],
-  [ zlib.createBrotliCompress, zlib.createBrotliDecompress ],
-]) {
-  const gzip = createCompress();
-  const gunz = createDecompress();
+require('../common');
 
-  gzip.pipe(gunz);
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
 
-  let output = '';
-  const input = 'A line of data\n';
-  gunz.setEncoding('utf8');
-  gunz.on('data', (c) => output += c);
-  gunz.on('end', common.mustCall(() => {
-    assert.strictEqual(output, input);
-  }));
+test('zlib should accept writing after flush', async () => {
+  for (const [createCompress, createDecompress] of [
+    [zlib.createGzip, zlib.createGunzip],
+    [zlib.createBrotliCompress, zlib.createBrotliDecompress],
+  ]) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const gzip = createCompress();
+    const gunz = createDecompress();
 
-  // Make sure that flush/write doesn't trigger an assert failure
-  gzip.flush();
-  gzip.write(input);
-  gzip.end();
-  gunz.read(0);
-}
+    gzip.pipe(gunz);
+
+    let output = '';
+    const input = 'A line of data\n';
+    gunz.setEncoding('utf8');
+    gunz.on('error', reject);
+    gunz.on('data', (c) => output += c);
+    gunz.on('end', () => {
+      assert.strictEqual(output, input);
+      resolve();
+    });
+
+    // Make sure that flush/write doesn't trigger an assert failure
+    gzip.flush();
+    gzip.write(input);
+    gzip.end();
+    gunz.read(0);
+    await promise;
+  }
+});

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -20,24 +20,31 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const zlib = require('zlib');
 
-for (const Compressor of [ zlib.Gzip, zlib.BrotliCompress ]) {
-  const gz = Compressor();
-  const emptyBuffer = Buffer.alloc(0);
-  let received = 0;
-  gz.on('data', function(c) {
-    received += c.length;
-  });
+require('../common');
 
-  gz.on('end', common.mustCall(function() {
-    const expected = Compressor === zlib.Gzip ? 20 : 1;
-    assert.strictEqual(received, expected,
-                       `${received}, ${expected}, ${Compressor.name}`);
-  }));
-  gz.on('finish', common.mustCall());
-  gz.write(emptyBuffer);
-  gz.end();
-}
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
+
+test('zlib should properly handle zero byte input', async () => {
+  for (const Compressor of [zlib.Gzip, zlib.BrotliCompress]) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const gz = Compressor();
+    const emptyBuffer = Buffer.alloc(0);
+    let received = 0;
+    gz.on('data', function(c) {
+      received += c.length;
+    });
+    gz.on('error', reject);
+    gz.on('end', function() {
+      const expected = Compressor === zlib.Gzip ? 20 : 1;
+      assert.strictEqual(received, expected,
+                         `${received}, ${expected}, ${Compressor.name}`);
+      resolve();
+    });
+    gz.write(emptyBuffer);
+    gz.end();
+    await promise;
+  }
+});

--- a/test/parallel/test-zlib-zero-windowBits.js
+++ b/test/parallel/test-zlib-zero-windowBits.js
@@ -1,33 +1,30 @@
 'use strict';
 
 require('../common');
-const assert = require('assert');
-const zlib = require('zlib');
 
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
 
 // windowBits is a special case in zlib. On the compression side, 0 is invalid.
 // On the decompression side, it indicates that zlib should use the value from
 // the header of the compressed stream.
-{
+test('zlib should support zero windowBits', (t) => {
   const inflate = zlib.createInflate({ windowBits: 0 });
-  assert(inflate instanceof zlib.Inflate);
-}
+  assert.ok(inflate instanceof zlib.Inflate);
 
-{
   const gunzip = zlib.createGunzip({ windowBits: 0 });
-  assert(gunzip instanceof zlib.Gunzip);
-}
+  assert.ok(gunzip instanceof zlib.Gunzip);
 
-{
   const unzip = zlib.createUnzip({ windowBits: 0 });
-  assert(unzip instanceof zlib.Unzip);
-}
+  assert.ok(unzip instanceof zlib.Unzip);
+});
 
-{
+test('windowBits should be valid', () => {
   assert.throws(() => zlib.createGzip({ windowBits: 0 }), {
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "options.windowBits" is out of range. ' +
-             'It must be >= 9 and <= 15. Received 0'
+      'It must be >= 9 and <= 15. Received 0'
   });
-}
+});


### PR DESCRIPTION
Moving zlib tests to use `node:test`