### PR TITLE
Revert "console: colorize console error and warn"

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -8,7 +8,6 @@ const {
   ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypePush,
-  ArrayPrototypeSome,
   ArrayPrototypeUnshift,
   Boolean,
   ErrorCaptureStackTrace,
@@ -60,7 +59,6 @@ const {
 const {
   CHAR_UPPERCASE_C: kTraceCount,
 } = require('internal/constants');
-const { styleText } = require('util');
 const kCounts = Symbol('counts');
 const { time, timeLog, timeEnd, kNone } = require('internal/util/debuglog');
 
@@ -264,7 +262,7 @@ ObjectDefineProperties(Console.prototype, {
   [kWriteToConsole]: {
     __proto__: null,
     ...consolePropAttributes,
-    value: function(streamSymbol, string, color = '') {
+    value: function(streamSymbol, string) {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = internalIndentationMap.get(this) || '';
 
@@ -279,11 +277,6 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
-
-      if (color) {
-        string = styleText(color, string);
-      }
-
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -382,15 +375,12 @@ const consoleMethods = {
   log(...args) {
     this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
   },
+
+
   warn(...args) {
-    const color = (shouldColorize(args) && 'yellow') || '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
   },
 
-  error(...args) {
-    const color = (shouldColorize(args) && 'red') || '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
-  },
 
   dir(object, options) {
     this[kWriteToConsole](kUseStdout, inspect(object, {
@@ -621,12 +611,6 @@ const iterKey = '(iteration index)';
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
-// TODO: remove string type check once the styleText supports objects
-// Return true if all args are type string
-const shouldColorize = (args) => {
-  return lazyUtilColors().hasColors && !ArrayPrototypeSome(args, (arg) => typeof arg !== 'string');
-};
-
 function noop() {}
 
 for (const method of ReflectOwnKeys(consoleMethods))
@@ -635,6 +619,7 @@ for (const method of ReflectOwnKeys(consoleMethods))
 Console.prototype.debug = Console.prototype.log;
 Console.prototype.info = Console.prototype.log;
 Console.prototype.dirxml = Console.prototype.log;
+Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 function initializeGlobalConsole(globalConsole) {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -772,7 +772,6 @@ const errorTests = [
       'Object [console] {',
       '  log: [Function: log],',
       '  warn: [Function: warn],',
-      '  error: [Function: error],',
       '  dir: [Function: dir],',
       '  time: [Function: time],',
       '  timeEnd: [Function: timeEnd],',
@@ -788,6 +787,7 @@ const errorTests = [
       / {2}debug: \[Function: (debug|log)],/,
       / {2}info: \[Function: (info|log)],/,
       / {2}dirxml: \[Function: (dirxml|log)],/,
+      / {2}error: \[Function: (error|warn)],/,
       / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
       / {2}Console: \[Function: Console],?/,
       ...process.features.inspector ? [

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
-*(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
-*(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
-*(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)


### PR DESCRIPTION
Fixes #53661

This PR reverts #51629.

**Why was this change made?**

IMO The original PR introduces more issues than it resolves, negatively impacting the intended use of standard streams in several ways, such as:

**Misuse of Standard Streams:** The primary purpose of `stdout` is to handle program output, whereas `stderr` is designated for diagnostics, status updates, and runtime user messages. Showing this output red may confuse users, as this content isn't always an error. (For example, run `ncu-ci` with no args...)

**Inconsistency in Color Handling:** If the input passed to `console.error` or `console.warn` already includes color formatting, the additional internal coloring introduced by the original PR can result in a clash of styles.

---

CC @MrJithil 