### PR TITLE
meta: allow users to reopen stale issues via commands

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -1,0 +1,26 @@
+name: "Comment Commands"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  reopen_and_disable_stale:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository == 'nodejs/node' &&
+      github.event.comment.body == '/reopen-stale' &&
+      contains(github.event.issue.labels.*.name, 'stale') &&
+      github.event.issue.state == 'closed'
+      
+    steps:
+      - name: Reopen issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue reopen "$ISSUE_NUMBER" --repo ${{ github.repository }}


### PR DESCRIPTION
This is a draft as I'd love some opinions on whether this is behavior the project would like to support.

@ljharb pointed out in [this thread](https://openjs-foundation.slack.com/archives/CK9Q4MB53/p1729616650629699) that it would be ideal if we "can offer a stalebot command that anyone can use to reopen [the issue]".

This is a basic implemention of such commands, so I'd love some opinions on whether this behavior we'd want to support.

---

(@ljharb do you have anything to add?)