### PR TITLE
module: fix error thrown from require(esm) hitting TLA repeatedly

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1650,6 +1650,9 @@ E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_QUIC_CONNECTION_FAILED', 'QUIC connection failed', Error);
 E('ERR_QUIC_ENDPOINT_CLOSED', 'QUIC endpoint closed: %s (%d)', Error);
 E('ERR_QUIC_OPEN_STREAM_FAILED', 'Failed to open QUIC stream', Error);
+E('ERR_REQUIRE_ASYNC_MODULE', 'require() cannot be used on an ESM ' +
+  'graph with top-level await. Use import() instead. To see where the' +
+  ' top-level await comes from, use --experimental-print-required-tla.', Error);
 E('ERR_REQUIRE_CYCLE_MODULE', '%s', Error);
 E('ERR_REQUIRE_ESM',
   function(filename, hasEsmSyntax, parentPath = null, packageJsonPath = null) {

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -23,6 +23,7 @@ const { imported_cjs_symbol } = internalBinding('symbols');
 
 const assert = require('internal/assert');
 const {
+  ERR_REQUIRE_ASYNC_MODULE,
   ERR_REQUIRE_CYCLE_MODULE,
   ERR_REQUIRE_ESM,
   ERR_NETWORK_IMPORT_DISALLOWED,
@@ -302,6 +303,9 @@ class ModuleLoader {
     //    evaluated at this point.
     if (job !== undefined) {
       mod[kRequiredModuleSymbol] = job.module;
+      if (job.module.async) {
+        throw new ERR_REQUIRE_ASYNC_MODULE();
+      }
       if (job.module.getStatus() !== kEvaluated) {
         const parentFilename = urlToFilename(parent?.filename);
         let message = `Cannot require() ES Module ${filename} in a cycle.`;

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -37,8 +37,11 @@ const resolvedPromise = PromiseResolve();
 const {
   setHasStartedUserESMExecution,
 } = require('internal/modules/helpers');
+const { getOptionValue } = require('internal/options');
 const noop = FunctionPrototype;
-
+const {
+  ERR_REQUIRE_ASYNC_MODULE,
+} = require('internal/errors').codes;
 let hasPausedEntry = false;
 
 const CJSGlobalLike = [
@@ -362,7 +365,16 @@ class ModuleJobSync extends ModuleJobBase {
 
   runSync() {
     // TODO(joyeecheung): add the error decoration logic from the async instantiate.
-    this.module.instantiateSync();
+    this.module.async = this.module.instantiateSync();
+    // If --experimental-print-required-tla is true, proceeds to evaluation even
+    // if it's async because we want to search for the TLA and help users locate
+    // them.
+    // TODO(joyeecheung): track the asynchroniticy using v8::Module::HasTopLevelAwait()
+    // and we'll be able to throw right after compilation of the modules, using acron
+    // to find and print the TLA.
+    if (this.module.async && !getOptionValue('--experimental-print-required-tla')) {
+      throw new ERR_REQUIRE_ASYNC_MODULE();
+    }
     setHasStartedUserESMExecution();
     const namespace = this.module.evaluateSync();
     return { __proto__: null, module: this.module, namespace };

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -31,7 +31,6 @@ using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::Int32;
 using v8::Integer;
-using v8::IntegrityLevel;
 using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
@@ -634,8 +633,8 @@ void ModuleWrap::InstantiateSync(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  // TODO(joyeecheung): record Module::HasTopLevelAwait() in every ModuleWrap and
-  // infer the asynchronicity from a module's children during linking.
+  // TODO(joyeecheung): record Module::HasTopLevelAwait() in every ModuleWrap
+  // and infer the asynchronicity from a module's children during linking.
   args.GetReturnValue().Set(module->IsGraphAsync());
 }
 

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -332,7 +332,6 @@ void ModuleWrap::New(const FunctionCallbackInfo<Value>& args) {
 
   obj->contextify_context_ = contextify_context;
 
-  that->SetIntegrityLevel(context, IntegrityLevel::kFrozen);
   args.GetReturnValue().Set(that);
 }
 
@@ -635,13 +634,9 @@ void ModuleWrap::InstantiateSync(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  // If --experimental-print-required-tla is true, proceeds to evaluation even
-  // if it's async because we want to search for the TLA and help users locate
-  // them.
-  if (module->IsGraphAsync() && !env->options()->print_required_tla) {
-    THROW_ERR_REQUIRE_ASYNC_MODULE(env);
-    return;
-  }
+  // TODO(joyeecheung): record Module::HasTopLevelAwait() in every ModuleWrap and
+  // infer the asynchronicity from a module's children during linking.
+  args.GetReturnValue().Set(module->IsGraphAsync());
 }
 
 void ModuleWrap::EvaluateSync(const FunctionCallbackInfo<Value>& args) {

--- a/test/es-module/test-require-module-tla-retry-require.js
+++ b/test/es-module/test-require-module-tla-retry-require.js
@@ -1,5 +1,5 @@
 // This tests that after failing to require an ESM that contains TLA,
-// retrying with import() still works, and produces consistent results.
+// retrying with require() still throws, and produces consistent results.
 'use strict';
 require('../common');
 const assert = require('assert');

--- a/test/es-module/test-require-module-tla-retry-require.js
+++ b/test/es-module/test-require-module-tla-retry-require.js
@@ -1,0 +1,16 @@
+// This tests that after failing to require an ESM that contains TLA,
+// retrying with import() still works, and produces consistent results.
+'use strict';
+require('../common');
+const assert = require('assert');
+
+assert.throws(() => {
+  require('../fixtures/es-modules/tla/resolved.mjs');
+}, {
+  code: 'ERR_REQUIRE_ASYNC_MODULE'
+});
+assert.throws(() => {
+  require('../fixtures/es-modules/tla/resolved.mjs');
+}, {
+  code: 'ERR_REQUIRE_ASYNC_MODULE'
+});


### PR DESCRIPTION
This tracks the asynchronicity in the ModuleWraps when they turn out to contain TLA after instantiation, and throw the right error (ERR_REQUIRE_ASYNC_MODULE) when it's required again. It removes the freezing of ModuleWraps since it's not meaningful to freeze this when the rest of the module loader is mutable, and we can record the asynchronicity in the ModuleWrap right after compilation after we get a V8 upgrade that contains v8::Module::HasTopLevelAwait() instead of searching through the module graph repeatedly which can be slow.

Fixes: https://github.com/nodejs/node/issues/55516
Refs: https://github.com/nodejs/node/issues/52697

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
