### PR TITLE
fix async context frame test when tests are run with --shell option

### DIFF
--- a/test/parallel/test-async-context-frame.mjs
+++ b/test/parallel/test-async-context-frame.mjs
@@ -49,6 +49,7 @@ describe('AsyncContextFrame', {
     it(test, async () => {
       const proc = spawn(python, [
         testRunner,
+        '--shell', process.execPath,
         '--node-args=--experimental-async-context-frame',
         test,
       ], {


### PR DESCRIPTION
I run node's unit tests with the `--shell` option to test an executable that isn't in `out/Debug/node`. The test-async-local-storage tests  fail because they call test.py again, but without forwarding the --shell argument and test.py fails to find the vm/shell to spawn. 

With this change we set the shell option so the spawned tests run with the same node executable as the parent test.

I wonder if passing thru test.py is required tho? Why doesn't this fork and run the `test` file with additional arguments?