### PR TITLE
src: improve `node:os` userInfo performance

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -358,11 +358,6 @@ function userInfo(options) {
   if (user === undefined)
     throw new ERR_SYSTEM_ERROR(ctx);
 
-  if (isWindows) {
-    user.uid |= 0;
-    user.gid |= 0;
-  }
-
   return user;
 }
 


### PR DESCRIPTION
Improve `node:os` userInfo performance by reducing the cost of creating a v8::Object.