### PR TITLE
events: remove redundant default parameter

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -111,7 +111,7 @@ class Event {
    *   composed?: boolean,
    * }} [options]
    */
-  constructor(type, options = undefined) {
+  constructor(type, options) {
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('type');
     if (options != null)


### PR DESCRIPTION
A default function parameter only activates when nothing or `undefined` is passed

In other words, defaulting to `undefined` when nothing (`=== undefined`) or `undefined` is passed is redundant

Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters