### PR TITLE
url: runtime deprecate url.parse

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3454,6 +3454,10 @@ Node-API callbacks.
 <!-- YAML
 changes:
   - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55017
+    description: Application deprecation.
+  - version:
       - v19.9.0
       - v18.17.0
     pr-url: https://github.com/nodejs/node/pull/47203
@@ -3465,7 +3469,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Application (non-`node_modules` code only)
 
 [`url.parse()`][] behavior is not standardized and prone to errors that
 have security implications. Use the [WHATWG URL API][] instead. CVEs are not

--- a/lib/url.js
+++ b/lib/url.js
@@ -46,6 +46,7 @@ const {
 // This ensures setURLConstructor() is called before the native
 // URL::ToObject() method is used.
 const { spliceOne } = require('internal/util');
+const { isInsideNodeModules } = internalBinding('util');
 
 // WHATWG URL implementation provided by internal/url
 const {
@@ -62,8 +63,6 @@ const {
 } = require('internal/url');
 
 const bindingUrl = internalBinding('url');
-
-const { getOptionValue } = require('internal/options');
 
 // Original url.parse() API
 
@@ -125,7 +124,7 @@ const {
 let urlParseWarned = false;
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (!urlParseWarned && getOptionValue('--pending-deprecation')) {
+  if (!urlParseWarned && !isInsideNodeModules(100, true)) {
     urlParseWarned = true;
     process.emitWarning(
       '`url.parse()` behavior is not standardized and prone to ' +

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -90,12 +90,12 @@ if (common.hasIntl) {
   });
 
   // Warning should only happen once per process.
-  const expectedWarning = [
-    `The URL ${badURLs[0]} is invalid. Future versions of Node.js will throw an error.`,
-    'DEP0170',
-  ];
   common.expectWarning({
-    DeprecationWarning: expectedWarning,
+    DeprecationWarning: {
+      // eslint-disable-next-line @stylistic/js/max-len
+      DEP0169: '`url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
+      DEP0170: `The URL ${badURLs[0]} is invalid. Future versions of Node.js will throw an error.`,
+    },
   });
   badURLs.forEach((badURL) => {
     url.parse(badURL);

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -45,4 +45,5 @@ export interface UtilBinding {
   guessHandleType(fd: number): 'TCP' | 'TTY' | 'UDP' | 'FILE' | 'PIPE' | 'UNKNOWN';
   parseEnv(content: string): Record<string, string>;
   styleText(format: Array<string> | string, text: string): string;
+  isInsideNodeModules(frameLimit: number, defaultValue: unknown): boolean;
 }


### PR DESCRIPTION
We documentation-only deprecated URL.parse on v18, almost 2 years ago. Without a runtime deprecation people will continue to use it and be exposed to security flaws. This is a nudge on the direction for a possible EOL in 3-5 years?

cc @nodejs/tsc