### PR TITLE
process: deprecate `features.{ipv6,uv}` and `features.tls_*`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3774,6 +3774,33 @@ Type: Runtime
 
 The `util.getCallSite` API has been removed. Please use [`util.getCallSites()`][] instead.
 
+### DEP0187: `process.features.ipv6` and `process.features.uv`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55545
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+These properties are unconditionally `true`. Any checks based on these properties are redundant.
+
+### DEP0188: `process.features.tls_*`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55545
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+`process.features.tls_alpn`, `process.features.tls_ocsp`, and `process.features.tls_sni` are
+deprecated, as their values are guaranteed to be identical to that of `process.features.tls`.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1930,11 +1930,17 @@ A boolean value that is `true` if the current Node.js build includes the inspect
 
 <!-- YAML
 added: v0.5.3
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. This property is always true, and any checks based on it are
+> redundant.
 
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for IPv6.
+
+Since all Node.js builds have IPv6 support, this value is always `true`.
 
 ## `process.features.require_module`
 
@@ -1963,31 +1969,49 @@ A boolean value that is `true` if the current Node.js build includes support for
 
 <!-- YAML
 added: v4.8.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use `process.features.tls` instead.
 
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for ALPN in TLS.
 
+In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional ALPN support.
+This value is therefore identical to that of `process.features.tls`.
+
 ## `process.features.tls_ocsp`
 
 <!-- YAML
 added: v0.11.13
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use `process.features.tls` instead.
 
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for OCSP in TLS.
 
+In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional OCSP support.
+This value is therefore identical to that of `process.features.tls`.
+
 ## `process.features.tls_sni`
 
 <!-- YAML
 added: v0.5.3
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use `process.features.tls` instead.
 
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for SNI in TLS.
+
+In Node.js 11.0.0 and later versions, the OpenSSL dependencies feature unconditional SNI support.
+This value is therefore identical to that of `process.features.tls`.
 
 ## `process.features.typescript`
 
@@ -2008,12 +2032,17 @@ A value that is `"strip"` if Node.js is run with `--experimental-strip-types`,
 
 <!-- YAML
 added: v0.5.3
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. This property is always true, and any checks based on it are
+> redundant.
 
 * {boolean}
 
 A boolean value that is `true` if the current Node.js build includes support for libuv.
-Since it's currently not possible to build Node.js without libuv, this value is always `true`.
+
+Since it's not possible to build Node.js without libuv, this value is always `true`.
 
 ## `process.finalization.register(ref, callback)`
 


### PR DESCRIPTION
Resolves: #55537

As per the linked issue.

- `ipv6` and `uv` are unconditionally true, and have been since v0.5.x.
- Not all builds supported ALPN/OCSP/SNI prior to OpenSSL 1.0.2, hence the existence of individual `tls_*` properties. Since v11.0.0, this is no longer the case, and so these properties are now redundant.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
