### PR TITLE
module: use kNodeModulesRE to detect node_modules

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -124,6 +124,7 @@ const { pathToFileURL, fileURLToPath, isURL } = require('internal/url');
 const {
   pendingDeprecate,
   emitExperimentalWarning,
+  isUnderNodeModules,
   kEmptyObject,
   setOwnProperty,
   getLazy,
@@ -146,7 +147,6 @@ const { safeGetenv } = internalBinding('credentials');
 const {
   getCjsConditions,
   initializeCjsConditions,
-  isUnderNodeModules,
   loadBuiltinModule,
   makeRequireFunction,
   setHasStartedUserCJSExecution,

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -3,7 +3,10 @@
 const {
   RegExpPrototypeExec,
 } = primordials;
-const { kEmptyObject } = require('internal/util');
+const {
+  isUnderNodeModules,
+  kEmptyObject,
+} = require('internal/util');
 
 const { defaultGetFormat } = require('internal/modules/esm/get_format');
 const { validateAttributes, emitImportAssertionWarning } = require('internal/modules/esm/assert');
@@ -14,9 +17,6 @@ const defaultType =
   getOptionValue('--experimental-default-type');
 
 const { Buffer: { from: BufferFrom } } = require('buffer');
-const {
-  isUnderNodeModules,
-} = require('internal/modules/helpers');
 
 const { URL } = require('internal/url');
 const {

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -2,7 +2,6 @@
 
 const {
   ArrayPrototypeForEach,
-  ArrayPrototypeIncludes,
   ObjectDefineProperty,
   ObjectFreeze,
   ObjectPrototypeHasOwnProperty,
@@ -11,7 +10,6 @@ const {
   StringPrototypeCharCodeAt,
   StringPrototypeIncludes,
   StringPrototypeSlice,
-  StringPrototypeSplit,
   StringPrototypeStartsWith,
 } = primordials;
 const {
@@ -387,13 +385,6 @@ function stripTypeScriptTypes(source, filename) {
   return `${code}\n\n//# sourceURL=${filename}`;
 }
 
-function isUnderNodeModules(filename) {
-  const resolvedPath = path.resolve(filename);
-  const normalizedPath = path.normalize(resolvedPath);
-  const splitPath = StringPrototypeSplit(normalizedPath, path.sep);
-  return ArrayPrototypeIncludes(splitPath, 'node_modules');
-}
-
 /** @type {import('internal/util/types')} */
 let _TYPES = null;
 /**
@@ -494,7 +485,6 @@ module.exports = {
   getCjsConditions,
   getCompileCacheDir,
   initializeCjsConditions,
-  isUnderNodeModules,
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -484,6 +484,10 @@ function spliceOne(list, index) {
 
 const kNodeModulesRE = /^(?:.*)[\\/]node_modules[\\/]/;
 
+function isUnderNodeModules(filename) {
+  return filename && (RegExpPrototypeExec(kNodeModulesRE, filename) !== null);
+}
+
 let getStructuredStackImpl;
 
 function lazyGetStructuredStack() {
@@ -531,7 +535,7 @@ function isInsideNodeModules() {
       ) {
         continue;
       }
-      return RegExpPrototypeExec(kNodeModulesRE, filename) !== null;
+      return isUnderNodeModules(filename);
     }
   }
   return false;
@@ -911,6 +915,7 @@ module.exports = {
   guessHandleType,
   isError,
   isInsideNodeModules,
+  isUnderNodeModules,
   isMacOS,
   isWindows,
   join,


### PR DESCRIPTION
This is faster and more consistent with other places using the regular expression to detect node_modules.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
