### PR TITLE
test_runner: fix mocking modules with quote in their URL

### DIFF
--- a/lib/internal/test_runner/mock/loader.js
+++ b/lib/internal/test_runner/mock/loader.js
@@ -139,7 +139,7 @@ async function createSourceFromMock(mock, format) {
   const { exportNames, hasDefaultExport, url } = mock;
   const useESM = format === 'module' || format === 'module-typescript';
   const source = `${testImportSource(useESM)}
-if (!$__test.mock._mockExports.has('${url}')) {
+if (!$__test.mock._mockExports.has(${JSONStringify(url)})) {
   throw new Error(${JSONStringify(`mock exports not found for "${url}"`)});
 }
 

--- a/test/fixtures/module-mocking/don't-open.mjs
+++ b/test/fixtures/module-mocking/don't-open.mjs
@@ -1,0 +1,1 @@
+export let string = 'original esm string';

--- a/test/parallel/test-runner-module-mocking.js
+++ b/test/parallel/test-runner-module-mocking.js
@@ -413,6 +413,15 @@ test('modules cannot be mocked multiple times at once', async (t) => {
     t.mock.module(fixture, { namedExports: { fn() { return 42; } } });
     await assert.rejects(import(fixture), { code: 'ERR_UNSUPPORTED_ESM_URL_SCHEME' });
   });
+
+  await t.test('Importing a module with a quote in its URL should work', async (t) => {
+    const fixture = fixtures.fileURL('module-mocking', 'don\'t-open.mjs');
+    t.mock.module(fixture, { namedExports: { fn() { return 42; } } });
+
+    const mocked = await import(fixture);
+
+    assert.strictEqual(mocked.fn(), 42);
+  });
 });
 
 test('mocks are automatically restored', async (t) => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
