### PR TITLE
doc: remove `parseREPLKeyword` from REPL documentation

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -534,22 +534,6 @@ buffered but not yet executed. This method is primarily intended to be
 called from within the action function for commands registered using the
 `replServer.defineCommand()` method.
 
-### `replServer.parseREPLKeyword(keyword[, rest])`
-
-<!-- YAML
-added: v0.8.9
-deprecated: v9.0.0
--->
-
-> Stability: 0 - Deprecated.
-
-* `keyword` {string} the potential keyword to parse and execute
-* `rest` {any} any parameters to the keyword command
-* Returns: {boolean}
-
-An internal method used to parse and execute `REPLServer` keywords.
-Returns `true` if `keyword` is a valid keyword, otherwise `false`.
-
 ### `replServer.setupHistory(historyPath, callback)`
 
 <!-- YAML


### PR DESCRIPTION
As of v15.0.0, this function no longer exists (see DEP0075)