### PR TITLE
test: fix tests when Amaro is unavailable

### DIFF
--- a/test/es-module/test-esm-loader-entry-url.mjs
+++ b/test/es-module/test-esm-loader-entry-url.mjs
@@ -76,7 +76,7 @@ describe('--entry-url', { concurrency: true }, () => {
     );
   });
 
-  it('should support loading TypeScript URLs', async () => {
+  it('should support loading TypeScript URLs', { skip: !process.config.variables.node_use_amaro }, async () => {
     const typescriptUrls = [
       'typescript/cts/test-require-ts-file.cts',
       'typescript/mts/test-import-ts-file.mts',

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -67,17 +67,22 @@ for (const isolation of ['none', 'process']) {
                   `--experimental-${type}-types`, `--experimental-test-isolation=${isolation}`];
     const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'matching-patterns') });
 
-    assert.strictEqual(child.stderr.toString(), '');
-    const stdout = child.stdout.toString();
+    if (!process.config.variables.node_use_amaro) {
+      // e.g. Compiled with `--without-amaro`.
+      assert.strictEqual(child.status, 1);
+    } else {
+      assert.strictEqual(child.stderr.toString(), '');
+      const stdout = child.stdout.toString();
 
-    assert.match(stdout, /ok 1 - this should pass/);
-    assert.match(stdout, /ok 2 - this should pass/);
-    assert.match(stdout, /ok 3 - this should pass/);
-    assert.match(stdout, /ok 4 - this should pass/);
-    assert.match(stdout, /ok 5 - this should pass/);
-    assert.match(stdout, /ok 6 - this should pass/);
-    assert.strictEqual(child.status, 0);
-    assert.strictEqual(child.signal, null);
+      assert.match(stdout, /ok 1 - this should pass/);
+      assert.match(stdout, /ok 2 - this should pass/);
+      assert.match(stdout, /ok 3 - this should pass/);
+      assert.match(stdout, /ok 4 - this should pass/);
+      assert.match(stdout, /ok 5 - this should pass/);
+      assert.match(stdout, /ok 6 - this should pass/);
+      assert.strictEqual(child.status, 0);
+      assert.strictEqual(child.signal, null);
+    }
   }
 
   {


### PR DESCRIPTION
Fix two tests that fail when `node` is configured `--without-amaro`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
