### PR TITLE
repl: avoid interpreting 'npm' as a command when errors are recoverable

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -931,7 +931,9 @@ function REPLServer(prompt,
       ReflectApply(_memory, self, [cmd]);
 
       if (e && !self[kBufferedCommandSymbol] &&
-          StringPrototypeStartsWith(StringPrototypeTrim(cmd), 'npm ')) {
+          StringPrototypeStartsWith(StringPrototypeTrim(cmd), 'npm ') &&
+          !(e instanceof Recoverable)
+      ) {
         self.output.write('npm should be run outside of the ' +
                                 'Node.js REPL, in your normal shell.\n' +
                                 '(Press Ctrl+D to exit.)\n');

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -129,18 +129,6 @@ const strictModeTests = [
   },
 ];
 
-const possibleTokensAfterIdentifier = [
-  '()',
-  '[0]',
-  '+ 1', '- 1', '* 1', '/ 1', '% 1', '** 1',
-  '== 1', '=== 1', '!= 1', '!== 1', '< 1', '> 1', '<= 1', '>= 1',
-  '&& 1', '|| 1', '?? 1',
-  '= 1', '+= 1', '-= 1', '*= 1', '/= 1', '%= 1',
-  '++', '--',
-  ':',
-  '? 1: 1',
-];
-
 const possibleTokensAfterIdentifierWithLineBreak = [
   '(\n)',
   '[\n0]',
@@ -412,16 +400,6 @@ const errorTests = [
   {
     send: 'let npm = () => {};',
     expect: 'undefined'
-  },
-  ...possibleTokensAfterIdentifier.map((token) => (
-    {
-      send: `npm ${token}; undefined`,
-      expect: 'undefined'
-    }
-  )),
-  {
-    send: 'npm = () => {};',
-    expect: '[Function: npm]'
   },
   ...possibleTokensAfterIdentifierWithLineBreak.map((token) => (
     {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -129,6 +129,18 @@ const strictModeTests = [
   },
 ];
 
+const possibleTokensAfterIdentifier = [
+  '()',
+  '[0]',
+  '+ 1', '- 1', '* 1', '/ 1', '% 1', '** 1',
+  '== 1', '=== 1', '!= 1', '!== 1', '< 1', '> 1', '<= 1', '>= 1',
+  '&& 1', '|| 1', '?? 1',
+  '= 1', '+= 1', '-= 1', '*= 1', '/= 1', '%= 1',
+  '++', '--',
+  ':',
+  '? 1: 1',
+];
+
 const errorTests = [
   // Uncaught error throws and prints out
   {
@@ -386,6 +398,16 @@ const errorTests = [
       '(Press Ctrl+D to exit.)',
     ]
   },
+  {
+    send: 'let npm = () => {};',
+    expect: 'undefined'
+  },
+  ...possibleTokensAfterIdentifier.map((token) => (
+    {
+      send: `npm ${token}; undefined`,
+      expect: 'undefined'
+    }
+  )),
   {
     send: '(function() {\n\nreturn 1;\n})()',
     expect: '... ... ... 1'

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -141,6 +141,17 @@ const possibleTokensAfterIdentifier = [
   '? 1: 1',
 ];
 
+const possibleTokensAfterIdentifierWithLineBreak = [
+  '(\n)',
+  '[\n0]',
+  '+\n1', '- \n1', '* \n1', '/ \n1', '% \n1', '** \n1',
+  '== \n1', '=== \n1', '!= \n1', '!== \n1', '< \n1', '> \n1', '<= \n1', '>= \n1',
+  '&& \n1', '|| \n1', '?? \n1',
+  '= \n1', '+= \n1', '-= \n1', '*= \n1', '/= \n1', '%= \n1',
+  ': \n',
+  '? \n1: 1',
+] 
+
 const errorTests = [
   // Uncaught error throws and prints out
   {
@@ -406,6 +417,16 @@ const errorTests = [
     {
       send: `npm ${token}; undefined`,
       expect: 'undefined'
+    }
+  )),
+  {
+    send: 'npm = () => {};',
+    expect: '[Function: npm]'
+  },
+  ...possibleTokensAfterIdentifierWithLineBreak.map((token) => (
+    {
+      send: `npm ${token}; undefined`,
+      expect: '... undefined'
     }
   )),
   {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -138,7 +138,7 @@ const possibleTokensAfterIdentifierWithLineBreak = [
   '= \n1', '+= \n1', '-= \n1', '*= \n1', '/= \n1', '%= \n1',
   ': \n',
   '? \n1: 1',
-] 
+];
 
 const errorTests = [
   // Uncaught error throws and prints out


### PR DESCRIPTION
This change ensures that 'npm' within JavaScript code is not mistakenly interpreted as an npm command when the error is recoverable. This allows 'npm' to be treated as expected in such scenarios.

Fixes: https://github.com/nodejs/node/issues/54830

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
