### PR TITLE
test,crypto: make crypto tests work with BoringSSL

### DIFF
--- a/test/parallel/test-crypto-dh-errors.js
+++ b/test/parallel/test-crypto-dh-errors.js
@@ -43,7 +43,7 @@ for (const g of [-1, 1]) {
   const ex = {
     code: 'ERR_OSSL_DH_BAD_GENERATOR',
     name: 'Error',
-    message: /bad generator/,
+    message: /(?:bad[_ ]generator)/i,
   };
   assert.throws(() => crypto.createDiffieHellman('abcdef', g), ex);
   assert.throws(() => crypto.createDiffieHellman('abcdef', 'hex', g), ex);
@@ -55,7 +55,7 @@ for (const g of [Buffer.from([]),
   const ex = {
     code: 'ERR_OSSL_DH_BAD_GENERATOR',
     name: 'Error',
-    message: /bad generator/,
+    message: /(?:bad[_ ]generator)/i,
   };
   assert.throws(() => crypto.createDiffieHellman('abcdef', g), ex);
   assert.throws(() => crypto.createDiffieHellman('abcdef', 'hex', g), ex);

--- a/test/parallel/test-crypto-private-decrypt-gh32240.js
+++ b/test/parallel/test-crypto-private-decrypt-gh32240.js
@@ -24,7 +24,7 @@ const pkeyEncrypted =
   pair.privateKey.export({
     type: 'pkcs1',
     format: 'pem',
-    cipher: 'aes128',
+    cipher: 'aes-128-cbc',
     passphrase: 'secret',
   });
 

--- a/test/parallel/test-tls-getcertificate-x509.js
+++ b/test/parallel/test-tls-getcertificate-x509.js
@@ -20,9 +20,7 @@ const server = tls.createServer(options, function(cleartext) {
 server.once('secureConnection', common.mustCall(function(socket) {
   const cert = socket.getX509Certificate();
   assert(cert instanceof X509Certificate);
-  assert.strictEqual(
-    cert.serialNumber,
-    '5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE');
+  assert.match(cert.serialNumber, /5B75D77EDC7FB5B7FA9F1424DA4C64FB815DCBDE/i);
 }));
 
 server.listen(0, common.mustCall(function() {
@@ -33,10 +31,7 @@ server.listen(0, common.mustCall(function() {
     const peerCert = socket.getPeerX509Certificate();
     assert(peerCert.issuerCertificate instanceof X509Certificate);
     assert.strictEqual(peerCert.issuerCertificate.issuerCertificate, undefined);
-    assert.strictEqual(
-      peerCert.issuerCertificate.serialNumber,
-      '147D36C1C2F74206DE9FAB5F2226D78ADB00A425'
-    );
+    assert.match(peerCert.issuerCertificate.serialNumber, /147D36C1C2F74206DE9FAB5F2226D78ADB00A425/i);
     server.close();
   }));
   socket.end('Hello');


### PR DESCRIPTION
This PR tweaks crypto tests a bit to make them work for both OpenSSL and BoringSSL. This allows Electron to reduce relevant patch surface area.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
