### PR TITLE
benchmark: use options.filename when, for esm, require.main.filename is undefined

### DIFF
--- a/benchmark/common.js
+++ b/benchmark/common.js
@@ -19,7 +19,9 @@ class Benchmark {
     this._time = 0n;
 
     // Use the file name as the name of the benchmark
-    this.name = require.main.filename.slice(__dirname.length + 1);
+    // For esm, require.main is undefined so use options.filename
+    this.filename = options.filename || require.main?.filename
+    this.name = this.filename.replace(/.*\//, '')
 
     // Execution arguments i.e. flags used to run the jobs
     this.flags = process.env.NODE_BENCHMARK_FLAGS?.split(/\s+/) ?? [];
@@ -224,7 +226,7 @@ class Benchmark {
         childArgs.push(`${key}=${value}`);
       }
 
-      const child = child_process.fork(require.main.filename, childArgs, {
+      const child = child_process.fork(this.filename, childArgs, {
         env: childEnv,
         execArgv: this.flags.concat(process.execArgv),
       });


### PR DESCRIPTION
These changes allow `benchmark/common.js` to be imported and used by esm scripts.

Advice, suggestions and any input at all are welcome. Thank you for reading me :)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
