### PR TITLE
deps: V8: cherry-pick f915fa4c9f41

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.10',
+    'v8_embedder_string': '-node.11',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -1338,7 +1338,14 @@ MaybeHandle<Code> GetOrCompileOptimized(
   }
 
   // Do not optimize when debugger needs to hook into every call.
-  if (isolate->debug()->needs_check_on_function_call()) return {};
+  if (isolate->debug()->needs_check_on_function_call()) {
+    // Reset the OSR urgency to avoid triggering this compilation request on
+    // every iteration and thereby skipping other interrupts.
+    if (IsOSR(osr_offset)) {
+      function->feedback_vector()->reset_osr_urgency();
+    }
+    return {};
+  }
 
   // Do not optimize if we need to be able to set break points.
   if (shared->HasBreakInfo(isolate)) return {};

--- a/deps/v8/test/debugger/regress/regress-374013413.js
+++ b/deps/v8/test/debugger/regress/regress-374013413.js
@@ -1,0 +1,15 @@
+// Copyright 2024 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --enable-inspector
+
+var Debug = debug.Debug;
+Debug.sendMessageForMethodChecked('Runtime.enable', {});
+const {msgid, msg} = Debug.createMessage('Runtime.evaluate', {
+  expression: 'while(true) {}',
+  throwOnSideEffect: true,
+  timeout: 1000,
+})
+Debug.sendMessage(msg);
+Debug.takeReplyChecked(msgid).toString();

--- a/test/parallel/test-repl-preview-timeout.js
+++ b/test/parallel/test-repl-preview-timeout.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+common.skipIfInspectorDisabled();
+
+const inputStream = new ArrayStream();
+const outputStream = new ArrayStream();
+repl.start({
+  input: inputStream,
+  output: outputStream,
+  useGlobal: false,
+  terminal: true,
+  useColors: true
+});
+
+let output = '';
+outputStream.write = (chunk) => output += chunk;
+
+// Input without '\n' triggering actual run.
+const input = 'while (true) {}';
+inputStream.emit('data', input);
+// No preview available when timed out.
+assert.strictEqual(output, input);


### PR DESCRIPTION
#### deps: V8: cherry-pick f915fa4c9f41

Original commit message:

    [osr] Ensure trying to osr does not skip loop interrupts

    Fixed: 374013413
    Change-Id: I52d7b4e165e0abd0bd517a81d2e8ef3f1f802bfb
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5946288
    Commit-Queue: Darius Mercadier <dmercadier@chromium.org>
    Auto-Submit: Olivier Flückiger <olivf@chromium.org>
    Reviewed-by: Darius Mercadier <dmercadier@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#96708}

Refs: https://github.com/v8/v8/commit/f915fa4c9f4162dd9258535eee03b1b0484bf38e

#### test: add repl preview timeout test

Fixes https://github.com/nodejs/node/issues/54193