### PR TITLE
test: ignore unrelated events in FS watch tests

### DIFF
--- a/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-existing-subfolder.js
@@ -40,9 +40,8 @@ const relativePath = path.join(file, path.basename(subfolderPath), childrenFile)
 const watcher = fs.watch(testDirectory, { recursive: true });
 let watcherClosed = false;
 watcher.on('change', function(event, filename) {
-  assert.strictEqual(event, 'rename');
-
   if (filename === relativePath) {
+    assert.strictEqual(event, 'rename');
     watcher.close();
     watcherClosed = true;
   }

--- a/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
@@ -36,10 +36,9 @@ let watcherClosed = false;
 function doWatch() {
   const watcher = fs.watch(testDirectory, { recursive: true });
   watcher.on('change', function(event, filename) {
-    assert.strictEqual(event, 'rename');
-    assert.ok(filename === path.basename(filePath) || filename === childrenRelativePath);
-
     if (filename === childrenRelativePath) {
+      assert.strictEqual(event, 'rename');
+      assert.ok(filename === path.basename(filePath) || filename === childrenRelativePath);
       watcher.close();
       watcherClosed = true;
     }

--- a/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
@@ -38,7 +38,6 @@ function doWatch() {
   watcher.on('change', function(event, filename) {
     if (filename === childrenRelativePath) {
       assert.strictEqual(event, 'rename');
-      assert.ok(filename === path.basename(filePath) || filename === childrenRelativePath);
       watcher.close();
       watcherClosed = true;
     }

--- a/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-to-new-folder.js
@@ -33,30 +33,20 @@ const childrenAbsolutePath = path.join(filePath, childrenFile);
 const childrenRelativePath = path.join(path.basename(filePath), childrenFile);
 let watcherClosed = false;
 
-function doWatch() {
-  const watcher = fs.watch(testDirectory, { recursive: true });
-  watcher.on('change', function(event, filename) {
-    if (filename === childrenRelativePath) {
-      assert.strictEqual(event, 'rename');
-      watcher.close();
-      watcherClosed = true;
-    }
-  });
+const watcher = fs.watch(testDirectory, { recursive: true });
+watcher.on('change', function(event, filename) {
+  if (filename === childrenRelativePath) {
+    assert.strictEqual(event, 'rename');
+    watcher.close();
+    watcherClosed = true;
+  }
+});
 
-  // Do the write with a delay to ensure that the OS is ready to notify us.
-  setTimeout(() => {
-    fs.mkdirSync(filePath);
-    fs.writeFileSync(childrenAbsolutePath, 'world');
-  }, common.platformTimeout(200));
-}
-
-if (common.isMacOS) {
-  // On macOS delay watcher start to avoid leaking previous events.
-  // Refs: https://github.com/libuv/libuv/pull/4503
-  setTimeout(doWatch, common.platformTimeout(100));
-} else {
-  doWatch();
-}
+// Do the write with a delay to ensure that the OS is ready to notify us.
+setTimeout(() => {
+  fs.mkdirSync(filePath);
+  fs.writeFileSync(childrenAbsolutePath, 'world');
+}, common.platformTimeout(200));
 
 process.once('exit', function() {
   assert(watcherClosed, 'watcher Object was not closed');

--- a/test/parallel/test-fs-watch-recursive-add-file-with-url.js
+++ b/test/parallel/test-fs-watch-recursive-add-file-with-url.js
@@ -35,9 +35,8 @@ tmpdir.refresh();
   const watcher = fs.watch(url, { recursive: true });
   let watcherClosed = false;
   watcher.on('change', function(event, filename) {
-    assert.strictEqual(event, 'rename');
-
     if (filename === path.basename(filePath)) {
+      assert.strictEqual(event, 'rename');
       watcher.close();
       watcherClosed = true;
     }

--- a/test/parallel/test-fs-watch-recursive-add-file.js
+++ b/test/parallel/test-fs-watch-recursive-add-file.js
@@ -31,9 +31,8 @@ const testFile = path.join(testDirectory, 'file-1.txt');
 const watcher = fs.watch(testDirectory, { recursive: true });
 let watcherClosed = false;
 watcher.on('change', function(event, filename) {
-  assert.strictEqual(event, 'rename');
-
   if (filename === path.basename(testFile)) {
+    assert.strictEqual(event, 'rename');
     watcher.close();
     watcherClosed = true;
   }

--- a/test/parallel/test-fs-watch-recursive-add-folder.js
+++ b/test/parallel/test-fs-watch-recursive-add-folder.js
@@ -33,9 +33,8 @@ tmpdir.refresh();
   const watcher = fs.watch(testDirectory, { recursive: true });
   let watcherClosed = false;
   watcher.on('change', function(event, filename) {
-    assert.strictEqual(event, 'rename');
-
     if (filename === path.basename(testFile)) {
+      assert.strictEqual(event, 'rename');
       watcher.close();
       watcherClosed = true;
     }


### PR DESCRIPTION
change assertions on test-fs-watch-recursive-add-* tests to only take into account change events that match the file

Fixes #55592 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
