### PR TITLE
doc: add path aliases typescript doc

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -174,16 +174,16 @@ a `node_modules` path.
 
 ### Paths aliases
 
-[Path aliases][] won't be transformed and therefore produce an error. The closest
+[`tsconfig` "paths"][] won't be transformed and therefore produce an error. The closest
 feature available are [subpath imports][] with the limitation that they need to start
 with `#`
 
 [CommonJS]: modules.md
 [ES Modules]: esm.md
 [Full TypeScript support]: #full-typescript-support
-[Path aliases]: https://www.typescriptlang.org/tsconfig/#paths
 [`--experimental-strip-types`]: cli.md#--experimental-strip-types
 [`--experimental-transform-types`]: cli.md#--experimental-transform-types
+[`tsconfig` "paths"]: https://www.typescriptlang.org/tsconfig/#paths
 [`tsx`]: https://tsx.is/
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax
 [file extensions are mandatory]: esm.md#mandatory-file-extensions

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -172,14 +172,22 @@ To discourage package authors from publishing packages written in TypeScript,
 Node.js will by default refuse to handle TypeScript files inside folders under
 a `node_modules` path.
 
+### Paths aliases
+
+[Path aliases][] won't be transformed and therefore produce an error. The closest
+feature available are [subpath imports][] with the limitation that they need to start
+with `#`
+
 [CommonJS]: modules.md
 [ES Modules]: esm.md
 [Full TypeScript support]: #full-typescript-support
+[Path aliases]: https://www.typescriptlang.org/tsconfig/#paths
 [`--experimental-strip-types`]: cli.md#--experimental-strip-types
 [`--experimental-transform-types`]: cli.md#--experimental-transform-types
 [`tsx`]: https://tsx.is/
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax
 [file extensions are mandatory]: esm.md#mandatory-file-extensions
 [full support]: #full-typescript-support
+[subpath imports]: packages.md#subpath-imports
 [the same way as `.js` files.]: packages.md#determining-module-system
 [type stripping]: #type-stripping

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -175,8 +175,8 @@ a `node_modules` path.
 ### Paths aliases
 
 [`tsconfig` "paths"][] won't be transformed and therefore produce an error. The closest
-feature available are [subpath imports][] with the limitation that they need to start
-with `#`
+feature available is [subpath imports][] with the limitation that they need to start
+with `#`.
 
 [CommonJS]: modules.md
 [ES Modules]: esm.md


### PR DESCRIPTION
Adding path aliases not supported documentation and alternative to TypeScript documentation
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
