### PR TITLE
lib: clean up references to GCed abort signals

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -242,8 +242,6 @@ class AbortSignal extends EventTarget {
     }
     const resultSignalWeakRef = new SafeWeakRef(resultSignal);
     resultSignal[kSourceSignals] = new SafeSet();
-
-
     for (let i = 0; i < signalsArray.length; i++) {
       const signal = signalsArray[i];
       finalizers.register(resultSignal, signal);
@@ -252,7 +250,6 @@ class AbortSignal extends EventTarget {
         return resultSignal;
       }
       signal[kDependantSignals] ??= new SafeSet();
-
       if (!signal[kComposite]) {
         resultSignal[kSourceSignals].add(new SafeWeakRef(signal));
         signal[kDependantSignals].add(resultSignalWeakRef);

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -84,7 +84,11 @@ function lazyMessageChannel() {
 }
 
 const clearTimeoutRegistry = new SafeFinalizationRegistry(clearTimeout);
-const finalizers = new SafeFinalizationRegistry((signal) => {
+const finalizers = new SafeFinalizationRegistry((signalWeakRef) => {
+  const signal = signalWeakRef.deref();
+  if (!signal) {
+    return;
+  }
   signal[kDependantSignals].forEach((ref) => {
     if (!ref.deref()) {
       signal[kDependantSignals].delete(ref);
@@ -244,14 +248,15 @@ class AbortSignal extends EventTarget {
     resultSignal[kSourceSignals] = new SafeSet();
     for (let i = 0; i < signalsArray.length; i++) {
       const signal = signalsArray[i];
-      finalizers.register(resultSignal, signal);
       if (signal.aborted) {
         abortSignal(resultSignal, signal.reason);
         return resultSignal;
       }
+      const signalWeakRef = new SafeWeakRef(signal);
+      finalizers.register(resultSignal, signalWeakRef);
       signal[kDependantSignals] ??= new SafeSet();
       if (!signal[kComposite]) {
-        resultSignal[kSourceSignals].add(new SafeWeakRef(signal));
+        resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
       } else if (!signal[kSourceSignals]) {
         continue;

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -84,6 +84,13 @@ function lazyMessageChannel() {
 }
 
 const clearTimeoutRegistry = new SafeFinalizationRegistry(clearTimeout);
+const finalizers = new SafeFinalizationRegistry((signal) => {
+  signal[kDependantSignals].forEach((ref) => {
+    if (!ref.deref()) {
+      signal[kDependantSignals].delete(ref);
+    }
+  });
+});
 const gcPersistentSignals = new SafeSet();
 
 const kAborted = Symbol('kAborted');
@@ -235,13 +242,17 @@ class AbortSignal extends EventTarget {
     }
     const resultSignalWeakRef = new SafeWeakRef(resultSignal);
     resultSignal[kSourceSignals] = new SafeSet();
+
+
     for (let i = 0; i < signalsArray.length; i++) {
       const signal = signalsArray[i];
+      finalizers.register(resultSignal, signal);
       if (signal.aborted) {
         abortSignal(resultSignal, signal.reason);
         return resultSignal;
       }
       signal[kDependantSignals] ??= new SafeSet();
+
       if (!signal[kComposite]) {
         resultSignal[kSourceSignals].add(new SafeWeakRef(signal));
         signal[kDependantSignals].add(resultSignalWeakRef);

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -84,13 +84,13 @@ function lazyMessageChannel() {
 }
 
 const clearTimeoutRegistry = new SafeFinalizationRegistry(clearTimeout);
-const finalizers = new SafeFinalizationRegistry((signalWeakRef) => {
+const dependantSignalsCleanupRegistry = new SafeFinalizationRegistry((signalWeakRef) => {
   const signal = signalWeakRef.deref();
-  if (!signal) {
+  if (signal === undefined) {
     return;
   }
   signal[kDependantSignals].forEach((ref) => {
-    if (!ref.deref()) {
+    if (ref.deref() === undefined) {
       signal[kDependantSignals].delete(ref);
     }
   });
@@ -255,9 +255,9 @@ class AbortSignal extends EventTarget {
       signal[kDependantSignals] ??= new SafeSet();
       if (!signal[kComposite]) {
         const signalWeakRef = new SafeWeakRef(signal);
-        finalizers.register(resultSignal, signalWeakRef);
         resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
+        dependantSignalsCleanupRegistry.register(resultSignal, signalWeakRef);
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {
@@ -274,7 +274,7 @@ class AbortSignal extends EventTarget {
           }
           resultSignal[kSourceSignals].add(sourceSignalWeakRef);
           sourceSignal[kDependantSignals].add(resultSignalWeakRef);
-          finalizers.register(resultSignal, sourceSignalWeakRef);
+          dependantSignalsCleanupRegistry.register(resultSignal, sourceSignalWeakRef);
         }
       }
     }

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -261,21 +261,20 @@ class AbortSignal extends EventTarget {
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {
-        for (const sourceSignal of signal[kSourceSignals]) {
-          const sourceSignalRef = sourceSignal.deref();
-          if (!sourceSignalRef) {
+        for (const sourceSignalWeakRef of signal[kSourceSignals]) {
+          const sourceSignal = sourceSignalWeakRef.deref();
+          if (!sourceSignal) {
             continue;
           }
-          assert(!sourceSignalRef.aborted);
-          assert(!sourceSignalRef[kComposite]);
+          assert(!sourceSignal.aborted);
+          assert(!sourceSignal[kComposite]);
 
-          if (resultSignal[kSourceSignals].has(sourceSignal)) {
+          if (resultSignal[kSourceSignals].has(sourceSignalWeakRef)) {
             continue;
           }
-          resultSignal[kSourceSignals].add(sourceSignal);
-          sourceSignalRef[kDependantSignals].add(resultSignalWeakRef);
-          // Here, sourceSignal is a WeakRef
-          finalizers.register(resultSignal, sourceSignal);
+          resultSignal[kSourceSignals].add(sourceSignalWeakRef);
+          sourceSignal[kDependantSignals].add(resultSignalWeakRef);
+          finalizers.register(resultSignal, sourceSignalWeakRef);
         }
       }
     }

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -252,10 +252,10 @@ class AbortSignal extends EventTarget {
         abortSignal(resultSignal, signal.reason);
         return resultSignal;
       }
-      const signalWeakRef = new SafeWeakRef(signal);
-      finalizers.register(resultSignal, signalWeakRef);
       signal[kDependantSignals] ??= new SafeSet();
       if (!signal[kComposite]) {
+        const signalWeakRef = new SafeWeakRef(signal);
+        finalizers.register(resultSignal, signalWeakRef);
         resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
       } else if (!signal[kSourceSignals]) {
@@ -274,6 +274,8 @@ class AbortSignal extends EventTarget {
           }
           resultSignal[kSourceSignals].add(sourceSignal);
           sourceSignalRef[kDependantSignals].add(resultSignalWeakRef);
+          // Here, sourceSignal is a WeakRef
+          finalizers.register(resultSignal, sourceSignal);
         }
       }
     }

--- a/test/parallel/test-abortsignal-drop-settled-signals.mjs
+++ b/test/parallel/test-abortsignal-drop-settled-signals.mjs
@@ -1,0 +1,64 @@
+// Flags: --expose_gc
+
+import * as common from '../common/index.mjs';
+
+if (common.isASan) {
+  common.skip('ASan messes with memory measurements');
+}
+
+import { describe, it } from 'node:test';
+
+const makeSubseSequentCalls = (limit, done, holdReferences = false) => {
+  const ac = new AbortController();
+  const x = [];
+  let dependantSymbol;
+
+  let i = 0;
+  function run() {
+    if (!holdReferences) {
+      AbortSignal.any([ac.signal]);
+    } else {
+      x.push(AbortSignal.any([ac.signal]));
+    }
+
+    if (!dependantSymbol) {
+      const kDependantSignals = Object.getOwnPropertySymbols(ac.signal).filter(
+        (s) => s.toString() === 'Symbol(kDependantSignals)'
+      )[0];
+      dependantSymbol ??= kDependantSignals;
+    }
+
+    if (++i >= limit) {
+      global.gc();
+      done(ac.signal[dependantSymbol].size);
+      return;
+    }
+    setImmediate(run);
+  }
+  return run();
+};
+
+const limit = 50000;
+
+describe('when there is a long-lived signal', () => {
+  describe('and dependant signals are Ced', () => {
+    it('drops settled signals', (t, done) => {
+      makeSubseSequentCalls(limit, (totalDependantSignals) => {
+        // We're unable to assert how many signals are dropped (since it depens on gc), but we can assert that some are.
+        t.assert.equal(totalDependantSignals < limit, true);
+
+        done();
+      });
+    });
+  });
+
+  describe('and dependant signals are still valid references', () => {
+    it('keeps all dependant signals', (t, done) => {
+      makeSubseSequentCalls(limit, (totalDependantSignals) => {
+        t.assert.equal(totalDependantSignals, limit);
+
+        done();
+      }, true);
+    });
+  });
+});

--- a/test/parallel/test-abortsignal-drop-settled-signals.mjs
+++ b/test/parallel/test-abortsignal-drop-settled-signals.mjs
@@ -13,7 +13,6 @@ const makeSubsequentCalls = (limit, done, holdReferences = false) => {
   const retainedSignals = [];
   let dependantSymbol;
 
-  // let i = 0;
   function run(iteration) {
     if (iteration > limit) {
       global.gc();
@@ -28,9 +27,9 @@ const makeSubsequentCalls = (limit, done, holdReferences = false) => {
     }
 
     if (!dependantSymbol) {
-      const kDependantSignals = Object.getOwnPropertySymbols(ac.signal).filter(
+      const kDependantSignals = Object.getOwnPropertySymbols(ac.signal).find(
         (s) => s.toString() === 'Symbol(kDependantSignals)'
-      )[0];
+      );
       dependantSymbol = kDependantSignals;
     }
 

--- a/test/parallel/test-abortsignal-drop-settled-signals.mjs
+++ b/test/parallel/test-abortsignal-drop-settled-signals.mjs
@@ -93,15 +93,13 @@ describe('when there is a long-lived signal', () => {
   });
 });
 
-describe('when there is a short-lived signal', () => {
-  it('does not prevent source signal from being GCed', (t, done) => {
-    runShortLivedSourceSignal(limit, (signalRefs) => {
-      setImmediate(() => {
-        const unGCedSignals = [...signalRefs].filter((ref) => ref.deref());
+it('does not prevent source signal from being GCed if it is short-lived', (t, done) => {
+  runShortLivedSourceSignal(limit, (signalRefs) => {
+    setImmediate(() => {
+      const unGCedSignals = [...signalRefs].filter((ref) => ref.deref());
 
-        t.assert.equal(unGCedSignals, 0);
-        done();
-      });
+      t.assert.equal(unGCedSignals, 0);
+      done();
     });
   });
 });


### PR DESCRIPTION
Refs #55351

Using this [commit's description](https://github.com/chromium/chromium/commit/d5b7539036199ad653125222f061f39c66e91a86) as a reference, this PR adds a `SafeFinalizationRegistry` to remove GCed dependant signals' references since they will no longer abort.