### PR TITLE
test: improve output of child process utilities

### DIFF
--- a/test/common/child_process.js
+++ b/test/common/child_process.js
@@ -60,13 +60,14 @@ function checkOutput(str, check) {
   return { passed: true };
 }
 
-function expectSyncExit(child, {
+function expectSyncExit(caller, spawnArgs, {
   status,
   signal,
   stderr: stderrCheck,
   stdout: stdoutCheck,
   trim = false,
 }) {
+  const child = spawnSync(...spawnArgs);
   const failures = [];
   let stderrStr, stdoutStr;
   if (status !== undefined && child.status !== status) {
@@ -83,7 +84,18 @@ function expectSyncExit(child, {
     console.error(`${tag} --- stdout ---`);
     console.error(stdoutStr === undefined ? child.stdout.toString() : stdoutStr);
     console.error(`${tag} status = ${child.status}, signal = ${child.signal}`);
-    throw new Error(`${failures.join('\n')}`);
+
+    const error = new Error(`${failures.join('\n')}`);
+    if (spawnArgs[2]) {
+      error.options = spawnArgs[2];
+    }
+    let command = spawnArgs[0];
+    if (Array.isArray(spawnArgs[1])) {
+      command += ' ' + spawnArgs[1].join(' ');
+    }
+    error.command = command;
+    Error.captureStackTrace(error, caller);
+    throw error;
   }
 
   // If status and signal are not matching expectations, fail early.
@@ -114,12 +126,11 @@ function expectSyncExit(child, {
 function spawnSyncAndExit(...args) {
   const spawnArgs = args.slice(0, args.length - 1);
   const expectations = args[args.length - 1];
-  const child = spawnSync(...spawnArgs);
-  return expectSyncExit(child, expectations);
+  return expectSyncExit(spawnSyncAndExit, spawnArgs, expectations);
 }
 
 function spawnSyncAndExitWithoutError(...args) {
-  return expectSyncExit(spawnSync(...args), {
+  return expectSyncExit(spawnSyncAndExitWithoutError, [...args], {
     status: 0,
     signal: null,
   });
@@ -127,8 +138,7 @@ function spawnSyncAndExitWithoutError(...args) {
 
 function spawnSyncAndAssert(...args) {
   const expectations = args.pop();
-  const child = spawnSync(...args);
-  return expectSyncExit(child, {
+  return expectSyncExit(spawnSyncAndAssert, [...args], {
     status: 0,
     signal: null,
     ...expectations,


### PR DESCRIPTION
- Display command and options when it fails
- Keep the caller line at the top of the stack trace.

Example output (just modified the expected stderr to something it's not):

Before:

<img width="1065" alt="Screen Shot 2024-08-29 at 00 33 40" src="https://github.com/user-attachments/assets/fdeef0c6-2635-497f-ba3a-37d136a4ed48">


After:


<img width="1216" alt="Screen Shot 2024-08-29 at 00 34 42" src="https://github.com/user-attachments/assets/d7056837-3385-406f-9122-ce7547e8c1dc">


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
