### PR TITLE
build: drop support for python 3.8

### DIFF
--- a/android-configure
+++ b/android-configure
@@ -9,7 +9,6 @@ command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
 command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
-command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
 command -v python3 >/dev/null && exec python3 "$0" "$@"
 exec python "$0" "$@"
 ''' "$0" "$@"
@@ -23,7 +22,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
+acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
 if sys.version_info[:2] in acceptable_pythons:
   import android_configure
 else:

--- a/configure
+++ b/configure
@@ -9,7 +9,6 @@ command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
 command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
 command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
-command -v python3.8 >/dev/null && exec python3.8 "$0" "$@"
 command -v python3 >/dev/null && exec python3 "$0" "$@"
 exec python "$0" "$@"
 ''' "$0" "$@"
@@ -23,7 +22,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
+acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:

--- a/configure.py
+++ b/configure.py
@@ -2130,7 +2130,7 @@ def make_bin_override():
   if sys.platform == 'win32':
     raise Exception('make_bin_override should not be called on win32.')
   # If the system python is not the python we are running (which should be
-  # python 3.8+), then create a directory with a symlink called `python` to our
+  # python 3.9+), then create a directory with a symlink called `python` to our
   # sys.executable. This directory will be prefixed to the PATH, so that
   # other tools that shell out to `python` will use the appropriate python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = [
   "tools/github_reporter"
 ]
 line-length = 172
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
> After next Monday ___acceptable___ versions should be py39, py310, py311, py312, py313.

_Originally posted by @cclauss in https://github.com/nodejs/node/issues/54358#issuecomment-2388762359_
