### PR TITLE
doc: edit onboarding guide to clarify when mailmap addition is needed

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -219,7 +219,7 @@ needs to be pointed out separately during the onboarding.
 * Commit, including a `Fixes: <collaborator-nomination-issue-url>` trailer
   so that when the commit lands, the nomination issue url will be
   automatically closed.
-* Run `tools/find-inactive-collaborators.mjs`. If that command output your name,
+* Run `tools/find-inactive-collaborators.mjs`. If that command outputs your name,
   amend the commit to include an addition to the [mailmap](.mailmap) file. See
   [gitmailmap](https://git-scm.com/docs/gitmailmap) for information on the
   format of the mailmap file.

--- a/onboarding.md
+++ b/onboarding.md
@@ -216,16 +216,14 @@ needs to be pointed out separately during the onboarding.
     `git show --format=%B 6669b3857f0f43ee0296eb7ac45086cd907b9e94`
 * Collaborators are in alphabetical order by GitHub username.
 * Optionally, include your personal pronouns.
-* The PR should include an addition to the
-  [mailmap](.mailmap) file if the email
-  being added to the collaborator list does not match the email used for
-  commits. Otherwise tooling will not see the collaborator as being active and
-  may suggest removing them. See
-  [gitmailmap](https://git-scm.com/docs/gitmailmap) for information on the
-  format of the mailmap file.
-* Add the `Fixes: <collaborator-nomination-issue-url>` to the commit message
+* Commit, including a `Fixes: <collaborator-nomination-issue-url>` trailer
   so that when the commit lands, the nomination issue url will be
   automatically closed.
+* Run `tools/find-inactive-collaborators.mjs`. If that command output your name,
+  amend the commit to include an addition to the [mailmap](.mailmap) file. See
+  [gitmailmap](https://git-scm.com/docs/gitmailmap) for information on the
+  format of the mailmap file.
+* Push the commit to your own fork.
 * Label your pull request with the `doc`, `notable-change`, and `fast-track`
   labels. The `fast-track` label should cause the Node.js GitHub bot to post a
   comment in the pull request asking collaborators to approve the pull request


### PR DESCRIPTION
As pointed out in https://github.com/nodejs/node/pull/55331#discussion_r1793473803, adding a mailmap entry is not always necessary, we might as well put instructions regarding how to check whether adding such entry is necessary or not.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
