### PR TITLE
doc: don't require anchor in `errors.md`

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -639,11 +639,7 @@ The OpenSSL library the error originates in.
 
 A human-readable string describing the reason for the error.
 
-<a id="nodejs-error-codes"></a>
-
 ## Node.js error codes
-
-<a id="ABORT_ERR"></a>
 
 ### `ABORT_ERR`
 
@@ -658,14 +654,10 @@ APIs _not_ using `AbortSignal`s typically do not raise an error with this code.
 This code does not use the regular `ERR_*` convention Node.js errors use in
 order to be compatible with the web platform's `AbortError`.
 
-<a id="ERR_ACCESS_DENIED"></a>
-
 ### `ERR_ACCESS_DENIED`
 
 A special type of error that is triggered whenever Node.js tries to get access
 to a resource restricted by the [Permission Model][].
-
-<a id="ERR_AMBIGUOUS_ARGUMENT"></a>
 
 ### `ERR_AMBIGUOUS_ARGUMENT`
 
@@ -676,14 +668,10 @@ message thrown by `block` because that usage suggests that the user believes
 `message` is the expected message rather than the message the `AssertionError`
 will display if `block` does not throw.
 
-<a id="ERR_ARG_NOT_ITERABLE"></a>
-
 ### `ERR_ARG_NOT_ITERABLE`
 
 An iterable argument (i.e. a value that works with `for...of` loops) was
 required, but not provided to a Node.js API.
-
-<a id="ERR_ASSERTION"></a>
 
 ### `ERR_ASSERTION`
 
@@ -691,33 +679,23 @@ A special type of error that can be triggered whenever Node.js detects an
 exceptional logic violation that should never occur. These are raised typically
 by the `node:assert` module.
 
-<a id="ERR_ASYNC_CALLBACK"></a>
-
 ### `ERR_ASYNC_CALLBACK`
 
 An attempt was made to register something that is not a function as an
 `AsyncHooks` callback.
-
-<a id="ERR_ASYNC_TYPE"></a>
 
 ### `ERR_ASYNC_TYPE`
 
 The type of an asynchronous resource was invalid. Users are also able
 to define their own types if using the public embedder API.
 
-<a id="ERR_BROTLI_COMPRESSION_FAILED"></a>
-
 ### `ERR_BROTLI_COMPRESSION_FAILED`
 
 Data passed to a Brotli stream was not successfully compressed.
 
-<a id="ERR_BROTLI_INVALID_PARAM"></a>
-
 ### `ERR_BROTLI_INVALID_PARAM`
 
 An invalid parameter key was passed during construction of a Brotli stream.
-
-<a id="ERR_BUFFER_CONTEXT_NOT_AVAILABLE"></a>
 
 ### `ERR_BUFFER_CONTEXT_NOT_AVAILABLE`
 
@@ -731,45 +709,31 @@ instance is to create a normal `Uint8Array`, which only differs in the
 prototype of the resulting object. `Uint8Array`s are generally accepted in all
 Node.js core APIs where `Buffer`s are; they are available in all Contexts.
 
-<a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
-
 ### `ERR_BUFFER_OUT_OF_BOUNDS`
 
 An operation outside the bounds of a `Buffer` was attempted.
-
-<a id="ERR_BUFFER_TOO_LARGE"></a>
 
 ### `ERR_BUFFER_TOO_LARGE`
 
 An attempt has been made to create a `Buffer` larger than the maximum allowed
 size.
 
-<a id="ERR_CANNOT_WATCH_SIGINT"></a>
-
 ### `ERR_CANNOT_WATCH_SIGINT`
 
 Node.js was unable to watch for the `SIGINT` signal.
-
-<a id="ERR_CHILD_CLOSED_BEFORE_REPLY"></a>
 
 ### `ERR_CHILD_CLOSED_BEFORE_REPLY`
 
 A child process was closed before the parent received a reply.
 
-<a id="ERR_CHILD_PROCESS_IPC_REQUIRED"></a>
-
 ### `ERR_CHILD_PROCESS_IPC_REQUIRED`
 
 Used when a child process is being forked without specifying an IPC channel.
-
-<a id="ERR_CHILD_PROCESS_STDIO_MAXBUFFER"></a>
 
 ### `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`
 
 Used when the main process is trying to read data from the child process's
 STDERR/STDOUT, and the data's length is longer than the `maxBuffer` option.
-
-<a id="ERR_CLOSED_MESSAGE_PORT"></a>
 
 ### `ERR_CLOSED_MESSAGE_PORT`
 
@@ -789,14 +753,10 @@ changes:
 There was an attempt to use a `MessagePort` instance in a closed
 state, usually after `.close()` has been called.
 
-<a id="ERR_CONSOLE_WRITABLE_STREAM"></a>
-
 ### `ERR_CONSOLE_WRITABLE_STREAM`
 
 `Console` was instantiated without `stdout` stream, or `Console` has a
 non-writable `stdout` or `stderr` stream.
-
-<a id="ERR_CONSTRUCT_CALL_INVALID"></a>
 
 ### `ERR_CONSTRUCT_CALL_INVALID`
 
@@ -806,13 +766,9 @@ added: v12.5.0
 
 A class constructor was called that is not callable.
 
-<a id="ERR_CONSTRUCT_CALL_REQUIRED"></a>
-
 ### `ERR_CONSTRUCT_CALL_REQUIRED`
 
 A constructor for a class was called without `new`.
-
-<a id="ERR_CONTEXT_NOT_INITIALIZED"></a>
 
 ### `ERR_CONTEXT_NOT_INITIALIZED`
 
@@ -821,22 +777,16 @@ when an error occurs (and is caught) during the creation of the
 context, for example, when the allocation fails or the maximum call stack
 size is reached when the context is created.
 
-<a id="ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED"></a>
-
 ### `ERR_CRYPTO_CUSTOM_ENGINE_NOT_SUPPORTED`
 
 An OpenSSL engine was requested (for example, through the `clientCertEngine` or
 `privateKeyEngine` TLS options) that is not supported by the version of OpenSSL
 being used, likely due to the compile-time flag `OPENSSL_NO_ENGINE`.
 
-<a id="ERR_CRYPTO_ECDH_INVALID_FORMAT"></a>
-
 ### `ERR_CRYPTO_ECDH_INVALID_FORMAT`
 
 An invalid value for the `format` argument was passed to the `crypto.ECDH()`
 class `getPublicKey()` method.
-
-<a id="ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY"></a>
 
 ### `ERR_CRYPTO_ECDH_INVALID_PUBLIC_KEY`
 
@@ -844,53 +794,37 @@ An invalid value for the `key` argument has been passed to the
 `crypto.ECDH()` class `computeSecret()` method. It means that the public
 key lies outside of the elliptic curve.
 
-<a id="ERR_CRYPTO_ENGINE_UNKNOWN"></a>
-
 ### `ERR_CRYPTO_ENGINE_UNKNOWN`
 
 An invalid crypto engine identifier was passed to
 [`require('node:crypto').setEngine()`][].
-
-<a id="ERR_CRYPTO_FIPS_FORCED"></a>
 
 ### `ERR_CRYPTO_FIPS_FORCED`
 
 The [`--force-fips`][] command-line argument was used but there was an attempt
 to enable or disable FIPS mode in the `node:crypto` module.
 
-<a id="ERR_CRYPTO_FIPS_UNAVAILABLE"></a>
-
 ### `ERR_CRYPTO_FIPS_UNAVAILABLE`
 
 An attempt was made to enable or disable FIPS mode, but FIPS mode was not
 available.
-
-<a id="ERR_CRYPTO_HASH_FINALIZED"></a>
 
 ### `ERR_CRYPTO_HASH_FINALIZED`
 
 [`hash.digest()`][] was called multiple times. The `hash.digest()` method must
 be called no more than one time per instance of a `Hash` object.
 
-<a id="ERR_CRYPTO_HASH_UPDATE_FAILED"></a>
-
 ### `ERR_CRYPTO_HASH_UPDATE_FAILED`
 
 [`hash.update()`][] failed for any reason. This should rarely, if ever, happen.
-
-<a id="ERR_CRYPTO_INCOMPATIBLE_KEY"></a>
 
 ### `ERR_CRYPTO_INCOMPATIBLE_KEY`
 
 The given crypto keys are incompatible with the attempted operation.
 
-<a id="ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS"></a>
-
 ### `ERR_CRYPTO_INCOMPATIBLE_KEY_OPTIONS`
 
 The selected public or private key encoding is incompatible with other options.
-
-<a id="ERR_CRYPTO_INITIALIZATION_FAILED"></a>
 
 ### `ERR_CRYPTO_INITIALIZATION_FAILED`
 
@@ -900,8 +834,6 @@ added: v15.0.0
 
 Initialization of the crypto subsystem failed.
 
-<a id="ERR_CRYPTO_INVALID_AUTH_TAG"></a>
-
 ### `ERR_CRYPTO_INVALID_AUTH_TAG`
 
 <!-- YAML
@@ -909,8 +841,6 @@ added: v15.0.0
 -->
 
 An invalid authentication tag was provided.
-
-<a id="ERR_CRYPTO_INVALID_COUNTER"></a>
 
 ### `ERR_CRYPTO_INVALID_COUNTER`
 
@@ -920,8 +850,6 @@ added: v15.0.0
 
 An invalid counter was provided for a counter-mode cipher.
 
-<a id="ERR_CRYPTO_INVALID_CURVE"></a>
-
 ### `ERR_CRYPTO_INVALID_CURVE`
 
 <!-- YAML
@@ -930,13 +858,9 @@ added: v15.0.0
 
 An invalid elliptic-curve was provided.
 
-<a id="ERR_CRYPTO_INVALID_DIGEST"></a>
-
 ### `ERR_CRYPTO_INVALID_DIGEST`
 
 An invalid [crypto digest algorithm][] was specified.
-
-<a id="ERR_CRYPTO_INVALID_IV"></a>
 
 ### `ERR_CRYPTO_INVALID_IV`
 
@@ -946,8 +870,6 @@ added: v15.0.0
 
 An invalid initialization vector was provided.
 
-<a id="ERR_CRYPTO_INVALID_JWK"></a>
-
 ### `ERR_CRYPTO_INVALID_JWK`
 
 <!-- YAML
@@ -956,13 +878,9 @@ added: v15.0.0
 
 An invalid JSON Web Key was provided.
 
-<a id="ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE"></a>
-
 ### `ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE`
 
 The given crypto key object's type is invalid for the attempted operation.
-
-<a id="ERR_CRYPTO_INVALID_KEYLEN"></a>
 
 ### `ERR_CRYPTO_INVALID_KEYLEN`
 
@@ -972,8 +890,6 @@ added: v15.0.0
 
 An invalid key length was provided.
 
-<a id="ERR_CRYPTO_INVALID_KEYPAIR"></a>
-
 ### `ERR_CRYPTO_INVALID_KEYPAIR`
 
 <!-- YAML
@@ -981,8 +897,6 @@ added: v15.0.0
 -->
 
 An invalid key pair was provided.
-
-<a id="ERR_CRYPTO_INVALID_KEYTYPE"></a>
 
 ### `ERR_CRYPTO_INVALID_KEYTYPE`
 
@@ -992,8 +906,6 @@ added: v15.0.0
 
 An invalid key type was provided.
 
-<a id="ERR_CRYPTO_INVALID_MESSAGELEN"></a>
-
 ### `ERR_CRYPTO_INVALID_MESSAGELEN`
 
 <!-- YAML
@@ -1001,8 +913,6 @@ added: v15.0.0
 -->
 
 An invalid message length was provided.
-
-<a id="ERR_CRYPTO_INVALID_SCRYPT_PARAMS"></a>
 
 ### `ERR_CRYPTO_INVALID_SCRYPT_PARAMS`
 
@@ -1013,14 +923,10 @@ added: v15.0.0
 One or more [`crypto.scrypt()`][] or [`crypto.scryptSync()`][] parameters are
 outside their legal range.
 
-<a id="ERR_CRYPTO_INVALID_STATE"></a>
-
 ### `ERR_CRYPTO_INVALID_STATE`
 
 A crypto method was used on an object that was in an invalid state. For
 instance, calling [`cipher.getAuthTag()`][] before calling `cipher.final()`.
-
-<a id="ERR_CRYPTO_INVALID_TAG_LENGTH"></a>
 
 ### `ERR_CRYPTO_INVALID_TAG_LENGTH`
 
@@ -1030,8 +936,6 @@ added: v15.0.0
 
 An invalid authentication tag length was provided.
 
-<a id="ERR_CRYPTO_JOB_INIT_FAILED"></a>
-
 ### `ERR_CRYPTO_JOB_INIT_FAILED`
 
 <!-- YAML
@@ -1040,21 +944,15 @@ added: v15.0.0
 
 Initialization of an asynchronous crypto operation failed.
 
-<a id="ERR_CRYPTO_JWK_UNSUPPORTED_CURVE"></a>
-
 ### `ERR_CRYPTO_JWK_UNSUPPORTED_CURVE`
 
 Key's Elliptic Curve is not registered for use in the
 [JSON Web Key Elliptic Curve Registry][].
 
-<a id="ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE"></a>
-
 ### `ERR_CRYPTO_JWK_UNSUPPORTED_KEY_TYPE`
 
 Key's Asymmetric Key Type is not registered for use in the
 [JSON Web Key Types Registry][].
-
-<a id="ERR_CRYPTO_OPERATION_FAILED"></a>
 
 ### `ERR_CRYPTO_OPERATION_FAILED`
 
@@ -1064,47 +962,33 @@ added: v15.0.0
 
 A crypto operation failed for an otherwise unspecified reason.
 
-<a id="ERR_CRYPTO_PBKDF2_ERROR"></a>
-
 ### `ERR_CRYPTO_PBKDF2_ERROR`
 
 The PBKDF2 algorithm failed for unspecified reasons. OpenSSL does not provide
 more details and therefore neither does Node.js.
-
-<a id="ERR_CRYPTO_SCRYPT_NOT_SUPPORTED"></a>
 
 ### `ERR_CRYPTO_SCRYPT_NOT_SUPPORTED`
 
 Node.js was compiled without `scrypt` support. Not possible with the official
 release binaries but can happen with custom builds, including distro builds.
 
-<a id="ERR_CRYPTO_SIGN_KEY_REQUIRED"></a>
-
 ### `ERR_CRYPTO_SIGN_KEY_REQUIRED`
 
 A signing `key` was not provided to the [`sign.sign()`][] method.
-
-<a id="ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH"></a>
 
 ### `ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH`
 
 [`crypto.timingSafeEqual()`][] was called with `Buffer`, `TypedArray`, or
 `DataView` arguments of different lengths.
 
-<a id="ERR_CRYPTO_UNKNOWN_CIPHER"></a>
-
 ### `ERR_CRYPTO_UNKNOWN_CIPHER`
 
 An unknown cipher was specified.
-
-<a id="ERR_CRYPTO_UNKNOWN_DH_GROUP"></a>
 
 ### `ERR_CRYPTO_UNKNOWN_DH_GROUP`
 
 An unknown Diffie-Hellman group name was given. See
 [`crypto.getDiffieHellman()`][] for a list of valid group names.
-
-<a id="ERR_CRYPTO_UNSUPPORTED_OPERATION"></a>
 
 ### `ERR_CRYPTO_UNSUPPORTED_OPERATION`
 
@@ -1116,8 +1000,6 @@ added:
 
 An attempt to invoke an unsupported crypto operation was made.
 
-<a id="ERR_DEBUGGER_ERROR"></a>
-
 ### `ERR_DEBUGGER_ERROR`
 
 <!-- YAML
@@ -1127,8 +1009,6 @@ added:
 -->
 
 An error occurred with the [debugger][].
-
-<a id="ERR_DEBUGGER_STARTUP_ERROR"></a>
 
 ### `ERR_DEBUGGER_STARTUP_ERROR`
 
@@ -1140,8 +1020,6 @@ added:
 
 The [debugger][] timed out waiting for the required host/port to be free.
 
-<a id="ERR_DLOPEN_DISABLED"></a>
-
 ### `ERR_DLOPEN_DISABLED`
 
 <!-- YAML
@@ -1152,8 +1030,6 @@ added:
 
 Loading native addons has been disabled using [`--no-addons`][].
 
-<a id="ERR_DLOPEN_FAILED"></a>
-
 ### `ERR_DLOPEN_FAILED`
 
 <!-- YAML
@@ -1162,13 +1038,9 @@ added: v15.0.0
 
 A call to `process.dlopen()` failed.
 
-<a id="ERR_DIR_CLOSED"></a>
-
 ### `ERR_DIR_CLOSED`
 
 The [`fs.Dir`][] was previously closed.
-
-<a id="ERR_DIR_CONCURRENT_OPERATION"></a>
 
 ### `ERR_DIR_CONCURRENT_OPERATION`
 
@@ -1179,13 +1051,9 @@ added: v14.3.0
 A synchronous read or close call was attempted on an [`fs.Dir`][] which has
 ongoing asynchronous operations.
 
-<a id="ERR_DNS_SET_SERVERS_FAILED"></a>
-
 ### `ERR_DNS_SET_SERVERS_FAILED`
 
 `c-ares` failed to set the DNS server.
-
-<a id="ERR_DOMAIN_CALLBACK_NOT_AVAILABLE"></a>
 
 ### `ERR_DOMAIN_CALLBACK_NOT_AVAILABLE`
 
@@ -1193,8 +1061,6 @@ The `node:domain` module was not usable since it could not establish the
 required error handling hooks, because
 [`process.setUncaughtExceptionCaptureCallback()`][] had been called at an
 earlier point in time.
-
-<a id="ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE"></a>
 
 ### `ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE`
 
@@ -1204,40 +1070,28 @@ because the `node:domain` module has been loaded at an earlier point in time.
 The stack trace is extended to include the point in time at which the
 `node:domain` module had been loaded.
 
-<a id="ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION"></a>
-
 ### `ERR_DUPLICATE_STARTUP_SNAPSHOT_MAIN_FUNCTION`
 
 [`v8.startupSnapshot.setDeserializeMainFunction()`][] could not be called
 because it had already been called before.
-
-<a id="ERR_ENCODING_INVALID_ENCODED_DATA"></a>
 
 ### `ERR_ENCODING_INVALID_ENCODED_DATA`
 
 Data provided to `TextDecoder()` API was invalid according to the encoding
 provided.
 
-<a id="ERR_ENCODING_NOT_SUPPORTED"></a>
-
 ### `ERR_ENCODING_NOT_SUPPORTED`
 
 Encoding provided to `TextDecoder()` API was not one of the
 [WHATWG Supported Encodings][].
 
-<a id="ERR_EVAL_ESM_CANNOT_PRINT"></a>
-
 ### `ERR_EVAL_ESM_CANNOT_PRINT`
 
 `--print` cannot be used with ESM input.
 
-<a id="ERR_EVENT_RECURSION"></a>
-
 ### `ERR_EVENT_RECURSION`
 
 Thrown when an attempt is made to recursively dispatch an event on `EventTarget`.
-
-<a id="ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE"></a>
 
 ### `ERR_EXECUTION_ENVIRONMENT_NOT_AVAILABLE`
 
@@ -1245,14 +1099,10 @@ The JS execution context is not associated with a Node.js environment.
 This may occur when Node.js is used as an embedded library and some hooks
 for the JS engine are not set up properly.
 
-<a id="ERR_FALSY_VALUE_REJECTION"></a>
-
 ### `ERR_FALSY_VALUE_REJECTION`
 
 A `Promise` that was callbackified via `util.callbackify()` was rejected with a
 falsy value.
-
-<a id="ERR_FEATURE_UNAVAILABLE_ON_PLATFORM"></a>
 
 ### `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM`
 
@@ -1263,8 +1113,6 @@ added: v14.0.0
 Used when a feature that is not available
 to the current platform which is running Node.js is used.
 
-<a id="ERR_FS_CP_DIR_TO_NON_DIR"></a>
-
 ### `ERR_FS_CP_DIR_TO_NON_DIR`
 
 <!-- YAML
@@ -1273,8 +1121,6 @@ added: v16.7.0
 
 An attempt was made to copy a directory to a non-directory (file, symlink,
 etc.) using [`fs.cp()`][].
-
-<a id="ERR_FS_CP_EEXIST"></a>
 
 ### `ERR_FS_CP_EEXIST`
 
@@ -1285,8 +1131,6 @@ added: v16.7.0
 An attempt was made to copy over a file that already existed with
 [`fs.cp()`][], with the `force` and `errorOnExist` set to `true`.
 
-<a id="ERR_FS_CP_EINVAL"></a>
-
 ### `ERR_FS_CP_EINVAL`
 
 <!-- YAML
@@ -1295,20 +1139,14 @@ added: v16.7.0
 
 When using [`fs.cp()`][], `src` or `dest` pointed to an invalid path.
 
-<a id="ERR_HTTP_BODY_NOT_ALLOWED"></a>
-
 ### `ERR_HTTP_BODY_NOT_ALLOWED`
 
 An error is thrown when writing to an HTTP response which does not allow
 contents.
 
-<a id="ERR_HTTP_CONTENT_LENGTH_MISMATCH"></a>
-
 ### `ERR_HTTP_CONTENT_LENGTH_MISMATCH`
 
 Response body size doesn't match with the specified content-length header value.
-
-<a id="ERR_FS_CP_FIFO_PIPE"></a>
 
 ### `ERR_FS_CP_FIFO_PIPE`
 
@@ -1317,8 +1155,6 @@ added: v16.7.0
 -->
 
 An attempt was made to copy a named pipe with [`fs.cp()`][].
-
-<a id="ERR_FS_CP_NON_DIR_TO_DIR"></a>
 
 ### `ERR_FS_CP_NON_DIR_TO_DIR`
 
@@ -1329,8 +1165,6 @@ added: v16.7.0
 An attempt was made to copy a non-directory (file, symlink, etc.) to a directory
 using [`fs.cp()`][].
 
-<a id="ERR_FS_CP_SOCKET"></a>
-
 ### `ERR_FS_CP_SOCKET`
 
 <!-- YAML
@@ -1338,8 +1172,6 @@ added: v16.7.0
 -->
 
 An attempt was made to copy to a socket with [`fs.cp()`][].
-
-<a id="ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY"></a>
 
 ### `ERR_FS_CP_SYMLINK_TO_SUBDIRECTORY`
 
@@ -1350,8 +1182,6 @@ added: v16.7.0
 When using [`fs.cp()`][], a symlink in `dest` pointed to a subdirectory
 of `src`.
 
-<a id="ERR_FS_CP_UNKNOWN"></a>
-
 ### `ERR_FS_CP_UNKNOWN`
 
 <!-- YAML
@@ -1360,161 +1190,111 @@ added: v16.7.0
 
 An attempt was made to copy to an unknown file type with [`fs.cp()`][].
 
-<a id="ERR_FS_EISDIR"></a>
-
 ### `ERR_FS_EISDIR`
 
 Path is a directory.
-
-<a id="ERR_FS_FILE_TOO_LARGE"></a>
 
 ### `ERR_FS_FILE_TOO_LARGE`
 
 An attempt has been made to read a file whose size is larger than the maximum
 allowed size for a `Buffer`.
 
-<a id="ERR_HTTP_HEADERS_SENT"></a>
-
 ### `ERR_HTTP_HEADERS_SENT`
 
 An attempt was made to add more headers after the headers had already been sent.
-
-<a id="ERR_HTTP_INVALID_HEADER_VALUE"></a>
 
 ### `ERR_HTTP_INVALID_HEADER_VALUE`
 
 An invalid HTTP header value was specified.
 
-<a id="ERR_HTTP_INVALID_STATUS_CODE"></a>
-
 ### `ERR_HTTP_INVALID_STATUS_CODE`
 
 Status code was outside the regular status code range (100-999).
-
-<a id="ERR_HTTP_REQUEST_TIMEOUT"></a>
 
 ### `ERR_HTTP_REQUEST_TIMEOUT`
 
 The client has not sent the entire request within the allowed time.
 
-<a id="ERR_HTTP_SOCKET_ASSIGNED"></a>
-
 ### `ERR_HTTP_SOCKET_ASSIGNED`
 
 The given [`ServerResponse`][] was already assigned a socket.
 
-<a id="ERR_HTTP_SOCKET_ENCODING"></a>
-
 ### `ERR_HTTP_SOCKET_ENCODING`
 
 Changing the socket encoding is not allowed per [RFC 7230 Section 3][].
-
-<a id="ERR_HTTP_TRAILER_INVALID"></a>
 
 ### `ERR_HTTP_TRAILER_INVALID`
 
 The `Trailer` header was set even though the transfer encoding does not support
 that.
 
-<a id="ERR_HTTP2_ALTSVC_INVALID_ORIGIN"></a>
-
 ### `ERR_HTTP2_ALTSVC_INVALID_ORIGIN`
 
 HTTP/2 ALTSVC frames require a valid origin.
 
-<a id="ERR_HTTP2_ALTSVC_LENGTH"></a>
-
 ### `ERR_HTTP2_ALTSVC_LENGTH`
 
 HTTP/2 ALTSVC frames are limited to a maximum of 16,382 payload bytes.
-
-<a id="ERR_HTTP2_CONNECT_AUTHORITY"></a>
 
 ### `ERR_HTTP2_CONNECT_AUTHORITY`
 
 For HTTP/2 requests using the `CONNECT` method, the `:authority` pseudo-header
 is required.
 
-<a id="ERR_HTTP2_CONNECT_PATH"></a>
-
 ### `ERR_HTTP2_CONNECT_PATH`
 
 For HTTP/2 requests using the `CONNECT` method, the `:path` pseudo-header is
 forbidden.
-
-<a id="ERR_HTTP2_CONNECT_SCHEME"></a>
 
 ### `ERR_HTTP2_CONNECT_SCHEME`
 
 For HTTP/2 requests using the `CONNECT` method, the `:scheme` pseudo-header is
 forbidden.
 
-<a id="ERR_HTTP2_ERROR"></a>
-
 ### `ERR_HTTP2_ERROR`
 
 A non-specific HTTP/2 error has occurred.
-
-<a id="ERR_HTTP2_GOAWAY_SESSION"></a>
 
 ### `ERR_HTTP2_GOAWAY_SESSION`
 
 New HTTP/2 Streams may not be opened after the `Http2Session` has received a
 `GOAWAY` frame from the connected peer.
 
-<a id="ERR_HTTP2_HEADER_SINGLE_VALUE"></a>
-
 ### `ERR_HTTP2_HEADER_SINGLE_VALUE`
 
 Multiple values were provided for an HTTP/2 header field that was required to
 have only a single value.
 
-<a id="ERR_HTTP2_HEADERS_AFTER_RESPOND"></a>
-
 ### `ERR_HTTP2_HEADERS_AFTER_RESPOND`
 
 An additional headers was specified after an HTTP/2 response was initiated.
 
-<a id="ERR_HTTP2_HEADERS_SENT"></a>
-
 ### `ERR_HTTP2_HEADERS_SENT`
 
 An attempt was made to send multiple response headers.
-
-<a id="ERR_HTTP2_INFO_STATUS_NOT_ALLOWED"></a>
 
 ### `ERR_HTTP2_INFO_STATUS_NOT_ALLOWED`
 
 Informational HTTP status codes (`1xx`) may not be set as the response status
 code on HTTP/2 responses.
 
-<a id="ERR_HTTP2_INVALID_CONNECTION_HEADERS"></a>
-
 ### `ERR_HTTP2_INVALID_CONNECTION_HEADERS`
 
 HTTP/1 connection specific headers are forbidden to be used in HTTP/2
 requests and responses.
 
-<a id="ERR_HTTP2_INVALID_HEADER_VALUE"></a>
-
 ### `ERR_HTTP2_INVALID_HEADER_VALUE`
 
 An invalid HTTP/2 header value was specified.
-
-<a id="ERR_HTTP2_INVALID_INFO_STATUS"></a>
 
 ### `ERR_HTTP2_INVALID_INFO_STATUS`
 
 An invalid HTTP informational status code has been specified. Informational
 status codes must be an integer between `100` and `199` (inclusive).
 
-<a id="ERR_HTTP2_INVALID_ORIGIN"></a>
-
 ### `ERR_HTTP2_INVALID_ORIGIN`
 
 HTTP/2 `ORIGIN` frames require a valid origin.
-
-<a id="ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH"></a>
 
 ### `ERR_HTTP2_INVALID_PACKED_SETTINGS_LENGTH`
 
@@ -1522,33 +1302,23 @@ Input `Buffer` and `Uint8Array` instances passed to the
 `http2.getUnpackedSettings()` API must have a length that is a multiple of
 six.
 
-<a id="ERR_HTTP2_INVALID_PSEUDOHEADER"></a>
-
 ### `ERR_HTTP2_INVALID_PSEUDOHEADER`
 
 Only valid HTTP/2 pseudoheaders (`:status`, `:path`, `:authority`, `:scheme`,
 and `:method`) may be used.
-
-<a id="ERR_HTTP2_INVALID_SESSION"></a>
 
 ### `ERR_HTTP2_INVALID_SESSION`
 
 An action was performed on an `Http2Session` object that had already been
 destroyed.
 
-<a id="ERR_HTTP2_INVALID_SETTING_VALUE"></a>
-
 ### `ERR_HTTP2_INVALID_SETTING_VALUE`
 
 An invalid value has been specified for an HTTP/2 setting.
 
-<a id="ERR_HTTP2_INVALID_STREAM"></a>
-
 ### `ERR_HTTP2_INVALID_STREAM`
 
 An operation was performed on a stream that had already been destroyed.
-
-<a id="ERR_HTTP2_MAX_PENDING_SETTINGS_ACK"></a>
 
 ### `ERR_HTTP2_MAX_PENDING_SETTINGS_ACK`
 
@@ -1558,80 +1328,56 @@ required to send an acknowledgment that it has received and applied the new
 be sent at any given time. This error code is used when that limit has been
 reached.
 
-<a id="ERR_HTTP2_NESTED_PUSH"></a>
-
 ### `ERR_HTTP2_NESTED_PUSH`
 
 An attempt was made to initiate a new push stream from within a push stream.
 Nested push streams are not permitted.
 
-<a id="ERR_HTTP2_NO_MEM"></a>
-
 ### `ERR_HTTP2_NO_MEM`
 
 Out of memory when using the `http2session.setLocalWindowSize(windowSize)` API.
-
-<a id="ERR_HTTP2_NO_SOCKET_MANIPULATION"></a>
 
 ### `ERR_HTTP2_NO_SOCKET_MANIPULATION`
 
 An attempt was made to directly manipulate (read, write, pause, resume, etc.) a
 socket attached to an `Http2Session`.
 
-<a id="ERR_HTTP2_ORIGIN_LENGTH"></a>
-
 ### `ERR_HTTP2_ORIGIN_LENGTH`
 
 HTTP/2 `ORIGIN` frames are limited to a length of 16382 bytes.
-
-<a id="ERR_HTTP2_OUT_OF_STREAMS"></a>
 
 ### `ERR_HTTP2_OUT_OF_STREAMS`
 
 The number of streams created on a single HTTP/2 session reached the maximum
 limit.
 
-<a id="ERR_HTTP2_PAYLOAD_FORBIDDEN"></a>
-
 ### `ERR_HTTP2_PAYLOAD_FORBIDDEN`
 
 A message payload was specified for an HTTP response code for which a payload is
 forbidden.
 
-<a id="ERR_HTTP2_PING_CANCEL"></a>
-
 ### `ERR_HTTP2_PING_CANCEL`
 
 An HTTP/2 ping was canceled.
 
-<a id="ERR_HTTP2_PING_LENGTH"></a>
-
 ### `ERR_HTTP2_PING_LENGTH`
 
 HTTP/2 ping payloads must be exactly 8 bytes in length.
-
-<a id="ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED"></a>
 
 ### `ERR_HTTP2_PSEUDOHEADER_NOT_ALLOWED`
 
 An HTTP/2 pseudo-header has been used inappropriately. Pseudo-headers are header
 key names that begin with the `:` prefix.
 
-<a id="ERR_HTTP2_PUSH_DISABLED"></a>
-
 ### `ERR_HTTP2_PUSH_DISABLED`
 
 An attempt was made to create a push stream, which had been disabled by the
 client.
 
-<a id="ERR_HTTP2_SEND_FILE"></a>
-
 ### `ERR_HTTP2_SEND_FILE`
 
 An attempt was made to use the `Http2Stream.prototype.responseWithFile()` API to
 send a directory.
-
-<a id="ERR_HTTP2_SEND_FILE_NOSEEK"></a>
 
 ### `ERR_HTTP2_SEND_FILE_NOSEEK`
 
@@ -1639,59 +1385,41 @@ An attempt was made to use the `Http2Stream.prototype.responseWithFile()` API to
 send something other than a regular file, but `offset` or `length` options were
 provided.
 
-<a id="ERR_HTTP2_SESSION_ERROR"></a>
-
 ### `ERR_HTTP2_SESSION_ERROR`
 
 The `Http2Session` closed with a non-zero error code.
 
-<a id="ERR_HTTP2_SETTINGS_CANCEL"></a>
-
 ### `ERR_HTTP2_SETTINGS_CANCEL`
 
 The `Http2Session` settings canceled.
-
-<a id="ERR_HTTP2_SOCKET_BOUND"></a>
 
 ### `ERR_HTTP2_SOCKET_BOUND`
 
 An attempt was made to connect a `Http2Session` object to a `net.Socket` or
 `tls.TLSSocket` that had already been bound to another `Http2Session` object.
 
-<a id="ERR_HTTP2_SOCKET_UNBOUND"></a>
-
 ### `ERR_HTTP2_SOCKET_UNBOUND`
 
 An attempt was made to use the `socket` property of an `Http2Session` that
 has already been closed.
 
-<a id="ERR_HTTP2_STATUS_101"></a>
-
 ### `ERR_HTTP2_STATUS_101`
 
 Use of the `101` Informational status code is forbidden in HTTP/2.
-
-<a id="ERR_HTTP2_STATUS_INVALID"></a>
 
 ### `ERR_HTTP2_STATUS_INVALID`
 
 An invalid HTTP status code has been specified. Status codes must be an integer
 between `100` and `599` (inclusive).
 
-<a id="ERR_HTTP2_STREAM_CANCEL"></a>
-
 ### `ERR_HTTP2_STREAM_CANCEL`
 
 An `Http2Stream` was destroyed before any data was transmitted to the connected
 peer.
 
-<a id="ERR_HTTP2_STREAM_ERROR"></a>
-
 ### `ERR_HTTP2_STREAM_ERROR`
 
 A non-zero error code was been specified in an `RST_STREAM` frame.
-
-<a id="ERR_HTTP2_STREAM_SELF_DEPENDENCY"></a>
 
 ### `ERR_HTTP2_STREAM_SELF_DEPENDENCY`
 
@@ -1699,13 +1427,9 @@ When setting the priority for an HTTP/2 stream, the stream may be marked as
 a dependency for a parent stream. This error code is used when an attempt is
 made to mark a stream and dependent of itself.
 
-<a id="ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS"></a>
-
 ### `ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS`
 
 The number of supported custom settings (10) has been exceeded.
-
-<a id="ERR_HTTP2_TOO_MANY_INVALID_FRAMES"></a>
 
 ### `ERR_HTTP2_TOO_MANY_INVALID_FRAMES`
 
@@ -1716,13 +1440,9 @@ added: v15.14.0
 The limit of acceptable invalid HTTP/2 protocol frames sent by the peer,
 as specified through the `maxSessionInvalidFrames` option, has been exceeded.
 
-<a id="ERR_HTTP2_TRAILERS_ALREADY_SENT"></a>
-
 ### `ERR_HTTP2_TRAILERS_ALREADY_SENT`
 
 Trailing headers have already been sent on the `Http2Stream`.
-
-<a id="ERR_HTTP2_TRAILERS_NOT_READY"></a>
 
 ### `ERR_HTTP2_TRAILERS_NOT_READY`
 
@@ -1731,20 +1451,14 @@ The `http2stream.sendTrailers()` method cannot be called until after the
 `'wantTrailers'` event will only be emitted if the `waitForTrailers` option
 is set for the `Http2Stream`.
 
-<a id="ERR_HTTP2_UNSUPPORTED_PROTOCOL"></a>
-
 ### `ERR_HTTP2_UNSUPPORTED_PROTOCOL`
 
 `http2.connect()` was passed a URL that uses any protocol other than `http:` or
 `https:`.
 
-<a id="ERR_ILLEGAL_CONSTRUCTOR"></a>
-
 ### `ERR_ILLEGAL_CONSTRUCTOR`
 
 An attempt was made to construct an object using a non-public constructor.
-
-<a id="ERR_IMPORT_ATTRIBUTE_TYPE_INCOMPATIBLE"></a>
 
 ### `ERR_IMPORT_ATTRIBUTE_TYPE_INCOMPATIBLE`
 
@@ -1756,8 +1470,6 @@ added:
 An import `type` attribute was provided, but the specified module is of a
 different type.
 
-<a id="ERR_IMPORT_ATTRIBUTE_MISSING"></a>
-
 ### `ERR_IMPORT_ATTRIBUTE_MISSING`
 
 <!-- YAML
@@ -1766,8 +1478,6 @@ added:
 -->
 
 An import attribute is missing, preventing the specified module to be imported.
-
-<a id="ERR_IMPORT_ATTRIBUTE_UNSUPPORTED"></a>
 
 ### `ERR_IMPORT_ATTRIBUTE_UNSUPPORTED`
 
@@ -1780,14 +1490,10 @@ added:
 
 An import attribute is not supported by this version of Node.js.
 
-<a id="ERR_INCOMPATIBLE_OPTION_PAIR"></a>
-
 ### `ERR_INCOMPATIBLE_OPTION_PAIR`
 
 An option pair is incompatible with each other and cannot be used at the same
 time.
-
-<a id="ERR_INPUT_TYPE_NOT_ALLOWED"></a>
 
 ### `ERR_INPUT_TYPE_NOT_ALLOWED`
 
@@ -1796,131 +1502,91 @@ time.
 The `--input-type` flag was used to attempt to execute a file. This flag can
 only be used with input via `--eval`, `--print`, or `STDIN`.
 
-<a id="ERR_INSPECTOR_ALREADY_ACTIVATED"></a>
-
 ### `ERR_INSPECTOR_ALREADY_ACTIVATED`
 
 While using the `node:inspector` module, an attempt was made to activate the
 inspector when it already started to listen on a port. Use `inspector.close()`
 before activating it on a different address.
 
-<a id="ERR_INSPECTOR_ALREADY_CONNECTED"></a>
-
 ### `ERR_INSPECTOR_ALREADY_CONNECTED`
 
 While using the `node:inspector` module, an attempt was made to connect when the
 inspector was already connected.
-
-<a id="ERR_INSPECTOR_CLOSED"></a>
 
 ### `ERR_INSPECTOR_CLOSED`
 
 While using the `node:inspector` module, an attempt was made to use the
 inspector after the session had already closed.
 
-<a id="ERR_INSPECTOR_COMMAND"></a>
-
 ### `ERR_INSPECTOR_COMMAND`
 
 An error occurred while issuing a command via the `node:inspector` module.
-
-<a id="ERR_INSPECTOR_NOT_ACTIVE"></a>
 
 ### `ERR_INSPECTOR_NOT_ACTIVE`
 
 The `inspector` is not active when `inspector.waitForDebugger()` is called.
 
-<a id="ERR_INSPECTOR_NOT_AVAILABLE"></a>
-
 ### `ERR_INSPECTOR_NOT_AVAILABLE`
 
 The `node:inspector` module is not available for use.
-
-<a id="ERR_INSPECTOR_NOT_CONNECTED"></a>
 
 ### `ERR_INSPECTOR_NOT_CONNECTED`
 
 While using the `node:inspector` module, an attempt was made to use the
 inspector before it was connected.
 
-<a id="ERR_INSPECTOR_NOT_WORKER"></a>
-
 ### `ERR_INSPECTOR_NOT_WORKER`
 
 An API was called on the main thread that can only be used from
 the worker thread.
-
-<a id="ERR_INTERNAL_ASSERTION"></a>
 
 ### `ERR_INTERNAL_ASSERTION`
 
 There was a bug in Node.js or incorrect usage of Node.js internals.
 To fix the error, open an issue at <https://github.com/nodejs/node/issues>.
 
-<a id="ERR_INVALID_ADDRESS"></a>
-
 ### `ERR_INVALID_ADDRESS`
 
 The provided address is not understood by the Node.js API.
-
-<a id="ERR_INVALID_ADDRESS_FAMILY"></a>
 
 ### `ERR_INVALID_ADDRESS_FAMILY`
 
 The provided address family is not understood by the Node.js API.
 
-<a id="ERR_INVALID_ARG_TYPE"></a>
-
 ### `ERR_INVALID_ARG_TYPE`
 
 An argument of the wrong type was passed to a Node.js API.
 
-<a id="ERR_INVALID_ARG_VALUE"></a>
-
 ### `ERR_INVALID_ARG_VALUE`
 
 An invalid or unsupported value was passed for a given argument.
-
-<a id="ERR_INVALID_ASYNC_ID"></a>
 
 ### `ERR_INVALID_ASYNC_ID`
 
 An invalid `asyncId` or `triggerAsyncId` was passed using `AsyncHooks`. An id
 less than -1 should never happen.
 
-<a id="ERR_INVALID_BUFFER_SIZE"></a>
-
 ### `ERR_INVALID_BUFFER_SIZE`
 
 A swap was performed on a `Buffer` but its size was not compatible with the
 operation.
 
-<a id="ERR_INVALID_CHAR"></a>
-
 ### `ERR_INVALID_CHAR`
 
 Invalid characters were detected in headers.
-
-<a id="ERR_INVALID_CURSOR_POS"></a>
 
 ### `ERR_INVALID_CURSOR_POS`
 
 A cursor on a given stream cannot be moved to a specified row without a
 specified column.
 
-<a id="ERR_INVALID_FD"></a>
-
 ### `ERR_INVALID_FD`
 
 A file descriptor ('fd') was not valid (e.g. it was a negative value).
 
-<a id="ERR_INVALID_FD_TYPE"></a>
-
 ### `ERR_INVALID_FD_TYPE`
 
 A file descriptor ('fd') type was not valid.
-
-<a id="ERR_INVALID_FILE_URL_HOST"></a>
 
 ### `ERR_INVALID_FILE_URL_HOST`
 
@@ -1929,15 +1595,11 @@ A Node.js API that consumes `file:` URLs (such as certain functions in the
 situation can only occur on Unix-like systems where only `localhost` or an empty
 host is supported.
 
-<a id="ERR_INVALID_FILE_URL_PATH"></a>
-
 ### `ERR_INVALID_FILE_URL_PATH`
 
 A Node.js API that consumes `file:` URLs (such as certain functions in the
 [`fs`][] module) encountered a file URL with an incompatible path. The exact
 semantics for determining whether a path can be used is platform-dependent.
-
-<a id="ERR_INVALID_HANDLE_TYPE"></a>
 
 ### `ERR_INVALID_HANDLE_TYPE`
 
@@ -1945,25 +1607,17 @@ An attempt was made to send an unsupported "handle" over an IPC communication
 channel to a child process. See [`subprocess.send()`][] and [`process.send()`][]
 for more information.
 
-<a id="ERR_INVALID_HTTP_TOKEN"></a>
-
 ### `ERR_INVALID_HTTP_TOKEN`
 
 An invalid HTTP token was supplied.
-
-<a id="ERR_INVALID_IP_ADDRESS"></a>
 
 ### `ERR_INVALID_IP_ADDRESS`
 
 An IP address is not valid.
 
-<a id="ERR_INVALID_MIME_SYNTAX"></a>
-
 ### `ERR_INVALID_MIME_SYNTAX`
 
 The syntax of a MIME is not valid.
-
-<a id="ERR_INVALID_MODULE"></a>
 
 ### `ERR_INVALID_MODULE`
 
@@ -1976,82 +1630,58 @@ added:
 An attempt was made to load a module that does not exist or was otherwise not
 valid.
 
-<a id="ERR_INVALID_MODULE_SPECIFIER"></a>
-
 ### `ERR_INVALID_MODULE_SPECIFIER`
 
 The imported module string is an invalid URL, package name, or package subpath
 specifier.
-
-<a id="ERR_INVALID_OBJECT_DEFINE_PROPERTY"></a>
 
 ### `ERR_INVALID_OBJECT_DEFINE_PROPERTY`
 
 An error occurred while setting an invalid attribute on the property of
 an object.
 
-<a id="ERR_INVALID_PACKAGE_CONFIG"></a>
-
 ### `ERR_INVALID_PACKAGE_CONFIG`
 
 An invalid [`package.json`][] file failed parsing.
-
-<a id="ERR_INVALID_PACKAGE_TARGET"></a>
 
 ### `ERR_INVALID_PACKAGE_TARGET`
 
 The `package.json` [`"exports"`][] field contains an invalid target mapping
 value for the attempted module resolution.
 
-<a id="ERR_INVALID_PERFORMANCE_MARK"></a>
-
 ### `ERR_INVALID_PERFORMANCE_MARK`
 
 While using the Performance Timing API (`perf_hooks`), a performance mark is
 invalid.
 
-<a id="ERR_INVALID_PROTOCOL"></a>
-
 ### `ERR_INVALID_PROTOCOL`
 
 An invalid `options.protocol` was passed to `http.request()`.
-
-<a id="ERR_INVALID_REPL_EVAL_CONFIG"></a>
 
 ### `ERR_INVALID_REPL_EVAL_CONFIG`
 
 Both `breakEvalOnSigint` and `eval` options were set in the [`REPL`][] config,
 which is not supported.
 
-<a id="ERR_INVALID_REPL_INPUT"></a>
-
 ### `ERR_INVALID_REPL_INPUT`
 
 The input may not be used in the [`REPL`][]. The conditions under which this
 error is used are described in the [`REPL`][] documentation.
-
-<a id="ERR_INVALID_RETURN_PROPERTY"></a>
 
 ### `ERR_INVALID_RETURN_PROPERTY`
 
 Thrown in case a function option does not provide a valid value for one of its
 returned object properties on execution.
 
-<a id="ERR_INVALID_RETURN_PROPERTY_VALUE"></a>
-
 ### `ERR_INVALID_RETURN_PROPERTY_VALUE`
 
 Thrown in case a function option does not provide an expected value
 type for one of its returned object properties on execution.
 
-<a id="ERR_INVALID_RETURN_VALUE"></a>
-
 ### `ERR_INVALID_RETURN_VALUE`
 
 Thrown in case a function option does not return an expected value
 type on execution, such as when a function is expected to return a promise.
-
-<a id="ERR_INVALID_STATE"></a>
 
 ### `ERR_INVALID_STATE`
 
@@ -2063,15 +1693,11 @@ Indicates that an operation cannot be completed due to an invalid state.
 For instance, an object may have already been destroyed, or may be
 performing another operation.
 
-<a id="ERR_INVALID_SYNC_FORK_INPUT"></a>
-
 ### `ERR_INVALID_SYNC_FORK_INPUT`
 
 A `Buffer`, `TypedArray`, `DataView`, or `string` was provided as stdio input to
 an asynchronous fork. See the documentation for the [`child_process`][] module
 for more information.
-
-<a id="ERR_INVALID_THIS"></a>
 
 ### `ERR_INVALID_THIS`
 
@@ -2085,8 +1711,6 @@ urlSearchParams.has.call(buf, 'foo');
 // Throws a TypeError with code 'ERR_INVALID_THIS'
 ```
 
-<a id="ERR_INVALID_TUPLE"></a>
-
 ### `ERR_INVALID_TUPLE`
 
 An element in the `iterable` provided to the [WHATWG][WHATWG URL API]
@@ -2094,13 +1718,9 @@ An element in the `iterable` provided to the [WHATWG][WHATWG URL API]
 represent a `[name, value]` tuple – that is, if an element is not iterable, or
 does not consist of exactly two elements.
 
-<a id="ERR_INVALID_URI"></a>
-
 ### `ERR_INVALID_URI`
 
 An invalid URI was passed.
-
-<a id="ERR_INVALID_URL"></a>
 
 ### `ERR_INVALID_URL`
 
@@ -2109,8 +1729,6 @@ constructor][`new URL(input)`] or the legacy [`url.parse()`][] to be parsed.
 The thrown error object typically has an additional property `'input'` that
 contains the URL that failed to parse.
 
-<a id="ERR_INVALID_URL_SCHEME"></a>
-
 ### `ERR_INVALID_URL_SCHEME`
 
 An attempt was made to use a URL of an incompatible scheme (protocol) for a
@@ -2118,13 +1736,9 @@ specific purpose. It is only used in the [WHATWG URL API][] support in the
 [`fs`][] module (which only accepts URLs with `'file'` scheme), but may be used
 in other Node.js APIs as well in the future.
 
-<a id="ERR_IPC_CHANNEL_CLOSED"></a>
-
 ### `ERR_IPC_CHANNEL_CLOSED`
 
 An attempt was made to use an IPC communication channel that was already closed.
-
-<a id="ERR_IPC_DISCONNECTED"></a>
 
 ### `ERR_IPC_DISCONNECTED`
 
@@ -2132,23 +1746,17 @@ An attempt was made to disconnect an IPC communication channel that was already
 disconnected. See the documentation for the [`child_process`][] module
 for more information.
 
-<a id="ERR_IPC_ONE_PIPE"></a>
-
 ### `ERR_IPC_ONE_PIPE`
 
 An attempt was made to create a child Node.js process using more than one IPC
 communication channel. See the documentation for the [`child_process`][] module
 for more information.
 
-<a id="ERR_IPC_SYNC_FORK"></a>
-
 ### `ERR_IPC_SYNC_FORK`
 
 An attempt was made to open an IPC communication channel with a synchronously
 forked Node.js process. See the documentation for the [`child_process`][] module
 for more information.
-
-<a id="ERR_LOADER_CHAIN_INCOMPLETE"></a>
 
 ### `ERR_LOADER_CHAIN_INCOMPLETE`
 
@@ -2161,14 +1769,10 @@ added:
 An ESM loader hook returned without calling `next()` and without explicitly
 signaling a short circuit.
 
-<a id="ERR_MEMORY_ALLOCATION_FAILED"></a>
-
 ### `ERR_MEMORY_ALLOCATION_FAILED`
 
 An attempt was made to allocate memory (usually in the C++ layer) but it
 failed.
-
-<a id="ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE"></a>
 
 ### `ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE`
 
@@ -2183,13 +1787,9 @@ A message posted to a [`MessagePort`][] could not be deserialized in the target
 any context at this time, and attempting to transfer them using `postMessage()`
 can fail on the receiving side in that case.
 
-<a id="ERR_METHOD_NOT_IMPLEMENTED"></a>
-
 ### `ERR_METHOD_NOT_IMPLEMENTED`
 
 A method is required but not implemented.
-
-<a id="ERR_MISSING_ARGS"></a>
 
 ### `ERR_MISSING_ARGS`
 
@@ -2199,20 +1799,14 @@ strict compliance with the API specification (which in some cases may accept
 `func(undefined)` and `func()` are treated identically, and the
 [`ERR_INVALID_ARG_TYPE`][] error code may be used instead.
 
-<a id="ERR_MISSING_OPTION"></a>
-
 ### `ERR_MISSING_OPTION`
 
 For APIs that accept options objects, some options might be mandatory. This code
 is thrown if a required option is missing.
 
-<a id="ERR_MISSING_PASSPHRASE"></a>
-
 ### `ERR_MISSING_PASSPHRASE`
 
 An attempt was made to read an encrypted key without specifying a passphrase.
-
-<a id="ERR_MISSING_PLATFORM_FOR_WORKER"></a>
 
 ### `ERR_MISSING_PLATFORM_FOR_WORKER`
 
@@ -2220,14 +1814,10 @@ The V8 platform used by this instance of Node.js does not support creating
 Workers. This is caused by lack of embedder support for Workers. In particular,
 this error will not occur with standard builds of Node.js.
 
-<a id="ERR_MODULE_NOT_FOUND"></a>
-
 ### `ERR_MODULE_NOT_FOUND`
 
 A module file could not be resolved by the ECMAScript modules loader while
 attempting an `import` operation or when loading the program entry point.
-
-<a id="ERR_MULTIPLE_CALLBACK"></a>
 
 ### `ERR_MULTIPLE_CALLBACK`
 
@@ -2237,55 +1827,39 @@ A callback is almost always meant to only be called once as the query
 can either be fulfilled or rejected but not both at the same time. The latter
 would be possible by calling a callback more than once.
 
-<a id="ERR_NAPI_CONS_FUNCTION"></a>
-
 ### `ERR_NAPI_CONS_FUNCTION`
 
 While using `Node-API`, a constructor passed was not a function.
-
-<a id="ERR_NAPI_INVALID_DATAVIEW_ARGS"></a>
 
 ### `ERR_NAPI_INVALID_DATAVIEW_ARGS`
 
 While calling `napi_create_dataview()`, a given `offset` was outside the bounds
 of the dataview or `offset + length` was larger than a length of given `buffer`.
 
-<a id="ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT"></a>
-
 ### `ERR_NAPI_INVALID_TYPEDARRAY_ALIGNMENT`
 
 While calling `napi_create_typedarray()`, the provided `offset` was not a
 multiple of the element size.
-
-<a id="ERR_NAPI_INVALID_TYPEDARRAY_LENGTH"></a>
 
 ### `ERR_NAPI_INVALID_TYPEDARRAY_LENGTH`
 
 While calling `napi_create_typedarray()`, `(length * size_of_element) +
 byte_offset` was larger than the length of given `buffer`.
 
-<a id="ERR_NAPI_TSFN_CALL_JS"></a>
-
 ### `ERR_NAPI_TSFN_CALL_JS`
 
 An error occurred while invoking the JavaScript portion of the thread-safe
 function.
-
-<a id="ERR_NAPI_TSFN_GET_UNDEFINED"></a>
 
 ### `ERR_NAPI_TSFN_GET_UNDEFINED`
 
 An error occurred while attempting to retrieve the JavaScript `undefined`
 value.
 
-<a id="ERR_NOT_BUILDING_SNAPSHOT"></a>
-
 ### `ERR_NOT_BUILDING_SNAPSHOT`
 
 An attempt was made to use operations that can only be used when building
 V8 startup snapshot even though Node.js isn't building one.
-
-<a id="ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION"></a>
 
 ### `ERR_NOT_IN_SINGLE_EXECUTABLE_APPLICATION`
 
@@ -2298,55 +1872,39 @@ added:
 The operation cannot be performed when it's not in a single-executable
 application.
 
-<a id="ERR_NOT_SUPPORTED_IN_SNAPSHOT"></a>
-
 ### `ERR_NOT_SUPPORTED_IN_SNAPSHOT`
 
 An attempt was made to perform operations that are not supported when
 building a startup snapshot.
-
-<a id="ERR_NO_CRYPTO"></a>
 
 ### `ERR_NO_CRYPTO`
 
 An attempt was made to use crypto features while Node.js was not compiled with
 OpenSSL crypto support.
 
-<a id="ERR_NO_ICU"></a>
-
 ### `ERR_NO_ICU`
 
 An attempt was made to use features that require [ICU][], but Node.js was not
 compiled with ICU support.
 
-<a id="ERR_NON_CONTEXT_AWARE_DISABLED"></a>
-
 ### `ERR_NON_CONTEXT_AWARE_DISABLED`
 
 A non-context-aware native addon was loaded in a process that disallows them.
 
-<a id="ERR_OUT_OF_RANGE"></a>
-
 ### `ERR_OUT_OF_RANGE`
 
 A given value is out of the accepted range.
-
-<a id="ERR_PACKAGE_IMPORT_NOT_DEFINED"></a>
 
 ### `ERR_PACKAGE_IMPORT_NOT_DEFINED`
 
 The `package.json` [`"imports"`][] field does not define the given internal
 package specifier mapping.
 
-<a id="ERR_PACKAGE_PATH_NOT_EXPORTED"></a>
-
 ### `ERR_PACKAGE_PATH_NOT_EXPORTED`
 
 The `package.json` [`"exports"`][] field does not export the requested subpath.
 Because exports are encapsulated, private internal modules that are not exported
 cannot be imported through the package resolution, unless using an absolute URL.
-
-<a id="ERR_PARSE_ARGS_INVALID_OPTION_VALUE"></a>
 
 ### `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`
 
@@ -2360,8 +1918,6 @@ When `strict` set to `true`, thrown by [`util.parseArgs()`][] if a {boolean}
 value is provided for an option of type {string}, or if a {string}
 value is provided for an option of type {boolean}.
 
-<a id="ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL"></a>
-
 ### `ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL`
 
 <!-- YAML
@@ -2372,8 +1928,6 @@ added:
 
 Thrown by [`util.parseArgs()`][], when a positional argument is provided and
 `allowPositionals` is set to `false`.
-
-<a id="ERR_PARSE_ARGS_UNKNOWN_OPTION"></a>
 
 ### `ERR_PARSE_ARGS_UNKNOWN_OPTION`
 
@@ -2386,19 +1940,13 @@ added:
 When `strict` set to `true`, thrown by [`util.parseArgs()`][] if an argument
 is not configured in `options`.
 
-<a id="ERR_PERFORMANCE_INVALID_TIMESTAMP"></a>
-
 ### `ERR_PERFORMANCE_INVALID_TIMESTAMP`
 
 An invalid timestamp value was provided for a performance mark or measure.
 
-<a id="ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS"></a>
-
 ### `ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS`
 
 Invalid options were provided for a performance measure.
-
-<a id="ERR_PROTO_ACCESS"></a>
 
 ### `ERR_PROTO_ACCESS`
 
@@ -2406,8 +1954,6 @@ Accessing `Object.prototype.__proto__` has been forbidden using
 [`--disable-proto=throw`][]. [`Object.getPrototypeOf`][] and
 [`Object.setPrototypeOf`][] should be used to get and set the prototype of an
 object.
-
-<a id="ERR_REQUIRE_CYCLE_MODULE"></a>
 
 ### `ERR_REQUIRE_CYCLE_MODULE`
 
@@ -2422,8 +1968,6 @@ To avoid the cycle, the `require()` call involved in a cycle should not happen
 at the top-level of either an ES Module (via `createRequire()`) or a CommonJS
 module, and should be done lazily in an inner function.
 
-<a id="ERR_REQUIRE_ASYNC_MODULE"></a>
-
 ### `ERR_REQUIRE_ASYNC_MODULE`
 
 > Stability: 1 - Experimental
@@ -2434,8 +1978,6 @@ That is, it contains top-level await.
 To see where the top-level await is, use
 `--experimental-print-required-tla` (this would execute the modules
 before looking for the top-level awaits).
-
-<a id="ERR_REQUIRE_ESM"></a>
 
 ### `ERR_REQUIRE_ESM`
 
@@ -2454,20 +1996,14 @@ This error has been deprecated since `require()` now supports loading synchronou
 ES modules. When `require()` encounters an ES module that contains top-level
 `await`, it will throw [`ERR_REQUIRE_ASYNC_MODULE`][] instead.
 
-<a id="ERR_SCRIPT_EXECUTION_INTERRUPTED"></a>
-
 ### `ERR_SCRIPT_EXECUTION_INTERRUPTED`
 
 Script execution was interrupted by `SIGINT` (For
 example, <kbd>Ctrl</kbd>+<kbd>C</kbd> was pressed.)
 
-<a id="ERR_SCRIPT_EXECUTION_TIMEOUT"></a>
-
 ### `ERR_SCRIPT_EXECUTION_TIMEOUT`
 
 Script execution timed out, possibly due to bugs in the script being executed.
-
-<a id="ERR_SERVER_ALREADY_LISTEN"></a>
 
 ### `ERR_SERVER_ALREADY_LISTEN`
 
@@ -2475,15 +2011,11 @@ The [`server.listen()`][] method was called while a `net.Server` was already
 listening. This applies to all instances of `net.Server`, including HTTP, HTTPS,
 and HTTP/2 `Server` instances.
 
-<a id="ERR_SERVER_NOT_RUNNING"></a>
-
 ### `ERR_SERVER_NOT_RUNNING`
 
 The [`server.close()`][] method was called when a `net.Server` was not
 running. This applies to all instances of `net.Server`, including HTTP, HTTPS,
 and HTTP/2 `Server` instances.
-
-<a id="ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND"></a>
 
 ### `ERR_SINGLE_EXECUTABLE_APPLICATION_ASSET_NOT_FOUND`
 
@@ -2496,91 +2028,63 @@ added:
 A key was passed to single executable application APIs to identify an asset,
 but no match could be found.
 
-<a id="ERR_SOCKET_ALREADY_BOUND"></a>
-
 ### `ERR_SOCKET_ALREADY_BOUND`
 
 An attempt was made to bind a socket that has already been bound.
-
-<a id="ERR_SOCKET_BAD_BUFFER_SIZE"></a>
 
 ### `ERR_SOCKET_BAD_BUFFER_SIZE`
 
 An invalid (negative) size was passed for either the `recvBufferSize` or
 `sendBufferSize` options in [`dgram.createSocket()`][].
 
-<a id="ERR_SOCKET_BAD_PORT"></a>
-
 ### `ERR_SOCKET_BAD_PORT`
 
 An API function expecting a port >= 0 and < 65536 received an invalid value.
-
-<a id="ERR_SOCKET_BAD_TYPE"></a>
 
 ### `ERR_SOCKET_BAD_TYPE`
 
 An API function expecting a socket type (`udp4` or `udp6`) received an invalid
 value.
 
-<a id="ERR_SOCKET_BUFFER_SIZE"></a>
-
 ### `ERR_SOCKET_BUFFER_SIZE`
 
 While using [`dgram.createSocket()`][], the size of the receive or send `Buffer`
 could not be determined.
 
-<a id="ERR_SOCKET_CLOSED"></a>
-
 ### `ERR_SOCKET_CLOSED`
 
 An attempt was made to operate on an already closed socket.
-
-<a id="ERR_SOCKET_CLOSED_BEFORE_CONNECTION"></a>
 
 ### `ERR_SOCKET_CLOSED_BEFORE_CONNECTION`
 
 When calling [`net.Socket.write()`][] on a connecting socket and the socket was
 closed before the connection was established.
 
-<a id="ERR_SOCKET_CONNECTION_TIMEOUT"></a>
-
 ### `ERR_SOCKET_CONNECTION_TIMEOUT`
 
 The socket was unable to connect to any address returned by the DNS within the
 allowed timeout when using the family autoselection algorithm.
 
-<a id="ERR_SOCKET_DGRAM_IS_CONNECTED"></a>
-
 ### `ERR_SOCKET_DGRAM_IS_CONNECTED`
 
 A [`dgram.connect()`][] call was made on an already connected socket.
-
-<a id="ERR_SOCKET_DGRAM_NOT_CONNECTED"></a>
 
 ### `ERR_SOCKET_DGRAM_NOT_CONNECTED`
 
 A [`dgram.disconnect()`][] or [`dgram.remoteAddress()`][] call was made on a
 disconnected socket.
 
-<a id="ERR_SOCKET_DGRAM_NOT_RUNNING"></a>
-
 ### `ERR_SOCKET_DGRAM_NOT_RUNNING`
 
 A call was made and the UDP subsystem was not running.
-
-<a id="ERR_SOURCE_MAP_CORRUPT"></a>
 
 ### `ERR_SOURCE_MAP_CORRUPT`
 
 The source map could not be parsed because it does not exist, or is corrupt.
 
-<a id="ERR_SOURCE_MAP_MISSING_SOURCE"></a>
-
 ### `ERR_SOURCE_MAP_MISSING_SOURCE`
 
 A file imported from a source map was not found.
-
-<a id="ERR_SQLITE_ERROR"></a>
 
 ### `ERR_SQLITE_ERROR`
 
@@ -2590,68 +2094,48 @@ added: v22.5.0
 
 An error was returned from [SQLite][].
 
-<a id="ERR_SRI_PARSE"></a>
-
 ### `ERR_SRI_PARSE`
 
 A string was provided for a Subresource Integrity check, but was unable to be
 parsed. Check the format of integrity attributes by looking at the
 [Subresource Integrity specification][].
 
-<a id="ERR_STREAM_ALREADY_FINISHED"></a>
-
 ### `ERR_STREAM_ALREADY_FINISHED`
 
 A stream method was called that cannot complete because the stream was
 finished.
 
-<a id="ERR_STREAM_CANNOT_PIPE"></a>
-
 ### `ERR_STREAM_CANNOT_PIPE`
 
 An attempt was made to call [`stream.pipe()`][] on a [`Writable`][] stream.
-
-<a id="ERR_STREAM_DESTROYED"></a>
 
 ### `ERR_STREAM_DESTROYED`
 
 A stream method was called that cannot complete because the stream was
 destroyed using `stream.destroy()`.
 
-<a id="ERR_STREAM_NULL_VALUES"></a>
-
 ### `ERR_STREAM_NULL_VALUES`
 
 An attempt was made to call [`stream.write()`][] with a `null` chunk.
-
-<a id="ERR_STREAM_PREMATURE_CLOSE"></a>
 
 ### `ERR_STREAM_PREMATURE_CLOSE`
 
 An error returned by `stream.finished()` and `stream.pipeline()`, when a stream
 or a pipeline ends non gracefully with no explicit error.
 
-<a id="ERR_STREAM_PUSH_AFTER_EOF"></a>
-
 ### `ERR_STREAM_PUSH_AFTER_EOF`
 
 An attempt was made to call [`stream.push()`][] after a `null`(EOF) had been
 pushed to the stream.
 
-<a id="ERR_STREAM_UNABLE_TO_PIPE"></a>
-
 ### `ERR_STREAM_UNABLE_TO_PIPE`
 
 An attempt was made to pipe to a closed or destroyed stream in a pipeline.
-
-<a id="ERR_STREAM_UNSHIFT_AFTER_END_EVENT"></a>
 
 ### `ERR_STREAM_UNSHIFT_AFTER_END_EVENT`
 
 An attempt was made to call [`stream.unshift()`][] after the `'end'` event was
 emitted.
-
-<a id="ERR_STREAM_WRAP"></a>
 
 ### `ERR_STREAM_WRAP`
 
@@ -2665,28 +2149,20 @@ const instance = new Socket();
 instance.setEncoding('utf8');
 ```
 
-<a id="ERR_STREAM_WRITE_AFTER_END"></a>
-
 ### `ERR_STREAM_WRITE_AFTER_END`
 
 An attempt was made to call [`stream.write()`][] after `stream.end()` has been
 called.
-
-<a id="ERR_STRING_TOO_LONG"></a>
 
 ### `ERR_STRING_TOO_LONG`
 
 An attempt has been made to create a string longer than the maximum allowed
 length.
 
-<a id="ERR_SYNTHETIC"></a>
-
 ### `ERR_SYNTHETIC`
 
 An artificial error object used to capture the call stack for diagnostic
 reports.
-
-<a id="ERR_SYSTEM_ERROR"></a>
 
 ### `ERR_SYSTEM_ERROR`
 
@@ -2694,26 +2170,18 @@ An unspecified or non-specific system error has occurred within the Node.js
 process. The error object will have an `err.info` object property with
 additional details.
 
-<a id="ERR_TAP_LEXER_ERROR"></a>
-
 ### `ERR_TAP_LEXER_ERROR`
 
 An error representing a failing lexer state.
-
-<a id="ERR_TAP_PARSER_ERROR"></a>
 
 ### `ERR_TAP_PARSER_ERROR`
 
 An error representing a failing parser state. Additional information about
 the token causing the error is available via the `cause` property.
 
-<a id="ERR_TAP_VALIDATION_ERROR"></a>
-
 ### `ERR_TAP_VALIDATION_ERROR`
 
 This error represents a failed TAP validation.
-
-<a id="ERR_TEST_FAILURE"></a>
 
 ### `ERR_TEST_FAILURE`
 
@@ -2721,21 +2189,15 @@ This error represents a failed test. Additional information about the failure
 is available via the `cause` property. The `failureType` property specifies
 what the test was doing when the failure occurred.
 
-<a id="ERR_TLS_ALPN_CALLBACK_INVALID_RESULT"></a>
-
 ### `ERR_TLS_ALPN_CALLBACK_INVALID_RESULT`
 
 This error is thrown when an `ALPNCallback` returns a value that is not in the
 list of ALPN protocols offered by the client.
 
-<a id="ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS"></a>
-
 ### `ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS`
 
 This error is thrown when creating a `TLSServer` if the TLS options include
 both `ALPNProtocols` and `ALPNCallback`. These options are mutually exclusive.
-
-<a id="ERR_TLS_CERT_ALTNAME_FORMAT"></a>
 
 ### `ERR_TLS_CERT_ALTNAME_FORMAT`
 
@@ -2744,14 +2206,10 @@ This error is thrown by `checkServerIdentity` if a user-supplied
 by Node.js itself always comply with encoding rules and will never cause
 this error.
 
-<a id="ERR_TLS_CERT_ALTNAME_INVALID"></a>
-
 ### `ERR_TLS_CERT_ALTNAME_INVALID`
 
 While using TLS, the host name/IP of the peer did not match any of the
 `subjectAltNames` in its certificate.
-
-<a id="ERR_TLS_DH_PARAM_SIZE"></a>
 
 ### `ERR_TLS_DH_PARAM_SIZE`
 
@@ -2760,14 +2218,10 @@ key-agreement protocol is too small. By default, the key length must be greater
 than or equal to 1024 bits to avoid vulnerabilities, even though it is strongly
 recommended to use 2048 bits or larger for stronger security.
 
-<a id="ERR_TLS_HANDSHAKE_TIMEOUT"></a>
-
 ### `ERR_TLS_HANDSHAKE_TIMEOUT`
 
 A TLS/SSL handshake timed out. In this case, the server must also abort the
 connection.
-
-<a id="ERR_TLS_INVALID_CONTEXT"></a>
 
 ### `ERR_TLS_INVALID_CONTEXT`
 
@@ -2777,20 +2231,14 @@ added: v13.3.0
 
 The context must be a `SecureContext`.
 
-<a id="ERR_TLS_INVALID_PROTOCOL_METHOD"></a>
-
 ### `ERR_TLS_INVALID_PROTOCOL_METHOD`
 
 The specified  `secureProtocol` method is invalid. It is  either unknown, or
 disabled because it is insecure.
 
-<a id="ERR_TLS_INVALID_PROTOCOL_VERSION"></a>
-
 ### `ERR_TLS_INVALID_PROTOCOL_VERSION`
 
 Valid TLS protocol versions are `'TLSv1'`, `'TLSv1.1'`, or `'TLSv1.2'`.
-
-<a id="ERR_TLS_INVALID_STATE"></a>
 
 ### `ERR_TLS_INVALID_STATE`
 
@@ -2803,87 +2251,61 @@ added:
 The TLS socket must be connected and securely established. Ensure the 'secure'
 event is emitted before continuing.
 
-<a id="ERR_TLS_PROTOCOL_VERSION_CONFLICT"></a>
-
 ### `ERR_TLS_PROTOCOL_VERSION_CONFLICT`
 
 Attempting to set a TLS protocol `minVersion` or `maxVersion` conflicts with an
 attempt to set the `secureProtocol` explicitly. Use one mechanism or the other.
 
-<a id="ERR_TLS_PSK_SET_IDENTITY_HINT_FAILED"></a>
-
 ### `ERR_TLS_PSK_SET_IDENTITY_HINT_FAILED`
 
 Failed to set PSK identity hint. Hint may be too long.
-
-<a id="ERR_TLS_RENEGOTIATION_DISABLED"></a>
 
 ### `ERR_TLS_RENEGOTIATION_DISABLED`
 
 An attempt was made to renegotiate TLS on a socket instance with renegotiation
 disabled.
 
-<a id="ERR_TLS_REQUIRED_SERVER_NAME"></a>
-
 ### `ERR_TLS_REQUIRED_SERVER_NAME`
 
 While using TLS, the `server.addContext()` method was called without providing
 a host name in the first parameter.
-
-<a id="ERR_TLS_SESSION_ATTACK"></a>
 
 ### `ERR_TLS_SESSION_ATTACK`
 
 An excessive amount of TLS renegotiations is detected, which is a potential
 vector for denial-of-service attacks.
 
-<a id="ERR_TLS_SNI_FROM_SERVER"></a>
-
 ### `ERR_TLS_SNI_FROM_SERVER`
 
 An attempt was made to issue Server Name Indication from a TLS server-side
 socket, which is only valid from a client.
-
-<a id="ERR_TRACE_EVENTS_CATEGORY_REQUIRED"></a>
 
 ### `ERR_TRACE_EVENTS_CATEGORY_REQUIRED`
 
 The `trace_events.createTracing()` method requires at least one trace event
 category.
 
-<a id="ERR_TRACE_EVENTS_UNAVAILABLE"></a>
-
 ### `ERR_TRACE_EVENTS_UNAVAILABLE`
 
 The `node:trace_events` module could not be loaded because Node.js was compiled
 with the `--without-v8-platform` flag.
 
-<a id="ERR_TRANSFORM_ALREADY_TRANSFORMING"></a>
-
 ### `ERR_TRANSFORM_ALREADY_TRANSFORMING`
 
 A `Transform` stream finished while it was still transforming.
-
-<a id="ERR_TRANSFORM_WITH_LENGTH_0"></a>
 
 ### `ERR_TRANSFORM_WITH_LENGTH_0`
 
 A `Transform` stream finished with data still in the write buffer.
 
-<a id="ERR_TTY_INIT_FAILED"></a>
-
 ### `ERR_TTY_INIT_FAILED`
 
 The initialization of a TTY failed due to a system error.
-
-<a id="ERR_UNAVAILABLE_DURING_EXIT"></a>
 
 ### `ERR_UNAVAILABLE_DURING_EXIT`
 
 Function was called within a [`process.on('exit')`][] handler that shouldn't be
 called within [`process.on('exit')`][] handler.
-
-<a id="ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET"></a>
 
 ### `ERR_UNCAUGHT_EXCEPTION_CAPTURE_ALREADY_SET`
 
@@ -2893,20 +2315,14 @@ without first resetting the callback to `null`.
 This error is designed to prevent accidentally overwriting a callback registered
 from another module.
 
-<a id="ERR_UNESCAPED_CHARACTERS"></a>
-
 ### `ERR_UNESCAPED_CHARACTERS`
 
 A string that contained unescaped characters was received.
-
-<a id="ERR_UNHANDLED_ERROR"></a>
 
 ### `ERR_UNHANDLED_ERROR`
 
 An unhandled error occurred (for instance, when an `'error'` event is emitted
 by an [`EventEmitter`][] but an `'error'` handler is not registered).
-
-<a id="ERR_UNKNOWN_BUILTIN_MODULE"></a>
 
 ### `ERR_UNKNOWN_BUILTIN_MODULE`
 
@@ -2914,19 +2330,13 @@ Used to identify a specific kind of internal Node.js error that should not
 typically be triggered by user code. Instances of this error point to an
 internal bug within the Node.js binary itself.
 
-<a id="ERR_UNKNOWN_CREDENTIAL"></a>
-
 ### `ERR_UNKNOWN_CREDENTIAL`
 
 A Unix group or user identifier that does not exist was passed.
 
-<a id="ERR_UNKNOWN_ENCODING"></a>
-
 ### `ERR_UNKNOWN_ENCODING`
 
 An invalid or unknown encoding option was passed to an API.
-
-<a id="ERR_UNKNOWN_FILE_EXTENSION"></a>
 
 ### `ERR_UNKNOWN_FILE_EXTENSION`
 
@@ -2935,22 +2345,16 @@ An invalid or unknown encoding option was passed to an API.
 An attempt was made to load a module with an unknown or unsupported file
 extension.
 
-<a id="ERR_UNKNOWN_MODULE_FORMAT"></a>
-
 ### `ERR_UNKNOWN_MODULE_FORMAT`
 
 > Stability: 1 - Experimental
 
 An attempt was made to load a module with an unknown or unsupported format.
 
-<a id="ERR_UNKNOWN_SIGNAL"></a>
-
 ### `ERR_UNKNOWN_SIGNAL`
 
 An invalid or unknown process signal was passed to an API expecting a valid
 signal (such as [`subprocess.kill()`][]).
-
-<a id="ERR_UNSUPPORTED_DIR_IMPORT"></a>
 
 ### `ERR_UNSUPPORTED_DIR_IMPORT`
 
@@ -2964,13 +2368,9 @@ import './index.js'; // supported
 import 'package-name'; // supported
 ```
 
-<a id="ERR_UNSUPPORTED_ESM_URL_SCHEME"></a>
-
 ### `ERR_UNSUPPORTED_ESM_URL_SCHEME`
 
 `import` with URL schemes other than `file` and `data` is unsupported.
-
-<a id="ERR_UNSUPPORTED_RESOLVE_REQUEST"></a>
 
 ### `ERR_UNSUPPORTED_RESOLVE_REQUEST`
 
@@ -2990,34 +2390,24 @@ try {
 }
 ```
 
-<a id="ERR_USE_AFTER_CLOSE"></a>
-
 ### `ERR_USE_AFTER_CLOSE`
 
 > Stability: 1 - Experimental
 
 An attempt was made to use something that was already closed.
 
-<a id="ERR_VALID_PERFORMANCE_ENTRY_TYPE"></a>
-
 ### `ERR_VALID_PERFORMANCE_ENTRY_TYPE`
 
 While using the Performance Timing API (`perf_hooks`), no valid performance
 entry types are found.
 
-<a id="ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG"></a>
-
 ### `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`
 
 A dynamic import callback was invoked without `--experimental-vm-modules`.
 
-<a id="ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING"></a>
-
 ### `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`
 
 A dynamic import callback was not specified.
-
-<a id="ERR_VM_MODULE_ALREADY_LINKED"></a>
 
 ### `ERR_VM_MODULE_ALREADY_LINKED`
 
@@ -3028,57 +2418,39 @@ the following reasons:
 * It is being linked (`linkingStatus` is `'linking'`)
 * Linking has failed for this module (`linkingStatus` is `'errored'`)
 
-<a id="ERR_VM_MODULE_CACHED_DATA_REJECTED"></a>
-
 ### `ERR_VM_MODULE_CACHED_DATA_REJECTED`
 
 The `cachedData` option passed to a module constructor is invalid.
 
-<a id="ERR_VM_MODULE_CANNOT_CREATE_CACHED_DATA"></a>
-
 ### `ERR_VM_MODULE_CANNOT_CREATE_CACHED_DATA`
 
 Cached data cannot be created for modules which have already been evaluated.
-
-<a id="ERR_VM_MODULE_DIFFERENT_CONTEXT"></a>
 
 ### `ERR_VM_MODULE_DIFFERENT_CONTEXT`
 
 The module being returned from the linker function is from a different context
 than the parent module. Linked modules must share the same context.
 
-<a id="ERR_VM_MODULE_LINK_FAILURE"></a>
-
 ### `ERR_VM_MODULE_LINK_FAILURE`
 
 The module was unable to be linked due to a failure.
 
-<a id="ERR_VM_MODULE_NOT_MODULE"></a>
-
 ### `ERR_VM_MODULE_NOT_MODULE`
 
 The fulfilled value of a linking promise is not a `vm.Module` object.
-
-<a id="ERR_VM_MODULE_STATUS"></a>
 
 ### `ERR_VM_MODULE_STATUS`
 
 The current module's status does not allow for this operation. The specific
 meaning of the error depends on the specific function.
 
-<a id="ERR_WASI_ALREADY_STARTED"></a>
-
 ### `ERR_WASI_ALREADY_STARTED`
 
 The WASI instance has already started.
 
-<a id="ERR_WASI_NOT_STARTED"></a>
-
 ### `ERR_WASI_NOT_STARTED`
 
 The WASI instance has not been started.
-
-<a id="ERR_WEBASSEMBLY_RESPONSE"></a>
 
 ### `ERR_WEBASSEMBLY_RESPONSE`
 
@@ -3089,39 +2461,27 @@ added: v18.1.0
 The `Response` that has been passed to `WebAssembly.compileStreaming` or to
 `WebAssembly.instantiateStreaming` is not a valid WebAssembly response.
 
-<a id="ERR_WORKER_INIT_FAILED"></a>
-
 ### `ERR_WORKER_INIT_FAILED`
 
 The `Worker` initialization failed.
-
-<a id="ERR_WORKER_INVALID_EXEC_ARGV"></a>
 
 ### `ERR_WORKER_INVALID_EXEC_ARGV`
 
 The `execArgv` option passed to the `Worker` constructor contains
 invalid flags.
 
-<a id="ERR_WORKER_NOT_RUNNING"></a>
-
 ### `ERR_WORKER_NOT_RUNNING`
 
 An operation failed because the `Worker` instance is not currently running.
-
-<a id="ERR_WORKER_OUT_OF_MEMORY"></a>
 
 ### `ERR_WORKER_OUT_OF_MEMORY`
 
 The `Worker` instance terminated because it reached its memory limit.
 
-<a id="ERR_WORKER_PATH"></a>
-
 ### `ERR_WORKER_PATH`
 
 The path for the main script of a worker is neither an absolute path
 nor a relative path starting with `./` or `../`.
-
-<a id="ERR_WORKER_MESSAGING_ERRORED"></a>
 
 ### `ERR_WORKER_MESSAGING_ERRORED`
 
@@ -3133,8 +2493,6 @@ added: v22.5.0
 
 The destination thread threw an error while processing a message sent via [`postMessageToThread()`][].
 
-<a id="ERR_WORKER_MESSAGING_FAILED"></a>
-
 ### `ERR_WORKER_MESSAGING_FAILED`
 
 <!-- YAML
@@ -3144,8 +2502,6 @@ added: v22.5.0
 > Stability: 1.1 - Active development
 
 The thread requested in [`postMessageToThread()`][] is invalid or has no `workerMessage` listener.
-
-<a id="ERR_WORKER_MESSAGING_SAME_THREAD"></a>
 
 ### `ERR_WORKER_MESSAGING_SAME_THREAD`
 
@@ -3157,8 +2513,6 @@ added: v22.5.0
 
 The thread id requested in [`postMessageToThread()`][] is the current thread id.
 
-<a id="ERR_WORKER_MESSAGING_TIMEOUT"></a>
-
 ### `ERR_WORKER_MESSAGING_TIMEOUT`
 
 <!-- YAML
@@ -3169,25 +2523,17 @@ added: v22.5.0
 
 Sending a message via [`postMessageToThread()`][] timed out.
 
-<a id="ERR_WORKER_UNSERIALIZABLE_ERROR"></a>
-
 ### `ERR_WORKER_UNSERIALIZABLE_ERROR`
 
 All attempts at serializing an uncaught exception from a worker thread failed.
-
-<a id="ERR_WORKER_UNSUPPORTED_OPERATION"></a>
 
 ### `ERR_WORKER_UNSUPPORTED_OPERATION`
 
 The requested functionality is not supported in worker threads.
 
-<a id="ERR_ZLIB_INITIALIZATION_FAILED"></a>
-
 ### `ERR_ZLIB_INITIALIZATION_FAILED`
 
 Creation of a [`zlib`][] object failed due to incorrect configuration.
-
-<a id="HPE_HEADER_OVERFLOW"></a>
 
 ### `HPE_HEADER_OVERFLOW`
 
@@ -3206,8 +2552,6 @@ malconfigured clients, if more than `maxHeaderSize` of HTTP header data is recei
 HTTP parsing will abort without a request or response object being created, and
 an `Error` with this code will be emitted.
 
-<a id="HPE_CHUNK_EXTENSIONS_OVERFLOW"></a>
-
 ### `HPE_CHUNK_EXTENSIONS_OVERFLOW`
 
 <!-- YAML
@@ -3221,8 +2565,6 @@ Too much data was received for a chunk extensions. In order to protect against
 malicious or malconfigured clients, if more than 16 KiB of data is received
 then an `Error` with this code will be emitted.
 
-<a id="HPE_UNEXPECTED_CONTENT_LENGTH"></a>
-
 ### `HPE_UNEXPECTED_CONTENT_LENGTH`
 
 Server is sending both a `Content-Length` header and `Transfer-Encoding: chunked`.
@@ -3232,8 +2574,6 @@ connection for dynamically generated content.
 In this case, the `Content-Length` HTTP header cannot be used.
 
 Use `Content-Length` or `Transfer-Encoding: chunked`.
-
-<a id="MODULE_NOT_FOUND"></a>
 
 ### `MODULE_NOT_FOUND`
 
@@ -3252,8 +2592,6 @@ attempting a [`require()`][] operation or when loading the program entry point.
 > Stability: 0 - Deprecated. These error codes are either inconsistent, or have
 > been removed.
 
-<a id="ERR_CANNOT_TRANSFER_OBJECT"></a>
-
 ### `ERR_CANNOT_TRANSFER_OBJECT`
 
 <!-- YAML
@@ -3263,8 +2601,6 @@ removed: v12.5.0
 
 The value passed to `postMessage()` contained an object that is not supported
 for transferring.
-
-<a id="ERR_CRYPTO_HASH_DIGEST_NO_UTF16"></a>
 
 ### `ERR_CRYPTO_HASH_DIGEST_NO_UTF16`
 
@@ -3278,8 +2614,6 @@ The UTF-16 encoding was used with [`hash.digest()`][]. While the
 causing the method to return a string rather than a `Buffer`, the UTF-16
 encoding (e.g. `ucs` or `utf16le`) is not supported.
 
-<a id="ERR_CRYPTO_SCRYPT_INVALID_PARAMETER"></a>
-
 ### `ERR_CRYPTO_SCRYPT_INVALID_PARAMETER`
 
 <!-- YAML
@@ -3290,8 +2624,6 @@ An incompatible combination of options was passed to [`crypto.scrypt()`][] or
 [`crypto.scryptSync()`][]. New versions of Node.js use the error code
 [`ERR_INCOMPATIBLE_OPTION_PAIR`][] instead, which is consistent with other APIs.
 
-<a id="ERR_FS_INVALID_SYMLINK_TYPE"></a>
-
 ### `ERR_FS_INVALID_SYMLINK_TYPE`
 
 <!-- YAML
@@ -3300,8 +2632,6 @@ removed: REPLACEME
 
 An invalid symlink type was passed to the [`fs.symlink()`][] or
 [`fs.symlinkSync()`][] methods.
-
-<a id="ERR_HTTP2_FRAME_ERROR"></a>
 
 ### `ERR_HTTP2_FRAME_ERROR`
 
@@ -3313,8 +2643,6 @@ removed: v10.0.0
 Used when a failure occurs sending an individual frame on the HTTP/2
 session.
 
-<a id="ERR_HTTP2_HEADERS_OBJECT"></a>
-
 ### `ERR_HTTP2_HEADERS_OBJECT`
 
 <!-- YAML
@@ -3324,8 +2652,6 @@ removed: v10.0.0
 
 Used when an HTTP/2 Headers Object is expected.
 
-<a id="ERR_HTTP2_HEADER_REQUIRED"></a>
-
 ### `ERR_HTTP2_HEADER_REQUIRED`
 
 <!-- YAML
@@ -3334,8 +2660,6 @@ removed: v10.0.0
 -->
 
 Used when a required header is missing in an HTTP/2 message.
-
-<a id="ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND"></a>
 
 ### `ERR_HTTP2_INFO_HEADERS_AFTER_RESPOND`
 
@@ -3347,8 +2671,6 @@ removed: v10.0.0
 HTTP/2 informational headers must only be sent _prior_ to calling the
 `Http2Stream.prototype.respond()` method.
 
-<a id="ERR_HTTP2_STREAM_CLOSED"></a>
-
 ### `ERR_HTTP2_STREAM_CLOSED`
 
 <!-- YAML
@@ -3358,8 +2680,6 @@ removed: v10.0.0
 
 Used when an action has been performed on an HTTP/2 Stream that has already
 been closed.
-
-<a id="ERR_HTTP_INVALID_CHAR"></a>
 
 ### `ERR_HTTP_INVALID_CHAR`
 
@@ -3371,8 +2691,6 @@ removed: v10.0.0
 Used when an invalid character is found in an HTTP response status message
 (reason phrase).
 
-<a id="ERR_INDEX_OUT_OF_RANGE"></a>
-
 ### `ERR_INDEX_OUT_OF_RANGE`
 
 <!-- YAML
@@ -3381,8 +2699,6 @@ Used when an invalid character is found in an HTTP response status message
 -->
 
 A given index was out of the accepted range (e.g. negative offsets).
-
-<a id="ERR_INVALID_OPT_VALUE"></a>
 
 ### `ERR_INVALID_OPT_VALUE`
 
@@ -3393,8 +2709,6 @@ removed: v15.0.0
 
 An invalid or unexpected value was passed in an options object.
 
-<a id="ERR_INVALID_OPT_VALUE_ENCODING"></a>
-
 ### `ERR_INVALID_OPT_VALUE_ENCODING`
 
 <!-- YAML
@@ -3403,8 +2717,6 @@ removed: v15.0.0
 -->
 
 An invalid or unknown file encoding was passed.
-
-<a id="ERR_INVALID_TRANSFER_OBJECT"></a>
 
 ### `ERR_INVALID_TRANSFER_OBJECT`
 
@@ -3418,8 +2730,6 @@ changes:
 
 An invalid transfer object was passed to `postMessage()`.
 
-<a id="ERR_IMPORT_ASSERTION_TYPE_FAILED"></a>
-
 ### `ERR_IMPORT_ASSERTION_TYPE_FAILED`
 
 <!-- YAML
@@ -3430,8 +2740,6 @@ removed: v21.1.0
 -->
 
 An import assertion has failed, preventing the specified module to be imported.
-
-<a id="ERR_IMPORT_ASSERTION_TYPE_MISSING"></a>
 
 ### `ERR_IMPORT_ASSERTION_TYPE_MISSING`
 
@@ -3444,8 +2752,6 @@ removed: v21.1.0
 
 An import assertion is missing, preventing the specified module to be imported.
 
-<a id="ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED"></a>
-
 ### `ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED`
 
 <!-- YAML
@@ -3457,8 +2763,6 @@ removed: v21.1.0
 
 An import attribute is not supported by this version of Node.js.
 
-<a id="ERR_MANIFEST_ASSERT_INTEGRITY"></a>
-
 ### `ERR_MANIFEST_ASSERT_INTEGRITY`
 
 <!-- YAML
@@ -3469,8 +2773,6 @@ An attempt was made to load a resource, but the resource did not match the
 integrity defined by the policy manifest. See the documentation for policy
 manifests for more information.
 
-<a id="ERR_MANIFEST_DEPENDENCY_MISSING"></a>
-
 ### `ERR_MANIFEST_DEPENDENCY_MISSING`
 
 <!-- YAML
@@ -3480,8 +2782,6 @@ removed: v22.2.0
 An attempt was made to load a resource, but the resource was not listed as a
 dependency from the location that attempted to load it. See the documentation
 for policy manifests for more information.
-
-<a id="ERR_MANIFEST_INTEGRITY_MISMATCH"></a>
 
 ### `ERR_MANIFEST_INTEGRITY_MISMATCH`
 
@@ -3494,8 +2794,6 @@ entries for a resource which did not match each other. Update the manifest
 entries to match in order to resolve this error. See the documentation for
 policy manifests for more information.
 
-<a id="ERR_MANIFEST_INVALID_RESOURCE_FIELD"></a>
-
 ### `ERR_MANIFEST_INVALID_RESOURCE_FIELD`
 
 <!-- YAML
@@ -3505,8 +2803,6 @@ removed: v22.2.0
 A policy manifest resource had an invalid value for one of its fields. Update
 the manifest entry to match in order to resolve this error. See the
 documentation for policy manifests for more information.
-
-<a id="ERR_MANIFEST_INVALID_SPECIFIER"></a>
 
 ### `ERR_MANIFEST_INVALID_SPECIFIER`
 
@@ -3518,8 +2814,6 @@ A policy manifest resource had an invalid value for one of its dependency
 mappings. Update the manifest entry to match to resolve this error. See the
 documentation for policy manifests for more information.
 
-<a id="ERR_MANIFEST_PARSE_POLICY"></a>
-
 ### `ERR_MANIFEST_PARSE_POLICY`
 
 <!-- YAML
@@ -3528,8 +2822,6 @@ removed: v22.2.0
 
 An attempt was made to load a policy manifest, but the manifest was unable to
 be parsed. See the documentation for policy manifests for more information.
-
-<a id="ERR_MANIFEST_TDZ"></a>
 
 ### `ERR_MANIFEST_TDZ`
 
@@ -3540,8 +2832,6 @@ removed: v22.2.0
 An attempt was made to read from a policy manifest, but the manifest
 initialization has not yet taken place. This is likely a bug in Node.js.
 
-<a id="ERR_MANIFEST_UNKNOWN_ONERROR"></a>
-
 ### `ERR_MANIFEST_UNKNOWN_ONERROR`
 
 <!-- YAML
@@ -3550,8 +2840,6 @@ removed: v22.2.0
 
 A policy manifest was loaded, but had an unknown value for its "onerror"
 behavior. See the documentation for policy manifests for more information.
-
-<a id="ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST"></a>
 
 ### `ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`
 
@@ -3562,8 +2850,6 @@ removed: v15.0.0
 This error code was replaced by [`ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`][]
 in Node.js v15.0.0, because it is no longer accurate as other types of
 transferable objects also exist now.
-
-<a id="ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST"></a>
 
 ### `ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`
 
@@ -3585,8 +2871,6 @@ In Node.js versions prior to v15.0.0, the error code being used here was
 transferable object types has been expanded to cover more types than
 `MessagePort`.
 
-<a id="ERR_NAPI_CONS_PROTOTYPE_OBJECT"></a>
-
 ### `ERR_NAPI_CONS_PROTOTYPE_OBJECT`
 
 <!-- YAML
@@ -3595,8 +2879,6 @@ removed: v10.0.0
 -->
 
 Used by the `Node-API` when `Constructor.prototype` is not an object.
-
-<a id="ERR_NAPI_TSFN_START_IDLE_LOOP"></a>
 
 ### `ERR_NAPI_TSFN_START_IDLE_LOOP`
 
@@ -3613,8 +2895,6 @@ On the main thread, values are removed from the queue associated with the
 thread-safe function in an idle loop. This error indicates that an error
 has occurred when attempting to start the loop.
 
-<a id="ERR_NAPI_TSFN_STOP_IDLE_LOOP"></a>
-
 ### `ERR_NAPI_TSFN_STOP_IDLE_LOOP`
 
 <!-- YAML
@@ -3629,14 +2909,10 @@ removed:
 Once no more items are left in the queue, the idle loop must be suspended. This
 error indicates that the idle loop has failed to stop.
 
-<a id="ERR_NO_LONGER_SUPPORTED"></a>
-
 ### `ERR_NO_LONGER_SUPPORTED`
 
 A Node.js API was called in an unsupported manner, such as
 `Buffer.write(string, encoding, offset[, length])`.
-
-<a id="ERR_OPERATION_FAILED"></a>
 
 ### `ERR_OPERATION_FAILED`
 
@@ -3646,8 +2922,6 @@ added: v15.0.0
 
 An operation failed. This is typically used to signal the general failure
 of an asynchronous operation.
-
-<a id="ERR_OUTOFMEMORY"></a>
 
 ### `ERR_OUTOFMEMORY`
 
@@ -3659,8 +2933,6 @@ removed: v10.0.0
 Used generically to identify that an operation caused an out of memory
 condition.
 
-<a id="ERR_PARSE_HISTORY_DATA"></a>
-
 ### `ERR_PARSE_HISTORY_DATA`
 
 <!-- YAML
@@ -3669,8 +2941,6 @@ removed: v10.0.0
 -->
 
 The `node:repl` module was unable to parse data from the REPL history file.
-
-<a id="ERR_QUIC_CONNECTION_FAILED"></a>
 
 ### `ERR_QUIC_CONNECTION_FAILED`
 
@@ -3682,8 +2952,6 @@ added: REPLACEME
 
 Establishing a QUIC connection failed.
 
-<a id="ERR_QUIC_ENDPOINT_CLOSED"></a>
-
 ### `ERR_QUIC_ENDPOINT_CLOSED`
 
 <!-- YAML
@@ -3693,8 +2961,6 @@ added: REPLACEME
 > Stability: 1 - Experimental
 
 A QUIC Endpoint closed with an error.
-
-<a id="ERR_QUIC_OPEN_STREAM_FAILED"></a>
 
 ### `ERR_QUIC_OPEN_STREAM_FAILED`
 
@@ -3706,8 +2972,6 @@ added: REPLACEME
 
 Opening a QUIC stream failed.
 
-<a id="ERR_SOCKET_CANNOT_SEND"></a>
-
 ### `ERR_SOCKET_CANNOT_SEND`
 
 <!-- YAML
@@ -3716,8 +2980,6 @@ removed: v14.0.0
 -->
 
 Data could not be sent on a socket.
-
-<a id="ERR_STDERR_CLOSE"></a>
 
 ### `ERR_STDERR_CLOSE`
 
@@ -3734,8 +2996,6 @@ changes:
 An attempt was made to close the `process.stderr` stream. By design, Node.js
 does not allow `stdout` or `stderr` streams to be closed by user code.
 
-<a id="ERR_STDOUT_CLOSE"></a>
-
 ### `ERR_STDOUT_CLOSE`
 
 <!-- YAML
@@ -3751,8 +3011,6 @@ changes:
 An attempt was made to close the `process.stdout` stream. By design, Node.js
 does not allow `stdout` or `stderr` streams to be closed by user code.
 
-<a id="ERR_STREAM_READ_NOT_IMPLEMENTED"></a>
-
 ### `ERR_STREAM_READ_NOT_IMPLEMENTED`
 
 <!-- YAML
@@ -3763,8 +3021,6 @@ removed: v10.0.0
 Used when an attempt is made to use a readable stream that has not implemented
 [`readable._read()`][].
 
-<a id="ERR_TLS_RENEGOTIATION_FAILED"></a>
-
 ### `ERR_TLS_RENEGOTIATION_FAILED`
 
 <!-- YAML
@@ -3773,8 +3029,6 @@ removed: v10.0.0
 -->
 
 Used when a TLS renegotiation request has failed in a non-specific way.
-
-<a id="ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER"></a>
 
 ### `ERR_TRANSFERRING_EXTERNALIZED_SHAREDARRAYBUFFER`
 
@@ -3790,8 +3044,6 @@ cannot be serialized.
 This can only happen when native addons create `SharedArrayBuffer`s in
 "externalized" mode, or put existing `SharedArrayBuffer` into externalized mode.
 
-<a id="ERR_UNKNOWN_STDIN_TYPE"></a>
-
 ### `ERR_UNKNOWN_STDIN_TYPE`
 
 <!-- YAML
@@ -3802,8 +3054,6 @@ removed: v11.7.0
 An attempt was made to launch a Node.js process with an unknown `stdin` file
 type. This error is usually an indication of a bug within Node.js itself,
 although it is possible for user code to trigger it.
-
-<a id="ERR_UNKNOWN_STREAM_TYPE"></a>
 
 ### `ERR_UNKNOWN_STREAM_TYPE`
 
@@ -3816,13 +3066,9 @@ An attempt was made to launch a Node.js process with an unknown `stdout` or
 `stderr` file type. This error is usually an indication of a bug within Node.js
 itself, although it is possible for user code to trigger it.
 
-<a id="ERR_V8BREAKITERATOR"></a>
-
 ### `ERR_V8BREAKITERATOR`
 
 The V8 `BreakIterator` API was used but the full ICU data set is not installed.
-
-<a id="ERR_VALUE_OUT_OF_RANGE"></a>
 
 ### `ERR_VALUE_OUT_OF_RANGE`
 
@@ -3833,13 +3079,9 @@ removed: v10.0.0
 
 Used when a given value is out of the accepted range.
 
-<a id="ERR_VM_MODULE_NOT_LINKED"></a>
-
 ### `ERR_VM_MODULE_NOT_LINKED`
 
 The module must be successfully linked before instantiation.
-
-<a id="ERR_VM_MODULE_LINKING_ERRORED"></a>
 
 ### `ERR_VM_MODULE_LINKING_ERRORED`
 
@@ -3852,8 +3094,6 @@ removed:
 
 The linker function returned a module for which linking has failed.
 
-<a id="ERR_WORKER_UNSUPPORTED_EXTENSION"></a>
-
 ### `ERR_WORKER_UNSUPPORTED_EXTENSION`
 
 <!-- YAML
@@ -3863,8 +3103,6 @@ removed: v16.9.0
 
 The pathname used for the main script of a worker has an
 unknown file extension.
-
-<a id="ERR_ZLIB_BINDING_CLOSED"></a>
 
 ### `ERR_ZLIB_BINDING_CLOSED`
 
@@ -3876,8 +3114,6 @@ removed: v10.0.0
 Used when an attempt is made to use a `zlib` object after it has already been
 closed.
 
-<a id="ERR_CPU_USAGE"></a>
-
 ### `ERR_CPU_USAGE`
 
 <!-- YAML
@@ -3886,186 +3122,122 @@ removed: v15.0.0
 
 The native call from `process.cpuUsage` could not be processed.
 
-<a id="openssl-error-codes"></a>
-
 ## OpenSSL Error Codes
 
-<a id="Time Validity Errors"></a>
-
 ### Time Validity Errors
-
-<a id="CERT_NOT_YET_VALID"></a>
 
 #### `CERT_NOT_YET_VALID`
 
 The certificate is not yet valid: the notBefore date is after the current time.
 
-<a id="CERT_HAS_EXPIRED"></a>
-
 #### `CERT_HAS_EXPIRED`
 
 The certificate has expired: the notAfter date is before the current time.
-
-<a id="CRL_NOT_YET_VALID"></a>
 
 #### `CRL_NOT_YET_VALID`
 
 The certificate revocation list (CRL) has a future issue date.
 
-<a id="CRL_HAS_EXPIRED"></a>
-
 #### `CRL_HAS_EXPIRED`
 
 The certificate revocation list (CRL) has expired.
-
-<a id="CERT_REVOKED"></a>
 
 #### `CERT_REVOKED`
 
 The certificate has been revoked; it is on a certificate revocation list (CRL).
 
-<a id="Trust or Chain Related Errors"></a>
-
 ### Trust or Chain Related Errors
-
-<a id="UNABLE_TO_GET_ISSUER_CERT"></a>
 
 #### `UNABLE_TO_GET_ISSUER_CERT`
 
 The issuer certificate of a looked up certificate could not be found. This
 normally means the list of trusted certificates is not complete.
 
-<a id="UNABLE_TO_GET_ISSUER_CERT_LOCALLY"></a>
-
 #### `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`
 
 The certificate’s issuer is not known. This is the case if the issuer is not
 included in the trusted certificate list.
-
-<a id="DEPTH_ZERO_SELF_SIGNED_CERT"></a>
 
 #### `DEPTH_ZERO_SELF_SIGNED_CERT`
 
 The passed certificate is self-signed and the same certificate cannot be found
 in the list of trusted certificates.
 
-<a id="SELF_SIGNED_CERT_IN_CHAIN"></a>
-
 #### `SELF_SIGNED_CERT_IN_CHAIN`
 
 The certificate’s issuer is not known. This is the case if the issuer is not
 included in the trusted certificate list.
 
-<a id="CERT_CHAIN_TOO_LONG"></a>
-
 #### `CERT_CHAIN_TOO_LONG`
 
 The certificate chain length is greater than the maximum depth.
 
-<a id="UNABLE_TO_GET_CRL"></a>
-
 #### `UNABLE_TO_GET_CRL`
 
 The CRL reference by the certificate could not be found.
-
-<a id="UNABLE_TO_VERIFY_LEAF_SIGNATURE"></a>
 
 #### `UNABLE_TO_VERIFY_LEAF_SIGNATURE`
 
 No signatures could be verified because the chain contains only one certificate
 and it is not self signed.
 
-<a id="CERT_UNTRUSTED"></a>
-
 #### `CERT_UNTRUSTED`
 
 The root certificate authority (CA) is not marked as trusted for the specified
 purpose.
 
-<a id="Basic Extension Errors"></a>
-
 ### Basic Extension Errors
-
-<a id="INVALID_CA"></a>
 
 #### `INVALID_CA`
 
 A CA certificate is invalid. Either it is not a CA or its extensions are not
 consistent with the supplied purpose.
 
-<a id="PATH_LENGTH_EXCEEDED"></a>
-
 #### `PATH_LENGTH_EXCEEDED`
 
 The basicConstraints pathlength parameter has been exceeded.
 
-<a id="Name Related Errors"></a>
-
 ### Name Related Errors
-
-<a id="HOSTNAME_MISMATCH"></a>
 
 #### `HOSTNAME_MISMATCH`
 
 Certificate does not match provided name.
 
-<a id="Usage and Policy Errors"></a>
-
 ### Usage and Policy Errors
-
-<a id="INVALID_PURPOSE"></a>
 
 #### `INVALID_PURPOSE`
 
 The supplied certificate cannot be used for the specified purpose.
 
-<a id="CERT_REJECTED"></a>
-
 #### `CERT_REJECTED`
 
 The root CA is marked to reject the specified purpose.
 
-<a id="Formatting Errors"></a>
-
 ### Formatting Errors
-
-<a id="CERT_SIGNATURE_FAILURE"></a>
 
 #### `CERT_SIGNATURE_FAILURE`
 
 The signature of the certificate is invalid.
 
-<a id="CRL_SIGNATURE_FAILURE"></a>
-
 #### `CRL_SIGNATURE_FAILURE`
 
 The signature of the certificate revocation list (CRL) is invalid.
-
-<a id="ERROR_IN_CERT_NOT_BEFORE_FIELD"></a>
 
 #### `ERROR_IN_CERT_NOT_BEFORE_FIELD`
 
 The certificate notBefore field contains an invalid time.
 
-<a id="ERROR_IN_CERT_NOT_AFTER_FIELD"></a>
-
 #### `ERROR_IN_CERT_NOT_AFTER_FIELD`
 
 The certificate notAfter field contains an invalid time.
-
-<a id="ERROR_IN_CRL_LAST_UPDATE_FIELD"></a>
 
 #### `ERROR_IN_CRL_LAST_UPDATE_FIELD`
 
 The CRL lastUpdate field contains an invalid time.
 
-<a id="ERROR_IN_CRL_NEXT_UPDATE_FIELD"></a>
-
 #### `ERROR_IN_CRL_NEXT_UPDATE_FIELD`
 
 The CRL nextUpdate field contains an invalid time.
-
-<a id="UNABLE_TO_DECRYPT_CERT_SIGNATURE"></a>
 
 #### `UNABLE_TO_DECRYPT_CERT_SIGNATURE`
 
@@ -4073,31 +3245,21 @@ The certificate signature could not be decrypted. This means that the actual
 signature value could not be determined rather than it not matching the expected
 value, this is only meaningful for RSA keys.
 
-<a id="UNABLE_TO_DECRYPT_CRL_SIGNATURE"></a>
-
 #### `UNABLE_TO_DECRYPT_CRL_SIGNATURE`
 
 The certificate revocation list (CRL) signature could not be decrypted: this
 means that the actual signature value could not be determined rather than it not
 matching the expected value.
 
-<a id="UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY"></a>
-
 #### `UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY`
 
 The public key in the certificate SubjectPublicKeyInfo could not be read.
 
-<a id="Other OpenSSL Errors"></a>
-
 ### Other OpenSSL Errors
-
-<a id="OUT_OF_MEM"></a>
 
 #### `OUT_OF_MEM`
 
 An error occurred trying to allocate memory. This should never happen.
-
-<a id="ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING"></a>
 
 #### `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`
 

--- a/tools/eslint-rules/documented-errors.js
+++ b/tools/eslint-rules/documented-errors.js
@@ -11,10 +11,6 @@ function isInDoc(code) {
   return doc.includes(`### \`${code}\``);
 }
 
-function includesAnchor(code) {
-  return doc.includes(`<a id="${code}"></a>`);
-}
-
 function errorForNode(node) {
   return node.expression.arguments[0].value;
 }
@@ -27,11 +23,6 @@ module.exports = {
         const code = errorForNode(node);
         if (!isInDoc(code)) {
           const message = `"${code}" is not documented in doc/api/errors.md`;
-          context.report({ node, message });
-        }
-        if (!includesAnchor(code)) {
-          const message =
-            `doc/api/errors.md does not have an anchor for "${code}"`;
           context.report({ node, message });
         }
       },


### PR DESCRIPTION
I've tested it, and the anchors aren't needed, as the headers themselves generate anchors:
![image](https://github.com/user-attachments/assets/fd026542-c47e-4792-a90c-249e484f24c0)
