### PR TITLE
test_runner: exclude test files from code coverage by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2352,6 +2352,9 @@ This option may be specified multiple times to include multiple glob patterns.
 If both `--test-coverage-exclude` and `--test-coverage-include` are provided,
 files must meet **both** criteria to be included in the coverage report.
 
+By default, the files being tested are excluded from code coverage. They can be explicitly
+included via this flag.
+
 ### `--test-coverage-lines=threshold`
 
 <!-- YAML

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1359,6 +1359,8 @@ changes:
     This property is only applicable when `coverage` was set to `true`.
     If both `coverageExcludeGlobs` and `coverageIncludeGlobs` are provided,
     files must meet **both** criteria to be included in the coverage report.
+    By default, the files being tested are excluded from code coverage. They can be explicitly
+	included via this parameter.
     **Default:** `undefined`.
   * `lineCoverage` {number} Require a minimum percent of covered lines. If code
     coverage does not reach the threshold specified, the process will exit with code `1`.

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -1,6 +1,7 @@
 'use strict';
 const {
   ArrayFrom,
+  ArrayPrototypeIncludes,
   ArrayPrototypeMap,
   ArrayPrototypePush,
   JSONParse,
@@ -463,6 +464,7 @@ class TestCoverage {
     const {
       coverageExcludeGlobs: excludeGlobs,
       coverageIncludeGlobs: includeGlobs,
+      testFiles,
     } = this.options;
     // This check filters out files that match the exclude globs.
     if (excludeGlobs?.length > 0) {
@@ -481,8 +483,8 @@ class TestCoverage {
       return true;
     }
 
-    // This check filters out the node_modules/ directory, unless it is explicitly included.
-    return StringPrototypeIncludes(url, '/node_modules/');
+    // This check filters out the node_modules/ directory and the test files, unless they are explicitly included.
+    return StringPrototypeIncludes(url, '/node_modules/') || ArrayPrototypeIncludes(testFiles, absolutePath);
   }
 }
 

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -13,7 +13,7 @@ const {
   createHook,
   executionAsyncId,
 } = require('async_hooks');
-const { relative } = require('path');
+const { relative, resolve } = require('path');
 const {
   codes: {
     ERR_TEST_FAILURE,
@@ -261,6 +261,7 @@ function lazyBootstrapRoot() {
     };
     const globalOptions = parseCommandLine();
     globalOptions.cwd = process.cwd();
+    globalOptions.testFiles = entryFile ? [resolve(globalOptions.cwd, entryFile)] : [];
     createTestTree(rootTestOptions, globalOptions);
     globalRoot.reporter.on('test:summary', (data) => {
       if (!data.success) {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -666,6 +666,8 @@ function run(options = kEmptyObject) {
   validateStringArray(execArgv, 'options.execArgv');
 
   const rootTestOptions = { __proto__: null, concurrency, timeout, signal };
+  let testFiles = files ?? createTestFileList(globPatterns, cwd);
+  const absoluteTestFiles = ArrayPrototypeMap(testFiles, (file) => resolve(cwd, file));
   const globalOptions = {
     __proto__: null,
     // parseCommandLine() should not be used here. However, The existing run()
@@ -675,13 +677,13 @@ function run(options = kEmptyObject) {
     coverage,
     coverageExcludeGlobs,
     coverageIncludeGlobs,
+    testFiles: absoluteTestFiles,
     lineCoverage: lineCoverage,
     branchCoverage: branchCoverage,
     functionCoverage: functionCoverage,
     cwd,
   };
   const root = createTestTree(rootTestOptions, globalOptions);
-  let testFiles = files ?? createTestFileList(globPatterns, cwd);
 
   if (shard) {
     testFiles = ArrayPrototypeFilter(testFiles, (_, index) => index % shard.total === shard.index - 1);
@@ -733,7 +735,6 @@ function run(options = kEmptyObject) {
     };
   } else if (isolation === 'none') {
     if (watch) {
-      const absoluteTestFiles = ArrayPrototypeMap(testFiles, (file) => (isAbsolute(file) ? file : resolve(cwd, file)));
       filesWatcher = watchFiles(absoluteTestFiles, opts);
       runFiles = async () => {
         root.harness.bootstrapPromise = null;

--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -20,6 +20,7 @@ function generateReport(report) {
 
 const flags = [
   '--enable-source-maps',
+  '--no-warnings', '--test-coverage-include=**',
   '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
 ];
 

--- a/test/parallel/test-runner-coverage-thresholds.js
+++ b/test/parallel/test-runner-coverage-thresholds.js
@@ -61,6 +61,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=25`,
       '--test-reporter', 'tap',
       fixture,
@@ -77,6 +79,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=25`,
       '--test-reporter', reporter,
       fixture,
@@ -92,6 +96,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=99`,
       '--test-reporter', 'tap',
       fixture,
@@ -108,6 +114,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=99`,
       '--test-reporter', reporter,
       fixture,
@@ -123,6 +131,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=101`,
       fixture,
     ]);
@@ -136,6 +146,8 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--no-warnings',
+      '--test-coverage-include=**',
       `${coverage.flag}=-1`,
       fixture,
     ]);


### PR DESCRIPTION
Is not usual to test the code coverage of test files.

To include test files in code coverage, they must be explicitly included by using `coverageIncludeGlobs` or `--test-coverage-include`.

This way, your default code coverage will not include the test files, so you can work out your include/exclude filters based on the first coverage output. I didn't like the idea of suddenly including all the test files just by adding an exclude flag to exclude that_util_file.js that you don't want to test.

What could happen is that you could set an include filter just to test one file, and then you notice that the test file is also being tested. Maybe we can add an extra flag `--include-test-files` or something like that, so the test files are completely invisible to the user until the user wants to explicitly include them. Although I think that this may be too granular and with the `--test-coverage-include/exclude` parameters is enough.

Fixes: https://github.com/nodejs/node/issues/53508

<!--
By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
