### PR TITLE
zlib: runtime deprecate initializing without new qualifier

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -706,32 +706,40 @@ Zlib.prototype.params = function params(level, strategy, callback) {
 // generic zlib
 // minimal 2-byte header
 function Deflate(opts) {
-  if (!(this instanceof Deflate))
+  if (!(this instanceof Deflate)) {
+    process.emitWarning('Initializing Deflate without "new" qualifier is deprecated', 'DEP0184');
     return new Deflate(opts);
+  }
   ReflectApply(Zlib, this, [opts, DEFLATE]);
 }
 ObjectSetPrototypeOf(Deflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Deflate, Zlib);
 
 function Inflate(opts) {
-  if (!(this instanceof Inflate))
+  if (!(this instanceof Inflate)) {
+    process.emitWarning('Initializing Inflate without "new" qualifier is deprecated', 'DEP0184');
     return new Inflate(opts);
+  }
   ReflectApply(Zlib, this, [opts, INFLATE]);
 }
 ObjectSetPrototypeOf(Inflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Inflate, Zlib);
 
 function Gzip(opts) {
-  if (!(this instanceof Gzip))
+  if (!(this instanceof Gzip)) {
+    process.emitWarning('Initializing Inflate without "new" qualifier is deprecated', 'DEP0184');
     return new Gzip(opts);
+  }
   ReflectApply(Zlib, this, [opts, GZIP]);
 }
 ObjectSetPrototypeOf(Gzip.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Gzip, Zlib);
 
 function Gunzip(opts) {
-  if (!(this instanceof Gunzip))
+  if (!(this instanceof Gunzip)) {
+    process.emitWarning('Initializing Gunzip without "new" qualifier is deprecated', 'DEP0184');
     return new Gunzip(opts);
+  }
   ReflectApply(Zlib, this, [opts, GUNZIP]);
 }
 ObjectSetPrototypeOf(Gunzip.prototype, Zlib.prototype);
@@ -739,24 +747,31 @@ ObjectSetPrototypeOf(Gunzip, Zlib);
 
 function DeflateRaw(opts) {
   if (opts && opts.windowBits === 8) opts.windowBits = 9;
-  if (!(this instanceof DeflateRaw))
+  if (!(this instanceof DeflateRaw)) {
+    process.emitWarning('Initializing DeflateRaw without "new" qualifier is deprecated', 'DEP0184');
     return new DeflateRaw(opts);
+  }
   ReflectApply(Zlib, this, [opts, DEFLATERAW]);
 }
 ObjectSetPrototypeOf(DeflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(DeflateRaw, Zlib);
 
 function InflateRaw(opts) {
-  if (!(this instanceof InflateRaw))
+  if (!(this instanceof InflateRaw)) {
+    process.emitWarning('Initializing InflateRaw without "new" qualifier is deprecated', 'DEP0184');
     return new InflateRaw(opts);
+  }
   ReflectApply(Zlib, this, [opts, INFLATERAW]);
 }
 ObjectSetPrototypeOf(InflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(InflateRaw, Zlib);
 
 function Unzip(opts) {
-  if (!(this instanceof Unzip))
+  if (!(this instanceof Unzip)) {
+    process.emitWarning('Initializing Unzip without "new" qualifier is deprecated', 'DEP0184');
     return new Unzip(opts);
+
+  }
   ReflectApply(Zlib, this, [opts, UNZIP]);
 }
 ObjectSetPrototypeOf(Unzip.prototype, Zlib.prototype);
@@ -831,16 +846,20 @@ ObjectSetPrototypeOf(Brotli.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Brotli, Zlib);
 
 function BrotliCompress(opts) {
-  if (!(this instanceof BrotliCompress))
+  if (!(this instanceof BrotliCompress)) {
+    process.emitWarning('Initializing BrotliCompress without "new" qualifier is deprecated', 'DEP0184');
     return new BrotliCompress(opts);
+  }
   ReflectApply(Brotli, this, [opts, BROTLI_ENCODE]);
 }
 ObjectSetPrototypeOf(BrotliCompress.prototype, Brotli.prototype);
 ObjectSetPrototypeOf(BrotliCompress, Brotli);
 
 function BrotliDecompress(opts) {
-  if (!(this instanceof BrotliDecompress))
+  if (!(this instanceof BrotliDecompress)) {
+    process.emitWarning('Initializing BrotliDecompress without "new" qualifier is deprecated', 'DEP0184');
     return new BrotliDecompress(opts);
+  }
   ReflectApply(Brotli, this, [opts, BROTLI_DECODE]);
 }
 ObjectSetPrototypeOf(BrotliDecompress.prototype, Brotli.prototype);

--- a/test/parallel/test-zlib-deflate-constructors.js
+++ b/test/parallel/test-zlib-deflate-constructors.js
@@ -1,3 +1,4 @@
+// Flags: --no-deprecation
 'use strict';
 
 require('../common');

--- a/test/parallel/test-zlib-deflate-raw-inherits.js
+++ b/test/parallel/test-zlib-deflate-raw-inherits.js
@@ -1,3 +1,4 @@
+// Flags: --no-deprecation
 'use strict';
 
 require('../common');

--- a/test/parallel/test-zlib-invalid-arg-value-brotli-compress.js
+++ b/test/parallel/test-zlib-invalid-arg-value-brotli-compress.js
@@ -15,6 +15,6 @@ const opts = {
   }
 };
 
-assert.throws(() => BrotliCompress(opts), {
+assert.throws(() => new BrotliCompress(opts), {
   code: 'ERR_INVALID_ARG_TYPE'
 });

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -35,11 +35,11 @@ const nonStringInputs = [
 
 // zlib.Unzip classes need to get valid data, or else they'll throw.
 const unzips = [
-  zlib.Unzip(),
-  zlib.Gunzip(),
-  zlib.Inflate(),
-  zlib.InflateRaw(),
-  zlib.BrotliDecompress(),
+  new zlib.Unzip(),
+  new zlib.Gunzip(),
+  new zlib.Inflate(),
+  new zlib.InflateRaw(),
+  new zlib.BrotliDecompress(),
 ];
 
 nonStringInputs.forEach(common.mustCall((input) => {

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -30,7 +30,7 @@ const { test } = require('node:test');
 test('zlib should properly handle zero byte input', async () => {
   for (const Compressor of [zlib.Gzip, zlib.BrotliCompress]) {
     const { promise, resolve, reject } = Promise.withResolvers();
-    const gz = Compressor();
+    const gz = new Compressor();
     const emptyBuffer = Buffer.alloc(0);
     let received = 0;
     gz.on('data', function(c) {


### PR DESCRIPTION
I wanted to open this pull-request as a draft to get a feedback from @nodejs/tsc the possibility of runtime deprecating `new` qualifier in the next major.

If we are OK with this change, I can open another pull-request before landing this to documentation-only deprecate it with the next release, before the next major.