### PR TITLE
[v20.x] build: pin doc workflow to Node.js 20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: lts/*
+  NODE_VERSION: 20
 
 permissions:
   contents: read


### PR DESCRIPTION
To save time, the `.github/workflows/doc.yml` workflow runs with a pre-built Node.js. The switch of `lts/*` to Node.js 22 has broken this workflow for Node.js 20 and 18 due to a mismatch in globals. Pin the version of Node.js back to 20.

Fixes: https://github.com/nodejs/node/issues/55754

---

cc @nodejs/releasers The workflow is broken for both `v18.x-staging` and `v20.x-staging`. I think if we land this on `v20.x-staging` we can cherry-pick this to `v18.x-staging` to fix the workflow there, but if you prefer I can open a `v18.x-staging` targeted PR that pins to Node.js 18 instead.

