### PR TITLE
repl: doc-deprecate instantiating `node:repl` classes without `new`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3726,6 +3726,21 @@ Instantiating classes without the `new` qualifier exported by the `node:zlib` mo
 It is recommended to use the `new` qualifier instead. This applies to all Zlib classes, such as `Deflate`,
 `DeflateRaw`, `Gunzip`, `Inflate`, `InflateRaw`, `Unzip`, and `Zlib`.
 
+### DEP0185: Instantiating `node:repl` classes without `new`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/54842
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Instantiating classes without the `new` qualifier exported by the `node:repl` module is deprecated.
+It is recommended to use the `new` qualifier instead. This applies to all REPL classes, including
+`REPLServer` and `Recoverable`.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4


### PR DESCRIPTION
Building on the approach taken in #54708:

In the past, I've submitted several PRs aimed at refactoring and modernizing the Node.js REPL with significant changes. Throughout that process, I’ve learned that progress often starts with smaller steps before larger changes can happen.

This is one of those small steps.

I propose deprecating the instantiation of `repl.REPLServer` (and `repl.Recoverable`) without the `new` keyword. This change would pave the way for these classes to be migrated to ECMAScript classes, helping Node.js move closer to fully using ECMAScript's potential.