### PR TITLE
src: add cli option to exclude env vars on dr

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2058,13 +2058,13 @@ Enables report to be generated upon receiving the specified (or predefined)
 signal to the running Node.js process. The signal to trigger the report is
 specified through `--report-signal`.
 
-### `--report-preserve-env`
+### `--report-exclude-env`
 
 <!-- YAML
 added: REPLACEME
 -->
 
-When `--report-preserve-env` is passed the diagnostic report generated will not
+When `--report-exclude-env` is passed the diagnostic report generated will not
 contain the `environmentVariables` data.
 
 ### `--report-signal=signal`
@@ -3126,6 +3126,7 @@ one is included in the list below.
 * `--redirect-warnings`
 * `--report-compact`
 * `--report-dir`, `--report-directory`
+* `--report-exclude-env`
 * `--report-exclude-network`
 * `--report-filename`
 * `--report-on-fatalerror`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2058,6 +2058,15 @@ Enables report to be generated upon receiving the specified (or predefined)
 signal to the running Node.js process. The signal to trigger the report is
 specified through `--report-signal`.
 
+### `--report-preserve-env`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+When `--report-preserve-env` is passed the diagnostic report generated will not
+contain the `environmentVariables` data.
+
 ### `--report-signal=signal`
 
 <!-- YAML

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3494,7 +3494,7 @@ const { report } = require('node:process');
 console.log(`Report on exception: ${report.reportOnUncaughtException}`);
 ```
 
-### `process.report.preserveEnv`
+### `process.report.excludeEnv`
 
 <!-- YAML
 added: REPLACEME

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3494,6 +3494,16 @@ const { report } = require('node:process');
 console.log(`Report on exception: ${report.reportOnUncaughtException}`);
 ```
 
+### `process.report.preserveEnv`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean}
+
+If `true`, a diagnostic report is generated without the environment variables.
+
 ### `process.report.signal`
 
 <!-- YAML

--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -10,6 +10,9 @@
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55697
+    description: Added `--report-exclude-env` option for excluding environment variables from report generation.
   - version:
     - v22.0.0
     - v20.13.0
@@ -464,6 +467,10 @@ meaning of `SIGUSR2` for the said purposes.
 * `--report-exclude-network` Exclude `header.networkInterfaces` from the
   diagnostic report. By default this is not set and the network interfaces
   are included.
+
+* `--report-exclude-env` Exclude `environmentVariables` from the
+  diagnostic report. By default this is not set and the environment
+  variables are included.
 
 A report can also be triggered via an API call from a JavaScript application:
 

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -105,6 +105,9 @@ const report = {
 
     nr.setReportOnUncaughtException(trigger);
   },
+  get preserveEnv() {
+    return !nr.shouldPreserveEnvironmentVariables();
+  },
 };
 
 function addSignalHandler(sig) {

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -16,8 +16,6 @@ const {
 } = require('internal/validators');
 const nr = internalBinding('report');
 
-let excludeEnv;
-
 const report = {
   writeReport(file, err) {
     if (typeof file === 'object' && file !== null) {
@@ -108,10 +106,11 @@ const report = {
     nr.setReportOnUncaughtException(trigger);
   },
   get excludeEnv() {
-    if (excludeEnv === undefined) {
-      excludeEnv = nr.shouldExcludeEnvironmentVariables();
-    }
-    return excludeEnv;
+    return nr.getExcludeEnv();
+  },
+  set excludeEnv(b) {
+    validateBoolean(b, 'excludeEnv');
+    nr.setExcludeEnv(b);
   },
 };
 

--- a/lib/internal/process/report.js
+++ b/lib/internal/process/report.js
@@ -16,6 +16,8 @@ const {
 } = require('internal/validators');
 const nr = internalBinding('report');
 
+let excludeEnv;
+
 const report = {
   writeReport(file, err) {
     if (typeof file === 'object' && file !== null) {
@@ -105,8 +107,11 @@ const report = {
 
     nr.setReportOnUncaughtException(trigger);
   },
-  get preserveEnv() {
-    return !nr.shouldPreserveEnvironmentVariables();
+  get excludeEnv() {
+    if (excludeEnv === undefined) {
+      excludeEnv = nr.shouldExcludeEnvironmentVariables();
+    }
+    return excludeEnv;
   },
 };
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -890,6 +890,10 @@ inline bool Environment::is_in_heapsnapshot_heap_limit_callback() const {
   return is_in_heapsnapshot_heap_limit_callback_;
 }
 
+inline bool Environment::report_exclude_env() const {
+  return options_->report_exclude_env;
+}
+
 inline void Environment::AddHeapSnapshotNearHeapLimitCallback() {
   DCHECK(!heapsnapshot_near_heap_limit_callback_added_);
   heapsnapshot_near_heap_limit_callback_added_ = true;
@@ -902,10 +906,6 @@ inline void Environment::RemoveHeapSnapshotNearHeapLimitCallback(
   heapsnapshot_near_heap_limit_callback_added_ = false;
   isolate_->RemoveNearHeapLimitCallback(Environment::NearHeapLimitCallback,
                                         heap_limit);
-}
-
-inline bool Environment::ShouldPreserveEnvOnReport() const {
-  return options_->report_preserve_env;
 }
 
 inline void Environment::SetAsyncResourceContextFrame(

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -904,6 +904,10 @@ inline void Environment::RemoveHeapSnapshotNearHeapLimitCallback(
                                         heap_limit);
 }
 
+inline bool Environment::ShouldPreserveEnvOnReport() const {
+  return options_->report_preserve_env;
+}
+
 inline void Environment::SetAsyncResourceContextFrame(
     std::uintptr_t async_resource_handle,
     v8::Global<v8::Value>&& context_frame) {

--- a/src/env.h
+++ b/src/env.h
@@ -1048,6 +1048,8 @@ class Environment final : public MemoryRetainer {
 
   inline void RemoveHeapSnapshotNearHeapLimitCallback(size_t heap_limit);
 
+  inline bool ShouldPreserveEnvOnReport() const;
+
   // Field identifiers for exit_info_
   enum ExitInfoField {
     kExiting = 0,

--- a/src/env.h
+++ b/src/env.h
@@ -1044,11 +1044,11 @@ class Environment final : public MemoryRetainer {
   inline void set_heap_snapshot_near_heap_limit(uint32_t limit);
   inline bool is_in_heapsnapshot_heap_limit_callback() const;
 
+  inline bool report_exclude_env() const;
+
   inline void AddHeapSnapshotNearHeapLimitCallback();
 
   inline void RemoveHeapSnapshotNearHeapLimitCallback(size_t heap_limit);
-
-  inline bool ShouldPreserveEnvOnReport() const;
 
   // Field identifiers for exit_info_
   enum ExitInfoField {

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -383,6 +383,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             " (default: current working directory)",
             &EnvironmentOptions::diagnostic_dir,
             kAllowedInEnvvar);
+  AddOption("--report-preserve-env",
+            "Preserve environment variables when generating report",
+            &EnvironmentOptions::report_preserve_env,
+            kAllowedInEnvvar);
   AddOption("--dns-result-order",
             "set default value of verbatim in dns.lookup. Options are "
             "'ipv4first' (IPv4 addresses are placed before IPv6 addresses) "

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -383,10 +383,6 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             " (default: current working directory)",
             &EnvironmentOptions::diagnostic_dir,
             kAllowedInEnvvar);
-  AddOption("--report-preserve-env",
-            "Preserve environment variables when generating report",
-            &EnvironmentOptions::report_preserve_env,
-            kAllowedInEnvvar);
   AddOption("--dns-result-order",
             "set default value of verbatim in dns.lookup. Options are "
             "'ipv4first' (IPv4 addresses are placed before IPv6 addresses) "
@@ -881,6 +877,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::tls_max_v1_3,
             kAllowedInEnvvar);
 
+  AddOption("--report-exclude-env",
+            "Exclude environment variables when generating report"
+            " (default: false)",
+            &EnvironmentOptions::report_exclude_env,
+            kAllowedInEnvvar);
   AddOption("--report-exclude-network",
             "exclude network interface diagnostics."
             " (default: false)",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -177,7 +177,6 @@ class EnvironmentOptions : public Options {
 #endif  // HAVE_INSPECTOR
   std::string redirect_warnings;
   std::string diagnostic_dir;
-  bool report_preserve_env = false;
   std::string env_file;
   std::string optional_env_file;
   bool has_env_file_string = false;
@@ -250,6 +249,7 @@ class EnvironmentOptions : public Options {
 
   std::vector<std::string> user_argv;
 
+  bool report_exclude_env = false;
   bool report_exclude_network = false;
 
   inline DebugOptions* get_debug_options() { return &debug_options_; }

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -177,6 +177,7 @@ class EnvironmentOptions : public Options {
 #endif  // HAVE_INSPECTOR
   std::string redirect_warnings;
   std::string diagnostic_dir;
+  bool report_preserve_env = false;
   std::string env_file;
   std::string optional_env_file;
   bool has_env_file_string = false;

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -61,7 +61,8 @@ static void WriteNodeReport(Isolate* isolate,
                             std::ostream& out,
                             Local<Value> error,
                             bool compact,
-                            bool exclude_network = false);
+                            bool exclude_network = false,
+                            bool exclude_env = false);
 static void PrintVersionInformation(JSONWriter* writer,
                                     bool exclude_network = false);
 static void PrintJavaScriptErrorStack(JSONWriter* writer,
@@ -96,7 +97,8 @@ static void WriteNodeReport(Isolate* isolate,
                             std::ostream& out,
                             Local<Value> error,
                             bool compact,
-                            bool exclude_network) {
+                            bool exclude_network,
+                            bool exclude_env) {
   // Obtain the current time and the pid.
   TIME_TYPE tm_struct;
   DiagnosticFilename::LocalTime(&tm_struct);
@@ -250,7 +252,7 @@ static void WriteNodeReport(Isolate* isolate,
   writer.json_arrayend();
 
   // Report operating system information
-  if (env->ShouldPreserveEnvOnReport()) {
+  if (exclude_env == false) {
     PrintEnvironmentVariables(&writer);
   }
   PrintSystemInformation(&writer);
@@ -921,6 +923,10 @@ std::string TriggerNodeReport(Isolate* isolate,
   bool exclude_network = env != nullptr ? env->options()->report_exclude_network
                                         : per_process::cli_options->per_isolate
                                               ->per_env->report_exclude_network;
+  bool exclude_env =
+      env != nullptr
+          ? env->report_exclude_env()
+          : per_process::cli_options->per_isolate->per_env->report_exclude_env;
 
   report::WriteNodeReport(isolate,
                           env,
@@ -930,7 +936,8 @@ std::string TriggerNodeReport(Isolate* isolate,
                           *outstream,
                           error,
                           compact,
-                          exclude_network);
+                          exclude_network,
+                          exclude_env);
 
   // Do not close stdout/stderr, only close files we opened.
   if (outfile.is_open()) {
@@ -984,8 +991,20 @@ void GetNodeReport(Isolate* isolate,
   bool exclude_network = env != nullptr ? env->options()->report_exclude_network
                                         : per_process::cli_options->per_isolate
                                               ->per_env->report_exclude_network;
-  report::WriteNodeReport(
-      isolate, env, message, trigger, "", out, error, false, exclude_network);
+  bool exclude_env =
+      env != nullptr
+          ? env->report_exclude_env()
+          : per_process::cli_options->per_isolate->per_env->report_exclude_env;
+  report::WriteNodeReport(isolate,
+                          env,
+                          message,
+                          trigger,
+                          "",
+                          out,
+                          error,
+                          false,
+                          exclude_network,
+                          exclude_env);
 }
 
 // External function to trigger a report, writing to a supplied stream.
@@ -1001,8 +1020,20 @@ void GetNodeReport(Environment* env,
   bool exclude_network = env != nullptr ? env->options()->report_exclude_network
                                         : per_process::cli_options->per_isolate
                                               ->per_env->report_exclude_network;
-  report::WriteNodeReport(
-      isolate, env, message, trigger, "", out, error, false, exclude_network);
+  bool exclude_env =
+      env != nullptr
+          ? env->report_exclude_env()
+          : per_process::cli_options->per_isolate->per_env->report_exclude_env;
+  report::WriteNodeReport(isolate,
+                          env,
+                          message,
+                          trigger,
+                          "",
+                          out,
+                          error,
+                          false,
+                          exclude_network,
+                          exclude_env);
 }
 
 }  // namespace node

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -78,6 +78,7 @@ static void PrintJavaScriptErrorProperties(JSONWriter* writer,
 static void PrintNativeStack(JSONWriter* writer);
 static void PrintResourceUsage(JSONWriter* writer);
 static void PrintGCStatistics(JSONWriter* writer, Isolate* isolate);
+static void PrintEnvironmentVariables(JSONWriter* writer);
 static void PrintSystemInformation(JSONWriter* writer);
 static void PrintLoadedLibraries(JSONWriter* writer);
 static void PrintComponentVersions(JSONWriter* writer);
@@ -249,6 +250,9 @@ static void WriteNodeReport(Isolate* isolate,
   writer.json_arrayend();
 
   // Report operating system information
+  if (env->ShouldPreserveEnvOnReport()) {
+    PrintEnvironmentVariables(&writer);
+  }
   PrintSystemInformation(&writer);
 
   writer.json_objectend();
@@ -694,8 +698,7 @@ static void PrintResourceUsage(JSONWriter* writer) {
 #endif  // RUSAGE_THREAD
 }
 
-// Report operating system information.
-static void PrintSystemInformation(JSONWriter* writer) {
+static void PrintEnvironmentVariables(JSONWriter* writer) {
   uv_env_item_t* envitems;
   int envcount;
   int r;
@@ -715,7 +718,10 @@ static void PrintSystemInformation(JSONWriter* writer) {
   }
 
   writer->json_objectend();
+}
 
+// Report operating system information.
+static void PrintSystemInformation(JSONWriter* writer) {
 #ifndef _WIN32
   static struct {
     const char* description;

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -170,6 +170,12 @@ static void ShouldReportOnUncaughtException(
       env->isolate_data()->options()->report_uncaught_exception);
 }
 
+static void ShouldPreserveEnvironmentVariables(
+    const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  info.GetReturnValue().Set(env->ShouldPreserveEnvOnReport());
+}
+
 static void SetReportOnUncaughtException(
     const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
@@ -204,6 +210,10 @@ static void Initialize(Local<Object> exports,
             ShouldReportOnUncaughtException);
   SetMethod(context,
             exports,
+            "shouldPreserveEnvironmentVariables",
+            ShouldPreserveEnvironmentVariables);
+  SetMethod(context,
+            exports,
             "setReportOnUncaughtException",
             SetReportOnUncaughtException);
 }
@@ -226,6 +236,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(ShouldReportOnSignal);
   registry->Register(SetReportOnSignal);
   registry->Register(ShouldReportOnUncaughtException);
+  registry->Register(ShouldPreserveEnvironmentVariables);
   registry->Register(SetReportOnUncaughtException);
 }
 

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -95,6 +95,17 @@ static void SetExcludeNetwork(const FunctionCallbackInfo<Value>& info) {
   env->options()->report_exclude_network = info[0]->IsTrue();
 }
 
+static void GetExcludeEnv(const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  info.GetReturnValue().Set(env->report_exclude_env());
+}
+
+static void SetExcludeEnv(const FunctionCallbackInfo<Value>& info) {
+  Environment* env = Environment::GetCurrent(info);
+  CHECK(info[0]->IsBoolean());
+  env->options()->report_exclude_env = info[0]->IsTrue();
+}
+
 static void GetDirectory(const FunctionCallbackInfo<Value>& info) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
   Environment* env = Environment::GetCurrent(info);
@@ -170,12 +181,6 @@ static void ShouldReportOnUncaughtException(
       env->isolate_data()->options()->report_uncaught_exception);
 }
 
-static void ShouldExcludeEnvironmentVariables(
-    const FunctionCallbackInfo<Value>& info) {
-  Environment* env = Environment::GetCurrent(info);
-  info.GetReturnValue().Set(env->report_exclude_env());
-}
-
 static void SetReportOnUncaughtException(
     const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
@@ -193,6 +198,8 @@ static void Initialize(Local<Object> exports,
   SetMethod(context, exports, "setCompact", SetCompact);
   SetMethod(context, exports, "getExcludeNetwork", GetExcludeNetwork);
   SetMethod(context, exports, "setExcludeNetwork", SetExcludeNetwork);
+  SetMethod(context, exports, "getExcludeEnv", GetExcludeEnv);
+  SetMethod(context, exports, "setExcludeEnv", SetExcludeEnv);
   SetMethod(context, exports, "getDirectory", GetDirectory);
   SetMethod(context, exports, "setDirectory", SetDirectory);
   SetMethod(context, exports, "getFilename", GetFilename);
@@ -210,10 +217,6 @@ static void Initialize(Local<Object> exports,
             ShouldReportOnUncaughtException);
   SetMethod(context,
             exports,
-            "shouldExcludeEnvironmentVariables",
-            ShouldExcludeEnvironmentVariables);
-  SetMethod(context,
-            exports,
             "setReportOnUncaughtException",
             SetReportOnUncaughtException);
 }
@@ -225,6 +228,8 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetCompact);
   registry->Register(GetExcludeNetwork);
   registry->Register(SetExcludeNetwork);
+  registry->Register(GetExcludeEnv);
+  registry->Register(SetExcludeEnv);
   registry->Register(GetDirectory);
   registry->Register(SetDirectory);
   registry->Register(GetFilename);
@@ -236,7 +241,6 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(ShouldReportOnSignal);
   registry->Register(SetReportOnSignal);
   registry->Register(ShouldReportOnUncaughtException);
-  registry->Register(ShouldExcludeEnvironmentVariables);
   registry->Register(SetReportOnUncaughtException);
 }
 

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -170,10 +170,10 @@ static void ShouldReportOnUncaughtException(
       env->isolate_data()->options()->report_uncaught_exception);
 }
 
-static void ShouldPreserveEnvironmentVariables(
+static void ShouldExcludeEnvironmentVariables(
     const FunctionCallbackInfo<Value>& info) {
   Environment* env = Environment::GetCurrent(info);
-  info.GetReturnValue().Set(env->ShouldPreserveEnvOnReport());
+  info.GetReturnValue().Set(env->report_exclude_env());
 }
 
 static void SetReportOnUncaughtException(
@@ -210,8 +210,8 @@ static void Initialize(Local<Object> exports,
             ShouldReportOnUncaughtException);
   SetMethod(context,
             exports,
-            "shouldPreserveEnvironmentVariables",
-            ShouldPreserveEnvironmentVariables);
+            "shouldExcludeEnvironmentVariables",
+            ShouldExcludeEnvironmentVariables);
   SetMethod(context,
             exports,
             "setReportOnUncaughtException",
@@ -236,7 +236,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(ShouldReportOnSignal);
   registry->Register(SetReportOnSignal);
   registry->Register(ShouldReportOnUncaughtException);
-  registry->Register(ShouldPreserveEnvironmentVariables);
+  registry->Register(ShouldExcludeEnvironmentVariables);
   registry->Register(SetReportOnUncaughtException);
 }
 

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -61,8 +61,9 @@ function _validateContent(report, fields = []) {
   const sections = ['header', 'nativeStack', 'javascriptStack', 'libuv',
                     'sharedObjects', 'resourceUsage', 'workers'];
 
-  if (!process.report.preserveEnv)
+  if (!process.report.excludeEnv) {
     sections.push('environmentVariables');
+  }
 
   if (!isWindows)
     sections.push('userLimits');
@@ -298,10 +299,12 @@ function _validateContent(report, fields = []) {
                        resource.type === 'loop' ? 'undefined' : 'boolean');
   });
 
-  // Verify the format of the environmentVariables section.
-  for (const [key, value] of Object.entries(report.environmentVariables)) {
-    assert.strictEqual(typeof key, 'string');
-    assert.strictEqual(typeof value, 'string');
+  if (!process.report.excludeEnv) {
+    // Verify the format of the environmentVariables section.
+    for (const [key, value] of Object.entries(report.environmentVariables)) {
+      assert.strictEqual(typeof key, 'string');
+      assert.strictEqual(typeof value, 'string');
+    }
   }
 
   // Verify the format of the userLimits section on non-Windows platforms.

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -59,7 +59,11 @@ function _validateContent(report, fields = []) {
 
   // Verify that all sections are present as own properties of the report.
   const sections = ['header', 'nativeStack', 'javascriptStack', 'libuv',
-                    'environmentVariables', 'sharedObjects', 'resourceUsage', 'workers'];
+                    'sharedObjects', 'resourceUsage', 'workers'];
+
+  if (!process.report.preserveEnv)
+    sections.push('environmentVariables');
+
   if (!isWindows)
     sections.push('userLimits');
 

--- a/test/report/test-report-writereport-exclude-env.js
+++ b/test/report/test-report-writereport-exclude-env.js
@@ -1,4 +1,4 @@
-// Flags: --report-preserve-env
+// Flags: --report-exclude-env
 'use strict';
 
 // Test producing a report via API call, using the no-hooks/no-signal interface.

--- a/test/report/test-report-writereport-preserve-env.js
+++ b/test/report/test-report-writereport-preserve-env.js
@@ -1,0 +1,80 @@
+// Flags: --report-preserve-env
+'use strict';
+
+// Test producing a report via API call, using the no-hooks/no-signal interface.
+require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const helper = require('../common/report');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+process.report.directory = tmpdir.path;
+
+function validate() {
+  const reports = helper.findReports(process.pid, tmpdir.path);
+  assert.strictEqual(reports.length, 1);
+  helper.validate(reports[0], arguments[0]);
+  fs.unlinkSync(reports[0]);
+  return reports[0];
+}
+
+{
+  // Test with no arguments.
+  process.report.writeReport();
+  validate();
+}
+
+{
+  // Test with an error argument.
+  process.report.writeReport(new Error('test error'));
+  validate();
+}
+
+{
+  // Test with an error with one line stack
+  const error = new Error();
+  error.stack = 'only one line';
+  process.report.writeReport(error);
+  validate();
+}
+
+{
+  const error = new Error();
+  error.foo = 'goo';
+  process.report.writeReport(error);
+  validate([['javascriptStack.errorProperties.foo', 'goo']]);
+}
+
+{
+  // Test with a file argument.
+  const file = process.report.writeReport('custom-name-1.json');
+  const absolutePath = tmpdir.resolve(file);
+  assert.strictEqual(helper.findReports(process.pid, tmpdir.path).length, 0);
+  assert.strictEqual(file, 'custom-name-1.json');
+  helper.validate(absolutePath);
+  fs.unlinkSync(absolutePath);
+}
+
+{
+  // Test with file and error arguments.
+  const file = process.report.writeReport('custom-name-2.json',
+                                          new Error('test error'));
+  const absolutePath = tmpdir.resolve(file);
+  assert.strictEqual(helper.findReports(process.pid, tmpdir.path).length, 0);
+  assert.strictEqual(file, 'custom-name-2.json');
+  helper.validate(absolutePath);
+  fs.unlinkSync(absolutePath);
+}
+
+{
+  // Test with a filename option.
+  process.report.filename = 'custom-name-3.json';
+  const file = process.report.writeReport();
+  assert.strictEqual(helper.findReports(process.pid, tmpdir.path).length, 0);
+  const filename = path.join(process.report.directory, 'custom-name-3.json');
+  assert.strictEqual(file, process.report.filename);
+  helper.validate(filename);
+  fs.unlinkSync(filename);
+}


### PR DESCRIPTION
This PR introduces a new cli flag `--report-exclude-env` to avoid writing env vars on diagnostic reports.

Some context: https://x.com/arthurfiorette/status/1848372069198614664