### PR TITLE
lib: prefer iterable weak set than WeakRefs in AbortSignal.any

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -4,6 +4,7 @@
 // in https://github.com/mysticatea/abort-controller (MIT license)
 
 const {
+  ArrayPrototypePush,
   ObjectAssign,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -11,8 +12,12 @@ const {
   SafeFinalizationRegistry,
   SafeSet,
   SafeWeakRef,
+  SafeWeakSet,
   Symbol,
   SymbolToStringTag,
+  WeakRefPrototypeDeref,
+  WeakSetPrototypeAdd,
+  WeakSetPrototypeHas,
 } = primordials;
 
 const {
@@ -99,6 +104,33 @@ const kMakeTransferable = Symbol('kMakeTransferable');
 const kComposite = Symbol('kComposite');
 const kSourceSignals = Symbol('kSourceSignals');
 const kDependantSignals = Symbol('kDependantSignals');
+
+// Since WeakSet is not iterable, we must use another iterable
+// data structure to make it "iterable".
+class IterableWeakSet {
+  #weakSet = new SafeWeakSet();
+  #weakRefs = [];
+
+  add(value) {
+    if (!this.has(value)) {
+      WeakSetPrototypeAdd(this.#weakSet, value);
+      ArrayPrototypePush(this.#weakRefs, new SafeWeakRef(value));
+    }
+  }
+
+  has(value) {
+    return WeakSetPrototypeHas(this.#weakSet, value);
+  }
+
+  getIterable() {
+    const iterable = [];
+    for (let i = 0; i < this.#weakRefs.length; i++) {
+      const item = WeakRefPrototypeDeref(this.#weakRefs[i]);
+      ArrayPrototypePush(iterable, item);
+    }
+    return iterable;
+  }
+}
 
 function customInspect(self, obj, depth, options) {
   if (depth < 0)
@@ -238,34 +270,32 @@ class AbortSignal extends EventTarget {
     if (!signalsArray.length) {
       return resultSignal;
     }
-    const resultSignalWeakRef = new SafeWeakRef(resultSignal);
-    resultSignal[kSourceSignals] = new SafeSet();
+    resultSignal[kSourceSignals] = new IterableWeakSet();
     for (let i = 0; i < signalsArray.length; i++) {
       const signal = signalsArray[i];
       if (signal.aborted) {
         abortSignal(resultSignal, signal.reason);
         return resultSignal;
       }
-      signal[kDependantSignals] ??= new SafeSet();
+      signal[kDependantSignals] ??= new IterableWeakSet();
       if (!signal[kComposite]) {
-        resultSignal[kSourceSignals].add(new SafeWeakRef(signal));
-        signal[kDependantSignals].add(resultSignalWeakRef);
+        resultSignal[kSourceSignals].add(signal);
+        signal[kDependantSignals].add(resultSignal);
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {
-        for (const sourceSignal of signal[kSourceSignals]) {
-          const sourceSignalRef = sourceSignal.deref();
-          if (!sourceSignalRef) {
+        for (const sourceSignal of signal[kSourceSignals].getIterable()) {
+          if (!sourceSignal) {
             continue;
           }
-          assert(!sourceSignalRef.aborted);
-          assert(!sourceSignalRef[kComposite]);
+          assert(!sourceSignal.aborted);
+          assert(!sourceSignal[kComposite]);
 
           if (resultSignal[kSourceSignals].has(sourceSignal)) {
             continue;
           }
           resultSignal[kSourceSignals].add(sourceSignal);
-          sourceSignalRef[kDependantSignals].add(resultSignalWeakRef);
+          sourceSignal[kDependantSignals].add(resultSignal);
         }
       }
     }
@@ -380,9 +410,8 @@ function abortSignal(signal, reason) {
     [kTrustEvent]: true,
   });
   signal.dispatchEvent(event);
-  signal[kDependantSignals]?.forEach((s) => {
-    const signalRef = s.deref();
-    if (signalRef) abortSignal(signalRef, reason);
+  signal[kDependantSignals]?.getIterable()?.forEach((s) => {
+    if (s) abortSignal(s, reason);
   });
 }
 


### PR DESCRIPTION
[The dom spec](https://dom.spec.whatwg.org/#abortsignal:~:text=An%20AbortSignal%20object%20has%20associated%20source%20signals,their%20aborted%20state) specified the usage of weak sets for dependent and source signals. This came from a discussion in the [original dom spec PR](https://github.com/whatwg/dom/pull/1152#discussion_r1155602317), which explicitly stated "weak sets" rather than "a set of weak references" to avoid extra `new WeakRef` and `deref` when interacting with the signals. This PR makes that behavior spec compliant.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
