### PR TITLE
build: fix building with system icu 76

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1879,7 +1879,7 @@ def configure_intl(o):
   elif with_intl == 'system-icu':
     # ICU from pkg-config.
     o['variables']['v8_enable_i18n_support'] = 1
-    pkgicu = pkg_config('icu-i18n')
+    pkgicu = pkg_config(['icu-i18n', 'icu-uc'])
     if not pkgicu[0]:
       error('''Could not load pkg-config data for "icu-i18n".
        See above errors or the README.md.''')


### PR DESCRIPTION
ICU 76 decided to reduce overlinking[^1] thus `icu-i18n` will no longer add `icu-uc` when linking to shared libraries. This results in undefined symbols/references when trying to build with system ICU 76.

[^1]: unicode-org/icu@199bc82

---

Example of build error (seen on v22.10.0 and v23.1.0) is:
```
.../out/Release/obj.target/gen-regexp-special-case/deps/v8/src/regexp/gen-regexp-special-case.o: in function `v8::internal::PrintSet(std::basic_ofstream<char, std::char_traits<char> >&, char const*, icu_76::UnicodeSet const&)':
gen-regexp-special-case.cc:(.text._ZN2v88internal8PrintSetERSt14basic_ofstreamIcSt11char_traitsIcEEPKcRKN6icu_7610UnicodeSetE+0x9c): undefined reference to `icu_76::UnicodeSet::getRangeStart(int) const'
/home/linuxbrew/.linuxbrew/opt/binutils/bin/ld: gen-regexp-special-case.cc:(.text._ZN2v88internal8PrintSetERSt14basic_ofstreamIcSt11char_traitsIcEEPKcRKN6icu_7610UnicodeSetE+0xc4): undefined reference to `icu_76::UnicodeSet::getRangeEnd(int) const'
```

ICU 76:
```console
$ pkg-config --libs-only-l icu-i18n
-licui18n

$ pkg-config --libs-only-l icu-i18n icu-uc
-licui18n -licuuc
```

ICU 75:
```console
$ pkg-config --libs-only-l icu-i18n
-licui18n -licuuc -licudata
```

---

Specifically seen at Homebrew when testing new ICU 76.1 release https://github.com/Homebrew/homebrew-core/pull/193114.

CI successfully built v22.10.0 after applying this patch.

Should be backwards compatible as `icu-uc.pc` has existed as long as `icu-i18n.pc` - https://github.com/unicode-org/icu/commit/d39075895576f183ef9756aabe34db8b64e6af38