### PR TITLE
lib: avoid excluding symlinks in recursive fs.readdir with filetypes

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1401,9 +1401,12 @@ function readdirSyncRecursive(basePath, options) {
       // of the first array within the result.
       const length = readdirResult[0].length;
       for (let i = 0; i < length; i++) {
+        // Avoid excluding symlinks, as they are not directories.
+        // Refs: https://github.com/nodejs/node/issues/52663
+        const stat = binding.internalModuleStat(binding, pathModule.join(path, readdirResult[0][i]));
         const dirent = getDirent(path, readdirResult[0][i], readdirResult[1][i]);
         ArrayPrototypePush(readdirResults, dirent);
-        if (dirent.isDirectory()) {
+        if (dirent.isDirectory() || stat === 1) {
           ArrayPrototypePush(pathsQueue, pathModule.join(dirent.parentPath, dirent.name));
         }
       }

--- a/test/parallel/test-fs-readdir-types-symlinks.js
+++ b/test/parallel/test-fs-readdir-types-symlinks.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// Refs: https://github.com/nodejs/node/issues/52663
+const common = require('../common');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+if (!common.canCreateSymLink())
+  common.skip('insufficient privileges');
+
+const tmpdir = require('../common/tmpdir');
+const readdirDir = tmpdir.path;
+// clean up the tmpdir
+tmpdir.refresh();
+
+// a/1, a/2
+const a = path.join(readdirDir, 'a');
+fs.mkdirSync(a);
+fs.writeFileSync(path.join(a, '1'), 'irrelevant');
+fs.writeFileSync(path.join(a, '2'), 'irrelevant');
+
+// b/1
+const b = path.join(readdirDir, 'b');
+fs.mkdirSync(b);
+fs.writeFileSync(path.join(b, '1'), 'irrelevant');
+
+// b/c -> a
+const c = path.join(readdirDir, 'b', 'c');
+fs.symlinkSync(a, c, 'dir');
+
+// Just check that the number of entries are the same
+assert.strictEqual(
+  fs.readdirSync(b, { recursive: true, withFileTypes: true }).length,
+  fs.readdirSync(b, { recursive: true, withFileTypes: false }).length
+);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/52663