### PR TITLE
cli: remove deprecated v8 flags

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3096,7 +3096,6 @@ V8 options that are allowed are:
 * `--disallow-code-generation-from-strings`
 * `--enable-etw-stack-walking`
 * `--expose-gc`
-* `--huge-max-old-generation-size`
 * `--interpreted-frames-native-stack`
 * `--jitless`
 * `--max-old-space-size`
@@ -3429,8 +3428,6 @@ documented here:
 ### `--expose-gc`
 
 ### `--harmony-shadow-realm`
-
-### `--huge-max-old-generation-size`
 
 ### `--jitless`
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -900,11 +900,6 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
             "disallow eval and friends",
             V8Option{},
             kAllowedInEnvvar);
-  AddOption("--huge-max-old-generation-size",
-            "increase default maximum heap size on machines with 16GB memory "
-            "or more",
-            V8Option{},
-            kAllowedInEnvvar);
   AddOption("--jitless",
             "disable runtime allocation of executable memory",
             V8Option{},

--- a/test/parallel/test-cli-node-options.js
+++ b/test/parallel/test-cli-node-options.js
@@ -70,7 +70,6 @@ if (common.hasCrypto) {
 expect('--abort_on-uncaught_exception', 'B\n');
 expect('--disallow-code-generation-from-strings', 'B\n');
 expect('--expose-gc', 'B\n');
-expect('--huge-max-old-generation-size', 'B\n');
 expect('--jitless', 'B\n');
 expect('--max-old-space-size=0', 'B\n');
 expect('--max-semi-space-size=0', 'B\n');


### PR DESCRIPTION
Node is currently exposing the `--huge-max-old-generation-size` V8 flag. That flag was recently deprecated (it currently remains as nop, see crrev.com/c/5831467) and will soon be completely removed.
This PR removes the flag from Node as well (cli, documentation and tests).
