### PR TITLE
[v22.x] Revert "build: do not build with code cache for core coverage collection"

### DIFF
--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -13,6 +13,7 @@ on:
       - tools/test.py
       - .github/workflows/coverage-linux.yml
       - codecov.yml
+      - configure.py
       - .nycrc
   push:
     branches:
@@ -27,6 +28,7 @@ on:
       - tools/test.py
       - .github/workflows/coverage-linux.yml
       - codecov.yml
+      - configure.py
       - .nycrc
 
 concurrency:

--- a/configure.py
+++ b/configure.py
@@ -1436,9 +1436,7 @@ def configure_node(o):
     o['variables']['node_use_node_snapshot'] = b(
       not cross_compiling and not options.shared)
 
-  # Do not use code cache when Node.js is built for collecting coverage of itself, this allows more
-  # precise coverage for the JS built-ins.
-  if options.without_node_code_cache or options.without_node_snapshot or options.node_builtin_modules_path or options.coverage:
+  if options.without_node_code_cache or options.without_node_snapshot or options.node_builtin_modules_path:
     o['variables']['node_use_node_code_cache'] = 'false'
   else:
     # TODO(refack): fix this when implementing embedded code-cache when cross-compiling.


### PR DESCRIPTION
This reverts commit 948bba396cb4f73f2962d04e53465247b3b1f356.

Refs: https://github.com/nodejs/node/issues/55510#issuecomment-2436042295

---

Opening this PR to see if reverting 948bba396cb4f73f2962d04e53465247b3b1f356 fixes the coverage workflows on `v22.x-staging`.

