### PR TITLE
util: runtime deprecate toUSVString()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3547,12 +3547,15 @@ the result of said promise, which can lead to unhandled promise rejections.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55018
+    description: Runtime deprecation.
   - version: v20.8.0
     pr-url: https://github.com/nodejs/node/pull/49725
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`util.toUSVString()`][] API is deprecated. Please use
 [`String.prototype.toWellFormed`][] instead.

--- a/lib/util.js
+++ b/lib/util.js
@@ -326,6 +326,10 @@ function getCallSite(frames = 10) {
   return binding.getCallSite(frames);
 };
 
+function toUSVString(input) {
+  return StringPrototypeToWellFormed(`${input}`);
+}
+
 // Keep the `exports =` so that various functions can still be monkeypatched
 module.exports = {
   _errnoException,
@@ -357,9 +361,8 @@ module.exports = {
   },
   promisify,
   stripVTControlCharacters,
-  toUSVString(input) {
-    return StringPrototypeToWellFormed(`${input}`);
-  },
+  toUSVString: deprecate(toUSVString, 'util.toUSVString() is deprecated. ' +
+    'Please use String.prototype.toWellFormed() instead.', 'DEP0175'),
   get transferableAbortSignal() {
     return lazyAbortController().transferableAbortSignal;
   },


### PR DESCRIPTION
Let's runtime deprecate `toUSVString()`

cc @nodejs/tsc