### PR TITLE
benchmark: add --runs support to run.js

### DIFF
--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -12,6 +12,8 @@ const cli = new CLI(`usage: ./node run.js [options] [--] <category> ...
                             (can be repeated)
   --exclude  pattern        excludes scripts matching <pattern> (can be
                             repeated)
+  --runs   variable=value   set the amount of benchmark suite execution.
+                            Default: 1
   --set    variable=value   set benchmark variable (can be repeated)
   --format [simple|csv]     optional value that specifies the output format
   test                      only run a single configuration from the options
@@ -45,8 +47,7 @@ if (format === 'csv') {
   console.log('"filename", "configuration", "rate", "time"');
 }
 
-(function recursive(i) {
-  const filename = benchmarks[i];
+async function runBenchmark(filename) {
   const scriptPath = path.resolve(__dirname, filename);
 
   const args = cli.test ? ['--test'] : cli.optional.set;
@@ -63,42 +64,54 @@ if (format === 'csv') {
     );
   }
 
-  if (format !== 'csv') {
-    console.log();
-    console.log(filename);
+  return new Promise((resolve, reject) => {
+    child.on('message', (data) => {
+      if (data.type !== 'report') {
+        return;
+      }
+      // Construct configuration string, " A=a, B=b, ..."
+      let conf = '';
+      for (const key of Object.keys(data.conf)) {
+        if (conf !== '')
+          conf += ' ';
+        conf += `${key}=${JSON.stringify(data.conf[key])}`;
+      }
+      if (format === 'csv') {
+        // Escape quotes (") for correct csv formatting
+        conf = conf.replace(/"/g, '""');
+        console.log(`"${data.name}", "${conf}", ${data.rate}, ${data.time}`);
+      } else {
+        let rate = data.rate.toString().split('.');
+        rate[0] = rate[0].replace(/(\d)(?=(?:\d\d\d)+(?!\d))/g, '$1,');
+        rate = (rate[1] ? rate.join('.') : rate[0]);
+        console.log(`${data.name} ${conf}: ${rate}`);
+      }
+    });
+    child.once('error', (err) => reject(err));
+    child.once('close', (code) => {
+      if (code) {
+        reject(code);
+      } else {
+        resolve(code);
+      }
+    });
+  });
+}
+
+let runs = cli.optional.runs ?? 1;
+
+async function run() {
+  for (let i = 0; i < benchmarks.length; ++i) {
+    const filename = benchmarks[i];
+    if (format !== 'csv') {
+      console.log();
+      console.log(filename);
+    }
+
+    while (runs--) {
+      await runBenchmark(filename);
+    }
   }
+}
 
-  child.on('message', (data) => {
-    if (data.type !== 'report') {
-      return;
-    }
-    // Construct configuration string, " A=a, B=b, ..."
-    let conf = '';
-    for (const key of Object.keys(data.conf)) {
-      if (conf !== '')
-        conf += ' ';
-      conf += `${key}=${JSON.stringify(data.conf[key])}`;
-    }
-    if (format === 'csv') {
-      // Escape quotes (") for correct csv formatting
-      conf = conf.replace(/"/g, '""');
-      console.log(`"${data.name}", "${conf}", ${data.rate}, ${data.time}`);
-    } else {
-      let rate = data.rate.toString().split('.');
-      rate[0] = rate[0].replace(/(\d)(?=(?:\d\d\d)+(?!\d))/g, '$1,');
-      rate = (rate[1] ? rate.join('.') : rate[0]);
-      console.log(`${data.name} ${conf}: ${rate}`);
-    }
-  });
-
-  child.once('close', (code) => {
-    if (code) {
-      process.exit(code);
-    }
-
-    // If there are more benchmarks execute the next
-    if (i + 1 < benchmarks.length) {
-      recursive(i + 1);
-    }
-  });
-})(0);
+run();

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -89,9 +89,9 @@ async function runBenchmark(filename) {
     });
     child.once('close', (code) => {
       if (code) {
-        resolve(code);
-      } else {
         reject(code);
+      } else {
+        resolve(code);
       }
     });
   });

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -47,7 +47,7 @@ if (format === 'csv') {
   console.log('"filename", "configuration", "rate", "time"');
 }
 
-async function runBenchmark(filename) {
+function runBenchmark(filename) {
   const scriptPath = path.resolve(__dirname, filename);
 
   const args = cli.test ? ['--test'] : cli.optional.set;

--- a/benchmark/run.js
+++ b/benchmark/run.js
@@ -87,28 +87,26 @@ async function runBenchmark(filename) {
         console.log(`${data.name} ${conf}: ${rate}`);
       }
     });
-    child.once('error', (err) => reject(err));
     child.once('close', (code) => {
       if (code) {
-        reject(code);
-      } else {
         resolve(code);
+      } else {
+        reject(code);
       }
     });
   });
 }
 
-let runs = cli.optional.runs ?? 1;
-
 async function run() {
   for (let i = 0; i < benchmarks.length; ++i) {
+    let runs = cli.optional.runs ?? 1;
     const filename = benchmarks[i];
     if (format !== 'csv') {
       console.log();
       console.log(filename);
     }
 
-    while (runs--) {
+    while (runs-- > 0) {
       await runBenchmark(filename);
     }
   }

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -174,6 +174,16 @@ It is possible to execute more groups by adding extra process arguments.
 node benchmark/run.js assert async_hooks
 ```
 
+It's also possible to execute the benchmark more than once using the
+`--runs` flag.
+
+```bash
+node benchmark/run.js --runs 10 assert async_hooks
+```
+
+This command will run the benchmark suite 10 times for both assert and
+async\_hooks group
+
 #### Specifying CPU Cores for Benchmarks with run.js
 
 When using `run.js` to execute a group of benchmarks,

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -181,8 +181,8 @@ It's also possible to execute the benchmark more than once using the
 node benchmark/run.js --runs 10 assert async_hooks
 ```
 
-This command will run the benchmark suite 10 times for both assert and
-async\_hooks group
+This command will run the benchmark files in `benchmark/assert` and `benchmark/async_hooks`
+10 times each.
 
 #### Specifying CPU Cores for Benchmarks with run.js
 


### PR DESCRIPTION
This PR adds a new flag to benchmark/run.js. You can pass the `--runs` to define the amount of benchmark suite runs.