### PR TITLE
[v20.x backport] buffer: fix out of range for toString

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -841,12 +841,12 @@ Buffer.prototype.toString = function toString(encoding, start, end) {
   else if (start >= len)
     return '';
   else
-    start |= 0;
+    start = MathTrunc(start) || 0;
 
   if (end === undefined || end > len)
     end = len;
   else
-    end |= 0;
+    end = MathTrunc(end) || 0;
 
   if (end <= start)
     return '';

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 
 const rangeBuffer = Buffer.from('abc');
@@ -98,3 +98,11 @@ assert.throws(() => {
   name: 'TypeError',
   message: 'Unknown encoding: null'
 });
+
+// Must not throw when start and end are within kMaxLength
+// Cannot test on 32bit machine as we are testing the case
+// when start and end are above the threshold
+common.skipIf32Bits();
+const threshold = 0xFFFFFFFF;
+const largeBuffer = Buffer.alloc(threshold);
+largeBuffer.toString('utf8', threshold + 0xF, threshold + 0xFF);


### PR DESCRIPTION
Fixed the failing test by decreasing the buffer allocation size.

Refs: https://github.com/nodejs/node/pull/54553
cc @targos 