### PR TITLE
module: expose `getPackageJSON` utility

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -217,7 +217,7 @@ added: v22.8.0
 * Returns: {string|undefined} Path to the [module compile cache][] directory if it is enabled,
   or `undefined` otherwise.
 
-### `module.getPackageJSON(startPath[, everything])`
+### `module.getPackageJSON(startLocation[, everything])`
 
 <!-- YAML
 added: REPLACEME
@@ -225,7 +225,7 @@ added: REPLACEME
 
 > Stability: 1.1 - Active Development
 
-* `startPath` {string} Where to start looking
+* `startLocation` {string} A fully resolved FS path or file URL to start looking
 * `everything` {boolean} Whether to return the full contents of the found package.json
 * Returns: {Object | undefined}
   * data: {Object}
@@ -236,7 +236,7 @@ added: REPLACEME
     *  \[key: string]?: {unknown}
   * path: {string}
 
-Retreives the contents and location of the package.json closest to the supplied `startPath`;
+Retreives the contents and location of the package.json closest to the supplied `startLocation`;
 this behaves identically to node's own lookup and consumption of package.json for a given module.
 
 ```mjs

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -225,18 +225,18 @@ added: REPLACEME
 
 > Stability: 1.1 - Active Development
 
-* `startPath` {URL['pathname']} Where to start looking
+* `startPath` {URL\['pathname']} Where to start looking
 * `everything` {boolean} Whether to return the full contents of the found package.json
 * Returns: {undefined | {
   data: {
-    name?: string,
-    type?: 'commonjs' | 'module' | 'none',
-    exports?: string | string[] | Record<string, unknown>,
-    imports?: string | string[] | Record<string, unknown>,
-    [key: string]?: unknown,
+  name?: string,
+  type?: 'commonjs' | 'module' | 'none',
+  exports?: string | string\[] | Record\<string, unknown>,
+  imports?: string | string\[] | Record\<string, unknown>,
+  \[key: string]?: unknown,
   },
-  path: URL['pathname'],
-}}
+  path: URL\['pathname'],
+  }}
 
 In addition to being available to users, this utility is used internally when
 resolving various aspects about a module.

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -225,7 +225,7 @@ added: REPLACEME
 
 > Stability: 1.1 - Active Development
 
-* `startPath` {URL\['pathname']} Where to start looking
+* `startPath` {string} Where to start looking
 * `everything` {boolean} Whether to return the full contents of the found package.json
 * Returns: {undefined | {
   data: {

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -236,16 +236,27 @@ added: REPLACEME
     *  \[key: string]?: {unknown}
   * path: {string}
 
-In addition to being available to users, this utility is used internally when
-resolving various aspects about a module.
+Retreives the contents and location of the package.json closest to the supplied `startPath`;
+this behaves identically to node's own lookup and consumption of package.json for a given module.
 
 ```mjs
 import { getPackageJSON } from 'node:module';
 
-const pjson = getPackageJSON(import.meta.resolve('some-package'), true)?.data;
+const somePackage = getPackageJSON(import.meta.resolve('some-package'), true);
 
-pjson?.name; // 'some-package-real-name'
-pjson?.types; // './index.d.ts'
+somePackage?.path; // '/…/node_modules/some-package/package.json'
+somePackage?.data.name; // 'some-package-real-name'
+somePackage?.data.types; // './index.d.ts'
+
+const thisParentPackage = getPackageJSON(import.meta.resolve('..'));
+
+thisParentPackage?.path; // '../../package.json'
+thisParentPackage?.data.type; // 'module'
+
+const thisSubPackage = getPackageJSON(import.meta.url);
+
+thisSubPackage?.path; // './package.json'
+thisSubPackage?.data.type; // 'commonjs'
 ```
 
 ### `module.isBuiltin(moduleName)`

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -230,10 +230,10 @@ added: REPLACEME
 * Returns: {Object | undefined}
   * data: {Object}
     * name: {string}
-    * type: {'commonjs' | 'module' | undefined}
+    * type: {string | undefined}
     * exports: string | string\[] | Record\<string, unknown> | undefined
     * imports: string | string\[] | Record\<string, unknown> | undefined
-    *  \[key: string]?: {unknown}
+    * …
   * path: {string}
 
 Retreives the contents and location of the package.json closest to the supplied `startLocation`;

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -227,16 +227,14 @@ added: REPLACEME
 
 * `startPath` {string} Where to start looking
 * `everything` {boolean} Whether to return the full contents of the found package.json
-* Returns: {undefined | {
-  data: {
-  name?: string,
-  type?: 'commonjs' | 'module' | 'none',
-  exports?: string | string\[] | Record\<string, unknown>,
-  imports?: string | string\[] | Record\<string, unknown>,
-  \[key: string]?: unknown,
-  },
-  path: URL\['pathname'],
-  }}
+* Returns: {Object | undefined}
+  * data: {Object}
+    * name: {string}
+    * type: {'commonjs' | 'module' | undefined}
+    * exports: string | string\[] | Record\<string, unknown> | undefined
+    * imports: string | string\[] | Record\<string, unknown> | undefined
+    *  \[key: string]?: {unknown}
+  * path: {string}
 
 In addition to being available to users, this utility is used internally when
 resolving various aspects about a module.

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -229,7 +229,7 @@ added: REPLACEME
 * `everything` {boolean} Whether to return the full contents of the found package.json
 * Returns: {Object | undefined}
   * data: {Object}
-    * name: {string}
+    * name: {string | undefined}
     * type: {string | undefined}
     * exports: string | string\[] | Record\<string, unknown> | undefined
     * imports: string | string\[] | Record\<string, unknown> | undefined

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -220,7 +220,7 @@ added: v22.8.0
 ### `module.getPackageJSON(startPath[, everything])`
 
 <!-- YAML
-added: VERSION
+added: REPLACEME
 -->
 
 > Stability: 1.1 - Active Development

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -217,6 +217,39 @@ added: v22.8.0
 * Returns: {string|undefined} Path to the [module compile cache][] directory if it is enabled,
   or `undefined` otherwise.
 
+### `module.getPackageJSON(startPath[, everything])`
+
+<!-- YAML
+added: VERSION
+-->
+
+> Stability: 1.1 - Active Development
+
+* `startPath` {URL['pathname']} Where to start looking
+* `everything` {boolean} Whether to return the full contents of the found package.json
+* Returns: {undefined | {
+  data: {
+    name?: string,
+    type?: 'commonjs' | 'module' | 'none',
+    exports?: string | string[] | Record<string, unknown>,
+    imports?: string | string[] | Record<string, unknown>,
+    [key: string]?: unknown,
+  },
+  path: URL['pathname'],
+}}
+
+In addition to being available to users, this utility is used internally when
+resolving various aspects about a module.
+
+```mjs
+import { getPackageJSON } from 'node:module';
+
+const pjson = getPackageJSON(import.meta.resolve('some-package'), true)?.data;
+
+pjson?.name; // 'some-package-real-name'
+pjson?.types; // './index.d.ts'
+```
+
 ### `module.isBuiltin(moduleName)`
 
 <!-- YAML

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1214,8 +1214,8 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   if (request[0] === '#' && (parent?.filename || parent?.id === '<repl>')) {
     const parentPath = parent?.filename ?? process.cwd() + path.sep;
-    const pkg = packageJsonReader.getNearestParentPackageJSON(parentPath) || { __proto__: null };
-    if (pkg.data?.imports != null) {
+    const pkg = packageJsonReader.getNearestParentPackageJSON(parentPath);
+    if (pkg?.data.imports != null) {
       try {
         const { packageImportsResolve } = require('internal/modules/esm/resolve');
         return finalizeEsmResolution(

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -476,7 +476,7 @@ ObjectDefineProperty(Module, '_readPackage', {
  * @param {string} originalPath The specifier passed to `require`
  */
 function tryPackage(requestPath, exts, isMain, originalPath) {
-  const { main: pkg, pjsonPath } = _readPackage(requestPath);
+  const { data: { main: pkg }, path: pjsonPath } = _readPackage(requestPath);
 
   if (!pkg) {
     return tryExtensions(path.resolve(requestPath, 'index'), exts, isMain);
@@ -632,16 +632,16 @@ function resolveExports(nmPath, request) {
     RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
   if (!name) { return; }
   const pkgPath = path.resolve(nmPath, name);
-  const pkg = _readPackage(pkgPath);
-  if (pkg.exists && pkg.exports != null) {
+  const { data: pkg, path: pjsonPath } = _readPackage(pkgPath);
+  if (pkg.type !== 'none' && pkg.exports != null) {
     try {
       const { packageExportsResolve } = require('internal/modules/esm/resolve');
       return finalizeEsmResolution(packageExportsResolve(
-        pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
+        pathToFileURL(pjsonPath), '.' + expansion, pkg, null,
         getCjsConditions()), null, pkgPath);
     } catch (e) {
       if (e.code === 'ERR_MODULE_NOT_FOUND') {
-        throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+        throw createEsmNotFoundErr(request, pjsonPath);
       }
       throw e;
     }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -476,7 +476,7 @@ ObjectDefineProperty(Module, '_readPackage', {
  * @param {string} originalPath The specifier passed to `require`
  */
 function tryPackage(requestPath, exts, isMain, originalPath) {
-  const { data: { main: pkg }, path: pjsonPath } = _readPackage(requestPath);
+  const { main: pkg, pjsonPath } = _readPackage(requestPath);
 
   if (!pkg) {
     return tryExtensions(path.resolve(requestPath, 'index'), exts, isMain);
@@ -632,16 +632,16 @@ function resolveExports(nmPath, request) {
     RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
   if (!name) { return; }
   const pkgPath = path.resolve(nmPath, name);
-  const { data: pkg, path: pjsonPath } = _readPackage(pkgPath);
-  if (pkg.type !== 'none' && pkg.exports != null) {
+  const pkg = _readPackage(pkgPath);
+  if (pkg.exists && pkg.exports != null) {
     try {
       const { packageExportsResolve } = require('internal/modules/esm/resolve');
       return finalizeEsmResolution(packageExportsResolve(
-        pathToFileURL(pjsonPath), '.' + expansion, pkg, null,
+        pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
         getCjsConditions()), null, pkgPath);
     } catch (e) {
       if (e.code === 'ERR_MODULE_NOT_FOUND') {
-        throw createEsmNotFoundErr(request, pjsonPath);
+        throw createEsmNotFoundErr(request, pkgPath + '/package.json');
       }
       throw e;
     }

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -57,7 +57,6 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeRepeat,
-  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -1220,9 +1219,9 @@ Module._resolveFilename = function(request, parent, isMain, options) {
       try {
         const { packageImportsResolve } = require('internal/modules/esm/resolve');
         return finalizeEsmResolution(
-          packageImportsResolve(request, pathToFileURL(parentPath),
-                                getCjsConditions()), parentPath,
-          StringPrototypeReplace(pkg.path, '/package.json', ''),
+          packageImportsResolve(request, pathToFileURL(parentPath), getCjsConditions()),
+          parentPath,
+          pkg.path,
         );
       } catch (e) {
         if (e.code === 'ERR_MODULE_NOT_FOUND') {
@@ -1283,8 +1282,7 @@ function finalizeEsmResolution(resolved, parentPath, pkgPath) {
   if (actual) {
     return actual;
   }
-  const err = createEsmNotFoundErr(filename,
-                                   path.resolve(pkgPath, 'package.json'));
+  const err = createEsmNotFoundErr(filename, pkgPath);
   throw err;
 }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -57,6 +57,7 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeRepeat,
+  StringPrototypeReplace,
   StringPrototypeSlice,
   StringPrototypeSplit,
   StringPrototypeStartsWith,
@@ -604,11 +605,11 @@ function trySelf(parentPath, request) {
   try {
     const { packageExportsResolve } = require('internal/modules/esm/resolve');
     return finalizeEsmResolution(packageExportsResolve(
-      pathToFileURL(pkg.path + '/package.json'), expansion, pkg.data,
+      pathToFileURL(pkg.path), expansion, pkg.data,
       pathToFileURL(parentPath), getCjsConditions()), parentPath, pkg.path);
   } catch (e) {
     if (e.code === 'ERR_MODULE_NOT_FOUND') {
-      throw createEsmNotFoundErr(request, pkg.path + '/package.json');
+      throw createEsmNotFoundErr(request, pkg.path);
     }
     throw e;
   }
@@ -1221,7 +1222,8 @@ Module._resolveFilename = function(request, parent, isMain, options) {
         return finalizeEsmResolution(
           packageImportsResolve(request, pathToFileURL(parentPath),
                                 getCjsConditions()), parentPath,
-          pkg.path);
+          StringPrototypeReplace(pkg.path, '/package.json', ''),
+        );
       } catch (e) {
         if (e.code === 'ERR_MODULE_NOT_FOUND') {
           throw createEsmNotFoundErr(request);
@@ -1614,7 +1616,7 @@ function loadTS(module, filename) {
 
     const parent = module[kModuleParent];
     const parentPath = parent?.filename;
-    const packageJsonPath = path.resolve(pkg.path, 'package.json');
+    const packageJsonPath = pkg.path;
     const usesEsm = containsModuleSyntax(content, filename);
     const err = new ERR_REQUIRE_ESM(filename, usesEsm, parentPath,
                                     packageJsonPath);
@@ -1673,7 +1675,7 @@ Module._extensions['.js'] = function(module, filename) {
       // This is an error path because `require` of a `.js` file in a `"type": "module"` scope is not allowed.
       const parent = module[kModuleParent];
       const parentPath = parent?.filename;
-      const packageJsonPath = path.resolve(pkg.path, 'package.json');
+      const packageJsonPath = pkg.path;
       const usesEsm = containsModuleSyntax(content, filename);
       const err = new ERR_REQUIRE_ESM(filename, usesEsm, parentPath,
                                       packageJsonPath);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -818,12 +818,7 @@ function packageResolve(specifier, base, conditions) {
     }
 
     // Package match.
-    const { data: packageConfig } = packageJsonReader.read(packageJSONPath, {
-      __proto__: null,
-      base,
-      isESM: true,
-      specifier,
-    });
+    const packageConfig = packageJsonReader.read(packageJSONPath, { __proto__: null, specifier, base, isESM: true });
     if (packageConfig.exports != null) {
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -818,7 +818,12 @@ function packageResolve(specifier, base, conditions) {
     }
 
     // Package match.
-    const packageConfig = packageJsonReader.read(packageJSONPath, { __proto__: null, specifier, base, isESM: true });
+    const { data: packageConfig } = packageJsonReader.read(packageJSONPath, {
+      __proto__: null,
+      base,
+      isESM: true,
+      specifier,
+    });
     if (packageConfig.exports != null) {
       return packageExportsResolve(
         packageJSONUrl, packageSubpath, packageConfig, base, conditions);

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -191,7 +191,7 @@ const legacyMainResolveExtensionsIndexes = {
  * 4. TRY(pkg_url/index.js, pkg_url/index.json, pkg_url/index.node)
  * 5. NOT_FOUND
  * @param {URL} packageJSONUrl
- * @param {import('typings/internalBinding/modules').PackageConfig} packageConfig
+ * @param {import('typings/internalBinding/modules').RecognisedPackageConfig} packageConfig
  * @param {string | URL | undefined} base
  * @returns {URL}
  */

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -191,7 +191,7 @@ const legacyMainResolveExtensionsIndexes = {
  * 4. TRY(pkg_url/index.js, pkg_url/index.json, pkg_url/index.node)
  * 5. NOT_FOUND
  * @param {URL} packageJSONUrl
- * @param {import('typings/internalBinding/modules').RecognisedPackageConfig} packageConfig
+ * @param {import('typings/internalBinding/modules').RecognizedPackageConfig} packageConfig
  * @param {string | URL | undefined} base
  * @returns {URL}
  */

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -59,9 +59,9 @@ function deserializePackageJSON(path, contents) {
   return {
     data: {
       __proto__: null,
-      ...(name != null && { name }),
-      ...(main != null && { main }),
-      ...(type != null && { type }),
+      ...(name != null && { __proto__: null, name }),
+      ...(main != null && { __proto__: null, main }),
+      ...(type != null && { __proto__: null, type }),
       ...(plainImports != null && {
         // This getters are used to lazily parse the imports and exports fields.
         get imports() {

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -107,7 +107,13 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
     specifier == null ? undefined : `${specifier}`,
   );
 
-  return deserializePackageJSON(jsonPath, parsed);
+  const result = deserializePackageJSON(jsonPath, parsed);
+
+  return {
+    ...result.data,
+    exists: result.data !== 'none',
+    pjsonPath: result.path,
+  };
 }
 
 /**

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -110,6 +110,7 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   const result = deserializePackageJSON(jsonPath, parsed);
 
   return {
+    __proto__: null,
     ...result.data,
     exists: result.data !== 'none',
     pjsonPath: result.path,

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -2,11 +2,18 @@
 
 const {
   ArrayIsArray,
+  ArrayPrototypeJoin,
   JSONParse,
   ObjectDefineProperty,
+  StringPrototypeEndsWith,
 } = primordials;
+const {
+  codes: {
+    ERR_INVALID_ARG_VALUE,
+  },
+} = require('internal/errors');
 const modulesBinding = internalBinding('modules');
-const { resolve } = require('path');
+const path = require('path');
 const { kEmptyObject } = require('internal/util');
 const { fileURLToPath, URL } = require('internal/url');
 const {
@@ -111,7 +118,7 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
  */
 function readPackage(requestPath) {
   // TODO(@anonrig): Remove this function.
-  return read(resolve(requestPath, 'package.json'));
+  return read(path.resolve(requestPath, 'package.json'));
 }
 
 /**
@@ -122,9 +129,25 @@ function readPackage(requestPath) {
  * @returns {undefined | DeserializedPackageConfig<everything>}
  */
 function getNearestParentPackageJSON(startLocation, everything = false) {
-  const startPath = URL.canParse(startLocation) ? fileURLToPath(startLocation) : startLocation;
+  let startPath = URL.canParse(startLocation) ? fileURLToPath(startLocation) : startLocation;
+
   validateString(startPath, 'startPath');
   validateBoolean(everything, 'everything');
+
+  if (!path.isAbsolute(startPath)) {
+    throw new ERR_INVALID_ARG_VALUE(
+      'startLocation',
+      startLocation,
+      ArrayPrototypeJoin([
+        'must be a fully resolved location. To use a relative location, first wrap with',
+        '`import.meta.resolve(startLocation)` in ESM',
+        'or',
+        '`path.resolve(__dirname, startLocation) in CJS',
+      ], ' '),
+    );
+  }
+
+  if (!StringPrototypeEndsWith(startPath, path.sep)) { startPath += path.sep; }
 
   if (everything) {
     const result = modulesBinding.getNearestRawParentPackageJSON(startPath);

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -9,10 +9,9 @@ const modulesBinding = internalBinding('modules');
 const { resolve } = require('path');
 const { kEmptyObject } = require('internal/util');
 const {
-  codes: {
-    ERR_INVALID_ARG_TYPE,
-  },
-} = require('internal/errors');
+  validateBoolean,
+  validateString,
+} = require('internal/validators');
 
 /**
  * @typedef {import('typings/internalBinding/modules').DeserializedPackageConfig} DeserializedPackageConfig
@@ -122,12 +121,8 @@ function readPackage(requestPath) {
  * @returns {undefined | DeserializedPackageConfig<everything>}
  */
 function getNearestParentPackageJSON(startPath, everything = false) {
-  if (typeof startPath !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('startPath', 'string', startPath);
-  }
-  if ( everything !== 'boolean') {
-    throw new ERR_INVALID_ARG_TYPE('everything', 'boolean', everything);
-  }
+  validateString(startPath, 'startPath');
+  validateBoolean(everything, 'everything');
 
   if (everything) {
     const result = modulesBinding.getNearestRawParentPackageJSON(startPath);

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -40,6 +40,7 @@ function deserializePackageJSON(path, contents) {
         __proto__: null,
         type: 'none', // Ignore unknown types for forwards compatibility
       },
+      exists: false,
       path,
     };
   }
@@ -78,6 +79,7 @@ function deserializePackageJSON(path, contents) {
         },
       }),
     },
+    exists: true,
     path: pjsonPath,
   };
 }
@@ -112,7 +114,7 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   return {
     __proto__: null,
     ...result.data,
-    exists: result.data !== 'none',
+    exists: result.exists,
     pjsonPath: result.path,
   };
 }
@@ -164,6 +166,7 @@ function getNearestParentPackageJSON(startLocation, everything = false) {
         __proto__: null,
         ...JSONParse(result?.[0]),
       },
+      exists: true,
       path: result?.[1],
     };
   }
@@ -189,10 +192,12 @@ function getPackageScopeConfig(resolved) {
   const result = modulesBinding.getPackageScopeConfig(`${resolved}`);
 
   if (ArrayIsArray(result)) {
-    const { data, path } = deserializePackageJSON(`${resolved}`, result);
+    const { data, exists, path } = deserializePackageJSON(`${resolved}`, result);
+
     return {
       __proto__: null,
       ...data,
+      exists,
       pjsonPath: path,
     };
   }

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -59,7 +59,7 @@ function deserializePackageJSON(path, contents) {
   return {
     data: {
       __proto__: null,
-      ...(name !== null && { name }),
+      ...(name != null && { name }),
       ...(main != null && { main }),
       ...(type != null && { type }),
       ...(plainImports != null && {

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -8,7 +8,7 @@ const {
 const modulesBinding = internalBinding('modules');
 const { resolve } = require('path');
 const { kEmptyObject } = require('internal/util');
-const { fileURLToPath, URL } = require('url');
+const { fileURLToPath, URL } = require('internal/url');
 const {
   validateBoolean,
   validateString,

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -8,6 +8,7 @@ const {
 const modulesBinding = internalBinding('modules');
 const { resolve } = require('path');
 const { kEmptyObject } = require('internal/util');
+const { fileURLToPath, URL } = require('url');
 const {
   validateBoolean,
   validateString,
@@ -116,11 +117,12 @@ function readPackage(requestPath) {
 /**
  * Get the nearest parent package.json file from a given path.
  * Return the package.json data and the path to the package.json file, or undefined.
- * @param {URL['href'] | URL['pathname']} startPath The path to start searching from.
+ * @param {URL['href'] | URL['pathname']} startLocation The path to start searching from.
  * @param {boolean} everything Whether to include the full contents of the package.json.
  * @returns {undefined | DeserializedPackageConfig<everything>}
  */
-function getNearestParentPackageJSON(startPath, everything = false) {
+function getNearestParentPackageJSON(startLocation, everything = false) {
+  const startPath = URL.canParse(startLocation) ? fileURLToPath(startLocation) : startLocation;
   validateString(startPath, 'startPath');
   validateBoolean(everything, 'everything');
 

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -52,7 +52,7 @@ function deserializePackageJSON(path, contents) {
   return {
     data: {
       __proto__: null,
-      name,
+      ...(name !== null && { name }),
       ...(main != null && { main }),
       ...(type != null && { type }),
       ...(plainImports != null && {

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -15,6 +15,7 @@ const {
 } = require('internal/errors');
 
 /**
+ * @typedef {import('typings/internalBinding/modules').DeserializedPackageConfig} DeserializedPackageConfig
  * @typedef {import('typings/internalBinding/modules').FullPackageConfig} FullPackageConfig
  * @typedef {import('typings/internalBinding/modules').RecognizedPackageConfig} RecognizedPackageConfig
  * @typedef {import('typings/internalBinding/modules').SerializedPackageConfig} SerializedPackageConfig
@@ -23,19 +24,19 @@ const {
 /**
  * @param {string} path
  * @param {SerializedPackageConfig} contents
- * @returns {RecognizedPackageConfig}
+ * @returns {DeserializedPackageConfig}
  */
 function deserializePackageJSON(path, contents) {
   if (contents === undefined) {
     return {
-      __proto__: null,
-      exists: false,
-      pjsonPath: path,
-      type: 'none', // Ignore unknown types for forwards compatibility
+      data: {
+        __proto__: null,
+        type: 'none', // Ignore unknown types for forwards compatibility
+      },
+      path,
     };
   }
 
-  let pjsonPath = path;
   const {
     0: name,
     1: main,
@@ -46,39 +47,38 @@ function deserializePackageJSON(path, contents) {
   } = contents;
 
   // This is required to be used in getPackageScopeConfig.
-  if (optionalFilePath) {
-    pjsonPath = optionalFilePath;
-  }
-
-  // The imports and exports fields can be either undefined or a string.
-  // - If it's a string, it's either plain string or a stringified JSON string.
-  // - If it's a stringified JSON string, it starts with either '[' or '{'.
-  const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' || value[0] === '{'));
+  const pjsonPath = optionalFilePath ?? path;
 
   return {
-    __proto__: null,
-    exists: true,
-    pjsonPath,
-    name,
-    ...(main != null && { main }),
-    ...(type != null && { type }),
-    ...(plainImports != null && {
-      // This getters are used to lazily parse the imports and exports fields.
-      get imports() {
-        const value = requiresJSONParse(plainImports) ? JSONParse(plainImports) : plainImports;
-        ObjectDefineProperty(this, 'imports', { __proto__: null, value });
-        return this.imports;
-      },
-    }),
-    ...(plainExports != null && {
-      get exports() {
-        const value = requiresJSONParse(plainExports) ? JSONParse(plainExports) : plainExports;
-        ObjectDefineProperty(this, 'exports', { __proto__: null, value });
-        return this.exports;
-      },
-    }),
+    data: {
+      __proto__: null,
+      name,
+      ...(main != null && { main }),
+      ...(type != null && { type }),
+      ...(plainImports != null && {
+        // This getters are used to lazily parse the imports and exports fields.
+        get imports() {
+          const value = requiresJSONParse(plainImports) ? JSONParse(plainImports) : plainImports;
+          ObjectDefineProperty(this, 'imports', { __proto__: null, value });
+          return this.imports;
+        },
+      }),
+      ...(plainExports != null && {
+        get exports() {
+          const value = requiresJSONParse(plainExports) ? JSONParse(plainExports) : plainExports;
+          ObjectDefineProperty(this, 'exports', { __proto__: null, value });
+          return this.exports;
+        },
+      }),
+    },
+    path: pjsonPath,
   };
 }
+
+// The imports and exports fields can be either undefined or a string.
+// - If it's a string, it's either plain string or a stringified JSON string.
+// - If it's a stringified JSON string, it starts with either '[' or '{'.
+const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' || value[0] === '{'));
 
 /**
  * Reads a package.json file and returns the parsed contents.
@@ -119,19 +119,13 @@ function readPackage(requestPath) {
  * Return the package.json data and the path to the package.json file, or undefined.
  * @param {URL['href'] | URL['pathname']} startPath The path to start searching from.
  * @param {boolean} everything Whether to include the full contents of the package.json.
- * @returns {undefined | {
- *   data: everything extends true ? FullPackageConfig : RecognizedPackageConfig,
- *   path: URL['pathname'],
- * }}
+ * @returns {undefined | DeserializedPackageConfig<everything>}
  */
 function getNearestParentPackageJSON(startPath, everything = false) {
   if (typeof startPath !== 'string') {
     throw new ERR_INVALID_ARG_TYPE('startPath', 'string', startPath);
   }
-  if (
-    everything !== undefined &&
-    typeof everything !== 'boolean'
-  ) {
+  if ( everything !== 'boolean') {
     throw new ERR_INVALID_ARG_TYPE('everything', 'boolean', everything);
   }
 
@@ -141,9 +135,9 @@ function getNearestParentPackageJSON(startPath, everything = false) {
     return {
       data: {
         __proto__: null,
-        ...JSONParse(result[0]),
+        ...JSONParse(result?.[0]),
       },
-      path: result[1],
+      path: result?.[1],
     };
   }
 
@@ -153,26 +147,27 @@ function getNearestParentPackageJSON(startPath, everything = false) {
     return undefined;
   }
 
-  const data = deserializePackageJSON(startPath, result);
-
-  const { pjsonPath: path } = data;
-
-  delete data.exists;
-  delete data.pjsonPath;
-
-  return { data, path };
+  return deserializePackageJSON(startPath, result);
 }
 
 /**
  * Returns the package configuration for the given resolved URL.
  * @param {URL | string} resolved - The resolved URL.
- * @returns {RecognizedPackageConfig} - The package configuration.
+ * @returns {RecognizedPackageConfig & {
+ *  exists: boolean,
+ *  pjsonPath: DeserializedPackageConfig['path'],
+ * }} - The package configuration.
  */
 function getPackageScopeConfig(resolved) {
   const result = modulesBinding.getPackageScopeConfig(`${resolved}`);
 
   if (ArrayIsArray(result)) {
-    return deserializePackageJSON(`${resolved}`, result);
+    const { data, path } = deserializePackageJSON(`${resolved}`, result);
+    return {
+      __proto__: null,
+      ...data,
+      pjsonPath: path,
+    };
   }
 
   // This means that the response is a string

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -137,9 +137,19 @@ function getNearestParentPackageJSON(startPath, everything = false) {
     throw new ERR_INVALID_ARG_TYPE('everything', 'boolean', everything);
   }
 
-  const result = everything
-    ? modulesBinding.getNearestRawParentPackageJSON(startPath)
-    : modulesBinding.getNearestParentPackageJSON(startPath);
+  if (everything) {
+    const result = modulesBinding.getNearestRawParentPackageJSON(startPath);
+
+    return {
+      data: {
+        __proto__: null,
+        ...JSON.parse(result[0]),
+      },
+      path: result[1],
+    }
+  }
+
+  const result = modulesBinding.getNearestParentPackageJSON(startPath);
 
   if (result === undefined) {
     return undefined;

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -4,11 +4,9 @@ const {
   ArrayIsArray,
   JSONParse,
   ObjectDefineProperty,
-  StringPrototypeLastIndexOf,
-  StringPrototypeSlice,
 } = primordials;
 const modulesBinding = internalBinding('modules');
-const { resolve, sep } = require('path');
+const { resolve } = require('path');
 const { kEmptyObject } = require('internal/util');
 const {
   codes: {
@@ -131,7 +129,7 @@ function getNearestParentPackageJSON(startPath, everything = false) {
     throw new ERR_INVALID_ARG_TYPE('startPath', 'string', startPath);
   }
   if (
-    everything != undefined &&
+    everything !== undefined &&
     typeof everything !== 'boolean'
   ) {
     throw new ERR_INVALID_ARG_TYPE('everything', 'boolean', everything);
@@ -143,10 +141,10 @@ function getNearestParentPackageJSON(startPath, everything = false) {
     return {
       data: {
         __proto__: null,
-        ...JSON.parse(result[0]),
+        ...JSONParse(result[0]),
       },
       path: result[1],
-    }
+    };
   }
 
   const result = modulesBinding.getNearestParentPackageJSON(startPath);

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -62,19 +62,23 @@ function deserializePackageJSON(path, contents) {
     exists: true,
     pjsonPath,
     name,
-    main,
-    type,
-    // This getters are used to lazily parse the imports and exports fields.
-    get imports() {
-      const value = requiresJSONParse(plainImports) ? JSONParse(plainImports) : plainImports;
-      ObjectDefineProperty(this, 'imports', { __proto__: null, value });
-      return this.imports;
-    },
-    get exports() {
-      const value = requiresJSONParse(plainExports) ? JSONParse(plainExports) : plainExports;
-      ObjectDefineProperty(this, 'exports', { __proto__: null, value });
-      return this.exports;
-    },
+    ...(main != null && { main }),
+    ...(type != null && { type }),
+    ...(plainImports != null && {
+      // This getters are used to lazily parse the imports and exports fields.
+      get imports() {
+        const value = requiresJSONParse(plainImports) ? JSONParse(plainImports) : plainImports;
+        ObjectDefineProperty(this, 'imports', { __proto__: null, value });
+        return this.imports;
+      },
+    }),
+    ...(plainExports != null && {
+      get exports() {
+        const value = requiresJSONParse(plainExports) ? JSONParse(plainExports) : plainExports;
+        ObjectDefineProperty(this, 'exports', { __proto__: null, value });
+        return this.exports;
+      },
+    }),
   };
 }
 

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -16,14 +16,14 @@ const {
 
 /**
  * @typedef {import('typings/internalBinding/modules').FullPackageConfig} FullPackageConfig
- * @typedef {import('typings/internalBinding/modules').RecognisedPackageConfig} RecognisedPackageConfig
+ * @typedef {import('typings/internalBinding/modules').RecognizedPackageConfig} RecognizedPackageConfig
  * @typedef {import('typings/internalBinding/modules').SerializedPackageConfig} SerializedPackageConfig
  */
 
 /**
  * @param {string} path
  * @param {SerializedPackageConfig} contents
- * @returns {RecognisedPackageConfig}
+ * @returns {RecognizedPackageConfig}
  */
 function deserializePackageJSON(path, contents) {
   if (contents === undefined) {
@@ -88,7 +88,7 @@ function deserializePackageJSON(path, contents) {
  *   specifier?: URL | string,
  *   isESM?: boolean,
  * }} options
- * @returns {RecognisedPackageConfig}
+ * @returns {RecognizedPackageConfig}
  */
 function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   // This function will be called by both CJS and ESM, so we need to make sure
@@ -107,7 +107,7 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
  * @deprecated Expected to be removed in favor of `read` in the future.
  * Behaves the same was as `read`, but appends package.json to the path.
  * @param {string} requestPath
- * @return {RecognisedPackageConfig}
+ * @return {RecognizedPackageConfig}
  */
 function readPackage(requestPath) {
   // TODO(@anonrig): Remove this function.
@@ -120,7 +120,7 @@ function readPackage(requestPath) {
  * @param {URL['href'] | URL['pathname']} startPath The path to start searching from.
  * @param {boolean} everything Whether to include the full contents of the package.json.
  * @returns {undefined | {
- *   data: everything extends true ? FullPackageConfig : RecognisedPackageConfig,
+ *   data: everything extends true ? FullPackageConfig : RecognizedPackageConfig,
  *   path: URL['pathname'],
  * }}
  */
@@ -166,7 +166,7 @@ function getNearestParentPackageJSON(startPath, everything = false) {
 /**
  * Returns the package configuration for the given resolved URL.
  * @param {URL | string} resolved - The resolved URL.
- * @returns {RecognisedPackageConfig} - The package configuration.
+ * @returns {RecognizedPackageConfig} - The package configuration.
  */
 function getPackageScopeConfig(resolved) {
   const result = modulesBinding.getPackageScopeConfig(`${resolved}`);

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -172,5 +172,4 @@ module.exports = {
   getNearestParentPackageJSON,
   getPackageScopeConfig,
   getPackageType,
-  findNearestPackageJSON,
 };

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -143,9 +143,10 @@ function getNearestParentPackageJSON(startPath, everything = false) {
 
   const data = deserializePackageJSON(startPath, result);
 
-  // Path should be the root folder of the matched package.json
-  // For example for ~/path/package.json, it should be ~/path
-  const path = StringPrototypeSlice(data.pjsonPath, 0, StringPrototypeLastIndexOf(data.pjsonPath, sep));
+  const { pjsonPath: path } = data;
+
+  delete data.exists;
+  delete data.pjsonPath;
 
   return { data, path };
 }

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -10,6 +10,11 @@ const {
 const modulesBinding = internalBinding('modules');
 const { resolve, sep } = require('path');
 const { kEmptyObject } = require('internal/util');
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+  },
+} = require('internal/errors');
 
 /**
  * @typedef {import('typings/internalBinding/modules').FullPackageConfig} FullPackageConfig
@@ -110,23 +115,33 @@ function readPackage(requestPath) {
 /**
  * Get the nearest parent package.json file from a given path.
  * Return the package.json data and the path to the package.json file, or undefined.
- * @param {URL['href'] | URL['pathname']} checkPath The path to start searching from.
+ * @param {URL['href'] | URL['pathname']} startPath The path to start searching from.
  * @param {boolean} everything Whether to include the full contents of the package.json.
  * @returns {undefined | {
  *   data: everything extends true ? FullPackageConfig : RecognisedPackageConfig,
  *   path: URL['pathname'],
  * }}
  */
-function getNearestParentPackageJSON(checkPath, everything = false) {
+function getNearestParentPackageJSON(startPath, everything = false) {
+  if (typeof startPath !== 'string') {
+    throw new ERR_INVALID_ARG_TYPE('startPath', 'string', startPath);
+  }
+  if (
+    everything != undefined &&
+    typeof everything !== 'boolean'
+  ) {
+    throw new ERR_INVALID_ARG_TYPE('everything', 'boolean', everything);
+  }
+
   const result = everything
-    ? JSON.parse(modulesBinding.getNearestRawParentPackageJSON(checkPath))
-    : modulesBinding.getNearestParentPackageJSON(checkPath);
+    ? JSON.parse(modulesBinding.getNearestRawParentPackageJSON(startPath))
+    : modulesBinding.getNearestParentPackageJSON(startPath);
 
   if (result === undefined) {
     return undefined;
   }
 
-  const data = deserializePackageJSON(checkPath, result);
+  const data = deserializePackageJSON(startPath, result);
 
   // Path should be the root folder of the matched package.json
   // For example for ~/path/package.json, it should be ~/path

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -138,7 +138,7 @@ function getNearestParentPackageJSON(startPath, everything = false) {
   }
 
   const result = everything
-    ? JSON.parse(modulesBinding.getNearestRawParentPackageJSON(startPath))
+    ? modulesBinding.getNearestRawParentPackageJSON(startPath)
     : modulesBinding.getNearestParentPackageJSON(startPath);
 
   if (result === undefined) {

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -12,9 +12,15 @@ const { resolve, sep } = require('path');
 const { kEmptyObject } = require('internal/util');
 
 /**
+ * @typedef {import('typings/internalBinding/modules').FullPackageConfig} FullPackageConfig
+ * @typedef {import('typings/internalBinding/modules').RecognisedPackageConfig} RecognisedPackageConfig
+ * @typedef {import('typings/internalBinding/modules').SerializedPackageConfig} SerializedPackageConfig
+ */
+
+/**
  * @param {string} path
- * @param {import('typings/internalBinding/modules').SerializedPackageConfig} contents
- * @returns {import('typings/internalBinding/modules').PackageConfig}
+ * @param {SerializedPackageConfig} contents
+ * @returns {RecognisedPackageConfig}
  */
 function deserializePackageJSON(path, contents) {
   if (contents === undefined) {
@@ -75,7 +81,7 @@ function deserializePackageJSON(path, contents) {
  *   specifier?: URL | string,
  *   isESM?: boolean,
  * }} options
- * @returns {import('typings/internalBinding/modules').PackageConfig}
+ * @returns {RecognisedPackageConfig}
  */
 function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
   // This function will be called by both CJS and ESM, so we need to make sure
@@ -94,7 +100,7 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
  * @deprecated Expected to be removed in favor of `read` in the future.
  * Behaves the same was as `read`, but appends package.json to the path.
  * @param {string} requestPath
- * @return {PackageConfig}
+ * @return {RecognisedPackageConfig}
  */
 function readPackage(requestPath) {
   // TODO(@anonrig): Remove this function.
@@ -104,11 +110,17 @@ function readPackage(requestPath) {
 /**
  * Get the nearest parent package.json file from a given path.
  * Return the package.json data and the path to the package.json file, or undefined.
- * @param {string} checkPath The path to start searching from.
- * @returns {undefined | {data: import('typings/internalBinding/modules').PackageConfig, path: string}}
+ * @param {URL['href'] | URL['pathname']} checkPath The path to start searching from.
+ * @param {boolean} everything Whether to include the full contents of the package.json.
+ * @returns {undefined | {
+ *   data: everything extends true ? FullPackageConfig : RecognisedPackageConfig,
+ *   path: URL['pathname'],
+ * }}
  */
-function getNearestParentPackageJSON(checkPath) {
-  const result = modulesBinding.getNearestParentPackageJSON(checkPath);
+function getNearestParentPackageJSON(checkPath, everything = false) {
+  const result = everything
+    ? JSON.parse(modulesBinding.getNearestRawParentPackageJSON(checkPath))
+    : modulesBinding.getNearestParentPackageJSON(checkPath);
 
   if (result === undefined) {
     return undefined;
@@ -126,7 +138,7 @@ function getNearestParentPackageJSON(checkPath) {
 /**
  * Returns the package configuration for the given resolved URL.
  * @param {URL | string} resolved - The resolved URL.
- * @returns {import('typings/internalBinding/modules').PackageConfig} - The package configuration.
+ * @returns {RecognisedPackageConfig} - The package configuration.
  */
 function getPackageScopeConfig(resolved) {
   const result = modulesBinding.getPackageScopeConfig(`${resolved}`);
@@ -160,4 +172,5 @@ module.exports = {
   getNearestParentPackageJSON,
   getPackageScopeConfig,
   getPackageType,
+  findNearestPackageJSON,
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -10,6 +10,9 @@ const {
   flushCompileCache,
   getCompileCacheDir,
 } = require('internal/modules/helpers');
+const {
+  getNearestParentPackageJSON,
+} = require('internal/modules/package_json_reader');
 
 Module.findSourceMap = findSourceMap;
 Module.register = register;
@@ -19,4 +22,5 @@ Module.enableCompileCache = enableCompileCache;
 Module.flushCompileCache = flushCompileCache;
 
 Module.getCompileCacheDir = getCompileCacheDir;
+Module.getPackageJSON = getNearestParentPackageJSON;
 module.exports = Module;

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -325,7 +325,7 @@ void BindingData::GetNearestRawParentPackageJSON(
   ToNamespacedPath(realm->env(), &path_value);
 
   auto package_json =
-      TraverseParent(realm, std::filesystem::path(path_value.ToString()));
+      TraverseParent(realm, std::filesystem::path(path_value.ToStringView()));
 
   if (package_json != nullptr) {
     Local<Value> result[2] = {

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -314,8 +314,7 @@ const BindingData::PackageConfig* BindingData::TraverseParent(
 }
 
 void BindingData::GetNearestRawParentPackageJSON(
-  const v8::FunctionCallbackInfo<v8::Value>& args
-) {
+    const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
 
@@ -325,14 +324,13 @@ void BindingData::GetNearestRawParentPackageJSON(
   // Required for long paths in Windows
   ToNamespacedPath(realm->env(), &path_value);
 
-  auto package_json = TraverseParent(
-    realm,
-    std::filesystem::path(path_value.ToString()));
+  auto package_json =
+      TraverseParent(realm, std::filesystem::path(path_value.ToString()));
 
   if (package_json != nullptr) {
     Local<Value> result[2] = {
-      ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked(),
-      ToV8Value(realm->context(), package_json->file_path).ToLocalChecked(),
+        ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked(),
+        ToV8Value(realm->context(), package_json->file_path).ToLocalChecked(),
     };
 
     args.GetReturnValue().Set(Array::New(realm->isolate(), result, 2));

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -313,6 +313,25 @@ const BindingData::PackageConfig* BindingData::TraverseParent(
   return nullptr;
 }
 
+void BindingData::GetNearestRawParentPackageJSON(
+  const v8::FunctionCallbackInfo<v8::Value>& args
+) {
+  CHECK_GE(args.Length(), 1);
+  CHECK(args[0]->IsString());
+
+  Realm* realm = Realm::GetCurrent(args);
+  BufferValue path_value(realm->isolate(), args[0]);
+
+  ToNamespacedPath(realm->env(), &path_value); // Required for long paths in Windows
+
+  auto package_json = TraverseParent(realm, std::filesystem::path(path_value));
+
+  if (package_json != nullptr) {
+    Local<Value> value = ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked();
+    args.GetReturnValue().Set(value);
+  }
+}
+
 void BindingData::GetNearestParentPackageJSON(
     const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK_GE(args.Length(), 1);
@@ -494,6 +513,10 @@ void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
             target,
             "getNearestParentPackageJSON",
             GetNearestParentPackageJSON);
+  SetMethod(isolate,
+            target,
+            "getNearestRawParentPackageJSON",
+            GetNearestRawParentPackageJSON);
   SetMethod(isolate, target, "getPackageScopeConfig", GetPackageScopeConfig);
   SetMethod(isolate, target, "enableCompileCache", EnableCompileCache);
   SetMethod(isolate, target, "getCompileCacheDir", GetCompileCacheDir);
@@ -527,6 +550,7 @@ void BindingData::RegisterExternalReferences(
   registry->Register(ReadPackageJSON);
   registry->Register(GetNearestParentPackageJSONType);
   registry->Register(GetNearestParentPackageJSON);
+  registry->Register(GetNearestRawParentPackageJSON);
   registry->Register(GetPackageScopeConfig);
   registry->Register(EnableCompileCache);
   registry->Register(GetCompileCacheDir);

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -324,7 +324,7 @@ void BindingData::GetNearestRawParentPackageJSON(
 
   ToNamespacedPath(realm->env(), &path_value); // Required for long paths in Windows
 
-  auto package_json = TraverseParent(realm, std::filesystem::path(path_value));
+  auto package_json = TraverseParent(realm, std::filesystem::path(path_value.ToString()));
 
   if (package_json != nullptr) {
     Local<Value> value = ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked();

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -327,8 +327,7 @@ void BindingData::GetNearestRawParentPackageJSON(
 
   auto package_json = TraverseParent(
     realm,
-    std::filesystem::path(path_value.ToString())
-  );
+    std::filesystem::path(path_value.ToString()));
 
   if (package_json != nullptr) {
     Local<Value> result[2] = {

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -322,9 +322,13 @@ void BindingData::GetNearestRawParentPackageJSON(
   Realm* realm = Realm::GetCurrent(args);
   BufferValue path_value(realm->isolate(), args[0]);
 
-  ToNamespacedPath(realm->env(), &path_value); // Required for long paths in Windows
+  // Required for long paths in Windows
+  ToNamespacedPath(realm->env(), &path_value);
 
-  auto package_json = TraverseParent(realm, std::filesystem::path(path_value.ToString()));
+  auto package_json = TraverseParent(
+    realm,
+    std::filesystem::path(path_value.ToString())
+  );
 
   if (package_json != nullptr) {
     Local<Value> result[2] = {

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -327,8 +327,12 @@ void BindingData::GetNearestRawParentPackageJSON(
   auto package_json = TraverseParent(realm, std::filesystem::path(path_value.ToString()));
 
   if (package_json != nullptr) {
-    Local<Value> value = ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked();
-    args.GetReturnValue().Set(value);
+    Local<Value> result[2] = {
+      ToV8Value(realm->context(), package_json->raw_json).ToLocalChecked(),
+      ToV8Value(realm->context(), package_json->file_path).ToLocalChecked(),
+    };
+
+    args.GetReturnValue().Set(Array::New(realm->isolate(), result, 2));
   }
 }
 

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -59,6 +59,8 @@ class BindingData : public SnapshotableObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetNearestParentPackageJSONType(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetNearestRawParentPackageJSON(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPackageScopeConfig(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetPackageJSONScripts(

--- a/test/fixtures/packages/cjs-main-no-index/main.js
+++ b/test/fixtures/packages/cjs-main-no-index/main.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/fixtures/packages/cjs-main-no-index/other.js
+++ b/test/fixtures/packages/cjs-main-no-index/other.js
@@ -1,0 +1,3 @@
+const answer = require('./');
+
+module.exports = answer+1;

--- a/test/fixtures/packages/cjs-main-no-index/package.json
+++ b/test/fixtures/packages/cjs-main-no-index/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "main-no-index",
+  "main": "./main.js",
+  "type":"commonjs"
+}

--- a/test/fixtures/packages/nested-types-field/package.json
+++ b/test/fixtures/packages/nested-types-field/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "package-with-unrecognised-fields",
+  "type": "module",
+  "exports": {
+    "default": "./index.js",
+    "types": "./index.d.ts"
+  },
+  "unrecognised": true
+}

--- a/test/fixtures/packages/nested/package.json
+++ b/test/fixtures/packages/nested/package.json
@@ -1,0 +1,1 @@
+{"name": "package-with-sub-package"}

--- a/test/fixtures/packages/nested/sub-pkg-cjs/index.js
+++ b/test/fixtures/packages/nested/sub-pkg-cjs/index.js
@@ -1,0 +1,4 @@
+const { getPackageJSON } = require('node:module');
+const { resolve } = require('node:path');
+
+module.exports = getPackageJSON(resolve(__dirname, '..'));

--- a/test/fixtures/packages/nested/sub-pkg-cjs/package.json
+++ b/test/fixtures/packages/nested/sub-pkg-cjs/package.json
@@ -1,0 +1,1 @@
+{"name": "sub-package", "type": "commonjs"}

--- a/test/fixtures/packages/nested/sub-pkg-mjs/index.js
+++ b/test/fixtures/packages/nested/sub-pkg-mjs/index.js
@@ -1,0 +1,3 @@
+import { getPackageJSON } from 'node:module';
+
+export default getPackageJSON(import.meta.resolve('..'));

--- a/test/fixtures/packages/nested/sub-pkg-mjs/package.json
+++ b/test/fixtures/packages/nested/sub-pkg-mjs/package.json
@@ -1,0 +1,1 @@
+{"name": "sub-package", "type": "module"}

--- a/test/fixtures/packages/root-types-field/package.json
+++ b/test/fixtures/packages/root-types-field/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-with-unrecognised-fields",
+  "type": "module",
+  "types": "./index.d.ts"
+}

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -5,6 +5,7 @@ const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const path = require('path');
 const { getPackageJSON } = require('module');
+const { pathToFileURL } = require('url');
 
 
 { // Throws when no arguments are provided
@@ -23,6 +24,20 @@ const { getPackageJSON } = require('module');
 
 const pkgName = 'package-with-unrecognised-fields';
 const pkgType = 'module'; // a non-default value
+
+{ // Accepts a file URL (string), like from `import.meta.resolve()`
+  const pathToDir = fixtures.path('packages/root-types-field/');
+  const pkg = getPackageJSON(`${pathToFileURL(pathToDir)}`);
+
+  assert.deepStrictEqual(pkg, {
+    path: path.join(pathToDir, 'package.json'),
+    data: {
+      __proto__: null,
+      name: pkgName,
+      type: pkgType,
+    }
+  });
+}
 
 { // Exclude unrecognised fields when `everything` is not `true`
   const pathToDir = fixtures.path('packages/root-types-field/');

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -31,6 +31,7 @@ const pkgType = 'module'; // a non-default value
 
   assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
+    exists: true,
     data: {
       __proto__: null,
       name: pkgName,
@@ -45,6 +46,7 @@ const pkgType = 'module'; // a non-default value
 
   assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
+    exists: true,
     data: {
       __proto__: null,
       name: pkgName,
@@ -59,6 +61,7 @@ const pkgType = 'module'; // a non-default value
 
   assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
+    exists: true,
     data: {
       __proto__: null,
       name: pkgName,
@@ -74,6 +77,7 @@ const pkgType = 'module'; // a non-default value
 
   assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
+    exists: true,
     data: {
       __proto__: null,
       name: pkgName,
@@ -92,6 +96,7 @@ const pkgType = 'module'; // a non-default value
 
   assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
+    exists: true,
     data: {
       __proto__: null,
       name: pkgName,

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -104,3 +104,36 @@ const pkgType = 'module'; // a non-default value
     },
   });
 }
+
+{ // Throws on unresolved location
+  let err;
+  try {
+    getPackageJSON('..');
+  } catch (e) {
+    err = e;
+  }
+
+  assert.strictEqual(err.code, 'ERR_INVALID_ARG_VALUE');
+  assert.match(err.message, /fully resolved/);
+  assert.match(err.message, /relative/);
+  assert.match(err.message, /import\.meta\.resolve/);
+  assert.match(err.message, /path\.resolve\(__dirname/);
+}
+
+{ // Can crawl up (CJS)
+  const pathToMod = fixtures.path('packages/nested/sub-pkg-cjs/index.js');
+  const parentPkg = require(pathToMod);
+
+  assert.strictEqual(parentPkg.data.name, 'package-with-sub-package');
+  const pathToParent = fixtures.path('packages/nested/package.json');
+  assert.strictEqual(parentPkg.path, pathToParent);
+}
+
+{ // Can crawl up (ESM)
+  const pathToMod = fixtures.path('packages/nested/sub-pkg-mjs/index.js');
+  const parentPkg = require(pathToMod).default;
+
+  assert.strictEqual(parentPkg.data.name, 'package-with-sub-package');
+  const pathToParent = fixtures.path('packages/nested/package.json');
+  assert.strictEqual(parentPkg.path, pathToParent);
+}

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -137,3 +137,11 @@ const pkgType = 'module'; // a non-default value
   const pathToParent = fixtures.path('packages/nested/package.json');
   assert.strictEqual(parentPkg.path, pathToParent);
 }
+
+{ // Can require via package.json
+  const pathToMod = fixtures.path('packages/cjs-main-no-index/other.js');
+  // require() falls back to package.json values like "main" to resolve when there is no index
+  const answer = require(pathToMod);
+
+  assert.strictEqual(answer, 43);
+}

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const common = require('../common');
-const assert = require('assert');
+require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert/strict');
+const path = require('path');
 const { getPackageJSON } = require('module');
 
 
@@ -17,4 +19,73 @@ const { getPackageJSON } = require('module');
     () => getPackageJSON('', invalid),
     { code: 'ERR_INVALID_ARG_TYPE' }
   );
+}
+
+const pkgName = 'package-with-unrecognised-fields';
+const pkgType = 'module'; // a non-default value
+
+{ // Exclude unrecognised fields when `everything` is not `true`
+  const pathToDir = fixtures.path('packages/root-types-field/');
+  const pkg = getPackageJSON(pathToDir);
+
+  assert.deepEqual(pkg, {
+    path: path.join(pathToDir, 'package.json'),
+    data: {
+      __proto__: null,
+      name: pkgName,
+      type: pkgType,
+    }
+  });
+}
+
+{ // Include unrecognised fields when `everything` is `true`
+  const pathToDir = fixtures.path('packages/root-types-field/');
+  const pkg = getPackageJSON(pathToDir, true);
+
+  assert.deepEqual(pkg, {
+    path: path.join(pathToDir, 'package.json'),
+    data: {
+      __proto__: null,
+      name: pkgName,
+      type: pkgType,
+      types: './index.d.ts',
+    }
+  });
+}
+
+{ // Exclude unrecognised fields when `everything` is not `true`
+  const pathToDir = fixtures.path('packages/nested-types-field/');
+  const pkg = getPackageJSON(pathToDir);
+
+  assert.deepEqual(pkg, {
+    path: path.join(pathToDir, 'package.json'),
+    data: {
+      __proto__: null,
+      name: pkgName,
+      type: pkgType,
+      exports: {
+        default: './index.js',
+        types: './index.d.ts', // I think this is unexpected?
+      },
+    },
+  });
+}
+
+{ // Include unrecognised fields when `everything` is not `true`
+  const pathToDir = fixtures.path('packages/nested-types-field/');
+  const pkg = getPackageJSON(pathToDir, true);
+
+  assert.deepEqual(pkg, {
+    path: path.join(pathToDir, 'package.json'),
+    data: {
+      __proto__: null,
+      name: pkgName,
+      type: pkgType,
+      exports: {
+        default: './index.js',
+        types: './index.d.ts', // I think this is unexpected?
+      },
+      unrecognised: true,
+    },
+  });
 }

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { getPackageJSON } = require('module');
+
+
+{ // Should throw when no arguments are provided
+  assert.throws(
+    () => getPackageJSON(),
+    {
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  )
+}

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -5,11 +5,16 @@ const assert = require('assert');
 const { getPackageJSON } = require('module');
 
 
-{ // Should throw when no arguments are provided
+{ // Throws when no arguments are provided
   assert.throws(
     () => getPackageJSON(),
-    {
-      code: 'ERR_INVALID_ARG_TYPE'
-    }
-  )
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
+}
+
+{ // Throw when `everything` is not a boolean
+  for (const invalid of ['', {}, [], Symbol(), 1, 0, ]) assert.throws(
+    () => getPackageJSON('', invalid),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 }

--- a/test/parallel/test-get-package-json.js
+++ b/test/parallel/test-get-package-json.js
@@ -2,7 +2,7 @@
 
 require('../common');
 const fixtures = require('../common/fixtures');
-const assert = require('assert/strict');
+const assert = require('assert');
 const path = require('path');
 const { getPackageJSON } = require('module');
 
@@ -15,7 +15,7 @@ const { getPackageJSON } = require('module');
 }
 
 { // Throw when `everything` is not a boolean
-  for (const invalid of ['', {}, [], Symbol(), 1, 0, ]) assert.throws(
+  for (const invalid of ['', {}, [], Symbol(), 1, 0]) assert.throws(
     () => getPackageJSON('', invalid),
     { code: 'ERR_INVALID_ARG_TYPE' }
   );
@@ -28,7 +28,7 @@ const pkgType = 'module'; // a non-default value
   const pathToDir = fixtures.path('packages/root-types-field/');
   const pkg = getPackageJSON(pathToDir);
 
-  assert.deepEqual(pkg, {
+  assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
     data: {
       __proto__: null,
@@ -42,7 +42,7 @@ const pkgType = 'module'; // a non-default value
   const pathToDir = fixtures.path('packages/root-types-field/');
   const pkg = getPackageJSON(pathToDir, true);
 
-  assert.deepEqual(pkg, {
+  assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
     data: {
       __proto__: null,
@@ -57,7 +57,7 @@ const pkgType = 'module'; // a non-default value
   const pathToDir = fixtures.path('packages/nested-types-field/');
   const pkg = getPackageJSON(pathToDir);
 
-  assert.deepEqual(pkg, {
+  assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
     data: {
       __proto__: null,
@@ -75,7 +75,7 @@ const pkgType = 'module'; // a non-default value
   const pathToDir = fixtures.path('packages/nested-types-field/');
   const pkg = getPackageJSON(pathToDir, true);
 
-  assert.deepEqual(pkg, {
+  assert.deepStrictEqual(pkg, {
     path: path.join(pathToDir, 'package.json'),
     data: {
       __proto__: null,

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -1,30 +1,32 @@
 export type PackageType = 'commonjs' | 'module' | 'none'
-export type RecognisedPackageConfig = {
-  pjsonPath: URL['pathname']
-  exists: boolean
-  name?: string
+export type RecognizedPackageConfig = {
+  name: string
   main?: any
   type: PackageType
   exports?: string | string[] | Record<string, unknown>
   imports?: string | string[] | Record<string, unknown>
 }
-export type FullPackageConfig = RecognisedPackageConfig & {
+export type FullPackageConfig = RecognizedPackageConfig & {
   [key: string]: unknown,
 }
+export type DeserializedPackageConfig<everything = false> = {
+  data: everything extends true ? FullPackageConfig : RecognizedPackageConfig
+  path: URL['pathname'],
+}
 export type SerializedPackageConfig = [
-  RecognisedPackageConfig['name'],
-  RecognisedPackageConfig['main'],
-  RecognisedPackageConfig['type'],
+  RecognizedPackageConfig['name'],
+  RecognizedPackageConfig['main'],
+  RecognizedPackageConfig['type'],
   string | undefined, // exports
   string | undefined, // imports
-  RecognisedPackageConfig['pjsonPath'], // pjson file path
+  DeserializedPackageConfig['path'], // pjson file path
 ]
 
 export interface ModulesBinding {
   readPackageJSON(path: string): SerializedPackageConfig | undefined;
   getNearestParentPackageJSON(path: string): SerializedPackageConfig | undefined
-  getNearestRawParentPackageJSON(origin: URL['pathname']): [ReturnType<JSON['stringify']>, RecognisedPackageConfig['pjsonPath']] | undefined
-  getNearestParentPackageJSONType(path: string): RecognisedPackageConfig['type']
+  getNearestRawParentPackageJSON(origin: URL['pathname']): [ReturnType<JSON['stringify']>, DeserializedPackageConfig['path']] | undefined
+  getNearestParentPackageJSONType(path: string): RecognizedPackageConfig['type']
   getPackageScopeConfig(path: string): SerializedPackageConfig | undefined
   getPackageJSONScripts(): string | undefined
 }

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -10,7 +10,8 @@ export type FullPackageConfig = RecognizedPackageConfig & {
   [key: string]: unknown,
 }
 export type DeserializedPackageConfig<everything = false> = {
-  data: everything extends true ? FullPackageConfig : RecognizedPackageConfig
+  data: everything extends true ? FullPackageConfig : RecognizedPackageConfig,
+  exists: boolean,
   path: URL['pathname'],
 }
 export type SerializedPackageConfig = [

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -1,6 +1,6 @@
 export type PackageType = 'commonjs' | 'module' | 'none'
 export type RecognizedPackageConfig = {
-  name: string
+  name?: string
   main?: any
   type: PackageType
   exports?: string | string[] | Record<string, unknown>

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -1,6 +1,6 @@
 export type PackageType = 'commonjs' | 'module' | 'none'
 export type RecognisedPackageConfig = {
-  pjsonPath: string
+  pjsonPath: URL['pathname']
   exists: boolean
   name?: string
   main?: any
@@ -17,12 +17,12 @@ export type SerializedPackageConfig = [
   RecognisedPackageConfig['type'],
   string | undefined, // exports
   string | undefined, // imports
-  string | undefined, // raw json available for experimental policy
+  RecognisedPackageConfig['pjsonPath'], // pjson file path
 ]
 
 export interface ModulesBinding {
   readPackageJSON(path: string): SerializedPackageConfig | undefined;
-  getNearestParentPackageJSON(path: string): RecognisedPackageConfig | undefined
+  getNearestParentPackageJSON(path: string): SerializedPackageConfig | undefined
   getNearestRawParentPackageJSON(origin: URL['pathname']): [ReturnType<JSON['stringify']>, RecognisedPackageConfig['pjsonPath']] | undefined
   getNearestParentPackageJSONType(path: string): RecognisedPackageConfig['type']
   getPackageScopeConfig(path: string): SerializedPackageConfig | undefined

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -23,7 +23,7 @@ export type SerializedPackageConfig = [
 export interface ModulesBinding {
   readPackageJSON(path: string): SerializedPackageConfig | undefined;
   getNearestParentPackageJSON(path: string): RecognisedPackageConfig | undefined
-  getNearestRawParentPackageJSON(origin: URL['pathname']): ReturnType<JSON['stringify']> | undefined
+  getNearestRawParentPackageJSON(origin: URL['pathname']): [ReturnType<JSON['stringify']>, RecognisedPackageConfig['pjsonPath']] | undefined
   getNearestParentPackageJSONType(path: string): RecognisedPackageConfig['type']
   getPackageScopeConfig(path: string): SerializedPackageConfig | undefined
   getPackageJSONScripts(): string | undefined

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -1,5 +1,5 @@
 export type PackageType = 'commonjs' | 'module' | 'none'
-export type PackageConfig = {
+export type RecognisedPackageConfig = {
   pjsonPath: string
   exists: boolean
   name?: string
@@ -8,10 +8,13 @@ export type PackageConfig = {
   exports?: string | string[] | Record<string, unknown>
   imports?: string | string[] | Record<string, unknown>
 }
+export type FullPackageConfig = RecognisedPackageConfig & {
+  [key: string]: unknown,
+}
 export type SerializedPackageConfig = [
-  PackageConfig['name'],
-  PackageConfig['main'],
-  PackageConfig['type'],
+  RecognisedPackageConfig['name'],
+  RecognisedPackageConfig['main'],
+  RecognisedPackageConfig['type'],
   string | undefined, // exports
   string | undefined, // imports
   string | undefined, // raw json available for experimental policy
@@ -19,8 +22,9 @@ export type SerializedPackageConfig = [
 
 export interface ModulesBinding {
   readPackageJSON(path: string): SerializedPackageConfig | undefined;
-  getNearestParentPackageJSON(path: string): PackageConfig | undefined
-  getNearestParentPackageJSONType(path: string): PackageConfig['type']
+  getNearestParentPackageJSON(path: string): RecognisedPackageConfig | undefined
+  getNearestRawParentPackageJSON(origin: URL['pathname']): ReturnType<JSON['stringify']> | undefined
+  getNearestParentPackageJSONType(path: string): RecognisedPackageConfig['type']
   getPackageScopeConfig(path: string): SerializedPackageConfig | undefined
   getPackageJSONScripts(): string | undefined
 }


### PR DESCRIPTION
Finally got around to exposing one of the utilities we've long-discussed providing to users.

Currently, users (particularly library authors like yarn, who I believe originally requested this) have to re-implement this functionality.

I ran into this issue when building a codemod that needs to consume `pjson.types` / `pjson.exports[…].types`

https://github.com/JakobJingleheimer/correct-ts-specifiers/pull/6

References:

* https://github.com/nodejs/loaders/issues/43
* https://github.com/nodejs/loaders/issues/26