### PR TITLE
test: remove need to make fs call for zlib test

### DIFF
--- a/test/parallel/test-zlib-flush.js
+++ b/test/parallel/test-zlib-flush.js
@@ -1,36 +1,38 @@
 'use strict';
+
 require('../common');
-const assert = require('assert');
-const zlib = require('zlib');
-const fixtures = require('../common/fixtures');
 
-const file = fixtures.readSync('person.jpg');
-const chunkSize = 16;
-const opts = { level: 0 };
-const deflater = zlib.createDeflate(opts);
+const assert = require('node:assert');
+const zlib = require('node:zlib');
+const { test } = require('node:test');
 
-const chunk = file.slice(0, chunkSize);
-const expectedNone = Buffer.from([0x78, 0x01]);
-const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
-const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
-const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
-let actualNone;
-let actualFull;
+test('zlib flush', async () => {
+  const { promise, resolve } = Promise.withResolvers();
 
-deflater.write(chunk, function() {
-  deflater.flush(zlib.constants.Z_NO_FLUSH, function() {
-    actualNone = deflater.read();
-    deflater.flush(function() {
-      const bufs = [];
-      let buf;
-      while ((buf = deflater.read()) !== null)
-        bufs.push(buf);
-      actualFull = Buffer.concat(bufs);
+  const opts = { level: 0 };
+  const deflater = zlib.createDeflate(opts);
+  const chunk = Buffer.from('/9j/4AAQSkZJRgABAQEASA==', 'base64');
+  const expectedNone = Buffer.from([0x78, 0x01]);
+  const blkhdr = Buffer.from([0x00, 0x10, 0x00, 0xef, 0xff]);
+  const adler32 = Buffer.from([0x00, 0x00, 0x00, 0xff, 0xff]);
+  const expectedFull = Buffer.concat([blkhdr, chunk, adler32]);
+  let actualNone;
+  let actualFull;
+
+  deflater.write(chunk, function() {
+    deflater.flush(zlib.constants.Z_NO_FLUSH, function() {
+      actualNone = deflater.read();
+      deflater.flush(function() {
+        const bufs = [];
+        let buf;
+        while ((buf = deflater.read()) !== null)
+          bufs.push(buf);
+        actualFull = Buffer.concat(bufs);
+        resolve();
+      });
     });
   });
-});
-
-process.once('exit', function() {
+  await promise;
   assert.deepStrictEqual(actualNone, expectedNone);
   assert.deepStrictEqual(actualFull, expectedFull);
 });


### PR DESCRIPTION
Removes the need for making a filesystem call to a fixture file, and wrap the test suite in test while also avoiding the call to listen for process on exit handler.