### PR TITLE
test_runner: pass `options` directly to `TestCoverage`

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -59,18 +59,10 @@ class CoverageLine {
 class TestCoverage {
   constructor(coverageDirectory,
               originalCoverageDirectory,
-              workingDirectory,
-              excludeGlobs,
-              includeGlobs,
-              sourceMaps,
-              thresholds) {
+              options) {
     this.coverageDirectory = coverageDirectory;
     this.originalCoverageDirectory = originalCoverageDirectory;
-    this.workingDirectory = workingDirectory;
-    this.excludeGlobs = excludeGlobs;
-    this.includeGlobs = includeGlobs;
-    this.sourceMaps = sourceMaps;
-    this.thresholds = thresholds;
+    this.options = options;
   }
 
   #sourceLines = new SafeMap();
@@ -143,7 +135,7 @@ class TestCoverage {
     const coverage = this.getCoverageFromDirectory();
     const coverageSummary = {
       __proto__: null,
-      workingDirectory: this.workingDirectory,
+      workingDirectory: this.options.cwd,
       files: [],
       totals: {
         __proto__: null,
@@ -157,7 +149,12 @@ class TestCoverage {
         coveredBranchPercent: 0,
         coveredFunctionPercent: 0,
       },
-      thresholds: this.thresholds,
+      thresholds: {
+        __proto__: null,
+        line: this.options.lineCoverage,
+        branch: this.options.branchCoverage,
+        function: this.options.functionCoverage,
+      },
     };
 
     if (!coverage) {
@@ -348,7 +345,7 @@ class TestCoverage {
   mapCoverageWithSourceMap(coverage) {
     const { result } = coverage;
     const sourceMapCache = coverage['source-map-cache'];
-    if (!this.sourceMaps || !sourceMapCache) {
+    if (!this.options.sourceMaps || !sourceMapCache) {
       return result;
     }
     const newResult = new SafeMap();
@@ -462,21 +459,24 @@ class TestCoverage {
     if (!StringPrototypeStartsWith(url, 'file:')) return true;
 
     const absolutePath = fileURLToPath(url);
-    const relativePath = relative(this.workingDirectory, absolutePath);
-
+    const relativePath = relative(this.options.cwd, absolutePath);
+    const {
+      coverageExcludeGlobs: excludeGlobs,
+      coverageIncludeGlobs: includeGlobs,
+    } = this.options;
     // This check filters out files that match the exclude globs.
-    if (this.excludeGlobs?.length > 0) {
-      for (let i = 0; i < this.excludeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, this.excludeGlobs[i]) ||
-            matchesGlob(absolutePath, this.excludeGlobs[i])) return true;
+    if (excludeGlobs?.length > 0) {
+      for (let i = 0; i < excludeGlobs.length; ++i) {
+        if (matchesGlob(relativePath, excludeGlobs[i]) ||
+            matchesGlob(absolutePath, excludeGlobs[i])) return true;
       }
     }
 
     // This check filters out files that do not match the include globs.
-    if (this.includeGlobs?.length > 0) {
-      for (let i = 0; i < this.includeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, this.includeGlobs[i]) ||
-            matchesGlob(absolutePath, this.includeGlobs[i])) return false;
+    if (includeGlobs?.length > 0) {
+      for (let i = 0; i < includeGlobs.length; ++i) {
+        if (matchesGlob(relativePath, includeGlobs[i]) ||
+            matchesGlob(absolutePath, includeGlobs[i])) return false;
       }
       return true;
     }
@@ -518,16 +518,7 @@ function setupCoverage(options) {
   return new TestCoverage(
     coverageDirectory,
     originalCoverageDirectory,
-    options.cwd,
-    options.coverageExcludeGlobs,
-    options.coverageIncludeGlobs,
-    options.sourceMaps,
-    {
-      __proto__: null,
-      line: options.lineCoverage,
-      branch: options.branchCoverage,
-      function: options.functionCoverage,
-    },
+    options,
   );
 }
 


### PR DESCRIPTION
This should make future modifications to the `TestCoverage` class simpler, as additional options don't need to be added to the constructor.