### PR TITLE
test: make `test-node-output-v8-warning` more flexible

### DIFF
--- a/test/parallel/test-node-output-v8-warning.mjs
+++ b/test/parallel/test-node-output-v8-warning.mjs
@@ -2,9 +2,15 @@ import '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import * as snapshot from '../common/assertSnapshot.js';
 import { describe, it } from 'node:test';
+import { basename } from 'node:path';
 
 function replaceNodeVersion(str) {
   return str.replaceAll(process.version, '*');
+}
+
+function replaceExecName(str) {
+  const baseName = basename(process.argv0 || 'node', '.exe');
+  return str.replaceAll(`${baseName} --`, '* --');
 }
 
 describe('v8 output', { concurrency: !process.env.TEST_PARALLEL }, () => {
@@ -14,11 +20,10 @@ describe('v8 output', { concurrency: !process.env.TEST_PARALLEL }, () => {
     .replaceAll('/', '*')
     .replaceAll('*test*', '*')
     .replaceAll(/.*?\*fixtures\*v8\*/g, '(node:*) V8: *') // Replace entire path before fixtures/v8
-    .replaceAll('*fixtures*v8*', '*')
-    .replaceAll('node --', '* --');
+    .replaceAll('*fixtures*v8*', '*');
   }
   const common = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion);
+    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, replaceExecName);
   const defaultTransform = snapshot.transform(common, normalize);
   const tests = [
     { name: 'v8/v8_warning.js' },


### PR DESCRIPTION
This PR makes snapshot testing slightly more flexible so that embedders can run smoke tests against it.

Previous similar PRs:
* https://github.com/nodejs/node/pull/36489
* https://github.com/nodejs/node/pull/54375

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
