### PR TITLE
module: support `import()`-ing `blob:` urls

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -246,7 +246,7 @@ added: REPLACEME
 * `application/wasm` for Wasm
 
 Blob URLs are registered within the current thread. Loaders will not be
-able to handle resolve Blob's from the main thread.
+able to resolve Blob URLs created from the main thread.
 
 ```mjs
 import { Blob } from 'node:buffer';

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -237,6 +237,8 @@ is no concept of relative resolution for `data:` URLs.
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 `blob:` URLs are supported for importing with the following MIME types:
 
 * `text/javascript` for ES modules

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -17,14 +17,16 @@ const {
 
 const detectModule = getOptionValue('--experimental-detect-module');
 const { containsModuleSyntax } = internalBinding('contextify');
+const { resolveObjectURL } = require('buffer');
 const { getPackageScopeConfig, getPackageType } = require('internal/modules/package_json_reader');
 const { fileURLToPath } = require('internal/url');
-const { ERR_UNKNOWN_FILE_EXTENSION } = require('internal/errors').codes;
+const { ERR_UNKNOWN_FILE_EXTENSION, ERR_INVALID_URL } = require('internal/errors').codes;
 
 const protocolHandlers = {
   '__proto__': null,
   'data:': getDataProtocolModuleFormat,
   'file:': getFileProtocolModuleFormat,
+  'blob:': getBlobProtocolModuleFormat,
   'node:'() { return 'builtin'; },
 };
 
@@ -216,6 +218,12 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
   if (ignoreErrors) { return undefined; }
   const filepath = fileURLToPath(url);
   throw new ERR_UNKNOWN_FILE_EXTENSION(ext, filepath);
+}
+
+function getBlobProtocolModuleFormat(url, context = { __proto__: null }, ignoreErrors) {
+  const blob = resolveObjectURL(url);
+  if (blob === undefined) { throw new ERR_INVALID_URL(blob); }
+  return mimeToFormat(blob.type);
 }
 
 /**

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -14,7 +14,7 @@ const { readFileSync } = require('fs');
 const defaultType =
   getOptionValue('--experimental-default-type');
 
-const { Buffer: { from: BufferFrom } } = require('buffer');
+const { Buffer: { from: BufferFrom }, resolveObjectURL } = require('buffer');
 const {
   isUnderNodeModules,
 } = require('internal/modules/helpers');
@@ -48,8 +48,12 @@ async function getSource(url, context) {
     }
     const { 1: base64, 2: body } = match;
     source = BufferFrom(decodeURIComponent(body), base64 ? 'base64' : 'utf8');
+  } else if (protocol === 'blob:') {
+    const blob = resolveObjectURL(url);
+    if (blob === undefined) { throw new ERR_INVALID_URL(blob); }
+    source = await blob.text();
   } else {
-    const supportedSchemes = ['file', 'data'];
+    const supportedSchemes = ['file', 'data', 'blob'];
     throw new ERR_UNSUPPORTED_ESM_URL_SCHEME(url, supportedSchemes);
   }
   return { __proto__: null, responseURL, source };
@@ -219,6 +223,7 @@ function throwIfUnsupportedURLScheme(parsed) {
     protocol !== 'file:' &&
     protocol !== 'data:' &&
     protocol !== 'node:' &&
+    protocol !== 'blob:' &&
     (
       protocol !== 'https:' &&
       protocol !== 'http:'

--- a/test/es-module/test-esm-blob-urls.js
+++ b/test/es-module/test-esm-blob-urls.js
@@ -1,0 +1,68 @@
+'use strict';
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const { test } = require('node:test');
+
+if (!common.hasCrypto) common.skip('missing crypto');
+
+async function createURL(mime, body) {
+  const blob = new Blob([body], { type: mime });
+  return URL.createObjectURL(blob);
+}
+
+function createBase64URL(mime, body) {
+  return `data:${mime};base64,${Buffer.from(body).toString('base64')}`;
+}
+
+test('importing JavaScript from a Blob: URL should work', async (t) => {
+  const url = await createURL('text/javascript', 'export default { "key": "value" }');
+  const { default: expected } = await import(url);
+  t.assert.deepStrictEqual(expected, { key: 'value' });
+});
+
+test('import.meta.url should be equal to the blob URL', async (t) => {
+  const url = await createURL('text/javascript', 'export default import.meta.url;');
+  const { default: expected } = await import(url);
+  t.assert.deepStrictEqual(expected, url);
+});
+
+
+test('importing JSON from a Blob: URL should work', async (t) => {
+  const url = await createURL('application/json', '{ "key": "value" }');
+  const { default: expected } = await import(url, { with: { type: 'json' } });
+  t.assert.deepStrictEqual(expected, { key: 'value' });
+});
+
+test('importing a module from within a blob: URL should work', async (t) => {
+  await t.test('file: URLs', async (t) => {
+    const url = await createURL('text/javascript', `import { message } from ${JSON.stringify(fixtures.fileURL('es-modules/message.mjs'))}; export default message;`);
+    const { default: expected } = await import(url);
+    t.assert.strictEqual(expected, 'A message');
+  });
+
+  await t.test('data: URLs', async (t) => {
+    const dataURL = createBase64URL('text/javascript', 'export const message = "Base64 Imported";');
+    const url = await createURL('text/javascript', `import { message } from "${dataURL}"; export default message;`);
+    const { default: expected } = await import(url);
+    t.assert.strictEqual(expected, 'Base64 Imported');
+  });
+
+  await t.test('blob: URLs', async (t) => {
+    const url = await createURL('text/javascript',
+                                `const blob = new Blob(["export default 'Blob Imported'"], { type: 'application/javascript' });` +
+      'const url = URL.createObjectURL(blob);' +
+      'export default await import(url);'
+    );
+    const { default: { default: expected } } = await import(url);
+    t.assert.strictEqual(expected, 'Blob Imported');
+  });
+});
+
+test('importing a disallowed mimetype should fail', async (t) => {
+  const url = await createURL('invalid/mime', '');
+  await t.assert.rejects(import(url), /ERR_UNKNOWN_MODULE_FORMAT/);
+});
+
+test('importing an invalid blob should fail', async (t) => {
+  await t.assert.rejects(import('blob:nodedata:123456'), /ERR_INVALID_URL/);
+});


### PR DESCRIPTION
Fixes #47573

## Notable Change

The `import()` function can now receive `blob:` protocol URLs as an input. These blobs must be one of the following types:

* `text/javascript` for ES modules
* `application/json` for JSON
* `application/wasm` for Wasm

Blob URLs are registered within the current thread. Loaders will not be able to handle resolve Blob's from the main thread.