### PR TITLE
lib: implement webidl dictionary converter and use it in structuredClone

### DIFF
--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -29,6 +29,15 @@ const { kEmptyObject } = require('internal/util');
 
 const converters = { __proto__: null };
 
+const UNDEFINED = 1;
+const BOOLEAN = 2;
+const STRING = 3;
+const SYMBOL = 4;
+const NUMBER = 5;
+const BIGINT = 6;
+const NULL = 7;
+const OBJECT = 8;
+
 /**
  * @see https://webidl.spec.whatwg.org/#es-any
  * @param {any} V
@@ -39,7 +48,7 @@ converters.any = (V) => {
 };
 
 converters.object = (V, opts = kEmptyObject) => {
-  if (type(V) !== 'Object') {
+  if (type(V) !== OBJECT) {
     throw makeException(
       'is not an object',
       kEmptyObject,
@@ -236,37 +245,37 @@ function createEnumConverter(name, values) {
 
 // https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values
 function type(V) {
-  if (V === null)
-    return 'Null';
-
   switch (typeof V) {
     case 'undefined':
-      return 'Undefined';
+      return UNDEFINED;
     case 'boolean':
-      return 'Boolean';
+      return BOOLEAN;
     case 'number':
-      return 'Number';
+      return NUMBER;
     case 'string':
-      return 'String';
+      return STRING;
     case 'symbol':
-      return 'Symbol';
+      return SYMBOL;
     case 'bigint':
-      return 'BigInt';
+      return BIGINT;
     case 'object': // Fall through
     case 'function': // Fall through
     default:
+      if (V === null) {
+        return NULL;
+      }
       // Per ES spec, typeof returns an implementation-defined value that is not
       // any of the existing ones for uncallable non-standard exotic objects.
       // Yet Type() which the Web IDL spec depends on returns Object for such
       // cases. So treat the default case as an object.
-      return 'Object';
+      return OBJECT;
   }
 }
 
 // https://webidl.spec.whatwg.org/#es-sequence
 function createSequenceConverter(converter) {
   return function(V, opts = kEmptyObject) {
-    if (type(V) !== 'Object') {
+    if (type(V) !== OBJECT) {
       throw makeException(
         'can not be converted to sequence.',
         opts);

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypePush,
+  ArrayPrototypeToSorted,
   MathAbs,
   MathMax,
   MathMin,
@@ -272,6 +273,67 @@ function type(V) {
   }
 }
 
+// https://webidl.spec.whatwg.org/#js-dictionary
+function createDictionaryConverter(members) {
+  // The spec requires us to operate the members of a dictionary in
+  // lexicographical order. We are doing this in the outer scope to
+  // reduce the overhead that could happen in the returned function.
+  const sortedMembers = ArrayPrototypeToSorted(members, (a, b) => {
+    if (a.key === b.key) {
+      return 0;
+    }
+    return a.key < b.key ? -1 : 1;
+  });
+
+  return function(
+    V,
+    opts = kEmptyObject,
+  ) {
+    if (V != null && type(V) !== OBJECT) {
+      throw makeException(
+        'cannot be converted to a dictionary',
+        opts,
+      );
+    }
+
+    const idlDict = { __proto__: null };
+    for (let i = 0; i < sortedMembers.length; i++) {
+      const member = sortedMembers[i];
+      const key = member.key;
+      let jsMemberValue;
+      if (V == null) {
+        jsMemberValue = undefined;
+      } else {
+        jsMemberValue = V[key];
+      }
+
+      if (jsMemberValue !== undefined) {
+        const memberContext = opts.context ? `${key} in ${opts.context}` : `${key}`;
+        const converter = member.converter;
+        const idlMemberValue = converter(
+          jsMemberValue,
+          {
+            __proto__: null,
+            prefix: opts.prefix,
+            context: memberContext,
+          },
+        );
+        idlDict[key] = idlMemberValue;
+      } else if (typeof member.defaultValue === 'function') {
+        const idlMemberValue = member.defaultValue();
+        idlDict[key] = idlMemberValue;
+      } else if (member.required) {
+        throw makeException(
+          `cannot be converted because of the missing '${key}'`,
+          opts,
+        );
+      }
+    }
+
+    return idlDict;
+  };
+}
+
 // https://webidl.spec.whatwg.org/#es-sequence
 function createSequenceConverter(converter) {
   return function(V, opts = kEmptyObject) {
@@ -327,6 +389,7 @@ module.exports = {
   createEnumConverter,
   createInterfaceConverter,
   createSequenceConverter,
+  createDictionaryConverter,
   evenRound,
   makeException,
 };

--- a/lib/internal/worker/js_transferable.js
+++ b/lib/internal/worker/js_transferable.js
@@ -5,7 +5,6 @@ const {
 } = primordials;
 const {
   codes: {
-    ERR_INVALID_ARG_TYPE,
     ERR_MISSING_ARGS,
   },
 } = require('internal/errors');
@@ -98,29 +97,31 @@ function markTransferMode(obj, cloneable = false, transferable = false) {
   obj[transfer_mode_private_symbol] = mode;
 }
 
+
+webidl.converters.StructuredSerializeOptions = webidl
+  .createDictionaryConverter(
+    [
+      {
+        key: 'transfer',
+        converter: webidl.converters['sequence<object>'],
+        defaultValue: () => [],
+      },
+    ],
+  );
+
 function structuredClone(value, options) {
   if (arguments.length === 0) {
     throw new ERR_MISSING_ARGS('The value argument must be specified');
   }
 
-  // TODO(jazelly): implement generic webidl dictionary converter
-  const prefix = 'Options';
-  const optionsType = webidl.type(options);
-  if (optionsType !== 'Undefined' && optionsType !== 'Null' && optionsType !== 'Object') {
-    throw new ERR_INVALID_ARG_TYPE(
-      prefix,
-      ['object', 'null', 'undefined'],
-      options,
-    );
-  }
-  const key = 'transfer';
-  const idlOptions = { __proto__: null, [key]: [] };
-  if (options != null && key in options && options[key] !== undefined) {
-    idlOptions[key] = webidl.converters['sequence<object>'](options[key], {
+  const idlOptions = webidl.converters.StructuredSerializeOptions(
+    options,
+    {
       __proto__: null,
-      context: 'Transfer',
-    });
-  }
+      prefix: "Failed to execute 'structuredClone'",
+      context: 'Options',
+    },
+  );
 
   const serializedData = nativeStructuredClone(value, idlOptions);
   return serializedData;

--- a/test/parallel/test-structuredClone-global.js
+++ b/test/parallel/test-structuredClone-global.js
@@ -3,12 +3,23 @@
 require('../common');
 const assert = require('assert');
 
+const prefix = "Failed to execute 'structuredClone'";
+const key = 'transfer';
+const context = 'Options';
+const memberConverterError = `${prefix}: ${key} in ${context} can not be converted to sequence.`;
+const dictionaryConverterError = `${prefix}: ${context} cannot be converted to a dictionary`;
+
 assert.throws(() => structuredClone(), { code: 'ERR_MISSING_ARGS' });
-assert.throws(() => structuredClone(undefined, ''), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, 1), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: '' }), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: null }), { code: 'ERR_INVALID_ARG_TYPE' });
+assert.throws(() => structuredClone(undefined, ''),
+              { code: 'ERR_INVALID_ARG_TYPE', message: dictionaryConverterError });
+assert.throws(() => structuredClone(undefined, 1),
+              { code: 'ERR_INVALID_ARG_TYPE', message: dictionaryConverterError });
+assert.throws(() => structuredClone(undefined, { transfer: 1 }),
+              { code: 'ERR_INVALID_ARG_TYPE', message: memberConverterError });
+assert.throws(() => structuredClone(undefined, { transfer: '' }),
+              { code: 'ERR_INVALID_ARG_TYPE', message: memberConverterError });
+assert.throws(() => structuredClone(undefined, { transfer: null }),
+              { code: 'ERR_INVALID_ARG_TYPE', message: memberConverterError });
 
 // Options can be null or undefined.
 assert.strictEqual(structuredClone(undefined), undefined);


### PR DESCRIPTION
The first commit optimizes `type(V)` in `webidl.js` to return enum
instead of string.

The second commit provides a factory to generate `dictionaryConverter`
compliant with the spec. The implemented factory function is used for
the `structuredClone` algorithm, along with updated test cases.