### PR TITLE
fs: pass correct path to `DirentFromStats` during `glob`

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -16,7 +16,7 @@ const {
 
 const { lstatSync, readdirSync } = require('fs');
 const { lstat, readdir } = require('fs/promises');
-const { join, resolve, basename, isAbsolute } = require('path');
+const { join, resolve, basename, isAbsolute, dirname } = require('path');
 
 const {
   kEmptyObject,
@@ -48,7 +48,7 @@ async function getDirent(path) {
   } catch {
     return null;
   }
-  return new DirentFromStats(basename(path), stat, path);
+  return new DirentFromStats(basename(path), stat, dirname(path));
 }
 
 /**
@@ -60,7 +60,7 @@ function getDirentSync(path) {
   if (stat === undefined) {
     return null;
   }
-  return new DirentFromStats(basename(path), stat, path);
+  return new DirentFromStats(basename(path), stat, dirname(path));
 }
 
 class Cache {

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -353,7 +353,7 @@ describe('glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.filter(Boolean).map(normalizePath).sort());
     });
   }
 });
@@ -367,7 +367,7 @@ describe('globSync - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.filter(Boolean).map(normalizePath).sort());
     });
   }
 });
@@ -382,7 +382,7 @@ describe('fsPromises glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       })) actual.push(item);
       assertDirents(actual);
-      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.filter(Boolean).map(normalizePath).sort());
     });
   }
 });

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -1,6 +1,6 @@
 import * as common from '../common/index.mjs';
 import tmpdir from '../common/tmpdir.js';
-import { resolve, dirname, sep, basename, relative, join, isAbsolute } from 'node:path';
+import { resolve, dirname, sep, relative, join, isAbsolute } from 'node:path';
 import { mkdir, writeFile, symlink, glob as asyncGlob } from 'node:fs/promises';
 import { glob, globSync, Dirent } from 'node:fs';
 import { test, describe } from 'node:test';
@@ -350,7 +350,7 @@ describe('glob - withFileTypes', function() {
       assertDirents(actual);
       assert.deepStrictEqual(
         actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
       );
     });
   }
@@ -367,7 +367,7 @@ describe('globSync - withFileTypes', function() {
       assertDirents(actual);
       assert.deepStrictEqual(
         actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
       );
     });
   }
@@ -385,7 +385,7 @@ describe('fsPromises glob - withFileTypes', function() {
       assertDirents(actual);
       assert.deepStrictEqual(
         actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
       );
     });
   }

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -339,6 +339,8 @@ describe('fsPromises glob', function() {
 });
 
 const normalizeDirent = (dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name));
+// The call to `join()` with only one argument is important, as
+// it ensures that the proper path seperators are applied.
 const normalizePath = (path) => (isAbsolute(path) ? relative(fixtureDir, path) : join(path));
 
 describe('glob - withFileTypes', function() {

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -1,6 +1,6 @@
 import * as common from '../common/index.mjs';
 import tmpdir from '../common/tmpdir.js';
-import { resolve, dirname, sep, basename } from 'node:path';
+import { resolve, dirname, sep, basename, relative, join, isAbsolute } from 'node:path';
 import { mkdir, writeFile, symlink, glob as asyncGlob } from 'node:fs/promises';
 import { glob, globSync, Dirent } from 'node:fs';
 import { test, describe } from 'node:test';
@@ -348,8 +348,10 @@ describe('glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
-      assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());
+      assert.deepStrictEqual(
+        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
+        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+      );
     });
   }
 });
@@ -363,8 +365,10 @@ describe('globSync - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
-      assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());
+      assert.deepStrictEqual(
+        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
+        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+      );
     });
   }
 });
@@ -379,8 +383,10 @@ describe('fsPromises glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       })) actual.push(item);
       assertDirents(actual);
-      const normalized = expected.filter(Boolean).map((item) => basename(item)).sort();
-      assert.deepStrictEqual(actual.map((dirent) => dirent.name).sort(), normalized.sort());
+      assert.deepStrictEqual(
+        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
+        expected.map(path => isAbsolute(path) ? relative(fixtureDir, path) : path).sort()
+      );
     });
   }
 });

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -338,6 +338,9 @@ describe('fsPromises glob', function() {
   }
 });
 
+const normalizeDirent = (dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name));
+const normalizePath = (path) => (isAbsolute(path) ? relative(fixtureDir, path) : join(path));
+
 describe('glob - withFileTypes', function() {
   const promisified = promisify(glob);
   for (const [pattern, expected] of Object.entries(patterns)) {
@@ -348,10 +351,7 @@ describe('glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      assert.deepStrictEqual(
-        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
-      );
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
     });
   }
 });
@@ -365,10 +365,7 @@ describe('globSync - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       });
       assertDirents(actual);
-      assert.deepStrictEqual(
-        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
-      );
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
     });
   }
 });
@@ -383,10 +380,7 @@ describe('fsPromises glob - withFileTypes', function() {
         exclude: (dirent) => assert.ok(dirent instanceof Dirent),
       })) actual.push(item);
       assertDirents(actual);
-      assert.deepStrictEqual(
-        actual.map((dirent) => relative(fixtureDir, join(dirent.parentPath, dirent.name))).sort(),
-        expected.map((path) => (isAbsolute(path) ? relative(fixtureDir, path) : path)).sort()
-      );
+      assert.deepStrictEqual(actual.map(normalizeDirent).sort(), expected.map(normalizePath).sort());
     });
   }
 });


### PR DESCRIPTION
Fixes #55060

Passes the dirname as parentPath, rather than the full file path.