### PR TITLE
crypto: fix `RSA_PKCS1_PADDING` error message

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -1092,8 +1092,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
     if (rsa_pkcs1_implicit_rejection <= 0) {
       return THROW_ERR_INVALID_ARG_VALUE(
           env,
-          "RSA_PKCS1_PADDING is no longer supported for private decryption,"
-          " this can be reverted with --security-revert=CVE-2024-PEND");
+          "RSA_PKCS1_PADDING is no longer supported for private decryption");
     }
   }
 


### PR DESCRIPTION
The ability to revert the fix for CVE-2023-46809 was only added to Node.js 18.x, 20.x and 21.x as, per policy, security reverts are only added to the existing supported release lines at the time of the fix.

The error message thrown when `RSA_PKCS1_PADDING` is used on `main` and subsequent major versions (i.e. Node.js 22 and 23) when OpenSSL does not support implicit rejections should not have suggested that it is possible to revert the fix.

Fixes: https://github.com/nodejs/node/issues/55628

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
