### PR TITLE
zlib: remove prototype primordials usage

### DIFF
--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -10,6 +10,7 @@ important than reliability against prototype pollution:
 * `node:http`
 * `node:http2`
 * `node:tls`
+* `node:zlib`
 
 Usage of primordials should be preferred for new code in other areas, but
 replacing current code with primordials should be

--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -498,6 +498,7 @@ export default [
       'lib/internal/http.js',
       'lib/internal/http2/*.js',
       'lib/tls.js',
+      'lib/zlib.js',
     ],
     rules: {
       'no-restricted-syntax': [

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -23,21 +23,16 @@
 
 const {
   ArrayBuffer,
-  ArrayPrototypeForEach,
-  ArrayPrototypeMap,
-  ArrayPrototypePush,
-  FunctionPrototypeBind,
-  MathMaxApply,
+  MathMax,
   NumberIsNaN,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectEntries,
   ObjectFreeze,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ReflectApply,
-  StringPrototypeStartsWith,
   Symbol,
-  TypedArrayPrototypeFill,
   Uint32Array,
 } = primordials;
 
@@ -130,10 +125,11 @@ function zlibBuffer(engine, buffer, callback) {
 }
 
 function zlibBufferOnData(chunk) {
-  if (!this.buffers)
+  if (!this.buffers) {
     this.buffers = [chunk];
-  else
-    ArrayPrototypePush(this.buffers, chunk);
+  } else {
+    this.buffers.push(chunk);
+  }
   this.nread += chunk.length;
   if (this.nread > this._maxOutputLength) {
     this.close();
@@ -442,7 +438,7 @@ function processChunkSync(self, chunk, flushFlag) {
     if (have > 0) {
       const out = buffer.slice(offset, offset + have);
       offset += have;
-      ArrayPrototypePush(buffers, out);
+      buffers.push(out);
       nread += out.byteLength;
 
       if (nread > self._maxOutputLength) {
@@ -700,9 +696,10 @@ Zlib.prototype.params = function params(level, strategy, callback) {
   checkRangesOrGetDefault(strategy, 'strategy', Z_DEFAULT_STRATEGY, Z_FIXED);
 
   if (this._level !== level || this._strategy !== strategy) {
-    this.flush(Z_SYNC_FLUSH,
-               FunctionPrototypeBind(paramsAfterFlushCallback, this,
-                                     level, strategy, callback));
+    this.flush(
+      Z_SYNC_FLUSH,
+      paramsAfterFlushCallback.bind(this, level, strategy, callback),
+    );
   } else {
     process.nextTick(callback);
   }
@@ -782,13 +779,10 @@ function createConvenienceMethod(ctor, sync) {
   };
 }
 
-const kMaxBrotliParam = MathMaxApply(ArrayPrototypeMap(
-  ObjectKeys(constants),
-  (key) => (StringPrototypeStartsWith(key, 'BROTLI_PARAM_') ?
-    constants[key] :
-    0),
-));
-
+const kMaxBrotliParam = MathMax.apply(
+  ObjectEntries(constants)
+    .map(({ 0: key, 1: value }) => (key.startsWith('BROTLI_PARAM_') ? value : 0)),
+);
 const brotliInitParamsArray = new Uint32Array(kMaxBrotliParam + 1);
 
 const brotliDefaultOpts = {
@@ -799,9 +793,9 @@ const brotliDefaultOpts = {
 function Brotli(opts, mode) {
   assert(mode === BROTLI_DECODE || mode === BROTLI_ENCODE);
 
-  TypedArrayPrototypeFill(brotliInitParamsArray, -1);
+  brotliInitParamsArray.fill(-1);
   if (opts?.params) {
-    ArrayPrototypeForEach(ObjectKeys(opts.params), (origKey) => {
+    ObjectKeys(opts.params).forEach((origKey) => {
       const key = +origKey;
       if (NumberIsNaN(key) || key < 0 || key > kMaxBrotliParam ||
           (brotliInitParamsArray[key] | 0) !== -1) {
@@ -939,10 +933,12 @@ ObjectDefineProperties(module.exports, {
 
 // These should be considered deprecated
 // expose all the zlib constants
-for (const bkey of ObjectKeys(constants)) {
-  if (StringPrototypeStartsWith(bkey, 'BROTLI')) continue;
-  ObjectDefineProperty(module.exports, bkey, {
+for (const { 0: key, 1: value } of ObjectEntries(constants)) {
+  if (key.startsWith('BROTLI')) continue;
+  ObjectDefineProperty(module.exports, key, {
     __proto__: null,
-    enumerable: false, value: constants[bkey], writable: false,
+    enumerable: false,
+    value,
+    writable: false,
   });
 }

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -779,8 +779,8 @@ function createConvenienceMethod(ctor, sync) {
   };
 }
 
-const kMaxBrotliParam = MathMax.apply(
-  ObjectEntries(constants)
+const kMaxBrotliParam = MathMax(
+  ...ObjectEntries(constants)
     .map(({ 0: key, 1: value }) => (key.startsWith('BROTLI_PARAM_') ? value : 0)),
 );
 const brotliInitParamsArray = new Uint32Array(kMaxBrotliParam + 1);


### PR DESCRIPTION
As a result of the primordials work done by @aduh95 and others, let's remove the prototypal primordials from `node:zlib`