### PR TITLE
fs: refactor rimraf to avoid using primordials

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const {
-  ArrayPrototypeForEach,
   Promise,
   SafeSet,
 } = primordials;
@@ -132,8 +131,10 @@ function _rmchildren(path, options, callback) {
 
     let done = false;
 
-    ArrayPrototypeForEach(files, (child) => {
-      const childPath = Buffer.concat([pathBuf, separator, child]);
+    const childPathPrefix = Buffer.concat([pathBuf, separator]);
+
+    for (let i = 0; i < files.length; i++) {
+      const childPath = Buffer.concat([childPathPrefix, files[i]]);
 
       rimraf(childPath, options, (err) => {
         if (done)
@@ -148,7 +149,7 @@ function _rmchildren(path, options, callback) {
         if (numFiles === 0)
           rmdir(path, callback);
       });
-    });
+    }
   });
 }
 


### PR DESCRIPTION
A small change to avoid using ArrayPrototypeForEach cc @nodejs/fs