### PR TITLE
node-api: allow napi_delete_reference in basic finalizers

### DIFF
--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2769,10 +2769,12 @@ napi_status NAPI_CDECL napi_create_reference(napi_env env,
 
 // Deletes a reference. The referenced value is released, and may be GC'd unless
 // there are other references to it.
+// For a napi_reference returned from `napi_wrap`, this must be called in the
+// finalizer.
 napi_status NAPI_CDECL napi_delete_reference(napi_env env, napi_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
-  CHECK_ENV_NOT_IN_GC(env);
+  CHECK_ENV(env);
   CHECK_ARG(env, ref);
 
   delete reinterpret_cast<v8impl::Reference*>(ref);

--- a/test/js-native-api/6_object_wrap/6_object_wrap.cc
+++ b/test/js-native-api/6_object_wrap/6_object_wrap.cc
@@ -3,6 +3,8 @@
 #include "assert.h"
 #include "myobject.h"
 
+typedef int32_t FinalizerData;
+
 napi_ref MyObject::constructor;
 
 MyObject::MyObject(double value)
@@ -15,6 +17,11 @@ void MyObject::Destructor(node_api_basic_env env,
                           void* /*finalize_hint*/) {
   MyObject* obj = static_cast<MyObject*>(nativeObject);
   delete obj;
+
+  FinalizerData* data;
+  NODE_API_BASIC_CALL_RETURN_VOID(
+      env, napi_get_instance_data(env, reinterpret_cast<void**>(&data)));
+  *data += 1;
 }
 
 void MyObject::Init(napi_env env, napi_value exports) {
@@ -199,8 +206,30 @@ napi_value ObjectWrapDanglingReferenceTest(napi_env env,
   return ret;
 }
 
+static napi_value GetFinalizerCallCount(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  FinalizerData* data;
+  napi_value result;
+
+  NODE_API_CALL(env,
+                napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr));
+  NODE_API_CALL(env,
+                napi_get_instance_data(env, reinterpret_cast<void**>(&data)));
+  NODE_API_CALL(env, napi_create_int32(env, *data, &result));
+  return result;
+}
+
+static void finalizeData(napi_env env, void* data, void* hint) {
+  delete reinterpret_cast<FinalizerData*>(data);
+}
+
 EXTERN_C_START
 napi_value Init(napi_env env, napi_value exports) {
+  FinalizerData* data = new FinalizerData;
+  *data = 0;
+  NODE_API_CALL(env, napi_set_instance_data(env, data, finalizeData, nullptr));
+
   MyObject::Init(env, exports);
 
   napi_property_descriptor descriptors[] = {
@@ -208,6 +237,7 @@ napi_value Init(napi_env env, napi_value exports) {
                                 ObjectWrapDanglingReference),
       DECLARE_NODE_API_PROPERTY("objectWrapDanglingReferenceTest",
                                 ObjectWrapDanglingReferenceTest),
+      DECLARE_NODE_API_PROPERTY("getFinalizerCallCount", GetFinalizerCallCount),
   };
 
   NODE_API_CALL(

--- a/test/js-native-api/6_object_wrap/6_object_wrap.cc
+++ b/test/js-native-api/6_object_wrap/6_object_wrap.cc
@@ -10,8 +10,9 @@ MyObject::MyObject(double value)
 
 MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
 
-void MyObject::Destructor(
-  napi_env env, void* nativeObject, void* /*finalize_hint*/) {
+void MyObject::Destructor(node_api_basic_env env,
+                          void* nativeObject,
+                          void* /*finalize_hint*/) {
   MyObject* obj = static_cast<MyObject*>(nativeObject);
   delete obj;
 }
@@ -154,7 +155,7 @@ napi_value MyObject::Multiply(napi_env env, napi_callback_info info) {
 }
 
 // This finalizer should never be invoked.
-void ObjectWrapDanglingReferenceFinalizer(napi_env env,
+void ObjectWrapDanglingReferenceFinalizer(node_api_basic_env env,
                                           void* finalize_data,
                                           void* finalize_hint) {
   assert(0 && "unreachable");

--- a/test/js-native-api/6_object_wrap/binding.gyp
+++ b/test/js-native-api/6_object_wrap/binding.gyp
@@ -5,6 +5,13 @@
       "sources": [
         "6_object_wrap.cc"
       ]
+    },
+    {
+      "target_name": "6_object_wrap_basic_finalizer",
+      "defines": [ "NAPI_EXPERIMENTAL" ],
+      "sources": [
+        "6_object_wrap.cc"
+      ]
     }
   ]
 }

--- a/test/js-native-api/6_object_wrap/myobject.h
+++ b/test/js-native-api/6_object_wrap/myobject.h
@@ -6,7 +6,9 @@
 class MyObject {
  public:
   static void Init(napi_env env, napi_value exports);
-  static void Destructor(napi_env env, void* nativeObject, void* finalize_hint);
+  static void Destructor(node_api_basic_env env,
+                         void* nativeObject,
+                         void* finalize_hint);
 
  private:
   explicit MyObject(double value_ = 0);

--- a/test/js-native-api/6_object_wrap/test-basic-finalizer.js
+++ b/test/js-native-api/6_object_wrap/test-basic-finalizer.js
@@ -1,0 +1,20 @@
+// Flags: --expose-gc
+
+'use strict';
+const common = require('../../common');
+const addon = require(`./build/${common.buildType}/6_object_wrap_basic_finalizer`);
+const { onGC } = require('../../common/gc');
+
+/**
+ * This test verifies that an ObjectWrap can be correctly finalized with an NAPI_EXPERIMENTAL
+ * node_api_basic_finalizer.
+ */
+
+{
+  let obj = new addon.MyObject(9);
+  onGC(obj, {
+    ongc: common.mustCall(),
+  });
+  obj = null;
+  global.gc();
+}

--- a/test/js-native-api/6_object_wrap/test-basic-finalizer.js
+++ b/test/js-native-api/6_object_wrap/test-basic-finalizer.js
@@ -2,19 +2,23 @@
 
 'use strict';
 const common = require('../../common');
+const assert = require('assert');
 const addon = require(`./build/${common.buildType}/6_object_wrap_basic_finalizer`);
-const { onGC } = require('../../common/gc');
 
-/**
- * This test verifies that an ObjectWrap can be correctly finalized with an NAPI_EXPERIMENTAL
- * node_api_basic_finalizer.
- */
-
-{
+// This test verifies that ObjectWrap can be correctly finalized with a node_api_basic_finalizer
+// in the current JS loop tick
+(() => {
   let obj = new addon.MyObject(9);
-  onGC(obj, {
-    ongc: common.mustCall(),
-  });
   obj = null;
+  // Silent eslint about unused variables.
+  assert.strictEqual(obj, null);
+})();
+
+for (let i = 0; i < 10; ++i) {
   global.gc();
+  if (addon.getFinalizerCallCount() === 1) {
+    break;
+  }
 }
+
+assert.strictEqual(addon.getFinalizerCallCount(), 1);


### PR DESCRIPTION
`napi_delete_reference` must be called immediately for a
`napi_reference` returned from `napi_wrap` in the corresponding
finalizer, in order to clean up the `napi_reference` timely.

`napi_delete_reference` is safe to be invoked during GC.