### PR TITLE
lib: refactor SubtleCrypto experimental warnings

### DIFF
--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -27,7 +27,6 @@ const {
 } = require('internal/crypto/util');
 
 const {
-  emitExperimentalWarning,
   lazyDOMException,
   promisify,
 } = require('internal/util');
@@ -105,7 +104,6 @@ function createCFRGRawKey(name, keyData, isPublic) {
 
 async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   const { name } = algorithm;
-  emitExperimentalWarning(`The ${name} Web Crypto API algorithm`);
 
   const usageSet = new SafeSet(keyUsages);
   switch (name) {
@@ -187,7 +185,6 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
 }
 
 function cfrgExportKey(key, format) {
-  emitExperimentalWarning(`The ${key.algorithm.name} Web Crypto API algorithm`);
   return jobPromise(() => new ECKeyExportJob(
     kCryptoJobAsync,
     format,
@@ -202,7 +199,6 @@ async function cfrgImportKey(
   keyUsages) {
 
   const { name } = algorithm;
-  emitExperimentalWarning(`The ${name} Web Crypto API algorithm`);
   let keyObject;
   const usagesSet = new SafeSet(keyUsages);
   switch (format) {
@@ -319,7 +315,6 @@ async function cfrgImportKey(
 }
 
 function eddsaSignVerify(key, data, { name, context }, signature) {
-  emitExperimentalWarning(`The ${name} Web Crypto API algorithm`);
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const type = mode === kSignJobModeSign ? 'private' : 'public';
 

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -11,6 +11,8 @@ const {
   DataViewPrototypeGetByteOffset,
   FunctionPrototypeBind,
   Number,
+  ObjectDefineProperty,
+  ObjectEntries,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   Promise,
@@ -63,6 +65,7 @@ const { Buffer } = require('buffer');
 
 const {
   cachedResult,
+  emitExperimentalWarning,
   filterDuplicateStrings,
   lazyDOMException,
 } = require('internal/util');
@@ -195,26 +198,18 @@ const kSupportedAlgorithms = {
     'AES-GCM': 'AesKeyGenParams',
     'AES-KW': 'AesKeyGenParams',
     'HMAC': 'HmacKeyGenParams',
-    'X25519': null,
-    'Ed25519': null,
-    'X448': null,
-    'Ed448': null,
   },
   'sign': {
     'RSASSA-PKCS1-v1_5': null,
     'RSA-PSS': 'RsaPssParams',
     'ECDSA': 'EcdsaParams',
     'HMAC': null,
-    'Ed25519': null,
-    'Ed448': 'Ed448Params',
   },
   'verify': {
     'RSASSA-PKCS1-v1_5': null,
     'RSA-PSS': 'RsaPssParams',
     'ECDSA': 'EcdsaParams',
     'HMAC': null,
-    'Ed25519': null,
-    'Ed448': 'Ed448Params',
   },
   'importKey': {
     'RSASSA-PKCS1-v1_5': 'RsaHashedImportParams',
@@ -229,17 +224,11 @@ const kSupportedAlgorithms = {
     'AES-CBC': null,
     'AES-GCM': null,
     'AES-KW': null,
-    'Ed25519': null,
-    'X25519': null,
-    'Ed448': null,
-    'X448': null,
   },
   'deriveBits': {
     'HKDF': 'HkdfParams',
     'PBKDF2': 'Pbkdf2Params',
     'ECDH': 'EcdhKeyDeriveParams',
-    'X25519': 'EcdhKeyDeriveParams',
-    'X448': 'EcdhKeyDeriveParams',
   },
   'encrypt': {
     'RSA-OAEP': 'RsaOaepParams',
@@ -269,6 +258,47 @@ const kSupportedAlgorithms = {
     'AES-KW': null,
   },
 };
+
+const experimentalAlgorithms = ObjectEntries({
+  'X25519': {
+    generateKey: null,
+    importKey: null,
+    deriveBits: 'EcdhKeyDeriveParams',
+  },
+  'Ed25519': {
+    generateKey: null,
+    sign: null,
+    verify: null,
+    importKey: null,
+  },
+  'X448': {
+    generateKey: null,
+    importKey: null,
+    deriveBits: 'EcdhKeyDeriveParams',
+  },
+  'Ed448': {
+    generateKey: null,
+    sign: 'Ed448Params',
+    verify: 'Ed448Params',
+    importKey: null,
+  },
+});
+
+for (let i = 0; i < experimentalAlgorithms.length; i++) {
+  const name = experimentalAlgorithms[i][0];
+  const ops = ObjectEntries(experimentalAlgorithms[i][1]);
+  for (let j = 0; j < ops.length; j++) {
+    const { 0: op, 1: dict } = ops[j];
+    ObjectDefineProperty(kSupportedAlgorithms[op], name, {
+      get() {
+        emitExperimentalWarning(`The ${name} Web Crypto API algorithm`);
+        return dict;
+      },
+      __proto__: null,
+      enumerable: true,
+    });
+  }
+}
 
 const simpleAlgorithmDictionaries = {
   AesGcmParams: { iv: 'BufferSource', additionalData: 'BufferSource' },


### PR DESCRIPTION
In preparation for eventual merge of Curve25519 into the main spec (which will make Ed25519 and X25519 stable but leave Curve448 experimental) as well as future introduction of more experimental algorithms this PR neatly organizes experimental algorithms in the code path of `normalizeAlgorithm` and ensures their experimental warnings are not called from all over their implementation.

~Also removes `kHashTypes` which is no longer used.~