### PR TITLE
esm: add import.meta.env

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -992,6 +992,17 @@ added: v22.3.0
 
 Enable exposition of [EventSource Web API][] on the global scope.
 
+### `--experimental-import-meta-env`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Enable experimental `import.meta.env` support.
+
 ### `--experimental-import-meta-resolve`
 
 <!-- YAML
@@ -3045,6 +3056,7 @@ one is included in the list below.
 * `--experimental-default-type`
 * `--experimental-detect-module`
 * `--experimental-eventsource`
+* `--experimental-import-meta-env`
 * `--experimental-import-meta-resolve`
 * `--experimental-json-modules`
 * `--experimental-loader`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -452,6 +452,18 @@ a second argument:
 * `parent` {string|URL} An optional absolute parent module URL to resolve from.
   **Default:** `import.meta.url`
 
+### `import.meta.env`
+
+<!--
+added:
+  - REPLACEME
+-->
+
+> Stability: 1 - Experimental. This feature is only available with the `--experimental-import-meta-env` command flag
+> enabled.
+
+Provides access to environment variables, just like `process.env`.
+
 ## Interoperability with CommonJS
 
 ### `import` statements

--- a/doc/node.1
+++ b/doc/node.1
@@ -168,6 +168,9 @@ Interpret as either ES modules or CommonJS modules input via --eval or STDIN, wh
 .js or extensionless files with no sibling or parent package.json;
 .js or extensionless files whose nearest parent package.json lacks a "type" field, unless under node_modules.
 .
+.It Fl -experimental-import-meta-env
+Enable experimental ES modules support for import.meta.env.
+.
 .It Fl -experimental-import-meta-resolve
 Enable experimental ES modules support for import.meta.resolve().
 .

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -7,6 +7,7 @@ const {
 const { getOptionValue } = require('internal/options');
 const { fileURLToPath } = require('internal/url');
 const { dirname } = require('path');
+const experimentalImportMetaEnv = getOptionValue('--experimental-import-meta-env');
 const experimentalImportMetaResolve = getOptionValue('--experimental-import-meta-resolve');
 
 /**
@@ -63,6 +64,10 @@ function initializeImportMeta(meta, context, loader) {
     const filePath = fileURLToPath(url);
     meta.dirname = dirname(filePath);
     meta.filename = filePath;
+  }
+
+  if (experimentalImportMetaEnv && (!loader || loader.loaderType !== 'internal')) {
+    meta.env = process.env;
   }
 
   if (!loader || loader.allowImportMetaResolve) {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -453,6 +453,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "experimental ES Module support for webassembly modules",
             &EnvironmentOptions::experimental_wasm_modules,
             kAllowedInEnvvar);
+  AddOption("--experimental-import-meta-env",
+            "experimental ES Module import.meta.env support",
+            &EnvironmentOptions::experimental_import_meta_env,
+            kAllowedInEnvvar);
   AddOption("--experimental-import-meta-resolve",
             "experimental ES Module import.meta.resolve() parentURL support",
             &EnvironmentOptions::experimental_import_meta_resolve,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -129,6 +129,7 @@ class EnvironmentOptions : public Options {
   bool experimental_global_navigator = true;
   bool experimental_global_web_crypto = true;
   bool experimental_wasm_modules = false;
+  bool experimental_import_meta_env = false;
   bool experimental_import_meta_resolve = false;
   std::string input_type;  // Value of --input-type
   std::string type;        // Value of --experimental-default-type

--- a/test/es-module/test-esm-import-meta-env.mjs
+++ b/test/es-module/test-esm-import-meta-env.mjs
@@ -1,0 +1,22 @@
+// Flags: --experimental-import-meta-env
+import '../common/index.mjs';
+import assert from 'assert';
+import { env } from 'process';
+
+// Currently, the object is literally the same.
+assert.strictEqual(import.meta.env, env);
+assert.strictEqual(import.meta.env, process.env);
+
+// It reflects changes to environment variables.
+assert.strictEqual(import.meta.env.TEST_VAR_1, undefined);
+process.env.TEST_VAR_1 = 'x';
+assert.strictEqual(import.meta.env.TEST_VAR_1, 'x');
+
+// It allows modifying environment variables.
+assert.strictEqual(process.env.TEST_VAR_2, undefined);
+import.meta.env.TEST_VAR_2 = 'x';
+assert.strictEqual(process.env.TEST_VAR_2, 'x');
+
+// It's possible to overwrite `import.meta.env`.
+import.meta.env = 42;
+assert.strictEqual(import.meta.env, 42);


### PR DESCRIPTION
Ever since Vite introduced it, `import.meta.env` has been spreading to other tools - and to user code. This leads to some disruptions: E.g. running code that's built using Vite in nodejs-based unit tests is tough because of this missing API.

The `import.meta.env` API has been added to Vite, bun, and rspack at the very least so far.