### PR TITLE
lib: fix typos

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -88,7 +88,7 @@ for (const m of [[kKeyEncodingPKCS1, 'pkcs1'], [kKeyEncodingPKCS8, 'pkcs8'],
   encodingNames[m[0]] = m[1];
 
 // Creating the KeyObject class is a little complicated due to inheritance
-// and the fact that KeyObjects should be transferrable between threads,
+// and the fact that KeyObjects should be transferable between threads,
 // which requires the KeyObject base class to be implemented in C++.
 // The creation requires a callback to make sure that the NativeKeyObject
 // base class cannot exist without the other KeyObject implementations.

--- a/lib/internal/crypto/webidl.js
+++ b/lib/internal/crypto/webidl.js
@@ -80,7 +80,7 @@ function type(V) {
     case 'object': // Fall through
     case 'function': // Fall through
     default:
-      // Per ES spec, typeof returns an implemention-defined value that is not
+      // Per ES spec, typeof returns an implementation-defined value that is not
       // any of the existing ones for uncallable non-standard exotic objects.
       // Yet Type() which the Web IDL spec depends on returns Object for such
       // cases. So treat the default case as an object.

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -59,7 +59,7 @@ const kSerializeResolver = Symbol('dns:resolver:serialize');
 const kDeserializeResolver = Symbol('dns:resolver:deserialize');
 const kSnapshotStates = Symbol('dns:resolver:config');
 const kInitializeHandle = Symbol('dns:resolver:initializeHandle');
-const kSetServersInteral = Symbol('dns:resolver:setServers');
+const kSetServersInternal = Symbol('dns:resolver:setServers');
 
 // Resolver instances correspond 1:1 to c-ares channels.
 
@@ -139,10 +139,10 @@ class ResolverBase {
       throw new ERR_INVALID_IP_ADDRESS(serv);
     });
 
-    this[kSetServersInteral](newSet, servers);
+    this[kSetServersInternal](newSet, servers);
   }
 
-  [kSetServersInteral](newSet, servers) {
+  [kSetServersInternal](newSet, servers) {
     const orig = ArrayPrototypeMap(this._handle.getServers() || [], (val) => {
       val.unshift(isIP(val[0]));
       return val;
@@ -194,7 +194,7 @@ class ResolverBase {
       this._handle.setLocalAddress(ipv4, ipv6);
     }
     if (servers) {
-      this[kSetServersInteral](servers, servers);
+      this[kSetServersInternal](servers, servers);
     }
   }
 }

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1715,7 +1715,7 @@ E('ERR_STREAM_DESTROYED', 'Cannot call %s after a stream was destroyed', Error);
 E('ERR_STREAM_NULL_VALUES', 'May not write null values to stream', TypeError);
 E('ERR_STREAM_PREMATURE_CLOSE', 'Premature close', Error);
 E('ERR_STREAM_PUSH_AFTER_EOF', 'stream.push() after EOF', Error);
-E('ERR_STREAM_UNABLE_TO_PIPE', 'Connot pipe to a closed or destroyed stream', Error);
+E('ERR_STREAM_UNABLE_TO_PIPE', 'Cannot pipe to a closed or destroyed stream', Error);
 E('ERR_STREAM_UNSHIFT_AFTER_END_EVENT',
   'stream.unshift() after end event', Error);
 E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -337,7 +337,7 @@ class Glob {
       const subPatterns = new SafeSet();
       const nSymlinks = new SafeSet();
       for (const index of pattern.indexes) {
-        // For each child, chek potential patterns
+        // For each child, check potential patterns
         if (this.#cache.seen(entryPath, pattern, index) || this.#cache.seen(entryPath, pattern, index + 1)) {
           return;
         }
@@ -365,7 +365,7 @@ class Glob {
             // If next pattern is the last one, add to results
             this.#results.add(entryPath);
           } else if (nextMatches && entry.isDirectory()) {
-            // Pattern mached, meaning two patterns forward
+            // Pattern matched, meaning two patterns forward
             // are also potential patterns
             // e.g **/b/c when entry is a/b - add c to potential patterns
             subPatterns.add(index + 2);
@@ -532,7 +532,7 @@ class Glob {
       const subPatterns = new SafeSet();
       const nSymlinks = new SafeSet();
       for (const index of pattern.indexes) {
-        // For each child, chek potential patterns
+        // For each child, check potential patterns
         if (this.#cache.seen(entryPath, pattern, index) || this.#cache.seen(entryPath, pattern, index + 1)) {
           return;
         }
@@ -566,7 +566,7 @@ class Glob {
               yield this.#withFileTypes ? entry : entryPath;
             }
           } else if (nextMatches && entry.isDirectory()) {
-            // Pattern mached, meaning two patterns forward
+            // Pattern matched, meaning two patterns forward
             // are also potential patterns
             // e.g **/b/c when entry is a/b - add c to potential patterns
             subPatterns.add(index + 2);

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -41,14 +41,14 @@ const cacheForGET = new SafeMap();
 // [1] The V8 snapshot doesn't like some C++ APIs to be loaded eagerly. Do it
 // lazily/at runtime and not top level of an internal module.
 
-// [2] Creating a new agent instead of using the gloabl agent improves
+// [2] Creating a new agent instead of using the global agent improves
 // performance and precludes the agent becoming tainted.
 
 /** @type {import('https').Agent} The Cached HTTP Agent for **secure** HTTP requests. */
 let HTTPSAgent;
 /**
  * Make a HTTPs GET request (handling agent setup if needed, caching the agent to avoid
- * redudant instantiations).
+ * redundant instantiations).
  * @param {Parameters<import('https').get>[0]} input - The URI to fetch.
  * @param {Parameters<import('https').get>[1]} options - See https.get() options.
  */
@@ -67,7 +67,7 @@ function HTTPSGet(input, options) {
 let HTTPAgent;
 /**
  * Make a HTTP GET request (handling agent setup if needed, caching the agent to avoid
- * redudant instantiations).
+ * redundant instantiations).
  * @param {Parameters<import('http').get>[0]} input - The URI to fetch.
  * @param {Parameters<import('http').get>[1]} options - See http.get() options.
  */

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -414,7 +414,7 @@ class ModuleLoader {
   /**
    * Translate a loaded module source into a ModuleWrap. This is run synchronously,
    * but the translator may return the ModuleWrap in a Promise.
-   * @param {stirng} url URL of the module to be translated.
+   * @param {string} url URL of the module to be translated.
    * @param {string} format Format of the module to be translated. This is used to find
    *                        matching translators.
    * @param {ModuleSource} source Source of the module to be translated.

--- a/lib/internal/process/finalization.js
+++ b/lib/internal/process/finalization.js
@@ -64,7 +64,7 @@ function createFinalization() {
       const fn = ref.fn;
 
       // This should always happen, however GC is
-      // undeterministic so it might not happen.
+      // indeterministic so it might not happen.
       /* istanbul ignore else */
       if (obj !== undefined) {
         fn(obj, event);

--- a/lib/internal/source_map/source_map_cache_map.js
+++ b/lib/internal/source_map/source_map_cache_map.js
@@ -26,7 +26,7 @@ const {
  * Obsolete `weakModuleMap` entries are removed by the `finalizationRegistry`
  * callback. This pattern decouples the strong url reference to the source map
  * data and allow the cache to be reclaimed eagerly, without depending on an
- * undeterministic callback of a finalization registry.
+ * indeterministic callback of a finalization registry.
  */
 class SourceMapCacheMap {
   /**

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -377,7 +377,7 @@ class MockTimers {
       return FunctionPrototypeToString(MockDate[kMock].#nativeDateDescriptor.value);
     };
 
-    // We need to polute the prototype of this
+    // We need to pollute the prototype of this
     ObjectDefineProperties(MockDate, {
       __proto__: null,
       [kMock]: {

--- a/lib/internal/test_runner/reporter/v8-serializer.js
+++ b/lib/internal/test_runner/reporter/v8-serializer.js
@@ -16,7 +16,7 @@ module.exports = async function* v8Reporter(source) {
   for await (const item of source) {
     const originalError = item.data.details?.error;
     if (originalError) {
-      // Error is overriden with a serialized version, so that it can be
+      // Error is overridden with a serialized version, so that it can be
       // deserialized in the parent process.
       // Error is restored after serialization.
       item.data.details.error = serializeError(originalError);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -275,7 +275,7 @@ class FileTest extends Test {
       ArrayPrototypePush(this.#rawBuffer, readData);
     }
     this.#rawBufferSize += dataLength;
-    this.#proccessRawBuffer();
+    this.#processRawBuffer();
 
     if (partialV8Header) {
       ArrayPrototypePush(this.#rawBuffer, TypedArrayPrototypeSubarray(v8Header, 0, 1));
@@ -284,10 +284,10 @@ class FileTest extends Test {
   }
   #drainRawBuffer() {
     while (this.#rawBuffer.length > 0) {
-      this.#proccessRawBuffer();
+      this.#processRawBuffer();
     }
   }
-  #proccessRawBuffer() {
+  #processRawBuffer() {
     // This method is called when it is known that there is at least one message
     let bufferHead = this.#rawBuffer[0];
     let headerIndex = bufferHead.indexOf(v8Header);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -768,9 +768,9 @@ function SideEffectFreeRegExpPrototypeExec(regex, string) {
   return FunctionPrototypeCall(RegExpFromAnotherRealm.prototype.exec, regex, string);
 }
 
-const crossRelmRegexes = new SafeWeakMap();
-function getCrossRelmRegex(regex) {
-  const cached = crossRelmRegexes.get(regex);
+const crossRealmRegexes = new SafeWeakMap();
+function getCrossRealmRegex(regex) {
+  const cached = crossRealmRegexes.get(regex);
   if (cached) return cached;
 
   let flagString = '';
@@ -783,17 +783,17 @@ function getCrossRelmRegex(regex) {
   if (RegExpPrototypeGetSticky(regex)) flagString += 'y';
 
   const { RegExp: RegExpFromAnotherRealm } = getInternalGlobal();
-  const crossRelmRegex = new RegExpFromAnotherRealm(RegExpPrototypeGetSource(regex), flagString);
-  crossRelmRegexes.set(regex, crossRelmRegex);
-  return crossRelmRegex;
+  const crossRealmRegex = new RegExpFromAnotherRealm(RegExpPrototypeGetSource(regex), flagString);
+  crossRealmRegexes.set(regex, crossRealmRegex);
+  return crossRealmRegex;
 }
 
 function SideEffectFreeRegExpPrototypeSymbolReplace(regex, string, replacement) {
-  return getCrossRelmRegex(regex)[SymbolReplace](string, replacement);
+  return getCrossRealmRegex(regex)[SymbolReplace](string, replacement);
 }
 
 function SideEffectFreeRegExpPrototypeSymbolSplit(regex, string, limit = undefined) {
-  return getCrossRelmRegex(regex)[SymbolSplit](string, limit);
+  return getCrossRealmRegex(regex)[SymbolSplit](string, limit);
 }
 
 /**

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -241,7 +241,7 @@ function type(V) {
     case 'object': // Fall through
     case 'function': // Fall through
     default:
-      // Per ES spec, typeof returns an implemention-defined value that is not
+      // Per ES spec, typeof returns an implementation-defined value that is not
       // any of the existing ones for uncallable non-standard exotic objects.
       // Yet Type() which the Web IDL spec depends on returns Object for such
       // cases. So treat the default case as an object.


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on. Nothing controversial (hopefully).

Use the following command to get a quick summary of the specific corrections made:
```shell
git diff HEAD^! --word-diff-regex='\w+' -U0 \
  | grep -E '\[\-.*\-\]\{\+.*\+\}' \
  | sed -r 's/.*\[\-(.*)\-\]\{\+(.*)\+\}.*/\1 \2/' \
  | sort | uniq -c | sort -n
```

FWIW, the typos are:
* relm
* interal
* proccess
* chek
* implemention
* mached
* redudant
* undeterministic
* connot
* gloabl
* overriden
* polute
* stirng
* transferrable