### PR TITLE
test_runner: mark mockTimers as stable

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2222,6 +2222,10 @@ set to `true`.
 added:
   - v20.4.0
   - v18.19.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55398
+    description: The Mock Timers is now stable.
 -->
 
 > Stability: 2 - Stable

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2224,7 +2224,7 @@ added:
   - v18.19.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 2 - Stable
 
 Mocking timers is a technique commonly used in software testing to simulate and
 control the behavior of timers, such as `setInterval` and `setTimeout`,

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -28,9 +28,6 @@ const {
 } = require('internal/validators');
 
 const {
-  emitExperimentalWarning,
-} = require('internal/util');
-const {
   AbortError,
   codes: {
     ERR_INVALID_ARG_VALUE,
@@ -132,10 +129,6 @@ class MockTimers {
   #setInterval = FunctionPrototypeBind(this.#createTimer, this, true);
   #clearInterval = FunctionPrototypeBind(this.#clearTimer, this);
   #clearImmediate = FunctionPrototypeBind(this.#clearTimer, this);
-
-  constructor() {
-    emitExperimentalWarning('The MockTimers API');
-  }
 
   #restoreSetImmediate() {
     ObjectDefineProperty(


### PR DESCRIPTION
The MockTimers feature was introduced back in April 2023 on https://github.com/nodejs/node/pull/47775 and had been receiving several fixes and improvements since then, currently there're no open issues.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
