### PR TITLE
test: refactor fs readdir buffer with test runner

### DIFF
--- a/test/parallel/test-fs-readdir-buffer.js
+++ b/test/parallel/test-fs-readdir-buffer.js
@@ -1,17 +1,24 @@
 'use strict';
+
 const common = require('../common');
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
 const fs = require('fs');
 
 if (!common.isMacOS) {
   common.skip('this tests works only on MacOS');
 }
 
-const assert = require('assert');
-
-fs.readdir(
-  Buffer.from('/dev'),
-  { withFileTypes: true, encoding: 'buffer' },
-  common.mustCall((e, d) => {
-    assert.strictEqual(e, null);
-  })
-);
+describe('fs.readdir from buffer', () => {
+  it('it should read from the buffer', (t, done) => {
+    fs.readdir(
+      Buffer.from('/dev'),
+      { withFileTypes: true, encoding: 'buffer' },
+      (e) => {
+        assert.strictEqual(e, null);
+        done();
+      }
+    );
+  });
+});


### PR DESCRIPTION
Refactor of `test/parallel/test-fs-readdir-buffer.js` with node test runner.