### PR TITLE
doc: correct `vm.runInThisContext` usage example

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -1500,7 +1500,7 @@ let localVar = 'initial value';
 
 const vmResult = vm.runInThisContext('localVar = "vm";');
 console.log(`vmResult: '${vmResult}', localVar: '${localVar}'`);
-// Prints: vmResult: 'vm', localVar: 'initial value'
+// Prints: vmResult: 'vm', localVar: 'vm'
 
 const evalResult = eval('localVar = "eval";');
 console.log(`evalResult: '${evalResult}', localVar: '${localVar}'`);


### PR DESCRIPTION
as stated in the docs, `vm.runInThisContext` operates in global context, so it should change the variable value (and it does)

![image](https://github.com/user-attachments/assets/ac606b3e-0335-4371-9663-7f5d9760ca3c)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
