### PR TITLE
test: do not assume `process.execPath` contains no spaces

### DIFF
--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -11,7 +11,8 @@ const invalidArgTypeError = {
 };
 
 const waitCommand = common.isWindows ?
-  `${process.execPath} -e "setInterval(()=>{}, 99)"` :
+  // `"` is forbidden for Windows paths, no need for escaping.
+  `"${process.execPath}" -e "setInterval(()=>{}, 99)"` :
   'sleep 2m';
 
 {

--- a/test/parallel/test-child-process-exec-maxbuf.js
+++ b/test/parallel/test-child-process-exec-maxbuf.js
@@ -10,12 +10,25 @@ function runChecks(err, stdio, streamName, expected) {
   assert.deepStrictEqual(stdio[streamName], expected);
 }
 
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (args, optionsOrCallback, callback) => {
+  let options = optionsOrCallback;
+  if (typeof optionsOrCallback === 'function') {
+    options = undefined;
+    callback = optionsOrCallback;
+  }
+  return cp.exec(
+    `"${common.isWindows ? process.execPath : '$NODE'}" ${args}`,
+    common.isWindows ? options : { ...options, env: { ...process.env, NODE: process.execPath } },
+    callback,
+  );
+};
+
 // default value
 {
-  const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
-
-  cp.exec(cmd, common.mustCall((err) => {
+  execNode(`-e "console.log('a'.repeat(1024 * 1024))"`, common.mustCall((err) => {
     assert(err instanceof RangeError);
     assert.strictEqual(err.message, 'stdout maxBuffer length exceeded');
     assert.strictEqual(err.code, 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER');
@@ -24,20 +37,16 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd =
-    `${process.execPath} -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
-
-  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  execNode(`-e "console.log('a'.repeat(1024 * 1024 - 1))"`, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('hello world');"`;
   const options = { maxBuffer: Infinity };
 
-  cp.exec(cmd, options, common.mustSucceed((stdout, stderr) => {
+  execNode(`-e "console.log('hello world');"`, options, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'hello world');
     assert.strictEqual(stderr, '');
   }));
@@ -57,11 +66,8 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024))"`;
-
-  cp.exec(
-    cmd,
+  execNode(
+    `-e "console.log('a'.repeat(1024 * 1024))"`,
     common.mustCall((err, stdout, stderr) => {
       runChecks(
         err,
@@ -75,10 +81,7 @@ function runChecks(err, stdio, streamName, expected) {
 
 // default value
 {
-  const cmd =
-    `"${process.execPath}" -e "console.log('a'.repeat(1024 * 1024 - 1))"`;
-
-  cp.exec(cmd, common.mustSucceed((stdout, stderr) => {
+  execNode(`-e "console.log('a'.repeat(1024 * 1024 - 1))"`, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), 'a'.repeat(1024 * 1024 - 1));
     assert.strictEqual(stderr, '');
   }));
@@ -87,10 +90,8 @@ function runChecks(err, stdio, streamName, expected) {
 const unicode = '中文测试'; // length = 4, byte length = 12
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('${unicode}');"`;
-
-  cp.exec(
-    cmd,
+  execNode(
+    `-e "console.log('${unicode}');"`,
     { maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
@@ -99,10 +100,8 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
-
-  cp.exec(
-    cmd,
+  execNode(
+    `-e "console.error('${unicode}');"`,
     { maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stderr', '中文测');
@@ -111,10 +110,8 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.log('${unicode}');"`;
-
-  const child = cp.exec(
-    cmd,
+  const child = execNode(
+    `-e "console.log('${unicode}');"`,
     { encoding: null, maxBuffer: 10 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stdout', '中文测试\n');
@@ -125,10 +122,8 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
-
-  const child = cp.exec(
-    cmd,
+  const child = execNode(
+    `-e "console.error('${unicode}');"`,
     { encoding: null, maxBuffer: 3 },
     common.mustCall((err, stdout, stderr) => {
       runChecks(err, { stdout, stderr }, 'stderr', '中文测');
@@ -139,10 +134,8 @@ const unicode = '中文测试'; // length = 4, byte length = 12
 }
 
 {
-  const cmd = `"${process.execPath}" -e "console.error('${unicode}');"`;
-
-  cp.exec(
-    cmd,
+  execNode(
+    `-e "console.error('${unicode}');"`,
     { encoding: null, maxBuffer: 5 },
     common.mustCall((err, stdout, stderr) => {
       const buf = Buffer.from(unicode).slice(0, 5);

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -49,8 +49,8 @@ command.on('close', common.mustCall((code, signal) => {
 }));
 
 // Verify that the environment is properly inherited
-const env = cp.spawn(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: { ...process.env, BAZ: 'buzz' },
+const env = cp.spawn(`"${common.isWindows ? process.execPath : '$NODE'}" -pe process.env.BAZ`, {
+  env: { ...process.env, BAZ: 'buzz', NODE: process.execPath },
   encoding: 'utf8',
   shell: true
 });

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -36,8 +36,8 @@ const command = cp.spawnSync(cmd, { shell: true });
 assert.strictEqual(command.stdout.toString().trim(), 'bar');
 
 // Verify that the environment is properly inherited
-const env = cp.spawnSync(`"${process.execPath}" -pe process.env.BAZ`, {
-  env: { ...process.env, BAZ: 'buzz' },
+const env = cp.spawnSync(`"${common.isWindows ? process.execPath : '$NODE'}" -pe process.env.BAZ`, {
+  env: { ...process.env, BAZ: 'buzz', NODE: process.execPath },
   shell: true
 });
 

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -11,9 +11,18 @@ const { exec, spawn } = require('child_process');
 const { once } = require('events');
 let stdOut;
 
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (args, callback) => exec(
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${args}`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath } },
+  callback,
+);
+
 
 function startPrintHelpTest() {
-  exec(`${process.execPath} --help`, common.mustSucceed((stdout, stderr) => {
+  execNode('--help', common.mustSucceed((stdout, stderr) => {
     stdOut = stdout;
     validateNodePrintHelp();
   }));

--- a/test/parallel/test-cli-syntax-eval.js
+++ b/test/parallel/test-cli-syntax-eval.js
@@ -4,19 +4,26 @@ const common = require('../common');
 const assert = require('assert');
 const { exec } = require('child_process');
 
-const node = process.execPath;
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (args, callback) => exec(
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${args}`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath } },
+  callback,
+);
+
 
 // Should throw if -c and -e flags are both passed
 ['-c', '--check'].forEach(function(checkFlag) {
   ['-e', '--eval'].forEach(function(evalFlag) {
     const args = [checkFlag, evalFlag, 'foo'];
-    const cmd = [node, ...args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+    execNode(args.join(' '), common.mustCall((err, stdout, stderr) => {
       assert.strictEqual(err instanceof Error, true);
       assert.strictEqual(err.code, 9);
       assert(
         stderr.startsWith(
-          `${node}: either --check or --eval can be used, not both`
+          `${process.execPath}: either --check or --eval can be used, not both`
         )
       );
     }));

--- a/test/parallel/test-npm-install.js
+++ b/test/parallel/test-npm-install.js
@@ -40,13 +40,15 @@ fs.writeFileSync(pkgPath, pkgContent);
 
 const env = { ...process.env,
               PATH: path.dirname(process.execPath),
+              NODE: process.execPath,
+              NPM: npmPath,
               NPM_CONFIG_PREFIX: path.join(npmSandbox, 'npm-prefix'),
               NPM_CONFIG_TMP: path.join(npmSandbox, 'npm-tmp'),
               NPM_CONFIG_AUDIT: false,
               NPM_CONFIG_UPDATE_NOTIFIER: false,
               HOME: homeDir };
 
-exec(`${process.execPath} ${npmPath} install`, {
+exec(`"${common.isWindows ? process.execPath : '$NODE'}" "${common.isWindows ? npmPath : '$NPM'}" install`, {
   cwd: installDir,
   env: env
 }, common.mustCall(handleExit));

--- a/test/parallel/test-permission-allow-child-process-cli.js
+++ b/test/parallel/test-permission-allow-child-process-cli.js
@@ -15,12 +15,20 @@ if (process.argv[2] === 'child') {
   assert.ok(process.permission.has('child'));
 }
 
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (args) => childProcess.execSync(
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${args}`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath } },
+);
+
 // When a permission is set by cli, the process shouldn't be able
 // to spawn unless --allow-child-process is sent
 {
   // doesNotThrow
   childProcess.spawnSync(process.execPath, ['--version']);
-  childProcess.execSync(process.execPath, ['--version']);
+  execNode('--version');
   childProcess.fork(__filename, ['child']);
   childProcess.execFileSync(process.execPath, ['--version']);
 }

--- a/test/parallel/test-permission-child-process-cli.js
+++ b/test/parallel/test-permission-child-process-cli.js
@@ -15,6 +15,14 @@ if (process.argv[2] === 'child') {
   assert.ok(!process.permission.has('child'));
 }
 
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (args) => [
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${args}`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath } },
+];
+
 // When a permission is set by cli, the process shouldn't be able
 // to spawn
 {
@@ -31,13 +39,13 @@ if (process.argv[2] === 'child') {
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
-    childProcess.exec(process.execPath, ['--version']);
+    childProcess.exec(...execNode('--version'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
-    childProcess.execSync(process.execPath, ['--version']);
+    childProcess.execSync(...execNode('--version'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
@@ -49,13 +57,13 @@ if (process.argv[2] === 'child') {
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
-    childProcess.execFile(process.execPath, ['--version']);
+    childProcess.execFile(...execNode('--version'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
   }));
   assert.throws(() => {
-    childProcess.execFileSync(process.execPath, ['--version']);
+    childProcess.execFileSync(...execNode('--version'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',

--- a/test/parallel/test-pipe-head.js
+++ b/test/parallel/test-pipe-head.js
@@ -5,12 +5,13 @@ const assert = require('assert');
 
 const exec = require('child_process').exec;
 
-const nodePath = process.argv[0];
 const script = fixtures.path('print-10-lines.js');
 
-const cmd = `"${nodePath}" "${script}" | head -2`;
+const cmd = `"${common.isWindows ? process.execPath : '$NODE'}" "${common.isWindows ? script : '$FILE'}" | head -2`;
 
-exec(cmd, common.mustSucceed((stdout, stderr) => {
+exec(cmd, {
+  env: common.isWindows ? process.env : { ...process.env, NODE: process.execPath, FILE: script },
+}, common.mustSucceed((stdout, stderr) => {
   const lines = stdout.split('\n');
   assert.strictEqual(lines.length, 3);
 }));

--- a/test/parallel/test-stdin-from-file-spawn.js
+++ b/test/parallel/test-stdin-from-file-spawn.js
@@ -39,4 +39,13 @@ setTimeout(() => {
 }, 100);
 `);
 
-execSync(`${process.argv[0]} ${tmpJsFile} < ${tmpCmdFile}`);
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+execSync(
+  `"${common.isWindows ? process.execPath : '$NODE'}" "${
+    common.isWindows ? tmpJsFile : '$FILE'}" < "${common.isWindows ? tmpCmdFile : '$CMD_FILE'}"`,
+  common.isWindows ? undefined : {
+    env: { ...process.env, NODE: process.execPath, FILE: tmpJsFile, CMD_FILE: tmpCmdFile },
+  },
+);

--- a/test/sequential/test-cli-syntax-file-not-found.js
+++ b/test/sequential/test-cli-syntax-file-not-found.js
@@ -5,12 +5,18 @@ const assert = require('assert');
 const { exec } = require('child_process');
 const fixtures = require('../common/fixtures');
 
-const node = process.execPath;
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (flag, file) => exec(
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${flag} "${common.isWindows ? file : '$FILE'}"`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath, FILE: file } },
+);
 
 // Test both sets of arguments that check syntax
 const syntaxArgs = [
-  ['-c'],
-  ['--check'],
+  '-c',
+  '--check',
 ];
 
 const notFoundRE = /^Error: Cannot find module/m;
@@ -23,10 +29,8 @@ const notFoundRE = /^Error: Cannot find module/m;
   file = fixtures.path(file);
 
   // Loop each possible option, `-c` or `--check`
-  syntaxArgs.forEach(function(args) {
-    const _args = args.concat(file);
-    const cmd = [node, ..._args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+  syntaxArgs.forEach(function(flag) {
+    execNode(flag, file, common.mustCall((err, stdout, stderr) => {
       // No stdout should be produced
       assert.strictEqual(stdout, '');
 

--- a/test/sequential/test-cli-syntax-file-not-found.js
+++ b/test/sequential/test-cli-syntax-file-not-found.js
@@ -8,9 +8,10 @@ const fixtures = require('../common/fixtures');
 // The execPath might contain chars that should be escaped in a shell context.
 // On non-Windows, we can pass the path via the env; `"` is not a valid char on
 // Windows, so we can simply pass the path.
-const execNode = (flag, file) => exec(
+const execNode = (flag, file, callback) => exec(
   `"${common.isWindows ? process.execPath : '$NODE'}" ${flag} "${common.isWindows ? file : '$FILE'}"`,
   common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath, FILE: file } },
+  callback,
 );
 
 // Test both sets of arguments that check syntax

--- a/test/sequential/test-cli-syntax-good.js
+++ b/test/sequential/test-cli-syntax-good.js
@@ -5,12 +5,18 @@ const assert = require('assert');
 const { exec } = require('child_process');
 const fixtures = require('../common/fixtures');
 
-const node = process.execPath;
+// The execPath might contain chars that should be escaped in a shell context.
+// On non-Windows, we can pass the path via the env; `"` is not a valid char on
+// Windows, so we can simply pass the path.
+const execNode = (flag, file) => exec(
+  `"${common.isWindows ? process.execPath : '$NODE'}" ${flag} "${common.isWindows ? file : '$FILE'}"`,
+  common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath, FILE: file } },
+);
 
 // Test both sets of arguments that check syntax
 const syntaxArgs = [
-  ['-c'],
-  ['--check'],
+  '-c',
+  '--check',
 ];
 
 // Test good syntax with and without shebang
@@ -25,11 +31,8 @@ const syntaxArgs = [
   file = fixtures.path(file);
 
   // Loop each possible option, `-c` or `--check`
-  syntaxArgs.forEach(function(args) {
-    const _args = args.concat(file);
-
-    const cmd = [node, ..._args].join(' ');
-    exec(cmd, common.mustCall((err, stdout, stderr) => {
+  syntaxArgs.forEach(function(flag) {
+    execNode(flag, file, common.mustCall((err, stdout, stderr) => {
       if (err) {
         console.log('-- stdout --');
         console.log(stdout);

--- a/test/sequential/test-cli-syntax-good.js
+++ b/test/sequential/test-cli-syntax-good.js
@@ -8,9 +8,10 @@ const fixtures = require('../common/fixtures');
 // The execPath might contain chars that should be escaped in a shell context.
 // On non-Windows, we can pass the path via the env; `"` is not a valid char on
 // Windows, so we can simply pass the path.
-const execNode = (flag, file) => exec(
+const execNode = (flag, file, callback) => exec(
   `"${common.isWindows ? process.execPath : '$NODE'}" ${flag} "${common.isWindows ? file : '$FILE'}"`,
   common.isWindows ? undefined : { env: { ...process.env, NODE: process.execPath, FILE: file } },
+  callback,
 );
 
 // Test both sets of arguments that check syntax


### PR DESCRIPTION
We had a bunch of tests that would fail if run from an executable that contains any char that should be escaped when run from a shell.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
