### PR TITLE
deps: V8: partially cherry-pick 8953e49478

### DIFF
--- a/deps/v8/src/flags/flags-impl.h
+++ b/deps/v8/src/flags/flags-impl.h
@@ -5,6 +5,8 @@
 #ifndef V8_FLAGS_FLAGS_IMPL_H_
 #define V8_FLAGS_FLAGS_IMPL_H_
 
+#include <unordered_set>
+
 #include "src/base/macros.h"
 #include "src/base/optional.h"
 #include "src/base/vector.h"
@@ -91,9 +93,12 @@ struct Flag {
 #ifdef DEBUG
   bool ImpliedBy(const void* ptr) const {
     const Flag* current = this->implied_by_ptr_;
+    std::unordered_set<const Flag*> visited_flags;
     while (current != nullptr) {
+      visited_flags.insert(current);
       if (current->PointsTo(ptr)) return true;
       current = current->implied_by_ptr_;
+      if (visited_flags.contains(current)) break;
     }
     return false;
   }


### PR DESCRIPTION
Very partial cherry-pick of upstream commit v8/v8@8953e49478 that fixes a hang that shows up in debug builds because of a buggy sanity check when computing relationships between command line flags.

Example of the hang:

    #include "v8.h"
    #include "libplatform/libplatform.h"
    int main(void) {
      // works: v8::V8::SetFlagsFromString("--gc-global --noincremental-marking");
      v8::V8::SetFlagsFromString("--gc-global");
      v8::V8::SetFlagsFromString("--noincremental-marking");
      v8::V8::InitializePlatform(v8::platform::NewDefaultPlatform().release());
      v8::V8::Initialize(); // hangs in ComputeFlagListHash when defined(DEBUG)
    }

<hr>

NB: fix already exists in main; newer V8