### PR TITLE
test: add test cases for `getDirents` and `getDirent` function

### DIFF
--- a/test/parallel/test-fs-utils-get-dirents.js
+++ b/test/parallel/test-fs-utils-get-dirents.js
@@ -5,7 +5,7 @@ const common = require('../common');
 const { getDirents, getDirent } = require('internal/fs/utils');
 const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
-const { UV_DIRENT_UNKNOWN } = internalBinding('constants').fs;
+const { UV_DIRENT_UNKNOWN, UV_DIRENT_FILE } = internalBinding('constants').fs;
 const fs = require('fs');
 
 const tmpdir = require('../common/tmpdir');
@@ -62,6 +62,36 @@ const filename = 'foo';
           'The "path" argument must be of type string or an ' +
           'instance of Buffer. Received type number (42)',
         ].join(''));
+    },
+    ));
+}
+{
+  // Intentional error in lstat
+  let path = '';
+  if (common.isWindows) {
+    path = 'c:\\dev\\null\\does\\not\\exist';
+  } else {
+    path = '/dev/null/does/not/exist';
+  }
+  let full_path = path;
+  if (common.isWindows) {
+    full_path = path + '\\' + filename;
+  } else {
+    full_path = path + '/' + filename;
+  }
+
+  const errmsg_enotdir_start =
+    'ENOTDIR: not a directory, ';
+  const errmsg_enoent_start =
+    'ENOENT: no such file or directory, ';
+
+  getDirents(
+    Buffer.from(path),
+    [[Buffer.from(filename)], [UV_DIRENT_UNKNOWN]],
+    common.mustCall((err) => {
+      assert.match(
+        err.message, new RegExp(`^${errmsg_enotdir_start}|${errmsg_enoent_start}$`)
+      );
     },
     ));
 }
@@ -122,6 +152,49 @@ const filename = 'foo';
           'The "path" argument must be of type string or an ' +
           'instance of Buffer. Received type number (42)',
         ].join(''));
+    },
+    ));
+}
+{
+  // When type != UV_DIRENT_UNKNOWN
+  getDirent(
+    tmpdir.path,
+    filename,
+    UV_DIRENT_FILE,
+    common.mustCall((err, dirent) => {
+      assert.strictEqual(err, null);
+      assert.strictEqual(dirent.name, filename);
+    },
+    ));
+}
+{
+  // Intentional error in lstat
+  let path = '';
+  if (common.isWindows) {
+    path = 'c:\\dev\\null\\does\\not\\exist';
+  } else {
+    path = '/dev/null/does/not/exist';
+  }
+  let full_path = path;
+  if (common.isWindows) {
+    full_path = path + '\\' + filename;
+  } else {
+    full_path = path + '/' + filename;
+  }
+
+  const errmsg_enotdir_start =
+    'ENOTDIR: not a directory, ';
+  const errmsg_enoent_start =
+    'ENOENT: no such file or directory, ';
+
+  getDirent(
+    path,
+    filename,
+    UV_DIRENT_UNKNOWN,
+    common.mustCall((err) => {
+      assert.match(
+        err.message, new RegExp(`^${errmsg_enotdir_start}|${errmsg_enoent_start}$`)
+      );
     },
     ));
 }


### PR DESCRIPTION
Add test case when `type` is not `UV_DIRENT_UNKNOWN` for test case of `getDirent`
Add test case when `path` is a nonexistent path for test case of `getDirents` and `getDirent`

This improves the branch coverage of `lib/internal/fs/utils.js`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
