### PR TITLE
doc: reflect toolchains used for official binaries

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -106,7 +106,7 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | x64              | kernel >= 3.10, musl >= 1.1.19    | Experimental | e.g. Alpine 3.8                      |
 | GNU/Linux        | x86              | kernel >= 3.10, glibc >= 2.17     | Experimental | Downgraded as of Node.js 10          |
 | GNU/Linux        | arm64            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1       | e.g. Ubuntu 20.04, Debian 10, RHEL 8 |
-| GNU/Linux        | armv7            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1       | e.g. Ubuntu 20.04, Debian 11         |
+| GNU/Linux        | armv7            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1       | e.g. Ubuntu 22.04, Debian 12         |
 | GNU/Linux        | armv6            | kernel >= 4.14, glibc >= 2.24     | Experimental | Downgraded as of Node.js 12          |
 | GNU/Linux        | ppc64le >=power8 | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2       | e.g. Ubuntu 20.04, RHEL 8            |
 | GNU/Linux        | s390x            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2       | e.g. RHEL 8                          |
@@ -158,17 +158,18 @@ Depending on the host platform, the selection of toolchains may vary.
 
 Binaries at <https://nodejs.org/download/release/> are produced on:
 
-| Binary package          | Platform and Toolchain                                                                                      |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------- |
-| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                                                                     |
-| darwin-x64              | macOS 11, Xcode 13 with -mmacosx-version-min=11.0                                                           |
-| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode 13 with -mmacosx-version-min=11.0                                                   |
-| linux-arm64             | RHEL 8 with GCC 10[^6]                                                                                      |
-| linux-armv7l            | Cross-compiled on RHEL 8 x64 with [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)[^7] |
-| linux-ppc64le           | RHEL 8 with gcc-toolset-10[^6]                                                                              |
-| linux-s390x             | RHEL 8 with gcc-toolset-10[^6]                                                                              |
-| linux-x64               | RHEL 8 with gcc-toolset-10[^6]                                                                              |
-| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022                                                           |
+| Binary package          | Platform and Toolchain                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                                                                       |
+| darwin-x64              | macOS 11, Xcode 13 with -mmacosx-version-min=11.0                                                             |
+| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode 13 with -mmacosx-version-min=11.0                                                     |
+| linux-arm64             | RHEL 8 with gcc-toolset-12[^6]                                                                                |
+| linux-armv7l            | Cross-compiled on RHEL 9 x64 with a [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)[^7] |
+| linux-ppc64le           | RHEL 8 with gcc-toolset-12[^6]                                                                                |
+| linux-s390x             | RHEL 8 with gcc-toolset-12[^6]                                                                                |
+| linux-x64               | RHEL 8 with gcc-toolset-12[^6]                                                                                |
+| win-arm64               | Windows Server 2022 (x64) with Visual Studio 2022                                                             |
+| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022                                                             |
 
 <!--lint disable final-definition-->
 
@@ -181,9 +182,9 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
     RHEL 8 and Ubuntu 20.04.
 
 [^7]: Binaries produced on these systems are compatible with glibc >= 2.28
-    and libstdc++ >= 6.0.28 (`GLIBCXX_3.4.28`). These are available on
-    distributions natively supporting GCC 9.3 or higher, such as Debian 11,
-    Ubuntu 20.04.
+    and libstdc++ >= 6.0.30 (`GLIBCXX_3.4.30`). These are available on
+    distributions natively supporting GCC 12.1 or higher, such as Debian 12,
+    Ubuntu 22.04.
 
 <!--lint enable final-definition-->
 


### PR DESCRIPTION
Update the list of toolchains used to build the official Node.js binaries for Node.js 23 onwards.

Refs: https://github.com/nodejs/build/issues/3806
Refs: https://github.com/nodejs/node/pull/54081
Refs: https://github.com/nodejs/node/pull/53184#discussion_r1617496804

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
