### PR TITLE
test_runner: consider --enable-source-maps option in coverage report

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -25,6 +25,7 @@ const {
   readFileSync,
   rmSync,
 } = require('fs');
+const { getOptionValue } = require('internal/options');
 const { setupCoverageHooks } = require('internal/util');
 const { tmpdir } = require('os');
 const { join, resolve, relative, matchesGlob } = require('path');
@@ -338,9 +339,10 @@ class TestCoverage {
 
 
   mapCoverageWithSourceMap(coverage) {
+    const sourceMapEnabled = getOptionValue('--enable-source-maps');
     const { result } = coverage;
     const sourceMapCache = coverage['source-map-cache'];
-    if (!sourceMapCache) {
+    if (!sourceMapEnabled || !sourceMapCache) {
       return result;
     }
     const newResult = new SafeMap();


### PR DESCRIPTION
Ref: #54753 