### PR TITLE
doc: consolidate history table of CustomEvent

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -2427,11 +2427,17 @@ added:
   - v18.7.0
   - v16.17.0
 changes:
+  - version: v23.0.0
+    pr-url: https://github.com/nodejs/node/pull/52723
+    description: No longer experimental.
   - version:
     - v22.1.0
     - v20.13.0
     pr-url: https://github.com/nodejs/node/pull/52618
     description: CustomEvent is now stable.
+  - version: v19.0.0
+    pr-url: https://github.com/nodejs/node/pull/44860
+    description: No longer behind `--experimental-global-customevent` CLI flag.
 -->
 
 > Stability: 2 - Stable

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -438,6 +438,11 @@ changes:
   - version: v23.0.0
     pr-url: https://github.com/nodejs/node/pull/52723
     description: No longer experimental.
+  - version:
+    - v22.1.0
+    - v20.13.0
+    pr-url: https://github.com/nodejs/node/pull/52618
+    description: CustomEvent is now stable.
   - version: v19.0.0
     pr-url: https://github.com/nodejs/node/pull/44860
     description: No longer behind `--experimental-global-customevent` CLI flag.


### PR DESCRIPTION
Refs: #55733
Fixes: #55733

This PR fixes inconsistencies in the `CustomEvent` docs by consolidating the history table in `globals` and `events`