### PR TITLE
lib: remove startsWith/endsWith primordials for char checks

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -341,7 +341,7 @@ function calculateServerName(options, req) {
     // abc:123 => abc
     // [::1] => ::1
     // [::1]:123 => ::1
-    if (hostHeader.startsWith('[')) {
+    if (hostHeader[0] === '[') {
       const index = hostHeader.indexOf(']');
       if (index === -1) {
         // Leading '[', but no ']'. Need to do something...

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -46,7 +46,7 @@ for (let i = 0; i < process.execArgv.length; i++) {
   if (StringPrototypeStartsWith(arg, '--watch')) {
     i++;
     const nextArg = process.execArgv[i];
-    if (nextArg && StringPrototypeStartsWith(nextArg, '-')) {
+    if (nextArg && nextArg[0] === '-') {
       ArrayPrototypePush(argsWithoutWatchOptions, nextArg);
     }
     continue;

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -5,7 +5,6 @@ const {
   SafeMap,
   StringPrototypeEndsWith,
   StringPrototypeSlice,
-  StringPrototypeStartsWith,
 } = primordials;
 const {
   Buffer: { concat: BufferConcat },
@@ -248,8 +247,9 @@ allowList.addRange('127.0.0.1', '127.255.255.255');
 async function isLocalAddress(hostname) {
   try {
     if (
-      StringPrototypeStartsWith(hostname, '[') &&
-      StringPrototypeEndsWith(hostname, ']')
+      hostname &&
+      hostname[0] === '[' &&
+      hostname[hostname.length - 1] === ']'
     ) {
       hostname = StringPrototypeSlice(hostname, 1, -1);
     }

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -246,7 +246,7 @@ allowList.addRange('127.0.0.1', '127.255.255.255');
 async function isLocalAddress(hostname) {
   try {
     if (
-      hostname &&
+      hostname.length &&
       hostname[0] === '[' &&
       hostname[hostname.length - 1] === ']'
     ) {

--- a/lib/internal/modules/esm/fetch_module.js
+++ b/lib/internal/modules/esm/fetch_module.js
@@ -3,7 +3,6 @@ const {
   ObjectPrototypeHasOwnProperty,
   PromisePrototypeThen,
   SafeMap,
-  StringPrototypeEndsWith,
   StringPrototypeSlice,
 } = primordials;
 const {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -373,8 +373,9 @@ function resolvePackageTargetString(
   }
 
   if (!StringPrototypeStartsWith(target, './')) {
-    if (internal && !StringPrototypeStartsWith(target, '../') &&
-        !StringPrototypeStartsWith(target, '/')) {
+    if (internal &&
+        target[0] !== '/' &&
+        !StringPrototypeStartsWith(target, '../')) {
       // No need to convert target to string, since it's already presumed to be
       if (!URLCanParse(target)) {
         const exportTarget = pattern ?

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -202,7 +202,7 @@ function addBuiltinLibsToObject(object, dummyModuleName) {
   ArrayPrototypeForEach(builtinModules, (name) => {
     // Neither add underscored modules, nor ones that contain slashes (e.g.,
     // 'fs/promises') or ones that are already defined.
-    if (StringPrototypeStartsWith(name, '_') ||
+    if (name[0] === '_' ||
         StringPrototypeIncludes(name, '/') ||
         ObjectPrototypeHasOwnProperty(object, name)) {
       return;

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -295,7 +295,7 @@ function buildAllowedFlags() {
   }
 
   function isAccepted(to) {
-    if (!to || to[0] !== '-' || to === '--') return true;
+    if (!to.length || to[0] !== '-' || to === '--') return true;
     const recursiveExpansion = aliases.get(to);
     if (recursiveExpansion) {
       if (recursiveExpansion[0] === to)

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -25,7 +25,6 @@ const {
   StringPrototypeEndsWith,
   StringPrototypeReplace,
   StringPrototypeSlice,
-  StringPrototypeStartsWith,
   Symbol,
   SymbolIterator,
 } = primordials;
@@ -296,7 +295,7 @@ function buildAllowedFlags() {
   }
 
   function isAccepted(to) {
-    if (!StringPrototypeStartsWith(to, '-') || to === '--') return true;
+    if (!to || to[0] !== '-' || to === '--') return true;
     const recursiveExpansion = aliases.get(to);
     if (recursiveExpansion) {
       if (recursiveExpansion[0] === to)

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -13,7 +13,6 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   String,
-  StringPrototypeStartsWith,
   globalThis,
 } = primordials;
 
@@ -206,8 +205,7 @@ function patchProcessObject(expandArgv1) {
   let mainEntry;
   // If requested, update process.argv[1] to replace whatever the user provided with the resolved absolute file path of
   // the entry point.
-  if (expandArgv1 && process.argv[1] &&
-      !StringPrototypeStartsWith(process.argv[1], '-')) {
+  if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
     // Expand process.argv[1] into a full path.
     const path = require('path');
     try {

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -15,7 +15,6 @@ const {
   StringPrototypeLastIndexOf,
   StringPrototypeReplaceAll,
   StringPrototypeSlice,
-  StringPrototypeStartsWith,
   StringPrototypeToLowerCase,
   StringPrototypeTrim,
   Symbol,
@@ -298,8 +297,7 @@ function setupPreview(repl, contextSymbol, bufferSymbol, active) {
   function getInputPreview(input, callback) {
     // For similar reasons as `defaultEval`, wrap expressions starting with a
     // curly brace with parenthesis.
-    if (StringPrototypeStartsWith(input, '{') &&
-        !StringPrototypeEndsWith(input, ';') && !wrapped) {
+    if (!wrapped && input[0] === '{' && input[input.length - 1] !== ';') {
       input = `(${input})`;
       wrapped = true;
     }

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -10,7 +10,6 @@ const {
   RegExpPrototypeExec,
   SafeSet,
   SafeStringIterator,
-  StringPrototypeEndsWith,
   StringPrototypeIndexOf,
   StringPrototypeLastIndexOf,
   StringPrototypeReplaceAll,

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1416,7 +1416,7 @@ function urlToHttpOptions(url) {
     __proto__: null,
     ...url, // In case the url object was extended by the user.
     protocol: url.protocol,
-    hostname: hostname && StringPrototypeStartsWith(hostname, '[') ?
+    hostname: hostname && hostname[0] === '[' ?
       StringPrototypeSlice(hostname, 1, -1) :
       hostname,
     hash: url.hash,

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1573,6 +1573,7 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
 function addNumericSeparator(integerString) {
   let result = '';
   let i = integerString.length;
+  assert(i !== 0);
   const start = integerString[0] === '-' ? 1 : 0;
   for (; i >= start + 4; i -= 3) {
     result = `_${StringPrototypeSlice(integerString, i - 3, i)}${result}`;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1190,7 +1190,7 @@ function getClassBase(value, constructor, tag) {
 
 function getFunctionBase(value, constructor, tag) {
   const stringified = FunctionPrototypeToString(value);
-  if (StringPrototypeStartsWith(stringified, 'class') && StringPrototypeEndsWith(stringified, '}')) {
+  if (StringPrototypeStartsWith(stringified, 'class') && stringified[stringified.length - 1] === '}') {
     const slice = StringPrototypeSlice(stringified, 5, -1);
     const bracketIndex = StringPrototypeIndexOf(slice, '{');
     if (bracketIndex !== -1 &&
@@ -1573,7 +1573,7 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
 function addNumericSeparator(integerString) {
   let result = '';
   let i = integerString.length;
-  const start = StringPrototypeStartsWith(integerString, '-') ? 1 : 0;
+  const start = integerString[0] === '-' ? 1 : 0;
   for (; i >= start + 4; i -= 3) {
     result = `_${StringPrototypeSlice(integerString, i - 3, i)}${result}`;
   }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -130,7 +130,7 @@ const { shouldColorize } = require('internal/util/colors');
 const CJSModule = require('internal/modules/cjs/loader').Module;
 let _builtinLibs = ArrayPrototypeFilter(
   CJSModule.builtinModules,
-  (e) => !StringPrototypeStartsWith(e, '_'),
+  (e) => e[0] !== '_',
 );
 const nodeSchemeBuiltinLibs = ArrayPrototypeMap(
   _builtinLibs, (lib) => `node:${lib}`);

--- a/test/fixtures/wpt/resources/webidl2/lib/webidl2.js
+++ b/test/fixtures/wpt/resources/webidl2/lib/webidl2.js
@@ -712,7 +712,7 @@ __webpack_require__.r(__webpack_exports__);
  * @param {string} identifier
  */
 function unescape(identifier) {
-  return identifier.startsWith("_") ? identifier.slice(1) : identifier;
+  return identifier && identifier[0] === "_" ? identifier.slice(1) : identifier;
 }
 
 /**
@@ -775,7 +775,7 @@ function const_data({ type, value }) {
       return { type: "boolean", value: value === "true" };
     case "Infinity":
     case "-Infinity":
-      return { type: "Infinity", negative: value.startsWith("-") };
+      return { type: "Infinity", negative: value[0] === "-" };
     case "[":
       return { type: "sequence", value: [] };
     case "{":
@@ -3590,7 +3590,7 @@ class Writer {
    */
   reference(raw, { unescaped, context }) {
     if (!unescaped) {
-      unescaped = raw.startsWith("_") ? raw.slice(1) : raw;
+      unescaped = raw && raw[0] === "_" ? raw.slice(1) : raw;
     }
     return this.ts.reference(raw, unescaped, context);
   }

--- a/test/fixtures/wpt/resources/webidl2/lib/webidl2.js
+++ b/test/fixtures/wpt/resources/webidl2/lib/webidl2.js
@@ -712,7 +712,7 @@ __webpack_require__.r(__webpack_exports__);
  * @param {string} identifier
  */
 function unescape(identifier) {
-  return identifier && identifier[0] === "_" ? identifier.slice(1) : identifier;
+  return identifier.startsWith("_") ? identifier.slice(1) : identifier;
 }
 
 /**
@@ -775,7 +775,7 @@ function const_data({ type, value }) {
       return { type: "boolean", value: value === "true" };
     case "Infinity":
     case "-Infinity":
-      return { type: "Infinity", negative: value[0] === "-" };
+      return { type: "Infinity", negative: value.startsWith("-") };
     case "[":
       return { type: "sequence", value: [] };
     case "{":
@@ -3590,7 +3590,7 @@ class Writer {
    */
   reference(raw, { unescaped, context }) {
     if (!unescaped) {
-      unescaped = raw && raw[0] === "_" ? raw.slice(1) : raw;
+      unescaped = raw.startsWith("_") ? raw.slice(1) : raw;
     }
     return this.ts.reference(raw, unescaped, context);
   }


### PR DESCRIPTION
Removes primordials when we're only checking for one character and leans on JavaScript syntax as much as possible for performance