### PR TITLE
http: add diagnostic channel `http.server.response.created`

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1159,6 +1159,14 @@ Emitted when client receives a response.
 
 Emitted when server receives a request.
 
+`http.server.response.created`
+
+* `request` {http.IncomingMessage}
+* `response` {http.ServerResponse}
+
+Emitted when server creates a response.
+The event is emitted before the response is sent.
+
 `http.server.response.finish`
 
 * `request` {http.IncomingMessage}

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -97,6 +97,7 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
 
 const dc = require('diagnostics_channel');
 const onRequestStartChannel = dc.channel('http.server.request.start');
+const onResponseCreatedChannel = dc.channel('http.server.response.created');
 const onResponseFinishChannel = dc.channel('http.server.response.finish');
 
 const kServerResponse = Symbol('ServerResponse');
@@ -223,6 +224,12 @@ function ServerResponse(req, options) {
   if (isTraceHTTPEnabled()) {
     this._traceEventId = getNextTraceEventId();
     traceBegin(HTTP_SERVER_TRACE_EVENT_NAME, this._traceEventId);
+  }
+  if (onResponseCreatedChannel.hasSubscribers) {
+    onResponseCreatedChannel.publish({
+      request: req,
+      response: this,
+    });
   }
 }
 ObjectSetPrototypeOf(ServerResponse.prototype, OutgoingMessage.prototype);

--- a/test/parallel/test-diagnostic-channel-http-response-created.js
+++ b/test/parallel/test-diagnostic-channel-http-response-created.js
@@ -1,0 +1,45 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const dc = require('diagnostics_channel');
+
+const isOutgoingMessage = (object) => object instanceof http.OutgoingMessage;
+const isIncomingMessage = (object) => object instanceof http.IncomingMessage;
+
+dc.subscribe('http.server.response.created', common.mustCall(({
+  request,
+  response,
+}) => {
+  assert.strictEqual(request.headers.foo, 'bar');
+  assert.strictEqual(response.getHeader('baz'), undefined);
+  assert.strictEqual(isIncomingMessage(request), true);
+  assert.strictEqual(isOutgoingMessage(response), true);
+}));
+
+dc.subscribe('http.server.response.finish', common.mustCall(({
+  request,
+  response,
+}) => {
+  assert.strictEqual(request.headers.foo, 'bar');
+  assert.strictEqual(response.getHeader('baz'), 'bar');
+  assert.strictEqual(isIncomingMessage(request), true);
+  assert.strictEqual(isOutgoingMessage(response), true);
+}));
+
+const server = http.createServer(common.mustCall((_, res) => {
+  res.setHeader('baz', 'bar');
+  res.end('done');
+}));
+
+server.listen(() => {
+  const { port } = server.address();
+  http.get({
+    port,
+    headers: {
+      'foo': 'bar',
+    }
+  }, common.mustCall(() => {
+    server.close();
+  }));
+});

--- a/test/parallel/test-diagnostics-channel-http.js
+++ b/test/parallel/test-diagnostics-channel-http.js
@@ -53,6 +53,14 @@ dc.subscribe('http.server.response.finish', common.mustCall(({
   assert.strictEqual(isHTTPServer(server), true);
 }));
 
+dc.subscribe('http.server.response.created', common.mustCall(({
+  request,
+  response,
+}) => {
+  assert.strictEqual(isIncomingMessage(request), true);
+  assert.strictEqual(isOutgoingMessage(response), true);
+}));
+
 dc.subscribe('http.client.request.created', common.mustCall(({ request }) => {
   assert.strictEqual(isOutgoingMessage(request), true);
   assert.strictEqual(isHTTPServer(server), true);


### PR DESCRIPTION
Followup of https://github.com/nodejs/node/pull/55586