### PR TITLE
tools: add util scripts to land and rebase PRs

### DIFF
--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -12,7 +12,7 @@ set -xe
 
 pr=$1
 commit_head=$2
-shift 2 || (echo "Expected two arguments" && exit 1)
+shift 2 || { echo "Expected two arguments"; exit 1; }
 
 commit_queue_failed() {
   pr=$1
@@ -34,8 +34,8 @@ elif ! expr "X$pr" : 'X[0-9]\{1,\}' >/dev/null; then
   echo "The first argument should be the PR ID or URL"
 fi
 
-git log -1 HEAD  --pretty='format:%B' | git interpret-trailers --parse --no-divider | grep -q -x "^PR-URL: https://github.com/$OWNER/$REPOSITORY/pull/$pr$" || (echo "Invalid PR-URL trailer" && exit 1)
-git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divider | grep -q -x "^PR-URL: https://github.com/$OWNER/$REPOSITORY/pull/$pr$" && echo "Refuse to squash and merge a PR landing in more than one commit" && exit 1
+git log -1 HEAD  --pretty='format:%B' | git interpret-trailers --parse --no-divider | grep -q -x "^PR-URL: https://github.com/$OWNER/$REPOSITORY/pull/$pr$" || { echo "Invalid PR-URL trailer"; exit 1; }
+git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divider | grep -q -x "^PR-URL: https://github.com/$OWNER/$REPOSITORY/pull/$pr$" && { echo "Refuse to squash and merge a PR landing in more than one commit"; exit 1; }
 
 commit_title=$(git log -1 --pretty='format:%s')
 commit_body=$(git log -1 --pretty='format:%b')

--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -59,4 +59,4 @@ if ! commits="$(jq -r 'if .merged then .sha else error("not merged") end' < outp
 fi
 rm output.json output
 
-gh pr comment "$pr" --body "Landed in $commits"
+gh pr comment "$pr" --repo "$OWNER/$REPOSITORY" --body "Landed in $commits"

--- a/tools/actions/rebase.sh
+++ b/tools/actions/rebase.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-gh api graphql -F "prID=$(gh pr view "$1" --json id --jq .id)" -f query='
+set -xe
+
+# shellcheck disable=SC2016
+gh api graphql -F "prID=$(gh pr view "$1" --json id --jq .id || true)" -f query='
 mutation RebasePR($prID: ID!) {
     updatePullRequestBranch(input:{pullRequestId:$prID,updateMethod:REBASE}) {
         clientMutationId

--- a/tools/actions/rebase.sh
+++ b/tools/actions/rebase.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+gh api graphql -F "prID=$(gh pr view "$1" --json id --jq .id)" -f query='
+mutation RebasePR($prID: ID!) {
+    updatePullRequestBranch(input:{pullRequestId:$prID,updateMethod:REBASE}) {
+        clientMutationId
+    }
+}'


### PR DESCRIPTION
I've been using those scripts for a while now, and I figured I may as well send those in a PR in case they can be helpful to someone else – although I don't expect those to be useful to most folks – and I don't lose them if I delete them by mistake.

- in case you want to land a PR without the CQ (not recommended), the script `merge.sh` in this PR provides an alternative to "purple-merge" a PR without force pushing its branch.
- the `rebase.sh` one is mostly useful when working with a very old PRs, or very large ones, when you want to rebase it without having to check it out locally. It's exactly equivalent to the "Update branch" button on the GitHub UI, that we had to disable because by default it creates a merge commit, that we never want as it breaks our tooling.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
