### PR TITLE
Document `Buffer.concat` zero-fill behavior

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1043,7 +1043,7 @@ in `list` by adding their lengths.
 If `totalLength` is provided, it is coerced to an unsigned integer. If the
 combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
 truncated to `totalLength`. If the combined length of the `Buffer`s in `list` is
-less than `totalLength` then the remaining space is filled with zeros.
+less than `totalLength`, the remaining space is filled with zeros.
 
 ```mjs
 import { Buffer } from 'node:buffer';

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1042,7 +1042,8 @@ in `list` by adding their lengths.
 
 If `totalLength` is provided, it is coerced to an unsigned integer. If the
 combined length of the `Buffer`s in `list` exceeds `totalLength`, the result is
-truncated to `totalLength`.
+truncated to `totalLength`. If the combined length of the `Buffer`s in `list` is
+less than `totalLength` then the remaining space is filled with zeros.
 
 ```mjs
 import { Buffer } from 'node:buffer';


### PR DESCRIPTION
`Buffer.concat` will zero-fill the tail of the destination buffer. This behavior is specified in `test/parallel/test-buffer-concat.js` but it is not yet documented in `doc/api/buffer.md`. This pull request updates the docs.

The zero-fill behavior is already implemented here.
https://github.com/duncpro/node/blob/6e59723fbf380950fa901fd33326a00346ead607/lib/buffer.js#L607-L616

There is already a test for it here.
https://github.com/duncpro/node/blob/6e59723fbf380950fa901fd33326a00346ead607/test/parallel/test-buffer-concat.js#L91-L93

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
