### PR TITLE
sqlite: add readOnly option

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -107,6 +107,8 @@ added: v22.5.0
   * `open` {boolean} If `true`, the database is opened by the constructor. When
     this value is `false`, the database must be opened via the `open()` method.
     **Default:** `true`.
+  * `readOnly` {boolean} If `true`, the database is opened in read-only mode.
+    If the database does not exist, opening it will fail. **Default:** `false`.
   * `enableForeignKeyConstraints` {boolean} If `true`, foreign key constraints
     are enabled. This is recommended but can be disabled for compatibility with
     legacy database schemas. The enforcement of foreign key constraints can be

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -21,6 +21,10 @@ class DatabaseOpenConfiguration {
 
   inline const std::string& location() const { return location_; }
 
+  inline bool get_read_only() const { return read_only_; }
+
+  inline void set_read_only(bool flag) { read_only_ = flag; }
+
   inline bool get_enable_foreign_keys() const { return enable_foreign_keys_; }
 
   inline void set_enable_foreign_keys(bool flag) {
@@ -33,6 +37,7 @@ class DatabaseOpenConfiguration {
 
  private:
   std::string location_;
+  bool read_only_ = false;
   bool enable_foreign_keys_ = true;
   bool enable_dqs_ = false;
 };


### PR DESCRIPTION
Allow opening existing SQLite databases with `SQLITE_OPEN_READONLY` set.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
