### PR TITLE
module: simplify ts under node_modules check

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -124,7 +124,6 @@ const { pathToFileURL, fileURLToPath, isURL } = require('internal/url');
 const {
   pendingDeprecate,
   emitExperimentalWarning,
-  isUnderNodeModules,
   kEmptyObject,
   setOwnProperty,
   getLazy,
@@ -170,7 +169,6 @@ const {
     ERR_REQUIRE_CYCLE_MODULE,
     ERR_REQUIRE_ESM,
     ERR_UNKNOWN_BUILTIN_MODULE,
-    ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING,
   },
   setArrowMessage,
 } = require('internal/errors');
@@ -1370,9 +1368,6 @@ let hasPausedEntry = false;
 function loadESMFromCJS(mod, filename) {
   let source = getMaybeCachedSource(mod, filename);
   if (getOptionValue('--experimental-strip-types') && path.extname(filename) === '.mts') {
-    if (isUnderNodeModules(filename)) {
-      throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
-    }
     source = stripTypeScriptTypes(source, filename);
   }
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
@@ -1594,9 +1589,6 @@ function getMaybeCachedSource(mod, filename) {
 }
 
 function loadCTS(module, filename) {
-  if (isUnderNodeModules(filename)) {
-    throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
-  }
   const source = getMaybeCachedSource(module, filename);
   const code = stripTypeScriptTypes(source, filename);
   module._compile(code, filename, 'commonjs');
@@ -1608,9 +1600,6 @@ function loadCTS(module, filename) {
  * @param {string} filename The file path of the module
  */
 function loadTS(module, filename) {
-  if (isUnderNodeModules(filename)) {
-    throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
-  }
   // If already analyzed the source, then it will be cached.
   const source = getMaybeCachedSource(module, filename);
   const content = stripTypeScriptTypes(source, filename);

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -4,7 +4,6 @@ const {
   RegExpPrototypeExec,
 } = primordials;
 const {
-  isUnderNodeModules,
   kEmptyObject,
 } = require('internal/util');
 
@@ -23,7 +22,6 @@ const {
   ERR_INVALID_URL,
   ERR_UNKNOWN_MODULE_FORMAT,
   ERR_UNSUPPORTED_ESM_URL_SCHEME,
-  ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING,
 } = require('internal/errors').codes;
 
 const {
@@ -130,12 +128,6 @@ async function defaultLoad(url, context = kEmptyObject) {
   }
 
   validateAttributes(url, format, importAttributes);
-
-  if (getOptionValue('--experimental-strip-types') &&
-    (format === 'module-typescript' || format === 'commonjs-typescript') &&
-    isUnderNodeModules(url)) {
-    throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(url);
-  }
 
   return {
     __proto__: null,

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -16,6 +16,7 @@ const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_RETURN_PROPERTY_VALUE,
   ERR_INVALID_TYPESCRIPT_SYNTAX,
+  ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING,
 } = require('internal/errors').codes;
 const { BuiltinModule } = require('internal/bootstrap/realm');
 
@@ -28,7 +29,7 @@ const assert = require('internal/assert');
 
 const { Buffer } = require('buffer');
 const { getOptionValue } = require('internal/options');
-const { assertTypeScript, setOwnProperty, getLazy } = require('internal/util');
+const { assertTypeScript, setOwnProperty, getLazy, isUnderNodeModules } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 
 const lazyTmpdir = getLazy(() => require('os').tmpdir());
@@ -358,6 +359,9 @@ function parseTypeScript(source, options) {
  * @returns {TransformOutput} The stripped TypeScript code.
  */
 function stripTypeScriptTypes(source, filename) {
+  if (isUnderNodeModules(filename)) {
+    throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
+  }
   assert(typeof source === 'string');
   const options = {
     __proto__: null,


### PR DESCRIPTION
Moves the check from random places in loaders to `stripTypeScriptTypes `