### PR TITLE
child_process: validate options.shell and correctly enforce shell invocation in exec/execSync

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -196,7 +196,12 @@ function normalizeExecArgs(command, options, callback) {
 
   // Make a shallow copy so we don't clobber the user's options object.
   options = { __proto__: null, ...options };
-  options.shell = typeof options.shell === 'string' ? options.shell : true;
+
+  // Validate the shell, if present, and ensure a truthy value.
+  if (options.shell != null) {
+    validateString(options.shell, 'options.shell');
+  }
+  options.shell ||= true;
 
   return {
     file: command,

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -33,7 +33,7 @@ const testCopy = (shellName, shellPath) => {
 const system32 = `${process.env.SystemRoot}\\System32`;
 
 // Test CMD
-test(true);
+test();
 test('cmd');
 testCopy('cmd.exe', `${system32}\\cmd.exe`);
 test('cmd.exe');

--- a/test/parallel/test-child-process-exec-enforce-shell.js
+++ b/test/parallel/test-child-process-exec-enforce-shell.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { exec, execSync } = require('child_process');
+
+const invalidArgTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError'
+};
+
+exec('echo should-be-passed-as-argument', { shell: '' }, common.mustSucceed((stdout, stderr) => {
+  assert.match(stdout, /should-be-passed-as-argument/);
+  assert.ok(!stderr);
+}));
+
+{
+  const ret = execSync('echo should-be-passed-as-argument', { encoding: 'utf-8', shell: '' });
+  assert.match(ret, /should-be-passed-as-argument/);
+}
+
+for (const fn of [exec, execSync]) {
+  assert.throws(() => fn('should-throw-on-boolean-shell-option', { shell: false }), invalidArgTypeError);
+}


### PR DESCRIPTION
The intention of exec and execSync is that a shell is always invoked to run the provided command, as opposed to execFile, which by default executes the target directly and does not invoke a shell. Unlike its counterparts elsewhere in child_process, exec's `options.shell` is documented as not accepting a boolean, as it's not intended to be possible to disable shell invocation and switch to execFile-like behaviour.

exec's `options.shell` is currently handled the following way:
- passed to `normalizeExecArgs()`
  - if the `shell` parameter is not a string, it is coerced to boolean `true`
- passed to `normalizeSpawnArguments()`
  - if non-nullish, the parameter is validated as being of type `string|boolean`
  - if the parameter is truthy at this point, then `spawn()` runs a shell; if not, it executes the target directly

The intention is clearly to force shell invocation with exec/execSync in all cases, but the current implementation has the following problems:
- The parameter is not validated at all; instead, if it's not a string, it's silently ignored and coerced to `true`, which passes downstream validation in `normalizeSpawnArguments()`. In other words, passing an invalid value to `options.shell` will never raise a validation error.
- The logic in the normalize functions combines to yield an edge case, which is when exec/execSync is called with `options.shell` set to the empty string:
  - the parameter is passed through unchanged by `normalizeExecArgs()`
  - the parameter passes validation in `normalizeSpawnArguments()`
  - the parameter is not truthy, so `normalizeSpawnArguments()` fails to set up the shell
  - the child process is spawned without a shell, with the file target set to the entire `command` string:
    ```js
    child_process.exec('./script some-parameter', { shell: '' })
    // should invoke a shell to run "./script" and pass an argument
    // instead, attempts to execute a file called "script some-parameter"
    ```
    
This patch makes two simple changes. Firstly, it validates the shell option sent to exec/execSync as a string. Secondly, it coerces all falsy values to boolean `true`, so will never bypass shell setup. (This makes `{ shell: '' }` equivalent to `{ shell: undefined }`, which matches how it behaves in the other child_process functions.)