### PR TITLE
test: fix test-tls-junk-closes-server

### DIFF
--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -39,6 +39,22 @@ const server = tls.createServer(options, common.mustNotCall());
 server.listen(0, common.mustCall(function() {
   const c = net.createConnection(this.address().port);
 
+  c.on('data', function() {
+    // We must consume all data sent by the server. Otherwise the
+    // end event will not be sent and the test will hang.
+    // For example, when compiled with OpenSSL32 we see the
+    // the following response '15 03 03 00 02 02 16' which
+    // decodes as a fatal (0x02) TLS error alert number 22 (0x16).
+    // which corresponds to TLS1_AD_RECORD_OVERFLOW which matches
+    // the error we see if NODE_DEBUG is turned on.
+    // Some earlier OpenSSL versions did not seem to send a response
+    // but the TLS spec seems to indicate there should be one
+    // https://datatracker.ietf.org/doc/html/rfc8446#page-85
+    // and error handling seems to have been re-written/improved
+    // in OpenSSL32. Consuming the data allows the test to pass
+    // either way.
+  });
+
   c.on('connect', common.mustCall(function() {
     c.write('blah\nblah\nblah\n');
   }));

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -44,7 +44,7 @@ server.listen(0, common.mustCall(function() {
     // end event will not be sent and the test will hang.
     // For example, when compiled with OpenSSL32 we see the
     // following response '15 03 03 00 02 02 16' which
-    // decodes as a fatal (0x02) TLS error alert number 22 (0x16).
+    // decodes as a fatal (0x02) TLS error alert number 22 (0x16),
     // which corresponds to TLS1_AD_RECORD_OVERFLOW which matches
     // the error we see if NODE_DEBUG is turned on.
     // Some earlier OpenSSL versions did not seem to send a response

--- a/test/parallel/test-tls-junk-closes-server.js
+++ b/test/parallel/test-tls-junk-closes-server.js
@@ -43,7 +43,7 @@ server.listen(0, common.mustCall(function() {
     // We must consume all data sent by the server. Otherwise the
     // end event will not be sent and the test will hang.
     // For example, when compiled with OpenSSL32 we see the
-    // the following response '15 03 03 00 02 02 16' which
+    // following response '15 03 03 00 02 02 16' which
     // decodes as a fatal (0x02) TLS error alert number 22 (0x16).
     // which corresponds to TLS1_AD_RECORD_OVERFLOW which matches
     // the error we see if NODE_DEBUG is turned on.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/53382
Refs: https://github.com/nodejs/node/issues/52482

TLS spec seems to indicate there should should be a response sent when TLS handshake fails. See
https://datatracker.ietf.org/doc/html/rfc8446#page-85

When compiled with OpenSSL32 we see the
the following response '15 03 03 00 02 02 16' which decodes as a fatal (0x02) TLS error alert number 22 (0x16). which corresponds to TLS1_AD_RECORD_OVERFLOW which matches the error we see if NODE_DEBUG is turned on once you get through the define aliases.

If there is a response from the server the test used to hang because the end event will not be emitted until after the response is consumed. This PR fixes the test so it consumes the response.

Some earlier OpenSSL versions did not seem to send a response but the error handling seems to have been re-written/improved in OpenSSL32.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
