### PR TITLE
sqlite: fix segfault in expandedSQL

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -52,11 +52,8 @@ using v8::Value;
     }                                                                          \
   } while (0)
 
-inline Local<Value> CreateSQLiteError(Isolate* isolate, sqlite3* db) {
-  int errcode = sqlite3_extended_errcode(db);
-  const char* errstr = sqlite3_errstr(errcode);
-  const char* errmsg = sqlite3_errmsg(db);
-  Local<String> js_msg = String::NewFromUtf8(isolate, errmsg).ToLocalChecked();
+inline Local<Object> CreateSQLiteError(Isolate* isolate, const char* message) {
+  Local<String> js_msg = String::NewFromUtf8(isolate, message).ToLocalChecked();
   Local<Object> e = Exception::Error(js_msg)
                         ->ToObject(isolate->GetCurrentContext())
                         .ToLocalChecked();
@@ -64,6 +61,14 @@ inline Local<Value> CreateSQLiteError(Isolate* isolate, sqlite3* db) {
          OneByteString(isolate, "code"),
          OneByteString(isolate, "ERR_SQLITE_ERROR"))
       .Check();
+  return e;
+}
+
+inline Local<Object> CreateSQLiteError(Isolate* isolate, sqlite3* db) {
+  int errcode = sqlite3_extended_errcode(db);
+  const char* errstr = sqlite3_errstr(errcode);
+  const char* errmsg = sqlite3_errmsg(db);
+  Local<Object> e = CreateSQLiteError(isolate, errmsg);
   e->Set(isolate->GetCurrentContext(),
          OneByteString(isolate, "errcode"),
          Integer::New(isolate, errcode))
@@ -77,6 +82,10 @@ inline Local<Value> CreateSQLiteError(Isolate* isolate, sqlite3* db) {
 
 inline void THROW_ERR_SQLITE_ERROR(Isolate* isolate, sqlite3* db) {
   isolate->ThrowException(CreateSQLiteError(isolate, db));
+}
+
+inline void THROW_ERR_SQLITE_ERROR(Isolate* isolate, const char* message) {
+  isolate->ThrowException(CreateSQLiteError(isolate, message));
 }
 
 DatabaseSync::DatabaseSync(Environment* env,
@@ -623,7 +632,13 @@ void StatementSync::ExpandedSQL(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_ON_BAD_STATE(
       env, stmt->IsFinalized(), "statement has been finalized");
+
+  // sqlite3_expanded_sql may return nullptr without producing an error code.
   char* expanded = sqlite3_expanded_sql(stmt->statement_);
+  if (expanded == nullptr) {
+    return THROW_ERR_SQLITE_ERROR(
+        env->isolate(), "Expanded SQL text would exceed configured limits");
+  }
   auto maybe_expanded = String::NewFromUtf8(env->isolate(), expanded);
   sqlite3_free(expanded);
   Local<String> result;


### PR DESCRIPTION
The call to `sqlite3_expanded_sql()` may return NULL depending on various factors. Handle this case instead of running into a segmentation fault.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
