### PR TITLE
tools: use `util.parseArgs` in `lint-md`

### DIFF
--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -1,4 +1,5 @@
-import fs from 'fs';
+import fs from 'node:fs';
+import { parseArgs } from 'node:util';
 
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
@@ -6,7 +7,6 @@ import remarkStringify from 'remark-stringify';
 import presetLintNode from 'remark-preset-lint-node';
 import { read } from 'to-vfile';
 import { reporter } from 'vfile-reporter';
-import { parseArgs } from 'util';
 
 const { values: { format }, positionals: paths } = parseArgs({
   options: {

--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -6,19 +6,18 @@ import remarkStringify from 'remark-stringify';
 import presetLintNode from 'remark-preset-lint-node';
 import { read } from 'to-vfile';
 import { reporter } from 'vfile-reporter';
+import { parseArgs } from 'util';
 
-const paths = process.argv.slice(2);
+const { values: { format }, positionals: paths } = parseArgs({
+  options: {
+    format: { type: 'boolean', default: false },
+  },
+  allowPositionals: true,
+});
 
 if (!paths.length) {
-  console.error('Usage: lint-md.mjs <path> [<path> ...]');
+  console.error('Usage: lint-md.mjs [--format] <path> [<path> ...]');
   process.exit(1);
-}
-
-let format = false;
-
-if (paths[0] === '--format') {
-  paths.shift();
-  format = true;
 }
 
 const linter = unified()


### PR DESCRIPTION
`node:util` provides a `parseArgs` export, so this PR switches `lint-md` to use it, as it's (IMO) a cleaner way to read arguments.