### PR TITLE
meta: add `linux` to OS labels in collaborator guide

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -974,10 +974,9 @@ need to be attached anymore, as only important bugfixes will be included.
 ### Other labels
 
 * Operating system labels
-  * `macos`, `windows`, `smartos`, `aix`
-  * No `linux` label because it is the implied default
+  * `macos`, `windows`, `smartos`, `aix`, `linux`, etc.
 * Architecture labels
-  * `arm`, `mips`, `s390`, `ppc`
+  * `arm`, `mips`, `s390`, `ppc`, etc.
   * No `x86{_64}` label because it is the implied default
 
 ["Merge pull request"]: https://help.github.com/articles/merging-a-pull-request/#merging-a-pull-request-on-github


### PR DESCRIPTION
The *linux* label **does** exist, so this PR updates the docs accordingly. (+ add `etc` to the end of the lists).