### PR TITLE
src: refactor ECDHBitsJob signature

### DIFF
--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -332,7 +332,6 @@ async function ecdhDeriveBits(algorithm, baseKey, length) {
 
   const bits = await jobPromise(() => new ECDHBitsJob(
     kCryptoJobAsync,
-    key.algorithm.name === 'ECDH' ? baseKey.algorithm.namedCurve : baseKey.algorithm.name,
     key[kKeyObject][kHandle],
     baseKey[kKeyObject][kHandle]));
 

--- a/src/crypto/crypto_ec.h
+++ b/src/crypto/crypto_ec.h
@@ -16,7 +16,6 @@
 namespace node {
 namespace crypto {
 int GetCurveFromName(const char* name);
-int GetOKPCurveFromName(const char* name);
 
 class ECDH final : public BaseObject {
  public:

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -909,6 +909,22 @@ void KeyObjectHandle::InitECRaw(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(true);
 }
 
+int GetOKPCurveFromName(const char* name) {
+  int nid;
+  if (strcmp(name, "Ed25519") == 0) {
+    nid = EVP_PKEY_ED25519;
+  } else if (strcmp(name, "Ed448") == 0) {
+    nid = EVP_PKEY_ED448;
+  } else if (strcmp(name, "X25519") == 0) {
+    nid = EVP_PKEY_X25519;
+  } else if (strcmp(name, "X448") == 0) {
+    nid = EVP_PKEY_X448;
+  } else {
+    nid = NID_undef;
+  }
+  return nid;
+}
+
 void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -408,6 +408,8 @@ WebCryptoKeyExportStatus PKEY_SPKI_Export(const KeyObjectData& key_data,
 WebCryptoKeyExportStatus PKEY_PKCS8_Export(const KeyObjectData& key_data,
                                            ByteSource* out);
 
+int GetOKPCurveFromName(const char* name);
+
 namespace Keys {
 void Initialize(Environment* env, v8::Local<v8::Object> target);
 void RegisterExternalReferences(ExternalReferenceRegistry* registry);


### PR DESCRIPTION
removes use of `GetOKPCurveFromName` in `ECDHBitsJob` and moves `GetOKPCurveFromName` closer to its only remaining invocation.