### PR TITLE
test: mark test-inspector-connect-to-main-thread as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -26,6 +26,9 @@ test-error-serdes: PASS, FLAKY
 # https://github.com/nodejs/build/issues/3043
 test-snapshot-incompatible: SKIP
 
+# https://github.com/nodejs/node/issues/54804
+test-inspector-connect-to-main-thread: PASS, FLAKY
+
 [$system==win32]
 
 # Windows on ARM


### PR DESCRIPTION
Have been unable to reproduce the failures locally.

Tracking issue: https://github.com/nodejs/node/issues/54804