### PR TITLE
path: remove repetitive conditional operator in `posix.resolve`

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1163,8 +1163,8 @@ const posix = {
     let resolvedPath = '';
     let resolvedAbsolute = false;
 
-    for (let i = args.length - 1; i >= -1 && !resolvedAbsolute; i--) {
-      const path = i >= 0 ? args[i] : posixCwd();
+    for (let i = args.length - 1; i >= 0 && !resolvedAbsolute; i--) {
+      const path = args[i];
       validateString(path, `paths[${i}]`);
 
       // Skip empty entries
@@ -1175,6 +1175,13 @@ const posix = {
       resolvedPath = `${path}/${resolvedPath}`;
       resolvedAbsolute =
         StringPrototypeCharCodeAt(path, 0) === CHAR_FORWARD_SLASH;
+    }
+
+    if (!resolvedAbsolute) {
+      const cwd = posixCwd();
+      resolvedPath = `${cwd}/${resolvedPath}`;
+      resolvedAbsolute =
+        StringPrototypeCharCodeAt(cwd, 0) === CHAR_FORWARD_SLASH;
     }
 
     // At this point the path should be resolved to a full absolute path, but


### PR DESCRIPTION
```
                                                                          confidence improvement accuracy (*)   (**)  (***)
path/resolve-posix.js n=100000 paths=''                                          ***      7.32 %       ±2.03% ±2.70% ±3.51%
path/resolve-posix.js n=100000 paths='|'                                         ***      6.23 %       ±0.74% ±0.98% ±1.28%
path/resolve-posix.js n=100000 paths='a/b/c/|../../..'                           ***      2.96 %       ±0.55% ±0.73% ±0.95%
path/resolve-posix.js n=100000 paths='foo/bar|/tmp/file/|..|a/../subfile'                -0.08 %       ±0.56% ±0.75% ±0.98%
```