### PR TITLE
[canary-base] Fix compile-time errors caused by ambiguous v8 Block types

### DIFF
--- a/deps/v8/src/interpreter/interpreter-generator-tsa.cc
+++ b/deps/v8/src/interpreter/interpreter-generator-tsa.cc
@@ -330,6 +330,8 @@ class TurboshaftBytecodeHandlerAssembler
 using NumberBuiltinsBytecodeHandlerAssembler =
     TurboshaftBytecodeHandlerAssembler<NumberBuiltinsReducer>;
 
+using Block = v8::internal::compiler::turboshaft::Block;
+
 IGNITION_HANDLER_TS(BitwiseNot, NumberBuiltinsBytecodeHandlerAssembler) {
   V<Object> value = GetAccumulator();
   V<Context> context = GetContext();


### PR DESCRIPTION
@targos 
The compiler reports an error saying that the `Block` here may be `v8::internal::Block` and `v8::internal::compiler::turboshaft::Block`
