### PR TITLE
test_runner: require `--enable-source-maps` for sourcemap coverage

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -57,12 +57,19 @@ class CoverageLine {
 }
 
 class TestCoverage {
-  constructor(coverageDirectory, originalCoverageDirectory, workingDirectory, excludeGlobs, includeGlobs, thresholds) {
+  constructor(coverageDirectory,
+              originalCoverageDirectory,
+              workingDirectory,
+              excludeGlobs,
+              includeGlobs,
+              sourceMaps,
+              thresholds) {
     this.coverageDirectory = coverageDirectory;
     this.originalCoverageDirectory = originalCoverageDirectory;
     this.workingDirectory = workingDirectory;
     this.excludeGlobs = excludeGlobs;
     this.includeGlobs = includeGlobs;
+    this.sourceMaps = sourceMaps;
     this.thresholds = thresholds;
   }
 
@@ -341,7 +348,7 @@ class TestCoverage {
   mapCoverageWithSourceMap(coverage) {
     const { result } = coverage;
     const sourceMapCache = coverage['source-map-cache'];
-    if (!sourceMapCache) {
+    if (!this.sourceMaps || !sourceMapCache) {
       return result;
     }
     const newResult = new SafeMap();
@@ -514,6 +521,7 @@ function setupCoverage(options) {
     options.cwd,
     options.coverageExcludeGlobs,
     options.coverageIncludeGlobs,
+    options.sourceMaps,
     {
       __proto__: null,
       line: options.lineCoverage,

--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -19,6 +19,7 @@ function generateReport(report) {
 }
 
 const flags = [
+  '--enable-source-maps',
   '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
 ];
 
@@ -38,6 +39,28 @@ describe('Coverage with source maps', async () => {
     ]);
 
     const spawned = await common.spawnPromisified(process.execPath, flags, {
+      cwd: fixtures.path('test-runner', 'coverage')
+    });
+
+    t.assert.strictEqual(spawned.stderr, '');
+    t.assert.ok(spawned.stdout.includes(report));
+    t.assert.strictEqual(spawned.code, 1);
+  });
+
+  await it('should only work with --enable-source-maps', async (t) => {
+    const report = generateReport([
+      '# --------------------------------------------------------------',
+      '# file          | line % | branch % | funcs % | uncovered lines',
+      '# --------------------------------------------------------------',
+      '# a.test.mjs    | 100.00 |   100.00 |  100.00 | ',
+      '# index.test.js |  71.43 |    66.67 |  100.00 | 6-7',
+      '# stdin.test.js | 100.00 |   100.00 |  100.00 | ',
+      '# --------------------------------------------------------------',
+      '# all files     |  85.71 |    87.50 |  100.00 | ',
+      '# --------------------------------------------------------------',
+    ]);
+
+    const spawned = await common.spawnPromisified(process.execPath, flags.slice(1), {
       cwd: fixtures.path('test-runner', 'coverage')
     });
     t.assert.strictEqual(spawned.stderr, '');


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/54753#issuecomment-2351142258 / https://github.com/nodejs/node/issues/54753#issuecomment-2351584729

This is not semver-major, as both code coverage and source maps experimental features.

The coverage constructer was changed to accept a `globalOptions` because of how cluttered it got from all the additional features.

Previously, there were some issues with coverage (See #55039), however, other test runner changes have resolved those issues.