### PR TITLE
test_runner: detect only tests when isolation is off

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2336,7 +2336,7 @@ changes:
 -->
 
 Configures the test runner to only execute top level tests that have the `only`
-option set.
+option set. This flag is not necessary when test isolation is disabled.
 
 ### `--test-reporter`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -229,10 +229,10 @@ const { describe, it } = require('node:test');
 
 ## `only` tests
 
-If Node.js is started with the [`--test-only`][] command-line option, it is
-possible to skip all tests except for a selected subset by passing
-the `only` option to the tests that should run. When a test with the `only`
-option is set, all subtests are also run.
+If Node.js is started with the [`--test-only`][] command-line option, or test
+isolation is disabled, it is possible to skip all tests except for a selected
+subset by passing the `only` option to the tests that should run. When a test
+with the `only` option is set, all subtests are also run.
 If a suite has the `only` option set, all tests within the suite are run,
 unless it has descendants with the `only` option set, in which case only those
 tests are run.

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -38,7 +38,8 @@ function createTestTree(rootTestOptions, globalOptions) {
   const buildPhaseDeferred = createDeferredPromise();
   const isFilteringByName = globalOptions.testNamePatterns ||
                             globalOptions.testSkipPatterns;
-  const isFilteringByOnly = globalOptions.only;
+  const isFilteringByOnly = globalOptions.only || (globalOptions.isTestRunner &&
+                                                   globalOptions.isolation === 'none');
   const harness = {
     __proto__: null,
     buildPromise: buildPhaseDeferred.promise,

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -36,6 +36,9 @@ testResources.set(reporterScope.asyncId(), reporterScope);
 
 function createTestTree(rootTestOptions, globalOptions) {
   const buildPhaseDeferred = createDeferredPromise();
+  const isFilteringByName = globalOptions.testNamePatterns ||
+                            globalOptions.testSkipPatterns;
+  const isFilteringByOnly = globalOptions.only;
   const harness = {
     __proto__: null,
     buildPromise: buildPhaseDeferred.promise,
@@ -62,6 +65,8 @@ function createTestTree(rootTestOptions, globalOptions) {
     shouldColorizeTestFiles: shouldColorizeTestFiles(globalOptions.destinations),
     teardown: null,
     snapshotManager: null,
+    isFilteringByName,
+    isFilteringByOnly,
     async waitForBuildPhase() {
       if (harness.buildSuites.length > 0) {
         await SafePromiseAllReturnVoid(harness.buildSuites);

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -395,8 +395,10 @@ class Test extends AsyncResource {
     this.parent = parent;
     this.testNumber = 0;
     this.outputSubtestCount = 0;
-    this.filteredSubtestCount = 0;
+    this.diagnostics = [];
     this.filtered = false;
+    this.filteredByName = false;
+    this.hasOnlyTests = false;
 
     if (parent === null) {
       this.root = this;
@@ -413,26 +415,48 @@ class Test extends AsyncResource {
     } else {
       const nesting = parent.parent === null ? parent.nesting :
         parent.nesting + 1;
+      const { config, isFilteringByName, isFilteringByOnly } = parent.root.harness;
 
       this.root = parent.root;
       this.harness = null;
-      this.config = this.root.harness.config;
+      this.config = config;
       this.concurrency = parent.concurrency;
       this.nesting = nesting;
-      this.only = only ?? (parent.only && !parent.runOnlySubtests);
+      this.only = only;
       this.reporter = parent.reporter;
       this.runOnlySubtests = false;
       this.childNumber = parent.subtests.length + 1;
       this.timeout = parent.timeout;
       this.entryFile = parent.entryFile;
 
-      if (this.willBeFiltered()) {
-        this.filtered = true;
-        this.parent.filteredSubtestCount++;
+      if (isFilteringByName) {
+        this.filteredByName = this.willBeFilteredByName();
+        if (!this.filteredByName) {
+          for (let t = this.parent; t !== null && t.filteredByName; t = t.parent) {
+            t.filteredByName = false;
+          }
+        }
       }
 
-      if (this.config.only && only === false) {
-        fn = noop;
+      if (isFilteringByOnly) {
+        if (this.only) {
+          // If filtering impacts the tests within a suite, then the suite only
+          // runs those tests. If filtering does not impact the tests within a
+          // suite, then all tests are run.
+          this.parent.runOnlySubtests = true;
+
+          if (this.parent === this.root || this.parent.startTime === null) {
+            for (let t = this.parent; t !== null && !t.hasOnlyTests; t = t.parent) {
+              t.hasOnlyTests = true;
+            }
+          }
+        } else if (this.only === false) {
+          fn = noop;
+        }
+      } else if (only || this.parent.runOnlySubtests) {
+        const warning =
+          "'only' and 'runOnly' require the --test-only command-line option.";
+        this.diagnostic(warning);
       }
     }
 
@@ -491,7 +515,6 @@ class Test extends AsyncResource {
     this.endTime = null;
     this.passed = false;
     this.error = null;
-    this.diagnostics = [];
     this.message = typeof skip === 'string' ? skip :
       typeof todo === 'string' ? todo : null;
     this.activeSubtests = 0;
@@ -508,12 +531,6 @@ class Test extends AsyncResource {
       afterEach: [],
       ownAfterEachCount: 0,
     };
-
-    if (!this.config.only && (only || this.parent?.runOnlySubtests)) {
-      const warning =
-        "'only' and 'runOnly' require the --test-only command-line option.";
-      this.diagnostic(warning);
-    }
 
     if (loc === undefined) {
       this.loc = undefined;
@@ -542,9 +559,27 @@ class Test extends AsyncResource {
     }
   }
 
-  willBeFiltered() {
-    if (this.config.only && !this.only) return true;
+  applyFilters() {
+    if (this.error) {
+      // Never filter out errors.
+      return;
+    }
 
+    if (this.filteredByName) {
+      this.filtered = true;
+      return;
+    }
+
+    if (this.root.harness.isFilteringByOnly && !this.only && !this.hasOnlyTests) {
+      if (this.parent.runOnlySubtests ||
+          this.parent.hasOnlyTests ||
+          this.only === false) {
+        this.filtered = true;
+      }
+    }
+  }
+
+  willBeFilteredByName() {
     const { testNamePatterns, testSkipPatterns } = this.config;
 
     if (testNamePatterns && !testMatchesPattern(this, testNamePatterns)) {
@@ -757,12 +792,10 @@ class Test extends AsyncResource {
     ArrayPrototypePush(this.diagnostics, message);
   }
 
-  get shouldFilter() {
-    return this.filtered && this.parent?.filteredSubtestCount > 0;
-  }
-
   start() {
-    if (this.shouldFilter) {
+    this.applyFilters();
+
+    if (this.filtered) {
       noopTestStream ??= new TestsStream();
       this.reporter = noopTestStream;
       this.run = this.filteredRun;
@@ -970,7 +1003,7 @@ class Test extends AsyncResource {
     this.mock?.reset();
 
     if (this.parent !== null) {
-      if (!this.shouldFilter) {
+      if (!this.filtered) {
         const report = this.getReportDetails();
         report.details.passed = this.passed;
         this.testNumber ||= ++this.parent.outputSubtestCount;
@@ -1159,7 +1192,7 @@ class TestHook extends Test {
   getRunArgs() {
     return this.#args;
   }
-  willBeFiltered() {
+  willBeFilteredByName() {
     return false;
   }
   postRun() {
@@ -1192,7 +1225,6 @@ class Suite extends Test {
       this.fn = options.fn || this.fn;
       this.skipped = false;
     }
-    this.runOnlySubtests = this.config.only;
 
     try {
       const { ctx, args } = this.getRunArgs();
@@ -1216,21 +1248,6 @@ class Suite extends Test {
 
   postBuild() {
     this.buildPhaseFinished = true;
-    if (this.filtered &&
-        (this.filteredSubtestCount !== this.subtests.length || this.error)) {
-      // A suite can transition from filtered to unfiltered based on the
-      // tests that it contains - in case of children matching patterns.
-      this.filtered = false;
-      this.parent.filteredSubtestCount--;
-    } else if (
-      this.config.only &&
-      this.config.testNamePatterns == null &&
-      this.config.testSkipPatterns == null &&
-      this.filteredSubtestCount === this.subtests.length
-    ) {
-      // If no subtests are marked as "only", run them all
-      this.filteredSubtestCount = 0;
-    }
   }
 
   getRunArgs() {

--- a/test/parallel/test-runner-no-isolation-filtering.js
+++ b/test/parallel/test-runner-no-isolation-filtering.js
@@ -45,10 +45,8 @@ test('works with --test-name-pattern', () => {
 
   assert.strictEqual(child.status, 0);
   assert.strictEqual(child.signal, null);
-  assert.match(stdout, /# tests 1/);
+  assert.match(stdout, /# tests 0/);
   assert.match(stdout, /# suites 0/);
-  assert.match(stdout, /# pass 1/);
-  assert.match(stdout, /ok 1 - test one/);
 });
 
 test('works with --test-skip-pattern', () => {

--- a/test/parallel/test-runner-no-isolation-hooks.mjs
+++ b/test/parallel/test-runner-no-isolation-hooks.mjs
@@ -30,15 +30,6 @@ const order = [
   'afterEach one: suite one - test',
   'afterEach two: suite one - test',
 
-  'beforeEach(): global',
-  'beforeEach one: test one',
-  'beforeEach two: test one',
-  'test one',
-
-  'afterEach(): global',
-  'afterEach one: test one',
-  'afterEach two: test one',
-
   'before suite two: suite two',
   'beforeEach(): global',
   'beforeEach one: suite two - test',


### PR DESCRIPTION
##### test_runner: apply filtering when tests begin

This commit updates the way filtering is applied to tests and
suites. After this change, filters are applied just before the
test/suite is started. The results are the same, but this allows
us to eventually move away from the --test-only flag except
when process level isolation is used.

##### test_runner: detect only tests when isolation is off

This commit updates the way the test runner processes 'only'
tests when process-based test isolation is disabled. The
--test-only flag is no longer necessary in this scenario. The
test runner will automatically detect 'only' tests and apply the
appropriate filtering.

This is not a breaking change because disabling test isolation is currently an experimental feature.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
