### PR TITLE
meta: fix links in `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -222,6 +222,6 @@ Security notifications will be distributed via the following methods.
 
 ## Comments on this policy
 
-If you have suggestions on how this process could be improved please submit a
-[pull request](https://github.com/nodejs/nodejs.org) or
-[file an issue](https://github.com/nodejs/security-wg/issues/new) to discuss.
+If you have suggestions on how this process could be improved, please visit
+the [nodejs/security-wg](https://github.com/nodejs/security-wg)
+repository.


### PR DESCRIPTION
Originally, this file linked to <https://github.com/nodejs/nodejs.org>, when it should link to <https://github.com/nodejs/security-wg>