### PR TITLE
report: fix network queries in getReport libuv with exclude-network

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -32,7 +32,7 @@ is provided below for reference.
 ```json
 {
   "header": {
-    "reportVersion": 3,
+    "reportVersion": 4,
     "event": "exception",
     "trigger": "Exception",
     "filename": "report.20181221.005011.8974.0.001.json",
@@ -322,6 +322,34 @@ is provided below for reference.
       "is_active": true,
       "address": "0x000055fc7b2cb180",
       "loopIdleTimeSeconds": 22644.8
+    },
+    {
+      type: 'tcp',
+      is_active: true,
+      is_referenced: true,
+      address: '0x000055e70fcb85d8',
+      localEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 48986 },
+      remoteEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 38573 },
+      sendBufferSize: 2626560,
+      recvBufferSize: 131072,
+      fd: 24,
+      writeQueueSize: 0,
+      readable: true,
+      writable: true
+    },
+    {
+      type: 'tcp',
+      is_active: true,
+      is_referenced: true,
+      address: '0x000055e70fcd68c8',
+      localEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 52266 },
+      remoteEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 38573 },
+      sendBufferSize: 2626560,
+      recvBufferSize: 131072,
+      fd: 25,
+      writeQueueSize: 0,
+      readable: false,
+      writable: false
     }
   ],
   "workers": [],
@@ -461,7 +489,7 @@ meaning of `SIGUSR2` for the said purposes.
 * `--report-signal` Sets or resets the signal for report generation
   (not supported on Windows). Default signal is `SIGUSR2`.
 
-* `--report-exclude-network` Exclude `header.networkInterfaces` from the
+* `--report-exclude-network` Exclude `header.networkInterfaces` and disable the reverse DNS queries in `libuv.*.(remote|local)Endpoint.host` from the
   diagnostic report. By default this is not set and the network interfaces
   are included.
 

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -324,32 +324,48 @@ is provided below for reference.
       "loopIdleTimeSeconds": 22644.8
     },
     {
-      type: 'tcp',
-      is_active: true,
-      is_referenced: true,
-      address: '0x000055e70fcb85d8',
-      localEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 48986 },
-      remoteEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 38573 },
-      sendBufferSize: 2626560,
-      recvBufferSize: 131072,
-      fd: 24,
-      writeQueueSize: 0,
-      readable: true,
-      writable: true
+      "type": "tcp",
+      "is_active": true,
+      "is_referenced": true,
+      "address": "0x000055e70fcb85d8",
+      "localEndpoint": {
+        "host": "localhost",
+        "ip4": "127.0.0.1",
+        "port": 48986
+      },
+      "remoteEndpoint": {
+        "host": "localhost",
+        "ip4": "127.0.0.1",
+        "port": 38573
+      },
+      "sendBufferSize": 2626560,
+      "recvBufferSize": 131072,
+      "fd": 24,
+      "writeQueueSize": 0,
+      "readable": true,
+      "writable": true
     },
     {
-      type: 'tcp',
-      is_active: true,
-      is_referenced: true,
-      address: '0x000055e70fcd68c8',
-      localEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 52266 },
-      remoteEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 38573 },
-      sendBufferSize: 2626560,
-      recvBufferSize: 131072,
-      fd: 25,
-      writeQueueSize: 0,
-      readable: false,
-      writable: false
+      "type": "tcp",
+      "is_active": true,
+      "is_referenced": true,
+      "address": "0x000055e70fcd68c8",
+      "localEndpoint": {
+        "host": "ip6-localhost",
+        "ip6": "::1",
+        "port": 52266
+      },
+      "remoteEndpoint": {
+        "host": "ip6-localhost",
+        "ip6": "::1",
+        "port": 38573
+      },
+      "sendBufferSize": 2626560,
+      "recvBufferSize": 131072,
+      "fd": 25,
+      "writeQueueSize": 0,
+      "readable": false,
+      "writable": false
     }
   ],
   "workers": [],

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -505,9 +505,9 @@ meaning of `SIGUSR2` for the said purposes.
 * `--report-signal` Sets or resets the signal for report generation
   (not supported on Windows). Default signal is `SIGUSR2`.
 
-* `--report-exclude-network` Exclude `header.networkInterfaces` and disable the reverse DNS queries in `libuv.*.(remote|local)Endpoint.host` from the
-  diagnostic report. By default this is not set and the network interfaces
-  are included.
+* `--report-exclude-network` Exclude `header.networkInterfaces` and disable the reverse DNS queries
+  in `libuv.*.(remote|local)Endpoint.host` from the diagnostic report.
+  By default this is not set and the network interfaces are included.
 
 A report can also be triggered via an API call from a JavaScript application:
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -23,7 +23,7 @@
 #include <cwctype>
 #include <fstream>
 
-constexpr int NODE_REPORT_VERSION = 3;
+constexpr int NODE_REPORT_VERSION = 4;
 constexpr int NANOS_PER_SEC = 1000 * 1000 * 1000;
 constexpr double SEC_PER_MICROS = 1e-6;
 constexpr int MAX_FRAME_COUNT = node::kMaxFrameCountForLogging;

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -202,7 +202,9 @@ static void WriteNodeReport(Isolate* isolate,
 
   writer.json_arraystart("libuv");
   if (env != nullptr) {
-    uv_walk(env->event_loop(), WalkHandle, static_cast<void*>(&writer));
+    uv_walk(env->event_loop(),
+            exclude_network ? WalkHandleNoNetwork : WalkHandleNetwork,
+            static_cast<void*>(&writer));
 
     writer.json_start();
     writer.json_keyvalue("type", "loop");

--- a/src/node_report.h
+++ b/src/node_report.h
@@ -19,7 +19,8 @@
 namespace node {
 namespace report {
 // Function declarations - utility functions in src/node_report_utils.cc
-void WalkHandle(uv_handle_t* h, void* arg);
+void WalkHandleNetwork(uv_handle_t* h, void* arg);
+void WalkHandleNoNetwork(uv_handle_t* h, void* arg);
 
 template <typename T>
 std::string ValueToHexString(T value) {

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -105,7 +105,7 @@ function _validateContent(report, fields = []) {
                         'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd',
                         'reportVersion', 'networkInterfaces', 'threadId'];
   checkForUnknownFields(header, headerFields);
-  assert.strictEqual(header.reportVersion, 3);  // Increment as needed.
+  assert.strictEqual(header.reportVersion, 4);  // Increment as needed.
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
   assert(typeof header.filename === 'string' || header.filename === null);

--- a/test/report/test-report-exclude-network.js
+++ b/test/report/test-report-exclude-network.js
@@ -92,7 +92,7 @@ describe('report exclude network option', () => {
         assert.strictEqual(findHandle(false, false)?.host, '::1');
       }
     } catch (e) {
-      throw new Error(e.message + ' in ' + JSON.stringify(tcp, null, 2));
+      throw new Error(e?.message + ' in ' + JSON.stringify(tcp, null, 2), { cause: e });
     }
   });
 });

--- a/test/report/test-report-exclude-network.js
+++ b/test/report/test-report-exclude-network.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+const http = require('node:http');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
 const tmpdir = require('../common/tmpdir');
@@ -37,5 +38,55 @@ describe('report exclude network option', () => {
 
     const report = process.report.getReport();
     assert.strictEqual(report.header.networkInterfaces, undefined);
+  });
+
+  it('should not do DNS queries in libuv if exclude network', async () => {
+    const server = http.createServer(function(req, res) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end();
+    });
+    const port = await new Promise((resolve) => server.listen(0, async () => {
+      await Promise.all([
+        fetch('http://127.0.0.1:' + server.address().port),
+        fetch('http://[::1]:' + server.address().port),
+      ]);
+      resolve(server.address().port);
+      server.close();
+    }));
+    process.report.excludeNetwork = false;
+    let report = process.report.getReport();
+    let tcp = report.libuv.filter((uv) => uv.type === 'tcp' && uv.remoteEndpoint?.port === port);
+    assert.strictEqual(tcp.length, 2);
+    const findHandle = (host, local = true, ip4 = true) => {
+      return tcp.some(
+        ({ [local ? 'localEndpoint' : 'remoteEndpoint']: ep }) =>
+          (ep[ip4 ? 'ip4' : 'ip6'] === (ip4 ? '127.0.0.1' : '::1') &&
+            (Array.isArray(host) ? host.includes(ep.host) : ep.host === host)),
+      );
+    };
+    try {
+      assert.ok(findHandle('localhost'), 'local localhost handle not found');
+      assert.ok(findHandle('localhost', false), 'remote localhost handle not found');
+
+      assert.ok(findHandle(['localhost', 'ip6-localhost'], true, false), 'local ip6-localhost handle not found');
+      assert.ok(findHandle(['localhost', 'ip6-localhost'], false, false), 'remote ip6-localhost handle not found');
+    } catch (e) {
+      throw new Error(e.message + ' in ' + JSON.stringify(tcp, null, 2));
+    }
+
+    process.report.excludeNetwork = true;
+    report = process.report.getReport();
+    tcp = report.libuv.filter((uv) => uv.type === 'tcp' && uv.remoteEndpoint?.port === port);
+
+    try {
+      assert.strictEqual(tcp.length, 2);
+      assert.ok(findHandle('127.0.0.1'), 'local 127.0.0.1 handle not found');
+      assert.ok(findHandle('127.0.0.1', false), 'remote 127.0.0.1 handle not found');
+
+      assert.ok(findHandle('::1', true, false), 'local ::1 handle not found');
+      assert.ok(findHandle('::1', false, false), 'remote ::1 handle not found');
+    } catch (e) {
+      throw new Error(e.message + ' in ' + JSON.stringify(tcp, null, 2));
+    }
   });
 });

--- a/test/report/test-report-exclude-network.js
+++ b/test/report/test-report-exclude-network.js
@@ -75,7 +75,7 @@ describe('report exclude network option', () => {
         assert.notStrictEqual(findHandle(false, false)?.host, '::1');
       }
     } catch (e) {
-      throw new Error(e.message + ' in ' + JSON.stringify(tcp, null, 2));
+      throw new Error(e?.message + ' in ' + JSON.stringify(tcp, null, 2), { cause: e });
     }
 
     process.report.excludeNetwork = true;


### PR DESCRIPTION
Fixes #55576 #46060 

I also added in the endpoint's report info the keys `ip4` or `ip6` which contain the ip address of the endpoint (as well as information on which stack it was via the key)

Example of a tcp uv with network (default) (note that the reverse hostname resolving is up to the system dns resolver and some implementation may not resolve 127.0.0.1 to localhost for example on one of the ci server it resolves to `test-ibm-rhel9-x64-1.nodejs.cloud`) 
```js
[
  {
    type: 'tcp',
    is_active: true,
    is_referenced: true,
    address: '0x000055e70fcb85d8',
    localEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 48986 },
    remoteEndpoint: { host: 'localhost', ip4: '127.0.0.1', port: 38573 },
    sendBufferSize: 2626560,
    recvBufferSize: 131072,
    fd: 24,
    writeQueueSize: 0,
    readable: true,
    writable: true
  },
  {
    type: 'tcp',
    is_active: true,
    is_referenced: true,
    address: '0x000055e70fcd68c8',
    localEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 52266 },
    remoteEndpoint: { host: 'ip6-localhost', ip6: '::1', port: 38573 },
    sendBufferSize: 2626560,
    recvBufferSize: 131072,
    fd: 25,
    writeQueueSize: 0,
    readable: true,
    writable: true
  }
]
```

Example of a tcp uv without network
```js
[
  {
    type: 'tcp',
    is_active: true,
    is_referenced: true,
    address: '0x000055e70fcb85d8',
    localEndpoint: { host: '127.0.0.1', ip4: '127.0.0.1', port: 48986 },
    remoteEndpoint: { host: '127.0.0.1', ip4: '127.0.0.1', port: 38573 },
    sendBufferSize: 2626560,
    recvBufferSize: 131072,
    fd: 24,
    writeQueueSize: 0,
    readable: true,
    writable: true
  },
  {
    type: 'tcp',
    is_active: true,
    is_referenced: true,
    address: '0x000055e70fcd68c8',
    localEndpoint: { host: '::1', ip6: '::1', port: 52266 },
    remoteEndpoint: { host: '::1', ip6: '::1', port: 38573 },
    sendBufferSize: 2626560,
    recvBufferSize: 131072,
    fd: 25,
    writeQueueSize: 0,
    readable: true,
    writable: true
  }
]
```

The only difference between the two is that a reverse lookup is not performed on the host and will always contain the ip address without network (this is already the fallback if the reverse lookup fails, so that the change is almost invisible)


It would be nice if eventually getReport could be made to accept options instead of the very weird api with assignements and be made async instead and uv_getnameinfo made in async as well, but that's way too big a task for me to take on (I already barely stitched that PR together with my C++ knowledge which is non existant, I only know C)
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
