### PR TITLE
test: fix test test-tls-dhe for OpenSSL32

### DIFF
--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -104,7 +104,11 @@ function testCustomParam(keylen, expectedCipher) {
   }, /DH parameter is less than 1024 bits/);
 
   // Custom DHE parameters are supported (but discouraged).
-  await testCustomParam(1024, dheCipher);
+  if (!common.hasOpenSSL(3, 2)) {
+    await testCustomParam(1024, dheCipher);
+  } else {
+    await testCustomParam(3072, dheCipher);
+  }
   await testCustomParam(2048, dheCipher);
 
   // Invalid DHE parameters are discarded. ECDHE remains enabled.

--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -43,9 +43,12 @@ const dheCipher = 'DHE-RSA-AES128-SHA256';
 const ecdheCipher = 'ECDHE-RSA-AES128-SHA256';
 const ciphers = `${dheCipher}:${ecdheCipher}`;
 
-// Test will emit a warning because the DH parameter size is < 2048 bits
-common.expectWarning('SecurityWarning',
-                     'DH parameter is less than 2048 bits');
+if (!common.hasOpenSSL(3, 2)) {
+  // Test will emit a warning because the DH parameter size is < 2048 bits
+  // when the test is run on versions lower than OpenSSL32
+  common.expectWarning('SecurityWarning',
+                       'DH parameter is less than 2048 bits');
+}
 
 function loadDHParam(n) {
   const keyname = `dh${n}.pem`;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/53382

- OpenSSL32 has a minimum dh key size by 2048 by default.
- Adjust test to use larger 3072 key instead of 1024 when OpenSSL32 is present.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
