### PR TITLE
test: increase coverage of `pathToFileURL`

### DIFF
--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -162,7 +162,7 @@ const posixTestCases = [
   { path: '/foo\r\n\t<>"#%{}|^[\\~]`?bar', expected: 'file:///foo%0D%0A%09%3C%3E%22%23%25%7B%7D%7C%5E%5B%5C%7E%5D%60%3Fbar' },
   // All of the 16-bit UTF-16 chars
   {
-    path: `/${String.fromCharCode(...Array.from({ length: 0x7FFF }, (_, i) => i))}`,
+    path: `/${Array.from({ length: 0x7FFF }, (_, i) => String.fromCharCode(i)).join('')}`,
     expected: `file:///${
       Array.from({ length: 0x21 }, (_, i) => `%${i.toString(16).toUpperCase().padStart(2, '0')}`).join('')
     }!%22%23$%25&'()*+,-./0123456789:;%3C=%3E%3F@${

--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -114,6 +114,7 @@ const windowsTestCases = [
   // Extended UNC path
   { path: '\\\\?\\UNC\\server\\share\\folder\\file.txt', expected: 'file://server/share/folder/file.txt' },
 ];
+const alphabet = String.fromCharCode(...Array.from({ length: 26 }, (_, i) => 'a'.charCodeAt() + i));
 const posixTestCases = [
   // Lowercase ascii alpha
   { path: '/foo', expected: 'file:///foo' },
@@ -159,6 +160,31 @@ const posixTestCases = [
   { path: '/🚀', expected: 'file:///%F0%9F%9A%80' },
   // "unsafe" chars
   { path: '/foo\r\n\t<>"#%{}|^[\\~]`?bar', expected: 'file:///foo%0D%0A%09%3C%3E%22%23%25%7B%7D%7C%5E%5B%5C%7E%5D%60%3Fbar' },
+  // All of the 16-bit UTF-16 chars
+  {
+    path: `/${String.fromCharCode(...Array.from({ length: 0x7FFF }, (_, i) => i))}`,
+    expected: `file:///${
+      Array.from({ length: 0x21 }, (_, i) => `%${i.toString(16).toUpperCase().padStart(2, '0')}`).join('')
+    }!%22%23$%25&'()*+,-./0123456789:;%3C=%3E%3F@${
+      alphabet.toUpperCase()
+    }%5B%5C%5D%5E_%60${alphabet}%7B%7C%7D%7E%7F${
+      Array.from({ length: 0x800 - 0x80 }, (_, i) => `%${
+        (Math.floor((i - 0x80) / 0x40) + 0xC4).toString(16).toUpperCase()
+      }%${
+        ((i % 0x40) + 0x80).toString(16).toUpperCase()
+      }`).join('')
+    }${
+      Array.from({ length: 0x7FFF - 0x800 }, (_, i) => i + 0x800).map((i) => `%E${
+        (i >> 12).toString(16).toUpperCase()
+      }%${
+        (((i >> 6) % 0x40) + 0x80).toString(16).toUpperCase()
+      }%${
+        ((i % 0x40) + 0x80).toString(16).toUpperCase()
+      }`).join('')
+    }`
+  },
+  // Trying with some pair of 16-bit surrogate pseudo-characters
+  { path: `/${String.fromCodePoint(0x1F303)}`, expected: 'file:///%F0%9F%8C%83' },
 ];
 
 for (const { path, expected } of windowsTestCases) {


### PR DESCRIPTION
In https://github.com/nodejs/node/pull/55476, we're changing the implementation of `pathToFileURL` to something more performant. In an early implementation, I realized some char were swallowed, but we didn't have a test to catch that. This PR is adding some additional test cases to catch this kind of bug.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
