### PR TITLE
src: do not call path.back() when it is empty

### DIFF
--- a/src/path.cc
+++ b/src/path.cc
@@ -266,11 +266,11 @@ std::string PathResolve(Environment* env,
   for (int i = numArgs - 1; i >= -1 && !resolvedAbsolute; i--) {
     const std::string& path = (i >= 0) ? std::string(paths[i]) : cwd;
 
-    if (static_cast<size_t>(i) == numArgs - 1 && path.back() == '/') {
-      slashCheck = true;
-    }
-
     if (!path.empty()) {
+      if (static_cast<size_t>(i) == numArgs - 1 && path.back() == '/') {
+        slashCheck = true;
+      }
+
       resolvedPath = std::string(path) + "/" + resolvedPath;
 
       if (path.front() == '/') {


### PR DESCRIPTION
Fix a crash when running tests with the GN build of node:

```
../out/Debug/node test/parallel/test-cli-permission-multiple-allow.js
```

Crash trace:

```
$ lldb ../out/Debug/node
(lldb) target create "../out/Debug/node"
Current executable set to '/Users/zcbenz/codes/node_with_gn/out/Debug/node' (arm64).
(lldb) run --experimental-permission --allow-fs-write /Users/zcbenz/codes/node_with_gn/node/tmp --allow-fs-write /Users/zcbenz/codes/node_with_gn/node/other-path -e 'console.log(process.permission.has("fs.write"));'
Process 28010 launched: '/Users/zcbenz/codes/node_with_gn/out/Debug/node' (arm64)
../../third_party/gn/third_party/libc++/src/include/string:1364: assertion !empty() failed: string::back(): string is empty
Process 28010 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x000000018b88e0dc libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x18b88e0dc <+8>:  b.lo   0x18b88e0fc               ; <+40>
    0x18b88e0e0 <+12>: pacibsp 
    0x18b88e0e4 <+16>: stp    x29, x30, [sp, #-0x10]!
    0x18b88e0e8 <+20>: mov    x29, sp
Target 0: (node) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x000000018b88e0dc libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x000000018b8c5cc0 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x000000018b7d1a40 libsystem_c.dylib`abort + 180
    frame #3: 0x0000000103ddb5bc node`std::__Cr::__libcpp_verbose_abort(format="%s") at verbose_abort.cpp:74:3
    frame #4: 0x00000001004f0ef8 node`std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>>::back(this="") const at string:1364:5
    frame #5: 0x000000010070bfd4 node`node::PathResolve(env=0x0000000134898a00, paths=size=1) at path.cc:269:55
    frame #6: 0x000000010070cd0c node`(anonymous namespace)::is_tree_granted(env=0x0000000134898a00, granted_tree=0x00006000006b44e8, param="") at fs_permission.cc:58:32
    frame #7: 0x000000010070cc2c node`node::permission::FSPermission::is_granted(this=0x00006000006b44d8, env=0x0000000134898a00, perm=kFileSystemWrite, param="") const at fs_permission.cc:168:15
    frame #8: 0x00000001000e0d10 node`node::permission::Permission::is_scope_granted(this=0x0000000134898f78, env=0x0000000134898a00, permission=kFileSystemWrite, res="") const at permission.h:83:33
    frame #9: 0x0000000100714878 node`node::permission::(anonymous namespace)::Has(v8::FunctionCallbackInfo<v8::Value> const&) [inlined] node::permission::Permission::is_granted(this=0x0000000134898f78, env=0x0000000134898a00, permission=kFileSystemWrite, res="") const at permission.h:56:12
    frame #10: 0x0000000100714844 node`node::permission::(anonymous namespace)::Has(args=0x000000016fdfa658) at permission.cc:58:55
```

Crash was introduced by #54224.