### PR TITLE
fs: translate error code properly in cpSync

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3147,7 +3147,14 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
                         ? std::filesystem::symlink_status(src_path, error_code)
                         : std::filesystem::status(src_path, error_code);
   if (error_code) {
-    return env->ThrowUVException(EEXIST, "lstat", nullptr, src.out());
+#ifdef _WIN32
+    int errorno = uv_translate_sys_error(error_code.value());
+#else
+    int errorno =
+        error_code.value() > 0 ? -error_code.value() : error_code.value();
+#endif
+    return env->ThrowUVException(
+        errorno, dereference ? "stat" : "lstat", nullptr, src.out());
   }
   auto dest_status =
       dereference ? std::filesystem::symlink_status(dest_path, error_code)

--- a/test/parallel/test-fs-cp.mjs
+++ b/test/parallel/test-fs-cp.mjs
@@ -419,6 +419,26 @@ if (!isWindows) {
   );
 }
 
+// It throws an error when attempting to copy a file with a name that is too long.
+{
+  const src = 'a'.repeat(5000);
+  const dest = nextdir();
+  assert.throws(
+    () => cpSync(src, dest),
+    { code: isWindows ? 'ENOENT' : 'ENAMETOOLONG' }
+  );
+}
+
+// It throws an error when attempting to copy a dir that does not exist.
+{
+  const src = nextdir();
+  const dest = nextdir();
+  assert.throws(
+    () => cpSync(src, dest, mustNotMutateObjectDeep({ recursive: true })),
+    { code: 'ENOENT' }
+  );
+}
+
 // It makes file writeable when updating timestamp, if not writeable.
 {
   const src = nextdir();


### PR DESCRIPTION
UV error code needs to be negative integer so it can be mapped correctly. The filesystem error are positive integer, so we need to handle it before throwing.

Refs: https://github.com/nodejs/node/pull/53614#discussion_r1726665705
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
