### PR TITLE
url: add V8 Fast API for Blob RevokeObjectURL

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -10,6 +10,9 @@
 
 namespace node {
 
+using CFunctionCallbackWithOneByteStringVoid =
+    void (*)(v8::Local<v8::Value>, const v8::FastOneByteString&);
+
 using CFunctionCallbackWithOneByteString =
     uint32_t (*)(v8::Local<v8::Value>, const v8::FastOneByteString&);
 using CFunctionCallback = void (*)(v8::Local<v8::Value> receiver);
@@ -96,6 +99,7 @@ class ExternalReferenceRegistry {
   V(CFunctionWithBool)                                                         \
   V(CFunctionBufferCopy)                                                       \
   V(CFunctionWriteString)                                                      \
+  V(CFunctionCallbackWithOneByteStringVoid)                                    \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
-->

#### Description

This pull request adds a V8 Fast API implementation for the `RevokeObjectURL` method in the Blob API. This optimization aims to improve the performance of URL operations related to Blob objects.

#### Local Evaluation
With fast api.
```bash
revokeObjectURL: 147.683ms
Operations per second: 6771268

revokeObjectURL: 233.320ms
Operations per second: 4285953

revokeObjectURL: 148.093ms
Operations per second: 6752493

revokeObjectURL: 145.851ms
Operations per second: 6856293

revokeObjectURL: 146.318ms
Operations per second: 6834450

revokeObjectURL: 147.066ms
Operations per second: 6799684

revokeObjectURL: 148.605ms
Operations per second: 6729260
```
Without fast api.

```bash
revokeObjectURL: 234.338ms
Operations per second: 4267337

revokeObjectURL: 232.052ms
Operations per second: 4309385

revokeObjectURL: 231.606ms
Operations per second: 4317682

revokeObjectURL: 234.309ms
Operations per second: 4267869
```

```js
const { performance, PerformanceObserver } = require('perf_hooks');

function revokeObjectURL(url) {
  URL.revokeObjectURL(url);
}

function runBenchmark(iterations = 1000000) {
  const url = URL.createObjectURL(new Blob(['hello world', '🍌🍌🍌']));
  performance.mark('start');
  
  for (let i = 0; i < iterations; i++) {
    revokeObjectURL(url);
  }
  
  performance.mark('end');
  performance.measure('revokeObjectURL', 'start', 'end');
}

const obs = new PerformanceObserver((list) => {
  const measurement = list.getEntries()[0];
  console.log(`revokeObjectURL: ${measurement.duration.toFixed(3)}ms`);
  
  const opsPerSecond = (1000000 / measurement.duration * 1000).toFixed(0);
  console.log(`Operations per second: ${opsPerSecond}`);

  performance.clearMarks();
  obs.disconnect();
});

obs.observe({ entryTypes: ['measure'] });

console.log("Running benchmark...");
runBenchmark();
```

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->