### PR TITLE
net: defer self.destroy calls to nextTick

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1053,7 +1053,7 @@ function internalConnect(
     err = checkBindError(err, localPort, self._handle);
     if (err) {
       const ex = new ExceptionWithHostPort(err, 'bind', localAddress, localPort);
-      self.destroy(ex);
+      process.nextTick(() => self.destroy(ex));
       return;
     }
   }
@@ -1091,7 +1091,7 @@ function internalConnect(
     }
 
     const ex = new ExceptionWithHostPort(err, 'connect', address, port, details);
-    self.destroy(ex);
+    process.nextTick(() => self.destroy(ex));
   } else if ((addressType === 6 || addressType === 4) && hasObserver('net')) {
     startPerf(self, kPerfHooksNetConnectContext, { type: 'net', name: 'connect', detail: { host: address, port } });
   }
@@ -1110,11 +1110,11 @@ function internalConnectMultiple(context, canceled) {
   // All connections have been tried without success, destroy with error
   if (canceled || context.current === context.addresses.length) {
     if (context.errors.length === 0) {
-      self.destroy(new ERR_SOCKET_CONNECTION_TIMEOUT());
+      process.nextTick(() => self.destroy(new ERR_SOCKET_CONNECTION_TIMEOUT()));
       return;
     }
 
-    self.destroy(new NodeAggregateError(context.errors));
+    process.nextTick(() => self.destroy(new NodeAggregateError(context.errors)));
     return;
   }
 

--- a/test/parallel/test-http-client-immediate-error.js
+++ b/test/parallel/test-http-client-immediate-error.js
@@ -9,36 +9,95 @@ const assert = require('assert');
 const net = require('net');
 const http = require('http');
 const { internalBinding } = require('internal/test/binding');
-const { UV_ENETUNREACH } = internalBinding('uv');
+const { UV_ENETUNREACH, UV_EADDRINUSE } = internalBinding('uv');
 const {
   newAsyncId,
   symbols: { async_id_symbol }
 } = require('internal/async_hooks');
 
-const agent = new http.Agent();
-agent.createConnection = common.mustCall((cfg) => {
-  const sock = new net.Socket();
+const config = {
+  host: 'http://example.com',
+  // We need to specify 'family' in both items of the array so 'internalConnectMultiple' is invoked
+  connectMultiple: [{ address: '192.4.4.4', family: 4 }, { address: '200::1', family: 6 }],
+  connectSolo: { address: '192.4.4.4', family: 4 },
+};
 
-  // Fake the handle so we can enforce returning an immediate error
-  sock._handle = {
-    connect: common.mustCall((req, addr, port) => {
-      return UV_ENETUNREACH;
-    }),
-    readStart() {},
-    close() {}
-  };
+function agentFactory(handle, count) {
+  const agent = new http.Agent();
+  agent.createConnection = common.mustCall((cfg) => {
+    const sock = new net.Socket();
 
-  // Simulate just enough socket handle initialization
-  sock[async_id_symbol] = newAsyncId();
+    // Fake the handle so we can enforce returning an immediate error
+    sock._handle = handle;
 
-  sock.connect(cfg);
-  return sock;
-});
+    // Simulate just enough socket handle initialization
+    sock[async_id_symbol] = newAsyncId();
+
+    sock.connect(cfg);
+    return sock;
+  }, count);
+
+  return agent;
+};
+
+const handleWithoutBind = {
+  connect: common.mustCall((req, addr, port) => {
+    return UV_ENETUNREACH;
+  }, 3), // Because two tests will use this
+  readStart() { },
+  close() { },
+};
+
+const handleWithBind = {
+  readStart() { },
+  close() { },
+  bind: common.mustCall(() => UV_EADDRINUSE, 2), // Because two tests will use this handle
+};
+
+const agentWithoutBind = agentFactory(handleWithoutBind, 3);
+const agentWithBind = agentFactory(handleWithBind, 2);
 
 http.get({
   host: '127.0.0.1',
   port: 1,
-  agent
+  agent: agentWithoutBind,
 }).on('error', common.mustCall((err) => {
   assert.strictEqual(err.code, 'ENETUNREACH');
+}));
+
+http.request(config.host, {
+  agent: agentWithoutBind,
+  lookup(_0, _1, cb) {
+    cb(null, config.connectMultiple);
+  },
+}).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ENETUNREACH');
+}));
+
+http.request(config.host, {
+  agent: agentWithoutBind,
+  lookup(_0, _1, cb) {
+    cb(null, config.connectSolo.address, config.connectSolo.family);
+  },
+  family: 4,
+}).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ENETUNREACH');
+}));
+
+http.request(config.host, {
+  agent: agentWithBind,
+  family: 4, // We specify 'family' so 'internalConnect' is invoked
+  localPort: 2222 // Required to trigger _handle.bind()
+}).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'EADDRINUSE');
+}));
+
+http.request(config.host, {
+  agent: agentWithBind,
+  lookup(_0, _1, cb) {
+    cb(null, config.connectMultiple);
+  },
+  localPort: 2222, // Required to trigger _handle.bind()
+}).on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'EADDRINUSE');
 }));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/48771

## What is the problem being solved?
#48771 Reported `request` object returned from `http.request` method cannot catch `error` events triggered when there’s an immediate failure trying to connect to an address returned from dns lookup.

## Solution
#51038 implemented changes suggested in https://github.com/nodejs/node/issues/48771#issuecomment-1661858958. However the #51038 couldn’t be merged due to lack of tests(https://github.com/nodejs/node/pull/51038#pullrequestreview-1761719500). In this PR, I apply the same fix but with some tests.

## Testing Considerations
All `process.nextTick(() => self.destroy())` are hit except one. Below is the `self.destroy()` call that is not hit in these tests provided:
https://github.com/nodejs/node/blob/9404d3aaaf0a8264ee08ba169ec24685bf8d487d/lib/net.js#L1113

I am not tagging this PR as "DRAFT" since the piece of code that isn't tested is for a connection timeout case.

@mcollina Please let me know if these tests are sufficient or not.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
