### PR TITLE
src,lib: optimize nodeTiming.uvMetricsInfo

### DIFF
--- a/benchmark/perf_hooks/nodetiming-uvmetricsinfo.js
+++ b/benchmark/perf_hooks/nodetiming-uvmetricsinfo.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const common = require('../common.js');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+
+const {
+  performance,
+} = require('perf_hooks');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  events: [1, 1000, 10000],
+});
+
+async function runEvents(events) {
+  for (let i = 0; i < events; ++i) {
+    assert.ok(await fs.statfs(__filename));
+  }
+}
+
+async function main({ n, events }) {
+  await runEvents(events);
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    assert.ok(performance.nodeTiming.uvMetricsInfo);
+  }
+  bench.end(n);
+}

--- a/lib/internal/perf/nodetiming.js
+++ b/lib/internal/perf/nodetiming.js
@@ -133,7 +133,7 @@ class PerformanceNodeTiming {
           return {
             loopCount: metrics[0],
             events: metrics[1],
-            events_waiting: metrics[2],
+            eventsWaiting: metrics[2],
           };
         },
       },

--- a/lib/internal/perf/nodetiming.js
+++ b/lib/internal/perf/nodetiming.js
@@ -128,7 +128,14 @@ class PerformanceNodeTiming {
         __proto__: null,
         enumerable: true,
         configurable: true,
-        get: uvMetricsInfo,
+        get: () => {
+          const metrics = uvMetricsInfo();
+          return {
+            loopCount: metrics[0],
+            events: metrics[1],
+            events_waiting: metrics[2],
+          };
+        },
       },
     });
   }

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -270,9 +270,9 @@ void UvMetricsInfo(const FunctionCallbackInfo<Value>& args) {
   // uv_metrics_info always return 0
   CHECK_EQ(uv_metrics_info(env->event_loop(), &metrics), 0);
   Local<Value> data[] = {
-    Integer::New(isolate, metrics.loop_count),
-    Integer::New(isolate, metrics.events),
-    Integer::New(isolate, metrics.events_waiting),
+      Integer::New(isolate, metrics.loop_count),
+      Integer::New(isolate, metrics.events),
+      Integer::New(isolate, metrics.events_waiting),
   };
   Local<Array> arr = Array::New(env->isolate(), data, arraysize(data));
   args.GetReturnValue().Set(arr);

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -14,6 +14,7 @@
 namespace node {
 namespace performance {
 
+using v8::Array;
 using v8::Context;
 using v8::DontDelete;
 using v8::Function;
@@ -264,26 +265,17 @@ void LoopIdleTime(const FunctionCallbackInfo<Value>& args) {
 
 void UvMetricsInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
   uv_metrics_t metrics;
-
   // uv_metrics_info always return 0
   CHECK_EQ(uv_metrics_info(env->event_loop(), &metrics), 0);
-
-  Local<Object> obj = Object::New(env->isolate());
-  obj->Set(env->context(),
-           env->loop_count(),
-           Integer::NewFromUnsigned(env->isolate(), metrics.loop_count))
-      .Check();
-  obj->Set(env->context(),
-           env->events(),
-           Integer::NewFromUnsigned(env->isolate(), metrics.events))
-      .Check();
-  obj->Set(env->context(),
-           env->events_waiting(),
-           Integer::NewFromUnsigned(env->isolate(), metrics.events_waiting))
-      .Check();
-
-  args.GetReturnValue().Set(obj);
+  Local<Value> data[] = {
+    Integer::New(isolate, metrics.loop_count),
+    Integer::New(isolate, metrics.events),
+    Integer::New(isolate, metrics.events_waiting),
+  };
+  Local<Array> arr = Array::New(env->isolate(), data, arraysize(data));
+  args.GetReturnValue().Set(arr);
 }
 
 void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
```
$ node benchmark/compare.js --old ./node-without --new ./node-with --filter "nodetiming" perf_hooks > res.out && node-benchmark-compare res.out
[00:00:43|% 100| 1/1 files | 60/60 runs | 3/3 configs]: Done
                                                               confidence improvement accuracy (*)    (**)   (***)
perf_hooks/nodetiming-uvmetricsinfo.js events=1 n=1000000            ***    467.03 %      ±12.50% ±16.82% ±22.27%
perf_hooks/nodetiming-uvmetricsinfo.js events=1000 n=1000000         ***    479.78 %      ±11.29% ±15.17% ±20.04%
perf_hooks/nodetiming-uvmetricsinfo.js events=10000 n=1000000        ***    486.76 %       ±9.85% ±13.23% ±17.46%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```