### PR TITLE
doc: capitalize "MIT License"

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ releases on a rotation basis as outlined in the
 ## License
 
 Node.js is available under the
-[MIT license](https://opensource.org/licenses/MIT). Node.js also includes
+[MIT License](https://opensource.org/licenses/MIT). Node.js also includes
 external libraries that are available under a variety of licenses.  See
 [LICENSE](https://github.com/nodejs/node/blob/HEAD/LICENSE) for the full
 license text.


### PR DESCRIPTION
According to the MIT Technology Licensing Office, "MIT License" appears to have a capital **L** in 'License', per the following statement:
> The MIT Open Source License, often referred to as the "MIT License," 