### PR TITLE
crypto: remove experimental Curve448 WebCryptoAPI algorithms

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -2,6 +2,9 @@
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'Ed448'` and `'X448'` algorithms.
   - version:
     - v20.0.0
     - v18.17.0
@@ -113,7 +116,7 @@ async function generateEcKey(namedCurve = 'P-521') {
 }
 ```
 
-#### Ed25519/Ed448/X25519/X448 key pairs
+#### Ed25519/X25519 key pairs
 
 > Stability: 1 - Experimental
 
@@ -360,10 +363,8 @@ implementation and the APIs supported for each:
 | `'RSA-OAEP'`                                              | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
 | `'ECDSA'`                                                 | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
 | `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
-| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔             | ✔           | ✔           |           |           |           |             |              |             | ✔      | ✔        |          |
 | `'ECDH'`                                                  | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
 | `'X25519'` <span class="experimental-inline"></span>[^1]  | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
-| `'X448'` <span class="experimental-inline"></span>[^1]    | ✔             | ✔           | ✔           |           |           |           |             | ✔            | ✔           |        |          |          |
 | `'AES-CTR'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
 | `'AES-CBC'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
 | `'AES-GCM'`                                               | ✔             | ✔           | ✔           | ✔         | ✔         | ✔         | ✔           |              |             |        |          |          |
@@ -504,10 +505,8 @@ Valid key usages depend on the key algorithm (identified by
 | `'AES-KW'`                                                |             |             |          |            |               |                | ✔           | ✔             |
 | `'ECDH'`                                                  |             |             |          |            | ✔             | ✔              |             |               |
 | `'X25519'` <span class="experimental-inline"></span>[^1]  |             |             |          |            | ✔             | ✔              |             |               |
-| `'X448'` <span class="experimental-inline"></span>[^1]    |             |             |          |            | ✔             | ✔              |             |               |
 | `'ECDSA'`                                                 |             |             | ✔        | ✔          |               |                |             |               |
 | `'Ed25519'` <span class="experimental-inline"></span>[^1] |             |             | ✔        | ✔          |               |                |             |               |
-| `'Ed448'` <span class="experimental-inline"></span>[^1]   |             |             | ✔        | ✔          |               |                |             |               |
 | `'HDKF'`                                                  |             |             |          |            | ✔             | ✔              |             |               |
 | `'HMAC'`                                                  |             |             | ✔        | ✔          |               |                |             |               |
 | `'PBKDF2'`                                                |             |             |          |            | ✔             | ✔              |             |               |
@@ -574,6 +573,9 @@ The algorithms currently supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'X448'` algorithm.
   - version:
     - v22.5.0
     - v20.17.0
@@ -604,7 +606,7 @@ The Node.js implementation requires that `length`, when a number, is a multiple
 of `8`.
 
 When `length` is not provided or `null` the maximum number of bits for a given
-algorithm is generated. This is allowed for the `'ECDH'`, `'X25519'`, and `'X448'`
+algorithm is generated. This is allowed for the `'ECDH'` and `'X25519'`
 algorithms, for other algorithms `length` is required to be a number.
 
 If successful, the returned promise will be resolved with an {ArrayBuffer}
@@ -614,7 +616,6 @@ The algorithms currently supported include:
 
 * `'ECDH'`
 * `'X25519'` <span class="experimental-inline"></span>[^1]
-* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -623,6 +624,9 @@ The algorithms currently supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'X448'` algorithm.
   - version:
     - v18.4.0
     - v16.17.0
@@ -654,7 +658,6 @@ The algorithms currently supported include:
 
 * `'ECDH'`
 * `'X25519'` <span class="experimental-inline"></span>[^1]
-* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HKDF'`
 * `'PBKDF2'`
 
@@ -710,6 +713,9 @@ The algorithms currently supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'Ed448'` and `'X448'` algorithms.
   - version:
     - v18.4.0
     - v16.17.0
@@ -746,7 +752,6 @@ specification.
 | `'ECDH'`                                                  | ✔        | ✔         | ✔       | ✔       |
 | `'ECDSA'`                                                 | ✔        | ✔         | ✔       | ✔       |
 | `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔        | ✔         | ✔       | ✔       |
-| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔        | ✔         | ✔       | ✔       |
 | `'HDKF'`                                                  |          |           |         |         |
 | `'HMAC'`                                                  |          |           | ✔       | ✔       |
 | `'PBKDF2'`                                                |          |           |         |         |
@@ -782,10 +787,8 @@ include:
 * `'RSA-OAEP'`
 * `'ECDSA'`
 * `'Ed25519'` <span class="experimental-inline"></span>[^1]
-* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'ECDH'`
 * `'X25519'` <span class="experimental-inline"></span>[^1]
-* `'X448'` <span class="experimental-inline"></span>[^1]
 
 The {CryptoKey} (secret key) generating algorithms supported include:
 
@@ -800,6 +803,9 @@ The {CryptoKey} (secret key) generating algorithms supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'Ed448'` and `'X448'` algorithms.
   - version:
     - v18.4.0
     - v16.17.0
@@ -841,10 +847,8 @@ The algorithms currently supported include:
 | `'AES-KW'`                                                |          |           | ✔       | ✔       |
 | `'ECDH'`                                                  | ✔        | ✔         | ✔       | ✔       |
 | `'X25519'` <span class="experimental-inline"></span>[^1]  | ✔        | ✔         | ✔       | ✔       |
-| `'X448'` <span class="experimental-inline"></span>[^1]    | ✔        | ✔         | ✔       | ✔       |
 | `'ECDSA'`                                                 | ✔        | ✔         | ✔       | ✔       |
 | `'Ed25519'` <span class="experimental-inline"></span>[^1] | ✔        | ✔         | ✔       | ✔       |
-| `'Ed448'` <span class="experimental-inline"></span>[^1]   | ✔        | ✔         | ✔       | ✔       |
 | `'HDKF'`                                                  |          |           |         | ✔       |
 | `'HMAC'`                                                  |          |           | ✔       | ✔       |
 | `'PBKDF2'`                                                |          |           |         | ✔       |
@@ -857,6 +861,9 @@ The algorithms currently supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'Ed448'` algorithm.
   - version:
     - v18.4.0
     - v16.17.0
@@ -866,7 +873,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {AlgorithmIdentifier|RsaPssParams|EcdsaParams|Ed448Params}
+* `algorithm`: {AlgorithmIdentifier|RsaPssParams|EcdsaParams}
 * `key`: {CryptoKey}
 * `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with an {ArrayBuffer}
@@ -884,7 +891,6 @@ The algorithms currently supported include:
 * `'RSA-PSS'`
 * `'ECDSA'`
 * `'Ed25519'` <span class="experimental-inline"></span>[^1]
-* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 
 ### `subtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extractable, keyUsages)`
@@ -932,10 +938,8 @@ The unwrapped key algorithms supported include:
 * `'RSA-OAEP'`
 * `'ECDSA'`
 * `'Ed25519'` <span class="experimental-inline"></span>[^1]
-* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'ECDH'`
 * `'X25519'` <span class="experimental-inline"></span>[^1]
-* `'X448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 * `'AES-CTR'`
 * `'AES-CBC'`
@@ -947,6 +951,9 @@ The unwrapped key algorithms supported include:
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55209
+    description: Removed the `'Ed448'` algorithm.
   - version:
     - v18.4.0
     - v16.17.0
@@ -956,7 +963,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {AlgorithmIdentifier|RsaPssParams|EcdsaParams|Ed448Params}
+* `algorithm`: {AlgorithmIdentifier|RsaPssParams|EcdsaParams}
 * `key`: {CryptoKey}
 * `signature`: {ArrayBuffer|TypedArray|DataView|Buffer}
 * `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
@@ -975,7 +982,6 @@ The algorithms currently supported include:
 * `'RSA-PSS'`
 * `'ECDSA'`
 * `'Ed25519'` <span class="experimental-inline"></span>[^1]
-* `'Ed448'` <span class="experimental-inline"></span>[^1]
 * `'HMAC'`
 
 ### `subtle.wrapKey(format, key, wrappingKey, wrapAlgo)`
@@ -1188,7 +1194,7 @@ added: v15.0.0
 added: v15.0.0
 -->
 
-* Type: {string} Must be `'ECDH'`, `'X25519'`, or `'X448'`.
+* Type: {string} Must be `'ECDH'` or `'X25519'`
 
 #### `ecdhKeyDeriveParams.public`
 
@@ -1278,37 +1284,6 @@ added: v15.0.0
 -->
 
 * Type: {string} Must be one of `'P-256'`, `'P-384'`, `'P-521'`.
-
-### Class: `Ed448Params`
-
-<!-- YAML
-added: v15.0.0
--->
-
-#### `ed448Params.name`
-
-<!-- YAML
-added:
-  - v18.4.0
-  - v16.17.0
--->
-
-* Type: {string} Must be `'Ed448'`.
-
-#### `ed448Params.context`
-
-<!-- YAML
-added:
-  - v18.4.0
-  - v16.17.0
--->
-
-* Type: {ArrayBuffer|TypedArray|DataView|Buffer|undefined}
-
-The `context` member represents the optional context data to associate with
-the message.
-The Node.js Web Crypto API implementation only supports zero-length context
-which is equivalent to not providing context at all.
 
 ### Class: `HkdfParams`
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -1194,7 +1194,7 @@ added: v15.0.0
 added: v15.0.0
 -->
 
-* Type: {string} Must be `'ECDH'` or `'X25519'`
+* Type: {string} Must be `'ECDH'` or `'X25519'`.
 
 #### `ecdhKeyDeriveParams.public`
 

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -55,13 +55,9 @@ function verifyAcceptableCfrgKeyUse(name, isPublic, usages) {
   let checkSet;
   switch (name) {
     case 'X25519':
-      // Fall through
-    case 'X448':
       checkSet = isPublic ? [] : ['deriveKey', 'deriveBits'];
       break;
     case 'Ed25519':
-      // Fall through
-    case 'Ed448':
       checkSet = isPublic ? ['verify'] : ['sign'];
       break;
     default:
@@ -86,18 +82,6 @@ function createCFRGRawKey(name, keyData, isPublic) {
           `${name} raw keys must be exactly 32-bytes`, 'DataError');
       }
       break;
-    case 'Ed448':
-      if (keyData.byteLength !== 57) {
-        throw lazyDOMException(
-          `${name} raw keys must be exactly 57-bytes`, 'DataError');
-      }
-      break;
-    case 'X448':
-      if (keyData.byteLength !== 56) {
-        throw lazyDOMException(
-          `${name} raw keys must be exactly 56-bytes`, 'DataError');
-      }
-      break;
   }
 
   const keyType = isPublic ? kKeyTypePublic : kKeyTypePrivate;
@@ -114,8 +98,6 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   const usageSet = new SafeSet(keyUsages);
   switch (name) {
     case 'Ed25519':
-      // Fall through
-    case 'Ed448':
       if (hasAnyNotIn(usageSet, ['sign', 'verify'])) {
         throw lazyDOMException(
           `Unsupported key usage for an ${name} key`,
@@ -123,8 +105,6 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
       }
       break;
     case 'X25519':
-      // Fall through
-    case 'X448':
       if (hasAnyNotIn(usageSet, ['deriveKey', 'deriveBits'])) {
         throw lazyDOMException(
           `Unsupported key usage for an ${name} key`,
@@ -137,14 +117,8 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
     case 'Ed25519':
       genKeyType = 'ed25519';
       break;
-    case 'Ed448':
-      genKeyType = 'ed448';
-      break;
     case 'X25519':
       genKeyType = 'x25519';
-      break;
-    case 'X448':
-      genKeyType = 'x448';
       break;
   }
 
@@ -158,14 +132,10 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   let privateUsages;
   switch (name) {
     case 'Ed25519':
-      // Fall through
-    case 'Ed448':
       publicUsages = getUsagesUnion(usageSet, 'verify');
       privateUsages = getUsagesUnion(usageSet, 'sign');
       break;
     case 'X25519':
-      // Fall through
-    case 'X448':
       publicUsages = [];
       privateUsages = getUsagesUnion(usageSet, 'deriveKey', 'deriveBits');
       break;
@@ -250,13 +220,9 @@ async function cfrgImportKey(
         let checkUse;
         switch (name) {
           case 'Ed25519':
-            // Fall through
-          case 'Ed448':
             checkUse = 'sig';
             break;
           case 'X25519':
-            // Fall through
-          case 'X448':
             checkUse = 'enc';
             break;
         }
@@ -330,11 +296,6 @@ function eddsaSignVerify(key, data, { name, context }, signature) {
 
   if (key.type !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
-
-  if (name === 'Ed448' && context?.byteLength) {
-    throw lazyDOMException(
-      'Non zero-length context is not yet supported.', 'NotSupportedError');
-  }
 
   return jobPromise(() => new SignJob(
     kCryptoJobAsync,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -311,10 +311,9 @@ async function ecdhDeriveBits(algorithm, baseKey, length) {
 
   if (
     key.algorithm.name !== 'ECDH' &&
-    key.algorithm.name !== 'X25519' &&
-    key.algorithm.name !== 'X448'
+    key.algorithm.name !== 'X25519'
   ) {
-    throw lazyDOMException('Keys must be ECDH, X25519, or X448 keys', 'InvalidAccessError');
+    throw lazyDOMException('Keys must be ECDH or X25519 keys', 'InvalidAccessError');
   }
 
   if (key.algorithm.name !== baseKey.algorithm.name) {

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -262,17 +262,6 @@ const experimentalAlgorithms = ObjectEntries({
     verify: null,
     importKey: null,
   },
-  'X448': {
-    generateKey: null,
-    importKey: null,
-    deriveBits: 'EcdhKeyDeriveParams',
-  },
-  'Ed448': {
-    generateKey: null,
-    sign: 'Ed448Params',
-    verify: 'Ed448Params',
-    importKey: null,
-  },
 });
 
 for (let i = 0; i < experimentalAlgorithms.length; i++) {
@@ -304,7 +293,6 @@ const simpleAlgorithmDictionaries = {
     salt: 'BufferSource',
     info: 'BufferSource',
   },
-  Ed448Params: { context: 'BufferSource' },
   Pbkdf2Params: { hash: 'HashAlgorithmIdentifier', salt: 'BufferSource' },
   RsaOaepParams: { label: 'BufferSource' },
   RsaHashedImportParams: { hash: 'HashAlgorithmIdentifier' },

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -123,11 +123,7 @@ async function generateKey(
       break;
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
     case 'X25519':
-      // Fall through
-    case 'X448':
       resultType = 'CryptoKeyPair';
       result = await require('internal/crypto/cfrg')
         .cfrgGenerateKey(algorithm, extractable, keyUsages);
@@ -204,8 +200,6 @@ async function deriveBits(algorithm, baseKey, length = null) {
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
   switch (algorithm.name) {
     case 'X25519':
-      // Fall through
-    case 'X448':
       // Fall through
     case 'ECDH':
       return require('internal/crypto/diffiehellman')
@@ -293,8 +287,6 @@ async function deriveKey(
   switch (algorithm.name) {
     case 'X25519':
       // Fall through
-    case 'X448':
-      // Fall through
     case 'ECDH':
       bits = await require('internal/crypto/diffiehellman')
         .ecdhDeriveBits(algorithm, baseKey, length);
@@ -340,11 +332,7 @@ async function exportKeySpki(key) {
       break;
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
     case 'X25519':
-      // Fall through
-    case 'X448':
       if (key.type === 'public') {
         return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatSPKI);
@@ -379,11 +367,7 @@ async function exportKeyPkcs8(key) {
       break;
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
     case 'X25519':
-      // Fall through
-    case 'X448':
       if (key.type === 'private') {
         return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatPKCS8);
@@ -408,11 +392,7 @@ async function exportKeyRaw(key) {
       break;
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
     case 'X25519':
-      // Fall through
-    case 'X448':
       if (key.type === 'public') {
         return require('internal/crypto/cfrg')
           .cfrgExportKey(key, kWebCryptoKeyFormatRaw);
@@ -462,13 +442,9 @@ async function exportKeyJWK(key) {
       jwk.crv ||= key.algorithm.namedCurve;
       return jwk;
     case 'X25519':
-      // Fall through
-    case 'X448':
       jwk.crv ||= key.algorithm.name;
       return jwk;
     case 'Ed25519':
-      // Fall through
-    case 'Ed448':
       jwk.crv ||= key.algorithm.name;
       return jwk;
     case 'AES-CTR':
@@ -617,11 +593,7 @@ async function importKey(
       break;
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
     case 'X25519':
-      // Fall through
-    case 'X448':
       result = await require('internal/crypto/cfrg')
         .cfrgImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
@@ -818,9 +790,6 @@ function signVerify(algorithm, key, data, signature) {
       return require('internal/crypto/ec')
         .ecdsaSignVerify(key, data, algorithm, signature);
     case 'Ed25519':
-      // Fall through
-    case 'Ed448':
-      // Fall through
       return require('internal/crypto/cfrg')
         .eddsaSignVerify(key, data, algorithm, signature);
     case 'HMAC':

--- a/lib/internal/crypto/webidl.js
+++ b/lib/internal/crypto/webidl.js
@@ -630,16 +630,6 @@ converters.EcdhKeyDeriveParams = createDictionaryConverter(
     },
   ]);
 
-converters.Ed448Params = createDictionaryConverter(
-  'Ed448Params', [
-    ...new SafeArrayIterator(dictAlgorithm),
-    {
-      key: 'context',
-      converter: converters.BufferSource,
-      required: false,
-    },
-  ]);
-
 module.exports = {
   converters,
   requiredArguments,

--- a/test/fixtures/crypto/eddsa.js
+++ b/test/fixtures/crypto/eddsa.js
@@ -5,20 +5,12 @@ module.exports = function() {
     'Ed25519': Buffer.from(
       '302e020100300506032b657004220420f3c8f4c48df878146e8cd3bf6df4e50e389b' +
       'a7074e15c2352dcd5d308d4ca81f', 'hex'),
-    'Ed448': Buffer.from(
-      '3047020100300506032b6571043b04390eff03458c28e0179c521de312c969b78343' +
-      '48ecab991a60e3b2e9a79e4cd9e480ef291712d2c83d047272d5c9f428664f696d26' +
-      '70458f1d2e', 'hex')
   }
 
   const spki = {
     'Ed25519': Buffer.from(
       '302a300506032b6570032100d8e18963d809d487d9549accaec6742e7eeba24d8a0d' +
       '3b14b7e3caea06893dcc', 'hex'),
-    'Ed448': Buffer.from(
-      '3043300506032b6571033a00ab4bb885fd7d2c5af24e83710cffa0c74a57e274801d' +
-      'b2057b0bdc5ea032b6fe6bc78b8045365aeb26e86e1f14fd349d07c48495f5a46a5a' +
-      '80', 'hex')
   }
 
   const data = Buffer.from(
@@ -30,14 +22,9 @@ module.exports = function() {
     'Ed25519': Buffer.from(
       '3d90de5e5743dfc28225bfadb341b116cbf8a3f1ceedbf4adc350ef5d3471843a418' +
       '614dcb6e614862614cf7af1496f9340b3c844ea4dceab1d3d155eb7ecc00', 'hex'),
-    'Ed448': Buffer.from(
-      '76897e8c50ac6b1132735c09c55f506c0149d2677c75664f8bc10b826fbd9df0a03c' +
-      'd986bce8339e64c7d1720ea9361784dc73837765ac2980c0dac0814a8bc187d1c9c9' +
-      '07c5dcc07956f85b70930fe42de764177217cb2d52bab7c1debe0ca89ccecbcd63f7' +
-      '025a2a5a572b9d23b0642f00', 'hex')
   }
 
-  const algorithms = ['Ed25519', 'Ed448'];
+  const algorithms = ['Ed25519'];
 
   const vectors = algorithms.map((algorithm) => ({
     publicKeyBuffer: spki[algorithm],

--- a/test/parallel/test-webcrypto-derivebits-cfrg.js
+++ b/test/parallel/test-webcrypto-derivebits-cfrg.js
@@ -18,18 +18,6 @@ const kTests = [
           '64ea51fae5b3307cfe9706',
     result: '2768409dfab99ec23b8c89b93ff5880295f76176088f89e43dfebe7ea1950008'
   },
-  {
-    name: 'X448',
-    size: 56,
-    pkcs8: '3046020100300506032b656f043a043858c7d29a3eb519b29d00cfb191bb64fc6' +
-           'd8a42d8f17176272b89f2272d1819295c6525c0829671b052ef0727530f188e31' +
-           'd0cc53bf26929e',
-    spki: '3042300506032b656f033900b604a1d1a5cd1d9426d561ef630a9eb16cbe69d5b9' +
-          'ca615edc53633efb52ea31e6e6a0a1dbacc6e76cbce6482d7e4ba3d55d9e802765' +
-          'ce6f',
-    result: 'f0f6c5f17f94f4291eab7178866d37ec8906dd6c514143dc85be7cf28deff39b' +
-            '726e0f6dcf810eb594dca97b4882bd44c43ea7dc67f49a4e',
-  },
 ];
 
 async function prepareKeys() {
@@ -151,9 +139,9 @@ async function prepareKeys() {
     // Missing public property
     await assert.rejects(
       subtle.deriveBits(
-        { name: 'X448' },
-        keys.X448.privateKey,
-        8 * keys.X448.size),
+        { name: 'X25519' },
+        keys.X25519.privateKey,
+        8 * keys.X25519.size),
       { code: 'ERR_MISSING_OPTION' });
   }
 
@@ -162,33 +150,20 @@ async function prepareKeys() {
     await assert.rejects(
       subtle.deriveBits(
         {
-          name: 'X448',
+          name: 'X25519',
           public: { message: 'Not a CryptoKey' }
         },
-        keys.X448.privateKey,
-        8 * keys.X448.size),
+        keys.X25519.privateKey,
+        8 * keys.X25519.size),
       { code: 'ERR_INVALID_ARG_TYPE' });
-  }
-
-  {
-    // Mismatched types
-    await assert.rejects(
-      subtle.deriveBits(
-        {
-          name: 'X448',
-          public: keys.X25519.publicKey
-        },
-        keys.X448.privateKey,
-        8 * keys.X448.size),
-      { message: 'The public and private keys must be of the same type' });
   }
 
   {
     // Base key is not a private key
     await assert.rejects(subtle.deriveBits({
-      name: 'X448',
-      public: keys.X448.publicKey
-    }, keys.X448.publicKey, null), {
+      name: 'X25519',
+      public: keys.X25519.publicKey
+    }, keys.X25519.publicKey, null), {
       name: 'InvalidAccessError'
     });
   }
@@ -196,9 +171,9 @@ async function prepareKeys() {
   {
     // Base key is not a private key
     await assert.rejects(subtle.deriveBits({
-      name: 'X448',
-      public: keys.X448.privateKey
-    }, keys.X448.publicKey, null), {
+      name: 'X25519',
+      public: keys.X25519.privateKey
+    }, keys.X25519.publicKey, null), {
       name: 'InvalidAccessError'
     });
   }
@@ -213,9 +188,9 @@ async function prepareKeys() {
       false, ['encrypt']);
 
     await assert.rejects(subtle.deriveBits({
-      name: 'X448',
+      name: 'X25519',
       public: key
-    }, keys.X448.publicKey, null), {
+    }, keys.X25519.publicKey, null), {
       name: 'InvalidAccessError'
     });
   }

--- a/test/parallel/test-webcrypto-derivebits-ecdh.js
+++ b/test/parallel/test-webcrypto-derivebits-ecdh.js
@@ -216,7 +216,7 @@ async function prepareKeys() {
       name: 'ECDH',
       public: publicKey
     }, keys['P-521'].privateKey, null), {
-      message: /Keys must be ECDH, X25519, or X448 keys/
+      message: /Keys must be ECDH or X25519 keys/
     });
   }
 

--- a/test/parallel/test-webcrypto-derivebits.js
+++ b/test/parallel/test-webcrypto-derivebits.js
@@ -101,7 +101,7 @@ const { subtle } = globalThis.crypto;
   tests.then(common.mustCall());
 }
 
-// Test X25519 and X448 bit derivation
+// Test X25519 bit derivation
 {
   async function test(name) {
     const [alice, bob] = await Promise.all([
@@ -124,5 +124,4 @@ const { subtle } = globalThis.crypto;
   }
 
   test('X25519').then(common.mustCall());
-  test('X448').then(common.mustCall());
 }

--- a/test/parallel/test-webcrypto-derivekey-cfrg.js
+++ b/test/parallel/test-webcrypto-derivekey-cfrg.js
@@ -18,17 +18,6 @@ const kTests = [
           '64ea51fae5b3307cfe9706',
     result: '2768409dfab99ec23b8c89b93ff5880295f76176088f89e43dfebe7ea1950008'
   },
-  {
-    name: 'X448',
-    size: 56,
-    pkcs8: '3046020100300506032b656f043a043858c7d29a3eb519b29d00cfb191bb64fc6' +
-           'd8a42d8f17176272b89f2272d1819295c6525c0829671b052ef0727530f188e31' +
-           'd0cc53bf26929e',
-    spki: '3042300506032b656f033900b604a1d1a5cd1d9426d561ef630a9eb16cbe69d5b9' +
-          'ca615edc53633efb52ea31e6e6a0a1dbacc6e76cbce6482d7e4ba3d55d9e802765' +
-          'ce6f',
-    result: 'f0f6c5f17f94f4291eab7178866d37ec8906dd6c514143dc85be7cf28deff39b'
-  },
 ];
 
 async function prepareKeys() {
@@ -107,8 +96,8 @@ async function prepareKeys() {
     // Missing public property
     await assert.rejects(
       subtle.deriveKey(
-        { name: 'X448' },
-        keys.X448.privateKey,
+        { name: 'X25519' },
+        keys.X25519.privateKey,
         ...otherArgs),
       { code: 'ERR_MISSING_OPTION' });
   }
@@ -118,25 +107,12 @@ async function prepareKeys() {
     await assert.rejects(
       subtle.deriveKey(
         {
-          name: 'X448',
+          name: 'X25519',
           public: { message: 'Not a CryptoKey' }
         },
-        keys.X448.privateKey,
+        keys.X25519.privateKey,
         ...otherArgs),
       { code: 'ERR_INVALID_ARG_TYPE' });
-  }
-
-  {
-    // Mismatched named curves
-    await assert.rejects(
-      subtle.deriveKey(
-        {
-          name: 'X448',
-          public: keys.X25519.publicKey
-        },
-        keys.X448.privateKey,
-        ...otherArgs),
-      { message: 'The public and private keys must be of the same type' });
   }
 
   {
@@ -144,10 +120,10 @@ async function prepareKeys() {
     await assert.rejects(
       subtle.deriveKey(
         {
-          name: 'X448',
-          public: keys.X448.publicKey
+          name: 'X25519',
+          public: keys.X25519.publicKey
         },
-        keys.X448.publicKey,
+        keys.X25519.publicKey,
         ...otherArgs),
       { name: 'InvalidAccessError' });
   }
@@ -157,10 +133,10 @@ async function prepareKeys() {
     await assert.rejects(
       subtle.deriveKey(
         {
-          name: 'X448',
-          public: keys.X448.privateKey
+          name: 'X25519',
+          public: keys.X25519.privateKey
         },
-        keys.X448.privateKey,
+        keys.X25519.privateKey,
         ...otherArgs),
       { name: 'InvalidAccessError' });
   }
@@ -177,10 +153,10 @@ async function prepareKeys() {
     await assert.rejects(
       subtle.deriveKey(
         {
-          name: 'X448',
+          name: 'X25519',
           public: key
         },
-        keys.X448.publicKey,
+        keys.X25519.publicKey,
         ...otherArgs),
       { name: 'InvalidAccessError' });
   }

--- a/test/parallel/test-webcrypto-derivekey-ecdh.js
+++ b/test/parallel/test-webcrypto-derivekey-ecdh.js
@@ -174,7 +174,7 @@ async function prepareKeys() {
         },
         keys['P-521'].privateKey,
         ...otherArgs),
-      { message: /Keys must be ECDH, X25519, or X448 keys/ });
+      { message: /Keys must be ECDH or X25519 keys/ });
   }
 
   {

--- a/test/parallel/test-webcrypto-derivekey.js
+++ b/test/parallel/test-webcrypto-derivekey.js
@@ -175,7 +175,7 @@ const { KeyObject } = require('crypto');
   })().then(common.mustCall());
 }
 
-// Test X25519 and X448 key derivation
+// Test X25519 key derivation
 {
   async function test(name) {
     const [alice, bob] = await Promise.all([
@@ -207,5 +207,4 @@ const { KeyObject } = require('crypto');
   }
 
   test('X25519').then(common.mustCall());
-  test('X448').then(common.mustCall());
 }

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -26,25 +26,6 @@ const keyData = {
       d: '1TFQvc0XtNSyGudW1JZWOddbKPVv-REbH4gyaRPkRbw'
     }
   },
-  'Ed448': {
-    jwsAlg: 'EdDSA',
-    spki: Buffer.from(
-      '3043300506032b6571033a0008cc38160c85bca5656ac4924af7ea97a9161b20' +
-      '2528273dcb84afd2eeb99ac912a401b34ef15ef4d9486406a6eecc31e5909219' +
-      'bd54866800', 'hex'),
-    pkcs8: Buffer.from(
-      '3047020100300506032b6571043b0439afd05b2fbb153b47c18dfa66baaed0de' +
-      'fb4e88c651487cdee0fafc40fa3d048fe1cd145a44143243c0468166b5bc161a' +
-      '82e3b904f3e2fcaaf9', 'hex'),
-    jwk: {
-      kty: 'OKP',
-      crv: 'Ed448',
-      x: 'CMw4FgyFvKVlasSSSvfql6kWGyAlKCc9y4Sv0u65mskSpAGzTvFe9NlIZAam7' +
-         'swx5ZCSGb1UhmgA',
-      d: 'r9BbL7sVO0fBjfpmuq7Q3vtOiMZRSHze4Pr8QPo9BI_hzRRaRBQyQ8BGgWa1v' +
-         'BYaguO5BPPi_Kr5'
-    }
-  },
   'X25519': {
     jwsAlg: 'ECDH-ES',
     spki: Buffer.from(
@@ -60,25 +41,6 @@ const keyData = {
       d: 'qDJ4UDF7SwOlqLTpI0E7HaSmQuDW96cs9NFqVJ5iil8'
     }
   },
-  'X448': {
-    jwsAlg: 'ECDH-ES',
-    spki: Buffer.from(
-      '3042300506032b656f0339001d451c8c0c369a42eadfc2875cd44953caeb46c4' +
-      '66dc86568280bfdbbb01f4709a1b0b1e0dd66cf7b11c84119ddc98890db72891' +
-      '29e30da4', 'hex'),
-    pkcs8: Buffer.from(
-      '3046020100300506032b656f043a0438fc818f6546a81f963c27765dc1c05bfd' +
-      'b169667e5e0cf45318ed1cb93872217ab0d9004e0c7dd0dcb00192f72039cc1a' +
-      '1dff750ec31c8afb', 'hex'),
-    jwk: {
-      kty: 'OKP',
-      crv: 'X448',
-      x: 'HUUcjAw2mkLq38KHXNRJU8rrRsRm3IZWgoC_27sB9HCaGwseDdZs97EchBGd3' +
-         'JiJDbcokSnjDaQ',
-      d: '_IGPZUaoH5Y8J3ZdwcBb_bFpZn5eDPRTGO0cuThyIXqw2QBODH3Q3LABkvcgO' +
-         'cwaHf91DsMcivs'
-    }
-  }
 };
 
 const testVectors = [
@@ -88,17 +50,7 @@ const testVectors = [
     publicUsages: ['verify']
   },
   {
-    name: 'Ed448',
-    privateUsages: ['sign'],
-    publicUsages: ['verify']
-  },
-  {
     name: 'X25519',
-    privateUsages: ['deriveKey', 'deriveBits'],
-    publicUsages: []
-  },
-  {
-    name: 'X448',
     privateUsages: ['deriveKey', 'deriveBits'],
     publicUsages: []
   },
@@ -368,7 +320,7 @@ async function testImportRaw({ name, publicUsages }) {
 
   for (const [name, publicUsages, privateUsages] of [
     ['Ed25519', ['verify'], ['sign']],
-    ['X448', [], ['deriveBits']],
+    ['X25519', [], ['deriveBits']],
   ]) {
     assert.rejects(subtle.importKey(
       'spki',

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -134,21 +134,7 @@ const vectors = {
       'verify',
     ],
   },
-  'Ed448': {
-    result: 'CryptoKeyPair',
-    usages: [
-      'sign',
-      'verify',
-    ],
-  },
   'X25519': {
-    result: 'CryptoKeyPair',
-    usages: [
-      'deriveKey',
-      'deriveBits',
-    ],
-  },
-  'X448': {
     result: 'CryptoKeyPair',
     usages: [
       'deriveKey',
@@ -641,17 +627,7 @@ assert.throws(() => new CryptoKey(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
       ['verify'],
     ],
     [
-      'Ed448',
-      ['sign'],
-      ['verify'],
-    ],
-    [
       'X25519',
-      ['deriveKey', 'deriveBits'],
-      [],
-    ],
-    [
-      'X448',
       ['deriveKey', 'deriveBits'],
       [],
     ],

--- a/test/parallel/test-webcrypto-sign-verify-eddsa.js
+++ b/test/parallel/test-webcrypto-sign-verify-eddsa.js
@@ -217,34 +217,3 @@ async function testSign({ name,
 
   await Promise.all(variations);
 })().then(common.mustCall());
-
-// Ed448 context
-{
-  const vector = vectors.find(({ name }) => name === 'Ed448');
-  Promise.all([
-    subtle.importKey(
-      'pkcs8',
-      vector.privateKeyBuffer,
-      { name: 'Ed448' },
-      false,
-      ['sign']),
-    subtle.importKey(
-      'spki',
-      vector.publicKeyBuffer,
-      { name: 'Ed448' },
-      false,
-      ['verify']),
-  ]).then(async ([privateKey, publicKey]) => {
-    const sig = await subtle.sign({ name: 'Ed448', context: Buffer.alloc(0) }, privateKey, vector.data);
-    assert.deepStrictEqual(Buffer.from(sig), vector.signature);
-    assert.strictEqual(
-      await subtle.verify({ name: 'Ed448', context: Buffer.alloc(0) }, publicKey, sig, vector.data), true);
-
-    await assert.rejects(subtle.sign({ name: 'Ed448', context: Buffer.alloc(1) }, privateKey, vector.data), {
-      message: /Non zero-length context is not yet supported/
-    });
-    await assert.rejects(subtle.verify({ name: 'Ed448', context: Buffer.alloc(1) }, publicKey, sig, vector.data), {
-      message: /Non zero-length context is not yet supported/
-    });
-  }).then(common.mustCall());
-}

--- a/test/parallel/test-webcrypto-sign-verify.js
+++ b/test/parallel/test-webcrypto-sign-verify.js
@@ -124,23 +124,3 @@ const { subtle } = globalThis.crypto;
 
   test('hello world').then(common.mustCall());
 }
-
-// Test Sign/Verify Ed448
-{
-  async function test(data) {
-    const ec = new TextEncoder();
-    const { publicKey, privateKey } = await subtle.generateKey({
-      name: 'Ed448',
-    }, true, ['sign', 'verify']);
-
-    const signature = await subtle.sign({
-      name: 'Ed448',
-    }, privateKey, ec.encode(data));
-
-    assert(await subtle.verify({
-      name: 'Ed448',
-    }, publicKey, signature, ec.encode(data)));
-  }
-
-  test('hello world').then(common.mustCall());
-}

--- a/test/parallel/test-webcrypto-webidl.js
+++ b/test/parallel/test-webcrypto-webidl.js
@@ -506,13 +506,3 @@ const opts = { prefix, context };
     });
   }).then(common.mustCall());
 }
-
-// Ed448Params
-{
-  for (const good of [
-    { name: 'Ed448', context: new Uint8Array() },
-    { name: 'Ed448' },
-  ]) {
-    assert.deepStrictEqual(converters.Ed448Params({ ...good, filtered: 'out' }, opts), good);
-  }
-}

--- a/test/parallel/test-webcrypto-wrap-unwrap.js
+++ b/test/parallel/test-webcrypto-wrap-unwrap.js
@@ -123,23 +123,7 @@ async function generateKeysToWrap() {
     },
     {
       algorithm: {
-        name: 'Ed448',
-      },
-      privateUsages: ['sign'],
-      publicUsages: ['verify'],
-      pair: true,
-    },
-    {
-      algorithm: {
         name: 'X25519',
-      },
-      privateUsages: ['deriveBits'],
-      publicUsages: [],
-      pair: true,
-    },
-    {
-      algorithm: {
-        name: 'X448',
       },
       privateUsages: ['deriveBits'],
       publicUsages: [],

--- a/test/wpt/status/WebCryptoAPI.cjs
+++ b/test/wpt/status/WebCryptoAPI.cjs
@@ -34,4 +34,37 @@ module.exports = {
       ],
     },
   },
+  'sign_verify/eddsa_curve448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'import_export/okp_importKey_failures_X448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'import_export/okp_importKey_failures_Ed448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'import_export/okp_importKey_Ed448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'import_export/okp_importKey_X448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'generateKey/successes_X448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'generateKey/successes_Ed448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'generateKey/failures_X448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'generateKey/failures_Ed448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'derive_bits_keys/cfrg_curves_keys_curve448.https.any.js': {
+    'skip': 'Not implemented',
+  },
+  'derive_bits_keys/cfrg_curves_bits_curve448.https.any.js': {
+    'skip': 'Not implemented',
+  },
 };


### PR DESCRIPTION
These https://github.com/nodejs/node/labels/experimental algoritms come from https://wicg.github.io/webcrypto-secure-curves/ and Node.js is [the only server runtime to implement them](https://github.com/WICG/webcrypto-secure-curves/issues/20#issue-1491482031). There's no indication that that would change in the future and browser support for them is very limited with no intents to ship or otherwise tracked standards positions. As a result [only Curve25519 is being added to the actual WebCryptoAPI Editor's Draft](https://github.com/w3c/webcrypto/pull/362) and so we can clean them up from our implementation.

This is not technically https://github.com/nodejs/node/labels/semver-major but we might as well treat it as such for v23.0 (or an early v23.x) to have a clear cut.