### PR TITLE
build: apply cpp linting and formatting to ncrypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1414,6 +1414,8 @@ LINT_CPP_EXCLUDE += $(LINT_CPP_ADDON_DOC_FILES)
 # These files were copied more or less verbatim from V8.
 LINT_CPP_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
 
+# deps/ncrypto is included in this list, as it lives in
+# this repository, and therefore is linted.
 LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	benchmark/napi/*/*.cc \
 	src/*.c \

--- a/Makefile
+++ b/Makefile
@@ -1414,8 +1414,11 @@ LINT_CPP_EXCLUDE += $(LINT_CPP_ADDON_DOC_FILES)
 # These files were copied more or less verbatim from V8.
 LINT_CPP_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
 
-# deps/ncrypto is included in this list, as it lives in
-# this repository, and therefore is linted.
+# deps/ncrypto is included in this list, as it is maintained in
+# this repository, and should be linted. Eventually it should move
+# to its own repo, at which point we should remove it from this list.
+LINT_CPP_DEPS = deps/ncrypto/*.cc deps/ncrypto/*.h
+
 LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	benchmark/napi/*/*.cc \
 	src/*.c \
@@ -1440,8 +1443,7 @@ LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	tools/code_cache/*.h \
 	tools/snapshot/*.cc \
 	tools/snapshot/*.h \
-	deps/ncrypto/*.cc \
-	deps/ncrypto/*.h \
+	$(LINT_CPP_DEPS) \
 	))
 
 FORMAT_CPP_FILES ?=

--- a/Makefile
+++ b/Makefile
@@ -1438,6 +1438,8 @@ LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	tools/code_cache/*.h \
 	tools/snapshot/*.cc \
 	tools/snapshot/*.h \
+	deps/ncrypto/*.cc \
+	deps/ncrypto/*.h \
 	))
 
 FORMAT_CPP_FILES ?=

--- a/deps/ncrypto/dh-primes.h
+++ b/deps/ncrypto/dh-primes.h
@@ -50,16 +50,19 @@
  * (eay@cryptsoft.com).  This product includes software written by Tim
  * Hudson (tjh@cryptsoft.com). */
 
+#ifndef DEPS_NCRYPTO_DH_PRIMES_H_
+#define DEPS_NCRYPTO_DH_PRIMES_H_
+
 #include <openssl/dh.h>
 
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/mem.h>
 
-extern "C" int bn_set_words(BIGNUM *bn, const BN_ULONG *words, size_t num);
+extern "C" int bn_set_words(BIGNUM* bn, const BN_ULONG* words, size_t num);
 
-// Backporting primes that may not be supported in earlier boringssl versions. Intentionally
-// keeping the existing C-style formatting.
+// Backporting primes that may not be supported in earlier boringssl versions.
+// Intentionally keeping the existing C-style formatting.
 
 #define OPENSSL_ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
 
@@ -71,25 +74,27 @@ extern "C" int bn_set_words(BIGNUM *bn, const BN_ULONG *words, size_t num);
 #error "Must define either OPENSSL_32_BIT or OPENSSL_64_BIT"
 #endif
 
-static BIGNUM *get_params(BIGNUM *ret, const BN_ULONG *words, size_t num_words) {
-  BIGNUM *alloc = NULL;
-  if (ret == NULL) {
+static BIGNUM* get_params(BIGNUM* ret,
+                          const BN_ULONG* words,
+                          size_t num_words) {
+  BIGNUM* alloc = nullptr;
+  if (ret == nullptr) {
     alloc = BN_new();
-    if (alloc == NULL) {
-      return NULL;
+    if (alloc == nullptr) {
+      return nullptr;
     }
     ret = alloc;
   }
 
   if (!bn_set_words(ret, words, num_words)) {
     BN_free(alloc);
-    return NULL;
+    return nullptr;
   }
 
   return ret;
 }
 
-BIGNUM *BN_get_rfc3526_prime_2048(BIGNUM *ret) {
+BIGNUM* BN_get_rfc3526_prime_2048(BIGNUM* ret) {
   static const BN_ULONG kWords[] = {
       TOBN(0xffffffff, 0xffffffff), TOBN(0x15728e5a, 0x8aacaa68),
       TOBN(0x15d22618, 0x98fa0510), TOBN(0x3995497c, 0xea956ae5),
@@ -111,7 +116,7 @@ BIGNUM *BN_get_rfc3526_prime_2048(BIGNUM *ret) {
   return get_params(ret, kWords, OPENSSL_ARRAY_SIZE(kWords));
 }
 
-BIGNUM *BN_get_rfc3526_prime_3072(BIGNUM *ret) {
+BIGNUM* BN_get_rfc3526_prime_3072(BIGNUM* ret) {
   static const BN_ULONG kWords[] = {
       TOBN(0xffffffff, 0xffffffff), TOBN(0x4b82d120, 0xa93ad2ca),
       TOBN(0x43db5bfc, 0xe0fd108e), TOBN(0x08e24fa0, 0x74e5ab31),
@@ -141,7 +146,7 @@ BIGNUM *BN_get_rfc3526_prime_3072(BIGNUM *ret) {
   return get_params(ret, kWords, OPENSSL_ARRAY_SIZE(kWords));
 }
 
-BIGNUM *BN_get_rfc3526_prime_4096(BIGNUM *ret) {
+BIGNUM* BN_get_rfc3526_prime_4096(BIGNUM* ret) {
   static const BN_ULONG kWords[] = {
       TOBN(0xffffffff, 0xffffffff), TOBN(0x4df435c9, 0x34063199),
       TOBN(0x86ffb7dc, 0x90a6c08f), TOBN(0x93b4ea98, 0x8d8fddc1),
@@ -179,7 +184,7 @@ BIGNUM *BN_get_rfc3526_prime_4096(BIGNUM *ret) {
   return get_params(ret, kWords, OPENSSL_ARRAY_SIZE(kWords));
 }
 
-BIGNUM *BN_get_rfc3526_prime_6144(BIGNUM *ret) {
+BIGNUM* BN_get_rfc3526_prime_6144(BIGNUM* ret) {
   static const BN_ULONG kWords[] = {
       TOBN(0xffffffff, 0xffffffff), TOBN(0xe694f91e, 0x6dcc4024),
       TOBN(0x12bf2d5b, 0x0b7474d6), TOBN(0x043e8f66, 0x3f4860ee),
@@ -233,7 +238,7 @@ BIGNUM *BN_get_rfc3526_prime_6144(BIGNUM *ret) {
   return get_params(ret, kWords, OPENSSL_ARRAY_SIZE(kWords));
 }
 
-BIGNUM *BN_get_rfc3526_prime_8192(BIGNUM *ret) {
+BIGNUM* BN_get_rfc3526_prime_8192(BIGNUM* ret) {
   static const BN_ULONG kWords[] = {
       TOBN(0xffffffff, 0xffffffff), TOBN(0x60c980dd, 0x98edd3df),
       TOBN(0xc81f56e8, 0x80b96e71), TOBN(0x9e3050e2, 0x765694df),
@@ -302,3 +307,5 @@ BIGNUM *BN_get_rfc3526_prime_8192(BIGNUM *ret) {
   };
   return get_params(ret, kWords, OPENSSL_ARRAY_SIZE(kWords));
 }
+
+#endif  // DEPS_NCRYPTO_DH_PRIMES_H_

--- a/deps/ncrypto/engine.cc
+++ b/deps/ncrypto/engine.cc
@@ -7,16 +7,16 @@ namespace ncrypto {
 
 #ifndef OPENSSL_NO_ENGINE
 EnginePointer::EnginePointer(ENGINE* engine_, bool finish_on_exit_)
-    : engine(engine_),
-      finish_on_exit(finish_on_exit_) {}
+    : engine(engine_), finish_on_exit(finish_on_exit_) {}
 
 EnginePointer::EnginePointer(EnginePointer&& other) noexcept
-    : engine(other.engine),
-      finish_on_exit(other.finish_on_exit) {
+    : engine(other.engine), finish_on_exit(other.finish_on_exit) {
   other.release();
 }
 
-EnginePointer::~EnginePointer() { reset(); }
+EnginePointer::~EnginePointer() {
+  reset();
+}
 
 EnginePointer& EnginePointer::operator=(EnginePointer&& other) noexcept {
   if (this == &other) return *this;
@@ -75,7 +75,8 @@ bool EnginePointer::init(bool finish_on_exit) {
 
 EVPKeyPointer EnginePointer::loadPrivateKey(const std::string_view key_name) {
   if (engine == nullptr) return EVPKeyPointer();
-  return EVPKeyPointer(ENGINE_load_private_key(engine, key_name.data(), nullptr, nullptr));
+  return EVPKeyPointer(
+      ENGINE_load_private_key(engine, key_name.data(), nullptr, nullptr));
 }
 
 void EnginePointer::initEnginesOnce() {

--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -1,13 +1,13 @@
 #include "ncrypto.h"
-#include <algorithm>
-#include <cstring>
-#include <openssl/dh.h>
 #include <openssl/bn.h>
+#include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
-#include <openssl/rand.h>
 #include <openssl/pkcs12.h>
+#include <openssl/rand.h>
 #include <openssl/x509v3.h>
+#include <algorithm>
+#include <cstring>
 #if OPENSSL_VERSION_MAJOR >= 3
 #include <openssl/provider.h>
 #endif
@@ -18,14 +18,13 @@
 namespace ncrypto {
 namespace {
 static constexpr int kX509NameFlagsRFC2253WithinUtf8JSON =
-    XN_FLAG_RFC2253 &
-    ~ASN1_STRFLGS_ESC_MSB &
-    ~ASN1_STRFLGS_ESC_CTRL;
+    XN_FLAG_RFC2253 & ~ASN1_STRFLGS_ESC_MSB & ~ASN1_STRFLGS_ESC_CTRL;
 }  // namespace
 
 // ============================================================================
 
-ClearErrorOnReturn::ClearErrorOnReturn(CryptoErrorList* errors) : errors_(errors) {
+ClearErrorOnReturn::ClearErrorOnReturn(CryptoErrorList* errors)
+    : errors_(errors) {
   ERR_clear_error();
 }
 
@@ -34,9 +33,12 @@ ClearErrorOnReturn::~ClearErrorOnReturn() {
   ERR_clear_error();
 }
 
-int ClearErrorOnReturn::peekError() { return ERR_peek_error(); }
+int ClearErrorOnReturn::peekError() {
+  return ERR_peek_error();
+}
 
-MarkPopErrorOnReturn::MarkPopErrorOnReturn(CryptoErrorList* errors) : errors_(errors) {
+MarkPopErrorOnReturn::MarkPopErrorOnReturn(CryptoErrorList* errors)
+    : errors_(errors) {
   ERR_set_mark();
 }
 
@@ -45,7 +47,9 @@ MarkPopErrorOnReturn::~MarkPopErrorOnReturn() {
   ERR_pop_to_mark();
 }
 
-int MarkPopErrorOnReturn::peekError() { return ERR_peek_error(); }
+int MarkPopErrorOnReturn::peekError() {
+  return ERR_peek_error();
+}
 
 CryptoErrorList::CryptoErrorList(CryptoErrorList::Option option) {
   if (option == Option::CAPTURE_ON_CONSTRUCT) capture();
@@ -53,7 +57,7 @@ CryptoErrorList::CryptoErrorList(CryptoErrorList::Option option) {
 
 void CryptoErrorList::capture() {
   errors_.clear();
-  while(const auto err = ERR_get_error()) {
+  while (const auto err = ERR_get_error()) {
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     errors_.emplace_front(buf);
@@ -101,7 +105,9 @@ DataPointer& DataPointer::operator=(DataPointer&& other) noexcept {
   return *new (this) DataPointer(std::move(other));
 }
 
-DataPointer::~DataPointer() { reset(); }
+DataPointer::~DataPointer() {
+  reset();
+}
 
 void DataPointer::reset(void* data, size_t length) {
   if (data_ != nullptr) {
@@ -116,9 +122,9 @@ void DataPointer::reset(const Buffer<void>& buffer) {
 }
 
 Buffer<void> DataPointer::release() {
-  Buffer<void> buf {
-    .data = data_,
-    .len = len_,
+  Buffer<void> buf{
+      .data = data_,
+      .len = len_,
   };
   data_ = nullptr;
   len_ = 0;
@@ -150,12 +156,13 @@ bool testFipsEnabled() {
   if (OSSL_PROVIDER_available(nullptr, "fips")) {
     fips_provider = OSSL_PROVIDER_load(nullptr, "fips");
   }
-  const auto enabled = fips_provider == nullptr ? 0 :
-      OSSL_PROVIDER_self_test(fips_provider) ? 1 : 0;
+  const auto enabled = fips_provider == nullptr                 ? 0
+                       : OSSL_PROVIDER_self_test(fips_provider) ? 1
+                                                                : 0;
 #else
 #ifdef OPENSSL_FIPS
   const auto enabled = FIPS_selftest() ? 1 : 0;
-#else  // OPENSSL_FIPS
+#else   // OPENSSL_FIPS
   const auto enabled = 0;
 #endif  // OPENSSL_FIPS
 #endif
@@ -187,7 +194,9 @@ BignumPointer& BignumPointer::operator=(BignumPointer&& other) noexcept {
   return *new (this) BignumPointer(std::move(other));
 }
 
-BignumPointer::~BignumPointer() { reset(); }
+BignumPointer::~BignumPointer() {
+  reset();
+}
 
 void BignumPointer::reset(BIGNUM* bn) {
   bn_.reset(bn);
@@ -228,16 +237,16 @@ DataPointer BignumPointer::Encode(const BIGNUM* bn) {
   return EncodePadded(bn, bn != nullptr ? BN_num_bytes(bn) : 0);
 }
 
-bool BignumPointer::setWord(unsigned long w) {
+bool BignumPointer::setWord(unsigned long w) {  // NOLINT(runtime/int)
   if (!bn_) return false;
   return BN_set_word(bn_.get(), w) == 1;
 }
 
-unsigned long BignumPointer::GetWord(const BIGNUM* bn) {
+unsigned long BignumPointer::GetWord(const BIGNUM* bn) {  // NOLINT(runtime/int)
   return BN_get_word(bn);
 }
 
-unsigned long BignumPointer::getWord() const {
+unsigned long BignumPointer::getWord() const {  // NOLINT(runtime/int)
   if (!bn_) return 0;
   return GetWord(bn_.get());
 }
@@ -249,7 +258,9 @@ DataPointer BignumPointer::EncodePadded(const BIGNUM* bn, size_t s) {
   BN_bn2binpad(bn, reinterpret_cast<unsigned char*>(buf.get()), size);
   return buf;
 }
-size_t BignumPointer::EncodePaddedInto(const BIGNUM* bn, unsigned char* out, size_t size) {
+size_t BignumPointer::EncodePaddedInto(const BIGNUM* bn,
+                                       unsigned char* out,
+                                       size_t size) {
   if (bn == nullptr) return 0;
   return BN_bn2binpad(bn, out, size);
 }
@@ -279,7 +290,7 @@ int BignumPointer::GetBitCount(const BIGNUM* bn) {
   return BN_num_bits(bn);
 }
 
-int BignumPointer::GetByteCount(const BIGNUM *bn) {
+int BignumPointer::GetByteCount(const BIGNUM* bn) {
   return BN_num_bytes(bn);
 }
 
@@ -348,8 +359,7 @@ int PasswordCallback(char* buf, int size, int rwflag, void* u) {
   if (passphrase != nullptr) {
     size_t buflen = static_cast<size_t>(size);
     size_t len = passphrase->len;
-    if (buflen < len)
-      return -1;
+    if (buflen < len) return -1;
     memcpy(buf, reinterpret_cast<const char*>(passphrase->data), len);
     return len;
   }
@@ -358,13 +368,13 @@ int PasswordCallback(char* buf, int size, int rwflag, void* u) {
 }
 
 // Algorithm: http://howardhinnant.github.io/date_algorithms.html
-constexpr int days_from_epoch(int y, unsigned m, unsigned d)
-{
+constexpr int days_from_epoch(int y, unsigned m, unsigned d) {
   y -= m <= 2;
   const int era = (y >= 0 ? y : y - 399) / 400;
-  const unsigned yoe = static_cast<unsigned>(y - era * 400);            // [0, 399]
-  const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;  // [0, 365]
-  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;           // [0, 146096]
+  const unsigned yoe = static_cast<unsigned>(y - era * 400);  // [0, 399]
+  const unsigned doy =
+      (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;          // [0, 365]
+  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;  // [0, 146096]
   return era * 146097 + static_cast<int>(doe) - 719468;
 }
 
@@ -383,7 +393,10 @@ int64_t PortableTimeGM(struct tm* t) {
   }
   int days_since_epoch = days_from_epoch(year, month + 1, t->tm_mday);
 
-  return 60 * (60 * (24LL * static_cast<int64_t>(days_since_epoch) + t->tm_hour) + t->tm_min) + t->tm_sec;
+  return 60 * (60 * (24LL * static_cast<int64_t>(days_since_epoch) +
+                     t->tm_hour) +
+               t->tm_min) +
+         t->tm_sec;
 }
 
 // ============================================================================
@@ -400,10 +413,8 @@ bool VerifySpkac(const char* input, size_t length) {
   // case.
   length = std::string_view(input, length).find_last_not_of(" \n\r\t") + 1;
 #endif
-  NetscapeSPKIPointer spki(
-      NETSCAPE_SPKI_b64_decode(input, length));
-  if (!spki)
-    return false;
+  NetscapeSPKIPointer spki(NETSCAPE_SPKI_b64_decode(input, length));
+  if (!spki) return false;
 
   EVPKeyPointer pkey(X509_PUBKEY_get(spki->spkac->pubkey));
   return pkey ? NETSCAPE_SPKI_verify(spki.get(), pkey.get()) > 0 : false;
@@ -419,14 +430,13 @@ BIOPointer ExportPublicKey(const char* input, size_t length) {
   // As such, we trim those characters here for compatibility.
   length = std::string_view(input, length).find_last_not_of(" \n\r\t") + 1;
 #endif
-  NetscapeSPKIPointer spki(
-      NETSCAPE_SPKI_b64_decode(input, length));
+  NetscapeSPKIPointer spki(NETSCAPE_SPKI_b64_decode(input, length));
   if (!spki) return {};
 
   EVPKeyPointer pkey(NETSCAPE_SPKI_get_pubkey(spki.get()));
   if (!pkey) return {};
 
-  if (PEM_write_bio_PUBKEY(bio.get(), pkey.get()) <= 0) return { };
+  if (PEM_write_bio_PUBKEY(bio.get(), pkey.get()) <= 0) return {};
 
   return bio;
 }
@@ -438,16 +448,15 @@ Buffer<char> ExportChallenge(const char* input, size_t length) {
   // As such, we trim those characters here for compatibility.
   length = std::string_view(input, length).find_last_not_of(" \n\r\t") + 1;
 #endif
-  NetscapeSPKIPointer sp(
-      NETSCAPE_SPKI_b64_decode(input, length));
+  NetscapeSPKIPointer sp(NETSCAPE_SPKI_b64_decode(input, length));
   if (!sp) return {};
 
   unsigned char* buf = nullptr;
   int buf_size = ASN1_STRING_to_UTF8(&buf, sp->spkac->challenge);
   if (buf_size >= 0) {
     return {
-      .data = reinterpret_cast<char*>(buf),
-      .len = static_cast<size_t>(buf_size),
+        .data = reinterpret_cast<char*>(buf),
+        .len = static_cast<size_t>(buf_size),
     };
   }
 
@@ -465,35 +474,36 @@ bool IsSafeAltName(const char* name, size_t length, AltNameOption option) {
   for (size_t i = 0; i < length; i++) {
     char c = name[i];
     switch (c) {
-    case '"':
-    case '\\':
-      // These mess with encoding rules.
-      // Fall through.
-    case ',':
-      // Commas make it impossible to split the list of subject alternative
-      // names unambiguously, which is why we have to escape.
-      // Fall through.
-    case '\'':
-      // Single quotes are unlikely to appear in any legitimate values, but they
-      // could be used to make a value look like it was escaped (i.e., enclosed
-      // in single/double quotes).
-      return false;
-    default:
-      if (option == AltNameOption::UTF8) {
-        // In UTF8 strings, we require escaping for any ASCII control character,
-        // but NOT for non-ASCII characters. Note that all bytes of any code
-        // point that consists of more than a single byte have their MSB set.
-        if (static_cast<unsigned char>(c) < ' ' || c == '\x7f') {
-          return false;
+      case '"':
+      case '\\':
+        // These mess with encoding rules.
+        // Fall through.
+      case ',':
+        // Commas make it impossible to split the list of subject alternative
+        // names unambiguously, which is why we have to escape.
+        // Fall through.
+      case '\'':
+        // Single quotes are unlikely to appear in any legitimate values, but
+        // they could be used to make a value look like it was escaped (i.e.,
+        // enclosed in single/double quotes).
+        return false;
+      default:
+        if (option == AltNameOption::UTF8) {
+          // In UTF8 strings, we require escaping for any ASCII control
+          // character, but NOT for non-ASCII characters. Note that all bytes of
+          // any code point that consists of more than a single byte have their
+          // MSB set.
+          if (static_cast<unsigned char>(c) < ' ' || c == '\x7f') {
+            return false;
+          }
+        } else {
+          // Check if the char is a control character or non-ASCII character.
+          // Note that char may or may not be a signed type. Regardless,
+          // non-ASCII values will always be outside of this range.
+          if (c < ' ' || c > '~') {
+            return false;
+          }
         }
-      } else {
-        // Check if the char is a control character or non-ASCII character. Note
-        // that char may or may not be a signed type. Regardless, non-ASCII
-        // values will always be outside of this range.
-        if (c < ' ' || c > '~') {
-          return false;
-        }
-      }
     }
   }
   return true;
@@ -538,7 +548,7 @@ void PrintAltName(const BIOPointer& out,
         // Control character or non-ASCII character. We treat everything as
         // Latin-1, which corresponds to the first 255 Unicode code points.
         const char hex[] = "0123456789abcdef";
-        char u[] = { '\\', 'u', '0', '0', hex[(c & 0xf0) >> 4], hex[c & 0x0f] };
+        char u[] = {'\\', 'u', '0', '0', hex[(c & 0xf0) >> 4], hex[c & 0x0f]};
         BIO_write(out.get(), u, sizeof(u));
       }
     }
@@ -584,17 +594,19 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
     BIO_printf(out.get(), "DirName:");
     BIOPointer tmp(BIO_new(BIO_s_mem()));
     NCRYPTO_ASSERT_TRUE(tmp);
-    if (X509_NAME_print_ex(tmp.get(),
-                           gen->d.dirn,
-                           0,
-                           kX509NameFlagsRFC2253WithinUtf8JSON) < 0) {
+    if (X509_NAME_print_ex(
+            tmp.get(), gen->d.dirn, 0, kX509NameFlagsRFC2253WithinUtf8JSON) <
+        0) {
       return false;
     }
     char* oline = nullptr;
     long n_bytes = BIO_get_mem_data(tmp.get(), &oline);  // NOLINT(runtime/int)
     NCRYPTO_ASSERT_TRUE(n_bytes >= 0);
-    PrintAltName(out, oline, static_cast<size_t>(n_bytes),
-        ncrypto::AltNameOption::UTF8, nullptr);
+    PrintAltName(out,
+                 oline,
+                 static_cast<size_t>(n_bytes),
+                 ncrypto::AltNameOption::UTF8,
+                 nullptr);
   } else if (gen->type == GEN_IPADD) {
     BIO_printf(out.get(), "IP Address:");
     const ASN1_OCTET_STRING* ip = gen->d.ip;
@@ -650,8 +662,7 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
     }
 #endif  // OPENSSL_VERSION_MAJOR >= 3
     int val_type = gen->d.otherName->value->type;
-    if (prefix == nullptr ||
-        (unicode && val_type != V_ASN1_UTF8STRING) ||
+    if (prefix == nullptr || (unicode && val_type != V_ASN1_UTF8STRING) ||
         (!unicode && val_type != V_ASN1_IA5STRING)) {
       BIO_printf(out.get(), "othername:<unsupported>");
     } else {
@@ -659,13 +670,17 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
       if (unicode) {
         auto name = gen->d.otherName->value->value.utf8string;
         PrintAltName(out,
-            reinterpret_cast<const char*>(name->data), name->length,
-            AltNameOption::UTF8, prefix);
+                     reinterpret_cast<const char*>(name->data),
+                     name->length,
+                     AltNameOption::UTF8,
+                     prefix);
       } else {
         auto name = gen->d.otherName->value->value.ia5string;
         PrintAltName(out,
-            reinterpret_cast<const char*>(name->data), name->length,
-            AltNameOption::NONE, prefix);
+                     reinterpret_cast<const char*>(name->data),
+                     name->length,
+                     AltNameOption::NONE,
+                     prefix);
       }
     }
   } else if (gen->type == GEN_X400) {
@@ -684,22 +699,19 @@ bool PrintGeneralName(const BIOPointer& out, const GENERAL_NAME* gen) {
 }
 }  // namespace
 
-
 bool SafeX509SubjectAltNamePrint(const BIOPointer& out, X509_EXTENSION* ext) {
   auto ret = OBJ_obj2nid(X509_EXTENSION_get_object(ext));
   NCRYPTO_ASSERT_EQUAL(ret, NID_subject_alt_name, "unexpected extension type");
 
   GENERAL_NAMES* names = static_cast<GENERAL_NAMES*>(X509V3_EXT_d2i(ext));
-  if (names == nullptr)
-    return false;
+  if (names == nullptr) return false;
 
   bool ok = true;
 
   for (int i = 0; i < sk_GENERAL_NAME_num(names); i++) {
     GENERAL_NAME* gen = sk_GENERAL_NAME_value(names, i);
 
-    if (i != 0)
-      BIO_write(out.get(), ", ", 2);
+    if (i != 0) BIO_write(out.get(), ", ", 2);
 
     if (!(ok = ncrypto::PrintGeneralName(out, gen))) {
       break;
@@ -716,16 +728,14 @@ bool SafeX509InfoAccessPrint(const BIOPointer& out, X509_EXTENSION* ext) {
 
   AUTHORITY_INFO_ACCESS* descs =
       static_cast<AUTHORITY_INFO_ACCESS*>(X509V3_EXT_d2i(ext));
-  if (descs == nullptr)
-    return false;
+  if (descs == nullptr) return false;
 
   bool ok = true;
 
   for (int i = 0; i < sk_ACCESS_DESCRIPTION_num(descs); i++) {
     ACCESS_DESCRIPTION* desc = sk_ACCESS_DESCRIPTION_value(descs, i);
 
-    if (i != 0)
-      BIO_write(out.get(), "\n", 1);
+    if (i != 0) BIO_write(out.get(), "\n", 1);
 
     char objtmp[80];
     i2t_ASN1_OBJECT(objtmp, sizeof(objtmp), desc->method);
@@ -757,7 +767,9 @@ X509Pointer& X509Pointer::operator=(X509Pointer&& other) noexcept {
   return *new (this) X509Pointer(std::move(other));
 }
 
-X509Pointer::~X509Pointer() { reset(); }
+X509Pointer::~X509Pointer() {
+  reset();
+}
 
 void X509Pointer::reset(X509* x509) {
   cert_.reset(x509);
@@ -794,8 +806,10 @@ BIOPointer X509View::getSubject() const {
   if (cert_ == nullptr) return {};
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!bio) return {};
-  if (X509_NAME_print_ex(bio.get(), X509_get_subject_name(cert_),
-                         0, kX509NameFlagsMultiline) <= 0) {
+  if (X509_NAME_print_ex(bio.get(),
+                         X509_get_subject_name(cert_),
+                         0,
+                         kX509NameFlagsMultiline) <= 0) {
     return {};
   }
   return bio;
@@ -807,7 +821,8 @@ BIOPointer X509View::getSubjectAltName() const {
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!bio) return {};
   int index = X509_get_ext_by_NID(cert_, NID_subject_alt_name, -1);
-  if (index < 0 || !SafeX509SubjectAltNamePrint(bio, X509_get_ext(cert_, index))) {
+  if (index < 0 ||
+      !SafeX509SubjectAltNamePrint(bio, X509_get_ext(cert_, index))) {
     return {};
   }
   return bio;
@@ -818,8 +833,9 @@ BIOPointer X509View::getIssuer() const {
   if (cert_ == nullptr) return {};
   BIOPointer bio(BIO_new(BIO_s_mem()));
   if (!bio) return {};
-  if (X509_NAME_print_ex(bio.get(), X509_get_issuer_name(cert_), 0,
-                         kX509NameFlagsMultiline) <= 0) {
+  if (X509_NAME_print_ex(
+          bio.get(), X509_get_issuer_name(cert_), 0, kX509NameFlagsMultiline) <=
+      0) {
     return {};
   }
   return bio;
@@ -871,7 +887,8 @@ int64_t X509View::getValidFromTime() const {
 DataPointer X509View::getSerialNumber() const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return {};
-  if (ASN1_INTEGER* serial_number = X509_get_serialNumber(const_cast<X509*>(cert_))) {
+  if (ASN1_INTEGER* serial_number =
+          X509_get_serialNumber(const_cast<X509*>(cert_))) {
     if (auto bn = BignumPointer(ASN1_INTEGER_to_BN(serial_number, nullptr))) {
       return bn.toHex();
     }
@@ -881,7 +898,7 @@ DataPointer X509View::getSerialNumber() const {
 
 Result<EVPKeyPointer, int> X509View::getPublicKey() const {
   ClearErrorOnReturn clearErrorOnReturn;
-  if (cert_ == nullptr) return Result<EVPKeyPointer, int>(EVPKeyPointer {});
+  if (cert_ == nullptr) return Result<EVPKeyPointer, int>(EVPKeyPointer{});
   auto pkey = EVPKeyPointer(X509_get_pubkey(const_cast<X509*>(cert_)));
   if (!pkey) return Result<EVPKeyPointer, int>(ERR_get_error());
   return pkey;
@@ -919,13 +936,16 @@ bool X509View::checkPublicKey(const EVPKeyPointer& pkey) const {
   return X509_verify(const_cast<X509*>(cert_), pkey.get()) == 1;
 }
 
-X509View::CheckMatch X509View::checkHost(const std::string_view host, int flags,
+X509View::CheckMatch X509View::checkHost(const std::string_view host,
+                                         int flags,
                                          DataPointer* peerName) const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return CheckMatch::NO_MATCH;
   char* peername;
-  switch (X509_check_host(const_cast<X509*>(cert_), host.data(), host.size(), flags, &peername)) {
-    case 0: return CheckMatch::NO_MATCH;
+  switch (X509_check_host(
+      const_cast<X509*>(cert_), host.data(), host.size(), flags, &peername)) {
+    case 0:
+      return CheckMatch::NO_MATCH;
     case 1: {
       if (peername != nullptr) {
         DataPointer name(peername, strlen(peername));
@@ -933,30 +953,43 @@ X509View::CheckMatch X509View::checkHost(const std::string_view host, int flags,
       }
       return CheckMatch::MATCH;
     }
-    case -2: return CheckMatch::INVALID_NAME;
-    default: return CheckMatch::OPERATION_FAILED;
+    case -2:
+      return CheckMatch::INVALID_NAME;
+    default:
+      return CheckMatch::OPERATION_FAILED;
   }
 }
 
-X509View::CheckMatch X509View::checkEmail(const std::string_view email, int flags) const {
+X509View::CheckMatch X509View::checkEmail(const std::string_view email,
+                                          int flags) const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return CheckMatch::NO_MATCH;
-  switch (X509_check_email(const_cast<X509*>(cert_), email.data(), email.size(), flags)) {
-    case 0: return CheckMatch::NO_MATCH;
-    case 1: return CheckMatch::MATCH;
-    case -2: return CheckMatch::INVALID_NAME;
-    default: return CheckMatch::OPERATION_FAILED;
+  switch (X509_check_email(
+      const_cast<X509*>(cert_), email.data(), email.size(), flags)) {
+    case 0:
+      return CheckMatch::NO_MATCH;
+    case 1:
+      return CheckMatch::MATCH;
+    case -2:
+      return CheckMatch::INVALID_NAME;
+    default:
+      return CheckMatch::OPERATION_FAILED;
   }
 }
 
-X509View::CheckMatch X509View::checkIp(const std::string_view ip, int flags) const {
+X509View::CheckMatch X509View::checkIp(const std::string_view ip,
+                                       int flags) const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (cert_ == nullptr) return CheckMatch::NO_MATCH;
   switch (X509_check_ip_asc(const_cast<X509*>(cert_), ip.data(), flags)) {
-    case 0: return CheckMatch::NO_MATCH;
-    case 1: return CheckMatch::MATCH;
-    case -2: return CheckMatch::INVALID_NAME;
-    default: return CheckMatch::OPERATION_FAILED;
+    case 0:
+      return CheckMatch::NO_MATCH;
+    case 1:
+      return CheckMatch::MATCH;
+    case -2:
+      return CheckMatch::INVALID_NAME;
+    default:
+      return CheckMatch::OPERATION_FAILED;
   }
 }
 
@@ -978,12 +1011,14 @@ X509Pointer X509View::clone() const {
   return X509Pointer(X509_dup(const_cast<X509*>(cert_)));
 }
 
-Result<X509Pointer, int> X509Pointer::Parse(Buffer<const unsigned char> buffer) {
+Result<X509Pointer, int> X509Pointer::Parse(
+    Buffer<const unsigned char> buffer) {
   ClearErrorOnReturn clearErrorOnReturn;
   BIOPointer bio(BIO_new_mem_buf(buffer.data, buffer.len));
   if (!bio) return Result<X509Pointer, int>(ERR_get_error());
 
-  X509Pointer pem(PEM_read_bio_X509_AUX(bio.get(), nullptr, NoPasswordCallback, nullptr));
+  X509Pointer pem(
+      PEM_read_bio_X509_AUX(bio.get(), nullptr, NoPasswordCallback, nullptr));
   if (pem) return Result<X509Pointer, int>(std::move(pem));
   BIO_reset(bio.get());
 
@@ -993,8 +1028,8 @@ Result<X509Pointer, int> X509Pointer::Parse(Buffer<const unsigned char> buffer) 
   return Result<X509Pointer, int>(ERR_get_error());
 }
 
-
-X509Pointer X509Pointer::IssuerFrom(const SSLPointer& ssl, const X509View& view) {
+X509Pointer X509Pointer::IssuerFrom(const SSLPointer& ssl,
+                                    const X509View& view) {
   return IssuerFrom(SSL_get_SSL_CTX(ssl.get()), view);
 }
 
@@ -1028,11 +1063,17 @@ BIOPointer& BIOPointer::operator=(BIOPointer&& other) noexcept {
   return *new (this) BIOPointer(std::move(other));
 }
 
-BIOPointer::~BIOPointer() { reset(); }
+BIOPointer::~BIOPointer() {
+  reset();
+}
 
-void BIOPointer::reset(BIO* bio) { bio_.reset(bio); }
+void BIOPointer::reset(BIO* bio) {
+  bio_.reset(bio);
+}
 
-BIO* BIOPointer::release() { return bio_.release(); }
+BIO* BIOPointer::release() {
+  return bio_.release();
+}
 
 bool BIOPointer::resetBio() const {
   if (!bio_) return 0;
@@ -1055,7 +1096,8 @@ BIOPointer BIOPointer::New(const void* data, size_t len) {
   return BIOPointer(BIO_new_mem_buf(data, len));
 }
 
-BIOPointer BIOPointer::NewFile(std::string_view filename, std::string_view mode) {
+BIOPointer BIOPointer::NewFile(std::string_view filename,
+                               std::string_view mode) {
   return BIOPointer(BIO_new_file(filename.data(), mode.data()));
 }
 
@@ -1074,8 +1116,9 @@ int BIOPointer::Write(BIOPointer* bio, std::string_view message) {
 namespace {
 bool EqualNoCase(const std::string_view a, const std::string_view b) {
   if (a.size() != b.size()) return false;
-  return std::equal(a.begin(), a.end(), b.begin(), b.end(),
-      [](char a, char b) { return std::tolower(a) == std::tolower(b); });
+  return std::equal(a.begin(), a.end(), b.begin(), b.end(), [](char a, char b) {
+    return std::tolower(a) == std::tolower(b);
+  });
 }
 }  // namespace
 
@@ -1089,15 +1132,22 @@ DHPointer& DHPointer::operator=(DHPointer&& other) noexcept {
   return *new (this) DHPointer(std::move(other));
 }
 
-DHPointer::~DHPointer() { reset(); }
+DHPointer::~DHPointer() {
+  reset();
+}
 
-void DHPointer::reset(DH* dh) { dh_.reset(dh); }
+void DHPointer::reset(DH* dh) {
+  dh_.reset(dh);
+}
 
-DH* DHPointer::release() { return dh_.release(); }
+DH* DHPointer::release() {
+  return dh_.release();
+}
 
 BignumPointer DHPointer::FindGroup(const std::string_view name,
                                    FindGroupOption option) {
-#define V(n, p) if (EqualNoCase(name, n)) return BignumPointer(p(nullptr));
+#define V(n, p)                                                                \
+  if (EqualNoCase(name, n)) return BignumPointer(p(nullptr));
   if (option != FindGroupOption::NO_SMALL_PRIMES) {
     V("modp1", BN_get_rfc2409_prime_768);
     V("modp2", BN_get_rfc2409_prime_1024);
@@ -1166,7 +1216,8 @@ DHPointer::CheckResult DHPointer::check() {
   return static_cast<CheckResult>(codes);
 }
 
-DHPointer::CheckPublicKeyResult DHPointer::checkPublicKey(const BignumPointer& pub_key) {
+DHPointer::CheckPublicKeyResult DHPointer::checkPublicKey(
+    const BignumPointer& pub_key) {
   ClearErrorOnReturn clearErrorOnReturn;
   if (!pub_key || !dh_) return DHPointer::CheckPublicKeyResult::CHECK_FAILED;
   int codes = 0;
@@ -1232,7 +1283,8 @@ DataPointer DHPointer::computeSecret(const BignumPointer& peer) const {
   auto dp = DataPointer::Alloc(size());
   if (!dp) return {};
 
-  int size = DH_compute_key(static_cast<uint8_t*>(dp.get()), peer.get(), dh_.get());
+  int size =
+      DH_compute_key(static_cast<uint8_t*>(dp.get()), peer.get(), dh_.get());
   if (size < 0) return {};
 
   // The size of the computed key can be smaller than the size of the DH key.
@@ -1271,8 +1323,7 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
   if (!ourKey || !theirKey) return {};
 
   EVPKeyCtxPointer ctx(EVP_PKEY_CTX_new(ourKey.get(), nullptr));
-  if (!ctx ||
-      EVP_PKEY_derive_init(ctx.get()) <= 0 ||
+  if (!ctx || EVP_PKEY_derive_init(ctx.get()) <= 0 ||
       EVP_PKEY_derive_set_peer(ctx.get(), theirKey.get()) <= 0 ||
       EVP_PKEY_derive(ctx.get(), nullptr, &out_size) <= 0) {
     return {};
@@ -1281,7 +1332,8 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
   if (out_size == 0) return {};
 
   auto out = DataPointer::Alloc(out_size);
-  if (EVP_PKEY_derive(ctx.get(), reinterpret_cast<uint8_t*>(out.get()), &out_size) <= 0) {
+  if (EVP_PKEY_derive(
+          ctx.get(), reinterpret_cast<uint8_t*>(out.get()), &out_size) <= 0) {
     return {};
   }
 
@@ -1319,16 +1371,14 @@ DataPointer hkdf(const EVP_MD* md,
                  size_t length) {
   ClearErrorOnReturn clearErrorOnReturn;
 
-  if (!checkHkdfLength(md, length) ||
-      info.len > INT_MAX ||
+  if (!checkHkdfLength(md, length) || info.len > INT_MAX ||
       salt.len > INT_MAX) {
     return {};
   }
 
   EVPKeyCtxPointer ctx =
       EVPKeyCtxPointer(EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr));
-  if (!ctx ||
-      !EVP_PKEY_derive_init(ctx.get()) ||
+  if (!ctx || !EVP_PKEY_derive_init(ctx.get()) ||
       !EVP_PKEY_CTX_set_hkdf_md(ctx.get(), md) ||
       !EVP_PKEY_CTX_add1_hkdf_info(ctx.get(), info.data, info.len)) {
     return {};
@@ -1345,9 +1395,9 @@ DataPointer hkdf(const EVP_MD* md,
   // We do not use EVP_PKEY_HKDF_MODE_EXTRACT_AND_EXPAND because and instead
   // implement the extraction step ourselves because EVP_PKEY_derive does not
   // handle zero-length keys, which are required for Web Crypto.
-  // TODO: Once OpenSSL 1.1.1 support is dropped completely, and once BoringSSL
-  // is confirmed to support it, wen can hopefully drop this and use EVP_KDF
-  // directly which does support zero length keys.
+  // TODO(jasnell): Once OpenSSL 1.1.1 support is dropped completely, and once
+  // BoringSSL is confirmed to support it, wen can hopefully drop this and use
+  // EVP_KDF directly which does support zero length keys.
   unsigned char pseudorandom_key[EVP_MAX_MD_SIZE];
   unsigned pseudorandom_key_len = sizeof(pseudorandom_key);
 
@@ -1361,14 +1411,16 @@ DataPointer hkdf(const EVP_MD* md,
     return {};
   }
   if (!EVP_PKEY_CTX_hkdf_mode(ctx.get(), EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) ||
-      !EVP_PKEY_CTX_set1_hkdf_key(ctx.get(), pseudorandom_key, pseudorandom_key_len)) {
+      !EVP_PKEY_CTX_set1_hkdf_key(
+          ctx.get(), pseudorandom_key, pseudorandom_key_len)) {
     return {};
   }
 
   auto buf = DataPointer::Alloc(length);
   if (!buf) return {};
 
-  if (EVP_PKEY_derive(ctx.get(), static_cast<unsigned char*>(buf.get()), &length) <= 0) {
+  if (EVP_PKEY_derive(
+          ctx.get(), static_cast<unsigned char*>(buf.get()), &length) <= 0) {
     return {};
   }
 
@@ -1376,7 +1428,8 @@ DataPointer hkdf(const EVP_MD* md,
 }
 
 bool checkScryptParams(uint64_t N, uint64_t r, uint64_t p, uint64_t maxmem) {
-  return EVP_PBE_scrypt(nullptr, 0, nullptr, 0, N, r, p, maxmem, nullptr, 0) == 1;
+  return EVP_PBE_scrypt(nullptr, 0, nullptr, 0, N, r, p, maxmem, nullptr, 0) ==
+         1;
 }
 
 DataPointer scrypt(const Buffer<const char>& pass,
@@ -1388,15 +1441,21 @@ DataPointer scrypt(const Buffer<const char>& pass,
                    size_t length) {
   ClearErrorOnReturn clearErrorOnReturn;
 
-  if (pass.len > INT_MAX ||
-      salt.len > INT_MAX) {
+  if (pass.len > INT_MAX || salt.len > INT_MAX) {
     return {};
   }
 
   auto dp = DataPointer::Alloc(length);
-  if (dp && EVP_PBE_scrypt(
-      pass.data, pass.len, salt.data, salt.len, N, r, p, maxmem,
-      reinterpret_cast<unsigned char*>(dp.get()), length)) {
+  if (dp && EVP_PBE_scrypt(pass.data,
+                           pass.len,
+                           salt.data,
+                           salt.len,
+                           N,
+                           r,
+                           p,
+                           maxmem,
+                           reinterpret_cast<unsigned char*>(dp.get()),
+                           length)) {
     return dp;
   }
 
@@ -1410,15 +1469,18 @@ DataPointer pbkdf2(const EVP_MD* md,
                    size_t length) {
   ClearErrorOnReturn clearErrorOnReturn;
 
-  if (pass.len > INT_MAX ||
-      salt.len > INT_MAX ||
-      length > INT_MAX) {
+  if (pass.len > INT_MAX || salt.len > INT_MAX || length > INT_MAX) {
     return {};
   }
 
   auto dp = DataPointer::Alloc(length);
-  if (dp && PKCS5_PBKDF2_HMAC(pass.data, pass.len, salt.data, salt.len,
-                              iterations, md, length,
+  if (dp && PKCS5_PBKDF2_HMAC(pass.data,
+                              pass.len,
+                              salt.data,
+                              salt.len,
+                              iterations,
+                              md,
+                              length,
                               reinterpret_cast<unsigned char*>(dp.get()))) {
     return dp;
   }
@@ -1430,7 +1492,8 @@ DataPointer pbkdf2(const EVP_MD* md,
 
 EVPKeyPointer::PrivateKeyEncodingConfig::PrivateKeyEncodingConfig(
     const PrivateKeyEncodingConfig& other)
-    : PrivateKeyEncodingConfig(other.output_key_object, other.format, other.type) {
+    : PrivateKeyEncodingConfig(
+          other.output_key_object, other.format, other.type) {
   cipher = other.cipher;
   if (other.passphrase.has_value()) {
     auto& otherPassphrase = other.passphrase.value();
@@ -1441,14 +1504,11 @@ EVPKeyPointer::PrivateKeyEncodingConfig::PrivateKeyEncodingConfig(
 }
 
 EVPKeyPointer::AsymmetricKeyEncodingConfig::AsymmetricKeyEncodingConfig(
-    bool output_key_object,
-    PKFormatType format,
-    PKEncodingType type)
-    : output_key_object(output_key_object),
-      format(format),
-      type(type) {}
+    bool output_key_object, PKFormatType format, PKEncodingType type)
+    : output_key_object(output_key_object), format(format), type(type) {}
 
-EVPKeyPointer::PrivateKeyEncodingConfig& EVPKeyPointer::PrivateKeyEncodingConfig::operator=(
+EVPKeyPointer::PrivateKeyEncodingConfig&
+EVPKeyPointer::PrivateKeyEncodingConfig::operator=(
     const PrivateKeyEncodingConfig& other) {
   if (this == &other) return *this;
   this->~PrivateKeyEncodingConfig();
@@ -1459,14 +1519,18 @@ EVPKeyPointer EVPKeyPointer::New() {
   return EVPKeyPointer(EVP_PKEY_new());
 }
 
-EVPKeyPointer EVPKeyPointer::NewRawPublic(int id, const Buffer<const unsigned char>& data) {
+EVPKeyPointer EVPKeyPointer::NewRawPublic(
+    int id, const Buffer<const unsigned char>& data) {
   if (id == 0) return {};
-  return EVPKeyPointer(EVP_PKEY_new_raw_public_key(id, nullptr, data.data, data.len));
+  return EVPKeyPointer(
+      EVP_PKEY_new_raw_public_key(id, nullptr, data.data, data.len));
 }
 
-EVPKeyPointer EVPKeyPointer::NewRawPrivate(int id, const Buffer<const unsigned char>& data) {
+EVPKeyPointer EVPKeyPointer::NewRawPrivate(
+    int id, const Buffer<const unsigned char>& data) {
   if (id == 0) return {};
-  return EVPKeyPointer(EVP_PKEY_new_raw_private_key(id, nullptr, data.data, data.len));
+  return EVPKeyPointer(
+      EVP_PKEY_new_raw_private_key(id, nullptr, data.data, data.len));
 }
 
 EVPKeyPointer::EVPKeyPointer(EVP_PKEY* pkey) : pkey_(pkey) {}
@@ -1480,7 +1544,9 @@ EVPKeyPointer& EVPKeyPointer::operator=(EVPKeyPointer&& other) noexcept {
   return *new (this) EVPKeyPointer(std::move(other));
 }
 
-EVPKeyPointer::~EVPKeyPointer() { reset(); }
+EVPKeyPointer::~EVPKeyPointer() {
+  reset();
+}
 
 void EVPKeyPointer::reset(EVP_PKEY* pkey) {
   pkey_.reset(pkey);
@@ -1542,9 +1608,7 @@ DataPointer EVPKeyPointer::rawPublicKey() const {
   if (auto data = DataPointer::Alloc(rawPublicKeySize())) {
     const Buffer<unsigned char> buf = data;
     size_t len = data.size();
-    if (EVP_PKEY_get_raw_public_key(get(),
-            buf.data,
-            &len) != 1) return {};
+    if (EVP_PKEY_get_raw_public_key(get(), buf.data, &len) != 1) return {};
     return data;
   }
   return {};
@@ -1555,9 +1619,7 @@ DataPointer EVPKeyPointer::rawPrivateKey() const {
   if (auto data = DataPointer::Alloc(rawPrivateKeySize())) {
     const Buffer<unsigned char> buf = data;
     size_t len = data.size();
-    if (EVP_PKEY_get_raw_private_key(get(),
-            buf.data,
-            &len) != 1) return {};
+    if (EVP_PKEY_get_raw_private_key(get(), buf.data, &len) != 1) return {};
     return data;
   }
   return {};
@@ -1572,45 +1634,46 @@ BIOPointer EVPKeyPointer::derPublicKey() const {
 }
 
 namespace {
-EVPKeyPointer::ParseKeyResult TryParsePublicKeyInner(
-    const BIOPointer& bp,
-    const char* name,
-    auto&& parse) {
+EVPKeyPointer::ParseKeyResult TryParsePublicKeyInner(const BIOPointer& bp,
+                                                     const char* name,
+                                                     auto&& parse) {
   if (!bp.resetBio()) {
     return EVPKeyPointer::ParseKeyResult(EVPKeyPointer::PKParseError::FAILED);
   }
   unsigned char* der_data;
-  long der_len;
+  long der_len;  // NOLINT(runtime/int)
 
   // This skips surrounding data and decodes PEM to DER.
   {
     MarkPopErrorOnReturn mark_pop_error_on_return;
-    if (PEM_bytes_read_bio(&der_data, &der_len, nullptr, name,
-                           bp.get(), nullptr, nullptr) != 1)
-      return EVPKeyPointer::ParseKeyResult(EVPKeyPointer::PKParseError::NOT_RECOGNIZED);
+    if (PEM_bytes_read_bio(
+            &der_data, &der_len, nullptr, name, bp.get(), nullptr, nullptr) !=
+        1)
+      return EVPKeyPointer::ParseKeyResult(
+          EVPKeyPointer::PKParseError::NOT_RECOGNIZED);
   }
   DataPointer data(der_data, der_len);
 
   // OpenSSL might modify the pointer, so we need to make a copy before parsing.
   const unsigned char* p = der_data;
   EVPKeyPointer pkey(parse(&p, der_len));
-  if (!pkey) return EVPKeyPointer::ParseKeyResult(EVPKeyPointer::PKParseError::FAILED);
+  if (!pkey)
+    return EVPKeyPointer::ParseKeyResult(EVPKeyPointer::PKParseError::FAILED);
   return EVPKeyPointer::ParseKeyResult(std::move(pkey));
 }
 
-constexpr bool IsASN1Sequence(const unsigned char* data, size_t size,
-                              size_t* data_offset, size_t* data_size) {
-  if (size < 2 || data[0] != 0x30)
-    return false;
+constexpr bool IsASN1Sequence(const unsigned char* data,
+                              size_t size,
+                              size_t* data_offset,
+                              size_t* data_size) {
+  if (size < 2 || data[0] != 0x30) return false;
 
   if (data[1] & 0x80) {
     // Long form.
     size_t n_bytes = data[1] & ~0x80;
-    if (n_bytes + 2 > size || n_bytes > sizeof(size_t))
-      return false;
+    if (n_bytes + 2 > size || n_bytes > sizeof(size_t)) return false;
     size_t length = 0;
-    for (size_t i = 0; i < n_bytes; i++)
-      length = (length << 8) | data[i + 2];
+    for (size_t i = 0; i < n_bytes; i++) length = (length << 8) | data[i + 2];
     *data_offset = 2 + n_bytes;
     *data_size = std::min(size - 2 - n_bytes, length);
   } else {
@@ -1622,12 +1685,12 @@ constexpr bool IsASN1Sequence(const unsigned char* data, size_t size,
   return true;
 }
 
-constexpr bool IsEncryptedPrivateKeyInfo(const Buffer<const unsigned char>& buffer) {
+constexpr bool IsEncryptedPrivateKeyInfo(
+    const Buffer<const unsigned char>& buffer) {
   // Both PrivateKeyInfo and EncryptedPrivateKeyInfo start with a SEQUENCE.
   if (buffer.len == 0 || buffer.data == nullptr) return false;
   size_t offset, len;
-  if (!IsASN1Sequence(buffer.data, buffer.len, &offset, &len))
-    return false;
+  if (!IsASN1Sequence(buffer.data, buffer.len, &offset, &len)) return false;
 
   // A PrivateKeyInfo sequence always starts with an integer whereas an
   // EncryptedPrivateKeyInfo starts with an AlgorithmIdentifier.
@@ -1639,48 +1702,50 @@ constexpr bool IsEncryptedPrivateKeyInfo(const Buffer<const unsigned char>& buff
 bool EVPKeyPointer::IsRSAPrivateKey(const Buffer<const unsigned char>& buffer) {
   // Both RSAPrivateKey and RSAPublicKey structures start with a SEQUENCE.
   size_t offset, len;
-  if (!IsASN1Sequence(buffer.data, buffer.len, &offset, &len))
-    return false;
+  if (!IsASN1Sequence(buffer.data, buffer.len, &offset, &len)) return false;
 
   // An RSAPrivateKey sequence always starts with a single-byte integer whose
   // value is either 0 or 1, whereas an RSAPublicKey starts with the modulus
   // (which is the product of two primes and therefore at least 4), so we can
   // decide the type of the structure based on the first three bytes of the
   // sequence.
-  return len >= 3 &&
-         buffer.data[offset] == 2 &&
-         buffer.data[offset + 1] == 1 &&
+  return len >= 3 && buffer.data[offset] == 2 && buffer.data[offset + 1] == 1 &&
          !(buffer.data[offset + 2] & 0xfe);
 }
 
 EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKeyPEM(
     const Buffer<const unsigned char>& buffer) {
   auto bp = BIOPointer::New(buffer.data, buffer.len);
-  if (!bp)
-    return ParseKeyResult(PKParseError::FAILED);
+  if (!bp) return ParseKeyResult(PKParseError::FAILED);
 
   // Try parsing as SubjectPublicKeyInfo (SPKI) first.
-  if (auto ret = TryParsePublicKeyInner(bp, "PUBLIC KEY",
-      [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
-        return d2i_PUBKEY(nullptr, p, l);
-      })) {
+  if (auto ret = TryParsePublicKeyInner(
+          bp,
+          "PUBLIC KEY",
+          [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
+            return d2i_PUBKEY(nullptr, p, l);
+          })) {
     return ret;
   }
 
   // Maybe it is PKCS#1.
-  if (auto ret = TryParsePublicKeyInner(bp, "RSA PUBLIC KEY",
-      [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
-        return d2i_PublicKey(EVP_PKEY_RSA, nullptr, p, l);
-      })) {
+  if (auto ret = TryParsePublicKeyInner(
+          bp,
+          "RSA PUBLIC KEY",
+          [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
+            return d2i_PublicKey(EVP_PKEY_RSA, nullptr, p, l);
+          })) {
     return ret;
   }
 
   // X.509 fallback.
-  if (auto ret = TryParsePublicKeyInner(bp, "CERTIFICATE",
-      [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
-        X509Pointer x509(d2i_X509(nullptr, p, l));
-        return x509 ? X509_get_pubkey(x509.get()) : nullptr;
-      })) {
+  if (auto ret = TryParsePublicKeyInner(
+          bp,
+          "CERTIFICATE",
+          [](const unsigned char** p, long l) {  // NOLINT(runtime/int)
+            X509Pointer x509(d2i_X509(nullptr, p, l));
+            return x509 ? X509_get_pubkey(x509.get()) : nullptr;
+          })) {
     return ret;
   };
 
@@ -1716,14 +1781,15 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePublicKey(
 }
 
 namespace {
-Buffer<char> GetPassphrase(const EVPKeyPointer::PrivateKeyEncodingConfig& config) {
-  Buffer<char> pass {
-    // OpenSSL will not actually dereference this pointer, so it can be any
-    // non-null pointer. We cannot assert that directly, which is why we
-    // intentionally use a pointer that will likely cause a segmentation fault
-    // when dereferenced.
-    .data = reinterpret_cast<char*>(-1),
-    .len = 0,
+Buffer<char> GetPassphrase(
+    const EVPKeyPointer::PrivateKeyEncodingConfig& config) {
+  Buffer<char> pass{
+      // OpenSSL will not actually dereference this pointer, so it can be any
+      // non-null pointer. We cannot assert that directly, which is why we
+      // intentionally use a pointer that will likely cause a segmentation fault
+      // when dereferenced.
+      .data = reinterpret_cast<char*>(-1),
+      .len = 0,
   };
   if (config.passphrase.has_value()) {
     auto& passphrase = config.passphrase.value();
@@ -1741,12 +1807,11 @@ Buffer<char> GetPassphrase(const EVPKeyPointer::PrivateKeyEncodingConfig& config
 EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePrivateKey(
     const PrivateKeyEncodingConfig& config,
     const Buffer<const unsigned char>& buffer) {
-
-  static constexpr auto keyOrError = [](EVPKeyPointer pkey, bool had_passphrase = false) {
+  static constexpr auto keyOrError = [](EVPKeyPointer pkey,
+                                        bool had_passphrase = false) {
     if (int err = ERR_peek_error()) {
       if (ERR_GET_LIB(err) == ERR_LIB_PEM &&
-          ERR_GET_REASON(err) == PEM_R_BAD_PASSWORD_READ &&
-          !had_passphrase) {
+          ERR_GET_REASON(err) == PEM_R_BAD_PASSWORD_READ && !had_passphrase) {
         return ParseKeyResult(PKParseError::NEED_PASSPHRASE);
       }
       return ParseKeyResult(PKParseError::FAILED, err);
@@ -1755,14 +1820,16 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePrivateKey(
     return ParseKeyResult(std::move(pkey));
   };
 
-
   auto bio = BIOPointer::New(buffer);
   if (!bio) return ParseKeyResult(PKParseError::FAILED);
 
   auto passphrase = GetPassphrase(config);
 
   if (config.format == PKFormatType::PEM) {
-    auto key = PEM_read_bio_PrivateKey(bio.get(), nullptr, PasswordCallback,
+    auto key = PEM_read_bio_PrivateKey(
+        bio.get(),
+        nullptr,
+        PasswordCallback,
         config.passphrase.has_value() ? &passphrase : nullptr);
     return keyOrError(EVPKeyPointer(key), config.passphrase.has_value());
   }
@@ -1778,10 +1845,11 @@ EVPKeyPointer::ParseKeyResult EVPKeyPointer::TryParsePrivateKey(
     }
     case PKEncodingType::PKCS8: {
       if (IsEncryptedPrivateKeyInfo(buffer)) {
-        auto key = d2i_PKCS8PrivateKey_bio(bio.get(),
-                                           nullptr,
-                                           PasswordCallback,
-                                           config.passphrase.has_value() ? &passphrase : nullptr);
+        auto key = d2i_PKCS8PrivateKey_bio(
+            bio.get(),
+            nullptr,
+            PasswordCallback,
+            config.passphrase.has_value() ? &passphrase : nullptr);
         return keyOrError(EVPKeyPointer(key), config.passphrase.has_value());
       }
 
@@ -1828,9 +1896,14 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
 #endif
       switch (config.format) {
         case PKFormatType::PEM: {
-          err = PEM_write_bio_RSAPrivateKey(bio.get(), rsa, config.cipher,
-              reinterpret_cast<unsigned char*>(passphrase.data),
-              passphrase.len, nullptr, nullptr) != 1;
+          err = PEM_write_bio_RSAPrivateKey(
+                    bio.get(),
+                    rsa,
+                    config.cipher,
+                    reinterpret_cast<unsigned char*>(passphrase.data),
+                    passphrase.len,
+                    nullptr,
+                    nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
@@ -1849,21 +1922,23 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
       switch (config.format) {
         case PKFormatType::PEM: {
           // Encode PKCS#8 as PEM.
-          err = PEM_write_bio_PKCS8PrivateKey(
-                    bio.get(), get(),
-                    config.cipher,
-                    passphrase.data,
-                    passphrase.len,
-                    nullptr, nullptr) != 1;
+          err = PEM_write_bio_PKCS8PrivateKey(bio.get(),
+                                              get(),
+                                              config.cipher,
+                                              passphrase.data,
+                                              passphrase.len,
+                                              nullptr,
+                                              nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
-          err = i2d_PKCS8PrivateKey_bio(
-                    bio.get(), get(),
-                    config.cipher,
-                    passphrase.data,
-                    passphrase.len,
-                    nullptr, nullptr) != 1;
+          err = i2d_PKCS8PrivateKey_bio(bio.get(),
+                                        get(),
+                                        config.cipher,
+                                        passphrase.data,
+                                        passphrase.len,
+                                        nullptr,
+                                        nullptr) != 1;
           break;
         }
         default: {
@@ -1884,13 +1959,14 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
 #endif
       switch (config.format) {
         case PKFormatType::PEM: {
-          err = PEM_write_bio_ECPrivateKey(bio.get(),
-                                          ec,
-                                          config.cipher,
-                                          reinterpret_cast<unsigned char*>(passphrase.data),
-                                          passphrase.len,
-                                          nullptr,
-                                          nullptr) != 1;
+          err = PEM_write_bio_ECPrivateKey(
+                    bio.get(),
+                    ec,
+                    config.cipher,
+                    reinterpret_cast<unsigned char*>(passphrase.data),
+                    passphrase.len,
+                    nullptr,
+                    nullptr) != 1;
           break;
         }
         case PKFormatType::DER: {
@@ -1913,14 +1989,15 @@ Result<BIOPointer, bool> EVPKeyPointer::writePrivateKey(
 
   if (err) {
     // Failed to encode the private key.
-    return Result<BIOPointer, bool>(false, mark_pop_error_on_return.peekError());
+    return Result<BIOPointer, bool>(false,
+                                    mark_pop_error_on_return.peekError());
   }
 
   return bio;
 }
 
 Result<BIOPointer, bool> EVPKeyPointer::writePublicKey(
-      const ncrypto::EVPKeyPointer::PublicKeyEncodingConfig& config) const {
+    const ncrypto::EVPKeyPointer::PublicKeyEncodingConfig& config) const {
   auto bio = BIOPointer::NewMem();
   if (!bio) return Result<BIOPointer, bool>(false);
 
@@ -1936,14 +2013,16 @@ Result<BIOPointer, bool> EVPKeyPointer::writePublicKey(
     if (config.format == ncrypto::EVPKeyPointer::PKFormatType::PEM) {
       // Encode PKCS#1 as PEM.
       if (PEM_write_bio_RSAPublicKey(bio.get(), rsa) != 1) {
-        return Result<BIOPointer, bool>(false, mark_pop_error_on_return.peekError());
+        return Result<BIOPointer, bool>(false,
+                                        mark_pop_error_on_return.peekError());
       }
       return bio;
     }
 
     // Encode PKCS#1 as DER.
     if (i2d_RSAPublicKey_bio(bio.get(), rsa) != 1) {
-      return Result<BIOPointer, bool>(false, mark_pop_error_on_return.peekError());
+      return Result<BIOPointer, bool>(false,
+                                      mark_pop_error_on_return.peekError());
     }
     return bio;
   }
@@ -1951,14 +2030,16 @@ Result<BIOPointer, bool> EVPKeyPointer::writePublicKey(
   if (config.format == ncrypto::EVPKeyPointer::PKFormatType::PEM) {
     // Encode SPKI as PEM.
     if (PEM_write_bio_PUBKEY(bio.get(), get()) != 1) {
-      return Result<BIOPointer, bool>(false, mark_pop_error_on_return.peekError());
+      return Result<BIOPointer, bool>(false,
+                                      mark_pop_error_on_return.peekError());
     }
     return bio;
   }
 
   // Encode SPKI as DER.
   if (i2d_PUBKEY_bio(bio.get(), get()) != 1) {
-    return Result<BIOPointer, bool>(false, mark_pop_error_on_return.peekError());
+    return Result<BIOPointer, bool>(false,
+                                    mark_pop_error_on_return.peekError());
   }
   return bio;
 }

--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -162,7 +162,7 @@ bool testFipsEnabled() {
 #else
 #ifdef OPENSSL_FIPS
   const auto enabled = FIPS_selftest() ? 1 : 0;
-#else   // OPENSSL_FIPS
+#else  // OPENSSL_FIPS
   const auto enabled = 0;
 #endif  // OPENSSL_FIPS
 #endif

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#include <cstddef>
-#include <list>
-#include <memory>
-#include <optional>
-#include <string>
-#include <string_view>
 #include <openssl/bio.h>
 #include <openssl/bn.h>
 #include <openssl/dh.h>
@@ -18,13 +12,19 @@
 #include <openssl/rsa.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <cstddef>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
 #ifndef OPENSSL_NO_ENGINE
-#  include <openssl/engine.h>
+#include <openssl/engine.h>
 #endif  // !OPENSSL_NO_ENGINE
 // The FIPS-related functions are only available
 // when the OpenSSL itself was compiled with FIPS support.
 #if defined(OPENSSL_FIPS) && OPENSSL_VERSION_MAJOR < 3
-#  include <openssl/fips.h>
+#include <openssl/fips.h>
 #endif  // OPENSSL_FIPS
 
 #ifdef __GNUC__
@@ -93,11 +93,8 @@ namespace ncrypto {
 }
 
 static constexpr int kX509NameFlagsMultiline =
-    ASN1_STRFLGS_ESC_2253 |
-    ASN1_STRFLGS_ESC_CTRL |
-    ASN1_STRFLGS_UTF8_CONVERT |
-    XN_FLAG_SEP_MULTILINE |
-    XN_FLAG_FN_SN;
+    ASN1_STRFLGS_ESC_2253 | ASN1_STRFLGS_ESC_CTRL | ASN1_STRFLGS_UTF8_CONVERT |
+    XN_FLAG_SEP_MULTILINE | XN_FLAG_FN_SN;
 
 // ============================================================================
 // Error handling utilities
@@ -106,11 +103,8 @@ static constexpr int kX509NameFlagsMultiline =
 // that the error currently at the top of the stack is at the end of the
 // list and the error at the bottom of the stack is at the beginning.
 class CryptoErrorList final {
-public:
-  enum class Option {
-    NONE,
-    CAPTURE_ON_CONSTRUCT
-  };
+ public:
+  enum class Option { NONE, CAPTURE_ON_CONSTRUCT };
   CryptoErrorList(Option option = Option::CAPTURE_ON_CONSTRUCT);
 
   void capture();
@@ -130,7 +124,7 @@ public:
   std::optional<std::string> pop_back();
   std::optional<std::string> pop_front();
 
-private:
+ private:
   std::list<std::string> errors_;
 };
 
@@ -142,7 +136,7 @@ private:
 // If created with a pointer to a CryptoErrorList, the current OpenSSL error
 // stack will be captured before clearing the error.
 class ClearErrorOnReturn final {
-public:
+ public:
   ClearErrorOnReturn(CryptoErrorList* errors = nullptr);
   ~ClearErrorOnReturn();
   NCRYPTO_DISALLOW_COPY_AND_MOVE(ClearErrorOnReturn)
@@ -150,7 +144,7 @@ public:
 
   int peekError();
 
-private:
+ private:
   CryptoErrorList* errors_;
 };
 
@@ -160,7 +154,7 @@ private:
 // If created with a pointer to a CryptoErrorList, the current OpenSSL error
 // stack will be captured before resetting the error to the mark.
 class MarkPopErrorOnReturn final {
-public:
+ public:
   MarkPopErrorOnReturn(CryptoErrorList* errors = nullptr);
   ~MarkPopErrorOnReturn();
   NCRYPTO_DISALLOW_COPY_AND_MOVE(MarkPopErrorOnReturn)
@@ -168,7 +162,7 @@ public:
 
   int peekError();
 
-private:
+ private:
   CryptoErrorList* errors_;
 };
 
@@ -220,7 +214,7 @@ using SSLPointer = DeleteFnPtr<SSL, SSL_free>;
 using SSLSessionPointer = DeleteFnPtr<SSL_SESSION, SSL_SESSION_free>;
 
 struct StackOfXASN1Deleter {
-  void operator()(STACK_OF(ASN1_OBJECT)* p) const {
+  void operator()(STACK_OF(ASN1_OBJECT) * p) const {
     sk_ASN1_OBJECT_pop_free(p, ASN1_OBJECT_free);
   }
 };
@@ -262,8 +256,8 @@ class DataPointer final {
   template <typename T = void>
   inline operator const Buffer<T>() const {
     return {
-      .data = static_cast<T*>(data_),
-      .len = len_,
+        .data = static_cast<T*>(data_),
+        .len = len_,
     };
   }
 
@@ -273,7 +267,7 @@ class DataPointer final {
 };
 
 class BIOPointer final {
-public:
+ public:
   static BIOPointer NewMem();
   static BIOPointer NewSecMem();
   static BIOPointer New(const BIO_METHOD* method);
@@ -314,13 +308,13 @@ public:
 
   static int Write(BIOPointer* bio, std::string_view message);
 
-  template <typename...Args>
-  static void Printf(BIOPointer* bio, const char* format, Args...args) {
+  template <typename... Args>
+  static void Printf(BIOPointer* bio, const char* format, Args... args) {
     if (bio == nullptr || !*bio) return;
     BIO_printf(bio->get(), format, std::forward<Args...>(args...));
   }
 
-private:
+ private:
   mutable DeleteFnPtr<BIO, BIO_free_all> bio_;
 };
 
@@ -345,8 +339,8 @@ class BignumPointer final {
   bool isZero() const;
   bool isOne() const;
 
-  bool setWord(unsigned long w);
-  unsigned long getWord() const;
+  bool setWord(unsigned long w);  // NOLINT(runtime/int)
+  unsigned long getWord() const;  // NOLINT(runtime/int)
 
   size_t byteLength() const;
 
@@ -360,10 +354,12 @@ class BignumPointer final {
   static BignumPointer NewSecure();
   static DataPointer Encode(const BIGNUM* bn);
   static DataPointer EncodePadded(const BIGNUM* bn, size_t size);
-  static size_t EncodePaddedInto(const BIGNUM* bn, unsigned char* out, size_t size);
+  static size_t EncodePaddedInto(const BIGNUM* bn,
+                                 unsigned char* out,
+                                 size_t size);
   static int GetBitCount(const BIGNUM* bn);
   static int GetByteCount(const BIGNUM* bn);
-  static unsigned long GetWord(const BIGNUM* bn);
+  static unsigned long GetWord(const BIGNUM* bn);  // NOLINT(runtime/int)
   static const BIGNUM* One();
 
   BignumPointer clone();
@@ -373,10 +369,12 @@ class BignumPointer final {
 };
 
 class EVPKeyPointer final {
-public:
+ public:
   static EVPKeyPointer New();
-  static EVPKeyPointer NewRawPublic(int id, const Buffer<const unsigned char>& data);
-  static EVPKeyPointer NewRawPrivate(int id, const Buffer<const unsigned char>& data);
+  static EVPKeyPointer NewRawPublic(int id,
+                                    const Buffer<const unsigned char>& data);
+  static EVPKeyPointer NewRawPrivate(int id,
+                                     const Buffer<const unsigned char>& data);
 
   enum class PKEncodingType {
     // RSAPublicKey / RSAPrivateKey according to PKCS#1.
@@ -395,11 +393,7 @@ public:
     JWK,
   };
 
-  enum class PKParseError {
-    NOT_RECOGNIZED,
-    NEED_PASSPHRASE,
-    FAILED
-  };
+  enum class PKParseError { NOT_RECOGNIZED, NEED_PASSPHRASE, FAILED };
   using ParseKeyResult = Result<EVPKeyPointer, PKParseError>;
 
   struct AsymmetricKeyEncodingConfig {
@@ -407,17 +401,22 @@ public:
     PKFormatType format = PKFormatType::DER;
     PKEncodingType type = PKEncodingType::PKCS8;
     AsymmetricKeyEncodingConfig() = default;
-    AsymmetricKeyEncodingConfig(bool output_key_object, PKFormatType format, PKEncodingType type);
+    AsymmetricKeyEncodingConfig(bool output_key_object,
+                                PKFormatType format,
+                                PKEncodingType type);
     AsymmetricKeyEncodingConfig(const AsymmetricKeyEncodingConfig&) = default;
-    AsymmetricKeyEncodingConfig& operator=(const AsymmetricKeyEncodingConfig&) = default;
+    AsymmetricKeyEncodingConfig& operator=(const AsymmetricKeyEncodingConfig&) =
+        default;
   };
   using PublicKeyEncodingConfig = AsymmetricKeyEncodingConfig;
 
-  struct PrivateKeyEncodingConfig: public AsymmetricKeyEncodingConfig {
+  struct PrivateKeyEncodingConfig : public AsymmetricKeyEncodingConfig {
     const EVP_CIPHER* cipher = nullptr;
     std::optional<DataPointer> passphrase = std::nullopt;
     PrivateKeyEncodingConfig() = default;
-    PrivateKeyEncodingConfig(bool output_key_object, PKFormatType format, PKEncodingType type)
+    PrivateKeyEncodingConfig(bool output_key_object,
+                             PKFormatType format,
+                             PKEncodingType type)
         : AsymmetricKeyEncodingConfig(output_key_object, format, type) {}
     PrivateKeyEncodingConfig(const PrivateKeyEncodingConfig&);
     PrivateKeyEncodingConfig& operator=(const PrivateKeyEncodingConfig&);
@@ -441,7 +440,9 @@ public:
   NCRYPTO_DISALLOW_COPY(EVPKeyPointer)
   ~EVPKeyPointer();
 
-  inline bool operator==(std::nullptr_t) const noexcept { return pkey_ == nullptr; }
+  inline bool operator==(std::nullptr_t) const noexcept {
+    return pkey_ == nullptr;
+  }
   inline operator bool() const { return pkey_ != nullptr; }
   inline EVP_PKEY* get() const { return pkey_.get(); }
   void reset(EVP_PKEY* pkey = nullptr);
@@ -461,20 +462,21 @@ public:
   DataPointer rawPrivateKey() const;
   BIOPointer derPublicKey() const;
 
-  Result<BIOPointer, bool> writePrivateKey(const PrivateKeyEncodingConfig& config) const;
-  Result<BIOPointer, bool> writePublicKey(const PublicKeyEncodingConfig& config) const;
+  Result<BIOPointer, bool> writePrivateKey(
+      const PrivateKeyEncodingConfig& config) const;
+  Result<BIOPointer, bool> writePublicKey(
+      const PublicKeyEncodingConfig& config) const;
 
   EVPKeyCtxPointer newCtx() const;
 
   static bool IsRSAPrivateKey(const Buffer<const unsigned char>& buffer);
 
-private:
+ private:
   DeleteFnPtr<EVP_PKEY, EVP_PKEY_free> pkey_;
 };
 
 class DHPointer final {
-public:
-
+ public:
   enum class FindGroupOption {
     NONE,
     // There are known and documented security issues with prime groups smaller
@@ -485,8 +487,9 @@ public:
 
   static BignumPointer GetStandardGenerator();
 
-  static BignumPointer FindGroup(const std::string_view name,
-                                 FindGroupOption option = FindGroupOption::NONE);
+  static BignumPointer FindGroup(
+      const std::string_view name,
+      FindGroupOption option = FindGroupOption::NONE);
   static DHPointer FromGroup(const std::string_view name,
                              FindGroupOption option = FindGroupOption::NONE);
 
@@ -544,7 +547,7 @@ public:
   static DataPointer stateless(const EVPKeyPointer& ourKey,
                                const EVPKeyPointer& theirKey);
 
-private:
+ private:
   DeleteFnPtr<DH, DH_free> dh_;
 };
 
@@ -594,7 +597,8 @@ class X509View final {
     INVALID_NAME,
     OPERATION_FAILED,
   };
-  CheckMatch checkHost(const std::string_view host, int flags,
+  CheckMatch checkHost(const std::string_view host,
+                       int flags,
                        DataPointer* peerName = nullptr) const;
   CheckMatch checkEmail(const std::string_view email, int flags) const;
   CheckMatch checkIp(const std::string_view ip, int flags) const;
@@ -632,7 +636,7 @@ class X509Pointer final {
 
 #ifndef OPENSSL_NO_ENGINE
 class EnginePointer final {
-public:
+ public:
   EnginePointer() = default;
 
   explicit EnginePointer(ENGINE* engine_, bool finish_on_exit = false);
@@ -663,7 +667,7 @@ public:
   // Call once when initializing OpenSSL at startup for the process.
   static void initEnginesOnce();
 
-private:
+ private:
   ENGINE* engine = nullptr;
   bool finish_on_exit = false;
 };


### PR DESCRIPTION
CC @jasnell (who appears to have contributed most of this work)

If these files are maintained in this repository, should they not follow the same linting / formatting rules? This PR has `clang-format` and `cpplint` apply to these files.