### PR TITLE
test: ensure that test priority is not higher than current priority

### DIFF
--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -83,11 +83,11 @@ assert.ok(hostname.length > 0);
 
 // IBMi process priority is different.
 if (!common.isIBMi) {
-  const DUMMY_PRIORITY = 10;
-  os.setPriority(DUMMY_PRIORITY);
+  const LOWER_PRIORITY = Math.max(os.getPriority() + 5, 19);
+  os.setPriority(LOWER_PRIORITY);
   const priority = os.getPriority();
   is.number(priority);
-  assert.strictEqual(priority, DUMMY_PRIORITY);
+  assert.strictEqual(priority, LOWER_PRIORITY);
 }
 
 // On IBMi, os.uptime() returns 'undefined'

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -83,7 +83,8 @@ assert.ok(hostname.length > 0);
 
 // IBMi process priority is different.
 if (!common.isIBMi) {
-  const LOWER_PRIORITY = Math.min(os.getPriority() + 5, 19);
+  const { PRIORITY_BELOW_NORMAL, PRIORITY_LOW } = os.constants.priority;
+  const LOWER_PRIORITY = os.getPriority() > PRIORITY_BELOW_NORMAL ? PRIORITY_BELOW_NORMAL : PRIORITY_LOW;
   os.setPriority(LOWER_PRIORITY);
   const priority = os.getPriority();
   is.number(priority);

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -83,7 +83,7 @@ assert.ok(hostname.length > 0);
 
 // IBMi process priority is different.
 if (!common.isIBMi) {
-  const LOWER_PRIORITY = Math.max(os.getPriority() + 5, 19);
+  const LOWER_PRIORITY = Math.min(os.getPriority() + 5, 19);
   os.setPriority(LOWER_PRIORITY);
   const priority = os.getPriority();
   is.number(priority);


### PR DESCRIPTION
This test fails if parent's (e.g. `sshd`) niceness is already lower than `10` and we're not root.