### PR TITLE
benchmark,doc: mention bar.R to the list of scripts

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -40,6 +40,7 @@ directories.
 * `_cli.R`: parses the command line arguments passed to `compare.R`
 * `_http-benchmarkers.js`: selects and runs external tools for benchmarking
   the `http` subsystem.
+* `bar.R`: R script for visualizing the output of benchmarks with bar plots.
 * `common.js`: see [Common API](#common-api).
 * `compare.js`: command line tool for comparing performance between different
   Node.js binaries.


### PR DESCRIPTION
I'm doing some work on the benchmark space and I noticed I forgot to mention `bar.R` on this file when I wrote it.