### PR TITLE
assert: show the diff when deep comparing data with a custom message

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -72,7 +72,11 @@ function inspectValue(val) {
   );
 }
 
-function createErrDiff(actual, expected, operator) {
+function getErrorMessage(operator, message) {
+  return message || kReadableOperator[operator];
+}
+
+function createErrDiff(actual, expected, operator, message = '') {
   let other = '';
   let res = '';
   let end = '';
@@ -110,7 +114,7 @@ function createErrDiff(actual, expected, operator) {
       if ((typeof actual !== 'object' || actual === null) &&
           (typeof expected !== 'object' || expected === null) &&
           (actual !== 0 || expected !== 0)) { // -0 === +0
-        return `${kReadableOperator[operator]}\n\n` +
+        return `${getErrorMessage(operator, message)}\n\n` +
             `${actualLines[0]} !== ${expectedLines[0]}\n`;
       }
     } else if (operator !== 'strictEqualObject') {
@@ -184,8 +188,7 @@ function createErrDiff(actual, expected, operator) {
 
   let printedLines = 0;
   let identical = 0;
-  const msg = kReadableOperator[operator] +
-        `\n${colors.green}+ actual${colors.white} ${colors.red}- expected${colors.white}`;
+  const msg = `${getErrorMessage(operator, message)}\n${colors.green}+ actual${colors.white} ${colors.red}- expected${colors.white}`;
   const skippedMsg = ` ${colors.blue}...${colors.white} Lines skipped`;
 
   let lines = actualLines;
@@ -337,7 +340,11 @@ class AssertionError extends Error {
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
 
     if (message != null) {
-      super(String(message));
+      if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
+        super(createErrDiff(actual, expected, operator, message));
+      } else {
+        super(String(message));
+      }
     } else {
       // Reset colors on each call to make sure we handle dynamically set environment
       // variables correct.

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -391,7 +391,7 @@ test('Test assertion messages', () => {
   assert.throws(
     () => assert.strictEqual(1, 2, 'oh no'),
     {
-      message: 'oh no',
+      message: 'oh no\n\n1 !== 2\n',
       generatedMessage: false
     }
   );
@@ -1204,7 +1204,7 @@ test('Additional assert', () => {
       ),
       {
         actual,
-        message,
+        message: "message\n+ actual - expected\n\n+ 'foobar'\n- {\n-   message: 'foobar'\n- }",
         operator: 'throws',
         generatedMessage: false
       }
@@ -1248,6 +1248,17 @@ test('Additional assert', () => {
       name: 'AssertionError',
       message: 'Expected "actual" not to be reference-equal to "expected":\n\n' +
               '{\n  a: true\n}\n'
+    }
+  );
+
+  assert.throws(
+    () => {
+      assert.deepStrictEqual({ a: true }, { a: false }, 'custom message');
+    },
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError',
+      message: 'custom message\n+ actual - expected\n\n  {\n+   a: true\n-   a: false\n  }'
     }
   );
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48465

This PR allows some assertion methods to show the diff when 2 data are different and a custom error message is passed

From this:

<img width="785" alt="image" src="https://github.com/user-attachments/assets/85471b5c-07de-49c1-8f0b-7ac59b85c3b4">


To this:

<img width="785" alt="image" src="https://github.com/user-attachments/assets/18e47ee2-2088-4fcc-b449-535e4189b7cf">
