### PR TITLE
test: convert readdir test to use test runner

### DIFF
--- a/test/parallel/test-fs-readdir-recursive.js
+++ b/test/parallel/test-fs-readdir-recursive.js
@@ -1,14 +1,18 @@
 'use strict';
-const common = require('../common');
-const fs = require('fs');
-const net = require('net');
 
+const { PIPE, mustCall } = require('../common');
 const tmpdir = require('../common/tmpdir');
-tmpdir.refresh();
+const { test } = require('node:test');
+const fs = require('node:fs');
+const net = require('node:net');
 
-const server = net.createServer().listen(common.PIPE, common.mustCall(() => {
-  // The process should not crash
-  // See https://github.com/nodejs/node/issues/52159
-  fs.readdirSync(tmpdir.path, { recursive: true });
-  server.close();
-}));
+test('readdir should not recurse into Unix domain sockets', (t, done) => {
+  tmpdir.refresh();
+  const server = net.createServer().listen(PIPE, mustCall(() => {
+    // The process should not crash
+    // See https://github.com/nodejs/node/issues/52159
+    fs.readdirSync(tmpdir.path, { recursive: true });
+    server.close();
+    done();
+  }));
+});


### PR DESCRIPTION
This PR is the result of a code & learn session at NodeConf EU 2024 in Waterford, Ireland.

It was part of a wider initiative to update Node.js tests to make use of the new built-in test apparatus.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
