### PR TITLE
tools: run daily WPT.fyi report on all supported releases

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -6,11 +6,6 @@ name: Daily WPT report
 
 on:
   workflow_dispatch:
-    inputs:
-      node-versions:
-        description: Node.js versions (as supported by actions/setup-node) to test as JSON array
-        required: false
-        default: '["current", "lts/*", "lts/-1"]'
   schedule:
     # This is 20 minutes after `epochs/daily` branch is triggered to be created
     # in WPT repo.
@@ -24,11 +19,22 @@ permissions:
   contents: read
 
 jobs:
-  report:
+  collect-versions:
     if: github.repository == 'nodejs/node' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.query.outputs.matrix }}
+    steps:
+      - id: query
+        run: |
+          matrix=$(curl -s https://raw.githubusercontent.com/nodejs/Release/refs/heads/main/schedule.json | jq --arg now "$(date +%Y-%m-%d)" '[with_entries(select(.value.end > $now and .value.start < $now)) | keys[] | ltrimstr("v") | tonumber] + ["latest-nightly"]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+  report:
+    needs:
+      - collect-versions
     strategy:
       matrix:
-        node-version: ${{ fromJSON(github.event.inputs.node-versions || '["latest-nightly", "current", "lts/*", "lts/-1"]') }}
+        node-version: ${{ fromJSON(needs.collect-versions.outputs.matrix) }}
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This updates the [Daily WPT report](https://github.com/nodejs/node/actions/workflows/daily-wpt-fyi.yml) job to always test on all releases that are not EOL + latest nightly and it uses the [schedule](https://raw.githubusercontent.com/nodejs/Release/refs/heads/main/schedule.json) from https://github.com/nodejs/Release/ to collect the versions.

Example output from the processed schedule given $now is `2024-10-31`

```
[
  18,
  20,
  22,
  23,
  "latest-nightly"
]
```

---

This resolves an issue with the delay coming from https://github.com/actions/node-versions manifest that `actions/setup-node` uses as well as actually not cutting off reporting on lts/-2 so long as it's still not EOL presented in the recent run - https://github.com/nodejs/node/actions/runs/11604060841 - where 18 is tested but 22 is not yet, but when https://github.com/actions/node-versions/pull/191 is merged 22 will be tested but 18 will not.