### PR TITLE
src: apply getCallSite optimization

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -250,7 +250,6 @@ static void ParseEnv(const FunctionCallbackInfo<Value>& args) {
 static void GetCallSite(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
-  v8::HandleScope handle_scope(isolate);
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsNumber());

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -276,16 +276,16 @@ static void GetCallSite(const FunctionCallbackInfo<Value>& args) {
     }
 
     Local<Name> names[] = {
-      env->function_name_string(),
-      env->script_name_string(),
-      env->line_number_string(),
-      env->column_string(),
+        env->function_name_string(),
+        env->script_name_string(),
+        env->line_number_string(),
+        env->column_string(),
     };
     Local<Value> values[] = {
-      function_name,
-      script_name,
-      Integer::NewFromUnsigned(isolate, stack_frame->GetLineNumber()),
-      Integer::NewFromUnsigned(isolate, stack_frame->GetColumn()),
+        function_name,
+        script_name,
+        Integer::NewFromUnsigned(isolate, stack_frame->GetLineNumber()),
+        Integer::NewFromUnsigned(isolate, stack_frame->GetColumn()),
     };
     Local<Object> obj = Object::New(
         isolate, v8::Null(isolate), names, values, arraysize(names));


### PR DESCRIPTION
Applying one of @jasnell suggestions https://github.com/nodejs/node/pull/54380#discussion_r1733197415

Result an _possible_ performance boost of ~14%

```
➜  node (optimize-getcallsite) node-benchmark-compare compare.csv                                                         ✭ ✱
                                                            confidence improvement accuracy (*)   (**)  (***)
util/get-callsite.js method='CPP' n=100                            ***     14.00 %       ±3.69% ±4.92% ±6.43%
```