### PR TITLE
worker: handle `--input-type` more consistently

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -55,6 +55,7 @@ let debug = require('internal/util/debuglog').debuglog('worker', (fn) => {
 });
 
 const assert = require('internal/assert');
+const { getOptionValue } = require('internal/options');
 const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 
 prepareWorkerThreadExecution();
@@ -152,7 +153,7 @@ port.on('message', (message) => {
         break;
       }
 
-      case 'classic': {
+      case 'classic': if (getOptionValue('--input-type') !== 'module') {
         const { evalScript } = require('internal/process/execution');
         const name = '[worker eval]';
         // This is necessary for CJS module compilation.
@@ -168,6 +169,7 @@ port.on('message', (message) => {
         break;
       }
 
+      // eslint-disable-next-line no-fallthrough
       case 'module': {
         const { evalModuleEntryPoint } = require('internal/process/execution');
         PromisePrototypeThen(evalModuleEntryPoint(filename), undefined, (e) => {

--- a/test/parallel/test-worker-cli-options.js
+++ b/test/parallel/test-worker-cli-options.js
@@ -1,6 +1,6 @@
 // Flags: --expose-internals --expose-gc
 'use strict';
-require('../common');
+const common = require('../common');
 const { Worker } = require('worker_threads');
 const assert = require('assert');
 
@@ -29,3 +29,11 @@ new Worker(CODE, { eval: true, env: process.env, execArgv: ['--expose-internals'
 assert.throws(() => {
   new Worker(CODE, { eval: true, execArgv: ['--expose-gc'] });
 }, /ERR_WORKER_INVALID_EXEC_ARGV/);
+
+// Test ESM eval
+new Worker('export {}', { eval: true, execArgv: ['--input-type=module'] });
+new Worker('export {}', { eval: true, execArgv: ['--input-type=commonjs'] })
+  .once('error', common.expectsError({ name: 'SyntaxError' }));
+new Worker('export {}', { eval: true, execArgv: ['--experimental-detect-module'] });
+new Worker('export {}', { eval: true, execArgv: ['--no-experimental-detect-module'] })
+  .once('error', common.expectsError({ name: 'SyntaxError' }));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/30682#issuecomment-2352453961
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
