### PR TITLE
test: adjust key sizes to support OpenSSL32

### DIFF
--- a/test/parallel/test-tls-getcipher.js
+++ b/test/parallel/test-tls-getcipher.js
@@ -47,13 +47,13 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   tls.connect({
     host: '127.0.0.1',
     port: this.address().port,
-    ciphers: 'AES128-SHA256',
+    ciphers: 'AES256-SHA256',
     rejectUnauthorized: false,
     maxVersion: 'TLSv1.2',
   }, common.mustCall(function() {
     const cipher = this.getCipher();
-    assert.strictEqual(cipher.name, 'AES128-SHA256');
-    assert.strictEqual(cipher.standardName, 'TLS_RSA_WITH_AES_128_CBC_SHA256');
+    assert.strictEqual(cipher.name, 'AES256-SHA256');
+    assert.strictEqual(cipher.standardName, 'TLS_RSA_WITH_AES_256_CBC_SHA256');
     assert.strictEqual(cipher.version, 'TLSv1.2');
     this.end();
   }));
@@ -62,14 +62,14 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
   tls.connect({
     host: '127.0.0.1',
     port: this.address().port,
-    ciphers: 'ECDHE-RSA-AES128-GCM-SHA256',
+    ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
     rejectUnauthorized: false,
     maxVersion: 'TLSv1.2',
   }, common.mustCall(function() {
     const cipher = this.getCipher();
-    assert.strictEqual(cipher.name, 'ECDHE-RSA-AES128-GCM-SHA256');
+    assert.strictEqual(cipher.name, 'ECDHE-RSA-AES256-GCM-SHA384');
     assert.strictEqual(cipher.standardName,
-                       'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256');
+                       'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384');
     assert.strictEqual(cipher.version, 'TLSv1.2');
     this.end();
   }));
@@ -78,19 +78,19 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
 tls.createServer({
   key: fixtures.readKey('agent2-key.pem'),
   cert: fixtures.readKey('agent2-cert.pem'),
-  ciphers: 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_CCM_8_SHA256',
+  ciphers: 'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384',
   maxVersion: 'TLSv1.3',
 }, common.mustCall(function() {
   this.close();
 })).listen(0, common.mustCall(function() {
   const client = tls.connect({
     port: this.address().port,
-    ciphers: 'TLS_AES_128_CCM_8_SHA256',
+    ciphers: 'TLS_AES_256_GCM_SHA384',
     maxVersion: 'TLSv1.3',
     rejectUnauthorized: false
   }, common.mustCall(() => {
     const cipher = client.getCipher();
-    assert.strictEqual(cipher.name, 'TLS_AES_128_CCM_8_SHA256');
+    assert.strictEqual(cipher.name, 'TLS_AES_256_GCM_SHA384');
     assert.strictEqual(cipher.standardName, cipher.name);
     assert.strictEqual(cipher.version, 'TLSv1.3');
     client.end();


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/53382

This test fails on OpenSSL32 because it complains the key being used is too short.

Adjust the key sizes so that they will pass on OpenSSL32 in addition to other OpenSSL3 versions.

Since the keys are not public key related I don't think the increase in key size will be too bad in terms of performance so I've just increased versus guarding for OpenSSL32

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
