### PR TITLE
string_decoder: refactor encoding validation

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -197,9 +197,12 @@ function assertCrypto() {
     throw new ERR_NO_CRYPTO();
 }
 
-// Return undefined if there is no match.
-// Move the "slow cases" to a separate function to make sure this function gets
-// inlined properly. That prioritizes the common case.
+/**
+ * Move the "slow cases" to a separate function to make sure this function gets
+ * inlined properly. That prioritizes the common case.
+ * @param {unknown} enc
+ * @returns {string | undefined} Returns undefined if there is no match.
+ */
 function normalizeEncoding(enc) {
   if (enc == null || enc === 'utf8' || enc === 'utf-8') return 'utf8';
   return slowCases(enc);

--- a/lib/string_decoder.js
+++ b/lib/string_decoder.js
@@ -40,37 +40,16 @@ const {
   flush,
 } = internalBinding('string_decoder');
 const {
-  kIsEncodingSymbol,
   encodingsMap,
-  normalizeEncoding: _normalizeEncoding,
+  normalizeEncoding,
 } = require('internal/util');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_THIS,
   ERR_UNKNOWN_ENCODING,
 } = require('internal/errors').codes;
-const isEncoding = Buffer[kIsEncodingSymbol];
 
 const kNativeDecoder = Symbol('kNativeDecoder');
-
-// Do not cache `Buffer.isEncoding` when checking encoding names as some
-// modules monkey-patch it to support additional encodings
-/**
- * Normalize encoding notation
- * @param {string} enc
- * @returns {"utf8" | "utf16le" | "hex" | "ascii"
- *           | "base64" | "latin1" | "base64url"}
- * @throws {TypeError} Throws an error when encoding is invalid
- */
-function normalizeEncoding(enc) {
-  const nenc = _normalizeEncoding(enc);
-  if (nenc === undefined) {
-    if (Buffer.isEncoding === isEncoding || !Buffer.isEncoding(enc))
-      throw new ERR_UNKNOWN_ENCODING(enc);
-    return enc;
-  }
-  return nenc;
-}
 
 /**
  * StringDecoder provides an interface for efficiently splitting a series of
@@ -80,6 +59,9 @@ function normalizeEncoding(enc) {
  */
 function StringDecoder(encoding) {
   this.encoding = normalizeEncoding(encoding);
+  if (this.encoding === undefined) {
+    throw new ERR_UNKNOWN_ENCODING(encoding);
+  }
   this[kNativeDecoder] = Buffer.alloc(kSize);
   this[kNativeDecoder][kEncodingField] = encodingsMap[this.encoding];
 }
@@ -112,11 +94,9 @@ StringDecoder.prototype.write = function write(buf) {
  * @returns {string}
  */
 StringDecoder.prototype.end = function end(buf) {
-  let ret = '';
-  if (buf !== undefined)
-    ret = this.write(buf);
+  const ret = buf === undefined ? '' : this.write(buf);
   if (this[kNativeDecoder][kBufferedBytes] > 0)
-    ret += flush(this[kNativeDecoder]);
+    return ret + flush(this[kNativeDecoder]);
   return ret;
 };
 


### PR DESCRIPTION
As far as I can tell, I couldn't find a valid reason to call normalizeEncoding and isEncoding for the same input. Normalize encoding function returns undefined if the encoding is not valid.

Benchmark ci: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1640/