### PR TITLE
build,win: enable clang-cl compilation

### DIFF
--- a/tools/icu/icu-generic.gyp
+++ b/tools/icu/icu-generic.gyp
@@ -139,20 +139,43 @@
               # full data - just build the full data file, then we are done.
               'sources': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)<(icu_endianness)_dat.<(icu_asm_ext)' ],
               'dependencies': [ 'genccode#host' ],
-              'actions': [
-                {
-                  'action_name': 'icudata',
-                  'msvs_quote_cmd': 0,
-                  'inputs': [ '<(icu_data_in)' ],
-                  'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)<(icu_endianness)_dat.<(icu_asm_ext)' ],
-                  # on Windows, we can go directly to .obj file (-o) option.
-                  'action': [ '<(PRODUCT_DIR)/genccode<(EXECUTABLE_SUFFIX)',
-                              '<@(icu_asm_opts)', # -o
-                              '-d', '<(SHARED_INTERMEDIATE_DIR)',
-                              '-n', 'icudata',
-                              '-e', 'icudt<(icu_ver_major)',
-                              '<@(_inputs)' ],
-                },
+              'conditions': [
+                [ 'clang==1', {
+                  'actions': [
+                    {
+                      'action_name': 'icudata',
+                      'msvs_quote_cmd': 0,
+                      'inputs': [ '<(icu_data_in)' ],
+                      'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)<(icu_endianness)_dat.<(icu_asm_ext)' ],
+                      # on Windows, we can go directly to .obj file (-o) option.
+                      # for Clang use "-c <(target_arch)" option
+                      'action': [ '<(PRODUCT_DIR)/genccode<(EXECUTABLE_SUFFIX)',
+                                  '<@(icu_asm_opts)', # -o
+                                  '-c', '<(target_arch)',
+                                  '-d', '<(SHARED_INTERMEDIATE_DIR)',
+                                  '-n', 'icudata',
+                                  '-e', 'icudt<(icu_ver_major)',
+                                  '<@(_inputs)' ],
+                    },
+                  ],
+                }, {
+                  'actions': [
+                    {
+                      'action_name': 'icudata',
+                      'msvs_quote_cmd': 0,
+                      'inputs': [ '<(icu_data_in)' ],
+                      'outputs': [ '<(SHARED_INTERMEDIATE_DIR)/icudt<(icu_ver_major)<(icu_endianness)_dat.<(icu_asm_ext)' ],
+                      # on Windows, we can go directly to .obj file (-o) option.
+                      # for MSVC do not use "-c <(target_arch)" option
+                      'action': [ '<(PRODUCT_DIR)/genccode<(EXECUTABLE_SUFFIX)',
+                                  '<@(icu_asm_opts)', # -o
+                                  '-d', '<(SHARED_INTERMEDIATE_DIR)',
+                                  '-n', 'icudata',
+                                  '-e', 'icudt<(icu_ver_major)',
+                                  '<@(_inputs)' ],
+                    },
+                  ],
+                }]
               ],
             }, { # icu_small == TRUE and OS == win
               # link against stub data primarily

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1890,7 +1890,31 @@
           ['enable_lto=="true"', {
             'cflags_cc': [ '-fno-lto' ],
           }],
-          ['clang==1 or OS!="win"', {
+          # Chnges in push_registers_asm.cc in V8 v12.8 requires using
+          # push_registers_masm on Windows even with ClangCL on x64
+          ['OS=="win"', {
+            'conditions': [
+              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
+                'sources': [
+                  '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_masm.asm',
+                ],
+              }],
+              ['_toolset == "host" and host_arch == "arm64" or _toolset == "target" and target_arch=="arm64"', {
+                'conditions': [
+                  ['clang==1', {
+                    'sources': [
+                      '<(V8_ROOT)/src/heap/base/asm/arm64/push_registers_asm.cc',
+                    ],
+                  }],
+                  ['clang==0', {
+                    'sources': [
+                      '<(V8_ROOT)/src/heap/base/asm/arm64/push_registers_masm.S',
+                    ],
+                  }],
+                ],
+              }],
+            ],
+          }, { # 'OS!="win"'
             'conditions': [
               ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
                 'sources': [
@@ -1938,20 +1962,6 @@
                 ],
               }],
             ]
-          }],
-          ['OS=="win" and clang==0', {
-            'conditions': [
-              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
-                'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_masm.asm',
-                ],
-              }],
-              ['_toolset == "host" and host_arch == "arm64" or _toolset == "target" and target_arch=="arm64"', {
-                'sources': [
-                  '<(V8_ROOT)/src/heap/base/asm/arm64/push_registers_masm.S',
-                ],
-              }],
-            ],
           }],
         ],
       },


### PR DESCRIPTION
This uses the previously backported ICU fix needed for compiling with ClangCL. 

To make sure all works well I tested these combinations locally (since half of them are not tested in the CI):
- MSVC x64
- MSVC ARM64
- ClangCL x64
- ClangCL ARM64

Once this lands main branch will have ClangCL compilation enabled on Windows and I'll start working on the CI to have it there as well. After some time I'll add testing those binaries too, and ultimately releases will be built by it).

Refs: https://github.com/nodejs/node/issues/52809
Refs: https://github.com/nodejs/node/pull/54502
Fixes: https://github.com/nodejs/node/issues/34201