### PR TITLE
buffer: make Buffer work with resizable ArrayBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -504,9 +504,7 @@ function fromArrayBuffer(obj, byteOffset, length) {
   if (maxLength < 0)
     throw new ERR_BUFFER_OUT_OF_BOUNDS('offset');
 
-  if (length === undefined) {
-    length = maxLength;
-  } else {
+  if (length !== undefined) {
     // Convert length to non-negative integer.
     length = +length;
     if (length > 0) {

--- a/test/parallel/test-buffer-resizable.js
+++ b/test/parallel/test-buffer-resizable.js
@@ -1,0 +1,29 @@
+// Flags: --no-warnings
+'use strict';
+
+require('../common');
+const { Buffer } = require('node:buffer');
+const { strictEqual } = require('node:assert');
+const { describe, it } = require('node:test');
+
+describe('Using resizable ArrayBuffer with Buffer...', () => {
+  it('works as expected', () => {
+    const ab = new ArrayBuffer(10, { maxByteLength: 20 });
+    const buffer = Buffer.from(ab, 1);
+    strictEqual(buffer.byteLength, 9);
+    ab.resize(15);
+    strictEqual(buffer.byteLength, 14);
+    ab.resize(5);
+    strictEqual(buffer.byteLength, 4);
+  });
+
+  it('works with the deprecated constructor also', () => {
+    const ab = new ArrayBuffer(10, { maxByteLength: 20 });
+    const buffer = new Buffer(ab, 1);
+    strictEqual(buffer.byteLength, 9);
+    ab.resize(15);
+    strictEqual(buffer.byteLength, 14);
+    ab.resize(5);
+    strictEqual(buffer.byteLength, 4);
+  });
+});


### PR DESCRIPTION
For release notes:

When a `Buffer` is created using a resizable `ArrayBuffer`, the `Buffer` length will now correctly change as the underlying `ArrayBuffer` size is changed.

```js
const ab = new ArrayBuffer(10, { maxByteLength: 20 });
const buffer = Buffer.from(ab);
console.log(buffer.byteLength); 10
ab.resize(15);
console.log(buffer.byteLength); 15
ab.resize(5);
console.log(buffer.byteLength); 5
```

Fixes: https://github.com/nodejs/node/issues/52195

