### PR TITLE
doc: add onboarding details for ambassador program

### DIFF
--- a/doc/contributing/advocacy-ambasador-program.md
+++ b/doc/contributing/advocacy-ambasador-program.md
@@ -39,6 +39,15 @@ a discussion issue with the nomination in
 [nodejs/collaborators](https://github.com/nodejs/collaborators/)
 titled `Nomination X to be an Ambassador`, where X is the name of the person
 being nominated.
+If there is no objection from the TSC within 14 days, the nomination is approved.
+
+## Onboarding
+
+To onboard an ambassador, the a member of the TSC will:
+
+* \[] Add the ambassador to the nodejs/ambassadors team.
+* \[] Add the ambassador to the nodejs/ambassadors `README.md`.
+* \[] Add the ambassador to the OpenJS Slack channel.
 
 ## Reviewing content
 

--- a/doc/contributing/advocacy-ambasador-program.md
+++ b/doc/contributing/advocacy-ambasador-program.md
@@ -43,7 +43,7 @@ If there is no objection from the TSC within 14 days, the nomination is approved
 
 ## Onboarding
 
-To onboard an ambassador, the a member of the TSC will:
+To onboard an ambassador, a member of the TSC will:
 
 * \[] Add the ambassador to the nodejs/ambassadors team.
 * \[] Add the ambassador to the nodejs/ambassadors `README.md`.

--- a/doc/contributing/advocacy-ambasador-program.md
+++ b/doc/contributing/advocacy-ambasador-program.md
@@ -39,7 +39,7 @@ a discussion issue with the nomination in
 [nodejs/collaborators](https://github.com/nodejs/collaborators/)
 titled `Nomination X to be an Ambassador`, where X is the name of the person
 being nominated.
-If there is no objection from the TSC within 14 days, the nomination is approved.
+If there is no objection within 14 days, the nomination is approved.
 
 ## Onboarding
 


### PR DESCRIPTION
Actually I noticed there is not @nodejs/ambassadors team, so I'll create one and give access only to the the nodejs/ambassadors repo (which is private). This way will be easier to offboard