### PR TITLE
test: update tls test to support OpenSSL32

### DIFF
--- a/test/parallel/test-tls-client-getephemeralkeyinfo.js
+++ b/test/parallel/test-tls-client-getephemeralkeyinfo.js
@@ -67,11 +67,15 @@ function test(size, type, name, cipher) {
   }));
 }
 
-test(undefined, undefined, undefined, 'AES128-SHA256');
-test('auto', 'DH', undefined, 'DHE-RSA-AES128-GCM-SHA256');
-test(1024, 'DH', undefined, 'DHE-RSA-AES128-GCM-SHA256');
-test(2048, 'DH', undefined, 'DHE-RSA-AES128-GCM-SHA256');
-test(256, 'ECDH', 'prime256v1', 'ECDHE-RSA-AES128-GCM-SHA256');
-test(521, 'ECDH', 'secp521r1', 'ECDHE-RSA-AES128-GCM-SHA256');
-test(253, 'ECDH', 'X25519', 'ECDHE-RSA-AES128-GCM-SHA256');
-test(448, 'ECDH', 'X448', 'ECDHE-RSA-AES128-GCM-SHA256');
+test(undefined, undefined, undefined, 'AES256-SHA256');
+test('auto', 'DH', undefined, 'DHE-RSA-AES256-GCM-SHA384');
+if (!common.hasOpenSSL(3, 2)) {
+  test(1024, 'DH', undefined, 'DHE-RSA-AES256-GCM-SHA384');
+} else {
+  test(3072, 'DH', undefined, 'DHE-RSA-AES256-GCM-SHA384');
+}
+test(2048, 'DH', undefined, 'DHE-RSA-AES256-GCM-SHA384');
+test(256, 'ECDH', 'prime256v1', 'ECDHE-RSA-AES256-GCM-SHA384');
+test(521, 'ECDH', 'secp521r1', 'ECDHE-RSA-AES256-GCM-SHA384');
+test(253, 'ECDH', 'X25519', 'ECDHE-RSA-AES256-GCM-SHA384');
+test(448, 'ECDH', 'X448', 'ECDHE-RSA-AES256-GCM-SHA384');


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/53382

OpenSSL32 does not support AES128 and DH 1024 to
update test to use newer algorithms.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
