### PR TITLE
lib: use `ObjectHasOwn` instead of alternatives

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -36,7 +36,7 @@ const {
   NumberIsInteger,
   ObjectAssign,
   ObjectDefineProperty,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   RegExpPrototypeExec,
   SafeSet,
   StringPrototypeIncludes,
@@ -538,7 +538,7 @@ ObjectDefineProperty(execFile, promisify.custom, {
 function copyProcessEnvToEnv(env, name, optionEnv) {
   if (process.env[name] &&
       (!optionEnv ||
-       !ObjectPrototypeHasOwnProperty(optionEnv, name))) {
+       !ObjectHasOwn(optionEnv, name))) {
     env[name] = process.env[name];
   }
 }

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -22,7 +22,7 @@
 'use strict';
 
 const {
-  ObjectPrototypeHasOwnProperty: ObjectHasOwn,
+  ObjectHasOwn,
 } = primordials;
 
 const childOrPrimary = ObjectHasOwn(process.env, 'NODE_UNIQUE_ID') ? 'child' : 'primary';

--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypeSlice,
   ErrorCaptureStackTrace,
   ObjectDefineProperty,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   Symbol,
 } = primordials;
 
@@ -419,7 +419,7 @@ function newAsyncId() {
 }
 
 function getOrSetAsyncId(object) {
-  if (ObjectPrototypeHasOwnProperty(object, async_id_symbol)) {
+  if (ObjectHasOwn(object, async_id_symbol)) {
     return object[async_id_symbol];
   }
 

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -57,8 +57,8 @@ const {
   ArrayPrototypeSlice,
   Error,
   ObjectDefineProperty,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   ReflectGet,
   SafeMap,
@@ -203,7 +203,7 @@ const { ModuleWrap } = internalBinding('module_wrap');
 ObjectSetPrototypeOf(ModuleWrap.prototype, null);
 
 const getOwn = (target, property, receiver) => {
-  return ObjectPrototypeHasOwnProperty(target, property) ?
+  return ObjectHasOwn(target, property) ?
     ReflectGet(target, property, receiver) :
     undefined;
 };

--- a/lib/internal/cli_table.js
+++ b/lib/internal/cli_table.js
@@ -6,7 +6,7 @@ const {
   MathCeil,
   MathMax,
   MathMaxApply,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   StringPrototypeRepeat,
 } = primordials;
 
@@ -63,7 +63,7 @@ const table = (head, columns) => {
       if (rows[j] === undefined)
         rows[j] = [];
       const value = rows[j][i] =
-        ObjectPrototypeHasOwnProperty(column, j) ? column[j] : '';
+        ObjectHasOwn(column, j) ? column[j] : '';
       const width = columnWidths[i] || 0;
       const counted = getStringWidth(value);
       columnWidths[i] = MathMax(width, counted);

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -15,8 +15,8 @@ const {
   FunctionPrototypeBind,
   ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ObjectValues,
   ReflectApply,
   ReflectConstruct,
@@ -593,7 +593,7 @@ const consoleMethods = {
         for (const key of keys) {
           map[key] ??= [];
           if ((primitive && properties) ||
-               !ObjectPrototypeHasOwnProperty(item, key))
+               !ObjectHasOwn(item, key))
             map[key][i] = '';
           else
             map[key][i] = _inspect(item[key]);

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -13,8 +13,8 @@ const {
   Number,
   ObjectDefineProperty,
   ObjectEntries,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   Promise,
   StringPrototypeToUpperCase,
   Symbol,
@@ -343,7 +343,7 @@ function normalizeAlgorithm(algorithm, op) {
   // 5.
   let desiredType;
   for (const key in registeredAlgorithms) {
-    if (!ObjectPrototypeHasOwnProperty(registeredAlgorithms, key)) {
+    if (!ObjectHasOwn(registeredAlgorithms, key)) {
       continue;
     }
     if (
@@ -374,7 +374,7 @@ function normalizeAlgorithm(algorithm, op) {
   const dictKeys = dict ? ObjectKeys(dict) : [];
   for (let i = 0; i < dictKeys.length; i++) {
     const member = dictKeys[i];
-    if (!ObjectPrototypeHasOwnProperty(dict, member))
+    if (!ObjectHasOwn(dict, member))
       continue;
     const idlType = dict[member];
     const idlValue = normalizedAlgorithm[member];

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -35,9 +35,9 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  ObjectHasOwn,
   ObjectIsExtensible,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   RangeError,
   ReflectApply,
   RegExpPrototypeExec,
@@ -248,8 +248,8 @@ function isErrorStackTraceLimitWritable() {
   if (desc === undefined) {
     return ObjectIsExtensible(Error);
   }
+  return ObjectHasOwn(desc, 'writable') ?
 
-  return ObjectPrototypeHasOwnProperty(desc, 'writable') ?
     desc.writable :
     desc.set !== undefined;
 }

--- a/lib/internal/freeze_intrinsics.js
+++ b/lib/internal/freeze_intrinsics.js
@@ -75,8 +75,8 @@ const {
   ObjectGetOwnPropertyNames,
   ObjectGetOwnPropertySymbols,
   ObjectGetPrototypeOf,
+  ObjectHasOwn,
   ObjectPrototype,
-  ObjectPrototypeHasOwnProperty,
   Promise,
   PromisePrototype,
   Proxy,
@@ -438,7 +438,7 @@ module.exports = function() {
         enqueue(proto);
         ArrayPrototypeForEach(ReflectOwnKeys(descs), (name) => {
           const desc = descs[name];
-          if (ObjectPrototypeHasOwnProperty(desc, 'value')) {
+          if (ObjectHasOwn(desc, 'value')) {
             // todo uncurried form
             enqueue(desc.value);
           } else {
@@ -490,7 +490,7 @@ module.exports = function() {
    * objects succeed if otherwise possible.
    */
   function enableDerivedOverride(obj, prop, desc) {
-    if (ObjectPrototypeHasOwnProperty(desc, 'value') && desc.configurable) {
+    if (ObjectHasOwn(desc, 'value') && desc.configurable) {
       const value = desc.value;
 
       function getter() {
@@ -508,7 +508,7 @@ module.exports = function() {
             `Cannot assign to read only property '${prop}' of object '${obj}'`,
           );
         }
-        if (ObjectPrototypeHasOwnProperty(this, prop)) {
+        if (ObjectHasOwn(this, prop)) {
           this[prop] = newValue;
         } else {
           ObjectDefineProperty(this, prop, {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -44,7 +44,6 @@ const {
   ObjectHasOwn,
   ObjectKeys,
   ObjectPrototype,
-  ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
   Proxy,
   ReflectApply,
@@ -984,7 +983,7 @@ const CircularRequirePrototypeWarningProxy = new Proxy({}, {
   },
 
   getOwnPropertyDescriptor(target, prop) {
-    if (ObjectPrototypeHasOwnProperty(target, prop) || prop === '__esModule') {
+    if (ObjectHasOwn(target, prop) || prop === '__esModule') {
       return ObjectGetOwnPropertyDescriptor(target, prop);
     }
     emitCircularRequireWarning(prop);

--- a/lib/internal/modules/esm/assert.js
+++ b/lib/internal/modules/esm/assert.js
@@ -3,8 +3,8 @@
 const {
   ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ObjectValues,
 } = primordials;
 const { validateString } = require('internal/validators');
@@ -71,7 +71,7 @@ function validateAttributes(url, format,
     case kImplicitTypeAttribute:
       // This format doesn't allow an import type attribute, so the property
       // must not be set on the import attributes object.
-      if (!ObjectPrototypeHasOwnProperty(importAttributes, 'type')) {
+      if (!ObjectHasOwn(importAttributes, 'type')) {
         return true;
       }
       return handleInvalidType(url, importAttributes.type);
@@ -83,7 +83,7 @@ function validateAttributes(url, format,
     default:
       // There is an expected type for this format, but the value of
       // `importAttributes.type` might not have been it.
-      if (!ObjectPrototypeHasOwnProperty(importAttributes, 'type')) {
+      if (!ObjectHasOwn(importAttributes, 'type')) {
         // `type` wasn't specified at all.
         throw new ERR_IMPORT_ATTRIBUTE_MISSING(url, 'type', validType);
       }

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -1,6 +1,6 @@
 'use strict';
 const {
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   PromisePrototypeThen,
   SafeMap,
   StringPrototypeEndsWith,
@@ -165,7 +165,7 @@ function fetchWithRedirects(parsed, context) {
     // `finally` on network error/timeout.
     const { 0: res } = await once(req, 'response');
     try {
-      const hasLocation = ObjectPrototypeHasOwnProperty(res.headers, 'location');
+      const hasLocation = ObjectHasOwn(res.headers, 'location');
       if (isRedirect(res.statusCode) && hasLocation) {
         const location = new URL(res.headers.location, parsed);
         if (location.protocol !== 'http:' && location.protocol !== 'https:') {

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   RegExpPrototypeExec,
   SafeSet,
   StringPrototypeCharCodeAt,
@@ -225,7 +225,7 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
  */
 function defaultGetFormatWithoutErrors(url, context) {
   const protocol = url.protocol;
-  if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
+  if (!ObjectHasOwn(protocolHandlers, protocol)) {
     return null;
   }
   return protocolHandlers[protocol](url, context, true);
@@ -238,7 +238,7 @@ function defaultGetFormatWithoutErrors(url, context) {
  */
 function defaultGetFormat(url, context) {
   const protocol = url.protocol;
-  if (!ObjectPrototypeHasOwnProperty(protocolHandlers, protocol)) {
+  if (!ObjectHasOwn(protocolHandlers, protocol)) {
     return null;
   }
   return protocolHandlers[protocol](url, context, false);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -6,7 +6,7 @@ const {
   ArrayPrototypeMap,
   JSONStringify,
   ObjectGetOwnPropertyNames,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   SafeMap,
@@ -573,7 +573,7 @@ function packageExportsResolve(
     exports = { '.': exports };
   }
 
-  if (ObjectPrototypeHasOwnProperty(exports, packageSubpath) &&
+  if (ObjectHasOwn(exports, packageSubpath) &&
       !StringPrototypeIncludes(packageSubpath, '*') &&
       !StringPrototypeEndsWith(packageSubpath, '/')) {
     const target = exports[packageSubpath];
@@ -685,7 +685,7 @@ function packageImportsResolve(name, base, conditions) {
     packageJSONUrl = pathToFileURL(packageConfig.pjsonPath);
     const imports = packageConfig.imports;
     if (imports) {
-      if (ObjectPrototypeHasOwnProperty(imports, name) &&
+      if (ObjectHasOwn(imports, name) &&
           !StringPrototypeIncludes(name, '*')) {
         const resolveResult = resolvePackageTarget(
           packageJSONUrl, imports[name], '', name, base, false, true, false,

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -5,8 +5,8 @@ const {
   Boolean,
   FunctionPrototypeCall,
   JSONParse,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ReflectApply,
   SafeArrayIterator,
   SafeMap,
@@ -221,7 +221,7 @@ function createCJSModuleWrap(url, source, isMain, loadCJS = loadCJSModule) {
       ({ exports } = module);
     }
     for (const exportName of exportNames) {
-      if (!ObjectPrototypeHasOwnProperty(exports, exportName) ||
+      if (!ObjectHasOwn(exports, exportName) ||
           exportName === 'default') {
         continue;
       }

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -5,7 +5,7 @@ const {
   ArrayPrototypeIncludes,
   ObjectDefineProperty,
   ObjectFreeze,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   SafeMap,
   SafeSet,
   StringPrototypeCharCodeAt,
@@ -202,7 +202,7 @@ function addBuiltinLibsToObject(object, dummyModuleName) {
     // 'fs/promises') or ones that are already defined.
     if (StringPrototypeStartsWith(name, '_') ||
         StringPrototypeIncludes(name, '/') ||
-        ObjectPrototypeHasOwnProperty(object, name)) {
+        ObjectHasOwn(object, name)) {
       return;
     }
     // Goals of this mechanism are:

--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -4,7 +4,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
   Error,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   SafeMap,
   SafeWeakMap,
 } = primordials;
@@ -172,7 +172,7 @@ function hasRejectionToWarn() {
 function isErrorLike(obj) {
   return typeof obj === 'object' &&
          obj !== null &&
-         ObjectPrototypeHasOwnProperty(obj, 'stack');
+         ObjectHasOwn(obj, 'stack');
 }
 
 /**

--- a/lib/internal/source_map/source_map.js
+++ b/lib/internal/source_map/source_map.js
@@ -71,7 +71,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   StringPrototypeCharAt,
   Symbol,
 } = primordials;
@@ -365,7 +365,7 @@ function cloneSourceMapV3(payload) {
   validateObject(payload, 'payload');
   payload = { ...payload };
   for (const key in payload) {
-    if (ObjectPrototypeHasOwnProperty(payload, key) &&
+    if (ObjectHasOwn(payload, key) &&
         ArrayIsArray(payload[key])) {
       payload[key] = ArrayPrototypeSlice(payload[key]);
     }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -16,7 +16,7 @@ const {
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   ObjectSetPrototypeOf,
   ObjectValues,
   Promise,
@@ -730,7 +730,7 @@ function filterOwnProperties(source, keys) {
   const filtered = { __proto__: null };
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
-    if (ObjectPrototypeHasOwnProperty(source, key)) {
+    if (ObjectHasOwn(source, key)) {
       filtered[key] = source[key];
     }
   }

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -12,9 +12,9 @@ const {
   NumberPrototypeValueOf,
   ObjectGetOwnPropertySymbols,
   ObjectGetPrototypeOf,
+  ObjectHasOwn,
   ObjectIs,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ObjectPrototypePropertyIsEnumerable,
   ObjectPrototypeToString,
   SafeSet,
@@ -605,19 +605,19 @@ function objEquiv(a, b, strict, keys, memos, iterationType) {
 
   if (iterationType === kIsArray) {
     for (let i = 0; i < a.length; i++) {
-      if (ObjectPrototypeHasOwnProperty(a, i)) {
-        if (!ObjectPrototypeHasOwnProperty(b, i) ||
+      if (ObjectHasOwn(a, i)) {
+        if (!ObjectHasOwn(b, i) ||
             !innerDeepEqual(a[i], b[i], strict, memos)) {
           return false;
         }
-      } else if (ObjectPrototypeHasOwnProperty(b, i)) {
+      } else if (ObjectHasOwn(b, i)) {
         return false;
       } else {
         // Array is sparse.
         const keysA = ObjectKeys(a);
         for (; i < keysA.length; i++) {
           const key = keysA[i];
-          if (!ObjectPrototypeHasOwnProperty(b, key) ||
+          if (!ObjectHasOwn(b, key) ||
               !innerDeepEqual(a[key], b[key], strict, memos)) {
             return false;
           }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -48,9 +48,9 @@ const {
   ObjectGetOwnPropertyNames,
   ObjectGetOwnPropertySymbols,
   ObjectGetPrototypeOf,
+  ObjectHasOwn,
   ObjectIs,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
   ObjectSetPrototypeOf,
@@ -349,7 +349,7 @@ function inspect(value, opts) {
         // this function public or add a new API with a similar or better
         // functionality.
         if (
-          ObjectPrototypeHasOwnProperty(inspectDefaultOptions, key) ||
+          ObjectHasOwn(inspectDefaultOptions, key) ||
           key === 'stylize') {
           ctx[key] = opts[key];
         } else if (ctx.userOptions === undefined) {
@@ -667,7 +667,7 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
     for (const key of keys) {
       // Ignore the `constructor` property and keys that exist on layers above.
       if (key === 'constructor' ||
-          ObjectPrototypeHasOwnProperty(main, key) ||
+          ObjectHasOwn(main, key) ||
           (depth !== 0 && keySet.has(key))) {
         continue;
       }
@@ -860,7 +860,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   if (typeof tag !== 'string' ||
       (tag !== '' &&
       (ctx.showHidden ?
-        ObjectPrototypeHasOwnProperty :
+        ObjectHasOwn :
         ObjectPrototypePropertyIsEnumerable)(
         value, SymbolToStringTag,
       ))) {
@@ -1155,7 +1155,7 @@ function getBoxedBase(value, ctx, keys, constructor, tag) {
 }
 
 function getClassBase(value, constructor, tag) {
-  const hasName = ObjectPrototypeHasOwnProperty(value, 'name');
+  const hasName = ObjectHasOwn(value, 'name');
   const name = (hasName && value.name) || '(anonymous)';
   let base = `class ${name}`;
   if (constructor !== 'Function' && constructor !== null) {
@@ -1747,7 +1747,7 @@ function formatArray(ctx, value, recurseTimes) {
   const output = [];
   for (let i = 0; i < len; i++) {
     // Special handle sparse arrays.
-    if (!ObjectPrototypeHasOwnProperty(value, i)) {
+    if (!ObjectHasOwn(value, i)) {
       return formatSpecialArray(ctx, value, recurseTimes, len, output, i);
     }
     ArrayPrototypePush(output, formatProperty(ctx, value, recurseTimes, i, kArrayType));
@@ -2115,7 +2115,7 @@ function hasBuiltInToString(value) {
   }
 
   // The object has a own `toString` property. Thus it's not not a built-in one.
-  if (ObjectPrototypeHasOwnProperty(value, 'toString')) {
+  if (ObjectHasOwn(value, 'toString')) {
     return false;
   }
 
@@ -2124,7 +2124,7 @@ function hasBuiltInToString(value) {
   let pointer = value;
   do {
     pointer = ObjectGetPrototypeOf(pointer);
-  } while (!ObjectPrototypeHasOwnProperty(pointer, 'toString'));
+  } while (!ObjectHasOwn(pointer, 'toString'));
 
   // Check closer if the object is a built-in.
   const descriptor = ObjectGetOwnPropertyDescriptor(pointer, 'constructor');

--- a/lib/internal/util/inspector.js
+++ b/lib/internal/util/inspector.js
@@ -5,8 +5,8 @@ const {
   ArrayPrototypeSome,
   FunctionPrototypeBind,
   ObjectDefineProperty,
+  ObjectHasOwn,
   ObjectKeys,
-  ObjectPrototypeHasOwnProperty,
   RegExpPrototypeExec,
   SafeWeakMap,
 } = primordials;
@@ -87,7 +87,7 @@ function wrapConsole(consoleFromNode) {
     // If global console has the same method as inspector console,
     // then wrap these two methods into one. Native wrapper will preserve
     // the original stack.
-    if (ObjectPrototypeHasOwnProperty(consoleFromNode, key)) {
+    if (ObjectHasOwn(consoleFromNode, key)) {
       consoleFromNode[key] = FunctionPrototypeBind(
         consoleCall,
         consoleFromNode,

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -10,7 +10,7 @@ const {
   ArrayPrototypeSlice,
   ArrayPrototypeUnshiftApply,
   ObjectEntries,
-  ObjectPrototypeHasOwnProperty: ObjectHasOwn,
+  ObjectHasOwn,
   StringPrototypeCharAt,
   StringPrototypeIndexOf,
   StringPrototypeSlice,

--- a/lib/internal/util/parse_args/utils.js
+++ b/lib/internal/util/parse_args/utils.js
@@ -3,7 +3,7 @@
 const {
   ArrayPrototypeFind,
   ObjectEntries,
-  ObjectPrototypeHasOwnProperty: ObjectHasOwn,
+  ObjectHasOwn,
   StringPrototypeCharAt,
   StringPrototypeIncludes,
   StringPrototypeStartsWith,

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -13,7 +13,7 @@ const {
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
   NumberParseInt,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   RegExpPrototypeExec,
   String,
   StringPrototypeToUpperCase,
@@ -527,7 +527,7 @@ const validateLinkHeaderFormat = hideStackFrames((value, name) => {
 });
 
 const validateInternalField = hideStackFrames((object, fieldKey, className) => {
-  if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, fieldKey)) {
+  if (typeof object !== 'object' || object === null || !ObjectHasOwn(object, fieldKey)) {
     throw new ERR_INVALID_ARG_TYPE('this', className, object);
   }
 });

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -10,7 +10,7 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   ObjectGetPrototypeOf,
-  ObjectPrototypeHasOwnProperty,
+  ObjectHasOwn,
   ObjectSetPrototypeOf,
   PromisePrototypeThen,
   PromiseResolve,
@@ -83,7 +83,7 @@ const kLink = Symbol('kLink');
 const { isContext } = require('internal/vm');
 
 function isModule(object) {
-  if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, kWrap)) {
+  if (typeof object !== 'object' || object === null || !ObjectHasOwn(object, kWrap)) {
     return false;
   }
   return true;

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -330,7 +330,7 @@ declare namespace primordials {
   export const ObjectEntries: typeof Object.entries
   export const ObjectFromEntries: typeof Object.fromEntries
   export const ObjectValues: typeof Object.values
-  export const ObjectPrototypeHasOwnProperty: UncurryThis<typeof Object.prototype.hasOwnProperty>
+  export const ObjectHasOwn: typeof Object.hasOwn
   export const ObjectPrototypeIsPrototypeOf: UncurryThis<typeof Object.prototype.isPrototypeOf>
   export const ObjectPrototypePropertyIsEnumerable: UncurryThis<typeof Object.prototype.propertyIsEnumerable>
   export const ObjectPrototypeToString: UncurryThis<typeof Object.prototype.toString>


### PR DESCRIPTION
Let's use `ObjectHasOwn` instead of the alternative: `ObjectPrototypeHasOwnProperty`