### PR TITLE
fs: fix bufferSize option for opendir recursive

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -164,12 +164,16 @@ class Dir {
       return;
     }
 
-    const result = handle.read(
+    // Fully read the directory and buffer the entries.
+    // This is a naive solution and for very large sub-directories
+    // it can even block the event loop. Essentially, `bufferSize` is
+    // not respected for recursive mode. This is a known limitation.
+    // Issue to fix: https://github.com/nodejs/node/issues/55764
+    let result;
+    while ((result = handle.read(
       this.#options.encoding,
       this.#options.bufferSize,
-    );
-
-    if (result) {
+    ))) {
       this.processReadResult(path, result);
     }
 


### PR DESCRIPTION
The bufferSize option was not respected in recursive mode. This PR
implements a naive solution to fix this issue until a better
implementation can be designed.

Fixes: https://github.com/nodejs/node/issues/48820