### PR TITLE
meta: remove never-used workflow trigger

### DIFF
--- a/.github/workflows/label-flaky-test-issue.yml
+++ b/.github/workflows/label-flaky-test-issue.yml
@@ -2,7 +2,7 @@ name: Label Flaky Test Issues
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
Because this workflow checks `github.event.label`, the `opened` trigger will *always* be skipped, so this PR removes it entirely.