### PR TITLE
lib: remove unnecessary optional chaining

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -958,7 +958,7 @@ function getMaxListeners(emitterOrTarget) {
  */
 async function once(emitter, name, options = kEmptyObject) {
   validateObject(options, 'options');
-  const signal = options?.signal;
+  const signal = options.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
     throw new AbortError(undefined, { cause: signal.reason });

--- a/lib/events.js
+++ b/lib/events.js
@@ -961,7 +961,7 @@ async function once(emitter, name, options = kEmptyObject) {
   const signal = options?.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
+    throw new AbortError(undefined, { cause: signal.reason });
   return new Promise((resolve, reject) => {
     const errorListener = (err) => {
       emitter.removeListener(name, resolver);
@@ -1049,7 +1049,7 @@ function on(emitter, event, options = kEmptyObject) {
   const signal = options.signal;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
+    throw new AbortError(undefined, { cause: signal.reason });
   // Support both highWaterMark and highWatermark for backward compatibility
   const highWatermark = options.highWaterMark ?? options.highWatermark ?? NumberMAX_SAFE_INTEGER;
   validateInteger(highWatermark, 'options.highWaterMark', 1);

--- a/lib/events.js
+++ b/lib/events.js
@@ -958,7 +958,7 @@ function getMaxListeners(emitterOrTarget) {
  */
 async function once(emitter, name, options = kEmptyObject) {
   validateObject(options, 'options');
-  const signal = options.signal;
+  const { signal } = options;
   validateAbortSignal(signal, 'options.signal');
   if (signal?.aborted)
     throw new AbortError(undefined, { cause: signal.reason });

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -340,7 +340,7 @@ function readFileAfterStat(err, stats) {
 
 function checkAborted(signal, callback) {
   if (signal?.aborted) {
-    callback(new AbortError(undefined, { cause: signal?.reason }));
+    callback(new AbortError(undefined, { cause: signal.reason }));
     return true;
   }
   return false;
@@ -2204,7 +2204,7 @@ function lutimesSync(path, atime, mtime) {
 
 function writeAll(fd, isUserFd, buffer, offset, length, signal, flush, callback) {
   if (signal?.aborted) {
-    const abortError = new AbortError(undefined, { cause: signal?.reason });
+    const abortError = new AbortError(undefined, { cause: signal.reason });
     if (isUserFd) {
       callback(abortError);
     } else {

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -471,7 +471,7 @@ async function fsCall(fn, handle, ...args) {
 
 function checkAborted(signal) {
   if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
+    throw new AbortError(undefined, { cause: signal.reason });
 }
 
 async function writeFileHandle(filehandle, data, signal, encoding) {

--- a/lib/internal/fs/read/context.js
+++ b/lib/internal/fs/read/context.js
@@ -89,7 +89,7 @@ class ReadFileContext {
 
     if (this.signal?.aborted) {
       return this.close(
-        new AbortError(undefined, { cause: this.signal?.reason }));
+        new AbortError(undefined, { cause: this.signal.reason }));
     }
     if (this.size === 0) {
       buffer = Buffer.allocUnsafeSlow(kReadFileUnknownBufferLength);

--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -322,7 +322,7 @@ async function* watch(filename, options = kEmptyObject) {
   }
 
   if (signal?.aborted)
-    throw new AbortError(undefined, { cause: signal?.reason });
+    throw new AbortError(undefined, { cause: signal.reason });
 
   const handle = new FSEvent();
   let { promise, resolve, reject } = PromiseWithResolvers();

--- a/lib/timers/promises.js
+++ b/lib/timers/promises.js
@@ -148,7 +148,7 @@ async function* setInterval(after, value, options = kEmptyObject) {
   const { signal, ref = true } = options;
 
   if (signal?.aborted) {
-    throw new AbortError(undefined, { cause: signal?.reason });
+    throw new AbortError(undefined, { cause: signal.reason });
   }
 
   let onCancel;


### PR DESCRIPTION
From the [V8 blog](https://v8.dev/features/optional-chaining):

> Still, be considerate about using more than one optional chaining operator in a single chain. If a value is guaranteed to not be nullish, then using ?. to access properties on it is discouraged.

It adds more bytecode to each property access, in all these cases we know that the variables are not nullish