### PR TITLE
lib: fix module print timing when specifier includes `"`

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -173,7 +173,7 @@ function formatTime(ms) {
 }
 
 function safeTraceLabel(label) {
-  return label.replace(/\\/g, '\\\\');
+  return label.replace(/\\/g, '\\\\').replaceAll('"', '\\"');
 }
 
 /**

--- a/test/parallel/test-module-print-timing.mjs
+++ b/test/parallel/test-module-print-timing.mjs
@@ -114,12 +114,12 @@ it('should support enable tracing dynamically', async () => {
 
 
   const outputFile = tmpdir.resolve('output-dynamic-trace.log');
-  let requireFileWithDoubleQuote = ''
+  let requireFileWithDoubleQuote = '';
   if (!isWindows) {
     // Double quotes are not valid char for a path on Windows.
     const fileWithDoubleQuote = tmpdir.resolve('filename-with-"double"-quotes.cjs');
     writeFileSync(fileWithDoubleQuote, ';\n');
-    requireFileWithDoubleQuote = `require(${JSON.stringify(fileWithDoubleQuote)});`
+    requireFileWithDoubleQuote = `require(${JSON.stringify(fileWithDoubleQuote)});`;
   }
   const jsScript = `
   const traceEvents = require("trace_events");

--- a/test/parallel/test-module-print-timing.mjs
+++ b/test/parallel/test-module-print-timing.mjs
@@ -1,5 +1,6 @@
-import '../common/index.mjs';
+import { isWindows } from '../common/index.mjs';
 import assert from 'node:assert';
+import { writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { it } from 'node:test';
 import tmpdir from '../common/tmpdir.js';
@@ -113,11 +114,19 @@ it('should support enable tracing dynamically', async () => {
 
 
   const outputFile = tmpdir.resolve('output-dynamic-trace.log');
+  let requireFileWithDoubleQuote = ''
+  if (!isWindows) {
+    // Double quotes are not valid char for a path on Windows.
+    const fileWithDoubleQuote = tmpdir.resolve('filename-with-"double"-quotes.cjs');
+    writeFileSync(fileWithDoubleQuote, ';\n');
+    requireFileWithDoubleQuote = `require(${JSON.stringify(fileWithDoubleQuote)});`
+  }
   const jsScript = `
   const traceEvents = require("trace_events");
   const tracing = traceEvents.createTracing({ categories: ["node.module_timer"] });
 
   tracing.enable();
+  ${requireFileWithDoubleQuote}
   require("http");
   tracing.disable();
 


### PR DESCRIPTION
Currently, we generate invalid JSON if the specifier contains `"`, this can be addressed by escaping all double quotes like this PR is doing.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
