### PR TITLE
stream: treat null asyncIterator as undefined

### DIFF
--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -211,11 +211,12 @@ function createAsyncFromSyncIterator(syncIteratorRecord) {
   return { iterator: asyncIterator, nextMethod, done: false };
 }
 
+// Refs: https://tc39.es/ecma262/#sec-getiterator
 function getIterator(obj, kind = 'sync', method) {
   if (method === undefined) {
     if (kind === 'async') {
       method = obj[SymbolAsyncIterator];
-      if (method === undefined) {
+      if (method == null) {
         const syncMethod = obj[SymbolIterator];
 
         if (syncMethod === undefined) {

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -16,13 +16,6 @@
   "readable-streams/cross-realm-crash.window.js": {
     "skip": "Browser-specific test"
   },
-  "readable-streams/from.any.js": {
-    "fail": {
-      "expected": [
-        "ReadableStream.from ignores a null @@asyncIterator"
-      ]
-    }
-  },
   "readable-streams/owning-type-message-port.any.js": {
     "fail": {
       "note": "Readable streams with type owning are not yet supported",


### PR DESCRIPTION
According to the spec, getIterator should normalize incoming method to
undefined if it is either undefined or null. This PR enforces that spec
compliance with passed WPT.
