### PR TITLE
test: improve test-internal-fs-syncwritestream

### DIFF
--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -71,9 +71,10 @@ const filename = tmpdir.resolve('sync-write-stream.txt');
   const fd = fs.openSync(filename, 'w');
   const stream = new SyncWriteStream(fd, { autoClose: false });
 
+  stream.on('close', common.mustCall());
+
   assert.strictEqual(stream.destroy(), stream);
   fs.fstatSync(fd); // Does not throw
-  stream.on('close', common.mustCall());
   fs.closeSync(fd);
 }
 

--- a/test/parallel/test-internal-fs-syncwritestream.js
+++ b/test/parallel/test-internal-fs-syncwritestream.js
@@ -66,16 +66,6 @@ const filename = tmpdir.resolve('sync-write-stream.txt');
   assert.strictEqual(stream.fd, null);
 }
 
-// Verify behavior of destroy() when already destroy()ed
-{
-  const fd = fs.openSync(filename, 'w');
-  const stream = new SyncWriteStream(fd);
-
-  stream.on('close', common.mustCall());
-  assert.strictEqual(stream.destroy(), stream);
-  assert.strictEqual(stream.destroy(), stream);
-}
-
 // Verify that the file is not closed when autoClose=false
 {
   const fd = fs.openSync(filename, 'w');


### PR DESCRIPTION
1. When `destroy()` called but already destroyed
2. Behavior of `SyncWriteStream.prototype._destroy()` when `autoClose=false`