### PR TITLE
[v20.x] Revert "console: colorize console error and warn"

### DIFF
--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -8,7 +8,6 @@ const {
   ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypePush,
-  ArrayPrototypeSome,
   ArrayPrototypeUnshift,
   Boolean,
   ErrorCaptureStackTrace,
@@ -68,7 +67,6 @@ const {
   CHAR_LOWERCASE_N: kTraceInstant,
   CHAR_UPPERCASE_C: kTraceCount,
 } = require('internal/constants');
-const { styleText } = require('util');
 const kCounts = Symbol('counts');
 
 const kTraceConsoleCategory = 'node,node.console';
@@ -274,7 +272,7 @@ ObjectDefineProperties(Console.prototype, {
   [kWriteToConsole]: {
     __proto__: null,
     ...consolePropAttributes,
-    value: function(streamSymbol, string, color = '') {
+    value: function(streamSymbol, string) {
       const ignoreErrors = this._ignoreErrors;
       const groupIndent = this[kGroupIndent];
 
@@ -289,11 +287,6 @@ ObjectDefineProperties(Console.prototype, {
         }
         string = groupIndent + string;
       }
-
-      if (color) {
-        string = styleText(color, string);
-      }
-
       string += '\n';
 
       if (ignoreErrors === false) return stream.write(string);
@@ -384,15 +377,12 @@ const consoleMethods = {
   log(...args) {
     this[kWriteToConsole](kUseStdout, this[kFormatForStdout](args));
   },
+
+
   warn(...args) {
-    const color = (shouldColorize(args) && 'yellow') || '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
+    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args));
   },
 
-  error(...args) {
-    const color = (shouldColorize(args) && 'red') || '';
-    this[kWriteToConsole](kUseStderr, this[kFormatForStderr](args), color);
-  },
 
   dir(object, options) {
     this[kWriteToConsole](kUseStdout, inspect(object, {
@@ -685,12 +675,6 @@ const iterKey = '(iteration index)';
 
 const isArray = (v) => ArrayIsArray(v) || isTypedArray(v) || isBuffer(v);
 
-// TODO: remove string type check once the styleText supports objects
-// Return true if all args are type string
-const shouldColorize = (args) => {
-  return lazyUtilColors().hasColors && !ArrayPrototypeSome(args, (arg) => typeof arg !== 'string');
-};
-
 function noop() {}
 
 for (const method of ReflectOwnKeys(consoleMethods))
@@ -699,6 +683,7 @@ for (const method of ReflectOwnKeys(consoleMethods))
 Console.prototype.debug = Console.prototype.log;
 Console.prototype.info = Console.prototype.log;
 Console.prototype.dirxml = Console.prototype.log;
+Console.prototype.error = Console.prototype.warn;
 Console.prototype.groupCollapsed = Console.prototype.group;
 
 function initializeGlobalConsole(globalConsole) {

--- a/test/parallel/test-repl.js
+++ b/test/parallel/test-repl.js
@@ -785,7 +785,6 @@ const errorTests = [
       'Object [console] {',
       '  log: [Function: log],',
       '  warn: [Function: warn],',
-      '  error: [Function: error],',
       '  dir: [Function: dir],',
       '  time: [Function: time],',
       '  timeEnd: [Function: timeEnd],',
@@ -801,6 +800,7 @@ const errorTests = [
       / {2}debug: \[Function: (debug|log)],/,
       / {2}info: \[Function: (info|log)],/,
       / {2}dirxml: \[Function: (dirxml|log)],/,
+      / {2}error: \[Function: (error|warn)],/,
       / {2}groupCollapsed: \[Function: (groupCollapsed|group)],/,
       / {2}Console: \[Function: Console],?/,
       ...process.features.inspector ? [

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
-*(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
-*(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
-*(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
-(Use `* --trace-warnings ...` to show where the warning was created)*
+(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `* --trace-warnings ...` to show where the warning was created)


### PR DESCRIPTION
- Fixes https://github.com/nodejs/node/issues/55726

This reverts commit a833c9e0bed85214884d6650fe344d5896c9e67a.

PR-URL: https://github.com/nodejs/node/pull/54677
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Michaël Zasso <targos@protonmail.com>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
