### PR TITLE
path,win: fix bug in resolve and normalize

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -268,10 +268,16 @@ const win32 = {
                 j++;
               }
               if (j === len || j !== last) {
-                // We matched a UNC root
-                device =
-                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-                rootEnd = j;
+                if (firstPart !== '.' && firstPart !== '?') {
+                  // We matched a UNC root
+                  device =
+                    `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+                  rootEnd = j;
+                } else {
+                  // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                  device = `\\\\${firstPart}`;
+                  rootEnd = 4;
+                }
               }
             }
           }
@@ -381,17 +387,22 @@ const win32 = {
                    !isPathSeparator(StringPrototypeCharCodeAt(path, j))) {
               j++;
             }
-            if (j === len) {
-              // We matched a UNC root only
-              // Return the normalized version of the UNC root since there
-              // is nothing left to process
-              return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
-            }
-            if (j !== last) {
-              // We matched a UNC root with leftovers
-              device =
-                `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-              rootEnd = j;
+            if (j === len || j !== last) {
+              if (firstPart === '.' || firstPart === '?') {
+                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                device = `\\\\${firstPart}`;
+                rootEnd = 4;
+              } else if (j === len) {
+                // We matched a UNC root only
+                // Return the normalized version of the UNC root since there
+                // is nothing left to process
+                return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
+              } else {
+                // We matched a UNC root with leftovers
+                device =
+                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+                rootEnd = j;
+              }
             }
           }
         }

--- a/src/path.cc
+++ b/src/path.cc
@@ -170,9 +170,16 @@ std::string PathResolve(Environment* env,
               j++;
             }
             if (j == len || j != last) {
-              // We matched a UNC root
-              device = "\\\\" + firstPart + "\\" + path.substr(last, j - last);
-              rootEnd = j;
+              if (firstPart != "." && firstPart != "?") {
+                // We matched a UNC root
+                device =
+                    "\\\\" + firstPart + "\\" + path.substr(last, j - last);
+                rootEnd = j;
+              } else {
+                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                device = "\\\\" + firstPart;
+                rootEnd = 4;
+              }
             }
           }
         }

--- a/test/cctest/test_path.cc
+++ b/test/cctest/test_path.cc
@@ -39,6 +39,10 @@ TEST_F(PathTest, PathResolve) {
   EXPECT_EQ(
       PathResolve(*env, {"C:\\foo\\tmp.3\\", "..\\tmp.3\\cycles\\root.js"}),
       "C:\\foo\\tmp.3\\cycles\\root.js");
+  EXPECT_EQ(PathResolve(*env, {"\\\\.\\PHYSICALDRIVE0"}),
+            "\\\\.\\PHYSICALDRIVE0");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\PHYSICALDRIVE0"}),
+            "\\\\?\\PHYSICALDRIVE0");
 #else
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "../", "file/"}), "/var/file");
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "/../", "file/"}), "/file");

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -79,7 +79,7 @@ assert.strictEqual(path.win32.toNamespacedPath('\\\\foo\\bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
 assert.strictEqual(path.win32.toNamespacedPath('//foo//bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
-assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo\\');
+assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo');
 assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\c:\\Windows/System'), '\\\\?\\c:\\Windows\\System');
 assert.strictEqual(path.win32.toNamespacedPath(null), null);
 assert.strictEqual(path.win32.toNamespacedPath(true), true);

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -40,6 +40,8 @@ assert.strictEqual(
   '..\\..\\..\\..\\baz'
 );
 assert.strictEqual(path.win32.normalize('foo/bar\\baz'), 'foo\\bar\\baz');
+assert.strictEqual(path.win32.normalize('\\\\.\\foo'), '\\\\.\\foo');
+assert.strictEqual(path.win32.normalize('\\\\.\\foo\\'), '\\\\.\\foo\\');
 
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
                    'fixtures/b/c.js');

--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -33,6 +33,8 @@ const resolveTests = [
      [['c:/', '///some//dir'], 'c:\\some\\dir'],
      [['C:\\foo\\tmp.3\\', '..\\tmp.3\\cycles\\root.js'],
       'C:\\foo\\tmp.3\\cycles\\root.js'],
+     [['\\\\.\\PHYSICALDRIVE0'], '\\\\.\\PHYSICALDRIVE0'],
+     [['\\\\?\\PHYSICALDRIVE0'], '\\\\?\\PHYSICALDRIVE0'],
     ],
   ],
   [ path.posix.resolve,


### PR DESCRIPTION
This PR fixes resolving device paths like `\\.\PHYSICALDRIVE`.
The `resolve` and `normalize` functions were adding a trailing backslash, considering that this device path was a UNC path. However, device paths are different than UNC paths.

In addition to fixing this issue, the previous attempt also fixed other inconsistencies. So, this PR only fixes the issue itself.

Previous PR: https://github.com/nodejs/node/pull/54224
Fixes: https://github.com/nodejs/node/issues/54025

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
