### PR TITLE
src: switch from `Get/SetPrototype` to `Get/SetPrototypeV2`

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -769,7 +769,7 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
 
   // Create primordials first and make it available to per-context scripts.
   Local<Object> primordials = Object::New(isolate);
-  if (primordials->SetPrototype(context, Null(isolate)).IsNothing() ||
+  if (primordials->SetPrototypeV2(context, Null(isolate)).IsNothing() ||
       !GetPerContextExports(context).ToLocal(&exports) ||
       exports->Set(context, primordials_string, primordials).IsNothing()) {
     return Nothing<void>();

--- a/src/internal_only_v8.cc
+++ b/src/internal_only_v8.cc
@@ -32,8 +32,8 @@ class PrototypeChainHas : public v8::QueryObjectPredicate {
     if (creation_context != context_) {
       return false;
     }
-    for (Local<Value> proto = object->GetPrototype(); proto->IsObject();
-         proto = proto.As<Object>()->GetPrototype()) {
+    for (Local<Value> proto = object->GetPrototypeV2(); proto->IsObject();
+         proto = proto.As<Object>()->GetPrototypeV2()) {
       if (search_ == proto) return true;
     }
     return false;

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1577,7 +1577,7 @@ napi_status NAPI_CDECL napi_get_prototype(napi_env env,
   CHECK_TO_OBJECT(env, context, obj, object);
 
   // This doesn't invokes Proxy's [[GetPrototypeOf]] handler.
-  v8::Local<v8::Value> val = obj->GetPrototype();
+  v8::Local<v8::Value> val = obj->GetPrototypeV2();
   *result = v8impl::JsValueFromV8LocalValue(val);
   return GET_RETURN_STATUS(env);
 }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -279,7 +279,7 @@ MaybeLocal<Uint8Array> New(Environment* env,
   CHECK(!env->buffer_prototype_object().IsEmpty());
   Local<Uint8Array> ui = Uint8Array::New(ab, byte_offset, length);
   Maybe<bool> mb =
-      ui->SetPrototype(env->context(), env->buffer_prototype_object());
+      ui->SetPrototypeV2(env->context(), env->buffer_prototype_object());
   if (mb.IsNothing())
     return MaybeLocal<Uint8Array>();
   return ui;

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1285,43 +1285,44 @@ void CreatePerContextProperties(Local<Object> target,
   Isolate* isolate = context->GetIsolate();
   Environment* env = Environment::GetCurrent(context);
 
-  CHECK(target->SetPrototypeV2(env->context(), Null(env->isolate())).FromJust());
+  CHECK(
+      target->SetPrototypeV2(env->context(), Null(env->isolate())).FromJust());
 
   Local<Object> os_constants = Object::New(isolate);
-  CHECK(os_constants->SetPrototypeV2(env->context(),
-                                   Null(env->isolate())).FromJust());
+  CHECK(os_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> err_constants = Object::New(isolate);
-  CHECK(err_constants->SetPrototypeV2(env->context(),
-                                    Null(env->isolate())).FromJust());
+  CHECK(err_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> sig_constants = Object::New(isolate);
-  CHECK(sig_constants->SetPrototypeV2(env->context(),
-                                    Null(env->isolate())).FromJust());
+  CHECK(sig_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> priority_constants = Object::New(isolate);
-  CHECK(priority_constants->SetPrototypeV2(env->context(),
-                                         Null(env->isolate())).FromJust());
+  CHECK(priority_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> fs_constants = Object::New(isolate);
-  CHECK(fs_constants->SetPrototypeV2(env->context(),
-                                   Null(env->isolate())).FromJust());
+  CHECK(fs_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> crypto_constants = Object::New(isolate);
-  CHECK(crypto_constants->SetPrototypeV2(env->context(),
-                                       Null(env->isolate())).FromJust());
+  CHECK(crypto_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> zlib_constants = Object::New(isolate);
-  CHECK(zlib_constants->SetPrototypeV2(env->context(),
-                                     Null(env->isolate())).FromJust());
+  CHECK(zlib_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> dlopen_constants = Object::New(isolate);
-  CHECK(dlopen_constants->SetPrototypeV2(env->context(),
-                                       Null(env->isolate())).FromJust());
+  CHECK(dlopen_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   Local<Object> trace_constants = Object::New(isolate);
-  CHECK(trace_constants->SetPrototypeV2(env->context(),
-                                      Null(env->isolate())).FromJust());
+  CHECK(trace_constants->SetPrototypeV2(env->context(), Null(env->isolate()))
+            .FromJust());
 
   DefineErrnoConstants(err_constants);
   DefineWindowsErrorConstants(err_constants);

--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1285,42 +1285,42 @@ void CreatePerContextProperties(Local<Object> target,
   Isolate* isolate = context->GetIsolate();
   Environment* env = Environment::GetCurrent(context);
 
-  CHECK(target->SetPrototype(env->context(), Null(env->isolate())).FromJust());
+  CHECK(target->SetPrototypeV2(env->context(), Null(env->isolate())).FromJust());
 
   Local<Object> os_constants = Object::New(isolate);
-  CHECK(os_constants->SetPrototype(env->context(),
+  CHECK(os_constants->SetPrototypeV2(env->context(),
                                    Null(env->isolate())).FromJust());
 
   Local<Object> err_constants = Object::New(isolate);
-  CHECK(err_constants->SetPrototype(env->context(),
+  CHECK(err_constants->SetPrototypeV2(env->context(),
                                     Null(env->isolate())).FromJust());
 
   Local<Object> sig_constants = Object::New(isolate);
-  CHECK(sig_constants->SetPrototype(env->context(),
+  CHECK(sig_constants->SetPrototypeV2(env->context(),
                                     Null(env->isolate())).FromJust());
 
   Local<Object> priority_constants = Object::New(isolate);
-  CHECK(priority_constants->SetPrototype(env->context(),
+  CHECK(priority_constants->SetPrototypeV2(env->context(),
                                          Null(env->isolate())).FromJust());
 
   Local<Object> fs_constants = Object::New(isolate);
-  CHECK(fs_constants->SetPrototype(env->context(),
+  CHECK(fs_constants->SetPrototypeV2(env->context(),
                                    Null(env->isolate())).FromJust());
 
   Local<Object> crypto_constants = Object::New(isolate);
-  CHECK(crypto_constants->SetPrototype(env->context(),
+  CHECK(crypto_constants->SetPrototypeV2(env->context(),
                                        Null(env->isolate())).FromJust());
 
   Local<Object> zlib_constants = Object::New(isolate);
-  CHECK(zlib_constants->SetPrototype(env->context(),
+  CHECK(zlib_constants->SetPrototypeV2(env->context(),
                                      Null(env->isolate())).FromJust());
 
   Local<Object> dlopen_constants = Object::New(isolate);
-  CHECK(dlopen_constants->SetPrototype(env->context(),
+  CHECK(dlopen_constants->SetPrototypeV2(env->context(),
                                        Null(env->isolate())).FromJust());
 
   Local<Object> trace_constants = Object::New(isolate);
-  CHECK(trace_constants->SetPrototype(env->context(),
+  CHECK(trace_constants->SetPrototypeV2(env->context(),
                                       Null(env->isolate())).FromJust());
 
   DefineErrnoConstants(err_constants);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1391,7 +1391,7 @@ void GetCLIOptionsInfo(const FunctionCallbackInfo<Value>& args) {
 
   Local<Map> options = Map::New(isolate);
   if (options
-          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
+          ->SetPrototypeV2(context, env->primordials_safe_map_prototype_object())
           .IsNothing()) {
     return;
   }
@@ -1431,7 +1431,7 @@ void GetCLIOptionsInfo(const FunctionCallbackInfo<Value>& args) {
   if (!ToV8Value(context, _ppop_instance.aliases_).ToLocal(&aliases)) return;
 
   if (aliases.As<Object>()
-          ->SetPrototype(context, env->primordials_safe_map_prototype_object())
+          ->SetPrototypeV2(context, env->primordials_safe_map_prototype_object())
           .IsNothing()) {
     return;
   }

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1391,7 +1391,8 @@ void GetCLIOptionsInfo(const FunctionCallbackInfo<Value>& args) {
 
   Local<Map> options = Map::New(isolate);
   if (options
-          ->SetPrototypeV2(context, env->primordials_safe_map_prototype_object())
+          ->SetPrototypeV2(context,
+                           env->primordials_safe_map_prototype_object())
           .IsNothing()) {
     return;
   }
@@ -1431,7 +1432,8 @@ void GetCLIOptionsInfo(const FunctionCallbackInfo<Value>& args) {
   if (!ToV8Value(context, _ppop_instance.aliases_).ToLocal(&aliases)) return;
 
   if (aliases.As<Object>()
-          ->SetPrototypeV2(context, env->primordials_safe_map_prototype_object())
+          ->SetPrototypeV2(context,
+                           env->primordials_safe_map_prototype_object())
           .IsNothing()) {
     return;
   }

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -530,7 +530,7 @@ template <typename T>
 static bool ShouldIntercept(Local<Name> property,
                             const PropertyCallbackInfo<T>& info) {
   Environment* env = Environment::GetCurrent(info);
-  Local<Value> proto = info.This()->GetPrototype();
+  Local<Value> proto = info.This()->GetPrototypeV2();
 
   if (proto->IsObject()) {
     bool has_prop;


### PR DESCRIPTION
Ref #55452

`GetPrototype` has been deprecated in favor of `GetPrototypeV2`. See https://issues.chromium.org/issues/333672197