### PR TITLE
build: fix make errors that occur in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ coverage-clean: ## Remove coverage artifacts.
 	$(RM) -r coverage/tmp
 	@if [ -d "out/Release/obj.target" ]; then \
 		$(FIND) out/$(BUILDTYPE)/obj.target \( -name "*.gcda" -o -name "*.gcno" \) \
-			-type f -exec $(RM) {};\
+			-type f | xargs $(RM); \
 	fi
 
 .PHONY: coverage
@@ -269,7 +269,7 @@ coverage-build-js: ## Build JavaScript coverage files.
 .PHONY: coverage-test
 coverage-test: coverage-build ## Run the tests and generate a coverage report.
 	@if [ -d "out/Release/obj.target" ]; then \
-		$(FIND) out/$(BUILDTYPE)/obj.target -name "*.gcda" -type f -exec $(RM) {}; \
+		$(FIND) out/$(BUILDTYPE)/obj.target -name "*.gcda" -type f | xargs $(RM); \
 	fi
 	-NODE_V8_COVERAGE=coverage/tmp \
 		TEST_CI_ARGS="$(TEST_CI_ARGS) --type=coverage" $(MAKE) $(COVTESTS)


### PR DESCRIPTION
### Fix make errors that occur in Makefile
fix make errors that occur in coverage-clean case and coverage-test case in Makefile 

AS-IS
![image](https://github.com/user-attachments/assets/0aeb5a4a-c3e6-44d3-9f84-c42e715add1c)

To-BE
![image](https://github.com/user-attachments/assets/0cc7bde3-3c9d-48e6-881f-c190b3ff4905)

