### PR TITLE
[v18.x] deps: V8: backport 2944ee9846e7 (V18.x CVE-2024-4947)

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.37',
+    'v8_embedder_string': '-node.38',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/compiler/access-info.cc
+++ b/deps/v8/src/compiler/access-info.cc
@@ -538,7 +538,7 @@ PropertyAccessInfo AccessorAccessInfoHelper(
     if (IsAnyStore(access_mode)) {
       // ES#sec-module-namespace-exotic-objects-set-p-v-receiver
       // ES#sec-module-namespace-exotic-objects-defineownproperty-p-desc
-      //
+      // 
       // Storing to a module namespace object is always an error or a no-op in
       // JS.
       return PropertyAccessInfo::Invalid(zone);

--- a/deps/v8/src/compiler/access-info.cc
+++ b/deps/v8/src/compiler/access-info.cc
@@ -535,6 +535,14 @@ PropertyAccessInfo AccessorAccessInfoHelper(
     Handle<Cell> cell = broker->CanonicalPersistentHandle(
         Cell::cast(module_namespace->module().exports().Lookup(
             isolate, name.object(), Smi::ToInt(name.object()->GetHash()))));
+    if (IsAnyStore(access_mode)) {
+      // ES#sec-module-namespace-exotic-objects-set-p-v-receiver
+      // ES#sec-module-namespace-exotic-objects-defineownproperty-p-desc
+      //
+      // Storing to a module namespace object is always an error or a no-op in
+      // JS.
+      return PropertyAccessInfo::Invalid(zone);
+    }        
     if (cell->value(kRelaxedLoad).IsTheHole(isolate)) {
       // This module has not been fully initialized yet.
       return PropertyAccessInfo::Invalid(zone);


### PR DESCRIPTION
V8 backport of https://github.com/v8/v8/commit/2944ee9846e
Applicable to v18.x
Fixes [CVE-2024-4947](https://nvd.nist.gov/vuln/detail/CVE-2024-4947) which has been tagged by CISA as KEV. 

Maglev-graph-builder.cc not updated as functionality not present in V18.x