### PR TITLE
doc: remove outdated https import reference

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -869,9 +869,6 @@ behaviors.
 
 #### Import from HTTPS
 
-In current Node.js, specifiers starting with `https://` are experimental (see
-\[HTTPS and HTTP imports]\[]).
-
 The hook below registers hooks to enable rudimentary support for such
 specifiers. While this may seem like a significant improvement to Node.js core
 functionality, there are substantial downsides to actually using these hooks:


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/53822
Fixes: https://github.com/nodejs/node/issues/55091
