### PR TITLE
assert: fix the string length check for printing the simple diff

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -134,7 +134,14 @@ function getStackedDiff(actual, expected) {
 }
 
 function getSimpleDiff(originalActual, actual, originalExpected, expected) {
-  const stringsLen = actual.length + expected.length;
+  let stringsLen = actual.length + expected.length;
+  // Accounting for the quotes wrapping strings
+  if (typeof originalActual === 'string') {
+    stringsLen -= 2;
+  }
+  if (typeof originalExpected === 'string') {
+    stringsLen -= 2;
+  }
   if (stringsLen <= kMaxShortStringLength && (originalActual !== 0 || originalExpected !== 0)) {
     return { message: `${actual} !== ${expected}`, header: '' };
   }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -846,6 +846,26 @@ test('Additional tests', () => {
     }
   );
 
+  assert.throws(
+    () => assert.strictEqual('apple', 'pear'),
+    {
+      name: 'AssertionError',
+      message: 'Expected values to be strictly equal:\n\n\'apple\' !== \'pear\'\n'
+    }
+  );
+
+  assert.throws(
+    () => assert.strictEqual('ABABABABABAB', 'BABABABABABA'),
+    {
+      name: 'AssertionError',
+      message: 'Expected values to be strictly equal:\n' +
+        '+ actual - expected\n' +
+        '\n' +
+        "+ 'ABABABABABAB'\n" +
+        "- 'BABABABABABA'\n"
+    }
+  );
+
   assert.notDeepStrictEqual(new Date(), new Date(2000, 3, 14));
 
   assert.throws(

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -919,11 +919,7 @@ test('Additional asserts', () => {
     {
       code: 'ERR_ASSERTION',
       constructor: assert.AssertionError,
-      message: 'Expected values to be strictly equal:\n' +
-        '+ actual - expected\n' +
-        '\n' +
-        "+ 'string'\n" +
-        '- false\n'
+      message: 'Expected values to be strictly equal:\n\n\'string\' !== false\n'
     }
   );
 
@@ -935,11 +931,7 @@ test('Additional asserts', () => {
     {
       code: 'ERR_ASSERTION',
       constructor: assert.AssertionError,
-      message: 'Expected values to be strictly equal:\n' +
-        '+ actual - expected\n' +
-        '\n' +
-        "+ 'string'\n" +
-        '- false\n'
+      message: 'Expected values to be strictly equal:\n\n\'string\' !== false\n'
     }
   );
 
@@ -951,11 +943,7 @@ test('Additional asserts', () => {
   }, {
     code: 'ERR_ASSERTION',
     constructor: assert.AssertionError,
-    message: 'Expected values to be strictly equal:\n' +
-      '+ actual - expected\n' +
-      '\n' +
-      "+ 'string'\n" +
-      '- false\n'
+    message: 'Expected values to be strictly equal:\n\n\'string\' !== false\n'
     }
   );
   /* eslint-enable @stylistic/js/indent */


### PR DESCRIPTION
Fixes a small issue introduced in https://github.com/nodejs/node/pull/54862

The check that was comparing the total string length to decide if the comparison was long enough to pick between the "stacked" diff or the "simple" one, was not considering the double quotes surrounding `actual` and `expected` when they are strings

