### PR TITLE
lib: add flag to drop connection when running in cluster mode

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -599,11 +599,24 @@ changes:
 
 * {integer}
 
-Set this property to reject connections when the server's connection count gets
-high.
+When the number of connections reaches the `server.maxConnections` threshold:
+
+1. If the process is not running in cluster mode, Node.js will close the connection.
+
+2. If the process is running in cluster mode, Node.js will, by default, route the connection to another worker process. To close the connection instead, set \[`server.dropMaxConnection`]\[] to `true`.
 
 It is not recommended to use this option once a socket has been sent to a child
 with [`child_process.fork()`][].
+
+### `server.dropMaxConnection`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+Set this property to `true` to begin closing connections once the number of connections reaches the \[`server.maxConnections`]\[] threshold. This setting is only effective in cluster mode.
 
 ### `server.ref()`
 

--- a/lib/internal/cluster/child.js
+++ b/lib/internal/cluster/child.js
@@ -233,7 +233,9 @@ function onconnection(message, handle) {
 
   if (accepted && server[owner_symbol]) {
     const self = server[owner_symbol];
-    if (self.maxConnections != null && self._connections >= self.maxConnections) {
+    if (self.maxConnections != null &&
+        self._connections >= self.maxConnections &&
+        !self.dropMaxConnection) {
       accepted = false;
     }
   }

--- a/test/parallel/test-net-server-drop-connections-in-cluster.js
+++ b/test/parallel/test-net-server-drop-connections-in-cluster.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const cluster = require('cluster');
+const http = require('http');
+
+if (cluster.isPrimary) {
+  cluster.fork();
+} else {
+  const server = http.createServer();
+  server.maxConnections = 0;
+  server.dropMaxConnection = true;
+  // When dropMaxConnection is false, the main process will continue to
+  // distribute the request to the child process, if true, the child will
+  // close the connection directly and emit drop event.
+  server.on('drop', common.mustCall((a) => {
+    process.exit();
+  }));
+  server.listen(common.mustCall(() => {
+    http.get(`http://localhost:${server.address().port}`).on('error', console.error);
+  }));
+}


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/54882

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
