### PR TITLE
zlib: deprecate instantiating classes without new

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3711,7 +3711,7 @@ switch to its new provider model. The `clientCertEngine` option for
 the `privateKeyEngine` and `privateKeyIdentifier` for [`tls.createSecureContext()`][];
 and [`crypto.setEngine()`][] all depend on this functionality from OpenSSL.
 
-### DEP0184: Zlib classes
+### DEP0184: Instantiating `node:zlib` classes without `new`
 
 <!-- YAML
 changes:

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3711,6 +3711,21 @@ switch to its new provider model. The `clientCertEngine` option for
 the `privateKeyEngine` and `privateKeyIdentifier` for [`tls.createSecureContext()`][];
 and [`crypto.setEngine()`][] all depend on this functionality from OpenSSL.
 
+### DEP0184: Zlib classes
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54708
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Instantiating classes without the `new` qualifier exported by the `node:zlib` module is deprecated.
+It is recommended to use the new qualifier instead. This applies to all Zlib classes such as `Deflate`,
+`DeflateRaw`, `Gunzip`, `Inflate`, `InflateRaw`, `Unzip`, and `Zlib`.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3723,7 +3723,7 @@ changes:
 Type: Documentation-only
 
 Instantiating classes without the `new` qualifier exported by the `node:zlib` module is deprecated.
-It is recommended to use the new qualifier instead. This applies to all Zlib classes such as `Deflate`,
+It is recommended to use the `new` qualifier instead. This applies to all Zlib classes, such as `Deflate`,
 `DeflateRaw`, `Gunzip`, `Inflate`, `InflateRaw`, `Unzip`, and `Zlib`.
 
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf


### PR DESCRIPTION
A documentation-only deprecation of instantiating `node:zlib` classes without `new` qualifier.

cc @nodejs/tsc