### PR TITLE
lib: move `Symbol[Async]Dispose` polyfills to `internal/util`

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -29,7 +29,6 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   Symbol,
-  SymbolAsyncDispose,
   SymbolFor,
 } = primordials;
 
@@ -82,6 +81,7 @@ const {
 const {
   kEmptyObject,
   promisify,
+  SymbolAsyncDispose,
 } = require('internal/util');
 const {
   validateInteger,

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -42,7 +42,6 @@ const {
   StringPrototypeIncludes,
   StringPrototypeSlice,
   StringPrototypeToUpperCase,
-  SymbolDispose,
 } = primordials;
 
 const {
@@ -51,6 +50,7 @@ const {
   getSystemErrorName,
   kEmptyObject,
   promisify,
+  SymbolDispose,
 } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 let debug = require('internal/util/debuglog').debuglog(

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -30,8 +30,6 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   ReflectApply,
-  SymbolAsyncDispose,
-  SymbolDispose,
 } = primordials;
 
 const {
@@ -63,7 +61,7 @@ const {
   validatePort,
 } = require('internal/validators');
 const { Buffer } = require('buffer');
-const { deprecate, guessHandleType, promisify } = require('internal/util');
+const { deprecate, guessHandleType, promisify, SymbolAsyncDispose, SymbolDispose } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const EventEmitter = require('events');
 const { addAbortListener } = require('internal/events/abort_listener');

--- a/lib/events.js
+++ b/lib/events.js
@@ -47,12 +47,11 @@ const {
   StringPrototypeSplit,
   Symbol,
   SymbolAsyncIterator,
-  SymbolDispose,
   SymbolFor,
 } = primordials;
 const kRejection = SymbolFor('nodejs.rejection');
 
-const { kEmptyObject } = require('internal/util');
+const { SymbolDispose, kEmptyObject } = require('internal/util');
 
 const {
   inspect,

--- a/lib/https.js
+++ b/lib/https.js
@@ -33,13 +33,13 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   ReflectConstruct,
-  SymbolAsyncDispose,
 } = primordials;
 
 const {
   assertCrypto,
   kEmptyObject,
   promisify,
+  SymbolAsyncDispose,
 } = require('internal/util');
 assertCrypto();
 

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -4,8 +4,11 @@ const {
   JSONParse,
   JSONStringify,
   SafeMap,
-  SymbolDispose,
 } = primordials;
+
+const {
+  SymbolDispose,
+} = require('internal/util');
 
 const {
   ERR_INSPECTOR_ALREADY_ACTIVATED,

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -12,7 +12,6 @@ const {
   ReflectApply,
   StringPrototypeSlice,
   Symbol,
-  SymbolDispose,
   Uint8Array,
 } = primordials;
 
@@ -56,7 +55,7 @@ const { TTY } = internalBinding('tty_wrap');
 const { UDP } = internalBinding('udp_wrap');
 const SocketList = require('internal/socket_list');
 const { owner_symbol } = require('internal/async_hooks').symbols;
-const { convertToValidSignal, deprecate } = require('internal/util');
+const { convertToValidSignal, deprecate, SymbolDispose } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');

--- a/lib/internal/events/abort_listener.js
+++ b/lib/internal/events/abort_listener.js
@@ -2,7 +2,7 @@
 
 const {
   SymbolDispose,
-} = primordials;
+} = require('internal/util');
 const {
   validateAbortSignal,
   validateFunction,

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -15,7 +15,6 @@ const {
   SafeArrayIterator,
   SafePromisePrototypeFinally,
   Symbol,
-  SymbolAsyncDispose,
   Uint8Array,
   uncurryThis,
 } = primordials;
@@ -100,6 +99,7 @@ const {
   promisify,
   isWindows,
   isMacOS,
+  SymbolAsyncDispose,
 } = require('internal/util');
 const EventEmitter = require('events');
 const { StringDecoder } = require('string_decoder');

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -19,8 +19,6 @@ const {
   SafeMap,
   SafeSet,
   Symbol,
-  SymbolAsyncDispose,
-  SymbolDispose,
   Uint32Array,
   Uint8Array,
 } = primordials;
@@ -30,6 +28,8 @@ const {
   customInspectSymbol: kInspect,
   kEmptyObject,
   promisify,
+  SymbolAsyncDispose,
+  SymbolDispose,
 } = require('internal/util');
 
 assertCrypto();

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -229,11 +229,6 @@ function copyPrototype(src, dest, prefix) {
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
 });
 
-// Define Symbol.dispose and Symbol.asyncDispose
-// Until these are defined by the environment.
-// TODO(MoLow): Remove this polyfill once Symbol.dispose and Symbol.asyncDispose are available in V8.
-primordials.SymbolDispose ??= primordials.SymbolFor('nodejs.dispose');
-primordials.SymbolAsyncDispose ??= primordials.SymbolFor('nodejs.asyncDispose');
 
 // Create copies of intrinsic objects that require a valid `this` to call
 // static methods.

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -15,8 +15,6 @@ const {
   String,
   StringPrototypeStartsWith,
   Symbol,
-  SymbolAsyncDispose,
-  SymbolDispose,
   globalThis,
 } = primordials;
 
@@ -31,6 +29,8 @@ const {
   defineReplaceableLazyAttribute,
   setupCoverageHooks,
   emitExperimentalWarning,
+  SymbolAsyncDispose,
+  SymbolDispose,
 } = require('internal/util');
 
 const {

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -30,7 +30,6 @@ const {
   StringPrototypeTrim,
   Symbol,
   SymbolAsyncIterator,
-  SymbolDispose,
 } = primordials;
 
 const { codes: {
@@ -45,7 +44,7 @@ const {
   validateString,
   validateUint32,
 } = require('internal/validators');
-const { kEmptyObject } = require('internal/util');
+const { SymbolDispose, kEmptyObject } = require('internal/util');
 const {
   inspect,
   getStringWidth,

--- a/lib/internal/streams/add-abort-signal.js
+++ b/lib/internal/streams/add-abort-signal.js
@@ -2,7 +2,7 @@
 
 const {
   SymbolDispose,
-} = primordials;
+} = require('internal/util');
 
 const {
   AbortError,

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -6,7 +6,6 @@
 const {
   Promise,
   PromisePrototypeThen,
-  SymbolDispose,
 } = primordials;
 
 const {
@@ -19,6 +18,7 @@ const {
 const {
   kEmptyObject,
   once,
+  SymbolDispose,
 } = require('internal/util');
 const {
   validateAbortSignal,

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -7,11 +7,10 @@ const {
   ArrayIsArray,
   Promise,
   SymbolAsyncIterator,
-  SymbolDispose,
 } = primordials;
 
 const eos = require('internal/streams/end-of-stream');
-const { once } = require('internal/util');
+const { SymbolDispose, once } = require('internal/util');
 const destroyImpl = require('internal/streams/destroy');
 const Duplex = require('internal/streams/duplex');
 const {

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -32,7 +32,6 @@ const {
   Promise,
   SafeSet,
   Symbol,
-  SymbolAsyncDispose,
   SymbolAsyncIterator,
   SymbolSpecies,
   TypedArrayPrototypeSet,
@@ -44,6 +43,9 @@ Readable.ReadableState = ReadableState;
 const EE = require('events');
 const { Stream, prependListener } = require('internal/streams/legacy');
 const { Buffer } = require('buffer');
+const {
+  SymbolAsyncDispose,
+} = require('internal/util');
 
 const {
   addAbortSignal,

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -35,7 +35,6 @@ const {
   Promise,
   StringPrototypeToLowerCase,
   Symbol,
-  SymbolAsyncDispose,
   SymbolHasInstance,
 } = primordials;
 
@@ -47,6 +46,9 @@ const Stream = require('internal/streams/legacy').Stream;
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
 const eos = require('internal/streams/end-of-stream');
+const {
+  SymbolAsyncDispose,
+} = require('internal/util');
 
 const {
   addAbortSignal,

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -17,7 +17,6 @@ const {
   Promise,
   Symbol,
   SymbolAsyncIterator,
-  SymbolDispose,
   globalThis,
 } = primordials;
 
@@ -29,6 +28,7 @@ const {
 
 const {
   emitExperimentalWarning,
+  SymbolDispose,
 } = require('internal/util');
 const {
   AbortError,

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -26,7 +26,6 @@ const {
   StringPrototypeStartsWith,
   StringPrototypeTrim,
   Symbol,
-  SymbolDispose,
 } = primordials;
 const { getCallerLocation } = internalBinding('util');
 const { exitCodes: { kGenericUserError } } = internalBinding('errors');
@@ -52,6 +51,7 @@ const {
   createDeferredPromise,
   kEmptyObject,
   once: runOnce,
+  SymbolDispose,
 } = require('internal/util');
 const { isPromise } = require('internal/util/types');
 const {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -936,6 +936,14 @@ module.exports = {
   setupCoverageHooks,
   removeColors,
 
+  // Define Symbol.dispose and Symbol.asyncDispose
+  // Until these are defined by the environment.
+  // TODO(MoLow): Remove this polyfill once Symbol.dispose and Symbol.asyncDispose are available in primordials.
+  // eslint-disable-next-line node-core/prefer-primordials
+  SymbolDispose: Symbol.dispose || SymbolFor('nodejs.dispose'),
+  // eslint-disable-next-line node-core/prefer-primordials
+  SymbolAsyncDispose: Symbol.asyncDispose || SymbolFor('nodejs.asyncDispose'),
+
   // Symbol used to customize promisify conversion
   customPromisifyArgs: kCustomPromisifyArgsSymbol,
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -20,7 +20,6 @@ const {
   SafePromiseAll,
   Symbol,
   SymbolAsyncIterator,
-  SymbolDispose,
   SymbolToStringTag,
   TypedArrayPrototypeGetLength,
   Uint8Array,
@@ -54,6 +53,7 @@ const {
   kEmptyObject,
   kEnumerableProperty,
   SideEffectFreeRegExpPrototypeSymbolReplace,
+  SymbolDispose,
 } = require('internal/util');
 
 const {

--- a/lib/net.js
+++ b/lib/net.js
@@ -36,8 +36,6 @@ const {
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
   Symbol,
-  SymbolAsyncDispose,
-  SymbolDispose,
 } = primordials;
 
 const EventEmitter = require('events');
@@ -116,7 +114,14 @@ const {
 } = require('internal/errors');
 const { isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
-const { kEmptyObject, guessHandleType, promisify, isWindows } = require('internal/util');
+const {
+  guessHandleType,
+  isWindows,
+  kEmptyObject,
+  promisify,
+  SymbolAsyncDispose,
+  SymbolDispose,
+} = require('internal/util');
 const {
   validateAbortSignal,
   validateBoolean,

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -30,7 +30,6 @@ const {
   Promise,
   PromiseReject,
   StringPrototypeSlice,
-  SymbolDispose,
 } = primordials;
 
 const {
@@ -51,6 +50,7 @@ const {
 const {
   kEmptyObject,
   promisify,
+  SymbolDispose,
 } = require('internal/util');
 const { validateAbortSignal } = require('internal/validators');
 

--- a/lib/readline/promises.js
+++ b/lib/readline/promises.js
@@ -2,7 +2,6 @@
 
 const {
   Promise,
-  SymbolDispose,
 } = primordials;
 
 const {
@@ -22,6 +21,7 @@ const { validateAbortSignal } = require('internal/validators');
 
 const {
   kEmptyObject,
+  SymbolDispose,
 } = require('internal/util');
 let addAbortListener;
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -25,7 +25,6 @@ const {
   MathTrunc,
   ObjectDefineProperties,
   ObjectDefineProperty,
-  SymbolDispose,
   SymbolToPrimitive,
 } = primordials;
 
@@ -57,6 +56,7 @@ const {
 const {
   promisify: { custom: customPromisify },
   deprecate,
+  SymbolDispose,
 } = require('internal/util');
 let debug = require('internal/util/debuglog').debuglog('timer', (fn) => {
   debug = fn;

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -429,8 +429,6 @@ declare namespace primordials {
   export const SymbolFor: typeof Symbol.for
   export const SymbolKeyFor: typeof Symbol.keyFor
   export const SymbolAsyncIterator: typeof Symbol.asyncIterator
-  export const SymbolDispose: typeof Symbol.dispose
-  export const SymbolAsyncDispose: typeof Symbol.asyncDispose
   export const SymbolHasInstance: typeof Symbol.hasInstance
   export const SymbolIsConcatSpreadable: typeof Symbol.isConcatSpreadable
   export const SymbolIterator: typeof Symbol.iterator


### PR DESCRIPTION
We can use it from primordials when the ad-hoc V8 flag will have been removed upstream: https://github.com/nodejs/node/blob/9404d3aaaf0a8264ee08ba169ec24685bf8d487d/deps/v8/src/flags/flag-definitions.h#L278

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
