### PR TITLE
doc: mark v21 as End-of-Life

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Select a Node.js version below to view the changelog history:
 
 * [Node.js 22](doc/changelogs/CHANGELOG_V22.md) **Current**
-* [Node.js 21](doc/changelogs/CHANGELOG_V21.md) **Current**
+* [Node.js 21](doc/changelogs/CHANGELOG_V21.md) End-of-Life
 * [Node.js 20](doc/changelogs/CHANGELOG_V20.md) **Long Term Support**
 * [Node.js 19](doc/changelogs/CHANGELOG_V19.md) End-of-Life
 * [Node.js 18](doc/changelogs/CHANGELOG_V18.md) **Long Term Support**
@@ -32,7 +32,6 @@ release.
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V22.md">22</a> (Current)</th>
-  <th title="Current"><a href="doc/changelogs/CHANGELOG_V21.md">21</a> (Current)</th>
   <th title="LTS Until 2026-04"><a href="doc/changelogs/CHANGELOG_V20.md">20</a> (LTS)</th>
   <th title="LTS Until 2025-04"><a href="doc/changelogs/CHANGELOG_V18.md">18</a> (LTS)</th>
 </tr>
@@ -49,21 +48,6 @@ release.
 <a href="doc/changelogs/CHANGELOG_V22.md#22.2.0">22.2.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V22.md#22.1.0">22.1.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V22.md#22.0.0">22.0.0</a><br/>
-  </td>
-  <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V21.md#21.7.3">21.7.3</a></b><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.7.2">21.7.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.7.1">21.7.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.7.0">21.7.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.6.2">21.6.2</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.6.1">21.6.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.6.0">21.6.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.5.0">21.5.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.4.0">21.4.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.3.0">21.3.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.2.0">21.2.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.1.0">21.1.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V21.md#21.0.0">21.0.0</a><br/>
   </td>
   <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V20.md#20.17.0">20.17.0</a></b><br/>


### PR DESCRIPTION
IIUC, v21 reached EoL on April 1st, so shouldn't this document be updated to reflect that?