### PR TITLE
fs: refactor and improve `cpSync`

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -37,6 +37,7 @@ const {
   resolve,
 } = require('path');
 const { isPromise } = require('util/types');
+let assert;
 
 function cpSyncFn(src, dest, opts) {
   // Warn about using preserveTimestamps on 32-bit node
@@ -53,15 +54,45 @@ function cpSyncFn(src, dest, opts) {
     if (!shouldCopy) return;
   }
 
-  fsBinding.cpSyncCheckPaths(src, dest, opts.dereference, opts.recursive);
+  // TODO: Performance optimization
+  // Return a single value that holds multiple fields. Preferably using bitmap.
+  // This would avoid constructing an array.
+  const {
+    0: destExists,
+    1: shouldCopyDirectory,
+    2: shouldCopyFile,
+    3: shouldCopySymlink,
+  } = fsBinding.cpSyncCheckPaths(src, dest, opts.dereference, opts.recursive);
 
-  return getStats(src, dest, opts);
+  // We conditionally call statSyncFn because we don't need it in symlink path.
+  const statSyncFn = opts.dereference ? statSync : lstatSync;
+
+  if (shouldCopyDirectory) {
+    // srcStat is only needed to get the mode of the file.
+    // TODO: Return the mode from `cpSyncCheckPaths` to avoid stat call.
+    const srcStat = statSyncFn(src);
+    return onDir(srcStat, destExists, src, dest, opts);
+  } else if (shouldCopyFile) {
+    // srcStat is actually needed here.
+    const srcStat = statSyncFn(src);
+    return onFile(srcStat, destExists, src, dest, opts);
+  } else if (shouldCopySymlink) {
+    return onLink(destExists, src, dest, opts.verbatimSymlinks);
+  }
+
+  // It is not possible to get here because all possible cases are handled above.
+  assert ??= require('internal/assert');
+  assert.fail('Unreachable code');
 }
 
 function getStats(src, dest, opts) {
   // TODO(@anonrig): Avoid making two stat calls.
   const statSyncFn = opts.dereference ? statSync : lstatSync;
   const srcStat = statSyncFn(src);
+
+  // Optimization opportunity:
+  // TODO: destStat is only used for checking if `dest` path exists or not.
+  // We don't need a whole Stats object here.
   const destStat = statSyncFn(dest, { bigint: true, throwIfNoEntry: false });
 
   if (srcStat.isDirectory() && opts.recursive) {
@@ -75,12 +106,19 @@ function getStats(src, dest, opts) {
   }
 
   // It is not possible to get here because all possible cases are handled above.
-  const assert = require('internal/assert');
+  assert ??= require('internal/assert');
   assert.fail('Unreachable code');
 }
 
-function onFile(srcStat, destStat, src, dest, opts) {
-  if (!destStat) return copyFile(srcStat, src, dest, opts);
+/**
+ * @param {fs.Stats} srcStat
+ * @param {boolean} destExists
+ * @param {string} src
+ * @param {string} dest
+ * @param {Record<string, unknown>} opts
+ */
+function onFile(srcStat, destExists, src, dest, opts) {
+  if (!destExists) return copyFile(srcStat, src, dest, opts);
   return mayCopyFile(srcStat, src, dest, opts);
 }
 
@@ -134,16 +172,22 @@ function setDestTimestamps(src, dest) {
   return utimesSync(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
 }
 
-// TODO(@anonrig): Move this function to C++.
-function onDir(srcStat, destStat, src, dest, opts) {
-  if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
+/**
+ * @param {fs.Stats} srcStat
+ * @param {boolean} destExists
+ * @param {string} src
+ * @param {string} dest
+ * @param {Record<string, unknown>} opts
+ */
+function onDir(srcStat, destExists, src, dest, opts) {
+  if (!destExists) {
+    // TODO: Optimization opportunity
+    // This can be moved to C++ and can significantly improve the performance.
+    mkdirSync(dest);
+    copyDir(src, dest, opts);
+    return setDestMode(dest, srcStat.mode);
+  }
   return copyDir(src, dest, opts);
-}
-
-function mkDirAndCopy(srcMode, src, dest, opts) {
-  mkdirSync(dest);
-  copyDir(src, dest, opts);
-  return setDestMode(dest, srcMode);
 }
 
 // TODO(@anonrig): Move this function to C++.
@@ -175,13 +219,19 @@ function copyDir(src, dest, opts) {
   }
 }
 
-// TODO(@anonrig): Move this function to C++.
-function onLink(destStat, src, dest, verbatimSymlinks) {
+/**
+ * TODO(@anonrig): Move this function to C++.
+ * @param {boolean} destExists
+ * @param {string} src
+ * @param {string} dest
+ * @param {boolean} verbatimSymlinks
+ */
+function onLink(destExists, src, dest, verbatimSymlinks) {
   let resolvedSrc = readlinkSync(src);
   if (!verbatimSymlinks && !isAbsolute(resolvedSrc)) {
     resolvedSrc = resolve(dirname(src), resolvedSrc);
   }
-  if (!destStat) {
+  if (!destExists) {
     return symlinkSync(resolvedSrc, dest);
   }
   let resolvedDest;

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3238,11 +3238,27 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
       break;
   }
 
-  // Optimization opportunity: Check if this "exists" call is good for
-  // performance.
+  // TODO(anonrig): Optimization opportunity:
+  // Check if this "exists" call is good for performance.
   if (!dest_exists || !std::filesystem::exists(dest_path.parent_path())) {
     std::filesystem::create_directories(dest_path.parent_path(), error_code);
   }
+
+  // TODO(anonrig): Performance optimization
+  // Return a single value that holds multiple fields. Preferably using bitmap.
+  // This would avoid constructing an array.
+  Local<Value> values[4] = {
+      v8::Boolean::New(isolate, dest_exists),
+      v8::Boolean::New(isolate, src_is_dir && recursive),
+      v8::Boolean::New(
+          isolate,
+          src_status.type() == std::filesystem::file_type::regular ||
+              src_status.type() == std::filesystem::file_type::character ||
+              src_status.type() == std::filesystem::file_type::block),
+      v8::Boolean::New(
+          isolate, src_status.type() == std::filesystem::file_type::symlink),
+  };
+  args.GetReturnValue().Set(Array::New(isolate, values, 4));
 }
 
 BindingData::FilePathIsFileReturnType BindingData::FilePathIsFile(


### PR DESCRIPTION
I've refactored the existing implementation to reduce the `fs.stat` calls, and left multiple TODOs that will improve the performance of `cpSync` on several paths.

I think this might be a good place for new contributors who are interested in improving the performance of Node.js

cc @nodejs/performance @nodejs/fs