### PR TITLE
lib: add warning when binding inspector to public IP

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -18,6 +18,8 @@ const {
   ERR_INSPECTOR_NOT_WORKER,
 } = require('internal/errors').codes;
 
+const { isLoopback } = require('internal/net');
+
 const { hasInspector } = internalBinding('config');
 if (!hasInspector)
   throw new ERR_INSPECTOR_NOT_AVAILABLE();
@@ -171,6 +173,16 @@ function inspectorOpen(port, host, wait) {
   if (isUint32(port)) {
     validateInt32(port, 'port', 0, 65535);
   }
+  if (host && !isLoopback(host)) {
+    process.emitWarning(
+      'Binding the inspector to a public IP with an open port is insecure, ',
+      'as it allows external hosts to connect to the inspector ',
+      'and perform a remote code execution attack.',
+      'Documentation can be found at ' +
+        'https://nodejs.org/api/cli.html#--inspecthostport',
+    );
+  }
+
   open(port, host);
   if (wait)
     waitForDebugger();

--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -68,6 +68,17 @@ function makeSyncWrite(fd) {
   };
 }
 
+function isLoopback(host) {
+  const hostLower = host.toLowerCase();
+
+  return (
+    hostLower === 'localhost' ||
+    hostLower.startsWith('127.') ||
+    hostLower.startsWith('[::1]') ||
+    hostLower.startsWith('[0:0:0:0:0:0:0:1]')
+  );
+}
+
 module.exports = {
   kReinitializeHandle: Symbol('kReinitializeHandle'),
   isIP,
@@ -75,4 +86,5 @@ module.exports = {
   isIPv6,
   makeSyncWrite,
   normalizedArgsSymbol: Symbol('normalizedArgs'),
+  isLoopback,
 };

--- a/test/parallel/test-internal-net-isLoopback.js
+++ b/test/parallel/test-internal-net-isLoopback.js
@@ -1,0 +1,32 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('assert');
+const net = require('internal/net');
+
+const loopback = [
+  'localhost',
+  '127.0.0.1',
+  '127.0.0.255',
+  '127.1.2.3',
+  '[::1]',
+  '[0:0:0:0:0:0:0:1]',
+];
+
+const loopbackNot = [
+  'example.com',
+  '192.168.1.1',
+  '10.0.0.1',
+  '255.255.255.255',
+  '[2001:db8::1]',
+  '[fe80::1]',
+  '8.8.8.8',
+];
+
+for (const address of loopback) {
+  assert.strictEqual(net.isLoopback(address), true);
+}
+
+for (const address of loopbackNot) {
+  assert.strictEqual(net.isLoopback(address), false);
+}


### PR DESCRIPTION
Add `isLoopback` function to `internal/net` module to check if a given host is a loopback address.

Add a warning when binding the inspector to a public IP with an open port, as it allows external hosts to connect to the inspector.

Fixes: https://github.com/nodejs/node/issues/23444
Refs: https://nodejs.org/api/cli.html#--inspecthostport

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
