### PR TITLE
doc: remove mention of ECDH-ES in crypto.diffieHellman

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3563,7 +3563,7 @@ added:
 
 Computes the Diffie-Hellman secret based on a `privateKey` and a `publicKey`.
 Both keys must have the same `asymmetricKeyType`, which must be one of `'dh'`
-(for Diffie-Hellman), `'ec'` (for ECDH), `'x448'`, or `'x25519'` (for ECDH-ES).
+(for Diffie-Hellman), `'ec'`, `'x448'`, or `'x25519'` (for ECDH).
 
 ### `crypto.hash(algorithm, data[, outputEncoding])`
 


### PR DESCRIPTION
EC, X448 and X25519 are all ECDH, `ECDH-ES` in here might have been a reference to the JWA algorithm identifier 🤷 