### PR TITLE
test: fix `soucre` to `source`

### DIFF
--- a/test/fixtures/test-runner/coverage/index.test.js
+++ b/test/fixtures/test-runner/coverage/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const test = require('node:test');
-test('no soucre map', () => {});
+test('no source map', () => {});
 if (false) {
   console.log('this does not execute');
 }


### PR DESCRIPTION
Can this be fast-tracked? it shouldn't cause any breakages.