### PR TITLE
src: parse dotenv with the rest of the options

### DIFF
--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -27,12 +27,9 @@ class Dotenv {
 
   void ParseContent(const std::string_view content);
   ParseResult ParsePath(const std::string_view path);
-  void AssignNodeOptionsIfAvailable(std::string* node_options) const;
+  std::string GetNodeOptions() const;
   void SetEnvironment(Environment* env);
   v8::Local<v8::Object> ToObject(Environment* env) const;
-
-  static std::vector<env_file_data> GetDataFromArgs(
-      const std::vector<std::string>& args);
 
  private:
   std::map<std::string, std::string> store_;

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -103,8 +103,7 @@ void OptionsParser<Options>::AddOption(
       name,
       OptionInfo{
           kDetailedStringList,
-          std::make_shared<
-              SimpleOptionField<std::vector<DetailedOption>>>(
+          std::make_shared<SimpleOptionField<std::vector<DetailedOption>>>(
               field),
           env_setting,
           help_text});

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -94,6 +94,23 @@ void OptionsParser<Options>::AddOption(
 }
 
 template <typename Options>
+void OptionsParser<Options>::AddOption(
+    const char* name,
+    const char* help_text,
+    std::vector<DetailedOption> Options::*field,
+    OptionEnvvarSettings env_setting) {
+  options_.emplace(
+      name,
+      OptionInfo{
+          kDetailedStringList,
+          std::make_shared<
+              SimpleOptionField<std::vector<DetailedOption>>>(
+              field),
+          env_setting,
+          help_text});
+}
+
+template <typename Options>
 void OptionsParser<Options>::AddOption(const char* name,
                                        const char* help_text,
                                        HostPort Options::* field,
@@ -465,6 +482,10 @@ void OptionsParser<Options>::Parse(
       case kStringList:
         Lookup<std::vector<std::string>>(info.field, options)
             ->emplace_back(std::move(value));
+        break;
+      case kDetailedStringList:
+        Lookup<std::vector<DetailedOption>>(info.field, options)
+            ->emplace_back(DetailedOption{value, name});
         break;
       case kHostPort:
         Lookup<HostPort>(info.field, options)

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1343,8 +1343,7 @@ void GetCLIOptionsValues(const FunctionCallbackInfo<Value>& args) {
         break;
       case kDetailedStringList: {
         const std::vector<DetailedOption>& detailed_options =
-            *_ppop_instance.Lookup<std::vector<DetailedOption>>(
-                field, opts);
+            *_ppop_instance.Lookup<std::vector<DetailedOption>>(field, opts);
         v8::Local<v8::Array> value_arr =
             v8::Array::New(isolate, detailed_options.size());
         for (size_t i = 0; i < detailed_options.size(); ++i) {

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -44,6 +44,15 @@ class HostPort {
   uint16_t port_;
 };
 
+class DetailedOption {
+ public:
+  DetailedOption(const std::string& value, std::string flag)
+      : value(value), flag(flag) {}
+
+  std::string value;
+  std::string flag;
+};
+
 class Options {
  public:
   virtual void CheckOptions(std::vector<std::string>* errors,
@@ -177,8 +186,7 @@ class EnvironmentOptions : public Options {
 #endif  // HAVE_INSPECTOR
   std::string redirect_warnings;
   std::string diagnostic_dir;
-  std::string env_file;
-  std::string optional_env_file;
+  std::vector<DetailedOption> env_files;
   bool has_env_file_string = false;
   bool test_runner = false;
   uint64_t test_runner_concurrency = 0;
@@ -380,6 +388,7 @@ enum OptionType {
   kString,
   kHostPort,
   kStringList,
+  kDetailedStringList,
 };
 
 template <typename Options>
@@ -415,6 +424,10 @@ class OptionsParser {
   void AddOption(const char* name,
                  const char* help_text,
                  std::vector<std::string> Options::*field,
+                 OptionEnvvarSettings env_setting = kDisallowedInEnvvar);
+  void AddOption(const char* name,
+                 const char* help_text,
+                 std::vector<DetailedOption> Options::*field,
                  OptionEnvvarSettings env_setting = kDisallowedInEnvvar);
   void AddOption(const char* name,
                  const char* help_text,

--- a/test/parallel/test-dotenv-without-node-options.js
+++ b/test/parallel/test-dotenv-without-node-options.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+if (!process.config.variables.node_without_node_options) {
+  common.skip('Requires the lack of NODE_OPTIONS support');
+}
+
+const relativePath = '../fixtures/dotenv/node-options.env';
+
+test('.env does not support NODE_OPTIONS', async () => {
+  const code = 'assert.strictEqual(process.permission, undefined)';
+  const child = await common.spawnPromisified(
+    process.execPath,
+    [ `--env-file=${relativePath}`, '--eval', code ],
+    { cwd: __dirname },
+  );
+  // NODE_NO_WARNINGS is set, so `stderr` should not contain
+  // "ExperimentalWarning: Permission is an experimental feature" message
+  // and thus be empty
+  assert.strictEqual(child.stdout, '');
+  assert.strictEqual(child.stderr, '');
+  assert.strictEqual(child.code, 0);
+});


### PR DESCRIPTION
~~Closes #54385~~
Fixes #54255
Ref #54232

---

I don't *think* this breaks anything. IIUC, the Dotenv parser was setup *before* everything else so that it triggered before  V8 initialized, however, even it's setup after the options are parsed, V8 still hasn't been initialized, so it should be fine.

---

This fixes *all* currently known dotenv edge cases, as it doesn't need a custom parser.

Such as:
```bash
node script.js --env-file .env
node --env-file-ABCD .env
node -- --env-file .env
node --invalid --env-file .env # this would've errored, but the env file is still parsed
```