### PR TITLE
doc: fix link in `test/README.md`

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -38,7 +38,7 @@ For the tests to run on Windows, be sure to clone Node.js source code with the
 | `tick-processor` | No         | Tests for the V8 tick processor integration.[^4]                                                              |
 | `v8-updates`     | No         | Tests for V8 performance integration.                                                                         |
 
-[^1]: [Documentation](./common/README.md)
+[^1]: [Documentation](../test/common/README.md)
 
 [^2]: Tests for networking related modules may also be present in other directories, but those tests do
     not make outbound connections.


### PR DESCRIPTION
The relative link points to wrong place when the page is opened as https://github.com/nodejs/node/tree/main/test (without trailing slash nor explicit `README.md`), because `new URL('./common/README.md', 'https://github.com/nodejs/node/tree/main/test').href === 'https://github.com/nodejs/node/tree/main/common/README.md'`.

Note that there are similar links in other places (example: https://github.com/nodejs/node/blob/103b8439cae2a113f4f0796dd6fcbced294a3ed8/test/wpt/README.md?plain=1#L8), but they work fine because GitHub resolves them internally to absolute links. I guess it just doesn't touch links in footnotes.