### PR TITLE
perf_hooks: add missing type argument to getEntriesByName

### DIFF
--- a/lib/internal/perf/performance.js
+++ b/lib/internal/perf/performance.js
@@ -97,13 +97,16 @@ class Performance extends EventTarget {
     return filterBufferMapByNameAndType();
   }
 
-  getEntriesByName(name) {
+  getEntriesByName(name, type = undefined) {
     validateInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('name');
     }
     name = `${name}`;
-    return filterBufferMapByNameAndType(name, undefined);
+    if (type !== undefined) {
+      type = `${type}`;
+    }
+    return filterBufferMapByNameAndType(name, type);
   }
 
   getEntriesByType(type) {

--- a/test/parallel/test-performance-timeline.mjs
+++ b/test/parallel/test-performance-timeline.mjs
@@ -33,6 +33,12 @@ await setTimeout(50);
 performance.measure('a', 'one');
 const entriesByName = performance.getEntriesByName('a');
 assert.deepStrictEqual(entriesByName.map((x) => x.entryType), ['measure', 'mark', 'measure', 'mark']);
+const marksByName = performance.getEntriesByName('a', 'mark');
+assert.deepStrictEqual(marksByName.map((x) => x.entryType), ['mark', 'mark']);
+const measuresByName = performance.getEntriesByName('a', 'measure');
+assert.deepStrictEqual(measuresByName.map((x) => x.entryType), ['measure', 'measure']);
+const invalidTypeEntriesByName = performance.getEntriesByName('a', null);
+assert.strictEqual(invalidTypeEntriesByName.length, 0);
 
 // getEntriesBy[Name|Type](undefined)
 performance.mark(undefined);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/54766

This change adds an optional `type` argument to `performance.getEntriesByName`, aligning with both the documented node.js method signature and the performance timing spec.