### PR TITLE
meta: assign CODEOWNERS for /deps/ncrypto/*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@
 /lib/tls.js @nodejs/crypto @nodejs/net
 /src/crypto/* @nodejs/crypto
 /src/node_crypto* @nodejs/crypto
+/deps/ncrypto/* @nodejs/crypto
 
 # http
 


### PR DESCRIPTION
AS per the title, noticed in #55425 where the team was not pinged