### PR TITLE
buffer: correctly apply prototype to cloned `File` / `Blob`

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -386,6 +386,7 @@ class Blob {
 }
 
 function TransferableBlob(handle, length, type = '') {
+  ObjectSetPrototypeOf(this, Blob.prototype);
   markTransferMode(this, true, false);
   this[kHandle] = handle;
   this[kType] = type;

--- a/lib/internal/file.js
+++ b/lib/internal/file.js
@@ -130,6 +130,7 @@ class File extends Blob {
 
 function TransferableFile(handle, length, type = '') {
   FunctionPrototypeApply(TransferableBlob, this, [handle, length, type]);
+  ObjectSetPrototypeOf(this, File.prototype);
 }
 
 ObjectSetPrototypeOf(TransferableFile.prototype, File.prototype);

--- a/test/parallel/test-structuredClone-global.js
+++ b/test/parallel/test-structuredClone-global.js
@@ -30,6 +30,19 @@ for (const StreamClass of [ReadableStream, WritableStream, TransformStream]) {
   assert.ok(extendedTransfer instanceof StreamClass);
 }
 
+for (const Transferrable of [File, Blob]) {
+  const a2 = Transferrable === File ? '' : {};
+  const original = new Transferrable([], a2);
+  const transfer = structuredClone(original);
+  assert.strictEqual(Object.getPrototypeOf(transfer), Transferrable.prototype);
+  assert.ok(transfer instanceof Transferrable);
+
+  const extendedOriginal = new (class extends Transferrable {})([], a2);
+  const extendedTransfer = structuredClone(extendedOriginal);
+  assert.strictEqual(Object.getPrototypeOf(extendedTransfer), Transferrable.prototype);
+  assert.ok(extendedTransfer instanceof Transferrable);
+}
+
 {
   // See: https://github.com/nodejs/node/issues/49940
   const cloned = structuredClone({}, {


### PR DESCRIPTION
Followup #47613 
Reference #55067

---

The prototype of the transferred File / Blob should be equal to it's closest transferable superclass. This PR applies the same change as #55067 did to Streams to Files and Blobs. 