### PR TITLE
src: fix unhandled error in structuredClone

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -567,7 +567,9 @@ Maybe<bool> Message::Serialize(Environment* env,
     if (host_object &&
         host_object->GetTransferMode() == TransferMode::kTransferable) {
       delegate.AddHostObject(host_object);
-      continue;
+    } else {
+      ThrowDataCloneException(context, env->clone_untransferable_str());
+      return Nothing<bool>();
     }
   }
   if (delegate.AddNestedHostObjects().IsNothing())

--- a/test/parallel/test-structuredClone-global.js
+++ b/test/parallel/test-structuredClone-global.js
@@ -26,3 +26,6 @@ assert.strictEqual(structuredClone(undefined, { }), undefined);
 
   assert.deepStrictEqual(cloned, {});
 }
+
+const blob = new Blob();
+assert.throws(() => structuredClone(blob, { transfer: [blob] }), { name: 'DataCloneError' });


### PR DESCRIPTION
Fixes: #54602

This patch adds error handling in `structuredClone` for objects set as cloneable but untransferable via `markTransferMode(this, true, false)`. As a result, it ensures that a DataCloneError is thrown when cloning a Blob with the transfer option.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>