### PR TITLE
build: display free disk space after build in the test-macOS workflow

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -73,7 +73,7 @@ jobs:
           echo "::endgroup::"
           echo "::group::Cleaned Files"
 
-          sudo rm -rfv /Users/runner/Library/Android/sdk
+          sudo rm -rf /Users/runner/Library/Android/sdk
 
           echo "::endgroup::"
           echo "::group::Free space after cleanup"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -81,5 +81,7 @@ jobs:
           echo "::endgroup::"
       - name: Build
         run: make build-ci -j$(getconf _NPROCESSORS_ONLN) V=1 CONFIG_FLAGS="--error-on-warn"
+      - name: Free Space After Build
+        run: df -h
       - name: Test
         run: make run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=spec' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"


### PR DESCRIPTION
Since we have a [temporary solution](https://github.com/nodejs/node/pull/54658) to the issue of the build fail on macOS arm64 due to disk out of space, it makes sense the _**test-macOS**_ workflow displays the disk usage after `nodejs` is built to easily monitor the runner disk space.

Update: also remove the `-v` flag from `rm -rfv` in the cleanup step to reduce noise as @jakecastelli mentioned.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
