### PR TITLE
tools: remove non-existent file from eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,7 +51,6 @@ export default [
       'test/.tmp.*/**',
       'test/addons/??_*',
       'test/fixtures/**',
-      'test/message/esm_display_syntax_error.mjs',
       'tools/github_reporter/**',
       'tools/icu/**',
     ],


### PR DESCRIPTION
This file no longer exists. It hasn't existed since 02de40246f261355ece1cc044e282db4db60d59b.