### PR TITLE
lib: runtime deprecate SlowBuffer

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -695,6 +695,9 @@ Type: End-of-Life
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55175
+    description: Runtime deprecation.
   - version: v6.12.0
     pr-url: https://github.com/nodejs/node/pull/10116
     description: A deprecation code has been assigned.
@@ -703,7 +706,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`SlowBuffer`][] class is deprecated. Please use
 [`Buffer.allocUnsafeSlow(size)`][] instead.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -88,6 +88,7 @@ const {
   kIsEncodingSymbol,
   defineLazyProperties,
   encodingsMap,
+  deprecate,
 } = require('internal/util');
 const {
   isAnyArrayBuffer,
@@ -1324,7 +1325,10 @@ function isAscii(input) {
 
 module.exports = {
   Buffer,
-  SlowBuffer,
+  SlowBuffer: deprecate(
+    SlowBuffer,
+    'SlowBuffer() is deprecated. Please use Buffer.allowUnsafeSlow()',
+    'DEP0030'),
   transcode,
   isUtf8,
   isAscii,

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1327,7 +1327,7 @@ module.exports = {
   Buffer,
   SlowBuffer: deprecate(
     SlowBuffer,
-    'SlowBuffer() is deprecated. Please use Buffer.allowUnsafeSlow()',
+    'SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()',
     'DEP0030'),
   transcode,
   isUtf8,

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -1,11 +1,17 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const buffer = require('buffer');
 const SlowBuffer = buffer.SlowBuffer;
 
 const ones = [1, 1, 1, 1];
+
+common.expectWarning(
+  'DeprecationWarning',
+  'SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()',
+  'DEP0030'
+);
 
 // Should create a Buffer
 let sb = SlowBuffer(4);


### PR DESCRIPTION
SlowBuffer has been doc-deprecated for a while and I couldn't find why we didn't want to proceed with the deprecation cycle on this feature. Therefore, this PR runtime deprecates SlowBuffer.