### PR TITLE
tools: fix `non-ascii` eslint rule

### DIFF
--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -39,12 +39,10 @@ converters.any = (V) => {
 // https://webidl.spec.whatwg.org/#abstract-opdef-integerpart
 const integerPart = MathTrunc;
 
-/* eslint-disable node-core/non-ascii-character */
 // Round x to the nearest integer, choosing the even integer if it lies halfway
 // between two, and choosing +0 rather than -0.
 // This is different from Math.round, which rounds to the next integer in the
 // direction of +∞ when the fraction portion is exactly 0.5.
-/* eslint-enable node-core/non-ascii-character */
 function evenRound(x) {
   // Convert -0 to +0.
   const i = integerPart(x) + 0;

--- a/tools/eslint-rules/non-ascii-character.js
+++ b/tools/eslint-rules/non-ascii-character.js
@@ -1,57 +1,23 @@
-/**
- * @fileOverview Any non-ASCII characters in lib/ will increase the size
- *               of the compiled node binary. This linter rule ensures that
- *               any such character is reported.
- * @author Sarat Addepalli <sarat.addepalli@gmail.com>
- */
-
 'use strict';
 
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
+function create(context) {
+  const sourceCode = context.getSourceCode();
+  const nonAsciiPattern = /[^\r\n\x20-\x7e]/g;
 
-const nonAsciiRegexPattern = /[^\r\n\x20-\x7e]/;
-const suggestions = {
-  '’': '\'',
-  '‛': '\'',
-  '‘': '\'',
-  '“': '"',
-  '‟': '"',
-  '”': '"',
-  '«': '"',
-  '»': '"',
-  '—': '-',
-};
-
-module.exports = {
-  create(context) {
-
-    const reportIfError = (node, sourceCode) => {
-
-      const matches = sourceCode.text.match(nonAsciiRegexPattern);
-
-      if (!matches) return;
-
-      const offendingCharacter = matches[0];
-      const offendingCharacterPosition = matches.index;
-      const suggestion = suggestions[offendingCharacter];
-
-      let message = `Non-ASCII character '${offendingCharacter}' detected.`;
-
-      message = suggestion ?
-        `${message} Consider replacing with: ${suggestion}` :
-        message;
-
-      context.report({
-        node,
-        message,
-        loc: sourceCode.getLocFromIndex(offendingCharacterPosition),
+  return {
+    Program(node) {
+      sourceCode.getTokens(node).forEach((token) => {
+        const match = token.value.match(nonAsciiPattern);
+        if (match) {
+          context.report({
+            node,
+            loc: token.loc.start,
+            message: `Non-ASCII character "${match[0]}" found`,
+          });
+        }
       });
-    };
+    },
+  };
+}
 
-    return {
-      Program: (node) => reportIfError(node, context.sourceCode),
-    };
-  },
-};
+module.exports = { create };


### PR DESCRIPTION
Currently, this rule will exit after **one** non-ascii character is found.

This PR changes the rule to do three things:
1. Exclude comments.
2. Not exit early.
3. Not map the ASCII characters to recommended replacements. IMO it can assumed that anyone recieving this lint error knows what a quote/dash is.