### PR TITLE
tools: add `polyfilled` option to `prefer-primordials` rule

### DIFF
--- a/test/parallel/test-eslint-prefer-primordials.js
+++ b/test/parallel/test-eslint-prefer-primordials.js
@@ -179,6 +179,22 @@ new RuleTester({
       },
       {
         code: `
+          const { SymbolAsyncDispose } = primordials;
+          const a = { [SymbolAsyncDispose] () {} }
+        `,
+        options: [{ name: 'Symbol', polyfilled: ['asyncDispose', 'dispose'] }],
+        errors: [{ message: /const { SymbolAsyncDispose } = require\("internal\/util"\)/ }]
+      },
+      {
+        code: `
+          const { SymbolDispose } = primordials;
+          const a = { [SymbolDispose] () {} }
+        `,
+        options: [{ name: 'Symbol', polyfilled: ['asyncDispose', 'dispose'] }],
+        errors: [{ message: /const { SymbolDispose } = require\("internal\/util"\)/ }]
+      },
+      {
+        code: `
           const { ObjectDefineProperty, Symbol } = primordials;
           ObjectDefineProperty(o, Symbol.toStringTag, { value: "o" })
         `,

--- a/tools/eslint-rules/prefer-primordials.js
+++ b/tools/eslint-rules/prefer-primordials.js
@@ -117,7 +117,7 @@ module.exports = {
       }
       if (option.polyfilled) {
         for (const propertyName of option.polyfilled) {
-          polyfilledSet.add(`${option.name}${propertyName[0].toUpperCase()}${propertyName.slice(1)}`)
+          polyfilledSet.add(`${option.name}${propertyName[0].toUpperCase()}${propertyName.slice(1)}`);
         }
       }
     }
@@ -197,8 +197,8 @@ module.exports = {
       },
       VariableDeclarator(node) {
         const name = node.init?.name;
-        if (name === 'primordials' && node.id.type === 'ObjectPattern'){
-          const name = node.id.properties.find(({key}) => polyfilledSet.has(key.name))?.key.name;
+        if (name === 'primordials' && node.id.type === 'ObjectPattern') {
+          const name = node.id.properties.find(({ key }) => polyfilledSet.has(key.name))?.key.name;
           if (name) {
             context.report({
               node,

--- a/tools/eslint-rules/prefer-primordials.js
+++ b/tools/eslint-rules/prefer-primordials.js
@@ -74,6 +74,7 @@ module.exports = {
   meta: {
     messages: {
       error: 'Use `const { {{name}} } = primordials;` instead of the global.',
+      errorPolyfill: 'Use `const { {{name}} } = require("internal/util");` instead of the primordial.',
     },
     schema: {
       type: 'array',
@@ -88,6 +89,10 @@ module.exports = {
               items: { type: 'string' },
             },
             into: { type: 'string' },
+            polyfilled: {
+              type: 'array',
+              items: { type: 'string' },
+            },
           },
           additionalProperties: false,
         },
@@ -99,6 +104,7 @@ module.exports = {
 
     const nameMap = new Map();
     const renameMap = new Map();
+    const polyfilledSet = new Set();
 
     for (const option of context.options) {
       const names = option.ignore || [];
@@ -108,6 +114,11 @@ module.exports = {
       );
       if (option.into) {
         renameMap.set(option.name, option.into);
+      }
+      if (option.polyfilled) {
+        for (const propertyName of option.polyfilled) {
+          polyfilledSet.add(`${option.name}${propertyName[0].toUpperCase()}${propertyName.slice(1)}`)
+        }
       }
     }
 
@@ -186,6 +197,17 @@ module.exports = {
       },
       VariableDeclarator(node) {
         const name = node.init?.name;
+        if (name === 'primordials' && node.id.type === 'ObjectPattern'){
+          const name = node.id.properties.find(({key}) => polyfilledSet.has(key.name))?.key.name;
+          if (name) {
+            context.report({
+              node,
+              messageId: 'errorPolyfill',
+              data: { name },
+            });
+            return;
+          }
+        }
         if (name !== undefined && isTarget(nameMap, name) &&
             node.id.type === 'Identifier' &&
             !globalScope.set.get(name)?.defs.length) {


### PR DESCRIPTION
Mostly relevant for the v22.x branch now that https://github.com/nodejs/node/pull/55276 has landed on `main` and won't land on v22.x. With this change, it's going to make backporting changes to v22.x easier, helping backporters pin point which commits need fixing when backporting to the v22.x staging branch without needing to run the whole test suite.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
