### PR TITLE
crypto: runtime deprecate crypto.fips

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2030,12 +2030,15 @@ or `module.exports` instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55019
+    description: Runtime deprecation.
   - version: v10.0.0
     pr-url: https://github.com/nodejs/node/pull/18335
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`crypto.fips`][] property is deprecated. Please use `crypto.setFips()`
 and `crypto.getFips()` instead.

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -330,11 +330,12 @@ function getRandomBytesAlias(key) {
 }
 
 ObjectDefineProperties(module.exports, {
-  // crypto.fips is deprecated. DEP0093. Use crypto.getFips()/crypto.setFips()
   fips: {
     __proto__: null,
-    get: getFips,
-    set: setFips,
+    get: deprecate(getFips, 'The crypto.fips is deprecated. ' +
+      'Please use crypto.getFips()', 'DEP0093'),
+    set: deprecate(setFips, 'The crypto.fips is deprecated. ' +
+      'Please use crypto.setFips()', 'DEP0093'),
   },
   constants: {
     __proto__: null,


### PR DESCRIPTION
Let's runtime deprecate `crypto.fips` attribute.

cc @nodejs/crypto 