### PR TITLE
[v20.x backport] doc: add missing EventSource docs to globals

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -451,6 +451,17 @@ changes:
 A browser-compatible implementation of the `Event` class. See
 [`EventTarget` and `Event` API][] for more details.
 
+## `EventSource`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental. Enable this API with the [`--experimental-eventsource`][]
+> CLI flag.
+
+A browser-compatible implementation of the [`EventSource`][] class.
+
 ## `EventTarget`
 
 <!-- YAML
@@ -1012,6 +1023,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [CommonJS modules]: modules.md
 [ECMAScript module]: esm.md
 [Web Crypto API]: webcrypto.md
+[`--experimental-eventsource`]: cli.md#--experimental-eventsource
 [`--experimental-websocket`]: cli.md#--experimental-websocket
 [`--no-experimental-fetch`]: cli.md#--no-experimental-fetch
 [`--no-experimental-global-customevent`]: cli.md#--no-experimental-global-customevent
@@ -1023,6 +1035,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [`CustomEvent` Web API]: https://dom.spec.whatwg.org/#customevent
 [`DOMException`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [`DecompressionStream`]: webstreams.md#class-decompressionstream
+[`EventSource`]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
 [`EventTarget` and `Event` API]: events.md#eventtarget-and-event-api
 [`MessageChannel`]: worker_threads.md#class-messagechannel
 [`MessageEvent`]: https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent/MessageEvent


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/55022 to fix the `added in` version. I'm requesting a fast-track so it can be added to the next v20.x release (the new global has already been added to the staging branch) since it's a doc-only change and IMO it makes more sense to not respect the maturation period in this case.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
