### PR TITLE
test: deflake `test-cluster-shared-handle-bind-privileged-port`

### DIFF
--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -21,7 +21,6 @@
 
 'use strict';
 const common = require('../common');
-const { readFileSync } = require('fs');
 
 // Skip on macOS Mojave. https://github.com/nodejs/node/issues/21679
 if (common.isMacOS)
@@ -39,6 +38,8 @@ if (process.getuid() === 0)
 // Some systems won't have port 42 set as a privileged port, in that
 // case, skip the test.
 if (common.isLinux) {
+  const { readFileSync } = require('fs');
+
   try {
     const unprivilegedPortStart = parseInt(readFileSync('/proc/sys/net/ipv4/ip_unprivileged_port_start'));
     if (unprivilegedPortStart <= 42) {

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -21,6 +21,7 @@
 
 'use strict';
 const common = require('../common');
+const { readFileSync } = require('fs');
 
 // Skip on macOS Mojave. https://github.com/nodejs/node/issues/21679
 if (common.isMacOS)
@@ -34,6 +35,18 @@ if (common.isWindows)
 
 if (process.getuid() === 0)
   common.skip('as this test should not be run as `root`');
+
+if (common.isLinux) {
+  try {
+    const unprivilegedPortStart = parseInt(readFileSync('/proc/sys/net/ipv4/ip_unprivileged_port_start'));
+    if (unprivilegedPortStart <= 42) {
+      common.skip('Port 42 is unprivileged');
+    }
+  } catch {
+    // Do nothing, feature doesn't exist, minimum is 1024 so 42 is usable.
+    // Continue...
+  }
+}
 
 const assert = require('assert');
 const cluster = require('cluster');

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -36,6 +36,8 @@ if (common.isWindows)
 if (process.getuid() === 0)
   common.skip('as this test should not be run as `root`');
 
+// Some systems won't have port 42 set as a privileged port, in that
+// case, skip the test.
 if (common.isLinux) {
   try {
     const unprivilegedPortStart = parseInt(readFileSync('/proc/sys/net/ipv4/ip_unprivileged_port_start'));


### PR DESCRIPTION
On some Linux systems (not reproducible in CI, but reproducible locally), this test will fail because the port 42 is not priviledged. For example, on my Kali Linux installation:

```console
└─$ out/Release/node test/parallel/test-cluster-shared-handle-bind-privileged-port.js
node:assert:137
  throw err;
  ^

AssertionError [ERR_ASSERTION]: listen should have failed at test/parallel/test-cluster-shared-handle-bind-privileged-port.js:51
    at Server.mustNotCall (test/common/index.js:557:12)
    at Object.onceWrapper (node:events:621:28)
    at Server.emit (node:events:519:35)
    at emitListeningNT (node:net:1948:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: undefined,
  operator: 'fail'
}

Node.js v23.0.0-pre
node:assert:90
  throw new AssertionError(obj);
  ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

1 !== 0

    at Worker.<anonymous> (test/parallel/test-cluster-shared-handle-bind-privileged-port.js:47:12)
    at Worker.<anonymous> (test/common/index.js:491:15)
    at Worker.emit (node:events:507:28)
    at ChildProcess.<anonymous> (node:internal/cluster/primary:187:12)
    at Object.onceWrapper (node:events:622:26)
    at ChildProcess.emit (node:events:507:28)
    at ChildProcess._handle.onexit (node:internal/child_process:294:12) {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: 1,
  expected: 0,
  operator: 'strictEqual'
}

Node.js v23.0.0-pre
```