### PR TITLE
worker: handle invalid BroadcastChannel postMessage after close

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -402,7 +402,7 @@ class BroadcastChannel extends EventTarget {
     if (arguments.length === 0)
       throw new ERR_MISSING_ARGS('message');
     if (this[kHandle] === undefined)
-      throw new DOMException('BroadcastChannel is closed.');
+      throw new DOMException('BroadcastChannel is closed.', 'InvalidStateError');
     if (this[kHandle].postMessage(message) === undefined)
       throw new DOMException('Message could not be posted.');
   }

--- a/test/wpt/status/webmessaging/broadcastchannel.json
+++ b/test/wpt/status/webmessaging/broadcastchannel.json
@@ -10,14 +10,6 @@
       ]
     }
   },
-  "interface.any.js": {
-    "fail": {
-      "expected": [
-        "postMessage after close should throw",
-        "postMessage should throw InvalidStateError after close, even with uncloneable data"
-      ]
-    }
-  },
   "origin.window.js": {
     "fail": {
       "expected": [


### PR DESCRIPTION
Align BroadcastChannel behavior with spec by throwing an InvalidStateError when postMessage is called after the channel is closed. This ensures that the BroadcastChannel properly handles closed states and throws the appropriate error for postMessage attempts.

This update addresses expected failures for invalid postMessage after close in WPT.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
