### PR TITLE
tools: compact jq output in daily-wpt-fyi.yml action

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - id: query
         run: |
-          matrix=$(curl -s https://raw.githubusercontent.com/nodejs/Release/refs/heads/main/schedule.json | jq --arg now "$(date +%Y-%m-%d)" '[with_entries(select(.value.end > $now and .value.start < $now)) | keys[] | ltrimstr("v") | tonumber] + ["latest-nightly"]')
+          matrix=$(curl -s https://raw.githubusercontent.com/nodejs/Release/refs/heads/main/schedule.json | jq -c --arg now "$(date +%Y-%m-%d)" '[with_entries(select(.value.end > $now and .value.start < $now)) | keys[] | ltrimstr("v") | tonumber] + ["latest-nightly"]')
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
   report:
     needs:


### PR DESCRIPTION
A quick followup to #55619, makes the jq output compact so that it can be processed by the actions runner properly.

Fixes https://github.com/nodejs/node/actions/runs/11645595593