### PR TITLE
util: don't catch on circular toStringTag error

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1072,6 +1072,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       ArrayPrototypePushApply(output, protoProps);
     }
   } catch (err) {
+    if (!isStackOverflowError(err)) throw err;
     const constructorName = StringPrototypeSlice(getCtxStyle(value, constructor, tag), 0, -1);
     return handleMaxCallStackSize(ctx, err, constructorName, indentationLvl);
   }
@@ -1557,17 +1558,13 @@ function groupArrayElements(ctx, output, value) {
 }
 
 function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
-  if (isStackOverflowError(err)) {
-    ctx.seen.pop();
-    ctx.indentationLvl = indentationLvl;
-    return ctx.stylize(
-      `[${constructorName}: Inspection interrupted ` +
-        'prematurely. Maximum call stack size exceeded.]',
-      'special',
-    );
-  }
-  /* c8 ignore next */
-  assert.fail(err.stack);
+  ctx.seen.pop();
+  ctx.indentationLvl = indentationLvl;
+  return ctx.stylize(
+    `[${constructorName}: Inspection interrupted ` +
+      'prematurely. Maximum call stack size exceeded.]',
+    'special',
+  );
 }
 
 function addNumericSeparator(integerString) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1644,6 +1644,15 @@ util.inspect(process);
 
   assert.throws(() => util.inspect(new ThrowingClass()), /toStringTag error/);
 
+  const y = {
+    get [Symbol.toStringTag]() {
+      return JSON.stringify(this);
+    }
+  };
+  const x = { y };
+  y.x = x;
+  assert.throws(() => util.inspect(x), /TypeError: Converting circular structure to JSON/);
+
   class NotStringClass {
     get [Symbol.toStringTag]() {
       return null;


### PR DESCRIPTION
Fixes #55539 by only supressing an error from a circular `inspectRaw` if it is a max-call-stack-exceeded error, otherwise, throw the error.