### PR TITLE
deps: allow amaro to be externalizable

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -58,9 +58,11 @@ valid_intl_modes = ('none', 'small-icu', 'full-icu', 'system-icu')
 icu_versions = json.loads((tools_path / 'icu' / 'icu_versions.json').read_text(encoding='utf-8'))
 maglev_enabled_architectures = ('x64', 'arm', 'arm64')
 
+# builtins may be removed later if they have been disabled by options
 shareable_builtins = {'cjs_module_lexer/lexer': 'deps/cjs-module-lexer/lexer.js',
                      'cjs_module_lexer/dist/lexer': 'deps/cjs-module-lexer/dist/lexer.js',
-                     'undici/undici': 'deps/undici/undici.js'
+                     'undici/undici': 'deps/undici/undici.js',
+                     'amaro/dist/index': 'deps/amaro/dist/index.js'
 }
 
 # create option groups
@@ -2201,6 +2203,10 @@ configure_intl(output)
 configure_static(output)
 configure_inspector(output)
 configure_section_file(output)
+
+# remove builtins that have been disabled
+if options.without_amaro:
+    del shareable_builtins['amaro/dist/index']
 
 # configure shareable builtins
 output['variables']['node_builtin_shareable_builtins'] = []

--- a/node.gni
+++ b/node.gni
@@ -20,6 +20,7 @@ declare_args() {
     "deps/cjs-module-lexer/lexer.js",
     "deps/cjs-module-lexer/dist/lexer.js",
     "deps/undici/undici.js",
+    "deps/amaro/dist/index.js",
   ]
 }
 

--- a/node.gyp
+++ b/node.gyp
@@ -465,11 +465,6 @@
       }, {
         'use_openssl_def%': 0,
       }],
-      [ 'node_use_amaro=="true"', {
-          'deps_files': [
-              'deps/amaro/dist/index.js',
-          ]
-      } ]
     ],
   },
 

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -56,7 +56,7 @@ BuiltinLoader::BuiltinLoader()
   AddExternalizedBuiltin("internal/deps/amaro/dist/index",
                          STRINGIFY(NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH));
 #endif  // NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
-#endif  // NODE_USE_ARARO
+#endif  // HAVE_AMARO
 }
 
 bool BuiltinLoader::Exists(const char* id) {

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -50,6 +50,13 @@ BuiltinLoader::BuiltinLoader()
   AddExternalizedBuiltin("internal/deps/undici/undici",
                          STRINGIFY(NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH));
 #endif  // NODE_SHARED_BUILTIN_UNDICI_UNDICI_PATH
+
+#if HAVE_AMARO
+#ifdef NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
+  AddExternalizedBuiltin("internal/deps/amaro/dist/index",
+                         STRINGIFY(NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH));
+#endif  // NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
+#endif  // NODE_USE_ARARO
 }
 
 bool BuiltinLoader::Exists(const char* id) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -127,8 +127,10 @@ Metadata::Versions::Versions() {
   cjs_module_lexer = CJS_MODULE_LEXER_VERSION;
   uvwasi = UVWASI_VERSION_STRING;
 
+#ifndef NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
 #if HAVE_AMARO
   amaro = AMARO_VERSION;
+#endif
 #endif
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -27,12 +27,8 @@ namespace node {
 #define NODE_HAS_RELEASE_URLS
 #endif
 
-#if HAVE_AMARO
-#ifndef NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
+#if HAVE_AMARO && !defined(NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH)
 #define NODE_VERSIONS_KEY_AMARO(V) V(amaro)
-#else
-#define NODE_VERSIONS_KEY_AMARO(V)
-#endif
 #else
 #define NODE_VERSIONS_KEY_AMARO(V)
 #endif

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -28,7 +28,11 @@ namespace node {
 #endif
 
 #if HAVE_AMARO
+#ifndef NODE_SHARED_BUILTIN_AMARO_DIST_INDEX_PATH
 #define NODE_VERSIONS_KEY_AMARO(V) V(amaro)
+#else
+#define NODE_VERSIONS_KEY_AMARO(V)
+#endif
 #else
 #define NODE_VERSIONS_KEY_AMARO(V)
 #endif

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -27,9 +27,12 @@ const expected_keys = [
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');
+const hasAmaro = process.config.variables.node_builtin_shareable_builtins.includes('deps/amaro/dist/index.js');
 
 if (process.config.variables.node_use_amaro) {
-  expected_keys.push('amaro');
+  if (hasAmaro) {
+    expected_keys.push('amaro');
+  }
 }
 if (hasUndici) {
   expected_keys.push('undici');


### PR DESCRIPTION
- allow amaro to be externalized like other builtins containing WASM. More context is available in https://github.com/nodejs/node/blob/main/doc/contributing/maintaining/maintaining-dependencies.md#supporting-externalizable-dependencies-with-javascript-code

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
