### PR TITLE
doc: clarify Web Storage behavior

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3384,13 +3384,13 @@ for MiB in 16 32 64 128; do
     node --max-semi-space-size=$MiB index.js
 done
 ```
+
 ### --localstorage-file
 
-The --localstorage-file option specifies the file used for localStorage in Node.js. 
+The --localstorage-file option specifies the file used for localStorage in Node.js.
 
-- This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms to ensure data integrity.
-- The storage quota for localStorage is 10MB per process.
-
+* This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms to ensure data integrity.
+* The storage quota for localStorage is 10MB per process.
 
 ### `--security-revert`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3384,6 +3384,13 @@ for MiB in 16 32 64 128; do
     node --max-semi-space-size=$MiB index.js
 done
 ```
+### --localstorage-file
+
+The --localstorage-file option specifies the file used for localStorage in Node.js. 
+
+- This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms to ensure data integrity.
+- The storage quota for localStorage is 10MB per process.
+
 
 ### `--security-revert`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3389,7 +3389,8 @@ done
 
 The --localstorage-file option specifies the file used for localStorage in Node.js.
 
-* This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms to ensure data integrity.
+* This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms
+  to ensure data integrity.
 * The storage quota for localStorage is 10MB per process.
 
 ### `--security-revert`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3389,9 +3389,10 @@ done
 
 The --localstorage-file option specifies the file used for localStorage in Node.js.
 
-* This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms
-  to ensure data integrity.
-* The storage quota for localStorage is 10MB per process.
+* This file can be accessed by multiple processes simultaneously, which
+  might require implementing file locking or other synchronization
+  mechanisms to ensure data integrity.
+* The storage quota for `localStorage` is 10MB per process.
 
 ### `--security-revert`
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1204,7 +1204,9 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 In Node.js, the localStorage and sessionStorage objects function differently compared to browsers or Deno:
 
 * Both localStorage and sessionStorage are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
-* localStorage uses the value of the --localstorage-file flag as its origin. This file can be accessed simultaneously by multiple processes, which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
+* `localStorage` uses the value of the `--localstorage-file` flag as its origin. This file can be accessed simultaneously by multiple processes,
+  which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
+  cli.md
 * The storage quota for both localStorage and sessionStorage is 10MB per process.
 
 [CommonJS module]: modules.md

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1203,9 +1203,9 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
 In Node.js, the localStorage and sessionStorage objects function differently compared to browsers or Deno:
 
-- Both localStorage and sessionStorage are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
-- localStorage uses the value of the --localstorage-file flag as its origin. This file can be accessed simultaneously by multiple processes, which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
-- The storage quota for both localStorage and sessionStorage is 10MB per process.
+* Both localStorage and sessionStorage are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
+* localStorage uses the value of the --localstorage-file flag as its origin. This file can be accessed simultaneously by multiple processes, which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
+* The storage quota for both localStorage and sessionStorage is 10MB per process.
 
 [CommonJS module]: modules.md
 [CommonJS modules]: modules.md

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1203,11 +1203,15 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
 In Node.js, the localStorage and sessionStorage objects function differently compared to browsers or Deno:
 
-* Both localStorage and sessionStorage are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
-* `localStorage` uses the value of the `--localstorage-file` flag as its origin. This file can be accessed simultaneously by multiple processes,
-  which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
-  cli.md
-* The storage quota for both localStorage and sessionStorage is 10MB per process.
+* Both `localStorage` and `sessionStorage` are scoped to the current process,
+  not individual users or server requests. This is crucial for applications
+  like server-side rendering.
+* `localStorage` uses the value of the `--localstorage-file` flag as its
+  origin. This file can be accessed simultaneously by multiple processes,
+  which may require implementing file locking or other synchronization
+  mechanisms to ensure data integrity.
+* The storage quota for both `localStorage` and `sessionStorage` is
+  10MB per process.
 
 [CommonJS module]: modules.md
 [CommonJS modules]: modules.md

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1199,6 +1199,14 @@ added: v18.0.0
 
 A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
+## Web Storage API
+
+In Node.js, the localStorage and sessionStorage objects function differently compared to browsers or Deno:
+
+- Both localStorage and sessionStorage are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
+- localStorage uses the value of the --localstorage-file flag as its origin. This file can be accessed simultaneously by multiple processes, which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
+- The storage quota for both localStorage and sessionStorage is 10MB per process.
+
 [CommonJS module]: modules.md
 [CommonJS modules]: modules.md
 [ECMAScript module]: esm.md


### PR DESCRIPTION
## **Title:**
`doc: clarify Web Storage behavior and document --localstorage-file option`

## **Description:**

### Issue Resolved
This pull request addresses the issue outlined in [#53871](https://github.com/nodejs/node/issues/53871). The changes clarify the Web Storage behavior in Node.js and document the `--localstorage-file` option.

### Changes Made

1. **`cli.md`**: Added documentation for the `--localstorage-file` option.
   - Placed after the `--max-old-space-size` section.
   - Described how to use the `--localstorage-file` option to specify the file used for `localStorage` in Node.js.
   - Mentioned key considerations such as the possibility of concurrent access by multiple processes and the 10MB storage quota per process.

   **Example documentation snippet added:**

   ```markdown
   ### --localstorage-file

   The `--localstorage-file` option specifies the file used for `localStorage` in Node.js.

   - This file can be accessed by multiple processes simultaneously, which might require implementing file locking or other synchronization mechanisms to ensure data integrity.
   - The storage quota for `localStorage` is 10MB per process.
   ```

2. **`globals.md`**: Added a new section describing how `localStorage` and `sessionStorage` behave in Node.js.

   - Clarified that both are scoped to the current process.
   - Explained that the `--localstorage-file` flag determines the file used for `localStorage`.
   - Reiterated the 10MB per process storage quota.

   **Example documentation snippet added:**

   ```markdown
   ## Web Storage API

   In Node.js, the `localStorage` and `sessionStorage` objects function differently compared to browsers or Deno:

   - Both `localStorage` and `sessionStorage` are scoped to the current process, not individual users or server requests. This is crucial for applications like server-side rendering.
   - `localStorage` uses the value of the `--localstorage-file` flag as its origin. This file can be accessed simultaneously by multiple processes, which may require implementing file locking or other synchronization mechanisms to ensure data integrity.
   - The storage quota for both `localStorage` and `sessionStorage` is 10MB per process.
   ```

### Note
- The `--localstorage-file` option is currently documented but not implemented in the Node.js core. Therefore, the added documentation is primarily for reference and future-proofing.
- No new tests have been included, as this PR only addresses documentation changes.
- I feel that my contributions are still lacking, and I appreciate any feedback you may have to help me improve. Thank you for your understanding.

Please review the documentation updates, and let me know if there are any additional changes or clarifications needed.