### PR TITLE
test: reduce `test-debugger-heap-profiler` duration

### DIFF
--- a/test/parallel/test-debugger-heap-profiler.js
+++ b/test/parallel/test-debugger-heap-profiler.js
@@ -6,10 +6,11 @@ common.skipIfInspectorDisabled();
 const fixtures = require('../common/fixtures');
 const startCLI = require('../common/debugger');
 const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const fs = require('node:fs');
 
 tmpdir.refresh();
 
-const { readFileSync } = require('fs');
 
 const filename = tmpdir.resolve('node.heapsnapshot');
 
@@ -23,11 +24,11 @@ const filename = tmpdir.resolve('node.heapsnapshot');
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.command('takeHeapSnapshot()');
-      JSON.parse(readFileSync(filename, 'utf8'));
+      assert.ok(fs.existsSync(filename));
       // Check that two simultaneous snapshots don't step all over each other.
       // Refs: https://github.com/nodejs/node/issues/39555
       await cli.command('takeHeapSnapshot(); takeHeapSnapshot()');
-      JSON.parse(readFileSync(filename, 'utf8'));
+      assert.ok(fs.existsSync(filename));
     } finally {
       await cli.quit();
     }


### PR DESCRIPTION
Reduces the filesystem operations done on `test-debugger-heap-profiler` test. I didn't understand why we called `JSON.parse(readfileSync)` in the first place.

```
node test/parallel/test-debugger-heap-profiler.js 
> 0.13s user 0.03s system 49% cpu 0.319 total
```