### PR TITLE
events: extract event listener validation as a function

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -673,7 +673,7 @@ EventEmitter.prototype.prependOnceListener =
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       checkListener(listener);
-      
+
       if (!hasEventListener(this, type))
         return this;
 
@@ -781,7 +781,7 @@ EventEmitter.prototype.removeAllListeners =
 function _listeners(target, type, unwrap) {
   if (!hasEventListener(target, type))
     return [];
-  
+
   const evlistener = target._events[type];
 
   if (typeof evlistener === 'function')

--- a/lib/events.js
+++ b/lib/events.js
@@ -275,6 +275,12 @@ ObjectDefineProperty(EventEmitter, 'defaultMaxListeners', {
   },
 });
 
+function hasEventListener(self, type) {
+  if (type === undefined)
+    return self._events !== undefined;
+  return self._events !== undefined && self._events[type] !== undefined;
+};
+
 ObjectDefineProperties(EventEmitter, {
   kMaxEventTargetListeners: {
     __proto__: null,
@@ -667,14 +673,12 @@ EventEmitter.prototype.prependOnceListener =
 EventEmitter.prototype.removeListener =
     function removeListener(type, listener) {
       checkListener(listener);
+      
+      if (!hasEventListener(this, type))
+        return this;
 
       const events = this._events;
-      if (events === undefined)
-        return this;
-
       const list = events[type];
-      if (list === undefined)
-        return this;
 
       if (list === listener || list.listener === listener) {
         this._eventsCount -= 1;
@@ -728,9 +732,9 @@ EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
  */
 EventEmitter.prototype.removeAllListeners =
     function removeAllListeners(type) {
-      const events = this._events;
-      if (events === undefined)
+      if (!hasEventListener(this))
         return this;
+      const events = this._events;
 
       // Not listening for removeListener, no need to emit
       if (events.removeListener === undefined) {
@@ -775,14 +779,10 @@ EventEmitter.prototype.removeAllListeners =
     };
 
 function _listeners(target, type, unwrap) {
-  const events = target._events;
-
-  if (events === undefined)
+  if (!hasEventListener(target, type))
     return [];
-
-  const evlistener = events[type];
-  if (evlistener === undefined)
-    return [];
+  
+  const evlistener = target._events[type];
 
   if (typeof evlistener === 'function')
     return unwrap ? [evlistener.listener || evlistener] : [evlistener];


### PR DESCRIPTION
There was some repetitive logics that validated the existence of eventlisteners.  
We now replace this with a single line of, `hasEventListener(self, type)`.  
- `self` is the object(e.g. EventEmitter) to be checked whether eventlisteners exists or not.  
- `type` is the type of eventlisteners, which can be `undefined`  