### PR TITLE
test: fix Windows async-context-frame memory failure

### DIFF
--- a/test/parallel/test-async-context-frame.mjs
+++ b/test/parallel/test-async-context-frame.mjs
@@ -42,7 +42,8 @@ const tests = testSets.reduce((m, v) => {
 }, []);
 
 describe('AsyncContextFrame', {
-  concurrency: tests.length
+  // TODO(qard): I think high concurrency causes memory problems on Windows
+  // concurrency: tests.length
 }, () => {
   for (const test of tests) {
     it(test, async () => {


### PR DESCRIPTION
Possible alternative to #54818 to fix the issue with AsyncContextFrame tests crashing with memory errors on Windows. I suspect we're just spinning up too much stuff and eating all the memory.

cc @nodejs/diagnostics 