### PR TITLE
doc: clarify removal of experimental API does not require a deprecation

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -45,8 +45,8 @@ The stability indexes are as follows:
 >   feedback so that we can know that this feature is ready to be marked as
 >   stable.
 >
-> Experimental features are typically either graduated to stable, or removed
-> without a deprecation cycle.
+> Experimental features leave the experimental status typically either by
+> graduating to stable, or are removed without a deprecation cycle.
 
 <!-- separator -->
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -44,6 +44,9 @@ The stability indexes are as follows:
 >   still occur in response to user feedback. We encourage user testing and
 >   feedback so that we can know that this feature is ready to be marked as
 >   stable.
+>
+> Experimental features are typically either graduated to stable, or removed
+> without a deprecation cycle.
 
 <!-- separator -->
 


### PR DESCRIPTION
As suggested in https://github.com/nodejs/node/pull/55740#pullrequestreview-2417943643.

IMO there's value in keeping the deprecated stability status for APIs that are stable. Users are already discouraged from using experimental APIs in production (because of the lack of stability), so applying a deprecated status on top of experimental only muddies the water, and I don't think it would be a stretch to imagine users starting to expect experimental APIs to follow semver until it's deprecated.
I'm not against emitting warnings when an experimental API is being modified and/or removed, I'm saying we should refrain from using the word deprecated in those cases.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
