### PR TITLE
meta: re-enable PR stalebot

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -1,5 +1,8 @@
 name: Close stale pull requests
 on:
+  schedule:
+    # Run every day at 1:00 AM UTC.
+    - cron: 0 1 * * *
   workflow_dispatch:
     inputs:
       endDate:


### PR DESCRIPTION
I propose that this stalebot be re-enabled.

This is a secondary approach to #54673.

I'm not sure if this change (being that it modifies the issue tracker) requires a TSC ping?