### PR TITLE
meta: remove non-collaborators from mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,96 +1,32 @@
-3nprob <git@3n.anonaddy.com> <3nprob@3nprob>
-Aaron Bieber <aaron@bolddaemon.com> <deftly@gmail.com>
-Aaron Heckmann <aaron.heckmann@gmail.com> <aaron.heckmann+github@gmail.com>
-Aayush Ahuja <aayush.a@directi.com>
-Abe Fettig <abefettig@gmail.com> <abe@fettig.net>
-Abhimanyu Vashisht <abhimanyuvashisht.av@gmail.com>
-Adam Langley <agl@imperialviolet.org> <agl@google.com>
 Akhil Marsonya <akhil.marsonya27@gmail.com>
 Akhil Marsonya <akhil.marsonya27@gmail.com> <16393876+marsonya@users.noreply.github.com>
-Akito Ito <akito0107@gmail.com> <akito_ito@r.recruit.co.jp>
-Alejandro Estrada <estrada9166@gmail.com>
-Alejandro Estrada <estrada9166@gmail.com> <estrada9166@hotmail.com>
-Alejandro Oviedo Garcia <alejandro.oviedo.g@gmail.com>
-Alex Gilbert <alex@punkave.com>
-Alex Hultman <alexhultman@gmail.com> <alexhultman@localhost.localdomain>
-Alex Jordan <alex@strugee.net>
 Alex Kocharin <rlidwka@kocharin.ru>
 Alex Kocharin <rlidwka@kocharin.ru> <alex@kocharin.ru>
-Alex Zherdev <alex.zherdev@gmail.com> <alex_zherdev@acl.com>
-Alexander Marchenko <axvmindaweb@gmail.com>
-Alexey Kupershtokh <alexey.kupershtokh@gmail.com> <wicked@alawar.com>
 Alexis Campailla <alexis@janeasystems.com> <orangemocha@github.com>
-Alexis Sellier <self@cloudhead.net>
-Alexis Sellier <self@cloudhead.net> <alexis@cloudhead.io>
-Alfred Cepeda <AlfredJCepeda@gmail.com>
-Allen Yonghuang Wang <helloshuangzi@gmail.com>
-Amery <amery@xiangfa.org>
-Amit Bendor <ajbendor@gmail.com>
 Anatoli Papirovski <apapirovski@mac.com> <anatoli.papirovski@postmates.com>
-Andreas Offenhaeuser <offenhaeuser@gmail.com>
-Andreas Schwab <schwab@linux-m68k.org> <schwab@suse.de>
-Andrew Hughes <Andrew.Hughes1@ibm.com> <andrew.hughes.101@outlook.com>
-Andy Bettisworth <andy.bettisworth@accreu.com>
-Angel Stoyanov <atstojanov@gmail.com>
 Anna Henningsen <anna@addaleax.net> <anna.henningsen@mongodb.com>
 Anna Henningsen <anna@addaleax.net> <github@addaleax.net>
 Anna Henningsen <anna@addaleax.net> <sqrt@entless.org>
-Anna Magdalena Kedzierska <anna.mag.kedzierska@gmail.com> <AnnaMag@users.noreply.github.com>
-Antoine Amara <amara.antoine@gmail.com>
-apeltop <sunshine@ptokos.com> <psycho3081@gmail.com>
-Aria Stewart <aredridel@dinhe.net> <aredridel@nbtsc.org>
-Arlo Breault <arlolra@gmail.com>
-Arnaud Lefebvre <a.lefebvre@outlook.fr>
-Arnout Kazemier <info@3rd-Eden.com> <3rd-Eden@users.noreply.github.com>
-Artem Zaytsev <a.arepo@gmail.com>
-Artur G Vieira <vieira.artur.g@gmail.com>
-Asaf David <asafdav2@gmail.com>
 Ash Cripps <email@ashleycripps.co.uk> <acripps@redhat.com>
 Ash Cripps <email@ashleycripps.co.uk> <ashley.cripps@ibm.com>
 Ash Cripps <email@ashleycripps.co.uk> <Ashley.Cripps@ibm.com>
-Ashley Maceli <ashley.maceli@gmail.com>
-Ashok Suthar <coderatlabs@gmail.com>
-Ashutosh Kumar Singh <singhjug1994@gmail.com>
-Atsuo Fukaya <fukayatsu@gmail.com>
-Austin Kelleher <austinlkelleher@gmail.com> <austin.kell47@gmail.com>
-Azard <azardf4yy@gmail.com> <330815461@qq.com>
-Ben Lugavere <b.lugavere@gmail.com>
 Ben Noordhuis <info@bnoordhuis.nl> <ben@strongloop.com>
 Ben Noordhuis <info@bnoordhuis.nl> <bnoordhuis@bender.(none)>
-Ben Taber <ben.taber@gmail.com>
 Benedikt Meurer <bmeurer@google.com> <bmeurer@chromium.org>
-Benjamin Coe <bencoe@gmail.com> <ben@npmjs.com>
-Benjamin Coe <bencoe@gmail.com> <bencoe@google.com>
-Benjamin Fleischer <github@benjaminfleischer.com> <benjamin.fleischer@swipesense.com>
 Benjamin Gruenbaum <benjamingr@gmail.com> <benjamingruenbaum@Benjamins-MacBook-Pro.local>
 Benjamin Gruenbaum <benjamingr@gmail.com> <benji@peer5.com>
 Benjamin Gruenbaum <benjamingr@gmail.com> <inglor@gmail.com>
-Benjamin Waters <benjamin.waters@outlook.com> <ben25890@gmail.com>
 Bert Belder <bertbelder@gmail.com> <bert@piscisaureus2.(none)>
 Bert Belder <bertbelder@gmail.com> <info@2bs.nl>
 Bert Belder <bertbelder@gmail.com> <piscisaureus@Berts-MacBook-Pro.local>
 Beth Griggs <bethanyngriggs@gmail.com> <Bethany.Griggs@uk.ibm.com>
 Beth Griggs <bethanyngriggs@gmail.com> <bgriggs@redhat.com>
-Bidisha Pyne <pyne.bidisha2017@gmail.com> <bidipyne@in.ibm.com>
-bl-ue <bl-ue@users.noreply.github.com> <54780737+bl-ue@users.noreply.github.com>
-Brad Decker <bhdecker84@gmail.com>
-Brad Larson <brad@waterfallmedia.net>
-Brandon Benvie <brandon@bbenvie.com> <brandon@brandonbenvie.com>
-Brandon Kobel <kobelb@gmail.com> <brandon.kobel@elastic.co>
 Brendan Ashworth <brendan.ashworth@me.com> <squirrelslikeacorns@gmail.com>
-Brent Pendergraft <bpent3l@gmail.com>
-Brett Kiefer <kiefer@gmail.com> <brett@trello.com>
-Brian Muenzenmeyer <brian.muenzenmeyer@gmail.com> <Brian.Muenzenmeyer@target.com>
 Brian White <mscdex@mscdex.net>
 Brian White <mscdex@mscdex.net> <mscdex@gmail.com>
 Brian White <mscdex@mscdex.net> <mscdex@users.noreply.github.com>
-Caleb Boyd <caleb.boyd@gmail.com>
 Calvin Metcalf <calvin.metcalf@gmail.com> <calvin.metcalf@state.ma.us>
 Calvin Metcalf <calvin.metcalf@gmail.com> <cmetcalf@appgeo.com>
-Camillo Bruni <camillobruni@users.noreply.github.com> <cbruni@chromium.org>
-Caralyn Reisle <caralynreisle@gmail.com>
-Charles <ineedpracticing@gmail.com> <cydjudge@users.noreply.github.com>
-Charles Rudolph <charles.rudolph@originate.com>
 Chemi Atlow <chemi@atlow.co.il>
 Chemi Atlow <chemi@atlow.co.il> <chemi@testim.io>
 Chemi Atlow <chemi@atlow.co.il> <chemiatlow@gmail.com>
@@ -99,514 +35,150 @@ Chen Gang <gangc.cxy@foxmail.com> <13298548+MoonBall@users.noreply.github.com>
 Chengzhong Wu <legendecas@gmail.com>
 Chengzhong Wu <legendecas@gmail.com> <chengzhong.wcz@alibaba-inc.com>
 Chengzhong Wu <legendecas@gmail.com> <cwu631@bloomberg.net>
-Chew Choon Keat <choonkeat@gmail.com>
-Chris Andrews <cpandrews8@gmail.com>
-Chris Johnson <chris.s.johnson4@gmail.com>
-Chris Young <chris.young@tinder.com> <chris.young@gotinder.com>
 Christian Clauss <cclauss@me.com>
 Christian Clauss <cclauss@me.com> <cclauss@bluewin.ch>
-Christophe Naud-Dulude <christophe.naud.dulude@gmail.com>
-Christopher Lenz <cmlenz@gmail.com> <chris@lamech.local>
 Claudio Rodriguez <cjrodr@yahoo.com> <cr@fansworld.tv>
 Claudio Wunder <cwunder@gnome.org> <cwunder@hubspot.com>
-Clemens Backes <post@clemens-backes.de> <clemensb@chromium.org>
 Colin Ihrig <cjihrig@gmail.com>
-Corey Martin <coreymartin496@gmail.com>
-Cyril Lakech <cyril.lakech@axa.fr> <1169286+clakech@users.noreply.github.com>
-Daiki Arai <darai0512@yahoo.co.jp> <darai@yahoo-corp.jp>
-Damien Simonin Feugas <damien.feugas@gmail.com>
-Dan Carney <dcarney@chromium.org>
-Dan Fabulich <dan@fabulich.com> <dan.fabulich@redfin.com>
-Dan Kaplun <dbkaplun@gmail.com> <dan@beardtree.com>
-Dan Williams <dan@igniter.com> <daniel@chat.za.net>
-Daniel Abrão <danielpaladar@gmail.com>
-Daniel Berger <code+node@dpbis.net>
 Daniel Bevenius <daniel.bevenius@gmail.com>
-Daniel Chcouri <333222@gmail.com>
-Daniel Clifford <danno@chromium.org>
-Daniel Gröber <darklord@darkboxed.org>
-Daniel Gröber <darklord@darkboxed.org> <dxld@darkboxed.org>
 Daniel Lemire <daniel@lemire.me> <lemire@gmail.com>
-Daniel Paulino <d_paulino@outlook.com>
-Daniel Pihlström <sciolist.se@gmail.com>
 Daniel Wang <wangyang0123@gmail.com>
 Daniel Wang <wangyang0123@gmail.com> <wangyang02@baidu.com>
 Danielle Adams <adamzdanielle@gmail.com> <6271256+danielleadams@users.noreply.github.com>
 Danielle Adams <adamzdanielle@gmail.com> <danielle.adams@heroku.com>
-Danny Guo <danny@dannyguo.com> <dannyguo91@gmail.com>
-Danny Nemer <hi@dannynemer.com> <DannyNemer@users.noreply.github.com>
-Danny Nemer <hi@dannynemer.com> <hi@DannyNemer.com>
 Darshan Sen <raisinten@gmail.com>
 Darshan Sen <raisinten@gmail.com> <darshan.sen@postman.com>
-Dave Olszewski <cxreg@pobox.com> <daveo@nodesource.com>
-Dave Pacheco <dap@joyent.com> <dap@cs.brown.edu>
 David Cai <davidcai1993@yahoo.com>
-David Mark Clements <david.clements@nearform.com>
-David Mark Clements <david.clements@nearform.com> <david.mark.clements@gmail.com>
-David Mark Clements <david.clements@nearform.com> <huperekchuno@googlemail.com>
-David Siegel <david@artcom.de> <david.siegel@artcom.de>
-DC <dcposch@dcpos.ch>
-Deepjyoti Mondal <djmdeveloper060796@gmail.com>
 Deokjin Kim <deokjin81.kim@gmail.com> <deokjin81.kim@samsung.com>
 dnlup <dnlup.dev@gmail.com> <dwon.dnl@gmail.com>
-Domenic Denicola <domenic@domenicdenicola.com>
-Domenic Denicola <domenic@domenicdenicola.com> <d@domenic.me>
-Doug Wade <doug@dougwade.io> <doug.wade@redfin.com>
-Eduard Burtescu <eddy_me08@yahoo.com>
-Einar Otto Stangvik <einaros@gmail.com>
-Elliott Cable <me@ell.io>
-Emanuel Buholzer <contact@emanuelbuholzer.com> <EmanuelBuholzer@outlook.com>
-Enrico Pertoso <epertoso@chromium.org>
-Eric Bickle <wolf.code@outlook.com> <ebickle@users.noreply.github.com>
-Eric Phetteplace <phette23@gmail.com>
-Erik Corry <erik.corry@gmail.com>
-Ernesto Salazar <ernestoalbertosalazar@gmail.com>
-Erwin W. Ramadhan <erwinwahyuramadhan@gmail.com>
 Ethan Arrowood <ethan@arrowood.dev> <ethan.arrowood@gmail.com>
 Ethan Arrowood <ethan@arrowood.dev> <ethan.arrowood@vercel.com>
-Eugene Obrezkov <ghaiklor@gmail.com>
 Eugene Ostroukhov <eostroukhov@google.com> <eostroukhov@chromium.org>
 Eugene Ostroukhov <eostroukhov@google.com> <eostroukhov@gmail.com>
 Eugene Ostroukhov <eostroukhov@google.com> <eostroukhov@netflix.com>
-EungJun Yi <semtlenori@gmail.com>
-Evan Larkin <evan.larkin.il.com> <evan.larkin.iit@gmail.com>
 Evan Lucas <evanlucas@me.com> <evan.lucas@help.com>
 Evan Lucas <evanlucas@me.com> <evan@btc.com>
-Evan Torrie <evan.torrie@yahoo.com> <evant@yahoo-inc.com>
-FangDun Cai <cfddream@gmail.com>
-Fangshi He <hefangshi@gmail.com>
-Farid Neshat <FaridN_SOAD@yahoo.com>
-Fatah N <nfatah41@gmail.com>
 Fedor Indutny <fedor@indutny.com> <fedor.indutny@gmail.com>
-Felix Böhm <felixboehm55@googlemail.com> <me@feedic.com>
-Felix Geisendörfer <felix@debuggable.com>
-Felix Geisendörfer <felix@debuggable.com>
-Flandre Scarlet <panyilinlove@qq.com>
-Florian Margaine <florian@margaine.com>
 Forrest L Norvell <othiym23@gmail.com> <forrest@npmjs.com>
 Forrest L Norvell <othiym23@gmail.com> <ogd@aoaioxxysz.net>
 Franziska Hinkelmann <franziska.hinkelmann@gmail.com> <fhinkel@vt.edu>
 Franziska Hinkelmann <franziska.hinkelmann@gmail.com> <franzih@chromium.org>
-Friedemann Altrock <frodenius@gmail.com>
-Fuji Goro <gfuji@cpan.org>
-Gabriel de Perthuis <g2p.code@gmail.com>
 Gabriel Schulhof <gabrielschulhof@gmail.com> <gabriel.schulhof@intel.com>
-Gareth Ellis <gareth.ellis@uk.ibm.com> <gareth@gsellis.com>
-Garwah Lam <garwahlam@gmail.com>
-garygsc <garygsc@gmail.com> <GaryGSC@users.noreply.github.com>
-Geir Hauge <geir.hauge@gmail.com> <geir.hauge@ntnu.no>
 Geoffrey Booth <webadmin@geoffreybooth.com> <456802+GeoffreyBooth@users.noreply.github.com>
 Geoffrey Booth <webadmin@geoffreybooth.com> <GeoffreyBooth@users.noreply.github.com>
 Geoffrey Booth <webadmin@geoffreybooth.com> <webmaster@geoffreybooth.com>
-Geoffrey Bugaisky <gbugaisk@gmail.com>
 George Adams <gadams@microsoft.com> <george.adams@uk.ibm.com>
 Gerhard Stöbich <deb2001-github@yahoo.de>
 Gibson Fahnestock <gibfahn@gmail.com> <gib@uk.ibm.com>
-Gil Pedersen <git@gpost.dk> <github@gpost.dk>
-Graham Fairweather <xotic750@gmail.com> <xotic750@gmail>
-Greg Sabia Tucker <greg@narrowlabs.com> <greg@tucke.rs>
-Gregor Martynus <gregor@martynus.net>
 Guy Bedford <guybedford@gmail.com>
-Halil İbrahim Şener <hisener@yahoo.com>
-Hannah Kim <h.heeeun.kim@gmail.com>
-Hannes Magnusson <hannes.magnusson@gmail.com> <hannes.magnusson@creditkarma.com>
-Hassaan Pasha <pasha.hassaan@gmail.com> <hassaan.pasha@teamo.io>
-Hendrik Schwalm <mail@hendrikschwalm.de>
-Henry Chin <hheennrryy@gmail.com>
-Herbert Vojčík <herby@mailbox.sk>
 Hitesh Kanwathirtha <hiteshk@microsoft.com> <digitalinfinity@gmail.com>
-Icer Liang <liangshuangde@163.com> <wizicer@users.noreply.github.com>
-Igor Savin <iselwin@gmail.com>
-Igor Soarez <igorsoarez@gmail.com>
-Igor Zinkovsky <igorzi@microsoft.com>
 Imran Iqbal <imran@imraniqbal.org> <imrani@ca.ibm.com>
-Ionică Bizău <bizauionica@gmail.com> <bizauionica@yahoo.com>
 Isaac Z. Schlueter <i@izs.me>
 Isaac Z. Schlueter <i@izs.me> <i@foohack.com>
 Isaac Z. Schlueter <i@izs.me> <nope@not.real>
-Isuru Siriwardana <isuruanatomy@gmail.com>
 Italo A. Casas <me@italoacasas.com> <italo@italoacasas.com>
 Jackson Tian <shyvo1987@gmail.com> <puling.tyq@alibaba-inc.com>
 Jacob Smith <3012099+JakobJingleheimer@users.noreply.github.com>
-Jake Verbaten <raynos2@gmail.com>
-Jakob Kummerow <jkummerow@chromium.org>
-Jamen Marzonie <jamenmarz@gmail.com> <jamenmarz+gh@gmail.com>
-James Beavers <jamesjbeavers@gmail.com>
-James Bromwell <james.bromwell@gdit.com> <943160+thw0rted@users.noreply.github.com>
-James Hartig <fastest963@gmail.com> <james.hartig@grooveshark.com>
-James Ide <ide@jameside.com> <ide@expo.io>
-James Ide <ide@jameside.com> <ide@users.noreply.github.com>
 James M Snell <jasnell@gmail.com>
-James Nimlos <james@nimlos.com>
-James Sumners <james@sumners.email> <james.sumners@gmail.com>
 Jan Krems <jan.krems@gmail.com> <jan.krems@groupon.com>
-Jem Bezooyen <github@jem.dev> <jem@hipmedia.ca>
-Jem Bezooyen <github@jem.dev> <jem@sendwithus.com>
-Jenna Vuong <jennavuong@gmail.com> <hello@jennavuong.com>
-Jennifer Bland <ratracegrad@gmail.com> <jennifer.bland@sbdinc.com>
-JeongHoon Byun <outsideris@gmail.com>
-Jered Schmidt <tr@nslator.jp>
 Jeremiah Senkpiel <fishrock123@rocketmail.com>
-Jeremy Apthorp <nornagon@nornagon.net> <jeremya@chromium.org>
-Jérémy Lal <kapouer@melix.org>
-Jérémy Lal <kapouer@melix.org> <holisme@gmail.com>
-Jerry Chin <qinjia@outlook.com>
-Jessica Quynh Tran <jessica.quynh.tran@gmail.com>
-Jesús Leganés-Combarro 'piranna <piranna@gmail.com>
-Jimb Esser <wasteland@gmail.com> <jimb@railgun3d.com>
 Jithil P Ponnan <jithil@outlook.com>
 Jithil P Ponnan <jithil@outlook.com> <MrJithil@users.noreply.github.com>
-Jochen Eisinger <jochen@chromium.org>
-Joe Shaw <joe@joeshaw.org> <joeshaw@litl.com>
 Johan Bergström <bugs@bergstroem.nu>
-Johan Dahlberg <jfd@distrop.com> <dahlberg.johan@gmail.com>
-Johann Hofmann <git@johann-hofmann.com>
-John Barboza <jbarboza@ca.ibm.com>
-John Barboza <jbarboza@ca.ibm.com> <jBarz@users.noreply.github.com>
-John Gardner <gardnerjohng@gmail.com>
-John McGuirk <johnmac81@gmail.com>
-John Musgrave <musgravejw@gmail.com>
-Johnny Ray Austin <johnny@johnnyray.me> <http://johnnyray.me>
-Jon Tippens <jwtippens@gmail.com>
-Jonas Pfenniger <jonas@pfenniger.name> <jonas@stvs.ch>
-Jonathan Gourlay <gourlayjd@linux.com>
-Jonathan Ong <jonathanrichardong@gmail.com> <jonathanong@users.noreply.github.com>
-Jonathan Persson <persson.jonathan@gmail.com> <jonathan.persson@creuna.se>
-Jonathan Rentzsch <jwr.git@redshed.net>
-Jose Luis Vivero <josluivivgar@gmail.com>
-Joseph Leon <joseph.leon.9@gmail.com>
-Josh Dague <jd@josh3736.net> <daguej@email.uc.edu>
-Josh Erickson <josh@snoj.us>
-Josh Hunter <jopann@gmail.com>
-Joshua S. Weinstein <josher19@users.sf.net>
 Joyee Cheung <joyeec9h3@gmail.com>
 Joyee Cheung <joyeec9h3@gmail.com> <joyee@igalia.com>
-Juan Sebastian Velez Posada <sebasvelez@gmail.com>
-Juan Soto <juan@juansoto.me>
 Julien Gilli <jgilli@netflix.com> <julien.gilli@joyent.com>
-Julien Klepatch <julien@julienklepatch.com>
-Julien Waechter <julien.waechter@gmail.com>
-Junliang Yan <john.yan1019@gmail.com>
-Junliang Yan <jyan@ca.ibm.com> <jyan@ca.ibm.ca>
-Junshu Okamoto <o_askgulf@icloud.com>
-Justin Beckwith <beckwith@google.com> <justin.beckwith@gmail.com>
-Justin Lee <justinlee0022@gmail.com> <justin.lee@ubc.ca>
-Kai Sasaki Lewuathe <sasaki_kai@lewuathe.sakura.ne.jp>
-Karl Skomski <karl@skomski.com> <mail@skomski.com>
-Kat Marchán <kzm@zkat.tech> <kzm@sykosomatic.org>
-Kathy Truong <kathy.yvy.truong@gmail.com>
-Kazuyuki Yamada <tasogare.pg@gmail.com>
-Ke Ding <dingkework@hotmail.com>
-Keith M Wesolowski <wesolows@joyent.com> <wesolows@foobazco.org>
-Kelsey Breseman <ifoundthemeaningoflife@gmail.com>
-Kevin Millikin <kmillikin@chromium.org>
 Keyhan Vakil <kvakil@sylph.kvakil.me> <60900335+airtable-keyhanvakil@users.noreply.github.com>
 Keyhan Vakil <kvakil@sylph.kvakil.me> <kvakil@github.kvakil.me>
 Khaidi Chu <i@2333.moe>
 Khaidi Chu <i@2333.moe> <admin@xcoder.in>
-Kimberly Wilber <gcr@sneakygcr.net>
-Kimberly Wilber <gcr@sneakygcr.net> <gcr@users.noreply.github.com>
-Kiyoshi Nomo <tokyoincidents.g@gmail.com>
-Koichi Kobayashi <koichik@improvement.jp>
-Kostiantyn Wandalen <wandalen.me@gmail.com>
-Kris Kowal <kris.kowal@cixar.com>
 Kunal Pathak <Kunal.Pathak@microsoft.com> <kpathak@microsoft.com>
-Kyle Robinson Young <kyle@dontkry.com>
-Lakshmi Swetha Gopireddy <lakshmiswethagopireddy@gmail.com> <lakshmigopireddy@in.ibm.com>
-Lakshmi Swetha Gopireddy <lakshmiswethagopireddy@gmail.com> <lgopired@in.ibm.com>
-Lars-Magnus Skog <ralphtheninja@riseup.net> <lars.magnus.skog@gmail.com>
-Lasse R.H. Nielsen <lrn@chromium.org>
-Leeseean Chiu <leeseean@qq.com>
 LiviaMedeiros <livia@cirno.name> <74449973+LiviaMedeiros@users.noreply.github.com>
-Lucas Pardue <lucaspardue.24.7@gmail.com> <lucas.pardue@bbc.co.uk>
-Luke Bayes <lbayes@patternpark.com>
-Lydia Kats <llkats@gmail.com>
-Maciej Małecki <maciej.malecki@notimplemented.org> <me@mmalecki.com>
-Maël Nison <nison.mael@gmail.com> <mael@fb.com>
-MaleDong <maledong_github@outlook.com> <maledong_private@qq.com>
-Malte-Thorben Bruns <skenqbx@gmail.com>
-Malte-Thorben Bruns <skenqbx@gmail.com> <skenqbx@googlemail.com>
-Mandeep Singh <mandeep25894@gmail.com> <mandeep.singh@zomato.com>
-Manil Chowdhurian <manil.chowdhury@gmail.com>
-Marcelo Gobelli <marcelo.gobelli@gmail.com>
-Marcin Cieślak <saper@marcincieslak.com>
-Marcin Cieślak <saper@marcincieslak.com> <saper@saper.info>
-Marcin Zielinski <marzelin@gmail.com>
-Marti Martz <thalamew@q.com>
-Martial James Jefferson <martial.jefferson@gmail.com>
-Martijn Schrage <martijn@oblomov.com>
 Mary Marchini <oss@mmarchini.me> <mat@mmarchini.me>
 Mary Marchini <oss@mmarchini.me> <matheus@sthima.com.br>
 Mary Marchini <oss@mmarchini.me> <matheus@sthima.com>
 Mary Marchini <oss@mmarchini.me> <matheusdot@gmail.com>
 Mary Marchini <oss@mmarchini.me> <mmarchini@netflix.com>
-Masato Ohba <over.rye@gmail.com>
 Mathias Buus <mathiasbuus@gmail.com> <m@ge.tt>
-Mathias Pettersson <mape@mape.me>
-Matt Lang <matt@mediasuite.co.nz>
-Matt Reed <matthewreed26@gmail.com>
 Matteo Collina <matteo.collina@gmail.com> <hello@matteocollina.com>
-Matthew Lye <muddletoes@hotmail.com>
-Matthew Turner <matty_t47@hotmail.com> <ramesius@users.noreply.github.com>
-Matthias Bastian <dev@matthias-bastian.de> <piepmatz@users.noreply.github.com>
 Matthew Aitken <maitken033380023@gmail.com>
-Maurice Hayward <mauricehayward1@gmail.com>
-Maya Lekova <apokalyptra@gmail.com> <mslekova@chromium.org>
 Mestery <mestery@protonmail.com> <mestery@pm.me>
-Michael Bernstein <michaelrbernstein@gmail.com>
 Michael Dawson <midawson@redhat.com> <mdawson@devrus.com>
 Michael Dawson <midawson@redhat.com> <michael_dawson@ca.ibm.com>
-Michael Starzinger <mstarzinger@chromium.org>
 Michaël Zasso <targos@protonmail.com> <mic.besace@gmail.com>
-Michael-Rainabba Richardson <rainabba@gmail.com>
-Michał Gołębiowski-Owczarek <m.goleb@gmail.com>
-Micheil Smith <micheil@brandedcode.com> <micheil@yettobebranded.net>
-Micleusanu Nicu <micnic90@gmail.com>
-Miguel Angel Asencio Hurtado <maasencioh@gmail.com>
-Mikael Bourges-Sevenier <mikeseven@gmail.com> <msevenier@motorola.com>
-Mike Kaufman <mike.kaufman@microsoft.com> <mkaufman@microsoft.com>
-Mike MacCana <mike.maccana@gmail.com> <mike@certsimple.com>
 Minqi Pan <pmq2001@gmail.com>
-Minuk Park <parkm86@gmail.com>
 Minwoo Jung <nodecorelab@gmail.com> <jmwsoft@gmail.com>
 Minwoo Jung <nodecorelab@gmail.com> <minwoo@nodesource.com>
-Miroslav Bajtoš <oss@bajtos.net> <mbajtoss@gmail.com>
-Miroslav Bajtoš <oss@bajtos.net> <miro.bajtos@gmail.com>
-Miroslav Bajtoš <oss@bajtos.net> <miroslav@strongloop.com>
-Mitar Milutinovic <mitar.git@tnode.com>
-Mithun Sasidharan <mithunsasidharan89@gmail.com> <msasidharan@paypal.com>
 Mohammed Keyvanzadeh <mohammadkeyvanzade94@gmail.com>
 Mohammed Keyvanzadeh <mohammadkeyvanzade94@gmail.com> <62040526+VoltrexMaster@users.noreply.github.com>
-Morgan Roderick <morgan@roderick.dk>
-Morgan Roderick <morgan@roderick.dk> <20321+mroderick@users.noreply.github.com>
-MURAKAMI Masahiko <m-murakami@esm.co.jp> <fossamagna2@gmail.com>
 Myles Borins <myles.borins@gmail.com> <mborins@us.ibm.com>
 Myles Borins <myles.borins@gmail.com> <mylesborins@github.com>
 Myles Borins <myles.borins@gmail.com> <mylesborins@google.com>
-Nam Nguyen <nam.nguyen@de.ibm.com>
-Nebu Pookins <nebu@nebupookins.net>
-Netto Farah <nettofarah@gmail.com>
-Nicholas Kinsey <pyrotechnick@feistystudios.com>
-Nick Sia <nicholas.sia@vgw.co> <31839263+nicksia-vgw@users.noreply.github.com>
-Nick Soggin <nicksoggin@gmail.com> <iSkore@users.noreply.github.com>
-Nicolas Stepien <stepien.nicolas@gmail.com>
-Nicolas Stepien <stepien.nicolas@gmail.com> <567105+nstepien@users.noreply.github.com>
-Nigel Kibodeaux <nigelmail@gmail.com> <nigel@team.about.me>
-Nikola Glavina <glavina.nikola5@gmail.com> <nikola.glavina@student.um.si>
 Nikolai Vavilov <vvnicholas@gmail.com>
-Nils Kuhnhenn <lain@volafile.io>
 Nitzan Uziely <linkgoron@gmail.com> <Linkgoron@users.noreply.github.com>
 Nitzan Uziely <linkgoron@gmail.com> <nitzan@testim.io>
-Noah Rose Ledesma <noahroseledesma@seattleacademy.org>
-npm team <ops+robot@npmjs.com>
-npm team <ops+robot@npmjs.com> <npm CLI robot>
-npm team <ops+robot@npmjs.com> <npm team>
-npm team <ops+robot@npmjs.com> <npm-cli+bot@github.com>
-Oliver Chang <ochang@chromium.org>
-Oluwaseun Omoyajowo <omoyajowo2015@gmail.com>
-OneNail <OneNail@yeah.net> <onenail@yeah.net>
-Onne Gorter <onne@onnlucky.com>
-Oscar Martinez <oscar@mtnz-web.com> <oscar.martinez@hautelook.com>
 Paolo Insogna <paolo@cowtech.it>
 Paolo Insogna <paolo@cowtech.it> <ShogunPanda@users.noreply.github.com>
-Paul Graham <homosaur@gmail.com> <paul@bytefair.com>
-Paul Querna <pquerna@apache.org> <paul@querna.org>
-Pedro Lima <pvsousalima@gmail.com>
-Peng Lyu <penn.lv@gmail.com>
-Peter Flannery <pflannery@users.noreply.github.com>
 Peter Marshall <p.s.marshall0@gmail.com> <petermarshall@chromium.org>
-Peter Marton <email@martonpeter.com> <peter@risingstack.com>
-Peter Paugh <ppaugh@chariotsolutions.com>
 Phillip Johnsen <johphi@gmail.com> <phillip.johnsen@finn.no>
-Prateek Singh <prateeksingh1@hotmail.com> <prateek1@ucla.edu>
 Qingyu Deng <i@ayase-lab.com> <bitdqy@hotmail.com>
-Rachel White <loveless@gmail.com>
-Ratikesh Misra <ratikesh92@gmail.com>
-Ravindra Barthwal <ravindrabarthwal@users.noreply.github.com>
-Ray <rayw.public@gmail.com> <ray@isrc.iscas.ac.cn>
-Ray Morgan <rmorgan@zappos.com>
-Ray Solomon <raybsolomon@gmail.com>
-Raymond Feng <enjoyjava@gmail.com> <raymond@strongloop.com>
 Raz Luvaton <rluvaton@gmail.com> <16746759+rluvaton@users.noreply.github.com>
 Rebecca Turner <me@re-becca.org> <rebecca@npmjs.com>
-Refael Ackermann <refack@gmail.com> <refael@empeeric.com>
-Reza Akhavan <reza@akhavan.me>
-Ricardo Sánchez Gregorio <me@richnologies.io>
 Richard Lau <rlau@redhat.com> <riclau@uk.ibm.com>
-Rick Olson <technoweenie@gmail.com>
-rickyes <0x19951125@gmail.com> <ives199511@gmail.com>
-rickyes <0x19951125@gmail.com> <mail@zhoumq.cn>
-Rob Adelmann <adelmann@adobe.com>
-Rob Adelmann <adelmann@adobe.com> <robadelmann@gmail.com>
 Robert Nagy <ronagy@icloud.com> <robertnagy@Roberts-MacBook-Pro.local>
 Robert Nagy <ronagy@icloud.com> <ronag@icloud.com>
-Robin Drexler <drexler.robin@gmail.com> <robin.drexler@xing.com>
-Rod Machen <rod.machen@help.com> <mail@rodmachen.com>
 Roman Klauke <romaaan.git@gmail.com> <romankl@users.noreply.github.com>
 Roman Reiss <me@silverwind.io>
 Ron Korving <ron@ronkorving.nl>
 Ron Korving <ron@ronkorving.nl> <rkorving@wizcorp.jp>
 Ruben Bridgewater <ruben@bridgewater.de> <ruben.bridgewater@fintura.de>
 Ruben Bridgewater <ruben@bridgewater.de> <ruben.bridgewater@maibornwolff.de>
-Russell Dempsey <sgtpooki@gmail.com> <SgtPooki@gmail.com>
 Ruy Adorno <ruy@vlt.sh> <ruyadorno@google.com>
 Ruy Adorno <ruy@vlt.sh> <ruyadorno@github.com>
 Ruy Adorno <ruy@vlt.sh> <ruyadorno@hotmail.com>
-Ryan Dahl <ry@tinyclouds.org>
-Ryan Emery <seebees@gmail.com>
-Ryan Mahan <ryanmahan97@gmail.com>
-Ryan Scheel <ryan.havvy@gmail.com>
-Saad Quadri <saad@saadq.com> <saad@saadquadri.com>
-Sagir Khan <sagir.khan@gmail.com>
 Sakthipriyan Vairamani <thechargingvolcano@gmail.com>
-Sam Mikes <smikes@cubane.com>
-Sam P Gallagher-Bishop <samgallagherb@gmail.com> <SPGB@users.noreply.github.com>
 Sam Roberts <vieuxtech@gmail.com> <sam@strongloop.com>
-Sam Shull <brickysam26@gmail.com> <brickysam26@samuel-shulls-computer.local>
-Sam Shull <brickysam26@gmail.com> <sam+github@samshull.com>
-Sam Shull <brickysam26@gmail.com> <sshull@squaremouth.com>
-Samantha Sample <ssample812@gmail.com> <=>
-Sambasiva Suda <sambasivarao@gmail.com>
-Samuel Attard <samuel.r.attard@gmail.com> <sattard@slack-corp.com>
-San-Tai Hsu <v@fatpipi.com>
 Santiago Gimeno <santiago.gimeno@gmail.com> <santiago.gimeno@ionide.es>
-Sarah Meyer <sarahsaltrick@gmail.com>
-Sartrey Lee <sartrey@163.com>
 Saúl Ibarra Corretgé <s@saghul.net> <saghul@gmail.com>
-Scott Blomquist <github@scott.blomqui.st> <sblom@microsoft.com>
-Segu Riluvan <rilwan22@hotmail.com> <riluvan@gmail.com>
-Sergey Kryzhanovsky <skryzhanovsky@gmail.com> <another@dhcp199-223-red.yandex.net>
-Sergey Petushkov <petushkov.sergey@gmail.com> <sergey.petushkov@protonmail.com>
-Sergey Zelenov <mail@zelenov.su> <sergey.zelenov@getyourguide.com>
-Shannen Saez <shannenlaptop@gmail.com>
-Shaopeng Zhang <szhang351@bloomberg.net>
 Shelley Vohr <shelley.vohr@gmail.com> <codebytere@gmail.com>
 Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@d.jp>
 Shigeki Ohtsu <ohtsu@ohtsu.org> <ohtsu@iij.ad.jp>
-Shivang Saxena <shivangs44@gmail.com>
-Shiya Luo <luo.shiya@gmail.com>
-Shobhit Chittora <chittorashobhit@gmail.com> <schittora@paypal.com>
-Siddharth Mahendraker <siddharth_mahen@hotmail.com> <siddharth_mahen@me.com>
-Simon Willison <simon@simonwillison.net>
-Simone Busoli <simone.busoli@nearform.com> <simone.busoli@gmail.com>
-Siobhan O'Donovan <siobhan@justshiv.com>
-Siyuan Gao <siyuangao@gmail.com>
-solebox <solekiller@gmail.com> <5013box@gmail.com>
-Sreepurna Jasti <sreepurna.jasti@gmail.com>
-Sreepurna Jasti <sreepurna.jasti@gmail.com> <jsreepur@in.ibm.com>
-Stanislav Opichal <opichals@gmail.com>
 Stefan Budeanu <stefan@budeanu.com> <stefanbu@ca.ibm.com>
-Stefan Bühler <stbuehler@web.de>
 Stefan Stojanovic <stefan.stojanovic@janeasystems.com> <StefanStojanovic@users.noreply.github.com>
 Stephen Belanger <admin@stephenbelanger.com> <stephen.belanger@datadoghq.com>
 Stephen Belanger <admin@stephenbelanger.com> <stephen.belanger@elastic.co>
-Steve Mao <maochenyan@gmail.com> <maochenyan@msn.com>
-Steven R. Loomis <srl295@gmail.com> <srloomis@us.ibm.com>
-Steven R. Loomis <srloomis@us.ibm.com> <srl@icu-project.org>
 Stewart X Addison <sxa@redhat.com> <sxa@uk.ibm.com>
-Suraiya Hameed <hameedsuraiya@gmail.com>
-Suramya shah <shah.suramya@gmail.com> <ss22ever@users.noreply.github.com>
-Surya Panikkal <surya.com@gmail.com>
-Sven Panne <svenpanne@chromium.org>
-Szymon Marczak <sz.marczak@gmail.com> <36894700+szmarczak@users.noreply.github.com>
-Tadashi SAWADA <cesare@mayverse.jp>
-Tadhg Creedon <tadhgcreedon@gmail.com> <tadhg.creedon@rangle.io>
-Taehee Kang <hugnosis@gmail.com>
-Takahiro ANDO <takahiro.ando@gmail.com>
-Tanuja-Sawant <f2013658@goa.bits-pilani.ac.in> <thinkbigtanu@gmail.com>
-Tarun Batra <tarun.batra00@gmail.com>
-Taylor Woll <taylor.woll@microsoft.com> <tawoll@ntdev.microsoft.com>
-Ted Young <ted@radicaldesigns.org>
-Teppei Sato <teppeis@gmail.com>
 theanarkh <theratliter@gmail.com> <2923878201@qq.com>
-Theotime Poisseau <theotime.poisseau@gmail.com>
-Thomas Hunter II <me@thomashunter.name> <tom@intrinsic.com>
-Thomas Lee <thomas.lee@shinetech.com> <tom@tom-debian.sensis.com.au>
-Thomas Reggi <thomas@reggi.com>
 Thomas Watson <w@tson.dk>
 Tierney Cyren <hello@bnb.im>
 Tierney Cyren <hello@bnb.im> <accounts@bnb.im>
 Tierney Cyren <hello@bnb.im> <tieliaco@gmail.com>
-Tim Caswell <tim@creationix.com> <tim@0-26-8-e9-4c-e1.dyn.utdallas.edu>
-Tim Costa <tim@timcosta.io> <tjsail33@gmail.com>
 Tim Perry <pimterry@gmail.com> <1526883+pimterry@users.noreply.github.com>
-Tim Price <timprice@mangoraft.com>
-Tim Ruffles <timruffles@googlemail.com> <oi@truffles.me.uk>
-Tim Smart <timehandgod@gmail.com>
-Tim Smart <timehandgod@gmail.com> <tim@fostle.com>
-Timothy Gu <timothygu99@gmail.com> <timothygu@chromium.org>
-Timothy Leverett <zzzzBov@gmail.com>
-Timothy O. Peters <timotewpeters@gmail.com>
-Timur Shemsedinov <timur.shemsedinov@gmail.com>
-Ting Shao <ting.shao@intel.com>
-TJ Holowaychuk <tj@vision-media.ca>
-TJ Holowaychuk <tj@vision-media.ca> <tjholowayhuk@gmail.com>
 Tobias Nießen <tniessen@tnie.de> <tniessen@cloudflare.com>
 Tobias Nießen <tniessen@tnie.de> <tniessen@users.noreply.github.com>
-Toby Farley <tobyfarley@gmail.com>
-Toby Stableford <tobytronics@gmail.com> <toboid@users.noreply.github.com>
-Todd Kennedy <todd@selfassembled.org> <toddself@users.noreply.github.com>
-Tom Atkinson <atkinson.tommy@nsoft.com> <atkinson.tommy@nhome.ba>
-Tom Atkinson <atkinson.tommy@nsoft.com> <atkinson.tommy@nsoft.ba>
-Tom Hughes <tom.hughes@palm.com> <tomtheengineer@gmail.com>
-Tom Hughes-Croucher <tom_croucher@yahoo.com>
-Tom Purcell <tpurcell@chariotsolutions.com>
-Tom White <tomtinkerer@gmail.com>
-Tomoki Okahana <umatomakun@gmail.com>
-Toon Verwaest <verwaest@chromium.org>
-Tracy Hinds <tracyhinds@gmail.com>
-Travis Meisenheimer <travis@indexoutofbounds.com> <tmeisenh@gmail.com>
-Trevor Burnham <trevor@databraid.com> <trevorburnham@gmail.com>
 Trivikram Kamat <trivikr.dev@gmail.com> <16024985+trivikr@users.noreply.github.com>
-ttzztztz <ttzztztz@outlook.com> <yangziyue80@outlook.com>
-Tyler Larson <talltyler@gmail.com>
 Ujjwal Sharma <ryzokuken@disroot.org> <ryzokuken@igalia.com>
 Ujjwal Sharma <ryzokuken@disroot.org> <usharma1998@gmail.com>
-Uttam Pawar <upawar@gmail.com> <uttam.c.pawar@intel.com>
-Viero Fernando <vierofernando9@gmail.com> <60427892+vierofernando@users.noreply.github.com>
-Viktor Karpov <viktor.s.karpov@gmail.com>
-Vincent Voyer <v@fasterize.com>
 Vladimir de Turckheim <vlad2t@hotmail.com>
 Vladimir de Turckheim <vlad2t@hotmail.com> <vdeturckheim@users.noreply.github.com>
 Vladimir Morozov <vmorozov@microsoft.com> <vmoroz@users.noreply.github.com>
-vsemozhetbyt <vsemozhetbyt@gmail.com>
-Vyacheslav Egorov <vegorov@chromium.org>
-Wang Xinyong <wang.xy.chn@gmail.com> <wangxy.chn@gmail.com>
-Wayne Zhang <zsw007@gmail.com> <shuowang.zhang@ibm.com>
-Wei-Wei Wu <wuxx1045@umn.edu>
 Weijia Wang <starkwang@126.com>
 Weijia Wang <starkwang@126.com> <381152119@qq.com>
 Weijia Wang <starkwang@126.com> <starkewang@tencent.com>
-Will Hayslett <william.hayslettjr@gmail.com>
-Willi Eggeling <email@wje-online.de>
-Wilson Lin <wla80@sfu.ca>
 Wyatt Preul <wpreul@gmail.com>
-Xavier J Ortiz <xavier.ortiz.ch@gmail.com>
-xiaoyu <306766053@qq.com>
 Xu Meng <dmabupt@gmail.com> <mengxumx@cn.ibm.com>
 Xuguang Mei <meixuguang@gmail.com> <meixg@foxmail.com>
-Yael Hermon <yaelherm@gmail.com> <yaelhe@wix.com>
 Yagiz Nizipli <yagiz@nizipli.com> <yagiz.nizipli@sentry.io>
 Yang Guo <yangguo@chromium.org>
 Yash Ladha <yash@yashladha.in> <18033231+yashLadha@users.noreply.github.com>
 Yash Ladha <yash@yashladha.in> <yashladhapankajladha123@gmail.com>
-ycjcl868 <45808948@qq.com> <chaolinjin@gmail.com>
-Yingchen Xue <yingchenxue@qq.com>
 Yongsheng Zhang <zyszys98@gmail.com>
 Yongsheng Zhang <zyszys98@gmail.com> <17367077526@163.com>
 Yongsheng Zhang <zyszys98@gmail.com> <zhangyongsheng@youzan.com>
 Yorkie Liu <yorkiefixer@gmail.com>
 Yorkie Liu <yorkiefixer@gmail.com> <l900422@vip.qq.com>
-Yoshihiro KIKUCHI <yknetg@gmail.com>
 Yosuke Furukawa <yosuke.furukawa@gmail.com> <furukawa.yosuke@dena.jp>
-Yuichiro MASUI <masui@masuidrive.jp>
 Yuta Hiroto <git@about-hiroppy.com>
-ywave620 <rogertyang@tencent.com> <60539365+ywave620@users.noreply.github.com>
-Zach Bjornson <bjornson@stanford.edu> <zbbjornson@gmail.com>
-Zachary Scott <zachary@zacharyscott.net> <zachary.s.scott@gmail.com>
-Zachary Vacura <admin@hackzzila.com>
 Zeyu "Alex" Yang <himself65@outlook.com> <himself65@mask.io>
 Zeyu "Alex" Yang <himself65@outlook.com> <himself6565@gmail.com>
-Zoran Tomicic <ztomicic@gmail.com>
 Сковорода Никита Андреевич <chalkerx@gmail.com>
-隋鑫磊 <joshuasui@163.com>


### PR DESCRIPTION
Now that the `AUTHORS` file has been removed, non-collaborators/emeritus are no longer needed in the mailmap file.