### PR TITLE
src: fixup Error.stackTraceLimit during snapshot building

### DIFF
--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -141,9 +141,9 @@ function main() {
   prepareMainThreadExecution(false, false);
   initializeCallbacks();
 
-  // In a context created for building snapshots, V8 does not install Erorr.stackTraceLimit and as
+  // In a context created for building snapshots, V8 does not install Error.stackTraceLimit and as
   // a result, if an error is created during the snapshot building process, error.stack would be
-  // undefined. To prevent users from tripping over this, install Erorr.stackTraceLimit based on
+  // undefined. To prevent users from tripping over this, install Error.stackTraceLimit based on
   // --stack-trace-limit by ourselves (which defaults to 10).
   // See https://chromium-review.googlesource.com/c/v8/v8/+/3319481
   const initialStackTraceLimitDesc = {
@@ -156,8 +156,8 @@ function main() {
   ObjectDefineProperty(Error, 'stackTraceLimit', initialStackTraceLimitDesc);
 
   let stackTraceLimitDescToRestore;
-  // Erorr.stackTraceLimit needs to be removed during serialization, because when V8 deserializes
-  // the snapshot, it expects Erorr.stackTraceLimit to be unset so that it can install it as a new property
+  // Error.stackTraceLimit needs to be removed during serialization, because when V8 deserializes
+  // the snapshot, it expects Error.stackTraceLimit to be unset so that it can install it as a new property
   // using the value of --stack-trace-limit.
   addAfterUserSerializeCallback(() => {
     const desc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -23,10 +23,10 @@ const { emitWarningSync } = require('internal/process/warning');
 const {
   initializeCallbacks,
   namespace: {
-    addSerializeCallback,
     addDeserializeCallback,
     isBuildingSnapshot,
   },
+  addAfterUserSerializeCallback,
 } = require('internal/v8/startup_snapshot');
 
 const {
@@ -34,6 +34,7 @@ const {
 } = require('internal/process/pre_execution');
 
 const path = require('path');
+const { getOptionValue } = require('internal/options');
 
 const supportedModules = new SafeSet(new SafeArrayIterator([
   // '_http_agent',
@@ -140,22 +141,56 @@ function main() {
   prepareMainThreadExecution(false, false);
   initializeCallbacks();
 
-  let stackTraceLimitDesc;
-  addDeserializeCallback(() => {
-    if (stackTraceLimitDesc !== undefined) {
-      ObjectDefineProperty(Error, 'stackTraceLimit', stackTraceLimitDesc);
-    }
-  });
-  addSerializeCallback(() => {
-    stackTraceLimitDesc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
+  // In a context created for building snapshots, V8 does not install Erorr.stackTraceLimit and as
+  // a result, if an error is created during the snapshot building process, error.stack would be
+  // undefined. To prevent users from tripping over this, install Erorr.stackTraceLimit based on
+  // --stack-trace-limit by ourselves (which defaults to 10).
+  // See https://chromium-review.googlesource.com/c/v8/v8/+/3319481
+  const initialStackTraceLimitDesc = {
+    value: getOptionValue('--stack-trace-limit'),
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    __proto__: null,
+  };
+  ObjectDefineProperty(Error, 'stackTraceLimit', initialStackTraceLimitDesc);
 
-    if (stackTraceLimitDesc !== undefined) {
+  let stackTraceLimitDescToRestore;
+  // Erorr.stackTraceLimit needs to be removed during serialization, because when V8 deserializes
+  // the snapshot, it expects Erorr.stackTraceLimit to be unset so that it can install it as a new property
+  // using the value of --stack-trace-limit.
+  addAfterUserSerializeCallback(() => {
+    const desc = ObjectGetOwnPropertyDescriptor(Error, 'stackTraceLimit');
+
+    // If it's modified by users, emit a warning.
+    if (desc && (
+      desc.value !== initialStackTraceLimitDesc.value ||
+        desc.configurable !== initialStackTraceLimitDesc.configurable ||
+        desc.writable !== initialStackTraceLimitDesc.writable ||
+        desc.enumerable !== initialStackTraceLimitDesc.enumerable
+    )) {
+      process._rawDebug('Error.stackTraceLimit has been modified by the snapshot builder script.');
       // We want to use null-prototype objects to not rely on globally mutable
       // %Object.prototype%.
-      ObjectSetPrototypeOf(stackTraceLimitDesc, null);
-      process._rawDebug('Deleting Error.stackTraceLimit from the snapshot. ' +
-                        'It will be re-installed after deserialization');
-      delete Error.stackTraceLimit;
+      if (desc.configurable) {
+        stackTraceLimitDescToRestore = desc;
+        ObjectSetPrototypeOf(stackTraceLimitDescToRestore, null);
+        process._rawDebug('It will be preserved after snapshot deserialization and override ' +
+                          '--stack-trace-limit passed into the deserialized application.\n' +
+                          'To allow --stack-trace-limit override in the deserialized application, ' +
+                          'delete Error.stackTraceLimit.');
+      } else {
+        process._rawDebug('It is not configurable and will crash the application upon deserialization.\n' +
+                          'To fix the error, make Error.stackTraceLimit configurable.');
+      }
+    }
+
+    delete Error.stackTraceLimit;
+  });
+
+  addDeserializeCallback(() => {
+    if (stackTraceLimitDescToRestore) {
+      ObjectDefineProperty(Error, 'stackTraceLimit', stackTraceLimitDescToRestore);
     }
   });
 

--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -58,9 +58,14 @@ function addDeserializeCallback(callback, data) {
 }
 
 const serializeCallbacks = [];
+const afterUserSerializeCallbacks = [];  // Callbacks to run after user callbacks
 function runSerializeCallbacks() {
   while (serializeCallbacks.length > 0) {
     const { 0: callback, 1: data } = serializeCallbacks.shift();
+    callback(data);
+  }
+  while (afterUserSerializeCallbacks.length > 0) {
+    const { 0: callback, 1: data } = afterUserSerializeCallbacks.shift();
     callback(data);
   }
 }
@@ -69,6 +74,10 @@ function addSerializeCallback(callback, data) {
   throwIfNotBuildingSnapshot();
   validateFunction(callback, 'callback');
   serializeCallbacks.push([callback, data]);
+}
+
+function addAfterUserSerializeCallback(callback, data) {
+  afterUserSerializeCallbacks.push([callback, data]);
 }
 
 function initializeCallbacks() {
@@ -117,4 +126,5 @@ module.exports = {
     setDeserializeMainFunction,
     isBuildingSnapshot,
   },
+  addAfterUserSerializeCallback,
 };

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -433,6 +433,10 @@ inline double Environment::get_default_trigger_async_id() {
   return default_trigger_async_id;
 }
 
+inline int64_t Environment::stack_trace_limit() const {
+  return isolate_data_->options()->stack_trace_limit;
+}
+
 inline std::shared_ptr<EnvironmentOptions> Environment::options() {
   return options_;
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -1241,9 +1241,11 @@ void Environment::PrintSyncTrace() const {
 
   fprintf(
       stderr, "(node:%d) WARNING: Detected use of sync API\n", uv_os_getpid());
-  PrintStackTrace(isolate(),
-                  StackTrace::CurrentStackTrace(
-                      isolate(), stack_trace_limit(), StackTrace::kDetailed));
+  PrintStackTrace(
+      isolate(),
+      StackTrace::CurrentStackTrace(isolate(),
+                                    static_cast<int>(stack_trace_limit()),
+                                    StackTrace::kDetailed));
 }
 
 MaybeLocal<Value> Environment::RunSnapshotSerializeCallback() const {
@@ -1845,9 +1847,11 @@ void Environment::Exit(ExitCode exit_code) {
     fprintf(stderr,
             "WARNING: Exited the environment with code %d\n",
             static_cast<int>(exit_code));
-    PrintStackTrace(isolate(),
-                    StackTrace::CurrentStackTrace(
-                        isolate(), stack_trace_limit(), StackTrace::kDetailed));
+    PrintStackTrace(
+        isolate(),
+        StackTrace::CurrentStackTrace(isolate(),
+                                      static_cast<int>(stack_trace_limit()),
+                                      StackTrace::kDetailed));
   }
   process_exit_handler_(this, exit_code);
 }

--- a/src/env.h
+++ b/src/env.h
@@ -977,7 +977,7 @@ class Environment final : public MemoryRetainer {
   inline std::shared_ptr<EnvironmentOptions> options();
   inline std::shared_ptr<ExclusiveAccess<HostPort>> inspector_host_port();
 
-  inline int32_t stack_trace_limit() const { return 10; }
+  inline int64_t stack_trace_limit() const;
 
 #if HAVE_INSPECTOR
   void set_coverage_connection(

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -447,9 +447,14 @@ void OptionsParser<Options>::Parse(
       case kBoolean:
         *Lookup<bool>(info.field, options) = !is_negation;
         break;
-      case kInteger:
+      case kInteger: {
+        // Special case to pass --stack-trace-limit down to V8.
+        if (name == "--stack-trace-limit") {
+          v8_args->push_back(arg);
+        }
         *Lookup<int64_t>(info.field, options) = std::atoll(value.c_str());
         break;
+      }
       case kUInteger:
         *Lookup<uint64_t>(info.field, options) =
             std::strtoull(value.c_str(), nullptr, 10);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -899,7 +899,10 @@ PerIsolateOptionsParser::PerIsolateOptionsParser(
       "--perf-basic-prof-only-functions", "", V8Option{}, kAllowedInEnvvar);
   AddOption("--perf-prof", "", V8Option{}, kAllowedInEnvvar);
   AddOption("--perf-prof-unwinding-info", "", V8Option{}, kAllowedInEnvvar);
-  AddOption("--stack-trace-limit", "", V8Option{}, kAllowedInEnvvar);
+  AddOption("--stack-trace-limit",
+            "",
+            &PerIsolateOptions::stack_trace_limit,
+            kAllowedInEnvvar);
   AddOption("--disallow-code-generation-from-strings",
             "disallow eval and friends",
             V8Option{},
@@ -1286,6 +1289,11 @@ void GetCLIOptionsValues(const FunctionCallbackInfo<Value>& args) {
         if (item.first == "--abort-on-uncaught-exception") {
           value = Boolean::New(isolate,
                                s.original_per_env->abort_on_uncaught_exception);
+        } else if (item.first == "--stack-trace-limit") {
+          value =
+              Number::New(isolate,
+                          static_cast<double>(
+                              *_ppop_instance.Lookup<int64_t>(field, opts)));
         } else {
           value = undefined_value;
         }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -270,6 +270,7 @@ class PerIsolateOptions : public Options {
   bool report_uncaught_exception = false;
   bool report_on_signal = false;
   bool experimental_shadow_realm = false;
+  int64_t stack_trace_limit = 10;
   std::string report_signal = "SIGUSR2";
   bool build_snapshot = false;
   std::string build_snapshot_config;

--- a/test/fixtures/deep-exit.js
+++ b/test/fixtures/deep-exit.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// This is meant to be run with --trace-exit.
+
+const depth = parseInt(process.env.STACK_DEPTH) || 30;
+let counter = 1;
+function recurse() {
+  if (counter++ < depth) {
+    recurse();
+  } else {
+    process.exit(0);
+  }
+}
+
+recurse();

--- a/test/fixtures/snapshot/error-stack.js
+++ b/test/fixtures/snapshot/error-stack.js
@@ -1,0 +1,24 @@
+
+const {
+  setDeserializeMainFunction,
+} = require('v8').startupSnapshot;
+
+console.log(`During snapshot building, Error.stackTraceLimit =`, Error.stackTraceLimit);
+console.log(getError('During snapshot building', 30));
+
+setDeserializeMainFunction(() => {
+  console.log(`After snapshot deserialization, Error.stackTraceLimit =`, Error.stackTraceLimit);
+  console.log(getError('After snapshot deserialization', 30));
+});
+
+function getError(message, depth) {
+  let counter = 1;
+  function recurse() {
+    if (counter++ < depth) {
+      return recurse();
+    }
+    const error = new Error(message);
+    return error.stack;
+  }
+  return recurse();
+}

--- a/test/fixtures/snapshot/mutate-error-stack-trace-limit.js
+++ b/test/fixtures/snapshot/mutate-error-stack-trace-limit.js
@@ -1,14 +1,23 @@
 
 const {
+  addSerializeCallback,
   setDeserializeMainFunction,
 } = require('v8').startupSnapshot;
 const assert = require('assert');
 
-// Check that mutation to Error.stackTraceLimit is effective in the snapshot
-// builder script.
-assert.strictEqual(typeof Error.stackTraceLimit, 'number');
-Error.stackTraceLimit = 0;
-assert.strictEqual(getError('', 30), 'Error');
+if (process.env.TEST_IN_SERIALIZER) {
+  addSerializeCallback(checkMutate);
+} else {
+  checkMutate();
+}
+
+function checkMutate() {
+  // Check that mutation to Error.stackTraceLimit is effective in the snapshot
+  // builder script.
+  assert.strictEqual(typeof Error.stackTraceLimit, 'number');
+  Error.stackTraceLimit = 0;
+  assert.strictEqual(getError('', 30), 'Error');
+}
 
 setDeserializeMainFunction(() => {
   // Check that the mutation is preserved in the deserialized main function.

--- a/test/fixtures/snapshot/mutate-error-stack-trace-limit.js
+++ b/test/fixtures/snapshot/mutate-error-stack-trace-limit.js
@@ -1,0 +1,35 @@
+
+const {
+  setDeserializeMainFunction,
+} = require('v8').startupSnapshot;
+const assert = require('assert');
+
+// Check that mutation to Error.stackTraceLimit is effective in the snapshot
+// builder script.
+assert.strictEqual(typeof Error.stackTraceLimit, 'number');
+Error.stackTraceLimit = 0;
+assert.strictEqual(getError('', 30), 'Error');
+
+setDeserializeMainFunction(() => {
+  // Check that the mutation is preserved in the deserialized main function.
+  assert.strictEqual(Error.stackTraceLimit, 0);
+  assert.strictEqual(getError('', 30), 'Error');
+
+  // Check that it can still be mutated.
+  Error.stackTraceLimit = 10;
+  const error = getError('', 30);
+  const matches = [...error.matchAll(/at recurse/g)];
+  assert.strictEqual(matches.length, 10);
+});
+
+function getError(message, depth) {
+  let counter = 1;
+  function recurse() {
+    if (counter++ < depth) {
+      return recurse();
+    }
+    const error = new Error(message);
+    return error.stack;
+  }
+  return recurse();
+}

--- a/test/parallel/test-snapshot-stack-trace-limit-mutation.js
+++ b/test/parallel/test-snapshot-stack-trace-limit-mutation.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// This tests mutation to Error.stackTraceLimit in both the snapshot builder script
+// and the snapshot main script work.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+const blobPath = tmpdir.resolve('snapshot.blob');
+
+{
+  tmpdir.refresh();
+  // Check the mutation works without --stack-trace-limit.
+  spawnSyncAndAssert(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    fixtures.path('snapshot', 'mutate-error-stack-trace-limit.js'),
+  ], {
+    cwd: tmpdir.path
+  }, {
+    stderr(output) {
+      assert.match(output, /Error\.stackTraceLimit has been modified by the snapshot builder script/);
+      assert.match(output, /It will be preserved after snapshot deserialization/);
+    }
+  });
+  spawnSyncAndExitWithoutError(process.execPath, [
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path
+  });
+}
+
+{
+  tmpdir.refresh();
+  // Check the mutation works with --stack-trace-limit.
+  spawnSyncAndAssert(process.execPath, [
+    '--stack-trace-limit=50',
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    fixtures.path('snapshot', 'mutate-error-stack-trace-limit.js'),
+  ], {
+    cwd: tmpdir.path
+  }, {
+    stderr(output) {
+      assert.match(output, /Error\.stackTraceLimit has been modified by the snapshot builder script/);
+      assert.match(output, /It will be preserved after snapshot deserialization/);
+    }
+  });
+  spawnSyncAndExitWithoutError(process.execPath, [
+    // This checks that --stack-trace-limit=50 is ignored if the buidler script already mutated
+    // Error.stackTraceLimit.
+    '--stack-trace-limit=50',
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path
+  });
+}

--- a/test/parallel/test-snapshot-stack-trace-limit.js
+++ b/test/parallel/test-snapshot-stack-trace-limit.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// This tests Error.stackTraceLimit is fixed up for snapshot-building contexts,
+// and can be restored after deserialization.
+
+require('../common');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+
+tmpdir.refresh();
+const blobPath = tmpdir.resolve('snapshot.blob');
+{
+  spawnSyncAndAssert(process.execPath, [
+    '--stack-trace-limit=50',
+    '--snapshot-blob',
+    blobPath,
+    '--build-snapshot',
+    fixtures.path('snapshot', 'error-stack.js'),
+  ], {
+    cwd: tmpdir.path
+  }, {
+    stdout(output) {
+      assert.match(output, /During snapshot building, Error\.stackTraceLimit = 50/);
+      const matches = [...output.matchAll(/at recurse/g)];
+      assert.strictEqual(matches.length, 30);
+    }
+  });
+}
+
+{
+  spawnSyncAndAssert(process.execPath, [
+    '--stack-trace-limit=20',
+    '--snapshot-blob',
+    blobPath,
+  ], {
+    cwd: tmpdir.path
+  }, {
+    stdout(output) {
+      assert.match(output, /After snapshot deserialization, Error\.stackTraceLimit = 20/);
+      const matches = [...output.matchAll(/at recurse/g)];
+      assert.strictEqual(matches.length, 20);
+    }
+  });
+}

--- a/test/parallel/test-trace-exit-stack-limit.js
+++ b/test/parallel/test-trace-exit-stack-limit.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// This tests that --stack-trace-limit can be used to tweak the stack trace size of --trace-exit.
+require('../common');
+const fixture = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+
+// When the stack trace limit is bigger than the stack trace size, it should output them all.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--trace-exit', '--stack-trace-limit=50', fixture.path('deep-exit.js')],
+  {
+    env: {
+      ...process.env,
+      STACK_DEPTH: 30
+    }
+  },
+  {
+    stderr(output) {
+      const matches = [...output.matchAll(/at recurse/g)];
+      assert.strictEqual(matches.length, 30);
+    }
+  });
+
+// When the stack trace limit is smaller than the stack trace size, it should truncate the stack size.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--trace-exit', '--stack-trace-limit=30', fixture.path('deep-exit.js')],
+  {
+    env: {
+      ...process.env,
+      STACK_DEPTH: 30
+    }
+  },
+  {
+    stderr(output) {
+      const matches = [...output.matchAll(/at recurse/g)];
+      // The top frame is process.exit(), so one frame from recurse() is truncated.
+      assert.strictEqual(matches.length, 29);
+    }
+  });


### PR DESCRIPTION
#### src: parse --stack-trace-limit and use it in --trace-* flags

Previously, --trace-exit and --trace-sync-io doesn't take care
of --stack-trace-limit and always print a stack trace with maximum
size of 10. This patch parses --stack-trace-limit during
initialization and use the value in --trace-* flags.

#### src: fixup Error.stackTraceLimit during snapshot building

When V8 creates a context for snapshot building, it does not
install Error.stackTraceLimit. As a result, error.stack would
be undefined in the snapshot builder script unless users
explicitly initialize Error.stackTraceLimit, which may be
surprising.

This patch initializes Error.stackTraceLimit based on the
value of --stack-trace-limit to prevent the surprise. If
users have modified Error.stackTraceLimit in the builder
script, the modified value would be restored during
deserialization. Otherwise, the fixed up limit would be
deleted since V8 expects to find it unset and re-initialize
it during snapshot deserialization.

Fixes: https://github.com/nodejs/node/issues/55100

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
