### PR TITLE
build: fix GN arg used in `generate_config_gypi.py`

### DIFF
--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -19,11 +19,7 @@ import getnapibuildversion
 
 # Regex used for parsing results of "gn args".
 GN_RE = re.compile(r'(\w+)\s+=\s+(.*?)$', re.MULTILINE)
-
-if sys.platform == 'win32':
-  GN = 'gn.exe'
-else:
-  GN = 'gn'
+GN = 'gn.bat' if sys.platform == 'win32' else 'gn'
 
 def bool_to_number(v):
   return 1 if v else 0


### PR DESCRIPTION
Fixes the following failure on Windows:

<details><summary>Details</summary>
<p>

```
NORTHAMERICA+cavohr@CODEBYTERE-WIN-WORK CLANGARM64 ~/Developer/node_gn/node ((001728f...))
$ ninja -C out/Release node
ninja: Entering directory `out/Release'
[0/1] Regenerating ninja files
[1/5950] ACTION //node:generat...toolchain/win:win_clang_arm64) 
FAILED: gen/node/config.gypi
C:/Users/cavohr/AppData/Local/.vpython-root/store/python_venv-8iu8g3np8f7r76gphtcf7o1v1s/contents/Scripts/python3.exe ../../node/tools/generate_config_gypi.py gen/node/config.gypi --out-dir . --dep-file gen/node/generate_config_gypi.d --node-gn-path //node
Traceback (most recent call last):
  File "../../node/tools/generate_config_gypi.py", line 116, in <module>
    main()
  File "../../node/tools/generate_config_gypi.py", line 103, in main
    config = get_gn_config(args.out_dir)
  File "../../node/tools/generate_config_gypi.py", line 36, in get_gn_config
    gn_args = subprocess.check_output(
  File "C:\Users\cavohr\AppData\Local\.vpython-root\store\cpython+dunqimq8p43kdruh73ujf8fpl8\contents\bin\Lib\subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "C:\Users\cavohr\AppData\Local\.vpython-root\store\cpython+dunqimq8p43kdruh73ujf8fpl8\contents\bin\Lib\subprocess.py", line 493, in run
    with Popen(*popenargs, **kwargs) as process:
  File "C:\Users\cavohr\AppData\Local\.vpython-root\store\cpython+dunqimq8p43kdruh73ujf8fpl8\contents\bin\Lib\subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "C:\Users\cavohr\AppData\Local\.vpython-root\store\cpython+dunqimq8p43kdruh73ujf8fpl8\contents\bin\Lib\subprocess.py", line 1311, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,  
FileNotFoundError: [WinError 2] The system cannot find the file specified
[6/5950] CXX obj/node/deps/v8/v8_heap_base/stack.obj
ninja: build stopped: subcommand failed.
```

</p>
</details> 

Which occurs because it's incorrectly trying to find `gn.exe` instead of `gn.bat` on Windows.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
