### PR TITLE
build: fix conflicting V8 object print flags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1671,7 +1671,7 @@ def configure_v8(o, configs):
     o['variables']['v8_enable_short_builtin_calls'] = 1
   if options.v8_enable_snapshot_compression:
     o['variables']['v8_enable_snapshot_compression'] = 1
-  if options.v8_enable_object_print and options.v8_disable_object_print:
+  if all(opt in sys.argv for opt in ['--v8-enable-object-print', '--v8-disable-object-print']):
     raise Exception(
         'Only one of the --v8-enable-object-print or --v8-disable-object-print options '
         'can be specified at a time.')


### PR DESCRIPTION
The `--v8-disable-object-print` flag doesn't work due to a conflict with the enabling flag. This patch fixes the bug mentioned in https://github.com/nodejs/node/pull/45458#discussion_r1083341900.

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>