### PR TITLE
doc: add esm examples to `node:readline`

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -713,11 +713,9 @@ const rl = createInterface({
 ```
 
 ```cjs
-const readlinePromises = require('node:readline/promises');
-const rl = readlinePromises.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
+const { createInterface } = require('node:readline/promises');
+const { stdin: input, stdout: output } = require('node:process');
+const rl = createInterface({ input, output });
 ```
 
 Once the `readlinePromises.Interface` instance is created, the most common case
@@ -979,11 +977,9 @@ const rl = createInterface({
 ```
 
 ```cjs
-const readline = require('node:readline');
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-});
+const { createInterface } = require('node:readline');
+const { stdin: input, stdout: output } = require('node:process');
+const rl = createInterface({ input, output });
 ```
 
 Once the `readline.Interface` instance is created, the most common case is to
@@ -1144,10 +1140,11 @@ rl.on('line', (line) => {
 ```
 
 ```cjs
-const readline = require('node:readline');
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
+const { createInterface } = require('node:readline');
+const { exit, stdin, stdout } = require('node:process');
+const rl = createInterface({
+  input: stdin,
+  output: stdout,
   prompt: 'OHAI> ',
 });
 
@@ -1165,7 +1162,7 @@ rl.on('line', (line) => {
   rl.prompt();
 }).on('close', () => {
   console.log('Have a great day!');
-  process.exit(0);
+  exit(0);
 });
 ```
 
@@ -1199,13 +1196,13 @@ processLineByLine();
 ```
 
 ```cjs
-const fs = require('node:fs');
-const readline = require('node:readline');
+const { createReadStream } = require('node:fs');
+const { createInterface } = require('node:readline');
 
 async function processLineByLine() {
-  const fileStream = fs.createReadStream('input.txt');
+  const fileStream = createReadStream('input.txt');
 
-  const rl = readline.createInterface({
+  const rl = createInterface({
     input: fileStream,
     crlfDelay: Infinity,
   });
@@ -1238,11 +1235,11 @@ rl.on('line', (line) => {
 ```
 
 ```cjs
-const fs = require('node:fs');
-const readline = require('node:readline');
+const { createReadStream } = require('node:fs');
+const { createInterface } = require('node:readline');
 
-const rl = readline.createInterface({
-  input: fs.createReadStream('sample.txt'),
+const rl = createInterface({
+  input: createReadStream('sample.txt'),
   crlfDelay: Infinity,
 });
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -703,7 +703,16 @@ added: v17.0.0
 The `readlinePromises.createInterface()` method creates a new `readlinePromises.Interface`
 instance.
 
-```js
+```mjs
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout } from 'node:process';
+const rl = createInterface({
+  input: stdin,
+  output: stdout,
+});
+```
+
+```cjs
 const readlinePromises = require('node:readline/promises');
 const rl = readlinePromises.createInterface({
   input: process.stdin,
@@ -960,7 +969,16 @@ changes:
 The `readline.createInterface()` method creates a new `readline.Interface`
 instance.
 
-```js
+```mjs
+import { createInterface } from 'node:readline';
+import { stdin, stdout } from 'node:process';
+const rl = createInterface({
+  input: stdin,
+  output: stdout,
+});
+```
+
+```cjs
 const readline = require('node:readline');
 const rl = readline.createInterface({
   input: process.stdin,
@@ -1098,7 +1116,34 @@ if (process.stdin.isTTY)
 The following example illustrates the use of `readline.Interface` class to
 implement a small command-line interface:
 
-```js
+```mjs
+import { createInterface } from 'node:readline';
+import { exit, stdin, stdout } from 'node:process';
+const rl = createInterface({
+  input: stdin,
+  output: stdout,
+  prompt: 'OHAI> ',
+});
+
+rl.prompt();
+
+rl.on('line', (line) => {
+  switch (line.trim()) {
+    case 'hello':
+      console.log('world!');
+      break;
+    default:
+      console.log(`Say what? I might have heard '${line.trim()}'`);
+      break;
+  }
+  rl.prompt();
+}).on('close', () => {
+  console.log('Have a great day!');
+  exit(0);
+});
+```
+
+```cjs
 const readline = require('node:readline');
 const rl = readline.createInterface({
   input: process.stdin,
@@ -1130,7 +1175,30 @@ A common use case for `readline` is to consume an input file one line at a
 time. The easiest way to do so is leveraging the [`fs.ReadStream`][] API as
 well as a `for await...of` loop:
 
-```js
+```mjs
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+async function processLineByLine() {
+  const fileStream = createReadStream('input.txt');
+
+  const rl = createInterface({
+    input: fileStream,
+    crlfDelay: Infinity,
+  });
+  // Note: we use the crlfDelay option to recognize all instances of CR LF
+  // ('\r\n') in input.txt as a single line break.
+
+  for await (const line of rl) {
+    // Each line in input.txt will be successively available here as `line`.
+    console.log(`Line from file: ${line}`);
+  }
+}
+
+processLineByLine();
+```
+
+```cjs
 const fs = require('node:fs');
 const readline = require('node:readline');
 
@@ -1155,7 +1223,21 @@ processLineByLine();
 
 Alternatively, one could use the [`'line'`][] event:
 
-```js
+```mjs
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+const rl = createInterface({
+  input: createReadStream('sample.txt'),
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  console.log(`Line from file: ${line}`);
+});
+```
+
+```cjs
 const fs = require('node:fs');
 const readline = require('node:readline');
 
@@ -1172,7 +1254,32 @@ rl.on('line', (line) => {
 Currently, `for await...of` loop can be a bit slower. If `async` / `await`
 flow and speed are both essential, a mixed approach can be applied:
 
-```js
+```mjs
+import { once } from 'node:events';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+
+(async function processLineByLine() {
+  try {
+    const rl = createInterface({
+      input: createReadStream('big-file.txt'),
+      crlfDelay: Infinity,
+    });
+
+    rl.on('line', (line) => {
+      // Process the line.
+    });
+
+    await once(rl, 'close');
+
+    console.log('File processed.');
+  } catch (err) {
+    console.error(err);
+  }
+})();
+```
+
+```cjs
 const { once } = require('node:events');
 const { createReadStream } = require('node:fs');
 const { createInterface } = require('node:readline');

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -714,8 +714,10 @@ const rl = createInterface({
 
 ```cjs
 const { createInterface } = require('node:readline/promises');
-const { stdin: input, stdout: output } = require('node:process');
-const rl = createInterface({ input, output });
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
 ```
 
 Once the `readlinePromises.Interface` instance is created, the most common case
@@ -978,8 +980,10 @@ const rl = createInterface({
 
 ```cjs
 const { createInterface } = require('node:readline');
-const { stdin: input, stdout: output } = require('node:process');
-const rl = createInterface({ input, output });
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
 ```
 
 Once the `readline.Interface` instance is created, the most common case is to
@@ -1141,10 +1145,9 @@ rl.on('line', (line) => {
 
 ```cjs
 const { createInterface } = require('node:readline');
-const { exit, stdin, stdout } = require('node:process');
 const rl = createInterface({
-  input: stdin,
-  output: stdout,
+  input: process.stdin,
+  output: process.stdout,
   prompt: 'OHAI> ',
 });
 
@@ -1162,7 +1165,7 @@ rl.on('line', (line) => {
   rl.prompt();
 }).on('close', () => {
   console.log('Have a great day!');
-  exit(0);
+  process.exit(0);
 });
 ```
 


### PR DESCRIPTION
This PR adds the missing `ESM` counterparts of the `CJS` examples for [the Readline documentation](https://nodejs.org/api/readline.html).

I've tested every single example and they all work/behave as expected.

Best regards!