### PR TITLE
src: migrate `String::Value` to `String::ValueView`

### DIFF
--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -246,8 +246,11 @@ static void AsyncTaskScheduledWrapper(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(args[0]->IsString());
   Local<String> task_name = args[0].As<String>();
-  String::Value task_name_value(args.GetIsolate(), task_name);
-  StringView task_name_view(*task_name_value, task_name_value.length());
+
+  std::vector<uint16_t> task_name_buffer(task_name->Length());
+  task_name->Write(
+      env->isolate(), task_name_buffer.data(), 0, task_name->Length());
+  StringView task_name_view(task_name_buffer.data(), task_name_buffer.size());
 
   CHECK(args[1]->IsNumber());
   int64_t task_id = args[1]->IntegerValue(env->context()).FromJust();

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -245,12 +245,9 @@ static void AsyncTaskScheduledWrapper(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
   CHECK(args[0]->IsString());
-  Local<String> task_name = args[0].As<String>();
 
-  std::vector<uint16_t> task_name_buffer(task_name->Length());
-  task_name->Write(
-      env->isolate(), task_name_buffer.data(), 0, task_name->Length());
-  StringView task_name_view(task_name_buffer.data(), task_name_buffer.size());
+  TwoByteValue task_name_buffer(args.GetIsolate(), args[0]);
+  StringView task_name_view(*task_name_buffer, task_name_buffer.length());
 
   CHECK(args[1]->IsNumber());
   int64_t task_id = args[1]->IntegerValue(env->context()).FromJust();

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -965,10 +965,9 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   size_t result = haystack_length;
 
   if (enc == UCS2) {
-    uint16_t* needle_buffer = new uint16_t[needle->Length()];
-    int needle_length = needle->Write(isolate, needle_buffer);
+    TwoByteValue needle_buffer(isolate, needle);
 
-    if (haystack_length < 2 || needle_length < 1) {
+    if (haystack_length < 2 || needle_buffer.length()) {
       return args.GetReturnValue().Set(-1);
     }
 
@@ -990,8 +989,8 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
     } else {
       result = nbytes::SearchString(reinterpret_cast<const uint16_t*>(haystack),
                                     haystack_length / 2,
-                                    needle_buffer,
-                                    needle_length,
+                                    needle_buffer.out(),
+                                    needle_buffer.length(),
                                     offset / 2,
                                     is_forward);
     }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -965,11 +965,11 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   size_t result = haystack_length;
 
   if (enc == UCS2) {
-    String::Value needle_value(isolate, needle);
-    if (*needle_value == nullptr)
-      return args.GetReturnValue().Set(-1);
+    std::unique_ptr<uint16_t[]> needle_buffer(new uint16_t[needle->Length()]);
+    int needle_length = needle->Write(
+        isolate, reinterpret_cast<uint16_t*>(needle_buffer.get()));
 
-    if (haystack_length < 2 || needle_value.length() < 1) {
+    if (haystack_length < 2 || needle_length < 1) {
       return args.GetReturnValue().Set(-1);
     }
 
@@ -989,13 +989,12 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
                                     offset / 2,
                                     is_forward);
     } else {
-      result =
-          nbytes::SearchString(reinterpret_cast<const uint16_t*>(haystack),
-                               haystack_length / 2,
-                               reinterpret_cast<const uint16_t*>(*needle_value),
-                               needle_value.length(),
-                               offset / 2,
-                               is_forward);
+      result = nbytes::SearchString(reinterpret_cast<const uint16_t*>(haystack),
+                                    haystack_length / 2,
+                                    needle_buffer.get(),
+                                    needle_length,
+                                    offset / 2,
+                                    is_forward);
     }
     result *= 2;
   } else if (enc == UTF8) {
@@ -1295,10 +1294,10 @@ static void Btoa(const FunctionCallbackInfo<Value>& args) {
                                   input->Length(),
                                   buffer.out());
   } else {
-    String::Value value(env->isolate(), input);
+    String::ValueView value(env->isolate(), input);
     MaybeStackBuffer<char> stack_buf(value.length());
     size_t out_len = simdutf::convert_utf16_to_latin1(
-        reinterpret_cast<const char16_t*>(*value),
+        reinterpret_cast<const char16_t*>(value.data16()),
         value.length(),
         stack_buf.out());
     if (out_len == 0) {  // error
@@ -1355,8 +1354,8 @@ static void Atob(const FunctionCallbackInfo<Value>& args) {
     buffer.SetLength(expected_length);
     result = simdutf::base64_to_binary(data, input->Length(), buffer.out());
   } else {  // 16-bit case
-    String::Value value(env->isolate(), input);
-    auto data = reinterpret_cast<const char16_t*>(*value);
+    String::ValueView value(env->isolate(), input);
+    auto data = reinterpret_cast<const char16_t*>(value.data16());
     size_t expected_length =
         simdutf::maximal_binary_length_from_base64(data, value.length());
     buffer.AllocateSufficientStorage(expected_length);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -967,7 +967,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   if (enc == UCS2) {
     TwoByteValue needle_buffer(isolate, needle);
 
-    if (haystack_length < 2 || needle_buffer.length()) {
+    if (haystack_length < 2 || needle_buffer.length() < 1) {
       return args.GetReturnValue().Set(-1);
     }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -965,9 +965,8 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
   size_t result = haystack_length;
 
   if (enc == UCS2) {
-    std::unique_ptr<uint16_t[]> needle_buffer(new uint16_t[needle->Length()]);
-    int needle_length = needle->Write(
-        isolate, reinterpret_cast<uint16_t*>(needle_buffer.get()));
+    uint16_t* needle_buffer = new uint16_t[needle->Length()];
+    int needle_length = needle->Write(isolate, needle_buffer);
 
     if (haystack_length < 2 || needle_length < 1) {
       return args.GetReturnValue().Set(-1);
@@ -991,7 +990,7 @@ void IndexOfString(const FunctionCallbackInfo<Value>& args) {
     } else {
       result = nbytes::SearchString(reinterpret_cast<const uint16_t*>(haystack),
                                     haystack_length / 2,
-                                    needle_buffer.get(),
+                                    needle_buffer,
                                     needle_length,
                                     offset / 2,
                                     is_forward);

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -305,10 +305,10 @@ size_t StringBytes::Write(Isolate* isolate,
               input_view.length());
         }
       } else {
-        String::Value value(isolate, str);
+        String::ValueView value(isolate, str);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char16_t*>(*value),
+            reinterpret_cast<const char16_t*>(value.data16()),
             value.length(),
             buf,
             written_len,
@@ -319,7 +319,8 @@ size_t StringBytes::Write(Isolate* isolate,
           // The input does not follow the WHATWG forgiving-base64 specification
           // (adapted for base64url with + and / replaced by - and _).
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes = nbytes::Base64Decode(buf, buflen, *value, value.length());
+          nbytes =
+              nbytes::Base64Decode(buf, buflen, value.data16(), value.length());
         }
       }
       break;
@@ -344,10 +345,10 @@ size_t StringBytes::Write(Isolate* isolate,
               input_view.length());
         }
       } else {
-        String::Value value(isolate, str);
+        String::ValueView value(isolate, str);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char16_t*>(*value),
+            reinterpret_cast<const char16_t*>(value.data16()),
             value.length(),
             buf,
             written_len);
@@ -356,7 +357,8 @@ size_t StringBytes::Write(Isolate* isolate,
         } else {
           // The input does not follow the WHATWG base64 specification
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes = nbytes::Base64Decode(buf, buflen, *value, value.length());
+          nbytes =
+              nbytes::Base64Decode(buf, buflen, value.data16(), value.length());
         }
       }
       break;
@@ -369,8 +371,8 @@ size_t StringBytes::Write(Isolate* isolate,
                               reinterpret_cast<const char*>(input_view.data8()),
                               input_view.length());
       } else {
-        String::Value value(isolate, str);
-        nbytes = nbytes::HexDecode(buf, buflen, *value, value.length());
+        String::ValueView value(isolate, str);
+        nbytes = nbytes::HexDecode(buf, buflen, value.data8(), value.length());
       }
       break;
 

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -305,11 +305,10 @@ size_t StringBytes::Write(Isolate* isolate,
               input_view.length());
         }
       } else {
-        String::ValueView value(isolate, str);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char16_t*>(value.data16()),
-            value.length(),
+            reinterpret_cast<const char16_t*>(input_view.data16()),
+            input_view.length(),
             buf,
             written_len,
             simdutf::base64_url);
@@ -319,8 +318,8 @@ size_t StringBytes::Write(Isolate* isolate,
           // The input does not follow the WHATWG forgiving-base64 specification
           // (adapted for base64url with + and / replaced by - and _).
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, value.data16(), value.length());
+          nbytes = nbytes::Base64Decode(
+              buf, buflen, input_view.data16(), input_view.length());
         }
       }
       break;
@@ -345,11 +344,10 @@ size_t StringBytes::Write(Isolate* isolate,
               input_view.length());
         }
       } else {
-        String::ValueView value(isolate, str);
         size_t written_len = buflen;
         auto result = simdutf::base64_to_binary_safe(
-            reinterpret_cast<const char16_t*>(value.data16()),
-            value.length(),
+            reinterpret_cast<const char16_t*>(input_view.data16()),
+            input_view.length(),
             buf,
             written_len);
         if (result.error == simdutf::error_code::SUCCESS) {
@@ -357,8 +355,8 @@ size_t StringBytes::Write(Isolate* isolate,
         } else {
           // The input does not follow the WHATWG base64 specification
           // https://infra.spec.whatwg.org/#forgiving-base64-decode
-          nbytes =
-              nbytes::Base64Decode(buf, buflen, value.data16(), value.length());
+          nbytes = nbytes::Base64Decode(
+              buf, buflen, input_view.data16(), input_view.length());
         }
       }
       break;


### PR DESCRIPTION
Fixes #54417
Ref: #55452

`v8::String::Value` is deprecated, so this PR replaces it with `v8::String::ValueView`