### PR TITLE
src: expose `WriteNodeReport` to embedders

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -53,15 +53,6 @@ using v8::Value;
 
 namespace report {
 // Internal/static function declarations
-static void WriteNodeReport(Isolate* isolate,
-                            Environment* env,
-                            const char* message,
-                            const char* trigger,
-                            const std::string& filename,
-                            std::ostream& out,
-                            Local<Value> error,
-                            bool compact,
-                            bool exclude_network = false);
 static void PrintVersionInformation(JSONWriter* writer,
                                     bool exclude_network = false);
 static void PrintJavaScriptErrorStack(JSONWriter* writer,
@@ -87,7 +78,7 @@ static void PrintNetworkInterfaceInfo(JSONWriter* writer);
 
 // Internal function to coordinate and write the various
 // sections of the report to the supplied stream
-static void WriteNodeReport(Isolate* isolate,
+void WriteNodeReport(Isolate* isolate,
                             Environment* env,
                             const char* message,
                             const char* trigger,

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -33,6 +33,15 @@ std::string ValueToHexString(T value) {
 // Function declarations - export functions in src/node_report_module.cc
 void WriteReport(const v8::FunctionCallbackInfo<v8::Value>& info);
 void GetReport(const v8::FunctionCallbackInfo<v8::Value>& info);
+void WriteNodeReport(v8::Isolate* isolate,
+                     Environment* env,
+                     const char* message,
+                     const char* trigger,
+                     const std::string& filename,
+                     std::ostream& out,
+                     v8::Local<v8::Value> error,
+                     bool compact,
+                     bool exclude_network = false);
 
 }  // namespace report
 }  // namespace node


### PR DESCRIPTION
Refs https://github.com/electron/electron/pull/43774

This PR allows creating Node.js diagnostic reports from Electron signal handlers. It's currently used by Electron's Utility Process to support `error` events.

cc @deepak1556 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
