### PR TITLE
test_runner: use `test:` symbol on second print of parent test

### DIFF
--- a/lib/internal/test_runner/reporter/utils.js
+++ b/lib/internal/test_runner/reporter/utils.js
@@ -72,16 +72,14 @@ function formatTestReport(type, data, prefix = '', indent = '', hasChildren = fa
     title += ` # ${typeof todo === 'string' && todo.length ? todo : 'TODO'}`;
   }
   const error = formatError(data.details?.error, indent);
-  if (hasChildren) {
-    // If this test has had children - it was already reported, so slightly modify the output
-    const err = !error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`;
-    return `${prefix}${indent}${color}${reporterUnicodeSymbolMap['arrow:right']}${colors.white}${title}${err}`;
-  }
+  const err = hasChildren ?
+    (!error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`) :
+    error;
   if (skip !== undefined) {
     color = colors.gray;
     symbol = reporterUnicodeSymbolMap['hyphen:minus'];
   }
-  return `${prefix}${indent}${color}${symbol}${title}${colors.white}${error}`;
+  return `${prefix}${indent}${color}${symbol}${title}${colors.white}${err}`;
 }
 
 module.exports = {

--- a/test/fixtures/test-runner/output/default_output.snapshot
+++ b/test/fixtures/test-runner/output/default_output.snapshot
@@ -27,7 +27,7 @@
   [31m✖ should pass but parent fail [90m(*ms)[39m[39m
     [32m'test did not finish before its parent and was cancelled'[39m
 
-[31m▶ [39mparent [90m(*ms)[39m
+[31m✖ parent [90m(*ms)[39m[39m
 [34mℹ tests 6[39m
 [34mℹ suites 0[39m
 [34mℹ pass 1[39m

--- a/test/fixtures/test-runner/output/suite-skip-hooks.snapshot
+++ b/test/fixtures/test-runner/output/suite-skip-hooks.snapshot
@@ -12,7 +12,7 @@ AFTER 2
   ✔ should run 1 (*ms)
   ﹣ should not run (*ms) # SKIP
   ✔ should run 2 (*ms)
-▶ suite runs with mixture of skipped tests (*ms)
+✔ suite runs with mixture of skipped tests (*ms)
 ℹ tests 4
 ℹ suites 2
 ℹ pass 2


### PR DESCRIPTION
Fixes https://github.com/nodejs/help/issues/4482

## Before | After
![image](https://github.com/user-attachments/assets/2a6da621-ac91-4e53-aa93-4ac946fcadb4)


While the first report of a test with subtests is a `▶` character, this PR updates the second report to be a `✔` or `✖`, indicating the actual success of the test, without the need for colorization.