### PR TITLE
doc: fix webcrypto.md AES-GCM backticks

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -567,7 +567,7 @@ The algorithms currently supported include:
 * `'RSA-OAEP'`
 * `'AES-CTR'`
 * `'AES-CBC'`
-* `'AES-GCM`'
+* `'AES-GCM'`
 
 ### `subtle.deriveBits(algorithm, baseKey[, length])`
 
@@ -703,7 +703,7 @@ The algorithms currently supported include:
 * `'RSA-OAEP'`
 * `'AES-CTR'`
 * `'AES-CBC'`
-* `'AES-GCM`'
+* `'AES-GCM'`
 
 ### `subtle.exportKey(format, key)`
 


### PR DESCRIPTION
Fixes the closing backticks on two AES-GCM occurences.