### PR TITLE
src: modernize likely/unlikely hints

### DIFF
--- a/.cpplint
+++ b/.cpplint
@@ -1,3 +1,3 @@
 set noparent
-filter=-build/include_alpha,-build/include_subdir,-build/include_what_you_use,-legal/copyright,-readability/nolint
+filter=-build/include_alpha,-build/include_subdir,-build/include_what_you_use,-legal/copyright,-readability/nolint,-readability/braces
 linelength=80

--- a/src/api/callback.cc
+++ b/src/api/callback.cc
@@ -74,7 +74,7 @@ InternalCallbackScope::InternalCallbackScope(Environment* env,
   // We first check `env->context() != current_context` because the contexts
   // likely *are* the same, in which case we can skip the slightly more
   // expensive Environment::GetCurrent() call.
-  if (UNLIKELY(env->context() != current_context)) {
+  if (env->context() != current_context) [[unlikely]] {
     CHECK_EQ(Environment::GetCurrent(isolate), env);
   }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -108,15 +108,17 @@ void* NodeArrayBufferAllocator::Allocate(size_t size) {
     ret = allocator_->Allocate(size);
   else
     ret = allocator_->AllocateUninitialized(size);
-  if (LIKELY(ret != nullptr))
+  if (ret != nullptr) [[likely]] {
     total_mem_usage_.fetch_add(size, std::memory_order_relaxed);
+  }
   return ret;
 }
 
 void* NodeArrayBufferAllocator::AllocateUninitialized(size_t size) {
   void* ret = allocator_->AllocateUninitialized(size);
-  if (LIKELY(ret != nullptr))
+  if (ret != nullptr) [[likely]] {
     total_mem_usage_.fetch_add(size, std::memory_order_relaxed);
+  }
   return ret;
 }
 

--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -31,7 +31,7 @@ BaseObject::BaseObject(Realm* realm, Local<Object> object)
 BaseObject::~BaseObject() {
   realm()->UntrackBaseObject(this);
 
-  if (UNLIKELY(has_pointer_data())) {
+  if (has_pointer_data()) [[unlikely]] {
     PointerData* metadata = pointer_data();
     CHECK_EQ(metadata->strong_ptr_count, 0);
     metadata->self = nullptr;

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -892,8 +892,9 @@ int SoaTraits::Send(QueryWrap<SoaTraits>* wrap, const char* name) {
 int AnyTraits::Parse(
     QueryAnyWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1059,8 +1060,9 @@ int AnyTraits::Parse(
 int ATraits::Parse(
     QueryAWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1093,8 +1095,9 @@ int ATraits::Parse(
 int AaaaTraits::Parse(
     QueryAaaaWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1127,8 +1130,9 @@ int AaaaTraits::Parse(
 int CaaTraits::Parse(
     QueryCaaWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1149,8 +1153,9 @@ int CaaTraits::Parse(
 int CnameTraits::Parse(
     QueryCnameWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1172,8 +1177,9 @@ int CnameTraits::Parse(
 int MxTraits::Parse(
     QueryMxWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1195,8 +1201,9 @@ int MxTraits::Parse(
 int NsTraits::Parse(
     QueryNsWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1218,8 +1225,9 @@ int NsTraits::Parse(
 int TxtTraits::Parse(
     QueryTxtWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1240,8 +1248,9 @@ int TxtTraits::Parse(
 int SrvTraits::Parse(
     QuerySrvWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
+  }
 
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
@@ -1262,9 +1271,9 @@ int SrvTraits::Parse(
 int PtrTraits::Parse(
     QueryPtrWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
-
+  }
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
 
@@ -1286,9 +1295,9 @@ int PtrTraits::Parse(
 int NaptrTraits::Parse(
     QueryNaptrWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
-
+  }
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
 
@@ -1308,9 +1317,9 @@ int NaptrTraits::Parse(
 int SoaTraits::Parse(
     QuerySoaWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(response->is_host))
+  if (response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
-
+  }
   unsigned char* buf = response->buf.data;
   int len = response->buf.size;
 
@@ -1388,9 +1397,9 @@ int ReverseTraits::Send(GetHostByAddrWrap* wrap, const char* name) {
 int ReverseTraits::Parse(
     GetHostByAddrWrap* wrap,
     const std::unique_ptr<ResponseData>& response) {
-  if (UNLIKELY(!response->is_host))
+  if (!response->is_host) [[unlikely]] {
     return ARES_EBADRESP;
-
+  }
   struct hostent* host = response->host.get();
 
   Environment* env = wrap->env();

--- a/src/compile_cache.cc
+++ b/src/compile_cache.cc
@@ -59,7 +59,7 @@ uint32_t GetCacheKey(std::string_view filename, CachedCodeType type) {
 template <typename... Args>
 inline void CompileCacheHandler::Debug(const char* format,
                                        Args&&... args) const {
-  if (UNLIKELY(is_debug_)) {
+  if (is_debug_) [[unlikely]] {
     FPrintF(stderr, format, std::forward<Args>(args)...);
   }
 }
@@ -458,20 +458,20 @@ CompileCacheEnableResult CompileCacheHandler::Enable(Environment* env,
         cache_tag,
         cache_dir_with_tag);
 
-  if (UNLIKELY(!env->permission()->is_granted(
+  if (!env->permission()->is_granted(
           env,
           permission::PermissionScope::kFileSystemWrite,
-          cache_dir_with_tag))) {
+          cache_dir_with_tag)) [[unlikely]] {
     result.message = "Skipping compile cache because write permission for " +
                      cache_dir_with_tag + " is not granted";
     result.status = CompileCacheEnableStatus::FAILED;
     return result;
   }
 
-  if (UNLIKELY(!env->permission()->is_granted(
+  if (!env->permission()->is_granted(
           env,
           permission::PermissionScope::kFileSystemRead,
-          cache_dir_with_tag))) {
+          cache_dir_with_tag)) [[unlikely]] {
     result.message = "Skipping compile cache because read permission for " +
                      cache_dir_with_tag + " is not granted";
     result.status = CompileCacheEnableStatus::FAILED;

--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -339,7 +339,7 @@ bool ValidateIV(
     Local<Value> value,
     AESCipherConfig* params) {
   ArrayBufferOrViewContents<char> iv(value);
-  if (UNLIKELY(!iv.CheckSizeInt32())) {
+  if (!iv.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "iv is too big");
     return false;
   }
@@ -377,7 +377,7 @@ bool ValidateAuthTag(
         return false;
       }
       ArrayBufferOrViewContents<char> tag_contents(value);
-      if (UNLIKELY(!tag_contents.CheckSizeInt32())) {
+      if (!tag_contents.CheckSizeInt32()) [[unlikely]] {
         THROW_ERR_OUT_OF_RANGE(env, "tagLength is too big");
         return false;
       }
@@ -412,7 +412,7 @@ bool ValidateAdditionalData(
   // Additional Data
   if (IsAnyBufferSource(value)) {
     ArrayBufferOrViewContents<char> additional(value);
-    if (UNLIKELY(!additional.CheckSizeInt32())) {
+    if (!additional.CheckSizeInt32()) [[unlikely]] {
       THROW_ERR_OUT_OF_RANGE(env, "additionalData is too big");
       return false;
     }

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -522,15 +522,16 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
   // raw bytes and proceed...
   const ByteSource key_buf = ByteSource::FromSecretKeyBytes(env, args[1]);
 
-  if (UNLIKELY(key_buf.size() > INT_MAX))
+  if (key_buf.size() > INT_MAX) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "key is too big");
+  }
 
   ArrayBufferOrViewContents<unsigned char> iv_buf(
       !args[2]->IsNull() ? args[2] : Local<Value>());
 
-  if (UNLIKELY(!iv_buf.CheckSizeInt32()))
+  if (!iv_buf.CheckSizeInt32()) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "iv is too big");
-
+  }
   // Don't assign to cipher->auth_tag_len_ directly; the value might not
   // represent a valid length at this point.
   unsigned int auth_tag_len;
@@ -672,9 +673,9 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
   }
 
   ArrayBufferOrViewContents<char> auth_tag(args[0]);
-  if (UNLIKELY(!auth_tag.CheckSizeInt32()))
+  if (!auth_tag.CheckSizeInt32()) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "buffer is too big");
-
+  }
   unsigned int tag_len = auth_tag.size();
 
   const int mode = EVP_CIPHER_CTX_mode(cipher->ctx_.get());
@@ -781,8 +782,9 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
   int plaintext_len = args[1].As<Int32>()->Value();
   ArrayBufferOrViewContents<unsigned char> buf(args[0]);
 
-  if (UNLIKELY(!buf.CheckSizeInt32()))
+  if (!buf.CheckSizeInt32()) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "buffer is too big");
+  }
   args.GetReturnValue().Set(cipher->SetAAD(buf, plaintext_len));
 }
 
@@ -858,9 +860,9 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
     std::unique_ptr<BackingStore> out;
     Environment* env = Environment::GetCurrent(args);
 
-    if (UNLIKELY(size > INT_MAX))
+    if (size > INT_MAX) [[unlikely]] {
       return THROW_ERR_OUT_OF_RANGE(env, "data is too long");
-
+    }
     UpdateResult r = cipher->Update(data, size, &out);
 
     if (r != kSuccess) {
@@ -1063,9 +1065,9 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
     return;
 
   ArrayBufferOrViewContents<unsigned char> buf(args[offset]);
-  if (UNLIKELY(!buf.CheckSizeInt32()))
+  if (!buf.CheckSizeInt32()) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "buffer is too long");
-
+  }
   uint32_t padding;
   if (!args[offset + 1]->Uint32Value(env->context()).To(&padding)) return;
 
@@ -1105,9 +1107,9 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
 
   ArrayBufferOrViewContents<unsigned char> oaep_label(
       !args[offset + 3]->IsUndefined() ? args[offset + 3] : Local<Value>());
-  if (UNLIKELY(!oaep_label.CheckSizeInt32()))
+  if (!oaep_label.CheckSizeInt32()) [[unlikely]] {
     return THROW_ERR_OUT_OF_RANGE(env, "oaepLabel is too big");
-
+  }
   std::unique_ptr<BackingStore> out;
   if (!Cipher<operation, EVP_PKEY_cipher_init, EVP_PKEY_cipher>(
           env, pkey, padding, digest, oaep_label, buf, &out)) {

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -685,7 +685,7 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 2);
 
-  if (UNLIKELY(env->permission()->enabled())) {
+  if (env->permission()->enabled()) [[unlikely]] {
     return THROW_ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED(
         env,
         "Programmatic selection of OpenSSL engines is unsupported while the "
@@ -1198,7 +1198,7 @@ void SecureContext::SetClientCertEngine(
   // support multiple calls to SetClientCertEngine.
   CHECK(!sc->client_cert_engine_provided_);
 
-  if (UNLIKELY(env->permission()->enabled())) {
+  if (env->permission()->enabled()) [[unlikely]] {
     return THROW_ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED(
         env,
         "Programmatic selection of OpenSSL engines is unsupported while the "

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -120,7 +120,7 @@ void New(const FunctionCallbackInfo<Value>& args) {
   // or an ArrayBuffer or ArrayBufferView with the generator.
 
   ArrayBufferOrViewContents<char> arg0(args[0]);
-  if (UNLIKELY(!arg0.CheckSizeInt32()))
+  if (!arg0.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "prime is too big");
 
   BignumPointer bn_p(reinterpret_cast<uint8_t*>(arg0.data()), arg0.size());
@@ -142,7 +142,7 @@ void New(const FunctionCallbackInfo<Value>& args) {
     }
   } else {
     ArrayBufferOrViewContents<char> arg1(args[1]);
-    if (UNLIKELY(!arg1.CheckSizeInt32()))
+    if (!arg1.CheckSizeInt32()) [[unlikely]]
       return THROW_ERR_OUT_OF_RANGE(env, "generator is too big");
     bn_g = BignumPointer(reinterpret_cast<uint8_t*>(arg1.data()), arg1.size());
     if (!bn_g) {
@@ -253,7 +253,7 @@ void ComputeSecret(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 1);
   ArrayBufferOrViewContents<unsigned char> key_buf(args[0]);
-  if (UNLIKELY(!key_buf.CheckSizeInt32()))
+  if (!key_buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "secret is too big");
   BignumPointer key(key_buf.data(), key_buf.size());
 
@@ -286,7 +286,7 @@ void SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   DHPointer& dh = *diffieHellman;
   CHECK_EQ(args.Length(), 1);
   ArrayBufferOrViewContents<unsigned char> buf(args[0]);
-  if (UNLIKELY(!buf.CheckSizeInt32()))
+  if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
   CHECK(num);
@@ -300,7 +300,7 @@ void SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   DHPointer& dh = *diffieHellman;
   CHECK_EQ(args.Length(), 1);
   ArrayBufferOrViewContents<unsigned char> buf(args[0]);
-  if (UNLIKELY(!buf.CheckSizeInt32()))
+  if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
   CHECK(num);
@@ -368,7 +368,7 @@ Maybe<void> DhKeyGenTraits::AdditionalConfig(
       params->params.prime = size;
     } else {
       ArrayBufferOrViewContents<unsigned char> input(args[*offset]);
-      if (UNLIKELY(!input.CheckSizeInt32())) {
+      if (!input.CheckSizeInt32()) [[unlikely]] {
         THROW_ERR_OUT_OF_RANGE(env, "prime is too big");
         return Nothing<void>();
       }

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -174,7 +174,7 @@ ECPointPointer ECDH::BufferToPoint(Environment* env,
   }
 
   ArrayBufferOrViewContents<unsigned char> input(buf);
-  if (UNLIKELY(!input.CheckSizeInt32())) {
+  if (!input.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "buffer is too big");
     return ECPointPointer();
   }
@@ -293,7 +293,7 @@ void ECDH::SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.This());
 
   ArrayBufferOrViewContents<unsigned char> priv_buffer(args[0]);
-  if (UNLIKELY(!priv_buffer.CheckSizeInt32()))
+  if (!priv_buffer.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "key is too big");
 
   BignumPointer priv(priv_buffer.data(), priv_buffer.size());
@@ -396,7 +396,7 @@ void ECDH::ConvertKey(const FunctionCallbackInfo<Value>& args) {
   CHECK(IsAnyBufferSource(args[0]));
 
   ArrayBufferOrViewContents<char> args0(args[0]);
-  if (UNLIKELY(!args0.CheckSizeInt32()))
+  if (!args0.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "key is too big");
   if (args0.empty()) return args.GetReturnValue().SetEmptyString();
 

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -67,11 +67,11 @@ Maybe<void> HKDFTraits::AdditionalConfig(
   ArrayBufferOrViewContents<char> salt(args[offset + 2]);
   ArrayBufferOrViewContents<char> info(args[offset + 3]);
 
-  if (UNLIKELY(!salt.CheckSizeInt32())) {
+  if (!salt.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "salt is too big");
     return Nothing<void>();
   }
-  if (UNLIKELY(!info.CheckSizeInt32())) {
+  if (!info.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "info is too big");
     return Nothing<void>();
   }

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -103,7 +103,7 @@ void Hmac::HmacUpdate(const FunctionCallbackInfo<Value>& args) {
   Decode<Hmac>(args, [](Hmac* hmac, const FunctionCallbackInfo<Value>& args,
                         const char* data, size_t size) {
     Environment* env = Environment::GetCurrent(args);
-    if (UNLIKELY(size > INT_MAX))
+    if (size > INT_MAX) [[unlikely]]
       return THROW_ERR_OUT_OF_RANGE(env, "data is too long");
     bool r = hmac->HmacUpdate(data, size);
     args.GetReturnValue().Set(r);
@@ -198,7 +198,7 @@ Maybe<void> HmacTraits::AdditionalConfig(
   params->key = key->Data().addRef();
 
   ArrayBufferOrViewContents<char> data(args[offset + 3]);
-  if (UNLIKELY(!data.CheckSizeInt32())) {
+  if (!data.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
@@ -208,7 +208,7 @@ Maybe<void> HmacTraits::AdditionalConfig(
 
   if (!args[offset + 4]->IsUndefined()) {
     ArrayBufferOrViewContents<char> signature(args[offset + 4]);
-    if (UNLIKELY(!signature.CheckSizeInt32())) {
+    if (!signature.CheckSizeInt32()) [[unlikely]] {
       THROW_ERR_OUT_OF_RANGE(env, "signature is too big");
       return Nothing<void>();
     }

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -178,7 +178,8 @@ struct KeyPairGenTraits final {
 
     auto data = KeyObjectData::CreateAsymmetric(KeyType::kKeyTypePrivate,
                                                 EVPKeyPointer(pkey));
-    if (UNLIKELY(!data)) return KeyGenJobStatus::FAILED;
+    if (!data) [[unlikely]]
+      return KeyGenJobStatus::FAILED;
     params->key = std::move(data);
     return KeyGenJobStatus::OK;
   }

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -639,7 +639,7 @@ KeyObjectData::GetPrivateKeyEncodingFromJs(
     if (IsAnyBufferSource(args[*offset])) {
       CHECK_IMPLIES(context != kKeyContextInput, result.cipher_ != nullptr);
       ArrayBufferOrViewContents<char> passphrase(args[*offset]);
-      if (UNLIKELY(!passphrase.CheckSizeInt32())) {
+      if (!passphrase.CheckSizeInt32()) [[unlikely]] {
         THROW_ERR_OUT_OF_RANGE(env, "passphrase is too big");
         return NonCopyableMaybe<PrivateKeyEncodingConfig>();
       }
@@ -697,7 +697,7 @@ KeyObjectData KeyObjectData::GetPublicOrPrivateKeyFromJs(
   if (IsAnyBufferSource(args[*offset])) {
     Environment* env = Environment::GetCurrent(args);
     ArrayBufferOrViewContents<char> data(args[(*offset)++]);
-    if (UNLIKELY(!data.CheckSizeInt32())) {
+    if (!data.CheckSizeInt32()) [[unlikely]] {
       THROW_ERR_OUT_OF_RANGE(env, "keyData is too big");
       return {};
     }

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -65,12 +65,12 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
   ArrayBufferOrViewContents<char> pass(args[offset]);
   ArrayBufferOrViewContents<char> salt(args[offset + 1]);
 
-  if (UNLIKELY(!pass.CheckSizeInt32())) {
+  if (!pass.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
     return Nothing<void>();
   }
 
-  if (UNLIKELY(!salt.CheckSizeInt32())) {
+  if (!salt.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "salt is too large");
     return Nothing<void>();
   }

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -320,7 +320,7 @@ Maybe<void> RSACipherTraits::AdditionalConfig(
 
       if (IsAnyBufferSource(args[offset + 2])) {
         ArrayBufferOrViewContents<char> label(args[offset + 2]);
-        if (UNLIKELY(!label.CheckSizeInt32())) {
+        if (!label.CheckSizeInt32()) [[unlikely]] {
           THROW_ERR_OUT_OF_RANGE(env, "label is too big");
           return Nothing<void>();
         }

--- a/src/crypto/crypto_scrypt.cc
+++ b/src/crypto/crypto_scrypt.cc
@@ -62,12 +62,12 @@ Maybe<void> ScryptTraits::AdditionalConfig(
   ArrayBufferOrViewContents<char> pass(args[offset]);
   ArrayBufferOrViewContents<char> salt(args[offset + 1]);
 
-  if (UNLIKELY(!pass.CheckSizeInt32())) {
+  if (!pass.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
     return Nothing<void>();
   }
 
-  if (UNLIKELY(!salt.CheckSizeInt32())) {
+  if (!salt.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "salt is too large");
     return Nothing<void>();
   }

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -370,7 +370,7 @@ void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
   Decode<Sign>(args, [](Sign* sign, const FunctionCallbackInfo<Value>& args,
                         const char* data, size_t size) {
     Environment* env = Environment::GetCurrent(args);
-    if (UNLIKELY(size > INT_MAX))
+    if (size > INT_MAX) [[unlikely]]
       return THROW_ERR_OUT_OF_RANGE(env, "data is too long");
     Error err = sign->Update(data, size);
     crypto::CheckThrow(sign->env(), err);
@@ -408,7 +408,8 @@ void Sign::SignFinal(const FunctionCallbackInfo<Value>& args) {
 
   unsigned int offset = 0;
   auto data = KeyObjectData::GetPrivateKeyFromJs(args, &offset, true);
-  if (UNLIKELY(!data)) return;
+  if (!data) [[unlikely]]
+    return;
   const auto& key = data.GetAsymmetricKey();
   if (!key)
     return;
@@ -493,7 +494,7 @@ void Verify::VerifyUpdate(const FunctionCallbackInfo<Value>& args) {
                           const FunctionCallbackInfo<Value>& args,
                           const char* data, size_t size) {
     Environment* env = Environment::GetCurrent(args);
-    if (UNLIKELY(size > INT_MAX))
+    if (size > INT_MAX) [[unlikely]]
       return THROW_ERR_OUT_OF_RANGE(env, "data is too long");
     Error err = verify->Update(data, size);
     crypto::CheckThrow(verify->env(), err);
@@ -554,7 +555,7 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   }
 
   ArrayBufferOrViewContents<char> hbuf(args[offset]);
-  if (UNLIKELY(!hbuf.CheckSizeInt32()))
+  if (!hbuf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buffer is too big");
 
   int padding = GetDefaultSignPadding(pkey);
@@ -643,7 +644,7 @@ Maybe<void> SignTraits::AdditionalConfig(
   }
 
   ArrayBufferOrViewContents<char> data(args[offset + 5]);
-  if (UNLIKELY(!data.CheckSizeInt32())) {
+  if (!data.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
@@ -681,7 +682,7 @@ Maybe<void> SignTraits::AdditionalConfig(
 
   if (params->mode == SignConfiguration::kVerify) {
     ArrayBufferOrViewContents<char> signature(args[offset + 10]);
-    if (UNLIKELY(!signature.CheckSizeInt32())) {
+    if (!signature.CheckSizeInt32()) [[unlikely]] {
       THROW_ERR_OUT_OF_RANGE(env, "signature is too big");
       return Nothing<void>();
     }

--- a/src/crypto/crypto_spkac.cc
+++ b/src/crypto/crypto_spkac.cc
@@ -23,7 +23,7 @@ void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   ArrayBufferOrViewContents<char> input(args[0]);
   if (input.empty()) return args.GetReturnValue().SetEmptyString();
 
-  if (UNLIKELY(!input.CheckSizeInt32()))
+  if (!input.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "spkac is too large");
 
   args.GetReturnValue().Set(ncrypto::VerifySpkac(input.data(), input.size()));
@@ -35,7 +35,7 @@ void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   ArrayBufferOrViewContents<char> input(args[0]);
   if (input.empty()) return args.GetReturnValue().SetEmptyString();
 
-  if (UNLIKELY(!input.CheckSizeInt32()))
+  if (!input.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "spkac is too large");
 
   BIOPointer bio = ncrypto::ExportPublicKey(input.data(), input.size());
@@ -51,7 +51,7 @@ void ExportChallenge(const FunctionCallbackInfo<Value>& args) {
   ArrayBufferOrViewContents<char> input(args[0]);
   if (input.empty()) return args.GetReturnValue().SetEmptyString();
 
-  if (UNLIKELY(!input.CheckSizeInt32()))
+  if (!input.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "spkac is too large");
 
   auto cert = ByteSource::Allocated(

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -141,7 +141,7 @@ void KeylogCallback(const SSL* s, const char* line) {
   const size_t size = strlen(line);
   Local<Value> line_bf = Buffer::Copy(env, line, 1 + size)
       .FromMaybe(Local<Value>());
-  if (UNLIKELY(line_bf.IsEmpty()))
+  if (line_bf.IsEmpty()) [[unlikely]]
     return;
 
   char* data = Buffer::Data(line_bf);
@@ -160,12 +160,12 @@ int NewSessionCallback(SSL* s, SSL_SESSION* sess) {
 
   // Check if session is small enough to be stored
   int size = i2d_SSL_SESSION(sess, nullptr);
-  if (UNLIKELY(size > SecureContext::kMaxSessionSize))
+  if (size > SecureContext::kMaxSessionSize) [[unlikely]]
     return 0;
 
   // Serialize session
   Local<Object> session = Buffer::New(env, size).FromMaybe(Local<Object>());
-  if (UNLIKELY(session.IsEmpty()))
+  if (session.IsEmpty()) [[unlikely]]
     return 0;
 
   unsigned char* session_data =
@@ -181,7 +181,7 @@ int NewSessionCallback(SSL* s, SSL_SESSION* sess) {
       env,
       reinterpret_cast<const char*>(session_id_data),
       session_id_length).FromMaybe(Local<Object>());
-  if (UNLIKELY(session_id.IsEmpty()))
+  if (session_id.IsEmpty()) [[unlikely]]
     return 0;
 
   Local<Value> argv[] = {
@@ -256,7 +256,7 @@ int SelectALPNCallback(
     MaybeLocal<Value> maybe_callback_result =
         w->MakeCallback(env->alpn_callback_string(), 1, &callback_arg);
 
-    if (UNLIKELY(maybe_callback_result.IsEmpty())) {
+    if (maybe_callback_result.IsEmpty()) [[unlikely]] {
       // Implies the callback didn't return, because some exception was thrown
       // during processing, e.g. if callback returned an invalid ALPN value.
       return SSL_TLSEXT_ERR_ALERT_FATAL;
@@ -324,7 +324,7 @@ int TLSExtStatusCallback(SSL* s, void* arg) {
   // Outgoing response
   Local<ArrayBufferView> obj =
       w->ocsp_response().FromMaybe(Local<ArrayBufferView>());
-  if (UNLIKELY(obj.IsEmpty()))
+  if (obj.IsEmpty()) [[unlikely]]
     return SSL_TLSEXT_ERR_NOACK;
 
   size_t len = obj->ByteLength();
@@ -626,7 +626,7 @@ void TLSWrap::EncOut() {
     return;
   }
 
-  if (UNLIKELY(has_active_write_issued_by_prev_listener_)) {
+  if (has_active_write_issued_by_prev_listener_) [[unlikely]] {
     Debug(this,
           "Returning from EncOut(), "
           "has_active_write_issued_by_prev_listener_ is true");
@@ -704,7 +704,7 @@ void TLSWrap::EncOut() {
 void TLSWrap::OnStreamAfterWrite(WriteWrap* req_wrap, int status) {
   Debug(this, "OnStreamAfterWrite(status = %d)", status);
 
-  if (UNLIKELY(has_active_write_issued_by_prev_listener_)) {
+  if (has_active_write_issued_by_prev_listener_) [[unlikely]] {
     Debug(this, "Notify write finish to the previous_listener_");
     CHECK_EQ(write_size_, 0);  // we must have restrained writes
 
@@ -827,15 +827,19 @@ void TLSWrap::ClearOut() {
           unsigned long ssl_err = ERR_peek_error();  // NOLINT(runtime/int)
 
           Local<Context> context = env()->isolate()->GetCurrentContext();
-          if (UNLIKELY(context.IsEmpty())) return;
+          if (context.IsEmpty()) [[unlikely]]
+            return;
           const std::string error_str = GetBIOError();
           Local<String> message = OneByteString(
               env()->isolate(), error_str.c_str(), error_str.size());
-          if (UNLIKELY(message.IsEmpty())) return;
+          if (message.IsEmpty()) [[unlikely]]
+            return;
           error = Exception::Error(message);
-          if (UNLIKELY(error.IsEmpty())) return;
+          if (error.IsEmpty()) [[unlikely]]
+            return;
           Local<Object> obj;
-          if (UNLIKELY(!error->ToObject(context).ToLocal(&obj))) return;
+          if (!error->ToObject(context).ToLocal(&obj)) [[unlikely]]
+            return;
 
           const char* ls = ERR_lib_error_string(ssl_err);
           const char* fs = ERR_func_error_string(ssl_err);
@@ -1364,7 +1368,7 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
   Local<Value> ctx = p->object()->Get(env->context(), env->sni_context_string())
       .FromMaybe(Local<Value>());
 
-  if (UNLIKELY(ctx.IsEmpty()) || !ctx->IsObject())
+  if (ctx.IsEmpty() || !ctx->IsObject()) [[unlikely]]
     return SSL_TLSEXT_ERR_NOACK;
 
   if (!env->secure_context_constructor_template()->HasInstance(ctx)) {
@@ -1439,7 +1443,7 @@ unsigned int TLSWrap::PskServerCallback(
 
   Local<String> identity_str =
       String::NewFromUtf8(env->isolate(), identity).FromMaybe(Local<String>());
-  if (UNLIKELY(identity_str.IsEmpty()))
+  if (identity_str.IsEmpty()) [[unlikely]]
     return 0;
 
   // Make sure there are no utf8 replacement symbols.
@@ -1454,7 +1458,7 @@ unsigned int TLSWrap::PskServerCallback(
   Local<Value> psk_val =
       p->MakeCallback(env->onpskexchange_symbol(), arraysize(argv), argv)
           .FromMaybe(Local<Value>());
-  if (UNLIKELY(psk_val.IsEmpty()) || !psk_val->IsArrayBufferView())
+  if (psk_val.IsEmpty() || !psk_val->IsArrayBufferView()) [[unlikely]]
     return 0;
 
   ArrayBufferViewContents<char> psk_buf(psk_val);
@@ -1487,7 +1491,7 @@ unsigned int TLSWrap::PskClientCallback(
   if (hint != nullptr) {
     Local<String> local_hint =
         String::NewFromUtf8(env->isolate(), hint).FromMaybe(Local<String>());
-    if (UNLIKELY(local_hint.IsEmpty()))
+    if (local_hint.IsEmpty()) [[unlikely]]
       return 0;
 
     argv[0] = local_hint;
@@ -1496,14 +1500,14 @@ unsigned int TLSWrap::PskClientCallback(
   Local<Value> ret =
       p->MakeCallback(env->onpskexchange_symbol(), arraysize(argv), argv)
           .FromMaybe(Local<Value>());
-  if (UNLIKELY(ret.IsEmpty()) || !ret->IsObject())
+  if (ret.IsEmpty() || !ret->IsObject()) [[unlikely]]
     return 0;
 
   Local<Object> obj = ret.As<Object>();
 
   Local<Value> psk_val = obj->Get(env->context(), env->psk_string())
       .FromMaybe(Local<Value>());
-  if (UNLIKELY(psk_val.IsEmpty()) || !psk_val->IsArrayBufferView())
+  if (psk_val.IsEmpty() || !psk_val->IsArrayBufferView()) [[unlikely]]
     return 0;
 
   ArrayBufferViewContents<char> psk_buf(psk_val);
@@ -1512,7 +1516,7 @@ unsigned int TLSWrap::PskClientCallback(
 
   Local<Value> identity_val = obj->Get(env->context(), env->identity_string())
       .FromMaybe(Local<Value>());
-  if (UNLIKELY(identity_val.IsEmpty()) || !identity_val->IsString())
+  if (identity_val.IsEmpty() || !identity_val->IsString()) [[unlikely]]
     return 0;
 
   Utf8Value identity_buf(env->isolate(), identity_val);
@@ -1561,7 +1565,7 @@ void TLSWrap::CertCbDone(const FunctionCallbackInfo<Value>& args) {
   Local<Object> object = w->object();
   Local<Value> ctx = object->Get(env->context(), env->sni_context_string())
       .FromMaybe(Local<Value>());
-  if (UNLIKELY(ctx.IsEmpty()))
+  if (ctx.IsEmpty()) [[unlikely]]
     return;
 
   Local<FunctionTemplate> cons = env->secure_context_constructor_template();
@@ -1627,7 +1631,8 @@ void TLSWrap::SetKeyCert(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowTypeError("Must give a SecureContext as first argument");
 
   Local<Value> ctx = args[0];
-  if (UNLIKELY(ctx.IsEmpty())) return;
+  if (ctx.IsEmpty()) [[unlikely]]
+    return;
 
   Local<FunctionTemplate> cons = env->secure_context_constructor_template();
   if (cons->HasInstance(ctx)) {

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -571,7 +571,7 @@ void ThrowCryptoError(Environment* env,
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
-  if (UNLIKELY(env->permission()->enabled())) {
+  if (env->permission()->enabled()) [[unlikely]] {
     return THROW_ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED(
         env,
         "Programmatic selection of OpenSSL engines is unsupported while the "

--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -67,7 +67,8 @@ std::string ToBaseString(const T& value) {
 
 inline std::string SPrintFImpl(const char* format) {
   const char* p = strchr(format, '%');
-  if (LIKELY(p == nullptr)) return format;
+  if (p == nullptr) [[unlikely]]
+    return format;
   CHECK_EQ(p[1], '%');  // Only '%%' allowed when there are no arguments.
 
   return std::string(format, p + 1) + SPrintFImpl(p + 2);
@@ -138,14 +139,16 @@ inline void FORCE_INLINE Debug(EnabledDebugList* list,
                                DebugCategory cat,
                                const char* format,
                                Args&&... args) {
-  if (!UNLIKELY(list->enabled(cat))) return;
+  if (!list->enabled(cat)) [[unlikely]]
+    return;
   FPrintF(stderr, format, std::forward<Args>(args)...);
 }
 
 inline void FORCE_INLINE Debug(EnabledDebugList* list,
                                DebugCategory cat,
                                const char* message) {
-  if (!UNLIKELY(list->enabled(cat))) return;
+  if (!list->enabled(cat)) [[unlikely]]
+    return;
   FPrintF(stderr, "%s", message);
 }
 
@@ -194,8 +197,10 @@ inline void FORCE_INLINE Debug(AsyncWrap* async_wrap,
                                const char* format,
                                Args&&... args) {
   DCHECK_NOT_NULL(async_wrap);
-  DebugCategory cat = static_cast<DebugCategory>(async_wrap->provider_type());
-  if (!UNLIKELY(async_wrap->env()->enabled_debug_list()->enabled(cat))) return;
+  if (auto cat = static_cast<DebugCategory>(async_wrap->provider_type());
+      !async_wrap->env()->enabled_debug_list()->enabled(cat)) [[unlikely]] {
+    return;
+  }
   UnconditionalAsyncWrapDebug(async_wrap, format, std::forward<Args>(args)...);
 }
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -108,7 +108,7 @@ inline AliasedFloat64Array& AsyncHooks::async_ids_stack() {
 }
 
 v8::Local<v8::Array> AsyncHooks::js_execution_async_resources() {
-  if (UNLIKELY(js_execution_async_resources_.IsEmpty())) {
+  if (js_execution_async_resources_.IsEmpty()) [[unlikely]] {
     js_execution_async_resources_.Reset(
         env()->isolate(), v8::Array::New(env()->isolate()));
   }
@@ -185,13 +185,14 @@ inline bool TickInfo::has_rejection_to_warn() const {
 }
 
 inline Environment* Environment::GetCurrent(v8::Isolate* isolate) {
-  if (UNLIKELY(!isolate->InContext())) return nullptr;
+  if (!isolate->InContext()) [[unlikely]]
+    return nullptr;
   v8::HandleScope handle_scope(isolate);
   return GetCurrent(isolate->GetCurrentContext());
 }
 
 inline Environment* Environment::GetCurrent(v8::Local<v8::Context> context) {
-  if (UNLIKELY(!ContextEmbedderTag::IsNodeContext(context))) {
+  if (!ContextEmbedderTag::IsNodeContext(context)) [[unlikely]] {
     return nullptr;
   }
   return static_cast<Environment*>(

--- a/src/env.cc
+++ b/src/env.cc
@@ -152,12 +152,13 @@ void AsyncHooks::push_async_context(double async_id,
 bool AsyncHooks::pop_async_context(double async_id) {
   // In case of an exception then this may have already been reset, if the
   // stack was multiple MakeCallback()'s deep.
-  if (UNLIKELY(fields_[kStackLength] == 0)) return false;
+  if (fields_[kStackLength] == 0) [[unlikely]]
+    return false;
 
   // Ask for the async_id to be restored as a check that the stack
   // hasn't been corrupted.
-  if (UNLIKELY(fields_[kCheck] > 0 &&
-               async_id_fields_[kExecutionAsyncId] != async_id)) {
+  if (fields_[kCheck] > 0 && async_id_fields_[kExecutionAsyncId] != async_id)
+      [[unlikely]] {
     FailWithCorruptedAsyncStack(async_id);
   }
 
@@ -166,8 +167,8 @@ bool AsyncHooks::pop_async_context(double async_id) {
   async_id_fields_[kTriggerAsyncId] = async_ids_stack_[2 * offset + 1];
   fields_[kStackLength] = offset;
 
-  if (LIKELY(offset < native_execution_async_resources_.size() &&
-             !native_execution_async_resources_[offset].IsEmpty())) {
+  if (offset < native_execution_async_resources_.size() &&
+      !native_execution_async_resources_[offset].IsEmpty()) [[likely]] {
 #ifdef DEBUG
     for (uint32_t i = offset + 1; i < native_execution_async_resources_.size();
          i++) {
@@ -182,7 +183,7 @@ bool AsyncHooks::pop_async_context(double async_id) {
     }
   }
 
-  if (UNLIKELY(js_execution_async_resources()->Length() > offset)) {
+  if (js_execution_async_resources()->Length() > offset) [[unlikely]] {
     HandleScope handle_scope(env()->isolate());
     USE(js_execution_async_resources()->Set(
         env()->context(),
@@ -1388,7 +1389,7 @@ void Environment::RunAndClearNativeImmediates(bool only_refed) {
 
       head.reset();  // Destroy now so that this is also observed by try_catch.
 
-      if (UNLIKELY(try_catch.HasCaught())) {
+      if (try_catch.HasCaught()) [[unlikely]] {
         if (!try_catch.HasTerminated() && can_call_into_js())
           errors::TriggerUncaughtException(isolate(), try_catch);
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -312,7 +312,7 @@ MaybeLocal<Object> New(Isolate* isolate,
   if (length > 0) {
     store = ArrayBuffer::NewBackingStore(isolate, length);
 
-    if (UNLIKELY(!store)) {
+    if (!store) [[unlikely]] {
       THROW_ERR_MEMORY_ALLOCATION_FAILED(isolate);
       return Local<Object>();
     }
@@ -325,7 +325,7 @@ MaybeLocal<Object> New(Isolate* isolate,
         enc);
     CHECK(actual <= length);
 
-    if (LIKELY(actual > 0)) {
+    if (actual > 0) [[likely]] {
       if (actual < length) {
         std::unique_ptr<BackingStore> old_store = std::move(store);
         store = ArrayBuffer::NewBackingStore(isolate, actual);
@@ -335,8 +335,9 @@ MaybeLocal<Object> New(Isolate* isolate,
       }
       Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, std::move(store));
       Local<Object> obj;
-      if (UNLIKELY(!New(isolate, buf, 0, actual).ToLocal(&obj)))
-        return MaybeLocal<Object>();
+      if (!New(isolate, buf, 0, actual).ToLocal(&obj)) [[unlikely]] {
+        return {};
+      }
       return scope.Escape(obj);
     }
   }

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -185,7 +185,7 @@ MaybeLocal<String> BuiltinLoader::LoadBuiltinSource(Isolate* isolate,
   auto source = source_.read();
 #ifndef NODE_BUILTIN_MODULES_PATH
   const auto source_it = source->find(id);
-  if (UNLIKELY(source_it == source->end())) {
+  if (source_it == source->end()) [[unlikely]] {
     fprintf(stderr, "Cannot find native builtin: \"%s\".\n", id);
     ABORT();
   }

--- a/src/node_context_data.h
+++ b/src/node_context_data.h
@@ -139,16 +139,16 @@ class ContextEmbedderTag {
   }
 
   static inline bool IsNodeContext(v8::Local<v8::Context> context) {
-    if (UNLIKELY(context.IsEmpty())) {
+    if (context.IsEmpty()) [[unlikely]] {
       return false;
     }
-    if (UNLIKELY(context->GetNumberOfEmbedderDataFields() <=
-                 ContextEmbedderIndex::kContextTag)) {
+    if (context->GetNumberOfEmbedderDataFields() <=
+        ContextEmbedderIndex::kContextTag) [[unlikely]] {
       return false;
     }
-    if (UNLIKELY(context->GetAlignedPointerFromEmbedderData(
-                     ContextEmbedderIndex::kContextTag) !=
-                 ContextEmbedderTag::kNodeContextTagPtr)) {
+    if (context->GetAlignedPointerFromEmbedderData(
+            ContextEmbedderIndex::kContextTag) !=
+        ContextEmbedderTag::kNodeContextTagPtr) [[unlikely]] {
       return false;
     }
     return true;

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -1271,10 +1271,10 @@ bool ContextifyScript::EvalMachine(Local<Context> context,
 
 #if HAVE_INSPECTOR
   if (break_on_first_line) {
-    if (UNLIKELY(!env->permission()->is_granted(
-            env,
-            permission::PermissionScope::kInspector,
-            "PauseOnNextJavascriptStatement"))) {
+    if (!env->permission()->is_granted(env,
+                                       permission::PermissionScope::kInspector,
+                                       "PauseOnNextJavascriptStatement"))
+        [[unlikely]] {
       node::permission::Permission::ThrowAccessDenied(
           env,
           permission::PermissionScope::kInspector,

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -732,8 +732,9 @@ MaybeLocal<Object> Http2SessionPerformanceEntryTraits::GetDetails(
 
 void Http2Stream::EmitStatistics() {
   CHECK_NOT_NULL(session());
-  if (LIKELY(!HasHttp2Observer(env())))
+  if (!HasHttp2Observer(env())) [[likely]] {
     return;
+  }
 
   double start = statistics_.start_time / 1e6;
   double duration = (PERFORMANCE_NOW() / 1e6) - start;
@@ -752,9 +753,9 @@ void Http2Stream::EmitStatistics() {
 }
 
 void Http2Session::EmitStatistics() {
-  if (LIKELY(!HasHttp2Observer(env())))
+  if (!HasHttp2Observer(env())) [[likely]] {
     return;
-
+  }
   double start = statistics_.start_time / 1e6;
   double duration = (PERFORMANCE_NOW() / 1e6) - start;
 
@@ -944,7 +945,7 @@ void Http2Session::ConsumeHTTP2Data() {
   }
 
 done:
-  if (UNLIKELY(ret < 0)) {
+  if (ret < 0) [[unlikely]] {
     Isolate* isolate = env()->isolate();
     Debug(this,
         "fatal error receiving data: %d (%s)",
@@ -991,10 +992,10 @@ int Http2Session::OnBeginHeadersCallback(nghttp2_session* handle,
   BaseObjectPtr<Http2Stream> stream = session->FindStream(id);
   // The common case is that we're creating a new stream. The less likely
   // case is that we're receiving a set of trailers
-  if (LIKELY(!stream)) {
-    if (UNLIKELY(!session->CanAddStream() ||
-                 Http2Stream::New(session, id, frame->headers.cat) ==
-                     nullptr)) {
+  if (!stream) [[likely]] {
+    if (!session->CanAddStream() ||
+        Http2Stream::New(session, id, frame->headers.cat) == nullptr)
+        [[unlikely]] {
       if (session->rejected_stream_count_++ >
           session->js_fields_->max_rejected_streams)
         return NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -1029,7 +1030,7 @@ int Http2Session::OnHeaderCallback(nghttp2_session* handle,
   // If stream is null at this point, either something odd has happened
   // or the stream was closed locally while header processing was occurring.
   // either way, do not proceed and close the stream.
-  if (UNLIKELY(!stream))
+  if (!stream) [[unlikely]]
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
 
   // If the stream has already been destroyed, ignore.
@@ -1300,10 +1301,16 @@ int Http2Session::OnDataChunkReceived(nghttp2_session* handle,
     // Since it has access to the original socket buffer from which the data
     // was read in the first place, it can use that to minimize ArrayBuffer
     // allocations.
-    if (LIKELY(buf.base == nullptr))
+    if (buf.base == nullptr) [[likely]] {
       buf.base = reinterpret_cast<char*>(const_cast<uint8_t*>(data));
-    else
+    } else {
       memcpy(buf.base, data, avail);
+    }
+    if (buf.base == nullptr) [[likely]] {
+      buf.base = reinterpret_cast<char*>(const_cast<uint8_t*>(data));
+    } else {
+      memcpy(buf.base, data, avail);
+    }
     data += avail;
     len -= avail;
     stream->EmitRead(avail, buf);
@@ -1740,8 +1747,9 @@ void Http2Session::OnStreamAfterWrite(WriteWrap* w, int status) {
 // queue), but only if a write has not already been scheduled.
 void Http2Session::MaybeScheduleWrite() {
   CHECK(!is_write_scheduled());
-  if (UNLIKELY(!session_))
+  if (!session_) [[unlikely]] {
     return;
+  }
 
   if (nghttp2_session_want_write(session_.get())) {
     HandleScope handle_scope(env()->isolate());
@@ -1813,8 +1821,9 @@ void Http2Session::ClearOutgoing(int status) {
 
     for (int32_t stream_id : current_pending_rst_streams) {
       BaseObjectPtr<Http2Stream> stream = FindStream(stream_id);
-      if (LIKELY(stream))
+      if (stream) [[likely]] {
         stream->FlushRstStream();
+      }
     }
   }
 }
@@ -2002,8 +2011,9 @@ Http2Stream* Http2Session::SubmitRequest(
       *prov,
       nullptr);
   CHECK_NE(*ret, NGHTTP2_ERR_NOMEM);
-  if (LIKELY(*ret > 0))
+  if (*ret > 0) [[likely]] {
     stream = Http2Stream::New(this, *ret, NGHTTP2_HCAT_HEADERS, options);
+  }
   return stream;
 }
 
@@ -2032,8 +2042,8 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
 
   statistics_.data_received += nread;
 
-  if (LIKELY(stream_buf_offset_ == 0 &&
-             static_cast<size_t>(nread) != bs->ByteLength())) {
+  if (stream_buf_offset_ == 0 && static_cast<size_t>(nread) != bs->ByteLength())
+      [[likely]] {
     // Shrink to the actual amount of used data.
     std::unique_ptr<BackingStore> old_bs = std::move(bs);
     bs = ArrayBuffer::NewBackingStore(env()->isolate(), nread);

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -289,11 +289,11 @@ const BindingData::PackageConfig* BindingData::TraverseParent(
 
     // Stop the search when the process doesn't have permissions
     // to walk upwards
-    if (UNLIKELY(is_permissions_enabled &&
-                 !env->permission()->is_granted(
-                     env,
-                     permission::PermissionScope::kFileSystemRead,
-                     current_path.generic_string()))) {
+    if (is_permissions_enabled &&
+        !env->permission()->is_granted(
+            env,
+            permission::PermissionScope::kFileSystemRead,
+            current_path.generic_string())) [[unlikely]] {
       return nullptr;
     }
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -190,8 +190,9 @@ void MarkGarbageCollectionEnd(
   }
   env->performance_state()->current_gc_type = 0;
   // If no one is listening to gc performance entries, do not create them.
-  if (LIKELY(!state->observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]))
+  if (!state->observers[NODE_PERFORMANCE_ENTRY_TYPE_GC]) [[likely]] {
     return;
+  }
 
   double start_time =
       (state->performance_last_gc_start_mark - env->time_origin()) /

--- a/src/node_realm-inl.h
+++ b/src/node_realm-inl.h
@@ -9,13 +9,17 @@
 namespace node {
 
 inline Realm* Realm::GetCurrent(v8::Isolate* isolate) {
-  if (UNLIKELY(!isolate->InContext())) return nullptr;
+  if (!isolate->InContext()) [[unlikely]] {
+    return nullptr;
+  }
   v8::HandleScope handle_scope(isolate);
   return GetCurrent(isolate->GetCurrentContext());
 }
 
 inline Realm* Realm::GetCurrent(v8::Local<v8::Context> context) {
-  if (UNLIKELY(!ContextEmbedderTag::IsNodeContext(context))) return nullptr;
+  if (!ContextEmbedderTag::IsNodeContext(context)) [[unlikely]] {
+    return nullptr;
+  }
   return static_cast<Realm*>(
       context->GetAlignedPointerFromEmbedderData(ContextEmbedderIndex::kRealm));
 }
@@ -75,7 +79,9 @@ inline T* Realm::GetBindingData() {
   constexpr size_t binding_index = static_cast<size_t>(T::binding_type_int);
   static_assert(binding_index < std::tuple_size_v<BindingDataStore>);
   auto ptr = binding_data_store_[binding_index];
-  if (UNLIKELY(!ptr)) return nullptr;
+  if (!ptr) [[unlikely]] {
+    return nullptr;
+  }
   T* result = static_cast<T*>(ptr.get());
   DCHECK_NOT_NULL(result);
   return result;

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -248,7 +248,9 @@ R WASI::WasiFunction<FT, F, R, Args...>::FastCallback(
     // NOLINTNEXTLINE(runtime/references) This is V8 api.
     FastApiCallbackOptions& options) {
   WASI* wasi = reinterpret_cast<WASI*>(BaseObject::FromJSObject(receiver));
-  if (UNLIKELY(wasi == nullptr)) return EinvalError<R>();
+  if (wasi == nullptr) [[unlikely]] {
+    return EinvalError<R>();
+  }
 
   Isolate* isolate = receiver->GetIsolate();
   HandleScope scope(isolate);

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -104,12 +104,12 @@ void WasmStreamingObject::Push(const FunctionCallbackInfo<Value>& args) {
   size_t offset;
   size_t size;
 
-  if (LIKELY(chunk->IsArrayBufferView())) {
+  if (chunk->IsArrayBufferView()) [[likely]] {
     Local<ArrayBufferView> view = chunk.As<ArrayBufferView>();
     bytes = view->Buffer()->Data();
     offset = view->ByteOffset();
     size = view->ByteLength();
-  } else if (LIKELY(chunk->IsArrayBuffer())) {
+  } else if (chunk->IsArrayBuffer()) [[likely]] {
     Local<ArrayBuffer> buffer = chunk.As<ArrayBuffer>();
     bytes = buffer->Data();
     offset = 0;

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -496,7 +496,9 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
     size += sizeof(size_t);
     CompressionStream* ctx = static_cast<CompressionStream*>(data);
     char* memory = UncheckedMalloc(size);
-    if (UNLIKELY(memory == nullptr)) return nullptr;
+    if (memory == nullptr) [[unlikely]] {
+      return nullptr;
+    }
     *reinterpret_cast<size_t*>(memory) = size;
     ctx->unreported_allocations_.fetch_add(size,
                                            std::memory_order_relaxed);
@@ -504,7 +506,9 @@ class CompressionStream : public AsyncWrap, public ThreadPoolWork {
   }
 
   static void FreeForZlib(void* data, void* pointer) {
-    if (UNLIKELY(pointer == nullptr)) return;
+    if (pointer == nullptr) [[unlikely]] {
+      return;
+    }
     CompressionStream* ctx = static_cast<CompressionStream*>(data);
     char* real_pointer = static_cast<char*>(pointer) - sizeof(size_t);
     size_t real_size = *reinterpret_cast<size_t*>(real_pointer);

--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -227,8 +227,8 @@ void FSPermission::RadixTree::Insert(const std::string& path) {
     }
   }
 
-  if (UNLIKELY(per_process::enabled_debug_list.enabled(
-          DebugCategory::PERMISSION_MODEL))) {
+  if (per_process::enabled_debug_list.enabled(DebugCategory::PERMISSION_MODEL))
+      [[unlikely]] {
     per_process::Debug(DebugCategory::PERMISSION_MODEL, "Inserting %s\n", path);
     PrintTree(root_node_);
   }

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -28,7 +28,7 @@ namespace permission {
 
 #define THROW_IF_INSUFFICIENT_PERMISSIONS(env, perm_, resource_, ...)          \
   do {                                                                         \
-    if (UNLIKELY(!(env)->permission()->is_granted(env, perm_, resource_))) {   \
+    if (!env->permission()->is_granted(env, perm_, resource_)) [[unlikely]] {  \
       node::permission::Permission::ThrowAccessDenied(                         \
           (env), perm_, resource_);                                            \
       return __VA_ARGS__;                                                      \
@@ -38,7 +38,7 @@ namespace permission {
 #define ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS(                               \
     env, wrap, perm_, resource_, ...)                                          \
   do {                                                                         \
-    if (UNLIKELY(!(env)->permission()->is_granted(env, perm_, resource_))) {   \
+    if (!env->permission()->is_granted(env, perm_, resource_)) [[unlikely]] {  \
       node::permission::Permission::AsyncThrowAccessDenied(                    \
           (env), wrap, perm_, resource_);                                      \
       return __VA_ARGS__;                                                      \
@@ -52,7 +52,9 @@ class Permission {
   FORCE_INLINE bool is_granted(Environment* env,
                                const PermissionScope permission,
                                const std::string_view& res = "") const {
-    if (LIKELY(!enabled_)) return true;
+    if (!enabled_) [[likely]] {
+      return true;
+    }
     return is_scope_granted(env, permission, res);
   }
 

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -480,7 +480,7 @@ class DefaultApplication final : public Session::Application {
           // the data until after we're sure it's written.
         };
 
-    if (LIKELY(!stream->is_eos())) {
+    if (!stream->is_eos()) [[likely]] {
       int ret = stream->Pull(std::move(next),
                              bob::Options::OPTIONS_SYNC,
                              stream_data->data,

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -17,7 +17,7 @@ namespace quic {
 #define NGTCP2_OK(V) (V == NGTCP2_SUCCESS)
 
 #define IF_QUIC_DEBUG(env)                                                     \
-  if (UNLIKELY(env->enabled_debug_list()->enabled(DebugCategory::QUIC)))
+  if (env->enabled_debug_list()->enabled(DebugCategory::QUIC)) [[unlikely]]
 
 #define DISALLOW_COPY(Name)                                                    \
   Name(const Name&) = delete;                                                  \

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -616,7 +616,9 @@ class Http3Application final : public Session::Application {
 
 #define NGHTTP3_CALLBACK_SCOPE(name)                                           \
   auto name = From(conn, conn_user_data);                                      \
-  if (UNLIKELY(name->is_destroyed())) return NGHTTP3_ERR_CALLBACK_FAILURE;     \
+  if (name->is_destroyed()) [[unlikely]] {                                     \
+    return NGHTTP3_ERR_CALLBACK_FAILURE;                                       \
+  }                                                                            \
   NgHttp3CallbackScope scope(name->env());
 
   static nghttp3_ssize on_read_data_callback(nghttp3_conn* conn,

--- a/src/quic/packet.cc
+++ b/src/quic/packet.cc
@@ -117,10 +117,10 @@ Packet* Packet::Create(Environment* env,
                        const char* diagnostic_label) {
   if (BindingData::Get(env).packet_freelist.empty()) {
     Local<Object> obj;
-    if (UNLIKELY(!GetConstructorTemplate(env)
-                      ->InstanceTemplate()
-                      ->NewInstance(env->context())
-                      .ToLocal(&obj))) {
+    if (!GetConstructorTemplate(env)
+             ->InstanceTemplate()
+             ->NewInstance(env->context())
+             .ToLocal(&obj)) [[unlikely]] {
       return nullptr;
     }
 
@@ -138,10 +138,10 @@ Packet* Packet::Clone() const {
   auto& binding = BindingData::Get(env());
   if (binding.packet_freelist.empty()) {
     Local<Object> obj;
-    if (UNLIKELY(!GetConstructorTemplate(env())
-                      ->InstanceTemplate()
-                      ->NewInstance(env()->context())
-                      .ToLocal(&obj))) {
+    if (!GetConstructorTemplate(env())
+             ->InstanceTemplate()
+             ->NewInstance(env()->context())
+             .ToLocal(&obj)) [[unlikely]] {
       return nullptr;
     }
 

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -871,7 +871,9 @@ bool Stream::AddHeader(const Header& header) {
 
   const auto push = [&](auto raw) {
     Local<Value> value;
-    if (UNLIKELY(!raw.ToLocal(&value))) return false;
+    if (!raw.ToLocal(&value)) [[unlikely]] {
+      return false;
+    }
     headers_.push_back(value);
     return true;
   };

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -515,8 +515,8 @@ crypto::SSLPointer TLSSession::Initialize(
   ngtcp2_conn_set_tls_native_handle(*session_, ssl.get());
 
   // Enable tracing if the `--trace-tls` command line flag is used.
-  if (UNLIKELY(session_->env()->options()->trace_tls ||
-               options.enable_tls_trace)) {
+  if (session_->env()->options()->trace_tls || options.enable_tls_trace)
+      [[unlikely]] {
     EnableTrace(session_->env(), &bio_trace_, *this);
   }
 

--- a/src/string_decoder.cc
+++ b/src/string_decoder.cc
@@ -114,7 +114,7 @@ MaybeLocal<String> StringDecoder::DecodeData(Isolate* isolate,
       state_[kMissingBytes] -= found_bytes;
       state_[kBufferedBytes] += found_bytes;
 
-      if (LIKELY(MissingBytes() == 0)) {
+      if (MissingBytes() == 0) [[likely]] {
         // If no more bytes are missing, create a small string that we
         // will later prepend.
         if (!MakeString(isolate,
@@ -132,7 +132,7 @@ MaybeLocal<String> StringDecoder::DecodeData(Isolate* isolate,
 
     // It could be that trying to finish the previous chunk already
     // consumed all data that we received in this chunk.
-    if (UNLIKELY(nread == 0)) {
+    if (nread == 0) [[unlikely]] {
       body = !prepend.IsEmpty() ? prepend : String::Empty(isolate);
       prepend = Local<String>();
     } else {

--- a/src/tracing/trace_event.h
+++ b/src/tracing/trace_event.h
@@ -321,7 +321,9 @@ class TraceEventHelper {
   static inline const uint8_t* GetCategoryGroupEnabled(const char* group) {
     v8::TracingController* controller = GetTracingController();
     static const uint8_t disabled = 0;
-    if (UNLIKELY(controller == nullptr)) return &disabled;
+    if (controller == nullptr) [[unlikely]] {
+      return &disabled;
+    }
     return controller->GetCategoryGroupEnabled(group);
   }
 };

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -589,7 +589,7 @@ ssize_t UDPWrap::Send(uv_buf_t* bufs_ptr,
     msg_size += bufs_ptr[i].len;
 
   int err = 0;
-  if (!UNLIKELY(env()->options()->test_udp_no_try_send)) {
+  if (!env()->options()->test_udp_no_try_send) [[unlikely]] {
     err = uv_udp_try_send(&handle_, bufs_ptr, count, addr);
     if (err == UV_ENOSYS || err == UV_EAGAIN) {
       err = 0;

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -247,7 +247,7 @@ T* UncheckedRealloc(T* pointer, size_t n) {
 
   void* allocated = realloc(pointer, full_size);
 
-  if (UNLIKELY(allocated == nullptr)) {
+  if (allocated == nullptr) [[unlikely]] {
     // Tell V8 that memory is low and retry.
     LowMemoryNotification();
     allocated = realloc(pointer, full_size);
@@ -326,7 +326,7 @@ v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
                                     std::string_view str,
                                     v8::Isolate* isolate) {
   if (isolate == nullptr) isolate = context->GetIsolate();
-  if (UNLIKELY(str.size() >= static_cast<size_t>(v8::String::kMaxLength))) {
+  if (str.size() >= static_cast<size_t>(v8::String::kMaxLength)) [[unlikely]] {
     // V8 only has a TODO comment about adding an exception when the maximum
     // string size is exceeded.
     ThrowErrStringTooLong(isolate);

--- a/src/util.cc
+++ b/src/util.cc
@@ -697,8 +697,9 @@ void SetConstructorFunction(Local<Context> context,
                             Local<String> name,
                             Local<FunctionTemplate> tmpl,
                             SetConstructorFunctionFlag flag) {
-  if (LIKELY(flag == SetConstructorFunctionFlag::SET_CLASS_NAME))
+  if (flag == SetConstructorFunctionFlag::SET_CLASS_NAME) [[likely]] {
     tmpl->SetClassName(name);
+  }
   that->Set(context, name, tmpl->GetFunction(context).ToLocalChecked()).Check();
 }
 
@@ -716,8 +717,9 @@ void SetConstructorFunction(Isolate* isolate,
                             Local<String> name,
                             Local<FunctionTemplate> tmpl,
                             SetConstructorFunctionFlag flag) {
-  if (LIKELY(flag == SetConstructorFunctionFlag::SET_CLASS_NAME))
+  if (flag == SetConstructorFunctionFlag::SET_CLASS_NAME) [[likely]] {
     tmpl->SetClassName(name);
+  }
   that->Set(name, tmpl);
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -158,12 +158,8 @@ void DumpJavaScriptBacktrace(FILE* fp);
   } while (0)
 
 #ifdef __GNUC__
-#define LIKELY(expr) __builtin_expect(!!(expr), 1)
-#define UNLIKELY(expr) __builtin_expect(!!(expr), 0)
 #define PRETTY_FUNCTION_NAME __PRETTY_FUNCTION__
 #else
-#define LIKELY(expr) expr
-#define UNLIKELY(expr) expr
 #if defined(_MSC_VER)
 #define PRETTY_FUNCTION_NAME __FUNCSIG__
 #else
@@ -174,11 +170,11 @@ void DumpJavaScriptBacktrace(FILE* fp);
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 
-#define CHECK(expr)                                                           \
-  do {                                                                        \
-    if (UNLIKELY(!(expr))) {                                                  \
-      ERROR_AND_ABORT(expr);                                                  \
-    }                                                                         \
+#define CHECK(expr)                                                            \
+  do {                                                                         \
+    if (!(expr)) [[unlikely]] {                                                \
+      ERROR_AND_ABORT(expr);                                                   \
+    }                                                                          \
   } while (0)
 
 #define CHECK_EQ(a, b) CHECK((a) == (b))


### PR DESCRIPTION
An attempt to modernize C++ code to use `[[likely]]` and `[[unlikely]]` available after C++20.

Reference: https://en.cppreference.com/w/cpp/language/attributes/likely

This pull-request also disables `readability/braces` rule from cpplint, since it doesn't support C++20. Main branch of cpplint supports it, but unfortunately they didn't release a new version in the last 2 years.