### PR TITLE
v8,tools: expose experimental wasm revectorize feature

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1675,8 +1675,9 @@ def configure_v8(o, configs):
     raise Exception(
         'Only one of the --v8-enable-object-print or --v8-disable-object-print options '
         'can be specified at a time.')
-  if o['variables']['v8_enable_webassembly'] and o['variables']['target_arch'] == 'x64':
-    o['variables']['v8_enable_wasm_simd256_revec'] = 1
+  if sys.platform != 'darwin':
+    if o['variables']['v8_enable_webassembly'] and o['variables']['target_arch'] == 'x64':
+      o['variables']['v8_enable_wasm_simd256_revec'] = 1
 
 def configure_openssl(o):
   variables = o['variables']

--- a/configure.py
+++ b/configure.py
@@ -1675,6 +1675,8 @@ def configure_v8(o, configs):
     raise Exception(
         'Only one of the --v8-enable-object-print or --v8-disable-object-print options '
         'can be specified at a time.')
+  if o['variables']['v8_enable_webassembly'] and o['variables']['target_arch'] == 'x64':
+    o['variables']['v8_enable_wasm_simd256_revec'] = 1
 
 def configure_openssl(o):
   variables = o['variables']

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -328,7 +328,10 @@
 
     # Enable advanced BigInt algorithms, costing about 10-30 KiB binary size
     # depending on platform.
-    'v8_advanced_bigint_algorithms%': 1
+    'v8_advanced_bigint_algorithms%': 1,
+
+    # Enable 256-bit long vector re-vectorization pass in WASM compilation pipeline.
+    'v8_enable_wasm_simd256_revec%' : 0
   },
 
   'target_defaults': {
@@ -540,6 +543,9 @@
       }],
       ['v8_advanced_bigint_algorithms==1', {
         'defines': ['V8_ADVANCED_BIGINT_ALGORITHMS',],
+      }],
+      ['v8_enable_wasm_simd256_revec==1', {
+        'defines': ['V8_ENABLE_WASM_SIMD256_REVEC',],
       }],
     ],  # conditions
     'defines': [

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -646,6 +646,11 @@
               '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_enable_webassembly.*?sources \\+= ")',
             ],
           }],
+          ['v8_enable_wasm_simd256_revec==1', {
+            'sources': [
+              '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_enable_wasm_simd256_revec.*?sources \\+= ")',
+            ],
+          }],
           ['v8_enable_i18n_support==1', {
             'sources': [
               '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_enable_i18n_support.*?sources \\+= ")',
@@ -880,6 +885,11 @@
           ['v8_enable_webassembly==1', {
             'sources': [
               '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_compiler_sources =.*?v8_enable_webassembly.*?v8_compiler_sources \\+= ")',
+            ],
+          }],
+          ['v8_enable_wasm_simd256_revec==1', {
+            'sources': [
+              '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_compiler_sources =.*?v8_enable_wasm_simd256_revec.*?v8_compiler_sources \\+= ")',
             ],
           }],
         ],


### PR DESCRIPTION
The wasm simd256 revectorization feature is enabled by default when v8_enable_webassembly is true on x64 target in V8. At runtime it will be enabled through flag --experimental-wasm-revectorize.

This PR adds the build configuration in Node to enable this feature and make it explicitly accessible through the same runtime flag for x64 build.