### PR TITLE
lib: use `Promise.withResolvers()` in timers

### DIFF
--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -4,6 +4,7 @@ const {
   FunctionPrototypeBind,
   Promise,
   PromiseReject,
+  PromiseWithResolvers,
   ReflectConstruct,
   SafePromisePrototypeFinally,
   Symbol,
@@ -75,20 +76,19 @@ function setTimeout(after, value, options = kEmptyObject) {
   }
 
   let oncancel;
-  const ret = new Promise((resolve, reject) => {
-    const timeout = new Timeout(resolve, after, [value], false, ref);
-    insert(timeout, timeout._idleTimeout);
-    if (signal) {
-      oncancel = FunctionPrototypeBind(cancelListenerHandler,
-                                       timeout, clearTimeout, reject, signal);
-      kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-      signal.addEventListener('abort', oncancel, { __proto__: null, [kResistStopPropagation]: true });
-    }
-  });
+  const { promise, resolve, reject } = PromiseWithResolvers();
+  const timeout = new Timeout(resolve, after, [value], false, ref);
+  insert(timeout, timeout._idleTimeout);
+  if (signal) {
+    oncancel = FunctionPrototypeBind(cancelListenerHandler,
+                                     timeout, clearTimeout, reject, signal);
+    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+    signal.addEventListener('abort', oncancel, { __proto__: null, [kResistStopPropagation]: true });
+  }
   return oncancel !== undefined ?
     SafePromisePrototypeFinally(
-      ret,
-      () => signal.removeEventListener('abort', oncancel)) : ret;
+      promise,
+      () => signal.removeEventListener('abort', oncancel)) : promise;
 }
 
 function setImmediate(value, options = kEmptyObject) {
@@ -113,21 +113,20 @@ function setImmediate(value, options = kEmptyObject) {
   }
 
   let oncancel;
-  const ret = new Promise((resolve, reject) => {
-    const immediate = new Immediate(resolve, [value]);
-    if (!ref) immediate.unref();
-    if (signal) {
-      oncancel = FunctionPrototypeBind(cancelListenerHandler,
-                                       immediate, clearImmediate, reject,
-                                       signal);
-      kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
-      signal.addEventListener('abort', oncancel, { __proto__: null, [kResistStopPropagation]: true });
-    }
-  });
+  const { promise, resolve, reject } = PromiseWithResolvers();
+  const immediate = new Immediate(resolve, [value]);
+  if (!ref) immediate.unref();
+  if (signal) {
+    oncancel = FunctionPrototypeBind(cancelListenerHandler,
+                                     immediate, clearImmediate, reject,
+                                     signal);
+    kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+    signal.addEventListener('abort', oncancel, { __proto__: null, [kResistStopPropagation]: true });
+  }
   return oncancel !== undefined ?
     SafePromisePrototypeFinally(
-      ret,
-      () => signal.removeEventListener('abort', oncancel)) : ret;
+      promise,
+      () => signal.removeEventListener('abort', oncancel)) : promise;
 }
 
 async function* setInterval(after, value, options = kEmptyObject) {


### PR DESCRIPTION
Let's use `Promise.withResolvers()` instead of creating a promise directly.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1652/console