### PR TITLE
tools: update error message for ICU in license-builder

### DIFF
--- a/tools/license-builder.sh
+++ b/tools/license-builder.sh
@@ -24,7 +24,7 @@ ${licenseTextTrimmed}
 
 
 if ! [ -d "${rootdir}/deps/icu/" ] && ! [ -d "${rootdir}/deps/icu-small/" ]; then
-  echo "ICU not installed, run configure to download it, e.g. ./configure --with-intl=small-icu --download=icu"
+  echo "ICU not installed, run \`./configure --with-intl=small-icu --download=icu\` to download it."
   exit 1
 fi
 


### PR DESCRIPTION
```
(Old) ICU not installed, run configure to download it, e.g. ./configure --with-intl=small-icu --download=icu
```
```
(New) ICU not installed, run `./configure --with-intl=small-icu --download=icu` to download it.
```