### PR TITLE
test: reduce fs calls in test-fs-existssync-false

### DIFF
--- a/test/parallel/test-fs-existssync-false.js
+++ b/test/parallel/test-fs-existssync-false.js
@@ -18,14 +18,12 @@ tmpdir.refresh();
 // Make a long path.
 for (let i = 0; i < 50; i++) {
   dir = `${dir}/1234567890`;
-  try {
-    fs.mkdirSync(dir, '0777');
-  } catch (e) {
-    if (e.code !== 'EEXIST') {
-      throw e;
-    }
-  }
 }
+
+fs.mkdirSync(dir, {
+  mode: '0777',
+  recursive: true,
+});
 
 // Test if file exists synchronously
 assert(fs.existsSync(dir), 'Directory is not accessible');


### PR DESCRIPTION
Reduces filesystem calls on a fs test.