### PR TITLE
meta: add `Windows ARM64` to flaky-tests list

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
@@ -36,6 +36,7 @@ body:
         - macOS x64
         - SmartOS
         - Windows
+        - Windows ARM64
         - Other
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
@@ -35,8 +35,8 @@ body:
         - macOS ARM64
         - macOS x64
         - SmartOS
-        - Windows x64
         - Windows ARM64
+        - Windows x64
         - Other
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
@@ -35,7 +35,7 @@ body:
         - macOS ARM64
         - macOS x64
         - SmartOS
-        - Windows
+        - Windows x64
         - Windows ARM64
         - Other
   - type: textarea


### PR DESCRIPTION
As seen in #54645, it is possible for issues to only affect this specific platform, so this PR adds it to selection menu when reporting a flaky test. 