### PR TITLE
build,win: add winget config to set up env

### DIFF
--- a/.configurations/configuration.dsc.yaml
+++ b/.configurations/configuration.dsc.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/nodejs/node/blob/main/BUILDING.md#windows
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pythonPackage
+      directives:
+        description: Install Python 3.12
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.12
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Community
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Community
+        source: winget
+        useLatest: true
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: vsComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads and components
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Community
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        components:
+          - Microsoft.VisualStudio.Workload.NativeDesktop
+          - Microsoft.VisualStudio.Component.VC.Llvm.Clang
+          - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: gitPackage
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: nasmPackage
+      directives:
+        description: Install NetWide Assembler (NASM)
+        allowPrerelease: true
+      settings:
+        id: Nasm.Nasm
+        source: winget
+  configurationVersion: 0.1.0

--- a/.configurations/configuration.vsEnterprise.dsc.yaml
+++ b/.configurations/configuration.vsEnterprise.dsc.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/nodejs/node/blob/main/BUILDING.md#windows
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pythonPackage
+      directives:
+        description: Install Python 3.12
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.12
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Enterprise
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Enterprise
+        source: winget
+        useLatest: true
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: vsComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads and components
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Enterprise
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        components:
+          - Microsoft.VisualStudio.Workload.NativeDesktop
+          - Microsoft.VisualStudio.Component.VC.Llvm.Clang
+          - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: gitPackage
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: nasmPackage
+      directives:
+        description: Install NetWide Assembler (NASM)
+        allowPrerelease: true
+      settings:
+        id: Nasm.Nasm
+        source: winget
+  configurationVersion: 0.1.0

--- a/.configurations/configuration.vsProfessional.dsc.yaml
+++ b/.configurations/configuration.vsProfessional.dsc.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/nodejs/node/blob/main/BUILDING.md#windows
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pythonPackage
+      directives:
+        description: Install Python 3.12
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.12
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Professional
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.Professional
+        source: winget
+        useLatest: true
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: vsComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads and components
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.Professional
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        components:
+          - Microsoft.VisualStudio.Workload.NativeDesktop
+          - Microsoft.VisualStudio.Component.VC.Llvm.Clang
+          - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: gitPackage
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: nasmPackage
+      directives:
+        description: Install NetWide Assembler (NASM)
+        allowPrerelease: true
+      settings:
+        id: Nasm.Nasm
+        source: winget
+  configurationVersion: 0.1.0

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 !.mailmap
 !.nycrc
 !.yamllint.yaml
+!.configurations/
 
 # === Rules for root dir ===
 /core


### PR DESCRIPTION
This PR contains 3 configuration files for each version of Visual Studio.
These configuration files can be used to set up the Node.js development environment for developers via Dev Home. 
The user can choose the configuration file from Dev Home and easily install the tools required to build Node.js. In addition, this configuration file can be run directly via `winget configure <configuration file>` command.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
