### PR TITLE
test: deflake test/pummel/test-timers.js

### DIFF
--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -36,7 +36,7 @@ const WINDOW = 200; // Why does this need to be so big?
     assert.ok(diff > 0);
     console.error(`diff: ${diff}`);
 
-    assert.ok(1000 <= diff && diff < 1000 + WINDOW);
+    assert.ok(Math.abs(diff - 1000) < WINDOW && diff < 1000 + WINDOW);
   }), 1000);
 }
 
@@ -61,7 +61,7 @@ const WINDOW = 200; // Why does this need to be so big?
 
     const t = interval_count * 1000;
 
-    assert.ok(t <= diff && diff < t + (WINDOW * interval_count));
+    assert.ok(Math.abs(diff - t) < WINDOW && diff < t + (WINDOW * interval_count));
 
     assert.ok(interval_count <= 3, `interval_count: ${interval_count}`);
     if (interval_count === 3)

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -36,7 +36,7 @@ const WINDOW = 200; // Why does this need to be so big?
     assert.ok(diff > 0);
     console.error(`diff: ${diff}`);
 
-    assert.ok(Math.abs(diff - 1000) < WINDOW && diff < 1000 + WINDOW);
+    assert.ok(Math.abs(diff - 1000) < WINDOW);
   }), 1000);
 }
 

--- a/test/pummel/test-timers.js
+++ b/test/pummel/test-timers.js
@@ -61,7 +61,7 @@ const WINDOW = 200; // Why does this need to be so big?
 
     const t = interval_count * 1000;
 
-    assert.ok(Math.abs(diff - t) < WINDOW && diff < t + (WINDOW * interval_count));
+    assert.ok(Math.abs(diff - t) < WINDOW * interval_count);
 
     assert.ok(interval_count <= 3, `interval_count: ${interval_count}`);
     if (interval_count === 3)


### PR DESCRIPTION
This PR fixes: https://github.com/nodejs/node/issues/55092

Timers are not guaranteed to fire exactly when specified, the flakiness of the test comes from the assumption that the timer will always fire **_at_** or **_after_** the `timeout`, however this is not always the case. For instance, a 1000ms `timeout` could be fired at anytime roughly between `98x ~ 100x` due to the CPU load, platform etc.

This could be easily verified by:

```js
let currentTime = Date.now();

setInterval(() => {
  const timeElapsed = Date.now();
  console.log(timeElapsed - currentTime);
  currentTime = Date.now();
}, 1000);
```

on my macOS nightly build here is the result:

```
1003
983
1000
1001
999
1001
1001
1000
1001
997
1000
1000
```

Here is a more precise timing mechanism by using `process.hrtime` version:

```js
let currentTimeHR = process.hrtime();

setInterval(() => {
  const [s, n] = process.hrtime(currentTimeHR);
  console.log(s * 1000 + n / 1e6);

  currentTimeHR = process.hrtime();
}, 1000);
```

```
1001.345709
978.22325
1001.416125
1000.27375
1001.791
999.609291
1000.354209
999.61925
999.512083
1000.2595
```