### PR TITLE
module: move redundant `throwIfUnsupportedURLScheme` call

### DIFF
--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -106,8 +106,6 @@ async function defaultLoad(url, context = kEmptyObject) {
 
   const urlInstance = new URL(url);
 
-  throwIfUnsupportedURLScheme(urlInstance);
-
   if (urlInstance.protocol === 'node:') {
     source = null;
     format ??= 'builtin';
@@ -115,6 +113,8 @@ async function defaultLoad(url, context = kEmptyObject) {
     if (source == null) {
       ({ responseURL, source } = await getSource(urlInstance, context));
       context = { __proto__: context, source };
+    } else {
+      throwIfUnsupportedURLScheme(urlInstance);
     }
 
     if (format == null) {
@@ -127,6 +127,8 @@ async function defaultLoad(url, context = kEmptyObject) {
         source = null;
       }
     }
+  } else {
+    throwIfUnsupportedURLScheme(urlInstance);
   }
 
   validateAttributes(url, format, importAttributes);


### PR DESCRIPTION
The URL scheme for a module is checked in the `getSource` function, so there is no need to validate it again before hand. This PR replaces the unneeded call with places where it is needed.