### PR TITLE
build,win: float VS 17.11 compilation patch

### DIFF
--- a/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
+++ b/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
@@ -33,7 +33,7 @@
 
 #include "nghttp3_macro.h"
 
-#if defined(_MSC_VER) && !defined(__clang__) &&                                \
+#if defined(_MSC_VER) && _MSC_VER < 1941 && !defined(__clang__) &&                                \
     (defined(_M_ARM) || defined(_M_ARM64))
 unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;

--- a/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
+++ b/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
@@ -31,7 +31,7 @@
 
 #include "ngtcp2_macro.h"
 
-#if defined(_MSC_VER) && !defined(__clang__) &&                                \
+#if defined(_MSC_VER) && _MSC_VER < 1941 && !defined(__clang__) &&                                \
     (defined(_M_ARM) || defined(_M_ARM64))
 static unsigned int __popcnt(unsigned int x) {
   unsigned int c = 0;


### PR DESCRIPTION
Floats dependency patch from https://github.com/ngtcp2/nghttp3/pull/252 to enable updating VS to the latest version (17.11) in the CI.

Fixes: https://github.com/nodejs/node/issues/54898