### PR TITLE
stream: handle undefined chunks correctly in decode stream

### DIFF
--- a/lib/internal/webstreams/encoding.js
+++ b/lib/internal/webstreams/encoding.js
@@ -133,6 +133,9 @@ class TextDecoderStream {
     this.#handle = new TextDecoder(encoding, options);
     this.#transform = new TransformStream({
       transform: (chunk, controller) => {
+        if (chunk === undefined) {
+          throw new ERR_INVALID_THIS('TextDecoderStream');
+        }
         const value = this.#handle.decode(chunk, { stream: true });
         if (value)
           controller.enqueue(value);

--- a/lib/internal/webstreams/encoding.js
+++ b/lib/internal/webstreams/encoding.js
@@ -20,6 +20,7 @@ const { customInspect } = require('internal/webstreams/util');
 
 const {
   codes: {
+    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_THIS,
   },
 } = require('internal/errors');
@@ -134,7 +135,7 @@ class TextDecoderStream {
     this.#transform = new TransformStream({
       transform: (chunk, controller) => {
         if (chunk === undefined) {
-          throw new ERR_INVALID_THIS('TextDecoderStream');
+          throw new ERR_INVALID_ARG_TYPE('chunk', 'string', chunk);
         }
         const value = this.#handle.decode(chunk, { stream: true });
         if (value)

--- a/test/wpt/status/encoding.json
+++ b/test/wpt/status/encoding.json
@@ -66,13 +66,6 @@
   "streams/decode-utf8.any.js": {
     "requires": ["small-icu"]
   },
-  "streams/decode-bad-chunks.any.js": {
-    "fail": {
-      "expected": [
-        "chunk of type undefined should error the stream"
-      ]
-    }
-  },
   "streams/decode-non-utf8.any.js": {
     "requires": ["full-icu"]
   },


### PR DESCRIPTION
Align TextDecoderStream behavior with WPT requirements by treating undefined chunks as errors. This change ensures that TextDecoderStream properly handles unexpected chunk types and throws an error when receiving undefined input.

This update addresses the failing WPT for decode stream error handling.