### PR TITLE
tls: add `allowPartialTrustChain` flag

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1856,6 +1856,9 @@ argument.
 <!-- YAML
 added: v0.11.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54790
+    description: The `allowPartialTrustChain` option has been added.
   - version:
     - v22.4.0
     - v20.16.0
@@ -1912,6 +1915,8 @@ changes:
 -->
 
 * `options` {Object}
+  * `allowPartialTrustChain` {boolean} Treat intermediate (non-self-signed)
+    certificates in the trust CA certificate list as trusted.
   * `ca` {string|string\[]|Buffer|Buffer\[]} Optionally override the trusted CA
     certificates. Default is to trust the well-known CAs curated by Mozilla.
     Mozilla's CAs are completely replaced when CAs are explicitly specified

--- a/lib/internal/tls/secure-context.js
+++ b/lib/internal/tls/secure-context.js
@@ -130,6 +130,7 @@ function configSecureContext(context, options = kEmptyObject, name = 'options') 
   validateObject(options, name);
 
   const {
+    allowPartialTrustChain,
     ca,
     cert,
     ciphers = getDefaultCiphers(),
@@ -180,6 +181,10 @@ function configSecureContext(context, options = kEmptyObject, name = 'options') 
     addCACerts(context, ArrayIsArray(ca) ? ca : [ca], `${name}.ca`);
   } else {
     context.addRootCerts();
+  }
+
+  if (allowPartialTrustChain) {
+    context.setAllowPartialTrustChain();
   }
 
   if (cert) {

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -314,6 +314,7 @@ Local<FunctionTemplate> SecureContext::GetConstructorTemplate(
     SetProtoMethod(isolate, tmpl, "setKey", SetKey);
     SetProtoMethod(isolate, tmpl, "setCert", SetCert);
     SetProtoMethod(isolate, tmpl, "addCACert", AddCACert);
+    SetProtoMethod(isolate, tmpl, "setAllowPartialTrustChain", SetAllowPartialTrustChain);
     SetProtoMethod(isolate, tmpl, "addCRL", AddCRL);
     SetProtoMethod(isolate, tmpl, "addRootCerts", AddRootCerts);
     SetProtoMethod(isolate, tmpl, "setCipherSuites", SetCipherSuites);
@@ -753,17 +754,35 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
   USE(sc->AddCert(env, std::move(bio)));
 }
 
+void SecureContext::SetX509StoreFlag(unsigned long flags) {
+  X509_STORE* cert_store = GetCertStoreOwnedByThisSecureContext();
+  CHECK_EQ(1, X509_STORE_set_flags(cert_store, flags));
+}
+
+X509_STORE* SecureContext::GetCertStoreOwnedByThisSecureContext() {
+  if (owned_cert_store_cached_ != nullptr) return owned_cert_store_cached_;
+
+  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
+  if (cert_store == GetOrCreateRootCertStore()) {
+    cert_store = NewRootCertStore();
+    SSL_CTX_set_cert_store(ctx_.get(), cert_store);
+  }
+
+  return owned_cert_store_cached_ = cert_store;
+}
+
+void SecureContext::SetAllowPartialTrustChain(const FunctionCallbackInfo<Value>& args) {
+  SecureContext* sc;
+  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
+  sc->SetX509StoreFlag(X509_V_FLAG_PARTIAL_CHAIN);
+}
+
 void SecureContext::SetCACert(const BIOPointer& bio) {
   ClearErrorOnReturn clear_error_on_return;
   if (!bio) return;
-  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
   while (X509Pointer x509 = X509Pointer(PEM_read_bio_X509_AUX(
              bio.get(), nullptr, NoPasswordCallback, nullptr))) {
-    if (cert_store == GetOrCreateRootCertStore()) {
-      cert_store = NewRootCertStore();
-      SSL_CTX_set_cert_store(ctx_.get(), cert_store);
-    }
-    CHECK_EQ(1, X509_STORE_add_cert(cert_store, x509.get()));
+    CHECK_EQ(1, X509_STORE_add_cert(GetCertStoreOwnedByThisSecureContext(), x509.get()));
     CHECK_EQ(1, SSL_CTX_add_client_CA(ctx_.get(), x509.get()));
   }
 }
@@ -793,11 +812,7 @@ Maybe<void> SecureContext::SetCRL(Environment* env, const BIOPointer& bio) {
     return Nothing<void>();
   }
 
-  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
-  if (cert_store == GetOrCreateRootCertStore()) {
-    cert_store = NewRootCertStore();
-    SSL_CTX_set_cert_store(ctx_.get(), cert_store);
-  }
+  X509_STORE* cert_store = GetCertStoreOwnedByThisSecureContext();
 
   CHECK_EQ(1, X509_STORE_add_crl(cert_store, crl.get()));
   CHECK_EQ(1,
@@ -1080,8 +1095,6 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   sc->issuer_.reset();
   sc->cert_.reset();
 
-  X509_STORE* cert_store = SSL_CTX_get_cert_store(sc->ctx_.get());
-
   DeleteFnPtr<PKCS12, PKCS12_free> p12;
   EVPKeyPointer pkey;
   X509Pointer cert;
@@ -1135,11 +1148,7 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
   for (int i = 0; i < sk_X509_num(extra_certs.get()); i++) {
     X509* ca = sk_X509_value(extra_certs.get(), i);
 
-    if (cert_store == GetOrCreateRootCertStore()) {
-      cert_store = NewRootCertStore();
-      SSL_CTX_set_cert_store(sc->ctx_.get(), cert_store);
-    }
-    X509_STORE_add_cert(cert_store, ca);
+    X509_STORE_add_cert(sc->GetCertStoreOwnedByThisSecureContext(), ca);
     SSL_CTX_add_client_CA(sc->ctx_.get(), ca);
   }
   ret = true;

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -756,6 +756,7 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
   USE(sc->AddCert(env, std::move(bio)));
 }
 
+// NOLINTNEXTLINE(runtime/int)
 void SecureContext::SetX509StoreFlag(unsigned long flags) {
   X509_STORE* cert_store = GetCertStoreOwnedByThisSecureContext();
   CHECK_EQ(1, X509_STORE_set_flags(cert_store, flags));

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -761,7 +761,7 @@ void SecureContext::SetX509StoreFlag(unsigned long flags) {
 }
 
 X509_STORE* SecureContext::GetCertStoreOwnedByThisSecureContext() {
-  if (owned_cert_store_cached_ != nullptr) return owned_cert_store_cached_;
+  if (own_cert_store_cache_ != nullptr) return own_cert_store_cache_;
 
   X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
   if (cert_store == GetOrCreateRootCertStore()) {
@@ -769,7 +769,7 @@ X509_STORE* SecureContext::GetCertStoreOwnedByThisSecureContext() {
     SSL_CTX_set_cert_store(ctx_.get(), cert_store);
   }
 
-  return owned_cert_store_cached_ = cert_store;
+  return own_cert_store_cache_ = cert_store;
 }
 
 void SecureContext::SetAllowPartialTrustChain(

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -392,6 +392,7 @@ void SecureContext::RegisterExternalReferences(
   registry->Register(AddCACert);
   registry->Register(AddCRL);
   registry->Register(AddRootCerts);
+  registry->Register(SetAllowPartialTrustChain);
   registry->Register(SetCipherSuites);
   registry->Register(SetCiphers);
   registry->Register(SetSigalgs);

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -314,7 +314,8 @@ Local<FunctionTemplate> SecureContext::GetConstructorTemplate(
     SetProtoMethod(isolate, tmpl, "setKey", SetKey);
     SetProtoMethod(isolate, tmpl, "setCert", SetCert);
     SetProtoMethod(isolate, tmpl, "addCACert", AddCACert);
-    SetProtoMethod(isolate, tmpl, "setAllowPartialTrustChain", SetAllowPartialTrustChain);
+    SetProtoMethod(
+        isolate, tmpl, "setAllowPartialTrustChain", SetAllowPartialTrustChain);
     SetProtoMethod(isolate, tmpl, "addCRL", AddCRL);
     SetProtoMethod(isolate, tmpl, "addRootCerts", AddRootCerts);
     SetProtoMethod(isolate, tmpl, "setCipherSuites", SetCipherSuites);
@@ -771,7 +772,8 @@ X509_STORE* SecureContext::GetCertStoreOwnedByThisSecureContext() {
   return owned_cert_store_cached_ = cert_store;
 }
 
-void SecureContext::SetAllowPartialTrustChain(const FunctionCallbackInfo<Value>& args) {
+void SecureContext::SetAllowPartialTrustChain(
+    const FunctionCallbackInfo<Value>& args) {
   SecureContext* sc;
   ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
   sc->SetX509StoreFlag(X509_V_FLAG_PARTIAL_CHAIN);
@@ -782,7 +784,9 @@ void SecureContext::SetCACert(const BIOPointer& bio) {
   if (!bio) return;
   while (X509Pointer x509 = X509Pointer(PEM_read_bio_X509_AUX(
              bio.get(), nullptr, NoPasswordCallback, nullptr))) {
-    CHECK_EQ(1, X509_STORE_add_cert(GetCertStoreOwnedByThisSecureContext(), x509.get()));
+    CHECK_EQ(1,
+             X509_STORE_add_cert(GetCertStoreOwnedByThisSecureContext(),
+                                 x509.get()));
     CHECK_EQ(1, SSL_CTX_add_client_CA(ctx_.get(), x509.get()));
   }
 }

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -64,6 +64,9 @@ class SecureContext final : public BaseObject {
   void SetCACert(const BIOPointer& bio);
   void SetRootCerts();
 
+  void SetX509StoreFlag(unsigned long flags);
+  X509_STORE* GetCertStoreOwnedByThisSecureContext();
+
   // TODO(joyeecheung): track the memory used by OpenSSL types
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(SecureContext)
@@ -90,6 +93,7 @@ class SecureContext final : public BaseObject {
 #endif  // !OPENSSL_NO_ENGINE
   static void SetCert(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddCACert(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetAllowPartialTrustChain(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCipherSuites(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -142,6 +146,7 @@ class SecureContext final : public BaseObject {
   SSLCtxPointer ctx_;
   X509Pointer cert_;
   X509Pointer issuer_;
+  X509_STORE* owned_cert_store_cached_ = nullptr;
 #ifndef OPENSSL_NO_ENGINE
   bool client_cert_engine_provided_ = false;
   ncrypto::EnginePointer private_key_engine_;

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -93,7 +93,8 @@ class SecureContext final : public BaseObject {
 #endif  // !OPENSSL_NO_ENGINE
   static void SetCert(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddCACert(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetAllowPartialTrustChain(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetAllowPartialTrustChain(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetCipherSuites(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -64,7 +64,7 @@ class SecureContext final : public BaseObject {
   void SetCACert(const BIOPointer& bio);
   void SetRootCerts();
 
-  void SetX509StoreFlag(unsigned long flags);
+  void SetX509StoreFlag(unsigned long flags);  // NOLINT(runtime/int)
   X509_STORE* GetCertStoreOwnedByThisSecureContext();
 
   // TODO(joyeecheung): track the memory used by OpenSSL types

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -147,7 +147,8 @@ class SecureContext final : public BaseObject {
   SSLCtxPointer ctx_;
   X509Pointer cert_;
   X509Pointer issuer_;
-  X509_STORE* owned_cert_store_cached_ = nullptr;
+  // Non-owning cache for SSL_CTX_get_cert_store(ctx_.get())
+  X509_STORE* own_cert_store_cache_ = nullptr;
 #ifndef OPENSSL_NO_ENGINE
   bool client_cert_engine_provided_ = false;
   ncrypto::EnginePointer private_key_engine_;

--- a/test/parallel/test-tls-client-allow-partial-trust-chain.js
+++ b/test/parallel/test-tls-client-allow-partial-trust-chain.js
@@ -1,12 +1,9 @@
 'use strict';
 const common = require('../common');
-
-if (!common.hasCrypto)
-  common.skip('missing crypto');
+if (!common.hasCrypto) { common.skip('missing crypto'); };
 
 const assert = require('assert');
 const { once } = require('events');
-const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
 // agent6-cert.pem is signed by intermediate cert of ca3.
@@ -14,7 +11,8 @@ const fixtures = require('../common/fixtures');
 
 const { it, beforeEach, afterEach, describe } = require('node:test');
 
-describe('allowPartialTrustChain', function() {
+describe('allowPartialTrustChain', { skip: !common.hasCrypto }, function() {
+  const tls = require('tls');
   let server;
   let client;
   let opts;

--- a/test/parallel/test-tls-client-allow-partial-trust-chain.js
+++ b/test/parallel/test-tls-client-allow-partial-trust-chain.js
@@ -10,35 +10,46 @@ const tls = require('tls');
 const fixtures = require('../common/fixtures');
 
 // agent6-cert.pem is signed by intermediate cert of ca3.
-// The server has a cert chain of agent6->ca3->ca1(root) but
+// The server has a cert chain of agent6->ca3->ca1(root).
 
-async function test() {
-  const server = tls.createServer({
-    ca: fixtures.readKey('ca3-cert.pem'),
-    key: fixtures.readKey('agent6-key.pem'),
-    cert: fixtures.readKey('agent6-cert.pem'),
-  }, (socket) => socket.resume());
-  server.listen(0);
-  await once(server, 'listening');
+const { it, beforeEach, afterEach, describe } = require('node:test');
 
-  const opts = {
-    port: server.address().port,
-    ca: fixtures.readKey('ca3-cert.pem'),
-    checkServerIdentity() {}
-  };
+describe('allowPartialTrustChain', function() {
+  let server;
+  let client;
+  let opts;
 
-  // Connecting succeeds with allowPartialTrustChain: true
-  const client = tls.connect({ ...opts, allowPartialTrustChain: true });
-  await once(client, 'secureConnect');
-  client.destroy();
+  beforeEach(async function() {
+    server = tls.createServer({
+      ca: fixtures.readKey('ca3-cert.pem'),
+      key: fixtures.readKey('agent6-key.pem'),
+      cert: fixtures.readKey('agent6-cert.pem'),
+    }, (socket) => socket.resume());
+    server.listen(0);
+    await once(server, 'listening');
 
-  // Consistency check: Connecting fails without allowPartialTrustChain: true
-  await assert.rejects(async () => {
-    const client = tls.connect(opts);
-    await once(client, 'secureConnect');
-  }, { code: 'UNABLE_TO_GET_ISSUER_CERT' });
+    opts = {
+      port: server.address().port,
+      ca: fixtures.readKey('ca3-cert.pem'),
+      checkServerIdentity() {}
+    };
+  });
 
-  server.close();
-}
+  afterEach(async function() {
+    client?.destroy();
+    server?.close();
+  });
 
-test().catch((err) => process.nextTick(() => { throw err; }));
+  it('can connect successfully with allowPartialTrustChain: true', async function() {
+    client = tls.connect({ ...opts, allowPartialTrustChain: true });
+    await once(client, 'secureConnect'); // Should not throw
+  });
+
+  it('fails without with allowPartialTrustChain: true for an intermediate cert in the CA', async function() {
+    // Consistency check: Connecting fails without allowPartialTrustChain: true
+    await assert.rejects(async () => {
+      const client = tls.connect(opts);
+      await once(client, 'secureConnect');
+    }, { code: 'UNABLE_TO_GET_ISSUER_CERT' });
+  });
+});


### PR DESCRIPTION
This commit exposes the `X509_V_FLAG_PARTIAL_CHAIN` OpenSSL flag to users. This is behavior that has been requested repeatedly in the Github issues, and allows aligning behavior with other TLS libraries and commonly used applications (e.g. `curl`).

As a drive-by, simplify the `SecureContext` source by deduplicating call sites at which a new custom certificate store was created for the `secureContext` in question.

Fixes: https://github.com/nodejs/node/issues/36453

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
