### PR TITLE
test: fix addons and node-api test assumptions

### DIFF
--- a/test/addons/repl-domain-abort/test.js
+++ b/test/addons/repl-domain-abort/test.js
@@ -38,7 +38,7 @@ process.on('exit', () => {
 
 const lines = [
   // This line shouldn't cause an assertion error.
-  `require('${buildPath}')` +
+  `require(${JSON.stringify(buildPath)})` +
   // Log output to double check callback ran.
   '.method(function(v1, v2) {' +
   'console.log(\'cb_ran\'); return v1 === true && v2 === false; });',

--- a/test/node-api/test_instance_data/test.js
+++ b/test/node-api/test_instance_data/test.js
@@ -38,13 +38,8 @@ if (module !== require.main) {
   function testProcessExit(addonName) {
     // Make sure that process exit is clean when the instance data has
     // references to JS objects.
-    const path = require
-      .resolve(`./build/${common.buildType}/${addonName}`)
-      // Replace any backslashes with double backslashes because they'll be re-
-      // interpreted back to single backslashes in the command line argument
-      // to the child process. Windows needs this.
-      .replace(/\\/g, '\\\\');
-    const child = spawnSync(process.execPath, ['-e', `require('${path}');`]);
+    const path = require.resolve(`./build/${common.buildType}/${addonName}`);
+    const child = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(path)});`]);
     assert.strictEqual(child.signal, null);
     assert.strictEqual(child.status, 0);
     assert.strictEqual(child.stderr.toString(), 'addon_free');

--- a/test/node-api/test_uv_threadpool_size/node-options.js
+++ b/test/node-api/test_uv_threadpool_size/node-options.js
@@ -12,12 +12,9 @@ if (process.config.variables.node_without_node_options) {
 const uvThreadPoolPath = '../../fixtures/dotenv/uv-threadpool.env';
 
 // Should update UV_THREADPOOL_SIZE
-let filePath = path.join(__dirname, `./build/${common.buildType}/test_uv_threadpool_size`);
-if (common.isWindows) {
-  filePath = filePath.replaceAll('\\', '\\\\');
-}
+const filePath = path.join(__dirname, `./build/${common.buildType}/test_uv_threadpool_size`);
 const code = `
-   const { test } = require('${filePath}');
+   const { test } = require(${JSON.stringify(filePath)});
    const size = parseInt(process.env.UV_THREADPOOL_SIZE, 10);
    require('assert').strictEqual(size, 4);
    test(size);


### PR DESCRIPTION
Some test was making assumptions about the path no containing `'` char, we can simplify it by relying on `JSON.stringify` to escape chars.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
