### PR TITLE
doc: add esm examples to `node:net`

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -14,7 +14,11 @@ TCP or [IPC][] servers ([`net.createServer()`][]) and clients
 
 It can be accessed using:
 
-```js
+```mjs
+import net from 'node:net';
+```
+
+```cjs
 const net = require('node:net');
 ```
 
@@ -1531,7 +1535,23 @@ Additional options:
 Following is an example of a client of the echo server described
 in the [`net.createServer()`][] section:
 
-```js
+```mjs
+import net from 'node:net';
+const client = net.createConnection({ port: 8124 }, () => {
+  // 'connect' listener.
+  console.log('connected to server!');
+  client.write('world!\r\n');
+});
+client.on('data', (data) => {
+  console.log(data.toString());
+  client.end();
+});
+client.on('end', () => {
+  console.log('disconnected from server');
+});
+```
+
+```cjs
 const net = require('node:net');
 const client = net.createConnection({ port: 8124 }, () => {
   // 'connect' listener.
@@ -1558,10 +1578,25 @@ option. In this case, the `onread` option will be only used to call
 `new net.Socket([options])` and the `port` option will be used to
 call `socket.connect(options[, connectListener])`.
 
-```js
+```mjs
+import net from 'node:net';
+net.createConnection({
+  port: 8124,
+  onread: {
+    // Reuses a 4KiB Buffer for every read from the socket.
+    buffer: Buffer.alloc(4 * 1024),
+    callback: function(nread, buf) {
+      // Received data is available in `buf` from 0 to `nread`.
+      console.log(buf.toString('utf8', 0, nread));
+    },
+  },
+});
+```
+
+```cjs
 const net = require('node:net');
 net.createConnection({
-  port: 80,
+  port: 8124,
   onread: {
     // Reuses a 4KiB Buffer for every read from the socket.
     buffer: Buffer.alloc(4 * 1024),
@@ -1684,7 +1719,26 @@ The server can be a TCP server or an [IPC][] server, depending on what it
 Here is an example of a TCP echo server which listens for connections
 on port 8124:
 
-```js
+```mjs
+import net from 'node:net';
+const server = net.createServer((c) => {
+  // 'connection' listener.
+  console.log('client connected');
+  c.on('end', () => {
+    console.log('client disconnected');
+  });
+  c.write('hello\r\n');
+  c.pipe(c);
+});
+server.on('error', (err) => {
+  throw err;
+});
+server.listen(8124, () => {
+  console.log('server bound');
+});
+```
+
+```cjs
 const net = require('node:net');
 const server = net.createServer((c) => {
   // 'connection' listener.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1580,6 +1580,7 @@ call `socket.connect(options[, connectListener])`.
 
 ```mjs
 import net from 'node:net';
+import { Buffer } from 'node:buffer';
 net.createConnection({
   port: 8124,
   onread: {


### PR DESCRIPTION
This PR adds the `ESM` counterparts of the `CJS` examples for [the Net documentation](https://nodejs.org/api/net.html).

I've also updated the `port` used in the [`net.createConnection(options[, connectListener])`](https://nodejs.org/api/net.html#netcreateconnectionoptions-connectlistener) (`onread` section) so it's the same port across examples, that way new users can follow the documentation to _create_ a server and then _connect_ to it using the provided examples.

I've tested every single example and they all work/behave as expected.

Best regards!