### PR TITLE
buffer: improve `toJSON` performance

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -24,6 +24,7 @@
 const {
   Array,
   ArrayBufferIsView,
+  ArrayFrom,
   ArrayIsArray,
   ArrayPrototypeForEach,
   MathFloor,
@@ -1141,10 +1142,10 @@ Buffer.prototype.write = function write(string, offset, length, encoding) {
 
 Buffer.prototype.toJSON = function toJSON() {
   if (this.length > 0) {
-    const data = new Array(this.length);
-    for (let i = 0; i < this.length; ++i)
-      data[i] = this[i];
-    return { type: 'Buffer', data };
+    return {
+      type: 'Buffer',
+      data: ArrayFrom(new Array(this.length), (_value, i) => this[i]),
+    };
   }
   return { type: 'Buffer', data: [] };
 };


### PR DESCRIPTION
I'm not sure if this will improve the performance, but let's see.

> Requires benchmark-ci.