### PR TITLE
tools: fix c-ares updater script for Node.js 18

### DIFF
--- a/tools/dep_updaters/update-c-ares.mjs
+++ b/tools/dep_updaters/update-c-ares.mjs
@@ -1,8 +1,9 @@
 // Synchronize the sources for our c-ares gyp file from c-ares' Makefiles.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const srcroot = join(import.meta.dirname, '..', '..');
+const srcroot = fileURLToPath(new URL('../../', import.meta.url));
 const options = { encoding: 'utf8' };
 
 // Extract list of sources from the gyp file.


### PR DESCRIPTION
GitHub Actions is by default running the tools updater workflow with Node.js 18. Avoid use of `import.meta.dirname`, which wasn't backported to Node.js 18.

Refs: https://github.com/nodejs/node/pull/55445

---

Example error, https://github.com/nodejs/node/actions/runs/11647004207/job/32431749696
```
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at join (node:path:1171:7)
    at file:///home/runner/work/node/node/tools/dep_updaters/update-c-ares.mjs:5:17
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v18.20.4
```

We could introduce the `setup-node` action into the workflow to pick a later Node.js version, but Node.js 18 is still in support and it's fairly trivial to workaround.