### PR TITLE
doc: add documentation about os.tmpdir() overrides

### DIFF
--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -416,6 +416,19 @@ changes:
 Returns the operating system's default directory for temporary files as a
 string.
 
+On Windows, the result can be overridden by `TEMP` and `TMP` environment variables, and
+`TEMP` takes precedence over `TMP`. If neither is set, it defaults to `%SystemRoot%\temp`
+or `%windir%\temp`.
+
+On non-Windows platforms, `TMPDIR`, `TMP` and `TEMP` environment variables will be checked
+to override the result of this method, in the described order. If none of them is set, it
+defaults to `/tmp`.
+
+Some operating system distributions would either configure `TMPDIR` (non-Windows) or
+`TEMP` and `TMP` (Windows) by default without additional configurations by the system
+administrators. The result of `os.tmpdir()` typically reflects the system preference
+unless it's explicitly overridden by the users.
+
 ## `os.totalmem()`
 
 <!-- YAML


### PR DESCRIPTION
This documents the TMPDIR, TEMP and TMP overrides on different platforms and that some operating systems set these by default.

1. It seems on Windows, TEMP and TMP tend to be configured by default on a fresh installation. I found an article listing the typical default values of TEMP and TMP in https://www.computerhope.com/issues/ch000088.htm which matches what I saw in the CI. 
2. On macOS TMPDIR seems to be configured by default as well. On my local environment I get a folder under `/var/folders` by default, and I found an article explaining this https://magnusviri.com/what-is-var-folders.html
3. On Linux it seems to vary depending on your distribution. In a fresh Ubuntu server installation `TMPDIR` seems unconfigured, so `os.tmpdir()` tends to default to `/tmp` which matches my memory.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
4. Update documentation if relevant.
5. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
