### PR TITLE
stream: catch and forward error from dest.write

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1004,10 +1004,15 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   src.on('data', ondata);
   function ondata(chunk) {
     debug('ondata');
-    const ret = dest.write(chunk);
-    debug('dest.write', ret);
-    if (ret === false) {
-      pause();
+    try {
+      const ret = dest.write(chunk);
+      debug('dest.write', ret);
+
+      if (ret === false) {
+        pause();
+      }
+    } catch (error) {
+      dest.destroy(error);
     }
   }
 

--- a/test/parallel/test-stream-pipe-objectmode-to-non-objectmode.js
+++ b/test/parallel/test-stream-pipe-objectmode-to-non-objectmode.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { Readable, Transform, Writable } = require('node:stream');
+
+// Pipeine objects from object mode to non-object mode should throw an error and
+// catch by the consumer
+{
+  const objectReadable = Readable.from([
+    { hello: 'hello' },
+    { world: 'world' },
+  ]);
+
+  const passThrough = new Transform({
+    transform(chunk, _encoding, cb) {
+      this.push(chunk);
+      cb(null);
+    },
+  });
+
+  passThrough.on('error', common.mustCall());
+
+  objectReadable.pipe(passThrough);
+
+  assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of passThrough);
+  }, /ERR_INVALID_ARG_TYPE/).then(common.mustCall());
+}
+
+// The error should be properly forwarded when the readable stream is in object mode,
+// the writable stream is in non-object mode, and the data is string.
+{
+  const stringReadable = Readable.from(['hello', 'world']);
+
+  const passThrough = new Transform({
+    transform(chunk, _encoding, cb) {
+      this.push(chunk);
+      throw new Error('something went wrong');
+    },
+  });
+
+  passThrough.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'something went wrong');
+  }));
+
+  stringReadable.pipe(passThrough);
+}
+
+// The error should be properly forwarded when the readable stream is in object mode,
+// the writable stream is in non-object mode, and the data is buffer.
+{
+  const binaryData = Buffer.from('binary data');
+
+  const binaryReadable = new Readable({
+    read() {
+      this.push(binaryData);
+      this.push(null);
+    }
+  });
+
+  const binaryWritable = new Writable({
+    write(chunk, _encoding, cb) {
+      throw new Error('something went wrong');
+    }
+  });
+
+  binaryWritable.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'something went wrong');
+  }));
+  binaryReadable.pipe(binaryWritable);
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/54945

Wanted to give a quick mention why [checking object modes at the start of the pipe function](https://github.com/nodejs/node/issues/54945#issuecomment-2351385474) wouldn't work (even though I liked the idea). Because if the chunk from the source stream is not object while source stream is in object mode and destination stream is not in object mode, it should still work.

Consider the following example:
```js
const { Readable, Writable } = require("node:stream");

const write = new Writable({
  write(data, enc, cb) {
    // do something with the data
    cb();
  },
});

write.on("error", (err) => {
  console.log(err);
});

Readable.from("hello hello").pipe(write);

```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
