### PR TITLE
doc: remove random horizontal separators in `process.md`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1956,8 +1956,6 @@ added: v4.8.0
 
 A boolean value that is `true` if the current Node.js build includes support for ALPN in TLS.
 
-***
-
 ## `process.features.tls_ocsp`
 
 <!-- YAML
@@ -1968,8 +1966,6 @@ added: v0.11.13
 
 A boolean value that is `true` if the current Node.js build includes support for OCSP in TLS.
 
-***
-
 ## `process.features.tls_sni`
 
 <!-- YAML
@@ -1979,8 +1975,6 @@ added: v0.5.3
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for SNI in TLS.
-
-***
 
 ## `process.features.uv`
 


### PR DESCRIPTION
They don't seem to have any meaning (the sections it separates are not more different than any other pair of two sections) and I don't think we use those anywhere else in our docs, I suspect they were added by mistake.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
