### PR TITLE
test_runner: don't set coverage threshold exitCode until `test:summary`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1336,14 +1336,11 @@ changes:
     If both `coverageExcludeGlobs` and `coverageIncludeGlobs` are provided,
     files must meet **both** criteria to be included in the coverage report.
     **Default:** `undefined`.
-  * `lineCoverage` {number} Require a minimum percent of covered lines. If code
-    coverage does not reach the threshold specified, the process will exit with code `1`.
+  * `lineCoverage` {number} Require a minimum percent of covered lines.
     **Default:** `0`.
-  * `branchCoverage` {number} Require a minimum percent of covered branches. If code
-    coverage does not reach the threshold specified, the process will exit with code `1`.
+  * `branchCoverage` {number} Require a minimum percent of covered branches.
     **Default:** `0`.
-  * `functionCoverage` {number} Require a minimum percent of covered functions. If code
-    coverage does not reach the threshold specified, the process will exit with code `1`.
+  * `functionCoverage` {number} Require a minimum percent of covered functions.
     **Default:** `0`.
 * Returns: {TestsStream}
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -28,7 +28,6 @@ const {
   Symbol,
 } = primordials;
 const { getCallerLocation } = internalBinding('util');
-const { exitCodes: { kGenericUserError } } = internalBinding('errors');
 const { addAbortListener } = require('internal/events/abort_listener');
 const { queueMicrotask } = require('internal/process/task_queues');
 const { AsyncResource } = require('async_hooks');
@@ -1069,7 +1068,6 @@ class Test extends AsyncResource {
           const { threshold, actual, name } = coverages[i];
           if (actual < threshold) {
             harness.success = false;
-            process.exitCode = kGenericUserError;
             reporter.diagnostic(nesting, loc, `Error: ${NumberPrototypeToFixed(actual, 2)}% ${name} coverage does not meet threshold of ${threshold}%.`);
           }
         }

--- a/test/parallel/test-runner-run-coverage.mjs
+++ b/test/parallel/test-runner-run-coverage.mjs
@@ -169,8 +169,6 @@ describe('require(\'node:test\').run coverage settings', { concurrency: true }, 
       // eslint-disable-next-line no-unused-vars
       for await (const _ of stream);
       assert.deepStrictEqual(thresholdErrors.sort(), ['branch', 'function', 'line']);
-      assert.strictEqual(process.exitCode, 1);
-      process.exitCode = originalExitCode;
     });
   });
 });


### PR DESCRIPTION
I'm not sure if this is `semver-major`, because coverage is experimental, and the behavior that is being changed hasn't landed on any release lines.

IMO no user is expected the test runner's `run` function to change the process's exitCode without throwing an error, and this behavior was a left-over from adding code coverage to the `run` function, so I propose handling it like everything else - without modifying the exitCode.