### PR TITLE
module: expose `resolveLoadAndCache` API

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -216,6 +216,33 @@ resolution and loading behavior. See [Customization hooks][].
 
 This feature requires `--allow-worker` if used with the [Permission Model][].
 
+### `module.resolveLoadAndCache(specifier[, parentURL[, importAttributes[, conditions]]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `specifier` {string|URL} Customization hooks to be registered; this should be
+  the same string that would be passed to `import()`, except that if it is
+  relative, it is resolved relative to `parentURL`.
+* `parentURL` {string|URL} If you want to resolve `specifier` relative to a base
+  URL, such as `import.meta.url`, you can pass that URL here. **Default:**
+  `'data:'`.
+* `importAttributes` {object}
+* `conditions` {Array}
+* Returns: {Promise} fulfills with an object with the following properties:
+  * `url` {string} The absolute URL for that module
+  * `format` {string} The format this module will be parsed as.
+  * `source` {null|TypedArray}
+
+This API tells you how a specific URL will be loaded by the ECMAScript loader if
+it was imported from the `parentURL` in the current process. If the module was
+already imported before `resolveLoadAndCache` is called, the cached version is
+returned; if not, it will populate the cache so future calls to
+`resolveLoadAndCache` or `import` do re-do the work.
+
 ### `module.registerHooks(options)`
 
 <!-- YAML

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -230,7 +230,7 @@ added: REPLACEME
 * `parentURL` {string|URL|undefined} If you want to resolve `specifier` relative to a base
   URL, such as `import.meta.url`, you can pass that URL here. If not provided,
   the `resolve` step will be skipped. **Default:** {undefined}.
-* `importAttributes` {object}
+* `importAttributes` {Object}
 * `conditions` {Array}
 * Returns: {Promise} fulfills with an object with the following properties:
   * `url` {string} The absolute URL for that module

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -227,9 +227,9 @@ added: REPLACEME
 * `specifier` {string|URL} Module to resolve and load; this should be
   the same string that would be passed to `import()`, except that if it is
   relative, it is resolved relative to `parentURL`.
-* `parentURL` {string|URL} If you want to resolve `specifier` relative to a base
-  URL, such as `import.meta.url`, you can pass that URL here. **Default:**
-  `'data:'`.
+* `parentURL` {string|URL|undefined} If you want to resolve `specifier` relative to a base
+  URL, such as `import.meta.url`, you can pass that URL here. If not provided,
+  the `resolve` step will be skipped. **Default:** {undefined}.
 * `importAttributes` {object}
 * `conditions` {Array}
 * Returns: {Promise} fulfills with an object with the following properties:

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -224,7 +224,7 @@ added: REPLACEME
 
 > Stability: 1 - Experimental
 
-* `specifier` {string|URL} Customization hooks to be registered; this should be
+* `specifier` {string|URL} Module to resolve and load; this should be
   the same string that would be passed to `import()`, except that if it is
   relative, it is resolved relative to `parentURL`.
 * `parentURL` {string|URL} If you want to resolve `specifier` relative to a base
@@ -237,11 +237,11 @@ added: REPLACEME
   * `format` {string} The format this module will be parsed as.
   * `source` {null|TypedArray}
 
-This API tells you how a specific URL will be loaded by the ECMAScript loader if
+This API tells you how a specific URL will be loaded by the module loader if
 it was imported from the `parentURL` in the current process. If the module was
 already imported before `resolveLoadAndCache` is called, the cached version is
 returned; if not, it will populate the cache so future calls to
-`resolveLoadAndCache` or `import` do re-do the work.
+`resolveLoadAndCache` or `import` do not re-do the work.
 
 ### `module.registerHooks(options)`
 

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -216,7 +216,7 @@ resolution and loading behavior. See [Customization hooks][].
 
 This feature requires `--allow-worker` if used with the [Permission Model][].
 
-### `module.resolveLoadAndCache(specifier[, parentURL[, importAttributes[, conditions]]])`
+### `module.resolve(specifier, parentURL[, importAttributes]])`
 
 <!-- YAML
 added: REPLACEME
@@ -227,21 +227,59 @@ added: REPLACEME
 * `specifier` {string|URL} Module to resolve and load; this should be
   the same string that would be passed to `import()`, except that if it is
   relative, it is resolved relative to `parentURL`.
-* `parentURL` {string|URL|undefined} If you want to resolve `specifier` relative to a base
-  URL, such as `import.meta.url`, you can pass that URL here. If not provided,
-  the `resolve` step will be skipped. **Default:** {undefined}.
-* `importAttributes` {Object}
+* `parentURL` {string|URL|undefined} The base URL to resolve `specifier` from,
+  such as `import.meta.url`.
+* `importAttributes` {Object} **Default:** an empty object.
+* Returns: {Promise} fulfills with a string containing the full URL of the
+  potential module corresponding to the given specifier.
+
+Analogous to `import.meta.resolve`, but asynchronous, accessible from CommonJS
+modules, and with additional parameters.
+
+### `module.load(url[, importAttributes[, conditions]]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `url` {string|URL|undefined} The URL of the module to load.
+* `importAttributes` {Object} **Default:** an empty object.
 * `conditions` {Array}
 * Returns: {Promise} fulfills with an object with the following properties:
   * `url` {string} The absolute URL for that module
   * `format` {string} The format this module will be parsed as.
   * `source` {null|TypedArray}
 
-This API tells you how a specific URL will be loaded by the module loader if
-it was imported from the `parentURL` in the current process. If the module was
-already imported before `resolveLoadAndCache` is called, the cached version is
-returned; if not, it will populate the cache so future calls to
-`resolveLoadAndCache` or `import` do not re-do the work.
+This API tells you how the passed URL would be loaded by the module loader if
+it was imported in the current process – or, if `conditions` is provided, how
+would it be loaded in a process with such configuration.
+
+### `module.resolveLoadAndCache(specifier, parentURL[, importAttributes[, conditions]]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `specifier` {string|URL} Module to resolve and load; this should be
+  the same string that would be passed to `import()`, except that if it is
+  relative, it is resolved relative to `parentURL`.
+* `parentURL` {string|URL|undefined} The base URL to resolve `specifier` from,
+  such as `import.meta.url`.
+* `importAttributes` {Object} **Default:** an empty object.
+* `conditions` {Array}
+* Returns: {Promise} fulfills with an object with the following properties:
+  * `url` {string} The absolute URL for that module
+  * `format` {string} The format this module will be parsed as.
+  * `source` {null|TypedArray}
+
+This API tells you how the passed specifier would be loaded by the module loader if
+it was imported from the `parentURL` in the current process – or, if
+`conditions` is provided, how would it be loaded in a process with such
+configuration.
 
 ### `module.registerHooks(options)`
 

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -391,14 +391,28 @@ ObjectFreeze(compileCacheStatus);
 const constants = { __proto__: null, compileCacheStatus };
 ObjectFreeze(constants);
 
-async function resolveLoadAndCache(specifier, base = undefined, importAttributes = kEmptyObject, conditions) {
+async function resolve(specifier, base, importAttributes = kEmptyObject) {
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-  let url, resolveFormat;
-  if (base == null) {
-    url = `${specifier}`;
-  } else {
-    ({ url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes));
-  }
+  const { url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes);
+  return url;
+}
+async function load(url, importAttributes = kEmptyObject, conditions) {
+  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  const { format, source } = await cascadedLoader.load(url, {
+    __proto__: null,
+    importAttributes,
+    conditions,
+  });
+  return {
+    __proto__: null,
+    format,
+    source,
+    url,
+  };
+}
+async function resolveAndLoad(specifier, base = undefined, importAttributes = kEmptyObject, conditions) {
+  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  const { url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes);
   const { format, source } = await cascadedLoader.load(url, {
     __proto__: null,
     importAttributes,
@@ -435,7 +449,9 @@ module.exports = {
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,
-  resolveLoadAndCache,
+  resolve,
+  load,
+  resolveAndLoad,
   stringify,
   stripBOM,
   toRealPath,

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -391,10 +391,14 @@ ObjectFreeze(compileCacheStatus);
 const constants = { __proto__: null, compileCacheStatus };
 ObjectFreeze(constants);
 
-async function resolveLoadAndCache(specifier, base = 'data:', importAttributes = kEmptyObject, conditions) {
+async function resolveLoadAndCache(specifier, base = undefined, importAttributes = kEmptyObject, conditions) {
   const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
-  // TODO: this should hit the cache (and populate it if it finds nothing)
-  const { url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes);
+  let url, resolveFormat;
+  if (base == null) {
+    url = `${specifier}`;
+  } else {
+    ({ url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes));
+  }
   const { format, source } = await cascadedLoader.load(url, {
     __proto__: null,
     importAttributes,

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -26,7 +26,7 @@ const { pathToFileURL, fileURLToPath } = require('internal/url');
 const assert = require('internal/assert');
 
 const { getOptionValue } = require('internal/options');
-const { setOwnProperty, getLazy } = require('internal/util');
+const { setOwnProperty, getLazy, kEmptyObject } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 
 const lazyTmpdir = getLazy(() => require('os').tmpdir());
@@ -391,6 +391,24 @@ ObjectFreeze(compileCacheStatus);
 const constants = { __proto__: null, compileCacheStatus };
 ObjectFreeze(constants);
 
+async function resolveLoadAndCache(specifier, base = 'data:', importAttributes = kEmptyObject, conditions) {
+  const cascadedLoader = require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
+  // TODO: this should hit the cache (and populate it if it finds nothing)
+  const { url, format: resolveFormat } = await cascadedLoader.resolve(`${specifier}`, `${base}`, importAttributes);
+  const { format, source } = await cascadedLoader.load(url, {
+    __proto__: null,
+    importAttributes,
+    format: resolveFormat,
+    conditions,
+  });
+  return {
+    __proto__: null,
+    format,
+    source,
+    url,
+  };
+}
+
 /**
  * Get the compile cache directory if on-disk compile cache is enabled.
  * @returns {string|undefined} Path to the module compile cache directory if it is enabled,
@@ -413,6 +431,7 @@ module.exports = {
   loadBuiltinModule,
   makeRequireFunction,
   normalizeReferrerURL,
+  resolveLoadAndCache,
   stringify,
   stripBOM,
   toRealPath,

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -407,7 +407,6 @@ async function load(url, importAttributes = kEmptyObject, conditions) {
     __proto__: null,
     format,
     source,
-    url,
   };
 }
 async function resolveAndLoad(specifier, base = undefined, importAttributes = kEmptyObject, conditions) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -15,18 +15,22 @@ const {
   enableCompileCache,
   flushCompileCache,
   getCompileCacheDir,
+  resolveLoadAndCache,
 } = require('internal/modules/helpers');
 const {
   findPackageJSON,
 } = require('internal/modules/package_json_reader');
 const { stripTypeScriptTypes } = require('internal/modules/typescript');
 
-Module.register = register;
 Module.constants = constants;
 Module.enableCompileCache = enableCompileCache;
 Module.findPackageJSON = findPackageJSON;
+Module.findSourceMap = findSourceMap;
 Module.flushCompileCache = flushCompileCache;
 Module.getCompileCacheDir = getCompileCacheDir;
+Module.register = register;
+Module.resolveLoadAndCache = resolveLoadAndCache;
+Module.SourceMap = SourceMap;
 Module.stripTypeScriptTypes = stripTypeScriptTypes;
 
 // SourceMap APIs

--- a/lib/module.js
+++ b/lib/module.js
@@ -15,7 +15,9 @@ const {
   enableCompileCache,
   flushCompileCache,
   getCompileCacheDir,
-  resolveLoadAndCache,
+  resolve,
+  load,
+  resolveAndLoad,
 } = require('internal/modules/helpers');
 const {
   findPackageJSON,
@@ -29,7 +31,9 @@ Module.findSourceMap = findSourceMap;
 Module.flushCompileCache = flushCompileCache;
 Module.getCompileCacheDir = getCompileCacheDir;
 Module.register = register;
-Module.resolveLoadAndCache = resolveLoadAndCache;
+Module.resolve= resolveLoadAndCache;
+Module.load = resolveLoadAndCache;
+Module.resolveAndLoad= resolveLoadAndCache;
 Module.SourceMap = SourceMap;
 Module.stripTypeScriptTypes = stripTypeScriptTypes;
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -31,9 +31,9 @@ Module.findSourceMap = findSourceMap;
 Module.flushCompileCache = flushCompileCache;
 Module.getCompileCacheDir = getCompileCacheDir;
 Module.register = register;
-Module.resolve= resolveLoadAndCache;
-Module.load = resolveLoadAndCache;
-Module.resolveAndLoad= resolveLoadAndCache;
+Module.resolve= resolve;
+Module.load = load;
+Module.resolveAndLoad= resolveAndLoad;
 Module.SourceMap = SourceMap;
 Module.stripTypeScriptTypes = stripTypeScriptTypes;
 

--- a/test/fixtures/typescript/legacy-module/README.md
+++ b/test/fixtures/typescript/legacy-module/README.md
@@ -1,0 +1,5 @@
+# Legacy TypeScript Module
+
+When `tsconfig.json` is set to `module: "node16"` or any `node*`, the TypeScript compiler will
+produce the output in the format by the extension (e.g. `.cts` or `.mts`), or set by the
+`package.json#type` field, regardless of the syntax of the original source code.

--- a/test/fixtures/typescript/legacy-module/package.json
+++ b/test/fixtures/typescript/legacy-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/fixtures/typescript/legacy-module/test-module-export.cts
+++ b/test/fixtures/typescript/legacy-module/test-module-export.cts
@@ -1,0 +1,1 @@
+export const foo: string = 'Hello, TypeScript!';

--- a/test/fixtures/typescript/legacy-module/test-module-export.mts
+++ b/test/fixtures/typescript/legacy-module/test-module-export.mts
@@ -1,0 +1,1 @@
+export const foo: string = 'Hello, TypeScript!';

--- a/test/fixtures/typescript/legacy-module/test-module-export.ts
+++ b/test/fixtures/typescript/legacy-module/test-module-export.ts
@@ -1,0 +1,1 @@
+export const foo: string = 'Hello, TypeScript!';

--- a/test/parallel/test-module-loadmodule-no-typescript.js
+++ b/test/parallel/test-module-loadmodule-no-typescript.js
@@ -1,0 +1,24 @@
+// Flags: --no-experimental-strip-types
+
+'use strict';
+
+require('../common');
+const test = require('node:test');
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const fixtures = require('../common/fixtures');
+const { resolveLoadAndCache } = require('node:module');
+
+const parentURL = pathToFileURL(__filename);
+
+test('should reject a TypeScript module', async () => {
+  const fileUrl = fixtures.fileURL('typescript/legacy-module/test-module-export.ts');
+  await assert.rejects(
+    async () => {
+      await resolveLoadAndCache(fileUrl, parentURL);
+    },
+    {
+      code: 'ERR_UNKNOWN_FILE_EXTENSION',
+    }
+  );
+});

--- a/test/parallel/test-module-loadmodule-typescript.js
+++ b/test/parallel/test-module-loadmodule-typescript.js
@@ -1,0 +1,49 @@
+// Flags: --experimental-strip-types
+
+'use strict';
+
+require('../common');
+const test = require('node:test');
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const fixtures = require('../common/fixtures');
+const { resolveLoadAndCache } = require('node:module');
+
+const parentURL = pathToFileURL(__filename);
+
+test('should load a TypeScript module source by package.json type', async () => {
+  // Even if the .ts file contains module syntax, it should be loaded as a CommonJS module
+  // because the package.json type is set to "commonjs".
+
+  const fileUrl = fixtures.fileURL('typescript/legacy-module/test-module-export.ts');
+  const { url, format, source } = await resolveLoadAndCache(fileUrl, parentURL);
+  assert.strictEqual(format, 'commonjs-typescript');
+  assert.strictEqual(url, fileUrl.href);
+
+  // Built-in TypeScript loader loads the source.
+  assert.ok(Buffer.isBuffer(source));
+});
+
+test('should load a TypeScript cts module source by extension', async () => {
+  // By extension, .cts files should be loaded as CommonJS modules.
+
+  const fileUrl = fixtures.fileURL('typescript/legacy-module/test-module-export.cts');
+  const { url, format, source } = await resolveLoadAndCache(fileUrl, parentURL);
+  assert.strictEqual(format, 'commonjs-typescript');
+  assert.strictEqual(url, fileUrl.href);
+
+  // Built-in TypeScript loader loads the source.
+  assert.ok(Buffer.isBuffer(source));
+});
+
+test('should load a TypeScript mts module source by extension', async () => {
+  // By extension, .mts files should be loaded as ES modules.
+
+  const fileUrl = fixtures.fileURL('typescript/legacy-module/test-module-export.mts');
+  const { url, format, source } = await resolveLoadAndCache(fileUrl, parentURL);
+  assert.strictEqual(format, 'module-typescript');
+  assert.strictEqual(url, fileUrl.href);
+
+  // Built-in TypeScript loader loads the source.
+  assert.ok(Buffer.isBuffer(source));
+});

--- a/test/parallel/test-module-loadmodule.js
+++ b/test/parallel/test-module-loadmodule.js
@@ -1,0 +1,31 @@
+'use strict';
+
+require('../common');
+const test = require('node:test');
+const assert = require('node:assert');
+const { pathToFileURL } = require('node:url');
+const fixtures = require('../common/fixtures');
+const { resolveLoadAndCache } = require('node:module');
+
+const parentURL = pathToFileURL(__filename);
+
+test('should throw if the module is not found', async () => {
+  await assert.rejects(
+    async () => {
+      await resolveLoadAndCache('nonexistent-module', parentURL);
+    },
+    {
+      code: 'ERR_MODULE_NOT_FOUND',
+    }
+  );
+});
+
+test('should load a module', async () => {
+  const fileUrl = fixtures.fileURL('es-modules/cjs.js');
+  const { url, format, source } = await resolveLoadAndCache(fileUrl, parentURL);
+  assert.strictEqual(format, 'commonjs');
+  assert.strictEqual(url, fileUrl.href);
+
+  // `source` is null and the final builtin loader will read the file.
+  assert.strictEqual(source, null);
+});

--- a/test/parallel/test-resolveLoadAndCache.js
+++ b/test/parallel/test-resolveLoadAndCache.js
@@ -3,37 +3,36 @@
 const { spawnPromisified } = require('../common');
 const fixtures = require('../common/fixtures');
 const assert = require('node:assert');
-const { resolveLoadAndCache } = require('node:module');
+const { resolve, load, resolveAndLoad } = require('node:module');
 const { describe, it } = require('node:test');
 
 
-describe('resolveLoadAndCache', () => { // Throws when no arguments are provided
+describe('load', () => {
   it('should return null source for CJS module and built-in modules', async () => {
-    assert.deepStrictEqual(await resolveLoadAndCache(fixtures.fileURL('empty.js')), {
+    assert.deepStrictEqual(await load(fixtures.fileURL('empty.js')), {
       __proto__: null,
-      url: `${fixtures.fileURL('empty.js')}`,
       format: 'commonjs',
       source: null,
     });
-    assert.deepStrictEqual(await resolveLoadAndCache('node:fs'), {
+    assert.deepStrictEqual(await load('node:fs'), {
       __proto__: null,
-      url: 'node:fs',
       format: 'builtin',
       source: null,
     });
   });
 
   it('should return full source for ESM module', async () => {
-    assert.deepStrictEqual(await resolveLoadAndCache(fixtures.fileURL('es-modules/print-3.mjs')), {
+    assert.deepStrictEqual(await load(fixtures.fileURL('es-modules/print-3.mjs')), {
       __proto__: null,
-      url: `${fixtures.fileURL('es-modules/print-3.mjs')}`,
       format: 'module',
       source: Buffer.from('console.log(3);\n'),
     });
   });
+});
 
+describe('resolveAndLoad', () => {
   it('should accept relative path when a base URL is provided', async () => {
-    assert.deepStrictEqual(await resolveLoadAndCache('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs')), {
+    assert.deepStrictEqual(await resolveAndLoad('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs')), {
       __proto__: null,
       url: `${fixtures.fileURL('es-modules/print-3.mjs')}`,
       format: 'module',
@@ -41,28 +40,28 @@ describe('resolveLoadAndCache', () => { // Throws when no arguments are provided
     });
   });
 
-  it('should throw when parentLocation is invalid', async () => {
+  it('should throw when parentURL is invalid', async () => {
     for (const invalid of [null, {}, [], () => {}, true, false, 1, 0]) {
       await assert.rejects(
-        () => resolveLoadAndCache('', invalid),
+        () => resolveAndLoad('', invalid),
         { code: 'ERR_INVALID_URL' },
       );
     }
 
-    await assert.rejects(resolveLoadAndCache('', Symbol()), {
+    await assert.rejects(resolveAndLoad('', Symbol()), {
       name: 'TypeError',
     });
   });
 
   it('should accept a file URL (string), like from `import.meta.resolve()`', async () => {
     const url = `${fixtures.fileURL('es-modules/print-3.mjs')}`;
-    assert.deepStrictEqual(await resolveLoadAndCache(url), {
+    assert.deepStrictEqual(await resolveAndLoad(url, 'data:'), {
       __proto__: null,
       url,
       format: 'module',
       source: Buffer.from('console.log(3);\n'),
     });
-    assert.deepStrictEqual(await resolveLoadAndCache('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs').href), {
+    assert.deepStrictEqual(await resolveAndLoad('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs').href), {
       __proto__: null,
       url,
       format: 'module',
@@ -72,16 +71,15 @@ describe('resolveLoadAndCache', () => { // Throws when no arguments are provided
 
   it('should require import attribute to load JSON files', async () => {
     const url = 'data:application/json,{}';
-    await assert.rejects(resolveLoadAndCache(url), { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' });
-    assert.deepStrictEqual(await resolveLoadAndCache(url, undefined, { type: 'json' }), {
+    await assert.rejects(load(url), { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' });
+    assert.deepStrictEqual(await load(url, { type: 'json' }), {
       __proto__: null,
       format: 'json',
-      url,
       source: Buffer.from('{}'),
     });
   });
 
-  it.skip('should use the existing cache', async () => {
+  it('should use the existing cache', async () => {
     const url = fixtures.fileURL('es-modules/print-3.mjs');
     assert.deepStrictEqual(await spawnPromisified(process.execPath, [
       '--no-warnings',
@@ -90,14 +88,31 @@ describe('resolveLoadAndCache', () => { // Throws when no arguments are provided
       '--loader',
       fixtures.fileURL('es-module-loaders/loader-load-passthru.mjs'),
       '-p',
-      `import(${JSON.stringify(url)}).then(() => module.resolveLoadAndCache(${JSON.stringify(url)}, url.pathToFileURL(__filename)))`,
+      `import(${JSON.stringify(url)}).then(() => module.resolveAndLoad(${JSON.stringify(url)}, url.pathToFileURL(__filename)))`,
     ]), {
       stderr: '',
-      stdout: `Promise <>`,
+      stdout: [
+        'resolve passthru',
+        'load passthru',
+        '3',
+        'resolve passthru',
+        'load passthru',
+        'Promise {',
+        '  [Object: null prototype] {',
+        '    format: \'module\',',
+        '    source: Uint8Array(16) [',
+        '       99, 111, 110, 115, 111,',
+        '      108, 101,  46, 108, 111,',
+        '      103,  40,  51,  41,  59,',
+        '       10',
+        '    ],',
+        `    url: '${url}'`,
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
       code: 0,
       signal: null,
     });
   });
-
-  it.skip('should populate the cache', async () => {});
 });

--- a/test/parallel/test-resolveLoadAndCache.js
+++ b/test/parallel/test-resolveLoadAndCache.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const { spawnPromisified } = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('node:assert');
+const { resolveLoadAndCache } = require('node:module');
+const { describe, it } = require('node:test');
+
+
+describe('resolveLoadAndCache', () => { // Throws when no arguments are provided
+  it('should return null source for CJS module and built-in modules', async () => {
+    assert.deepStrictEqual(await resolveLoadAndCache(fixtures.fileURL('empty.js')), {
+      __proto__: null,
+      url: `${fixtures.fileURL('empty.js')}`,
+      format: 'commonjs',
+      source: null,
+    });
+    assert.deepStrictEqual(await resolveLoadAndCache('node:fs'), {
+      __proto__: null,
+      url: 'node:fs',
+      format: 'builtin',
+      source: null,
+    });
+  });
+
+  it('should return full source for ESM module', async () => {
+    assert.deepStrictEqual(await resolveLoadAndCache(fixtures.fileURL('es-modules/print-3.mjs')), {
+      __proto__: null,
+      url: `${fixtures.fileURL('es-modules/print-3.mjs')}`,
+      format: 'module',
+      source: Buffer.from('console.log(3);\n'),
+    });
+  });
+
+  it('should accept relative path when a base URL is provided', async () => {
+    assert.deepStrictEqual(await resolveLoadAndCache('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs')), {
+      __proto__: null,
+      url: `${fixtures.fileURL('es-modules/print-3.mjs')}`,
+      format: 'module',
+      source: Buffer.from('console.log(3);\n'),
+    });
+  });
+
+  it('should throw when parentLocation is invalid', async () => {
+    for (const invalid of [null, {}, [], () => {}, true, false, 1, 0]) {
+      await assert.rejects(
+        () => resolveLoadAndCache('', invalid),
+        { code: 'ERR_INVALID_URL' },
+      );
+    }
+
+    await assert.rejects(resolveLoadAndCache('', Symbol()), {
+      name: 'TypeError',
+    });
+  });
+
+  it('should accept a file URL (string), like from `import.meta.resolve()`', async () => {
+    const url = `${fixtures.fileURL('es-modules/print-3.mjs')}`;
+    assert.deepStrictEqual(await resolveLoadAndCache(url), {
+      __proto__: null,
+      url,
+      format: 'module',
+      source: Buffer.from('console.log(3);\n'),
+    });
+    assert.deepStrictEqual(await resolveLoadAndCache('./print-3.mjs', fixtures.fileURL('es-modules/loop.mjs').href), {
+      __proto__: null,
+      url,
+      format: 'module',
+      source: Buffer.from('console.log(3);\n'),
+    });
+  });
+
+  it('should require import attribute to load JSON files', async () => {
+    const url = 'data:application/json,{}';
+    await assert.rejects(resolveLoadAndCache(url), { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' });
+    assert.deepStrictEqual(await resolveLoadAndCache(url, undefined, { type: 'json' }), {
+      __proto__: null,
+      format: 'json',
+      url,
+      source: Buffer.from('{}'),
+    });
+  });
+
+  it.skip('should use the existing cache', async () => {
+    const url = fixtures.fileURL('es-modules/print-3.mjs');
+    assert.deepStrictEqual(await spawnPromisified(process.execPath, [
+      '--no-warnings',
+      '--loader',
+      fixtures.fileURL('es-module-loaders/loader-resolve-passthru.mjs'),
+      '--loader',
+      fixtures.fileURL('es-module-loaders/loader-load-passthru.mjs'),
+      '-p',
+      `import(${JSON.stringify(url)}).then(() => module.resolveLoadAndCache(${JSON.stringify(url)}, url.pathToFileURL(__filename)))`,
+    ]), {
+      stderr: '',
+      stdout: `Promise <>`,
+      code: 0,
+      signal: null,
+    });
+  });
+
+  it.skip('should populate the cache', async () => {});
+});


### PR DESCRIPTION
Opening as draft as I'd like to get some feedback on the API design first. /cc @nodejs/loaders 

Use case for this is to get "final" format of the module that would result from importing a specific specifier. The cache part is primordial as otherwise you'd have no guarantee that the result would be accurate (if there's a user loader involved, we have no reason to believe it would be stable over time). However, caching a call that's sometimes async, sometimes sync is more or less impossible in JS, and on top of that there are loaders out there that rely on resolve NOT being cached (e.g the test runner `.mock` util), so instead I decided it'd be more useful to provide a way to skip the `resolve` call.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
