### PR TITLE
[v22.x] deps: V8: cherry-pick 217457d0a560

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/set-difference.tq
+++ b/deps/v8/src/builtins/set-difference.tq
@@ -85,7 +85,8 @@ transitioning javascript builtin SetPrototypeDifference(
     }
   } label SlowPath {
     // 6. If thisSize ≤ otherRec.[[Size]], then
-    if (thisSize <= Convert<int32>(otherRec.size)) {
+    if (otherRec.size == V8_INFINITY ||
+        thisSize <= Convert<int32>(otherRec.size)) {
       // a. Let index be 0.
       let thisIter = collections::NewOrderedHashSetIterator(table.GetTable());
 

--- a/deps/v8/src/builtins/set-intersection.tq
+++ b/deps/v8/src/builtins/set-intersection.tq
@@ -81,7 +81,8 @@ transitioning javascript builtin SetPrototypeIntersection(
     }
   } label SlowPath {
     // 6. If thisSize ≤ otherRec.[[Size]], then
-    if (thisSize <= Convert<int32>(otherRec.size)) {
+    if (otherRec.size == V8_INFINITY ||
+        thisSize <= Convert<int32>(otherRec.size)) {
       // a. Let index be 0.
       let thisIter = collections::NewOrderedHashSetIterator(table.GetTable());
 

--- a/deps/v8/src/builtins/set-is-disjoint-from.tq
+++ b/deps/v8/src/builtins/set-is-disjoint-from.tq
@@ -73,7 +73,8 @@ transitioning javascript builtin SetPrototypeIsDisjointFrom(
     }
   } label SlowPath {
     // 5. If thisSize ≤ otherRec.[[Size]], then
-    if (thisSize <= Convert<int32>(otherRec.size)) {
+    if (otherRec.size == V8_INFINITY ||
+        thisSize <= Convert<int32>(otherRec.size)) {
       // a. Let index be 0.
       let thisIter = collections::NewOrderedHashSetIterator(table.GetTable());
 

--- a/deps/v8/src/builtins/set-is-subset-of.tq
+++ b/deps/v8/src/builtins/set-is-subset-of.tq
@@ -25,7 +25,8 @@ transitioning javascript builtin SetPrototypeIsSubsetOf(
   const thisSize = table.LoadSize();
 
   // 5. If thisSize > otherRec.[[Size]], return false.
-  if (thisSize > Convert<int32>(otherRec.size)) {
+  if (!(otherRec.size == V8_INFINITY) &&
+      thisSize > Convert<int32>(otherRec.size)) {
     return False;
   }
 

--- a/deps/v8/src/builtins/set-is-superset-of.tq
+++ b/deps/v8/src/builtins/set-is-superset-of.tq
@@ -26,7 +26,8 @@ transitioning javascript builtin SetPrototypeIsSupersetOf(
   const thisSize = table.LoadSize();
 
   // 5. If thisSize < otherRec.[[Size]], return false.
-  if (thisSize < Convert<int32>(otherRec.size)) {
+  if (otherRec.size == V8_INFINITY ||
+      thisSize < Convert<int32>(otherRec.size)) {
     return False;
   }
 

--- a/deps/v8/test/mjsunit/harmony/set-difference.js
+++ b/deps/v8/test/mjsunit/harmony/set-difference.js
@@ -305,4 +305,43 @@
   assertThrows(() => {
     new Set().difference(setLike);
   }, RangeError, "'-1' is an invalid size");
-})()
+})();
+
+(function TestDifferenceSetLikeWithInfiniteSize() {
+  let setLike = {
+    size: Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  const firstSet = new Set();
+  firstSet.add(42);
+  firstSet.add(43);
+
+  const resultSet = new Set();
+
+  const resultArray = Array.from(resultSet);
+  const differenceArray = Array.from(firstSet.difference(setLike));
+
+  assertEquals(resultArray, differenceArray);
+})();
+
+(function TestDifferenceSetLikeWithNegativeInfiniteSize() {
+  let setLike = {
+    size: -Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  assertThrows(() => {
+    new Set().difference(setLike);
+  }, RangeError, '\'-Infinity\' is an invalid size');
+})();

--- a/deps/v8/test/mjsunit/harmony/set-intersection.js
+++ b/deps/v8/test/mjsunit/harmony/set-intersection.js
@@ -281,3 +281,40 @@
 
   assertEquals([43], Array.from(firstSet.intersection(evil)));
 })();
+
+(function TestIntersectionSetLikeWithInfiniteSize() {
+  let setLike = {
+    size: Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  const firstSet = new Set();
+  firstSet.add(42);
+  firstSet.add(43);
+
+  const resultArray = [42, 43];
+  const intersectionArray = Array.from(firstSet.intersection(setLike));
+
+  assertEquals(resultArray, intersectionArray);
+})();
+
+(function TestIntersectionSetLikeWithNegativeInfiniteSize() {
+  let setLike = {
+    size: -Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  assertThrows(() => {
+    new Set().intersection(setLike);
+  }, RangeError, '\'-Infinity\' is an invalid size');
+})();

--- a/deps/v8/test/mjsunit/harmony/set-is-disjoint-from.js
+++ b/deps/v8/test/mjsunit/harmony/set-is-disjoint-from.js
@@ -216,3 +216,37 @@
 
   assertFalse(firstSet.isDisjointFrom(evil));
 })();
+
+(function TestIsDisjointFromSetLikeWithInfiniteSize() {
+  let setLike = {
+    size: Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  const firstSet = new Set();
+  firstSet.add(42);
+  firstSet.add(43);
+
+  assertEquals(firstSet.isDisjointFrom(setLike), false);
+})();
+
+(function TestIsDisjointFromSetLikeWithNegativeInfiniteSize() {
+  let setLike = {
+    size: -Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  assertThrows(() => {
+    new Set().isDisjointFrom(setLike);
+  }, RangeError, '\'-Infinity\' is an invalid size');
+})();

--- a/deps/v8/test/mjsunit/harmony/set-is-subset-of.js
+++ b/deps/v8/test/mjsunit/harmony/set-is-subset-of.js
@@ -266,3 +266,37 @@
 
   assertEquals(firstSet.isSubsetOf(setLike), true);
 })();
+
+(function TestIsSubsetOfSetLikeWithInfiniteSize() {
+  let setLike = {
+    size: Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  const firstSet = new Set();
+  firstSet.add(42);
+  firstSet.add(43);
+
+  assertEquals(firstSet.isSubsetOf(setLike), true);
+})();
+
+(function TestIsSubsetOfSetLikeWithNegativeInfiniteSize() {
+  let setLike = {
+    size: -Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  assertThrows(() => {
+    new Set().isSubsetOf(setLike);
+  }, RangeError, '\'-Infinity\' is an invalid size');
+})();

--- a/deps/v8/test/mjsunit/harmony/set-is-superset-of.js
+++ b/deps/v8/test/mjsunit/harmony/set-is-superset-of.js
@@ -245,3 +245,37 @@
 
   assertTrue(firstSet.isSupersetOf(evil));
 })();
+
+(function TestIsSupersetOfSetLikeWithInfiniteSize() {
+  let setLike = {
+    size: Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  const firstSet = new Set();
+  firstSet.add(42);
+  firstSet.add(43);
+
+  assertEquals(firstSet.isSupersetOf(setLike), false);
+})();
+
+(function TestIsSupersetOfSetLikeWithNegativeInfiniteSize() {
+  let setLike = {
+    size: -Infinity,
+    has(v) {
+      return true;
+    },
+    keys() {
+      throw new Error('Unexpected call to |keys| method');
+    },
+  };
+
+  assertThrows(() => {
+    new Set().isSupersetOf(setLike);
+  }, RangeError, '\'-Infinity\' is an invalid size');
+})();


### PR DESCRIPTION
Fixes a bug in set methods.
This commit is already on `main` with V8 12.8.

Thanks @ljharb for reporting on Slack.

Original commit message:

    [set-methods] Handle SetLike with infinite size

    This CL adds a check for identifying SetLikes with infinite sizes in
    methods dependent on the size of `other`s.

    Bug: 351332634
    Change-Id: I5c6d9c0cc7f3f5fae5cedc72a44bc21c917c84b8
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5684652
    Reviewed-by: Shu-yu Guo <syg@chromium.org>
    Commit-Queue: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#94897}

Refs: https://github.com/v8/v8/commit/217457d0a560990b5ed41da9a5bfc0d224a0f060

