### PR TITLE
test_runner: require `--enable-source-maps` for source map coverage

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -51,13 +51,11 @@ class CoverageLine {
 }
 
 class TestCoverage {
-  constructor(coverageDirectory, originalCoverageDirectory, workingDirectory, excludeGlobs, includeGlobs, thresholds) {
+  constructor(coverageDirectory, originalCoverageDirectory, workingDirectory, globalOptions) {
     this.coverageDirectory = coverageDirectory;
     this.originalCoverageDirectory = originalCoverageDirectory;
     this.workingDirectory = workingDirectory;
-    this.excludeGlobs = excludeGlobs;
-    this.includeGlobs = includeGlobs;
-    this.thresholds = thresholds;
+    this.globalOptions = globalOptions;
   }
 
   #sourceLines = new SafeMap();
@@ -144,7 +142,12 @@ class TestCoverage {
         coveredBranchPercent: 0,
         coveredFunctionPercent: 0,
       },
-      thresholds: this.thresholds,
+      thresholds: {
+        __proto__: null,
+        line: this.globalOptions.lineCoverage,
+        branch: this.globalOptions.branchCoverage,
+        function: this.globalOptions.functionCoverage,
+      },
     };
 
     if (!coverage) {
@@ -448,18 +451,20 @@ class TestCoverage {
     const relativePath = relative(this.workingDirectory, absolutePath);
 
     // This check filters out files that match the exclude globs.
-    if (this.excludeGlobs?.length > 0) {
-      for (let i = 0; i < this.excludeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, this.excludeGlobs[i]) ||
-            matchesGlob(absolutePath, this.excludeGlobs[i])) return true;
+    const excludeGlobs = this.globalOptions.coverageExcludeGlobs;
+    if (excludeGlobs?.length > 0) {
+      for (let i = 0; i < excludeGlobs.length; ++i) {
+        if (matchesGlob(relativePath, excludeGlobs[i]) ||
+            matchesGlob(absolutePath, excludeGlobs[i])) return true;
       }
     }
 
     // This check filters out files that do not match the include globs.
-    if (this.includeGlobs?.length > 0) {
-      for (let i = 0; i < this.includeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, this.includeGlobs[i]) ||
-            matchesGlob(absolutePath, this.includeGlobs[i])) return false;
+    const includeGlobs = this.globalOptions.coverageIncludeGlobs;
+    if (includeGlobs?.length > 0) {
+      for (let i = 0; i < includeGlobs.length; ++i) {
+        if (matchesGlob(relativePath, includeGlobs[i]) ||
+            matchesGlob(absolutePath, includeGlobs[i])) return false;
       }
       return true;
     }
@@ -505,14 +510,7 @@ function setupCoverage(options) {
     coverageDirectory,
     originalCoverageDirectory,
     cwd,
-    options.coverageExcludeGlobs,
-    options.coverageIncludeGlobs,
-    {
-      __proto__: null,
-      line: options.lineCoverage,
-      branch: options.branchCoverage,
-      function: options.functionCoverage,
-    },
+    options,
   );
 }
 

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -338,7 +338,7 @@ class TestCoverage {
   mapCoverageWithSourceMap(coverage) {
     const { result } = coverage;
     const sourceMapCache = coverage['source-map-cache'];
-    if (!sourceMapCache) {
+    if (!this.globalOptions.sourceMaps || !sourceMapCache) {
       return result;
     }
     const newResult = new SafeMap();

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -552,7 +552,8 @@ class Test extends AsyncResource {
         file: loc[2],
       };
 
-      if (this.config.sourceMaps === true) {
+      // TODO(RedYetiDev): This should be supported with code coverage
+      if (this.config.sourceMaps && !this.config.coverage) {
         const map = lazyFindSourceMap(this.loc.file);
         const entry = map?.findEntry(this.loc.line - 1, this.loc.column - 1);
 
@@ -563,7 +564,7 @@ class Test extends AsyncResource {
         }
       }
 
-      if (StringPrototypeStartsWith(this.loc.file, 'file://')) {
+      if (this.loc.file && StringPrototypeStartsWith(this.loc.file, 'file://')) {
         this.loc.file = fileURLToPath(this.loc.file);
       }
     }

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -289,6 +289,37 @@ test('coverage reports on lines, functions, and branches', skipIfNoInspector, as
   });
 });
 
+test('coverage without --enable-source-map ignores sourcemaps', skipIfNoInspector, () => {
+  let report = [
+    '# start of coverage report',
+    '# --------------------------------------------------------------',
+    '# file          | line % | branch % | funcs % | uncovered lines',
+    '# --------------------------------------------------------------',
+    '# a.test.mjs    | 100.00 |   100.00 |  100.00 | ',
+    '# index.test.js |  71.43 |    66.67 |  100.00 | 6-7',
+    '# stdin.test.js | 100.00 |   100.00 |  100.00 | ',
+    '# --------------------------------------------------------------',
+    '# all files     |  85.71 |    87.50 |  100.00 | ',
+    '# --------------------------------------------------------------',
+    '# end of coverage report',
+  ].join('\n');
+
+  if (common.isWindows) {
+    report = report.replaceAll('/', '\\');
+  }
+
+  const fixture = fixtures.path('test-runner', 'coverage');
+  const args = [
+    '--test',
+    '--experimental-test-coverage',
+    '--test-reporter', 'tap',
+  ];
+  const result = spawnSync(process.execPath, args, { cwd: fixture });
+  assert.strictEqual(result.stderr.toString(), '');
+  assert(result.stdout.toString().includes(report));
+  assert.strictEqual(result.status, 1);
+});
+
 test('coverage with source maps', skipIfNoInspector, () => {
   let report = [
     '# start of coverage report',
@@ -311,7 +342,10 @@ test('coverage with source maps', skipIfNoInspector, () => {
 
   const fixture = fixtures.path('test-runner', 'coverage');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
+    '--enable-source-maps',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-reporter', 'tap',
   ];
   const result = spawnSync(process.execPath, args, { cwd: fixture });
 
@@ -489,7 +523,10 @@ test('coverage with included and excluded files', skipIfNoInspector, () => {
 test('properly accounts for line endings in source maps', skipIfNoInspector, () => {
   const fixture = fixtures.path('test-runner', 'source-map-line-lengths', 'index.js');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
+    '--enable-source-maps',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-reporter', 'tap',
     fixture,
   ];
   const report = [


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/54753#issuecomment-2351142258 (CC @MoLow @cjihrig)
Fixes: #55106

Coverage is currently an experimental feature, so this is non-breaking, right?