### PR TITLE
test: make `test-loaders-workers-spawned` less flaky

### DIFF
--- a/test/es-module/test-loaders-workers-spawned.mjs
+++ b/test/es-module/test-loaders-workers-spawned.mjs
@@ -76,7 +76,7 @@ describe('Worker threads do not spawn infinitely', { concurrency: !process.env.T
 
     assert.strictEqual(stderr, '');
     // The worker code should always run before the --import, but the console.log might arrive late.
-    assert.match(stdout, /^A\r?\nA\r?\n(B\r?\nC|C\r?\nB)\r?\nD\r?\n$/);
+    assert.match(stdout, /^A\r?\n(A\r?\nB\r?\nC|A\r?\nC\r?\nB|C\r?\nA\r?\nB)\r?\nD\r?\n$/);
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
   });


### PR DESCRIPTION
I've seen it fail on CI (e.g. https://github.com/nodejs/node/actions/runs/11084447570/job/30799766200), cannot reproduce locally. Calling `console.log` from both a worker and the main thread is always going to result in uncertain output, IMO it makes sense to considered the test passed as long as we got all of them, regardless of the order.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
