### PR TITLE
test: adjust tls test for OpenSSL32

### DIFF
--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -31,10 +31,17 @@ const max_iter = 20;
 let iter = 0;
 
 const errorHandler = common.mustCall((err) => {
-  assert.strictEqual(err.code, 'ERR_SSL_WRONG_VERSION_NUMBER');
+  let expectedErrorCode = 'ERR_SSL_WRONG_VERSION_NUMBER';
+  let expectedErrorReason = 'wrong version number';
+  if (common.hasOpenSSL(3, 2)) {
+    expectedErrorCode = 'ERR_SSL_PACKET_LENGTH_TOO_LONG';
+    expectedErrorReason = 'packet length too long';
+  };
+
+  assert.strictEqual(err.code, expectedErrorCode);
   assert.strictEqual(err.library, 'SSL routines');
   if (!common.hasOpenSSL3) assert.strictEqual(err.function, 'ssl3_get_record');
-  assert.strictEqual(err.reason, 'wrong version number');
+  assert.strictEqual(err.reason, expectedErrorReason);
   errorReceived = true;
   if (canCloseServer())
     server.close();
@@ -87,10 +94,16 @@ function sendBADTLSRecord() {
     });
   }));
   client.on('error', common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION');
+    let expectedErrorCode = 'ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION';
+    let expectedErrorReason = 'tlsv1 alert protocol version';
+    if (common.hasOpenSSL(3, 2)) {
+      expectedErrorCode = 'ERR_SSL_TLSV1_ALERT_RECORD_OVERFLOW';
+      expectedErrorReason = 'tlsv1 alert record overflow';
+    }
+    assert.strictEqual(err.code, expectedErrorCode);
     assert.strictEqual(err.library, 'SSL routines');
     if (!common.hasOpenSSL3)
       assert.strictEqual(err.function, 'ssl3_read_bytes');
-    assert.strictEqual(err.reason, 'tlsv1 alert protocol version');
+    assert.strictEqual(err.reason, expectedErrorReason);
   }));
 }


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/53382

Looks like test is forcing an error through bad data and the error code we get is different for OpenSSL32. Adjust test to cope with the variation across versions.

I looked through the test history and originally it did not check the specific error, and the updates suggest that a specific error is part of what is being tested. Intead it's testing that an error occurs and is handled with bad data. In that context I think updating to allow a different error for OpenSSL32 makes sense as it should not affect what the test was originaly intended to test.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
