### PR TITLE
v8.deserialize: Fix out of bounds write

### DIFF
--- a/lib/v8.js
+++ b/lib/v8.js
@@ -368,7 +368,7 @@ class DefaultDeserializer extends Deserializer {
     }
     // Copy to an aligned buffer first.
     const buffer_copy = Buffer.allocUnsafe(byteLength);
-    copy(this.buffer, buffer_copy, 0, byteOffset, byteOffset + byteLength);
+    copy(this.buffer, buffer_copy, 0, byteOffset, byteLength);
     return new ctor(buffer_copy.buffer,
                     buffer_copy.byteOffset,
                     byteLength / BYTES_PER_ELEMENT);


### PR DESCRIPTION
When v8.deserialized is passed a Buffer with non-zero byteOffset, it will call copy and try to copy more bytes than are allocated in the destination buffer. This will then call the SlowCopy method which will call memmove and write bytes after the buffer.

This crash has been observed with the parcel tool.