### PR TITLE
test: fix invalid `file:` URL in `test-fs-path-dir`

### DIFF
--- a/test/sequential/test-fs-path-dir.js
+++ b/test/sequential/test-fs-path-dir.js
@@ -5,7 +5,7 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const path = require('path');
 const fs = require('fs');
-const URL = require('url').URL;
+const { pathToFileURL } = require('url');
 
 tmpdir.refresh();
 
@@ -15,7 +15,7 @@ const nextFile = () => path.join(tmpdir.path, `file${fileCounter++}`);
 const generateStringPath = (file, suffix = '') => file + suffix;
 
 const generateURLPath = (file, suffix = '') =>
-  new URL('file://' + path.resolve(file) + suffix);
+  pathToFileURL(file + suffix);
 
 const generateUint8ArrayPath = (file, suffix = '') =>
   new Uint8Array(Buffer.from(file + suffix));


### PR DESCRIPTION
Trying to build a URL by concatenating `file://` and a path will always fail as soon as the path contains some URL-significant char (e.g. `%`, `?`, `#`)
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
