### PR TITLE
lib: optimize `type(V)` to only check null when V is webidl object

### DIFF
--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -236,9 +236,6 @@ function createEnumConverter(name, values) {
 
 // https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values
 function type(V) {
-  if (V === null)
-    return 'Null';
-
   switch (typeof V) {
     case 'undefined':
       return 'Undefined';
@@ -255,6 +252,9 @@ function type(V) {
     case 'object': // Fall through
     case 'function': // Fall through
     default:
+      if (V === null) {
+        return 'Null';
+      }
       // Per ES spec, typeof returns an implementation-defined value that is not
       // any of the existing ones for uncallable non-standard exotic objects.
       // Yet Type() which the Web IDL spec depends on returns Object for such


### PR DESCRIPTION
it is not necessary to always check if `V` is `null`.