### PR TITLE
module: simplify --inspect-brk handling

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1341,15 +1341,6 @@ Module.prototype.require = function(id) {
 };
 
 /**
- * Resolved path to `process.argv[1]` will be lazily placed here
- * (needed for setting breakpoint when called with `--inspect-brk`).
- * @type {string | undefined}
- */
-let resolvedArgv;
-let hasPausedEntry = false;
-/** @type {import('vm').Script} */
-
-/**
  * Resolve and evaluate it synchronously as ESM if it's ESM.
  * @param {Module} mod CJS module instance
  * @param {string} filename Absolute path of the file.
@@ -1530,32 +1521,6 @@ Module.prototype._compile = function(content, filename, format) {
     return;
   }
 
-  // TODO(joyeecheung): the detection below is unnecessarily complex. Using the
-  // kIsMainSymbol, or a kBreakOnStartSymbol that gets passed from
-  // higher level instead of doing hacky detection here.
-  let inspectorWrapper = null;
-  if (getOptionValue('--inspect-brk') && process._eval == null) {
-    if (!resolvedArgv) {
-      // We enter the repl if we're not given a filename argument.
-      if (process.argv[1]) {
-        try {
-          resolvedArgv = Module._resolveFilename(process.argv[1], null, false);
-        } catch {
-          // We only expect this codepath to be reached in the case of a
-          // preloaded module (it will fail earlier with the main entry)
-          assert(ArrayIsArray(getOptionValue('--require')));
-        }
-      } else {
-        resolvedArgv = 'repl';
-      }
-    }
-
-    // Set breakpoint on module start
-    if (resolvedArgv && !hasPausedEntry && filename === resolvedArgv) {
-      hasPausedEntry = true;
-      inspectorWrapper = internalBinding('inspector').callAndPauseOnStart;
-    }
-  }
   const dirname = path.dirname(filename);
   const require = makeRequireFunction(this, redirects);
   let result;
@@ -1565,9 +1530,10 @@ Module.prototype._compile = function(content, filename, format) {
   if (requireDepth === 0) { statCache = new SafeMap(); }
   setHasStartedUserCJSExecution();
   this[kIsExecuting] = true;
-  if (inspectorWrapper) {
-    result = inspectorWrapper(compiledWrapper, thisValue, exports,
-                              require, module, filename, dirname);
+  if (this[kIsMainSymbol] && getOptionValue('--inspect-brk')) {
+    const { callAndPauseOnStart } = internalBinding('inspector');
+    result = callAndPauseOnStart(compiledWrapper, thisValue, exports,
+                                 require, module, filename, dirname);
   } else {
     result = ReflectApply(compiledWrapper, thisValue,
                           [exports, require, module, filename, dirname]);


### PR DESCRIPTION
Previously in the CommonJS loader, --inspect-brk is implemented checking whether the module points to the result of re-resolving process.argv[1] to determine whether the module is the entry point. This is unnecessarily complex, especially now that we store that information in the module as kIsMainSymbol. This patch updates it to simply check that symbol property instead.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
