### PR TITLE
assert: fix deepStrictEqual on errors when cause is present

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -47,6 +47,15 @@ function copyError(source) {
     __proto__: null,
     value: source.message,
   });
+  if (source.cause !== undefined) {
+    let cause = source.cause;
+
+    if (cause instanceof Error) {
+      cause = copyError(cause);
+    }
+
+    ObjectDefineProperty(target, 'cause', { __proto__: null, value: cause });
+  }
   return target;
 }
 

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -15,6 +15,8 @@ const {
   StringPrototypeSplit,
 } = primordials;
 
+const { isError } = require('internal/util');
+
 const { inspect } = require('internal/util/inspect');
 const colors = require('internal/util/colors');
 const { validateObject } = require('internal/validators');
@@ -50,7 +52,7 @@ function copyError(source) {
   if (source.cause !== undefined) {
     let cause = source.cause;
 
-    if (cause instanceof Error) {
+    if (isError(cause)) {
       cause = copyError(cause);
     }
 

--- a/test/parallel/test-assert-deep-with-error.js
+++ b/test/parallel/test-assert-deep-with-error.js
@@ -13,14 +13,27 @@ test('Handle error causes', () => {
   }, { message: defaultStartMessage + '  [Error: a] {\n' +
     '+   [cause]: [Error: x]\n' +
     '-   [cause]: [Error: y]\n' +
-    '  }' });
+    '  }\n' });
 
   assert.throws(() => {
     assert.deepStrictEqual(new Error('a'), new Error('a', { cause: new Error('y') }));
   }, { message: defaultStartMessage + '+ [Error: a]\n' +
     '- [Error: a] {\n' +
     '-   [cause]: [Error: y]\n' +
-    '- }' });
+    '- }\n' });
+
+  assert.throws(() => {
+    assert.deepStrictEqual(new Error('a'), new Error('a', { cause: { prop: 'value' } }));
+  }, { message: defaultStartMessage + '+ [Error: a]\n' +
+    '- [Error: a] {\n' +
+    '-   [cause]: {\n' +
+    '-     prop: \'value\'\n' +
+    '-   }\n' +
+    '- }\n' });
 
   assert.notDeepStrictEqual(new Error('a', { cause: new Error('x') }), new Error('a', { cause: new Error('y') }));
+  assert.notDeepStrictEqual(
+    new Error('a', { cause: { prop: 'value' } }),
+    new Error('a', { cause: { prop: 'a different value' } })
+  );
 });

--- a/test/parallel/test-assert-deep-with-error.js
+++ b/test/parallel/test-assert-deep-with-error.js
@@ -1,0 +1,26 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { test } = require('node:test');
+
+const defaultStartMessage = 'Expected values to be strictly deep-equal:\n' +
+  '+ actual - expected\n' +
+  '\n';
+
+test('Handle error causes', () => {
+  assert.throws(() => {
+    assert.deepStrictEqual(new Error('a', { cause: new Error('x') }), new Error('a', { cause: new Error('y') }));
+  }, { message: defaultStartMessage + '  [Error: a] {\n' +
+    '+   [cause]: [Error: x]\n' +
+    '-   [cause]: [Error: y]\n' +
+    '  }' });
+
+  assert.throws(() => {
+    assert.deepStrictEqual(new Error('a'), new Error('a', { cause: new Error('y') }));
+  }, { message: defaultStartMessage + '+ [Error: a]\n' +
+    '- [Error: a] {\n' +
+    '-   [cause]: [Error: y]\n' +
+    '- }' });
+
+  assert.notDeepStrictEqual(new Error('a', { cause: new Error('x') }), new Error('a', { cause: new Error('y') }));
+});


### PR DESCRIPTION
Refs #55310
Fixes #55310

This PR fixes AssertionError reporting when [`cause`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) is present.
