### PR TITLE
benchmark: add access async version to bench

### DIFF
--- a/benchmark/fs/bench-accessSync.js
+++ b/benchmark/fs/bench-accessSync.js
@@ -52,7 +52,7 @@ function main({ n, type, method }) {
   }
 
   if (method === 'access') {
-    // warmup the filesystem - it doesn't need to use the async method
+    // Warmup the filesystem - it doesn't need to use the async method
     runBench(n, path);
 
     bench.start();

--- a/benchmark/fs/bench-accessSync.js
+++ b/benchmark/fs/bench-accessSync.js
@@ -10,6 +10,7 @@ fs.writeFileSync(tmpfile, 'this-is-for-a-benchmark', 'utf8');
 
 const bench = common.createBenchmark(main, {
   type: ['existing', 'non-existing', 'non-flat-existing'],
+  method: ['access', 'accessSync'],
   n: [1e5],
 });
 
@@ -23,7 +24,17 @@ function runBench(n, path) {
   }
 }
 
-function main({ n, type }) {
+function runAsyncBench(n, path) {
+  (function r(cntr, path) {
+    if (cntr-- <= 0)
+      return bench.end(n);
+    fs.access(path, () => {
+      r(cntr, path);
+    });
+  })(n, path);
+}
+
+function main({ n, type, method }) {
   let path;
 
   switch (type) {
@@ -39,10 +50,19 @@ function main({ n, type }) {
     default:
       new Error('Invalid type');
   }
-  // warmup
-  runBench(n, path);
 
-  bench.start();
-  runBench(n, path);
-  bench.end(n);
+  if (method === 'access') {
+    // warmup the filesystem - it doesn't need to use the async method
+    runBench(n, path);
+
+    bench.start();
+    runAsyncBench(n, path);
+  } else {
+    // warmup
+    runBench(n, path);
+
+    bench.start();
+    runBench(n, path);
+    bench.end(n);
+  }
 }


### PR DESCRIPTION
This covers both fs.access and fs.exists 