### PR TITLE
tools: update cpplint to 2.0.0

### DIFF
--- a/.cpplint
+++ b/.cpplint
@@ -1,3 +1,3 @@
 set noparent
-filter=-build/include_alpha,-build/include_subdir,-build/include_what_you_use,-legal/copyright,-readability/nolint,-readability/braces
+filter=-build/c++17,-build/include_order,-build/include_alpha,-build/include_subdir,-build/include_what_you_use,-legal/copyright,-readability/nolint,-readability/braces,-whitespace/indent_namespace
 linelength=80

--- a/Makefile
+++ b/Makefile
@@ -1506,9 +1506,11 @@ endif
 .PHONY: lint-cpp
 lint-cpp: tools/.cpplintstamp ## Lint the C++ code with cpplint.py and checkimports.py.
 
+# TODO(RedYetiDev): Replace cpplint with clang-tidy, so that it is fully compatible with
+# clang-format, and messy 'NOLINT' comments don't need to be used to ensure compatability
 tools/.cpplintstamp: $(LINT_CPP_FILES)
 	$(info Running C++ linter...)
-	@$(PYTHON) tools/cpplint.py $(CPPLINT_QUIET) $?
+	@$(PYTHON) tools/cpplint.py --config .cpplint $(CPPLINT_QUIET) $?
 	@$(PYTHON) tools/checkimports.py $?
 	@touch $@
 

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -519,7 +519,8 @@ Maybe<void> Decorate(Environment* env,
 #define V(name) case ERR_LIB_##name: lib = #name "_"; break;
     const char* lib = "";
     const char* prefix = "OSSL_";
-    switch (ERR_GET_LIB(err)) { OSSL_ERROR_CODES_MAP(V) }
+    switch (ERR_GET_LIB(err))
+      OSSL_ERROR_CODES_MAP(V)
 #undef V
 #undef OSSL_ERROR_CODES_MAP
     // Don't generate codes like "ERR_OSSL_SSL_".

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -205,7 +205,7 @@ static bool IsIPAddress(const std::string& host) {
     // (other than ::/128) that represent non-routable IPv4 addresses. However,
     // this translation assumes that the host is interpreted as an IPv6 address
     // in the first place, at which point DNS rebinding should not be an issue.
-    if (std::all_of(ipv6, ipv6 + sizeof(ipv6), [](auto b) { return b == 0; })) {
+    if (std::all_of(ipv6, ipv6 + sizeof(ipv6), [](auto b) { return b == 0; })) { //NOLINT
       return false;
     }
 

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -35,7 +35,7 @@ struct uv_loop_s;  // Forward declaration.
 
 typedef napi_value(NAPI_CDECL* napi_addon_register_func)(napi_env env,
                                                          napi_value exports);
-typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)(void);
+typedef int32_t(NAPI_CDECL* node_api_addon_get_api_version_func)(void); //NOLINT
 
 // Used by deprecated registration method napi_module_register.
 typedef struct napi_module {

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -243,7 +243,7 @@ size_t Http2Settings::Init(
     for (uint32_t i = 0; i < numAddSettings; i++) {
       uint32_t key = buffer[offset + i * 2 + 0];
       uint32_t val = buffer[offset + i * 2 + 1];
-      entries[count++] = nghttp2_settings_entry{(int32_t)key, val};
+      entries[count++] = nghttp2_settings_entry{static_cast<int32_t> key, val};
     }
   }
 
@@ -324,8 +324,8 @@ void Http2Settings::Update(Http2Session* session, get_setting fn, bool local) {
   for (size_t i = 0; i < imax; i++) {
     // We flag unset the settings with a bit above the allowed range
     if (!(custom_settings.entries[i].settings_id & (~0xffff))) {
-      uint32_t settings_id =
-          (uint32_t)(custom_settings.entries[i].settings_id & 0xffff);
+      uint32_t settings_id = static_cast<uint32_t>(
+          custom_settings.entries[i].settings_id & 0xffff);
       size_t j = 0;
       while (j < count) {
         if ((buffer[IDX_SETTINGS_COUNT + 1 + j * 2 + 1] & 0xffff) ==
@@ -639,7 +639,7 @@ void Http2Session::FetchAllowedRemoteCustomSettings() {
           (buffer[offset + i * 2 + 0] & 0xffff) |
           (1
            << 16);  // setting the bit 16 indicates, that no values has been set
-      entries[count++] = nghttp2_settings_entry{(int32_t)key, 0};
+      entries[count++] = nghttp2_settings_entry{static_cast<int32_t> key, 0};
     }
     remote_custom_settings_.number = count;
   }


### PR DESCRIPTION
A few days ago, CPPLint released (a long overdue) [v2.0.0](https://github.com/cpplint/cpplint/releases/tag/2.0.0).

This PR updates our CPPLint to 2.0.0, keeping the following Node.js patches:
- `build/include_inline`
- `readability/pointer_notation`
- `readability/null_usage`
- `runtime/v8_persistent`