### PR TITLE
meta: add more information about nightly releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ directory contains the latest Hydrogen (Node.js 18) release.
 
 Each directory and filename includes the version (e.g., `v22.0.0`),
 followed by the UTC date (e.g., `20240424` for April 24, 2024),
-and the short SHA of the latest commit (e.g., `ddd0a9e494`).
+and the short commit SHA of the HEAD of the release (e.g., `ddd0a9e494`).
 For instance, a full directory name might look like `v22.0.0-nightly20240424ddd0a9e494`.
 
 #### API documentation

--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ directory contains the latest Hydrogen (Node.js 18) release.
 
 <https://nodejs.org/download/nightly/>
 
-Each directory name and filename contains a date (in UTC) and the commit
-SHA at the HEAD of the release.
+Each directory and filename includes the version (e.g., `v22.0.0`),
+followed by the UTC date (e.g., `20240424` for April 24, 2024),
+and the short SHA of the latest commit (e.g., `ddd0a9e494`).
+For instance, a full directory name might look like `v22.0.0-nightly20240424ddd0a9e494`.
 
 #### API documentation
 


### PR DESCRIPTION
The directory / file names contain more than just the date commit SHA. They also contain the version.

Additionally, this change gives examples of each value, and places them in the correct order.