### PR TITLE
test_runner: improve code coverage cleanup

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -23,6 +23,7 @@ const {
   mkdtempSync,
   opendirSync,
   readFileSync,
+  rmSync,
 } = require('fs');
 const { setupCoverageHooks } = require('internal/util');
 const { tmpdir } = require('os');
@@ -272,27 +273,34 @@ class TestCoverage {
   cleanup() {
     // Restore the original value of process.env.NODE_V8_COVERAGE. Then, copy
     // all of the created coverage files to the original coverage directory.
+    internalBinding('profiler').endCoverage();
+
     if (this.originalCoverageDirectory === undefined) {
       delete process.env.NODE_V8_COVERAGE;
-      return;
+    } else {
+      process.env.NODE_V8_COVERAGE = this.originalCoverageDirectory;
+      let dir;
+
+      try {
+        mkdirSync(this.originalCoverageDirectory, { __proto__: null, recursive: true });
+        dir = opendirSync(this.coverageDirectory);
+
+        for (let entry; (entry = dir.readSync()) !== null;) {
+          const src = join(this.coverageDirectory, entry.name);
+          const dst = join(this.originalCoverageDirectory, entry.name);
+          copyFileSync(src, dst);
+        }
+      } finally {
+        if (dir) {
+          dir.closeSync();
+        }
+      }
     }
 
-    process.env.NODE_V8_COVERAGE = this.originalCoverageDirectory;
-    let dir;
-
     try {
-      mkdirSync(this.originalCoverageDirectory, { __proto__: null, recursive: true });
-      dir = opendirSync(this.coverageDirectory);
-
-      for (let entry; (entry = dir.readSync()) !== null;) {
-        const src = join(this.coverageDirectory, entry.name);
-        const dst = join(this.originalCoverageDirectory, entry.name);
-        copyFileSync(src, dst);
-      }
-    } finally {
-      if (dir) {
-        dir.closeSync();
-      }
+      rmSync(this.coverageDirectory, { __proto__: null, recursive: true });
+    } catch {
+      // Ignore cleanup errors.
     }
   }
 

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -159,12 +159,15 @@ function collectCoverage(rootTest, coverage) {
 
   try {
     summary = coverage.summary();
+  } catch (err) {
+    rootTest.diagnostic(`Warning: Could not report code coverage. ${err}`);
+    process.exitCode = kGenericUserError;
+  }
+
+  try {
     coverage.cleanup();
   } catch (err) {
-    const op = summary ? 'clean up' : 'report';
-    const msg = `Warning: Could not ${op} code coverage. ${err}`;
-
-    rootTest.diagnostic(msg);
+    rootTest.diagnostic(`Warning: Could not clean up code coverage. ${err}`);
     process.exitCode = kGenericUserError;
   }
 

--- a/src/inspector_profiler.cc
+++ b/src/inspector_profiler.cc
@@ -556,6 +556,21 @@ static void StopCoverage(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+static void EndCoverage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  V8CoverageConnection* connection = env->coverage_connection();
+
+  Debug(env,
+        DebugCategory::INSPECTOR_PROFILER,
+        "EndCoverage, connection %s nullptr\n",
+        connection == nullptr ? "==" : "!=");
+
+  if (connection != nullptr) {
+    Debug(env, DebugCategory::INSPECTOR_PROFILER, "Ending coverage\n");
+    connection->End();
+  }
+}
+
 static void Initialize(Local<Object> target,
                        Local<Value> unused,
                        Local<Context> context,
@@ -565,6 +580,7 @@ static void Initialize(Local<Object> target,
       context, target, "setSourceMapCacheGetter", SetSourceMapCacheGetter);
   SetMethod(context, target, "takeCoverage", TakeCoverage);
   SetMethod(context, target, "stopCoverage", StopCoverage);
+  SetMethod(context, target, "endCoverage", EndCoverage);
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
@@ -572,6 +588,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetSourceMapCacheGetter);
   registry->Register(TakeCoverage);
   registry->Register(StopCoverage);
+  registry->Register(EndCoverage);
 }
 
 }  // namespace profiler


### PR DESCRIPTION
The test runner's code coverage leaves old coverage data in the temp directory. This commit updates the cleanup logic to:

- Stop code collection. Otherwise V8 would write collection data again when the process exits.
- Remove the temp directory containing the coverage data.
- Attempt to clean up the coverage data even if parsing the data resulted in an error.

With this change, I no longer see any coverage data left behind in the system temp directory.

Refs: https://github.com/nodejs/build/issues/3864
Refs: https://github.com/nodejs/build/issues/3887

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
