### PR TITLE
meta: switch `label-pr` to use github-actions[bot]

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,9 +10,11 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: nodejs/node-pr-labeler@d4cf1b8b9f23189c37917000e5e17e796c770a6b  # v1
         with:
-          repo-token: ${{ secrets.GH_USER_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/label-pr-config.yml


### PR DESCRIPTION
IMO it's important for there to be a distinction between actions triggered via @nodejs-github-bot (at https://github.com/nodejs/github-bot) vs Github Actions (in this repo).

This PR updates the `label-pr` workflow to add labels as Github Actions, rather than as @nodejs-github-bot.