### PR TITLE
test: adjust test-tls-junk-server for OpenSSL32

### DIFF
--- a/test/parallel/test-tls-junk-server.js
+++ b/test/parallel/test-tls-junk-server.js
@@ -20,8 +20,12 @@ server.listen(0, function() {
   const req = https.request({ port: this.address().port });
   req.end();
 
+  let expectedErrorMessage = new RegExp('wrong version number');
+  if (common.hasOpenSSL(3, 2)) {
+    expectedErrorMessage = new RegExp('packet length too long');
+  };
   req.once('error', common.mustCall(function(err) {
-    assert(/wrong version number/.test(err.message));
+    assert(expectedErrorMessage.test(err.message));
     server.close();
   }));
 });


### PR DESCRIPTION
Refs: #53382

OpenSSL32 returns different error text. Looking through the test it seems like the expected error text has been adjusted for different OpenSSL versions in the past and what the test is testing is not related to the error being returned.

Update test to allow for error returned by OpenSSL32

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
