### PR TITLE
test_runner: throw on invalid source map

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2583,6 +2583,12 @@ disconnected socket.
 
 A call was made and the UDP subsystem was not running.
 
+<a id="ERR_SOURCE_MAP_CORRUPT"></a>
+
+### `ERR_SOURCE_MAP_CORRUPT`
+
+The source map could not be parsed because it does not exist, or is corrupt.
+
 <a id="ERR_SOURCE_MAP_MISSING_SOURCE"></a>
 
 ### `ERR_SOURCE_MAP_MISSING_SOURCE`

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1707,6 +1707,7 @@ E('ERR_SOCKET_CONNECTION_TIMEOUT',
 E('ERR_SOCKET_DGRAM_IS_CONNECTED', 'Already connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_CONNECTED', 'Not connected', Error);
 E('ERR_SOCKET_DGRAM_NOT_RUNNING', 'Not running', Error);
+E('ERR_SOURCE_MAP_CORRUPT', `The source map for '%s' does not exist or is corrupt.`, Error);
 E('ERR_SOURCE_MAP_MISSING_SOURCE', `Cannot find '%s' imported from the source map for '%s'`, Error);
 E('ERR_SRI_PARSE',
   'Subresource Integrity string %j had an unexpected %j at position %d',

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -32,6 +32,7 @@ const { fileURLToPath } = require('internal/url');
 const { kMappings, SourceMap } = require('internal/source_map/source_map');
 const {
   codes: {
+    ERR_SOURCE_MAP_CORRUPT,
     ERR_SOURCE_MAP_MISSING_SOURCE,
   },
 } = require('internal/errors');
@@ -353,6 +354,7 @@ class TestCoverage {
         continue;
       }
       const { data, lineLengths } = sourceMapCache[url];
+      if (!data) throw new ERR_SOURCE_MAP_CORRUPT(url);
       let offset = 0;
       const executedLines = ArrayPrototypeMap(lineLengths, (length, i) => {
         const coverageLine = new CoverageLine(i + 1, offset, null, length + 1);

--- a/test/fixtures/test-runner/source-maps/invalid-json/index.js
+++ b/test/fixtures/test-runner/source-maps/invalid-json/index.js
@@ -1,0 +1,2 @@
+export {};
+//# sourceMappingURL=index.js.map

--- a/test/fixtures/test-runner/source-maps/invalid-json/index.js.map
+++ b/test/fixtures/test-runner/source-maps/invalid-json/index.js.map
@@ -1,0 +1,1 @@
+invalid

--- a/test/fixtures/test-runner/source-maps/missing-map.js
+++ b/test/fixtures/test-runner/source-maps/missing-map.js
@@ -1,0 +1,1 @@
+//# sourceMappingURL=missing.js.map

--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -80,4 +80,18 @@ describe('Coverage with source maps', async () => {
     t.assert.ok(spawned.stdout.includes(error));
     t.assert.strictEqual(spawned.code, 1);
   });
+
+  for (const [file, message] of [
+    [fixtures.path('test-runner', 'source-maps', 'invalid-json', 'index.js'), 'is not valid JSON'],
+    [fixtures.path('test-runner', 'source-maps', 'missing-map.js'), 'does not exist'],
+  ]) {
+    await it(`should throw when a source map ${message}`, async (t) => {
+      const spawned = await common.spawnPromisified(process.execPath, [...flags, file]);
+
+      const error = `The source map for '${pathToFileURL(file)}' does not exist or is corrupt`;
+      t.assert.strictEqual(spawned.stderr, '');
+      t.assert.ok(spawned.stdout.includes(error));
+      t.assert.strictEqual(spawned.code, 1);
+    });
+  }
 }).then(common.mustCall());


### PR DESCRIPTION
This PR changes the code coverage test runner to throw `ERR_SOURCE_MAP_CORRUPT` when a sourcemap is not a valid JSON file, or does not exist.