### PR TITLE
deps: V8: backport 0d5d6e71bbb0

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -317,7 +317,6 @@ DEFINE_BOOL(js_shipping, true, "enable all shipped JavaScript features")
   V(harmony_import_attributes, "harmony import attributes")
 
 #define JAVASCRIPT_SHIPPING_FEATURES_BASE(V)                           \
-  V(js_promise_withresolvers, "Promise.withResolvers")                 \
   V(js_regexp_duplicate_named_groups, "RegExp duplicate named groups") \
   V(js_regexp_modifiers, "RegExp modifiers")                           \
   V(js_promise_try, "Promise.try")

--- a/deps/v8/src/init/bootstrapper.cc
+++ b/deps/v8/src/init/bootstrapper.cc
@@ -3228,6 +3228,15 @@ void Genesis::InitializeGlobal(Handle<JSGlobalObject> global_object,
     InstallFunctionWithBuiltinId(isolate_, promise_fun, "reject",
                                  Builtin::kPromiseReject, 1, true);
 
+    std::array<Handle<Name>, 3> fields{factory->promise_string(),
+                                       factory->resolve_string(),
+                                       factory->reject_string()};
+    DirectHandle<Map> result_map =
+        CreateLiteralObjectMapFromCache(isolate_, fields);
+    native_context()->set_promise_withresolvers_result_map(*result_map);
+    InstallFunctionWithBuiltinId(isolate_, promise_fun, "withResolvers",
+                                 Builtin::kPromiseWithResolvers, 0, true);
+
     SetConstructorInstanceType(isolate_, promise_fun,
                                JS_PROMISE_CONSTRUCTOR_TYPE);
 
@@ -5502,24 +5511,6 @@ void Genesis::InitializeGlobal_js_promise_try() {
       handle(native_context()->promise_function(), isolate());
   InstallFunctionWithBuiltinId(isolate(), promise_fun, "try",
                                Builtin::kPromiseTry, 1, false);
-}
-
-void Genesis::InitializeGlobal_js_promise_withresolvers() {
-  if (!v8_flags.js_promise_withresolvers) return;
-
-  Factory* factory = isolate()->factory();
-
-  std::array<Handle<Name>, 3> fields{factory->promise_string(),
-                                     factory->resolve_string(),
-                                     factory->reject_string()};
-  DirectHandle<Map> result_map =
-      CreateLiteralObjectMapFromCache(isolate(), fields);
-  native_context()->set_promise_withresolvers_result_map(*result_map);
-
-  Handle<JSFunction> promise_fun =
-      handle(native_context()->promise_function(), isolate());
-  InstallFunctionWithBuiltinId(isolate(), promise_fun, "withResolvers",
-                               Builtin::kPromiseWithResolvers, 0, true);
 }
 
 void Genesis::InitializeGlobal_harmony_set_methods() {

--- a/deps/v8/test/mjsunit/harmony/promise-withresolvers.js
+++ b/deps/v8/test/mjsunit/harmony/promise-withresolvers.js
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flags: --js-promise-withresolvers --allow-natives-syntax
+// Flags: --allow-natives-syntax
 
 const desc = Object.getOwnPropertyDescriptor(Promise, 'withResolvers');
 assertTrue(desc.configurable);

--- a/deps/v8/test/test262/testcfg.py
+++ b/deps/v8/test/test262/testcfg.py
@@ -58,7 +58,6 @@ FEATURE_FLAGS = {
     'json-parse-with-source': '--harmony-json-parse-with-source',
     'iterator-helpers': '--harmony-iterator-helpers',
     'set-methods': '--harmony-set-methods',
-    'promise-with-resolvers': '--js-promise-withresolvers',
     'import-attributes': '--harmony-import-attributes',
     'regexp-duplicate-named-groups': '--js-regexp-duplicate-named-groups',
     'regexp-modifiers': '--js-regexp-modifiers',


### PR DESCRIPTION
Original commit message:

    Remove `--js-promise-withresolvers` runtime flag

    Co-authored-by: Antoine du Hamel <duhamelantoine1995@gmail.com>
    Bug: 42204122
    Change-Id: I017a0d1ae0f8225513206ffb7806a4250be75d4c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5843972
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Commit-Queue: Erik Corry <erikcorry@chromium.org>
    Reviewed-by: Shu-yu Guo <syg@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#96215}

Refs: https://github.com/v8/v8/commit/0d5d6e71bbb0d2b0a12567fffa7e3375c427bc92

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
