### PR TITLE
src: fix winapi_strerror error string

### DIFF
--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -157,14 +157,14 @@ Local<Value> UVException(Isolate* isolate,
 static const char* winapi_strerror(const int errorno, bool* must_free) {
   char* errmsg = nullptr;
 
-  FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                    FORMAT_MESSAGE_IGNORE_INSERTS,
-                nullptr,
-                errorno,
-                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                reinterpret_cast<LPTSTR>(&errmsg),
-                0,
-                nullptr);
+  FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                     FORMAT_MESSAGE_IGNORE_INSERTS,
+                 nullptr,
+                 errorno,
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                 reinterpret_cast<LPSTR>(&errmsg),
+                 0,
+                 nullptr);
 
   if (errmsg) {
     *must_free = true;

--- a/test/parallel/test-debug-process.js
+++ b/test/parallel/test-debug-process.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child = require('child_process');
+
+if (!common.isWindows) {
+  common.skip('This test is specific to Windows to test winapi_strerror');
+}
+
+// Ref: https://github.com/nodejs/node/issues/23191
+// This test is specific to Windows.
+
+const cp = child.spawn('pwd');
+
+cp.on('exit', common.mustCall(function() {
+  try {
+    process._debugProcess(cp.pid);
+  } catch (error) {
+    assert.strictEqual(error.message, 'The system cannot find the file specified.');
+  }
+}));


### PR DESCRIPTION
This fixes the bug in printing the error messages when an exception is thrown on Windows.

Fixes: https://github.com/nodejs/node/issues/23191

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
