### PR TITLE
benchmark: adjust byte size for buffer-copy

### DIFF
--- a/benchmark/buffers/buffer-copy.js
+++ b/benchmark/buffers/buffer-copy.js
@@ -2,7 +2,7 @@
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  bytes: [0, 8, 128, 32 * 1024],
+  bytes: [8, 128, 1024],
   partial: ['true', 'false'],
   n: [6e6],
 });


### PR DESCRIPTION
Using bytes 0 doesn't make much sense for this benchmark. Using `32768` also makes it indeterministic. 