### PR TITLE
module: fix error reporting

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -36,6 +36,7 @@ const {
   ArrayPrototypeUnshiftApply,
   Boolean,
   Error,
+  ErrorCaptureStackTrace,
   JSONParse,
   ObjectDefineProperty,
   ObjectFreeze,
@@ -1674,6 +1675,7 @@ function getRequireESMError(mod, pkg, content, filename) {
   const usesEsm = containsModuleSyntax(content, filename);
   const err = new ERR_REQUIRE_ESM(filename, usesEsm, parentPath,
                                   packageJsonPath);
+  ErrorCaptureStackTrace(err, Module.prototype.require);
   // Attempt to reconstruct the parent require frame.
   const parentModule = Module._cache[parentPath];
   if (parentModule) {

--- a/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/app.js
+++ b/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/app.js
@@ -1,0 +1,1 @@
+import nothing from 'somewhere';

--- a/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/index.cjs
+++ b/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/index.cjs
@@ -1,0 +1,11 @@
+function main() {
+  func1(func2(func3()))
+}
+
+function func1() {
+  require('./app.js')
+}
+function func2() {}
+function func3() {}
+
+main()

--- a/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/package.json
+++ b/test/fixtures/es-modules/package-type-module/require-esm-error-annotation/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/parallel/test-require-esm-with-no-experimental-require-module.mjs
+++ b/test/parallel/test-require-esm-with-no-experimental-require-module.mjs
@@ -1,0 +1,29 @@
+import '../common/index.mjs';
+import { test } from 'node:test';
+import * as fixtures from '../common/fixtures.mjs';
+import { spawnSync } from 'node:child_process';
+import assert from 'node:assert';
+import { EOL } from 'node:os';
+
+test('correctly reports error for a longer stack trace', () => {
+  // The following regex matches the error message that is expected to be thrown
+  //
+  // package-type-module/require-esm-error-annotation/longer-stack.cjs:6
+  //   require('./app.js')
+  //   ^
+
+  const fixture = fixtures.path('es-modules/package-type-module/require-esm-error-annotation/index.cjs');
+  const args = ['--no-experimental-require-module', fixture];
+
+  const lineNumber = 6;
+  const lineContent = "require('./app.js')";
+  const fullMessage = `${fixture}:${lineNumber}${EOL}  ${lineContent}${EOL}  ^${EOL}`;
+
+  const result = spawnSync(process.execPath, args);
+
+  console.log(`STDERR: ${result.stderr.toString()}`);
+
+  assert.strictEqual(result.status, 1);
+  assert.strictEqual(result.stdout.toString(), '');
+  assert(result.stderr.toString().indexOf(fullMessage) > -1);
+});

--- a/test/parallel/test-require-esm-with-no-experimental-require-module.mjs
+++ b/test/parallel/test-require-esm-with-no-experimental-require-module.mjs
@@ -3,27 +3,22 @@ import { test } from 'node:test';
 import * as fixtures from '../common/fixtures.mjs';
 import { spawnSync } from 'node:child_process';
 import assert from 'node:assert';
-import { EOL } from 'node:os';
 
 test('correctly reports error for a longer stack trace', () => {
   // The following regex matches the error message that is expected to be thrown
   //
-  // package-type-module/require-esm-error-annotation/longer-stack.cjs:6
+  // package-type-module/require-esm-error-annotation/index.cjs:6
   //   require('./app.js')
   //   ^
 
   const fixture = fixtures.path('es-modules/package-type-module/require-esm-error-annotation/index.cjs');
   const args = ['--no-experimental-require-module', fixture];
-
-  const lineNumber = 6;
-  const lineContent = "require('./app.js')";
-  const fullMessage = `${fixture}:${lineNumber}${EOL}  ${lineContent}${EOL}  ^${EOL}`;
+  const regex = /index\.cjs:6[\n\r]+\s{2}require\('\.\/app\.js'\)[\n\r]+\s{2}\^/;
 
   const result = spawnSync(process.execPath, args);
-
-  console.log(`STDERR: ${result.stderr.toString()}`);
+  const stderr = result.stderr.toString();
 
   assert.strictEqual(result.status, 1);
   assert.strictEqual(result.stdout.toString(), '');
-  assert(result.stderr.toString().indexOf(fullMessage) > -1);
+  assert.match(stderr, regex);
 });


### PR DESCRIPTION
Refs: #55350
Fixes: #55350

The error is incorrectly reported because the `traceSync` call is on the stack frame. The code that computes the message was getting the first frame expecting it to have the information needed. Something like

```
at Object.<anonymous> (/Users/edysilva/test-node/issue-55350/test.cjs:1:1)
```

With `traceSync` it's like

```
 at TracingChannel.traceSync (node:diagnostics_channel:322:14)
 at Object.<anonymous> (/Users/edysilva/test-node/issue-55350/test.cjs:1:1)
```

This PR fixes this behavior by skipping cutting frames about the user's frame.