### PR TITLE
stream: propagate AbortSignal reason

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -203,7 +203,7 @@ function pipelineImpl(streams, callback, opts) {
   validateAbortSignal(outerSignal, 'options.signal');
 
   function abort() {
-    finishImpl(new AbortError());
+    finishImpl(new AbortError(undefined, { cause: outerSignal?.reason }));
   }
 
   addAbortListener ??= require('internal/events/abort_listener').addAbortListener;

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -1344,12 +1344,13 @@ tmpdir.refresh();
 
 {
   const ac = new AbortController();
+  const reason = new Error('Reason');
   const r = Readable.from(async function* () {
     for (let i = 0; i < 10; i++) {
       await Promise.resolve();
       yield String(i);
       if (i === 5) {
-        ac.abort();
+        ac.abort(reason);
       }
     }
   }());
@@ -1362,6 +1363,7 @@ tmpdir.refresh();
   });
   const cb = common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(err.cause, reason);
     assert.strictEqual(res, '012345');
     assert.strictEqual(w.destroyed, true);
     assert.strictEqual(r.destroyed, true);


### PR DESCRIPTION
This PR propagates the reason of the `AbortSignal` passed to the `pipeline` function (`node:stream/promises`) to the `cause` of the thrown `AbortError`.

The vast majority of `AbortError`s created by the standard library already propagates the reason, so this should bring more consistency.