### PR TITLE
tools: remove readability/fn_size rule

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -325,7 +325,6 @@ _ERROR_CATEGORIES = [
     'readability/casting',
     'readability/check',
     'readability/constructors',
-    'readability/fn_size',
     'readability/inheritance',
     'readability/pointer_notation',
     'readability/multiline_comment',


### PR DESCRIPTION
Due to https://github.com/nodejs/node/pull/53927 I had to update the v22.x-staging branch to include a `// NOLINT(readability/fn_size)` https://github.com/nodejs/node/blob/v22.x-staging/src/node_options.cc#L890

I'm questioning whether having this rule is really necessary or beneficial. This lint didn't fail on `main` (yet) because we have more code on this specific function in v22.x-staging. So, this will likely appear in a PR soon, and I think that dropping this rule instead of adding a `NOLINT` comment is a much better option.
