### PR TITLE
http: reduce likelihood of race conditions on keep-alive timeout

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -49,6 +49,9 @@ const {
 const kOnKeylog = Symbol('onkeylog');
 const kRequestOptions = Symbol('requestOptions');
 const kRequestAsyncResource = Symbol('requestAsyncResource');
+
+// TODO(jazelly): make this configurable
+const HTTP_AGENT_KEEP_ALIVE_TIMEOUT_BUFFER = 1000;
 // New Agent code.
 
 // The largest departure from the previous implementation is that
@@ -473,6 +476,7 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
   socket.unref();
 
   let agentTimeout = this.options.timeout || 0;
+  let canKeepSocketAlive = true;
 
   if (socket._httpMessage?.res) {
     const keepAliveHint = socket._httpMessage.res.headers['keep-alive'];
@@ -481,9 +485,15 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
       const hint = /^timeout=(\d+)/.exec(keepAliveHint)?.[1];
 
       if (hint) {
-        const serverHintTimeout = NumberParseInt(hint) * 1000;
-
-        if (serverHintTimeout < agentTimeout) {
+        // Let the timer expire before the announced timeout to reduce
+        // the likelihood of ECONNRESET errors
+        let serverHintTimeout = (NumberParseInt(hint) * 1000) - HTTP_AGENT_KEEP_ALIVE_TIMEOUT_BUFFER;
+        serverHintTimeout = serverHintTimeout > 0 ? serverHintTimeout : 0;
+        if (serverHintTimeout === 0) {
+          // Cannot safely reuse the socket because the server timeout is
+          // too short
+          canKeepSocketAlive = false;
+        } else if (serverHintTimeout < agentTimeout) {
           agentTimeout = serverHintTimeout;
         }
       }
@@ -494,7 +504,7 @@ Agent.prototype.keepSocketAlive = function keepSocketAlive(socket) {
     socket.setTimeout(agentTimeout);
   }
 
-  return true;
+  return canKeepSocketAlive;
 };
 
 Agent.prototype.reuseSocket = function reuseSocket(socket, req) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -182,6 +182,8 @@ const kConnections = Symbol('http.server.connections');
 const kConnectionsCheckingInterval = Symbol('http.server.connectionsCheckingInterval');
 
 const HTTP_SERVER_TRACE_EVENT_NAME = 'http.server.request';
+// TODO(jazelly): make this configurable
+const HTTP_SERVER_KEEP_ALIVE_TIMEOUT_BUFFER = 1000;
 
 class HTTPServerAsyncResource {
   constructor(type, socket) {
@@ -1007,7 +1009,9 @@ function resOnFinish(req, res, socket, state, server) {
     }
   } else if (state.outgoing.length === 0) {
     if (server.keepAliveTimeout && typeof socket.setTimeout === 'function') {
-      socket.setTimeout(server.keepAliveTimeout);
+      // Increase the internal timeout wrt the advertised value to reduce
+      // the likelihood of ECONNRESET errors.
+      socket.setTimeout(server.keepAliveTimeout + HTTP_SERVER_KEEP_ALIVE_TIMEOUT_BUFFER);
       state.keepAliveTimeoutSet = true;
     }
   } else {

--- a/test/parallel/test-http-keep-alive-timeout-race-condition.js
+++ b/test/parallel/test-http-keep-alive-timeout-race-condition.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const common = require('../common');
+const http = require('http');
+
+const makeRequest = (port, agent) =>
+  new Promise((resolve, reject) => {
+    const req = http.get(
+      { path: '/', port, agent },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve());
+      },
+    );
+    req.on('error', (e) => reject(e));
+    req.end();
+  });
+
+const server = http.createServer(
+  { keepAliveTimeout: common.platformTimeout(2000), keepAlive: true },
+  common.mustCall((req, res) => {
+    const body = 'hello world\n';
+    res.writeHead(200, { 'Content-Length': body.length });
+    res.write(body);
+    res.end();
+  }, 2)
+);
+
+const agent = new http.Agent({ maxSockets: 5, keepAlive: true });
+
+server.listen(0, common.mustCall(async function() {
+  await makeRequest(this.address().port, agent);
+  // Block the event loop for 2 seconds
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2000);
+  await makeRequest(this.address().port, agent);
+  server.close();
+  agent.destroy();
+}));


### PR DESCRIPTION
This is the continued work from https://github.com/nodejs/node/pull/52653 to fix many similar issues when request is near socket `keepAliveTimeout` threshold. Added 1 second internal timeout to account for network latency for both server and client side.

Fixes: https://github.com/nodejs/node/issues/52649
Refs: https://github.com/nodejs/node/issues/54293

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
