### PR TITLE
module: allow ESM that failed to be required to be re-imported

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -22,7 +22,7 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
 
-const { ModuleWrap, kEvaluated } = internalBinding('module_wrap');
+const { ModuleWrap, kEvaluated, kInstantiated } = internalBinding('module_wrap');
 const {
   privateSymbols: {
     entry_point_module_private_symbol,
@@ -354,10 +354,21 @@ class ModuleJobSync extends ModuleJobBase {
   }
 
   async run() {
+    // This path is hit by a require'd module that is imported again.
     const status = this.module.getStatus();
-    assert(status === kEvaluated,
-           `A require()-d module that is imported again must be evaluated. Status = ${status}`);
-    return { __proto__: null, module: this.module };
+    if (status === kEvaluated) {
+      return { __proto__: null, module: this.module };
+    } else if (status === kInstantiated) {
+      // The evaluation may have been canceled because instantiateSync() detected TLA first.
+      // But when it is imported again, it's fine to re-evaluate it asynchronously.
+      const timeout = -1;
+      const breakOnSigint = false;
+      await this.module.evaluate(timeout, breakOnSigint);
+      return { __proto__: null, module: this.module };
+    }
+
+    assert.fail('Unexpected status of a module that is imported again after being required. ' +
+                `Status = ${status}`);
   }
 
   runSync() {

--- a/test/es-module/test-require-module-tla-retry-import-2.js
+++ b/test/es-module/test-require-module-tla-retry-import-2.js
@@ -1,0 +1,26 @@
+// This tests that after loading a ESM with import() and then retrying
+// with require(), it errors as expected, and produces consistent results.
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+let ns;
+async function test() {
+  const newNs = await import('../fixtures/es-modules/tla/export-async.mjs');
+  if (ns === undefined) {
+    ns = newNs;
+  } else {
+    // Check that re-evalaution is returning the same namespace.
+    assert.strictEqual(ns, newNs);
+  }
+  assert.strictEqual(ns.hello, 'world');
+
+  assert.throws(() => {
+    require('../fixtures/es-modules/tla/export-async.mjs');
+  }, {
+    code: 'ERR_REQUIRE_ASYNC_MODULE'
+  });
+}
+
+// Run the test twice to check consistency after caching.
+test().then(common.mustCall(test)).catch(common.mustNotCall());

--- a/test/es-module/test-require-module-tla-retry-import.js
+++ b/test/es-module/test-require-module-tla-retry-import.js
@@ -1,0 +1,25 @@
+// This tests that after failing to require an ESM that contains TLA,
+// retrying with import() still works, and produces consistent results.
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+
+let ns;
+async function test() {
+  assert.throws(() => {
+    require('../fixtures/es-modules/tla/export-async.mjs');
+  }, {
+    code: 'ERR_REQUIRE_ASYNC_MODULE'
+  });
+  const newNs = await import('../fixtures/es-modules/tla/export-async.mjs');
+  if (ns === undefined) {
+    ns = newNs;
+  } else {
+    // Check that re-evalaution is returning the same namespace.
+    assert.strictEqual(ns, newNs);
+  }
+  assert.strictEqual(ns.hello, 'world');
+}
+
+// Run the test twice to check consistency after caching.
+test().then(common.mustCall(test)).catch(common.mustNotCall());

--- a/test/fixtures/es-modules/tla/export-async.mjs
+++ b/test/fixtures/es-modules/tla/export-async.mjs
@@ -1,0 +1,2 @@
+let hello = await Promise.resolve('world');
+export { hello };


### PR DESCRIPTION
When a ESM module cannot be loaded by require due to the presence of TLA, its module status would be stopped at kInstantiated. In this case, when it's imported again, we should allow it to be evaluated asynchronously, as it's also a common pattern for users to retry with dynamic import when require fails.

Fixes: https://github.com/nodejs/node/issues/55500
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
