### PR TITLE
doc: fix history of `process.features`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1899,7 +1899,7 @@ previous setting of `process.exitCode`.
 ## `process.features.cached_builtins`
 
 <!-- YAML
-added: REPLACEME
+added: v12.0.0
 -->
 
 * {boolean}
@@ -1909,7 +1909,7 @@ A boolean value that is `true` if the current Node.js build is caching builtin m
 ## `process.features.debug`
 
 <!-- YAML
-added: REPLACEME
+added: v0.5.5
 -->
 
 * {boolean}
@@ -1919,7 +1919,7 @@ A boolean value that is `true` if the current Node.js build is a debug build.
 ## `process.features.inspector`
 
 <!-- YAML
-added: REPLACEME
+added: v11.10.0
 -->
 
 * {boolean}
@@ -1929,7 +1929,7 @@ A boolean value that is `true` if the current Node.js build includes the inspect
 ## `process.features.ipv6`
 
 <!-- YAML
-added: REPLACEME
+added: v0.5.3
 -->
 
 * {boolean}
@@ -1939,7 +1939,7 @@ A boolean value that is `true` if the current Node.js build includes support for
 ## `process.features.tls`
 
 <!-- YAML
-added: REPLACEME
+added: v0.5.3
 -->
 
 * {boolean}
@@ -1949,7 +1949,7 @@ A boolean value that is `true` if the current Node.js build includes support for
 ## `process.features.tls_alpn`
 
 <!-- YAML
-added: REPLACEME
+added: v4.8.0
 -->
 
 * {boolean}
@@ -1961,7 +1961,7 @@ A boolean value that is `true` if the current Node.js build includes support for
 ## `process.features.tls_ocsp`
 
 <!-- YAML
-added: REPLACEME
+added: v0.11.13
 -->
 
 * {boolean}
@@ -1973,7 +1973,7 @@ A boolean value that is `true` if the current Node.js build includes support for
 ## `process.features.tls_sni`
 
 <!-- YAML
-added: REPLACEME
+added: v0.5.3
 -->
 
 * {boolean}
@@ -1985,7 +1985,7 @@ A boolean value that is `true` if the current Node.js build includes support for
 ## `process.features.uv`
 
 <!-- YAML
-added: REPLACEME
+added: v0.5.3
 -->
 
 * {boolean}


### PR DESCRIPTION
Refs: aa0308d6182b2f7a2508373770952eefd2fdb0ac
Refs: 9010f5fbab2695e6c0435db396f3e92118da6d76
Refs: 52a40e0fd5f59b295fe9bb74e7f14b35ca4bf96c
Refs: b3ef289ffb7db476d284866658213f04415ea92d
Refs: https://github.com/nodejs/node/pull/2564
Refs: https://github.com/nodejs/node/pull/25819
Refs: https://github.com/nodejs/node/pull/27311

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
