### PR TITLE
doc: spell out condition restrictions

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -755,6 +755,20 @@ exports, while resolving the existing `"node"`, `"node-addons"`, `"default"`,
 
 Any number of custom conditions can be set with repeat flags.
 
+Typical conditions should only contain alphanumerical characters,
+using ":", "-", or "=" as separators if necessary. Anything else may run
+into compability issues outside of node.
+
+In node, conditions have very few restrictions, but specifically these include:
+
+1. They must contain at least one character.
+2. They cannot start with "." since they may appear in places that also
+   allow relative paths.
+3. They cannot contain "," since they may be parsed as a comma-separated
+   list by some CLI tools.
+4. They cannot be integer property keys like "10" since that can have
+   unexpected effects on property key ordering for JS objects.
+
 ### Community Conditions Definitions
 
 Condition strings other than the `"import"`, `"require"`, `"node"`, `"module-sync"`,


### PR DESCRIPTION
I never really thought about what kinds of conditions are allowed and which aren't - and it looks like the answer is mostly "anything goes". This documents the status-quo from a practical perspective from what I can gather.

Some of these restrictions (e.g. "no comma") aren't actively enforced by nodejs but maybe should be in the future.