### PR TITLE
crypto: ensure invalid SubtleCrypto JWK data import results in DataError

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -295,7 +295,12 @@ async function aesImportKey(
       }
 
       const handle = new KeyObjectHandle();
-      handle.initJwk(keyData);
+      try {
+        handle.initJwk(keyData);
+      } catch (err) {
+        throw lazyDOMException(
+          'Invalid keyData', { name: 'DataError', cause: err });
+      }
 
       ({ length } = handle.keyDetail({ }));
       validateKeyLength(length);

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -18,6 +18,12 @@ const {
 } = internalBinding('crypto');
 
 const {
+  codes: {
+    ERR_CRYPTO_INVALID_JWK,
+  },
+} = require('internal/errors');
+
+const {
   getUsagesUnion,
   hasAnyNotIn,
   jobPromise,
@@ -277,22 +283,26 @@ async function cfrgImportKey(
         isPublic,
         usagesSet);
 
-      const publicKeyObject = createCFRGRawKey(
-        name,
-        Buffer.from(keyData.x, 'base64'),
-        true);
-
-      if (isPublic) {
-        keyObject = publicKeyObject;
-      } else {
-        keyObject = createCFRGRawKey(
+      try {
+        const publicKeyObject = createCFRGRawKey(
           name,
-          Buffer.from(keyData.d, 'base64'),
-          false);
+          Buffer.from(keyData.x, 'base64'),
+          true);
 
-        if (!createPublicKey(keyObject).equals(publicKeyObject)) {
-          throw lazyDOMException('Invalid JWK', 'DataError');
+        if (isPublic) {
+          keyObject = publicKeyObject;
+        } else {
+          keyObject = createCFRGRawKey(
+            name,
+            Buffer.from(keyData.d, 'base64'),
+            false);
+
+          if (!createPublicKey(keyObject).equals(publicKeyObject)) {
+            throw new ERR_CRYPTO_INVALID_JWK();
+          }
         }
+      } catch (err) {
+        throw lazyDOMException('Invalid keyData', { name: 'DataError', cause: err });
       }
       break;
     }

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -240,9 +240,15 @@ async function ecImportKey(
       }
 
       const handle = new KeyObjectHandle();
-      const type = handle.initJwk(keyData, namedCurve);
+      let type;
+      try {
+        type = handle.initJwk(keyData, namedCurve);
+      } catch (err) {
+        throw lazyDOMException(
+          'Invalid keyData', { name: 'DataError', cause: err });
+      }
       if (type === undefined)
-        throw lazyDOMException('Invalid JWK', 'DataError');
+        throw lazyDOMException('Invalid keyData', 'DataError');
       keyObject = type === kKeyTypePrivate ?
         new PrivateKeyObject(handle) :
         new PublicKeyObject(handle);

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -145,7 +145,12 @@ async function hmacImportKey(
       }
 
       const handle = new KeyObjectHandle();
-      handle.initJwk(keyData);
+      try {
+        handle.initJwk(keyData);
+      } catch (err) {
+        throw lazyDOMException(
+          'Invalid keyData', { name: 'DataError', cause: err });
+      }
       keyObject = new SecretKeyObject(handle);
       break;
     }

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -275,9 +275,15 @@ async function rsaImportKey(
       }
 
       const handle = new KeyObjectHandle();
-      const type = handle.initJwk(keyData);
+      let type;
+      try {
+        type = handle.initJwk(keyData);
+      } catch (err) {
+        throw lazyDOMException(
+          'Invalid keyData', { name: 'DataError', cause: err });
+      }
       if (type === undefined)
-        throw lazyDOMException('Invalid JWK', 'DataError');
+        throw lazyDOMException('Invalid keyData', 'DataError');
 
       keyObject = type === kKeyTypePrivate ?
         new PrivateKeyObject(handle) :

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -322,6 +322,15 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
       extractable,
       [/* empty usages */]),
     { name: 'SyntaxError', message: 'Usages cannot be empty when importing a private key.' });
+
+  await assert.rejects(
+    subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, /* missing x */ crv: jwk.crv },
+      { name },
+      extractable,
+      publicUsages),
+    { name: 'DataError', message: 'Invalid keyData' });
 }
 
 async function testImportRaw({ name, publicUsages }) {

--- a/test/parallel/test-webcrypto-export-import-ec.js
+++ b/test/parallel/test-webcrypto-export-import-ec.js
@@ -330,6 +330,15 @@ async function testImportJwk(
       extractable,
       [/* empty usages */]),
     { name: 'SyntaxError', message: 'Usages cannot be empty when importing a private key.' });
+
+  await assert.rejects(
+    subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, /* missing x */ y: jwk.y, crv: jwk.crv },
+      { name, namedCurve },
+      extractable,
+      publicUsages),
+    { name: 'DataError', message: 'Invalid keyData' });
 }
 
 async function testImportRaw({ name, publicUsages }, namedCurve) {

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -513,6 +513,15 @@ async function testImportJwk(
       extractable,
       [/* empty usages */]),
     { name: 'SyntaxError', message: 'Usages cannot be empty when importing a private key.' });
+
+  await assert.rejects(
+    subtle.importKey(
+      'jwk',
+      { kty: jwk.kty, /* missing e */ n: jwk.n },
+      { name, hash },
+      extractable,
+      publicUsages),
+    { name: 'DataError', message: 'Invalid keyData' });
 }
 
 // combinations to test


### PR DESCRIPTION
All invalid data during import is supposed to return `DataError` `DOMException`. See https://w3c.github.io/webcrypto/

The WPTs for this are coming in https://github.com/web-platform-tests/wpt/pull/48243 but I'm opening this separately to be able to backport this easily.