### PR TITLE
util: do not mark experimental feature as deprecated

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3761,18 +3761,7 @@ Instantiating classes without the `new` qualifier exported by the `node:repl` mo
 It is recommended to use the `new` qualifier instead. This applies to all REPL classes, including
 `REPLServer` and `Recoverable`.
 
-### DEP0186: `util.getCallSite`
-
-<!-- YAML
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/55626
-    description: Runtime deprecation.
--->
-
-Type: Runtime
-
-The `util.getCallSite` API has been removed. Please use [`util.getCallSites()`][] instead.
+<!-- md-lint skip-deprecation DEP0186 -->
 
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -3899,7 +3888,6 @@ The `util.getCallSite` API has been removed. Please use [`util.getCallSites()`][
 [`url.parse()`]: url.md#urlparseurlstring-parsequerystring-slashesdenotehost
 [`url.resolve()`]: url.md#urlresolvefrom-to
 [`util._extend()`]: util.md#util_extendtarget-source
-[`util.getCallSites()`]: util.md#utilgetcallsitesframecountoroptions-options
 [`util.getSystemErrorName()`]: util.md#utilgetsystemerrornameerr
 [`util.inspect()`]: util.md#utilinspectobject-options
 [`util.inspect.custom`]: util.md#utilinspectcustom

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -370,6 +370,10 @@ util.formatWithOptions({ colors: true }, 'See object %O', { foo: 42 });
 
 <!-- YAML
 added: v22.9.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55626
+    description: The API is renamed from `util.getCallSite` to `util.getCallSites()`.
 -->
 
 * `frameCount` {number} Optional number of frames to capture as call site objects.

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -107,7 +107,9 @@ function getDeprecationWarningEmitter(
   return function() {
     if (!warned && shouldEmitWarning()) {
       warned = true;
-      if (code !== undefined) {
+      if (code === 'ExperimentalWarning') {
+        process.emitWarning(msg, code, deprecated);
+      } else if (code !== undefined) {
         if (!codesWarned.has(code)) {
           const emitWarning = useEmitSync ?
             require('internal/process/warning').emitWarningSync :

--- a/lib/util.js
+++ b/lib/util.js
@@ -436,8 +436,8 @@ module.exports = {
   // Deprecated getCallSite.
   // This API can be removed in next semver-minor release.
   getCallSite: deprecate(getCallSites,
-                         'The `util.getCallSite` API is deprecated. Please use `util.getCallSites()` instead.',
-                         'DEP0186'),
+                         'The `util.getCallSite` API has been renamed to `util.getCallSites()`.',
+                         'ExperimentalWarning'),
   getCallSites,
   getSystemErrorMap,
   getSystemErrorName,

--- a/test/parallel/test-util-getcallsite.js
+++ b/test/parallel/test-util-getcallsite.js
@@ -4,6 +4,6 @@ require('../common');
 const { getCallSite } = require('node:util');
 const { expectWarning } = require('../common');
 
-const warning = 'The `util.getCallSite` API is deprecated. Please use `util.getCallSites()` instead.';
+const warning = 'The `util.getCallSite` API has been renamed to `util.getCallSites()`.';
 expectWarning('ExperimentalWarning', warning);
 getCallSite();

--- a/test/parallel/test-util-getcallsite.js
+++ b/test/parallel/test-util-getcallsite.js
@@ -5,5 +5,5 @@ const { getCallSite } = require('node:util');
 const { expectWarning } = require('../common');
 
 const warning = 'The `util.getCallSite` API is deprecated. Please use `util.getCallSites()` instead.';
-expectWarning('DeprecationWarning', warning, 'DEP0186');
+expectWarning('ExperimentalWarning', warning);
 getCallSite();


### PR DESCRIPTION
A deprecated API has stability guarantees that an experimental API does not. I don't think we should mark an experimental API as deprecated without first graduating it to stable. Instead we can emit an experimental warning which would tell the user the API was renamed.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
