### PR TITLE
src: provide workaround for container-overflow (issue 55584)

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -105,10 +105,12 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   // the string even when we are still within the capacity of the string.
   // https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
   // https://github.com/nodejs/node/issues/55584
-  // The next three lines are a workaround to avoid this false positive.
+  // The next lines are a workaround to avoid this false positive.
   size_t json_length = package_config.raw_json.size();
   package_config.raw_json.append(simdjson::SIMDJSON_PADDING, ' ');
-  simdjson::padded_string_view json_view(package_config.raw_json.data(), json_length, package_config.raw_json.size());
+  simdjson::padded_string_view json_view(package_config.raw_json.data(),
+                                         json_length,
+                                         package_config.raw_json.size());
   // End of workaround
 
   simdjson::ondemand::document document;

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -100,11 +100,21 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   if (ReadFileSync(&package_config.raw_json, path.data()) < 0) {
     return nullptr;
   }
+  // In some systems, std::string is annotated to generate an
+  // AddressSanitizer: container-overflow error when reading beyond the end of
+  // the string even when we are still within the capacity of the string.
+  // https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
+  // https://github.com/nodejs/node/issues/55584
+  // The next three lines are a workaround to avoid this false positive.
+  size_t json_length = package_config.raw_json.size();
+  package_config.raw_json.append(simdjson::SIMDJSON_PADDING, ' ');
+  simdjson::padded_string_view json_view(package_config.raw_json.data(), json_length, package_config.raw_json.size());
+  // End of workaround
 
   simdjson::ondemand::document document;
   simdjson::ondemand::object main_object;
   simdjson::error_code error =
-      binding_data->json_parser.iterate(package_config.raw_json).get(document);
+      binding_data->json_parser.iterate(json_view).get(document);
 
   const auto throw_invalid_package_config = [error_context, path, realm]() {
     if (error_context == nullptr) {


### PR DESCRIPTION
In issue https://github.com/nodejs/node/issues/55584, @codebytere reported a sanitizer error 'container-overflow'. This error happens only on systems where the standard library has been annotated to warn about reads between the std::string's end and the end of the its allocated memory (std::string:capacity). This reads are memory safe but they can also be a sign that there is a real bug. In the instance of issue 55584, it is not a bug, it is a false positive.

In some instances, it is possible to indicate to the compiler that we want to disallow these checks to avoid the false positive, but I could not find documentation on this topic. With some glue code, this PR should work around this issue. It somewhat ugly code. In a future release of simdjson, we will provide a more convenient function that avoids such ugly workaround. *However*, in this instance, I am sure @codebytere wants the sanitizers to turn green as soon as possible, hence this PR and the somewhat ugly code.

A future PR will make the code prettier.

Refs: https://github.com/nodejs/node/issues/55584

