### PR TITLE
fs: fix parentPath returned from getDirent() when type is `UV_DIRENT_UNKNOWN`

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -301,7 +301,7 @@ function getDirent(path, name, type, callback) {
           callback(err);
           return;
         }
-        callback(null, new DirentFromStats(name, stats, filepath));
+        callback(null, new DirentFromStats(name, stats, path));
       });
     } else {
       callback(null, new Dirent(name, type, path));

--- a/test/parallel/test-fs-utils-get-dirents.js
+++ b/test/parallel/test-fs-utils-get-dirents.js
@@ -75,6 +75,7 @@ const filename = 'foo';
     common.mustCall((err, dirent) => {
       assert.strictEqual(err, null);
       assert.strictEqual(dirent.name, filename);
+      assert.strictEqual(dirent.parentPath, tmpdir.path);
     },
     ));
 }
@@ -100,20 +101,22 @@ const filename = 'foo';
     common.mustCall((err, dirent) => {
       assert.strictEqual(err, null);
       assert.strictEqual(dirent.name, filenameBuffer);
-      assert.deepStrictEqual(dirent.parentPath, Buffer.from(tmpdir.resolve(`${filename}/`)));
+      assert.strictEqual(dirent.parentPath, tmpdir.path);
     },
     ));
 }
 {
   // Buffer + Buffer
   const filenameBuffer = Buffer.from(filename);
+  const dirnameBuffer = Buffer.from(tmpdir.path);
   getDirent(
-    Buffer.from(tmpdir.path),
+    dirnameBuffer,
     filenameBuffer,
     UV_DIRENT_UNKNOWN,
     common.mustCall((err, dirent) => {
       assert.strictEqual(err, null);
       assert.strictEqual(dirent.name, filenameBuffer);
+      assert.deepStrictEqual(dirent.parentPath, dirnameBuffer);
     },
     ));
 }


### PR DESCRIPTION
The `parentPath` must be a path to the parent directory rather than path to the file itself.

/cc @Ethan-Arrowood @nodejs/fs 