### PR TITLE
http: don't emit error after destroy

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -908,6 +908,10 @@ OutgoingMessage.prototype.write = function write(chunk, encoding, callback) {
 };
 
 function onError(msg, err, callback) {
+  if (msg.destroyed) {
+    return;
+  }
+
   const triggerAsyncId = msg.socket ? msg.socket[async_id_symbol] : undefined;
   defaultTriggerAsyncIdScope(triggerAsyncId,
                              process.nextTick,
@@ -919,7 +923,7 @@ function onError(msg, err, callback) {
 
 function emitErrorNt(msg, err, callback) {
   callback(err);
-  if (typeof msg.emit === 'function' && !msg._closed) {
+  if (typeof msg.emit === 'function' && !msg.destroyed) {
     msg.emit('error', err);
   }
 }

--- a/test/parallel/test-http-outgoing-destroyed.js
+++ b/test/parallel/test-http-outgoing-destroyed.js
@@ -67,7 +67,7 @@ const assert = require('assert');
         port: server.address().port,
         method: 'GET'
       })
-      .on('response', common.mustCall(res => {
+      .on('response', common.mustCall((res) => {
         res.resume().on('end', common.mustCall(() => {
           server.close();
         }));

--- a/test/parallel/test-http-outgoing-destroyed.js
+++ b/test/parallel/test-http-outgoing-destroyed.js
@@ -51,5 +51,27 @@ const assert = require('assert');
       .on('error', common.mustCall())
       .write('asd');
   });
+}
 
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.strictEqual(res.closed, false);
+    res.end();
+    res.destroy();
+    // Make sure not to emit 'error' after .destroy().
+    res.end('asd');
+    assert.strictEqual(res.errored, undefined);
+  })).listen(0, () => {
+    http
+      .request({
+        port: server.address().port,
+        method: 'GET'
+      })
+      .on('response', common.mustCall(res => {
+        res.resume().on('end', common.mustCall(() => {
+          server.close();
+        }));
+      }))
+      .end();
+  });
 }


### PR DESCRIPTION
Enforce stream invariant. No new errors can occur after `.destroy(err)`