### PR TITLE
lib: implement interface converter and use it for AbortSignal validation

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -41,12 +41,11 @@ const {
 } = require('internal/errors');
 const {
   converters,
+  createInterfaceConverter,
   createSequenceConverter,
 } = require('internal/webidl');
 
 const {
-  validateAbortSignal,
-  validateAbortSignalArray,
   validateObject,
   validateUint32,
   kValidateObjectAllowObjects,
@@ -229,11 +228,11 @@ class AbortSignal extends EventTarget {
    * @returns {AbortSignal}
    */
   static any(signals) {
-    const signalsArray = createSequenceConverter(
-      converters.any,
-    )(signals);
+    const signalsArray = converters['sequence<AbortSignal>'](
+      signals,
+      { __proto__: null, context: 'signals' },
+    );
 
-    validateAbortSignalArray(signalsArray, 'signals');
     const resultSignal = new AbortSignal(kDontThrowSymbol, { composite: true });
     if (!signalsArray.length) {
       return resultSignal;
@@ -353,6 +352,9 @@ class AbortSignal extends EventTarget {
   }
 }
 
+converters.AbortSignal = createInterfaceConverter('AbortSignal', AbortSignal.prototype);
+converters['sequence<AbortSignal>'] = createSequenceConverter(converters.AbortSignal);
+
 function ClonedAbortSignal() {
   return new AbortSignal(kDontThrowSymbol, { transferable: true });
 }
@@ -442,10 +444,7 @@ function transferableAbortController() {
  * @returns {Promise<void>}
  */
 async function aborted(signal, resource) {
-  if (signal === undefined) {
-    throw new ERR_INVALID_ARG_TYPE('signal', 'AbortSignal', signal);
-  }
-  validateAbortSignal(signal, 'signal');
+  converters.AbortSignal(signal, { __proto__: null, context: 'signal' });
   validateObject(resource, 'resource', kValidateObjectAllowObjects);
   if (signal.aborted)
     return PromiseResolve();

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -12,6 +12,7 @@ const {
   NumberMAX_SAFE_INTEGER,
   NumberMIN_SAFE_INTEGER,
   ObjectAssign,
+  ObjectPrototypeIsPrototypeOf,
   SafeSet,
   String,
   SymbolIterator,
@@ -20,6 +21,7 @@ const {
 
 const {
   codes: {
+    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
   },
 } = require('internal/errors');
@@ -275,11 +277,24 @@ function createSequenceConverter(converter) {
       const val = converter(res.value, {
         __proto__: null,
         ...opts,
-        context: `${opts.context}, index ${array.length}`,
+        context: `${opts.context}[${array.length}]`,
       });
       ArrayPrototypePush(array, val);
     };
     return array;
+  };
+}
+
+// https://webidl.spec.whatwg.org/#js-interface
+function createInterfaceConverter(name, I) {
+  return (V, opts = kEmptyObject) => {
+    // 1. If V implements I, then return the IDL interface type value that
+    //    represents a reference to that platform object.
+    if (ObjectPrototypeIsPrototypeOf(I, V)) return V;
+    // 2. Throw a TypeError.
+    throw new ERR_INVALID_ARG_TYPE(
+      typeof opts.context === 'string' ? opts.context : 'value', name, V,
+    );
   };
 }
 
@@ -289,6 +304,7 @@ module.exports = {
   converters,
   convertToInt,
   createEnumConverter,
+  createInterfaceConverter,
   createSequenceConverter,
   evenRound,
   makeException,

--- a/test/parallel/test-abortsignal-any.mjs
+++ b/test/parallel/test-abortsignal-any.mjs
@@ -118,4 +118,17 @@ describe('AbortSignal.any()', { concurrency: !process.env.TEST_PARALLEL }, () =>
     controller.abort();
     assert.strictEqual(result, 1);
   });
+
+  it('throws TypeError if any value does not implement AbortSignal', () => {
+    const expectedError = { code: 'ERR_INVALID_ARG_TYPE' };
+    assert.throws(() => AbortSignal.any([ null ]), expectedError);
+    assert.throws(() => AbortSignal.any([ undefined ]), expectedError);
+    assert.throws(() => AbortSignal.any([ '123' ]), expectedError);
+    assert.throws(() => AbortSignal.any([ 123 ]), expectedError);
+    assert.throws(() => AbortSignal.any([{}]), expectedError);
+    assert.throws(() => AbortSignal.any([{ aborted: true }]), expectedError);
+    assert.throws(() => AbortSignal.any([{
+      aborted: true, reason: '', throwIfAborted: null,
+    }]), expectedError);
+  });
 });


### PR DESCRIPTION
This PR contains 2 commits. 

The first one implements interface converter as per [the spec](https://webidl.spec.whatwg.org/#js-interface).
The one after uses the implemented interface converter to properly validate `AbortSiganl`s in `AbortSignal.any`

Fixes: https://github.com/nodejs/node/issues/54962