### PR TITLE
doc: add missing `:` to `run()`'s `globPatterns`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1277,7 +1277,7 @@ changes:
     If `false`, it would only run one test file at a time.
     **Default:** `false`.
   * `files`: {Array} An array containing the list of files to run.
-    **Default** matching files from [test runner execution model][].
+    **Default:** matching files from [test runner execution model][].
   * `forceExit`: {boolean} Configures the test runner to exit the process once
     all known tests have finished executing even if the event loop would
     otherwise remain active. **Default:** `false`.


### PR DESCRIPTION
I was looking over the documentation while working on adding `run()` coverage to https://github.com/nodejs/nodejs.org/pull/7006, and I noticed that there is a missing `:`, so this quick PR fixes that.

Fast-tracking, as this change is a one character change to the documentation, and shouldn't have any negative side effects.