### PR TITLE
build: explicitly set OpenSSL default TLS seclevel

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -359,7 +359,10 @@
       'defines': [ 'HAVE_OPENSSL=1' ],
       'conditions': [
         [ 'node_shared_openssl=="false"', {
-          'defines': [ 'OPENSSL_API_COMPAT=0x10100000L', ],
+          'defines': [
+            'OPENSSL_API_COMPAT=0x10100000L',
+            'OPENSSL_TLS_SECURITY_LEVEL=1',
+          ],
           'dependencies': [
             './deps/openssl/openssl.gyp:openssl',
 


### PR DESCRIPTION
Explicitly set the default TLS seclevel for OpenSSL. OpenSSL 3.2 changed the default TLS seclevel from 1 (default in OpenSSL 3.0 and 3.1) to 2. This causes smaller key sizes to be rejected, as well as any cipher suite that uses RC4.

Since the End-of-Life date for OpenSSL 3.0 is before the End-of-Life date for Node.js 22, we anticipate that we will need to update OpenSSL to whatever the next (as yet unannounced) LTS version of OpenSSL will be. Fixing the seclevel will minimize ecosystem disruption when that update happens.

Even with the seclevel fixed at 1, updating from OpenSSL 3.1 would still result in a change -- OpenSSL 3.1 disabled SSLv3, TLS 1.0, TLS 1.1 and DTLS 1.0 at seclevel 1.

Refs: https://docs.openssl.org/3.0/man3/SSL_CTX_set_security_level/#default-callback-behaviour
Refs: https://docs.openssl.org/3.1/man3/SSL_CTX_set_security_level/#default-callback-behaviour
Refs: https://docs.openssl.org/3.2/man3/SSL_CTX_set_security_level/#default-callback-behaviour
Refs: https://github.com/nodejs/collaborators/discussions/202#discussioncomment-10477925

--- 

I'm opening this to start the conversation/see if this is something we want to do. It turns out that the change in OpenSSL 3.2 of the default seclevel from 1 to 2 is the cause of the majority of the test failures identified in https://github.com/nodejs/node/issues/53382.

If we land this, then we will become responsible for setting the default TLS seclevel in Node.js (for the binaries we build) instead of leaving it to OpenSSL. We could opt to do nothing (retain the status quo) which potentially means updating to the next LTS OpenSSL (whatever that ends up being) in Node.js 22 could break users -- we do have an explicit exception in our release policy for [breaking changes for security reasons](https://github.com/nodejs/Release/blob/d90daee4e39ab94f0f7982a8717a4dbc03df7d40/README.md?plain=1#L35-L37) (which we could argue the OpenSSL update would be).

cc @nodejs/security-wg @nodejs/tsc @nodejs/releasers 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
