### PR TITLE
src: simplify string_bytes with views

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -248,6 +248,7 @@ size_t StringBytes::Write(Isolate* isolate,
 
   CHECK(val->IsString() == true);
   Local<String> str = val.As<String>();
+  String::ValueView input_view(isolate, str);
 
   int flags = String::HINT_MANY_WRITES_EXPECTED |
               String::NO_NULL_TERMINATION |
@@ -256,10 +257,9 @@ size_t StringBytes::Write(Isolate* isolate,
   switch (encoding) {
     case ASCII:
     case LATIN1:
-      if (str->IsExternalOneByte()) {
-        auto ext = str->GetExternalOneByteStringResource();
-        nbytes = std::min(buflen, ext->length());
-        memcpy(buf, ext->data(), nbytes);
+      if (input_view.is_one_byte()) {
+        nbytes = std::min(buflen, static_cast<size_t>(input_view.length()));
+        memcpy(buf, input_view.data8(), nbytes);
       } else {
         uint8_t* const dst = reinterpret_cast<uint8_t*>(buf);
         nbytes = str->WriteOneByte(isolate, dst, 0, buflen, flags);
@@ -284,31 +284,11 @@ size_t StringBytes::Write(Isolate* isolate,
     }
 
     case BASE64URL:
-      if (str->IsExternalOneByte()) {  // 8-bit case
-        auto ext = str->GetExternalOneByteStringResource();
+      if (input_view.is_one_byte()) {  // 8-bit case
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            ext->data(), ext->length(), buf, written_len, simdutf::base64_url);
-        if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = written_len;
-        } else {
-          // The input does not follow the WHATWG forgiving-base64 specification
-          // adapted for base64url
-          // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, ext->data(), ext->length());
-        }
-      } else if (str->IsOneByte()) {
-        MaybeStackBuffer<uint8_t> stack_buf(str->Length());
-        str->WriteOneByte(isolate,
-                          stack_buf.out(),
-                          0,
-                          str->Length(),
-                          String::NO_NULL_TERMINATION);
-        size_t written_len = buflen;
-        auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char*>(*stack_buf),
-            stack_buf.length(),
+            reinterpret_cast<const char*>(input_view.data8()),
+            input_view.length(),
             buf,
             written_len,
             simdutf::base64_url);
@@ -316,10 +296,13 @@ size_t StringBytes::Write(Isolate* isolate,
           nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
-          // (adapted for base64url with + and / replaced by - and _).
+          // adapted for base64url
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, *stack_buf, stack_buf.length());
+          nbytes = nbytes::Base64Decode(
+              buf,
+              buflen,
+              reinterpret_cast<const char*>(input_view.data8()),
+              input_view.length());
         }
       } else {
         String::Value value(isolate, str);
@@ -342,40 +325,23 @@ size_t StringBytes::Write(Isolate* isolate,
       break;
 
     case BASE64: {
-      if (str->IsExternalOneByte()) {  // 8-bit case
-        auto ext = str->GetExternalOneByteStringResource();
+      if (input_view.is_one_byte()) {  // 8-bit case
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            ext->data(), ext->length(), buf, written_len);
-        if (result.error == simdutf::error_code::SUCCESS) {
-          nbytes = written_len;
-        } else {
-          // The input does not follow the WHATWG forgiving-base64 specification
-          // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, ext->data(), ext->length());
-        }
-      } else if (str->IsOneByte()) {
-        MaybeStackBuffer<uint8_t> stack_buf(str->Length());
-        str->WriteOneByte(isolate,
-                          stack_buf.out(),
-                          0,
-                          str->Length(),
-                          String::NO_NULL_TERMINATION);
-        size_t written_len = buflen;
-        auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char*>(*stack_buf),
-            stack_buf.length(),
+            reinterpret_cast<const char*>(input_view.data8()),
+            input_view.length(),
             buf,
             written_len);
         if (result.error == simdutf::error_code::SUCCESS) {
           nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
-          // (adapted for base64url with + and / replaced by - and _).
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, *stack_buf, stack_buf.length());
+          nbytes = nbytes::Base64Decode(
+              buf,
+              buflen,
+              reinterpret_cast<const char*>(input_view.data8()),
+              input_view.length());
         }
       } else {
         String::Value value(isolate, str);
@@ -396,9 +362,12 @@ size_t StringBytes::Write(Isolate* isolate,
       break;
     }
     case HEX:
-      if (str->IsExternalOneByte()) {
-        auto ext = str->GetExternalOneByteStringResource();
-        nbytes = nbytes::HexDecode(buf, buflen, ext->data(), ext->length());
+      if (input_view.is_one_byte()) {
+        nbytes =
+            nbytes::HexDecode(buf,
+                              buflen,
+                              reinterpret_cast<const char*>(input_view.data8()),
+                              input_view.length());
       } else {
         String::Value value(isolate, str);
         nbytes = nbytes::HexDecode(buf, buflen, *value, value.length());

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -296,7 +296,7 @@ size_t StringBytes::Write(Isolate* isolate,
           nbytes = written_len;
         } else {
           // The input does not follow the WHATWG forgiving-base64 specification
-          // adapted for base64url
+          // (adapted for base64url with + and / replaced by - and _).
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
           nbytes = nbytes::Base64Decode(
               buf,


### PR DESCRIPTION
This PR adopts the new string views for latin1/base64/hex encoding/decoding. It should avoid unnecessary copies when the string is not external.


Compared to node 22:

```
                                                                               confidence improvement   accuracy (*)           (**)          (***)
buffers/buffer-base64-decode-wrapped.js n=32 linesCount=524288 charsPerLine=76        ***    183.12 %  14.24%  15.70%  17.51%
buffers/buffer-base64-decode.js size=8388608 n=32                                     ***    281.40 %  15.47%  17.32%  19.59%
buffers/buffer-base64-encode.js n=32 len=67108864                                              2.75 %  17.37%  19.81% 112.76%
buffers/buffer-base64url-decode.js size=8388608 n=32                                  ***    287.36 % 119.32% 125.94% 134.24%
buffers/buffer-base64url-encode.js n=32 len=67108864                                    *     -8.55 %  17.66% 110.19% 113.26%
```