### PR TITLE
benchmark,doc: add CPU scaling governor to perf

### DIFF
--- a/benchmark/cpu.sh
+++ b/benchmark/cpu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CPUPATH=/sys/devices/system/cpu
 
@@ -6,8 +6,10 @@ MAXID=$(cat $CPUPATH/present | awk -F- '{print $NF}')
 
 set_governor() {
   echo "Setting CPU frequency governor to \"$1\""
-  for (( i=0; i<=$MAXID; i++ )); do
-    echo "$1" > $CPUPATH/cpu$i/cpufreq/scaling_governor
+  i=0
+  while [ "$i" -le "$MAXID" ]; do
+    echo "$1" > "$CPUPATH/cpu$i/cpufreq/scaling_governor"
+    i=$((i + 1))
   done
 }
 
@@ -15,6 +17,7 @@ case "$1" in
   fast | performance)
     set_governor "performance"
     ;;
+  *)
     echo "Usage: $0 fast"
     exit 1
     ;;

--- a/benchmark/cpu.sh
+++ b/benchmark/cpu.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+CPUPATH=/sys/devices/system/cpu
+
+MAXID=$(cat $CPUPATH/present | awk -F- '{print $NF}')
+
+set_governor() {
+  echo "Setting CPU frequency governor to \"$1\""
+  for (( i=0; i<=$MAXID; i++ )); do
+    echo "$1" > $CPUPATH/cpu$i/cpufreq/scaling_governor
+  done
+}
+
+case "$1" in
+  fast | performance)
+    set_governor "performance"
+    ;;
+    echo "Usage: $0 fast"
+    exit 1
+    ;;
+esac

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -96,8 +96,8 @@ A list of mirrors is [located here](https://cran.r-project.org/mirrors.html).
 
 ### Setting CPU Frequency scaling governor to "performance"
 
-It is recommended to set the CPU frequency to 'performance' before running
-benchmarks. This ensures that each benchmark run can achieve peak performance
+It is recommended to set the CPU frequency to `performance` before running
+benchmarks. This increases the likelihood of each benchmark achieving peak performance
 according to the hardware. Therefore, run:
 
 ```console

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -94,6 +94,16 @@ A list of mirrors is [located here](https://cran.r-project.org/mirrors.html).
 
 ## Running benchmarks
 
+### Setting CPU Frequency scaling governor to "performance"
+
+It is recommended to set the CPU frequency to 'performance' before running
+benchmarks. This ensures that each benchmark run can achieve peak performance
+according to the hardware. Therefore, run:
+
+```console
+$ ./benchmarks/cpu.sh fast
+```
+
 ### Running individual benchmarks
 
 This can be useful for debugging a benchmark or doing a quick performance


### PR DESCRIPTION
When running V8 benchmarks, they recommend setting the CPU scaling governor to performance (https://v8.dev/docs/benchmarks). All the time, you might want to benchmark stuff using the maximum CPU capacity. Therefore, adding it as an intermediary step sounds like a good choice to me. 