### PR TITLE
meta: ping @nodejs/performance on bench changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,3 +189,6 @@
 /doc/api/typescript.md @nodejs/typescript
 /test/fixtures/typescript/ @nodejs/typescript
 /tools/dep_updaters/update-amaro.sh @nodejs/typescript
+
+# Performance
+/benchmark/* @nodejs/performance


### PR DESCRIPTION
Currently, no one is notified when a benchmark is changed/added. I'd like to get that notification but I thought @nodejs/performance might be a better place for that. 