### PR TITLE
meta: add old issue stalebot

### DIFF
--- a/.github/workflows/close-old-stale-issues.yml
+++ b/.github/workflows/close-old-stale-issues.yml
@@ -1,0 +1,59 @@
+name: Close stale issues
+on:
+  workflow_dispatch:
+    inputs:
+      endDate:
+        description: stop processing PRs after this date
+        required: false
+        type: string
+
+# yamllint disable rule:empty-lines
+env:
+  CLOSE_MESSAGE: >
+    This issue was opened more than 4 years ago and there has
+    been no activity in the last 6 months. We value your contribution
+    but since it has not progressed in the last 6 months it is being
+    closed. If you feel closing this issue is not the right thing
+    to do, please leave a comment.
+
+  WARN_MESSAGE: >
+    This issue was opened more than 4 years ago and there has
+    been no activity in the last 5 months. We value your contribution
+    but since it has not progressed in the last 5 months it is being
+    marked stale and will be closed if there is no progress in the
+    next month. If you feel that is not the right thing to do please
+    comment on the issue.
+# yamllint enable
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+    if: github.repository == 'nodejs/node'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set default end date which is 4 year ago
+        run: echo "END_DATE=$(date --date='2102400 minutes ago' --rfc-2822)"  >> "$GITHUB_ENV"
+      - name: if date set in event override the default end date
+        env:
+          END_DATE_INPUT_VALUE: ${{ github.event.inputs.endDate }}
+        if: ${{ github.event.inputs.endDate != '' }}
+        run: echo "END_DATE=$END_DATE_INPUT_VALUE"  >> "$GITHUB_ENV"
+      - uses: mhdawson/stale@453d6581568dc43dbe345757f24408d7b451c651  # PR to add support for endDate
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          end-date: ${{ env.END_DATE }}
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-stale: 150
+          days-before-close: 30
+          stale-issue-label: stale
+          close-issue-message: ${{ env.CLOSE_MESSAGE }}
+          stale-issue-message: ${{ env.WARN_MESSAGE }}
+          exempt-issue-labels: never-stale, feature requests
+          # max requests it will send per run to the GitHub API before it deliberately exits to avoid hitting API rate limits
+          operations-per-run: 500
+          remove-stale-when-updated: true


### PR DESCRIPTION
#52712 was an overly aggressive update to the stalebot, leading to mass notifications being sent out to users.

This PR is a much more restrained version of that update. It restricts the stalebot to only target non-feature request issues. The rules remain the same: if an issue is older than **4** years and hasn't been updated in over 5 months, it will be marked as stale. This approach is similar to #48051 but focused on issues rather than PRs.

The 4-year threshold was chosen because it applies to only [257](https://github.com/nodejs/node/issues?q=type%3Aissue+is%3Aopen+-label%3A%22feature+request%22+created%3A%3C2020-08-31+updated%3A%3C2024-02-28+) issues, which seems like a manageable starting point.

Over time, I think we can unify the stalebots with the following steps:

- [x] (This PR) Integrate non-feature request issues into the slower stalebot process.
- [ ] Gradually reduce the `END_DATE` to minimize disruption.
- [ ] Once the `END_DATE` is down to 1 year, merge with `close-stale-pull-requests.yml`.
- [ ] Once the `END_DATE` reaches 6 months, merge with `close-stale-feature-requests.yml`.