### PR TITLE
test: fix test-http2-socket-close.js

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -30,8 +30,6 @@ test-runner-watch-mode-complex: PASS, FLAKY
 test-async-context-frame: PASS, FLAKY
 # https://github.com/nodejs/node/issues/54534
 test-runner-run-watch: PASS, FLAKY
-# https://github.com/nodejs/node/issues/54819
-test-http2-socket-close: PASS, FLAKY
 
 # Windows on ARM
 [$system==win32 && $arch==arm64]

--- a/test/parallel/test-http2-socket-close.js
+++ b/test/parallel/test-http2-socket-close.js
@@ -42,6 +42,7 @@ netServer.listen(0, common.mustCall(() => {
     rejectUnauthorized: false
   });
 
+  proxyClient.on('error', () => {});
   proxyClient.on('close', common.mustCall(() => {
     netServer.close();
   }));
@@ -51,6 +52,7 @@ netServer.listen(0, common.mustCall(() => {
     ':path': '/'
   });
 
+  req.on('error', () => {});
   req.on('response', common.mustCall((response) => {
     assert.strictEqual(response[':status'], 200);
 


### PR DESCRIPTION
The client receives a response from the server and then destroys the connection after waiting 10ms. This waiting time is sometimes not enough so the connection is closed without seeing `UV_EOF`. 

In order to close the connection gracefully, I increased the waiting time to be on the safe side.
Note that this flakiness could have been fixed using `end()` instead of `destroy()`, but I didn't want to change the test logic.

Fixes: https://github.com/nodejs/node/issues/54819

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
