### PR TITLE
repl: runtime deprecate `inputStream`, `outputStream` and `_builtinLibs`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2874,12 +2874,15 @@ Use [`request.destroy()`][] instead of [`request.abort()`][].
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54750
+    description: Runtime Deprecation.
   - version: v14.3.0
     pr-url: https://github.com/nodejs/node/pull/33294
     description: Documentation-only (supports [`--pending-deprecation`][]).
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 The `node:repl` module exported the input and output stream twice. Use `.input`
 instead of `.inputStream` and `.output` instead of `.outputStream`.
@@ -2888,12 +2891,15 @@ instead of `.inputStream` and `.output` instead of `.outputStream`.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54750
+    description: Runtime Deprecation.
   - version: v14.3.0
     pr-url: https://github.com/nodejs/node/pull/33294
     description: Documentation-only (supports [`--pending-deprecation`][]).
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The `node:repl` module exports a `_builtinLibs` property that contains an array
 of built-in modules. It was incomplete so far and instead it's better to rely

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -163,7 +163,6 @@ const {
 const experimentalREPLAwait = getOptionValue(
   '--experimental-repl-await',
 );
-const pendingDeprecation = getOptionValue('--pending-deprecation');
 const {
   REPL_MODE_SLOPPY,
   REPL_MODE_STRICT,
@@ -312,35 +311,27 @@ function REPLServer(prompt,
 
   ObjectDefineProperty(this, 'inputStream', {
     __proto__: null,
-    get: pendingDeprecation ?
-      deprecate(() => this.input,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+    get: deprecate(() => this.input,
+                   'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      () => this.input,
-    set: pendingDeprecation ?
-      deprecate((val) => this.input = val,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+                   'DEP0141'),
+    set: deprecate((val) => this.input = val,
+                   'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      (val) => this.input = val,
+                   'DEP0141'),
     enumerable: false,
     configurable: true,
   });
   ObjectDefineProperty(this, 'outputStream', {
     __proto__: null,
-    get: pendingDeprecation ?
-      deprecate(() => this.output,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+    get: deprecate(() => this.output,
+                   'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      () => this.output,
-    set: pendingDeprecation ?
-      deprecate((val) => this.output = val,
-                'repl.inputStream and repl.outputStream are deprecated. ' +
+                   'DEP0141'),
+    set: deprecate((val) => this.output = val,
+                   'repl.inputStream and repl.outputStream are deprecated. ' +
                   'Use repl.input and repl.output instead',
-                'DEP0141') :
-      (val) => this.output = val,
+                   'DEP0141'),
     enumerable: false,
     configurable: true,
   });
@@ -1873,16 +1864,14 @@ ObjectDefineProperty(module.exports, 'builtinModules', {
 
 ObjectDefineProperty(module.exports, '_builtinLibs', {
   __proto__: null,
-  get: pendingDeprecation ? deprecate(
+  get: deprecate(
     () => _builtinLibs,
     'repl._builtinLibs is deprecated. Check module.builtinModules instead',
-    'DEP0142',
-  ) : () => _builtinLibs,
-  set: pendingDeprecation ? deprecate(
+    'DEP0142'),
+  set: deprecate(
     (val) => _builtinLibs = val,
     'repl._builtinLibs is deprecated. Check module.builtinModules instead',
-    'DEP0142',
-  ) : (val) => _builtinLibs = val,
+    'DEP0142'),
   enumerable: false,
   configurable: true,
 });

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -19,8 +19,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --pending-deprecation
-
 'use strict';
 const common = require('../common');
 const ArrayStream = require('../common/arraystream');

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -265,6 +265,6 @@ function runTest(assertCleaned) {
       }
     }
 
-    repl.inputStream.run(test);
+    repl.input.run(test);
   });
 }

--- a/test/parallel/test-repl-preview.js
+++ b/test/parallel/test-repl-preview.js
@@ -49,9 +49,9 @@ class REPLStream extends Stream {
 }
 
 function runAndWait(cmds, repl) {
-  const promise = repl.inputStream.wait();
+  const promise = repl.input.wait();
   for (const cmd of cmds) {
-    repl.inputStream.run(cmd);
+    repl.input.run(cmd);
   }
   return promise;
 }
@@ -65,7 +65,7 @@ async function tests(options) {
     ...options
   });
 
-  repl.inputStream.run([
+  repl.input.run([
     'function foo(x) { return x; }',
     'function koo() { console.log("abc"); }',
     'a = undefined;',

--- a/test/parallel/test-repl-programmatic-history.js
+++ b/test/parallel/test-repl-programmatic-history.js
@@ -265,6 +265,6 @@ function runTest(assertCleaned) {
       }
     }
 
-    repl.inputStream.run(test);
+    repl.input.run(test);
   });
 }

--- a/test/parallel/test-repl-reverse-search.js
+++ b/test/parallel/test-repl-reverse-search.js
@@ -352,7 +352,7 @@ function runTest() {
         enumerable: true
       });
     }
-    repl.inputStream.run(opts.test);
+    repl.input.run(opts.test);
   });
 }
 

--- a/test/parallel/test-repl-strict-mode-previews.js
+++ b/test/parallel/test-repl-strict-mode-previews.js
@@ -30,7 +30,7 @@ if (process.argv[2] === 'child') {
     }),
     useColors: false,
     terminal: true
-  }).inputStream.run('xyz');
+  }).input.run('xyz');
 } else {
   const assert = require('assert');
   const { spawnSync } = require('child_process');


### PR DESCRIPTION
These features have been doc-only deprecated for years (since v14!), so maybe they should finally be runtime deprecated?