### PR TITLE
meta: make review-wanted message minimal

### DIFF
--- a/.github/workflows/notify-on-review-wanted.yml
+++ b/.github/workflows/notify-on-review-wanted.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@4e5fb42d249be6a45a298f3c9543b111b02f7907  # 2.3.0
         env:
+          MSG_MINIMAL: actions url
           SLACK_COLOR: '#3d85c6'
           SLACK_ICON: https://github.com/nodejs.png?size=48
           SLACK_TITLE: ${{ steps.define-message.outputs.title }}


### PR DESCRIPTION
When the `review-wanted` message is sent, the ref will consistently be `refs/heads/main`, the event type will be `pull_request_target`, and I believe the most recent commit to main will likely not be relevant to the review request.

The `actions URL` is significant here, as it distinguishes this process from the force-push workflow.