### PR TITLE
doc: move typescript support to active development

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -983,7 +983,7 @@ JavaScript.
 added: v22.7.0
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 Enables the transformation of TypeScript-only syntax into JavaScript code.
 Implies `--experimental-strip-types` and `--enable-source-maps`.
@@ -1121,7 +1121,7 @@ Enable the experimental [`node:sqlite`][] module.
 added: v22.6.0
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 Enable experimental type-stripping for TypeScript files.
 For more information, see the [TypeScript type-stripping][] documentation.

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -276,7 +276,7 @@ resolution and loading behavior. See [Customization hooks][].
 added: REPLACEME
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 * `code` {string} The code to strip type annotations from.
 * `options` {Object}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1997,7 +1997,7 @@ added:
  - v22.10.0
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 * {boolean|string}
 

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -7,7 +7,7 @@ changes:
     description: Added `--experimental-transform-types` flag.
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 ## Enabling
 
@@ -50,7 +50,7 @@ To use TypeScript with full support for all TypeScript features, including
 added: v22.6.0
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.1 - Active development
 
 The flag [`--experimental-strip-types`][] enables Node.js to run TypeScript
 files. By default Node.js will execute only files that contain no


### PR DESCRIPTION
`--experimental-strip-types` has been released for almost ~3 months.
There is only one issue open and TypeScript has created a [flag for compatibility](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7-beta/) with our implementation.