### PR TITLE
meta: show PR/issue title on review-wanted

### DIFF
--- a/.github/workflows/notify-on-review-wanted.yml
+++ b/.github/workflows/notify-on-review-wanted.yml
@@ -16,17 +16,20 @@ jobs:
     steps:
       - name: Determine PR or Issue
         id: define-message
+        env:
+          TITLE_ISSUE: ${{ github.event.issue.title }}
+          TITLE_PR: ${{ github.event.pull_request.title }}
         run: |
           if [[ -n "${{ github.event.pull_request.number }}" ]]; then
             number="${{ github.event.pull_request.number }}"
             link="https://github.com/${{ github.repository }}/pull/$number"
             echo "message=The PR (#$number) requires review from Node.js maintainers. See: $link" >> "$GITHUB_OUTPUT"
-            echo "title=${{ github.actor }} asks for attention on pull request #$number" >> "$GITHUB_OUTPUT"
+            echo "title=$TITLE_PR" >> "$GITHUB_OUTPUT"
           else
             number="${{ github.event.issue.number }}"
             link="https://github.com/${{ github.repository }}/issues/$number"
             echo "message=The issue (#$number) requires review from Node.js maintainers. See: $link" >> "$GITHUB_OUTPUT"
-            echo "title=${{ github.actor }} asks for attention on issue #$number" >> "$GITHUB_OUTPUT"
+            echo "title=$TITLE_ISSUE" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Slack Notification


### PR DESCRIPTION
Ref: https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1730308054959239?thread_ts=1730296053.898089&cid=C019Y2T6STH

There is already a message stating that the PR/issue needs reviews, the title should (IMO) correspond to the issue/PR.