### PR TITLE
util: inspect: enumerable Symbols no longer have square brackets

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -878,7 +878,7 @@ assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol2]: 1 });
 // AssertionError [ERR_ASSERTION]: Inputs identical but not reference equal:
 //
 // {
-//   [Symbol()]: 1
+//   Symbol(): 1
 // }
 
 const weakMap1 = new WeakMap();
@@ -970,7 +970,7 @@ assert.deepStrictEqual({ [symbol1]: 1 }, { [symbol2]: 1 });
 // AssertionError [ERR_ASSERTION]: Inputs identical but not reference equal:
 //
 // {
-//   [Symbol()]: 1
+//   Symbol(): 1
 // }
 
 const weakMap1 = new WeakMap();

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -73,8 +73,8 @@ myEmitter.on('event', function(a, b) {
   //     _events: [Object: null prototype] { event: [Function (anonymous)] },
   //     _eventsCount: 1,
   //     _maxListeners: undefined,
-  //     [Symbol(shapeMode)]: false,
-  //     [Symbol(kCapture)]: false
+  //     Symbol(shapeMode): false,
+  //     Symbol(kCapture): false
   //   } true
 });
 myEmitter.emit('event', 'a', 'b');
@@ -91,8 +91,8 @@ myEmitter.on('event', function(a, b) {
   //     _events: [Object: null prototype] { event: [Function (anonymous)] },
   //     _eventsCount: 1,
   //     _maxListeners: undefined,
-  //     [Symbol(shapeMode)]: false,
-  //     [Symbol(kCapture)]: false
+  //     Symbol(shapeMode): false,
+  //     Symbol(kCapture): false
   //   } true
 });
 myEmitter.emit('event', 'a', 'b');

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1999,20 +1999,15 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc,
       SymbolPrototypeToString(key),
       escapeFn,
     );
-    name = `[${ctx.stylize(tmp, 'symbol')}]`;
-  } else if (key === '__proto__') {
-    name = "['__proto__']";
-  } else if (desc.enumerable === false) {
-    const tmp = RegExpPrototypeSymbolReplace(
-      strEscapeSequencesReplacer,
-      key,
-      escapeFn,
-    );
-    name = `[${tmp}]`;
+    name = ctx.stylize(tmp, 'symbol');
   } else if (RegExpPrototypeExec(keyStrRegExp, key) !== null) {
-    name = ctx.stylize(key, 'name');
+    name = key === '__proto__' ? "['__proto__']" : ctx.stylize(key, 'name');
   } else {
     name = ctx.stylize(strEscape(key), 'string');
+  }
+
+  if (desc.enumerable === false) {
+    name = `[${name}]`;
   }
   return `${name}:${extra}${str}`;
 }

--- a/test/fixtures/test-runner/output/describe_it.snapshot
+++ b/test/fixtures/test-runner/output/describe_it.snapshot
@@ -454,7 +454,7 @@ not ok 50 - custom inspect symbol that throws fail
   error: |-
     {
       foo: 1,
-      [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+      Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]
     }
   code: 'ERR_TEST_FAILURE'
   ...

--- a/test/fixtures/test-runner/output/dot_reporter.snapshot
+++ b/test/fixtures/test-runner/output/dot_reporter.snapshot
@@ -137,7 +137,7 @@ Failed tests:
 ✖ custom inspect symbol fail (*ms)
   customized
 ✖ custom inspect symbol that throws fail (*ms)
-  { foo: 1, [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] }
+  { foo: 1, Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] }
 ✖ sync throw fails at first (*ms)
   Error: thrown from subtest sync throw fails at first
       *

--- a/test/fixtures/test-runner/output/junit_reporter.snapshot
+++ b/test/fixtures/test-runner/output/junit_reporter.snapshot
@@ -319,15 +319,15 @@ Error [ERR_TEST_FAILURE]: thrown from callback async throw
 [Error [ERR_TEST_FAILURE]: customized] { code: 'ERR_TEST_FAILURE', failureType: 'testCodeFailure', cause: customized }
 		</failure>
 	</testcase>
-	<testcase name="custom inspect symbol that throws fail" time="*" classname="test" failure="{  foo: 1,  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]}">
-		<failure type="testCodeFailure" message="{  foo: 1,  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]}">
+	<testcase name="custom inspect symbol that throws fail" time="*" classname="test" failure="{  foo: 1,  Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]}">
+		<failure type="testCodeFailure" message="{  foo: 1,  Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]}">
 [Error [ERR_TEST_FAILURE]: {
   foo: 1,
-  [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+  Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]
 }] {
   code: 'ERR_TEST_FAILURE',
   failureType: 'testCodeFailure',
-  cause: { foo: 1, [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] }
+  cause: { foo: 1, Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] }
 }
 		</failure>
 	</testcase>

--- a/test/fixtures/test-runner/output/output.snapshot
+++ b/test/fixtures/test-runner/output/output.snapshot
@@ -502,7 +502,7 @@ not ok 51 - custom inspect symbol that throws fail
   error: |-
     {
       foo: 1,
-      [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+      Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]
     }
   code: 'ERR_TEST_FAILURE'
   ...

--- a/test/fixtures/test-runner/output/output_cli.snapshot
+++ b/test/fixtures/test-runner/output/output_cli.snapshot
@@ -509,7 +509,7 @@ not ok 51 - custom inspect symbol that throws fail
   error: |-
     {
       foo: 1,
-      [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]]
+      Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]]
     }
   code: 'ERR_TEST_FAILURE'
   ...

--- a/test/fixtures/test-runner/output/spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/spec_reporter.snapshot
@@ -194,7 +194,7 @@
   customized
 
  custom inspect symbol that throws fail (*ms)
-  { foo: 1, [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] }
+  { foo: 1, Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] }
 
  subtest sync throw fails
    sync throw fails at first (*ms)
@@ -476,7 +476,7 @@
 
 *
  custom inspect symbol that throws fail (*ms)
-  { foo: 1, [Symbol(nodejs.util.inspect.custom)]: [Function: [nodejs.util.inspect.custom]] }
+  { foo: 1, Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] }
 
 *
  sync throw fails at first (*ms)

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -801,7 +801,7 @@ test('Test strict assert', () => {
     '\n' +
     '+ {}\n' +
     '- {\n' +
-    '-   [Symbol(nodejs.util.inspect.custom)]: [Function (anonymous)],\n' +
+    '-   Symbol(nodejs.util.inspect.custom): [Function (anonymous)],\n' +
     "-   loop: 'forever'\n" +
     '- }\n'
   });

--- a/test/parallel/test-console.js
+++ b/test/parallel/test-console.js
@@ -234,10 +234,10 @@ for (const expected of expectedStrings) {
 }
 
 assert.strictEqual(strings.shift(),
-                   "{\n  foo: 'bar',\n  [Symbol(nodejs.util.inspect.custom)]:" +
+                   "{\n  foo: 'bar',\n  Symbol(nodejs.util.inspect.custom):" +
                     ' [Function: [nodejs.util.inspect.custom]]\n}\n');
 assert.strictEqual(strings.shift(),
-                   "{\n  foo: 'bar',\n  [Symbol(nodejs.util.inspect.custom)]:" +
+                   "{\n  foo: 'bar',\n  Symbol(nodejs.util.inspect.custom):" +
                     ' [Function: [nodejs.util.inspect.custom]]\n}\n');
 assert.ok(strings.shift().includes('foo: [Object]'));
 assert.strictEqual(strings.shift().includes('baz'), false);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -145,7 +145,7 @@ assert.strictEqual(
     Object.assign(new String('hello'), { [Symbol('foo')]: 123 }),
     { showHidden: true }
   ),
-  "[String: 'hello'] { [length]: 5, [Symbol(foo)]: 123 }"
+  "[String: 'hello'] { [length]: 5, Symbol(foo): 123 }"
 );
 
 assert.match(util.inspect((new JSStream())._externalStream),
@@ -823,7 +823,7 @@ assert.strictEqual(util.inspect({ __proto__: Date.prototype }), 'Date {}');
 {
   const x = { [util.inspect.custom]: util.inspect };
   assert(util.inspect(x).includes(
-    '[Symbol(nodejs.util.inspect.custom)]: [Function: inspect] {\n'));
+    'Symbol(nodejs.util.inspect.custom): [Function: inspect] {\n'));
 }
 
 // `util.inspect` should display the escaped value of a key.
@@ -1045,7 +1045,7 @@ util.inspect({ hasOwnProperty: null });
   const UIC = 'nodejs.util.inspect.custom';
   assert.strictEqual(
     util.inspect(subject),
-    `{\n  a: 123,\n  [Symbol(${UIC})]: [Function: [${UIC}]]\n}`
+    `{\n  a: 123,\n  Symbol(${UIC}): [Function: [${UIC}]]\n}`
   );
 }
 
@@ -1145,27 +1145,29 @@ if (typeof Symbol !== 'undefined') {
 
   subject[Symbol('sym\nbol')] = 42;
 
-  assert.strictEqual(util.inspect(subject), '{ [Symbol(sym\\nbol)]: 42 }');
+  assert.strictEqual(util.inspect(subject), '{ Symbol(sym\\nbol): 42 }');
   assert.strictEqual(
     util.inspect(subject, options),
-    '{ [Symbol(sym\\nbol)]: 42 }'
+    '{ Symbol(sym\\nbol): 42 }'
   );
 
   Object.defineProperty(
     subject,
     Symbol(),
     { enumerable: false, value: 'non-enum' });
-  assert.strictEqual(util.inspect(subject), '{ [Symbol(sym\\nbol)]: 42 }');
+  assert.strictEqual(util.inspect(subject), '{ Symbol(sym\\nbol): 42 }');
   assert.strictEqual(
     util.inspect(subject, options),
-    "{ [Symbol(sym\\nbol)]: 42, [Symbol()]: 'non-enum' }"
+    "{ Symbol(sym\\nbol): 42, [Symbol()]: 'non-enum' }"
   );
 
   subject = [1, 2, 3];
   subject[Symbol('symbol')] = 42;
 
-  assert.strictEqual(util.inspect(subject),
-                     '[ 1, 2, 3, [Symbol(symbol)]: 42 ]');
+  assert.strictEqual(
+    util.inspect(subject),
+    '[ 1, 2, 3, Symbol(symbol): 42 ]'
+  );
 }
 
 // Test Set.
@@ -1589,7 +1591,7 @@ util.inspect(process);
   const obj = { [util.inspect.custom]: 'fhqwhgads' };
   assert.strictEqual(
     util.inspect(obj),
-    "{ [Symbol(nodejs.util.inspect.custom)]: 'fhqwhgads' }"
+    "{ Symbol(nodejs.util.inspect.custom): 'fhqwhgads' }"
   );
 }
 
@@ -1598,7 +1600,7 @@ util.inspect(process);
   const obj = { [Symbol.toStringTag]: 'a' };
   assert.strictEqual(
     util.inspect(obj),
-    "{ [Symbol(Symbol.toStringTag)]: 'a' }"
+    "{ Symbol(Symbol.toStringTag): 'a' }"
   );
   Object.defineProperty(obj, Symbol.toStringTag, {
     value: 'a',
@@ -2268,7 +2270,7 @@ assert.strictEqual(util.inspect('"\'${a}'), "'\"\\'${a}'");
   value[Symbol('foo')] = 'yeah';
   res = util.inspect(value);
   assert.notStrictEqual(res, expectedWithoutProto);
-  assert.match(res, /\[Symbol\(foo\)]: 'yeah'/);
+  assert.match(res, /Symbol\(foo\): 'yeah'/);
 });
 
 assert.strictEqual(inspect(1n), '1n');
@@ -2284,7 +2286,7 @@ assert.strictEqual(
   Object.defineProperty(obj, 'Non\nenumerable\tkey', { value: true });
   assert.strictEqual(
     util.inspect(obj, { showHidden: true }),
-    '{ [Non\\nenumerable\\tkey]: true }'
+    '{ [\'Non\\nenumerable\\tkey\']: true }'
   );
 }
 
@@ -2375,7 +2377,7 @@ assert.strictEqual(
   arr[Symbol('a')] = false;
   assert.strictEqual(
     inspect(arr, { sorted: true }),
-    '[ 3, 2, 1, [Symbol(a)]: false, [Symbol(b)]: true, a: 1, b: 2, c: 3 ]'
+    '[ 3, 2, 1, Symbol(a): false, Symbol(b): true, a: 1, b: 2, c: 3 ]'
   );
 }
 
@@ -3263,7 +3265,7 @@ assert.strictEqual(
   Object.defineProperty(o, '__proto__', { enumerable: false });
   assert.strictEqual(
     util.inspect(o, { showHidden: true }),
-    "{ ['__proto__']: { a: 1 } }"
+    "{ [['__proto__']]: { a: 1 } }"
   );
 }
 
@@ -3328,11 +3330,11 @@ assert.strictEqual(
     get [Symbol.iterator]() {
       throw new Error();
     }
-  }), '{ [Symbol(Symbol.iterator)]: [Getter] }');
+  }), '{ Symbol(Symbol.iterator): [Getter] }');
 }
 
 {
-  const sym = Symbol('bar');
+  const sym = Symbol('bar()');
   const o = {
     'foo': 0,
     'Symbol(foo)': 0,
@@ -3347,9 +3349,9 @@ assert.strictEqual(
     '{\n' +
     '  foo: 0,\n' +
     "  'Symbol(foo)': 0,\n" +
-    '  [Symbol(foo)]: 0,\n' +
-    '  [Symbol(foo())]: 0,\n' +
-    '  [Symbol(bar)]: 0\n' +
+    '  Symbol(foo): 0,\n' +
+    '  Symbol(foo()): 0,\n' +
+    '  [Symbol(bar())]: 0\n' +
     '}',
   );
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3258,6 +3258,13 @@ assert.strictEqual(
     util.inspect({ ['__proto__']: { a: 1 } }),
     "{ ['__proto__']: { a: 1 } }"
   );
+
+  const o = { ['__proto__']: { a: 1 } };
+  Object.defineProperty(o, '__proto__', { enumerable: false });
+  assert.strictEqual(
+    util.inspect(o, { showHidden: true }),
+    "{ ['__proto__']: { a: 1 } }"
+  );
 }
 
 {
@@ -3322,4 +3329,27 @@ assert.strictEqual(
       throw new Error();
     }
   }), '{ [Symbol(Symbol.iterator)]: [Getter] }');
+}
+
+{
+  const sym = Symbol('bar');
+  const o = {
+    'foo': 0,
+    'Symbol(foo)': 0,
+    [Symbol('foo')]: 0,
+    [Symbol('foo()')]: 0,
+    [sym]: 0,
+  };
+  Object.defineProperty(o, sym, { enumerable: false });
+
+  assert.strictEqual(
+    util.inspect(o, { showHidden: true }),
+    '{\n' +
+    '  foo: 0,\n' +
+    "  'Symbol(foo)': 0,\n" +
+    '  [Symbol(foo)]: 0,\n' +
+    '  [Symbol(foo())]: 0,\n' +
+    '  [Symbol(bar)]: 0\n' +
+    '}',
+  );
 }

--- a/test/parallel/test-whatwg-encoding-custom-textdecoder.js
+++ b/test/parallel/test-whatwg-encoding-custom-textdecoder.js
@@ -127,8 +127,8 @@ if (common.hasIntl) {
       '  encoding: \'utf-8\',\n' +
       '  fatal: false,\n' +
       '  ignoreBOM: true,\n' +
-      '  [Symbol(flags)]: 4,\n' +
-      '  [Symbol(handle)]: undefined\n' +
+      '  Symbol(flags): 4,\n' +
+      '  Symbol(handle): undefined\n' +
       '}'
     );
   } else {
@@ -138,10 +138,10 @@ if (common.hasIntl) {
       "  encoding: 'utf-8',\n" +
       '  fatal: false,\n' +
       '  ignoreBOM: true,\n' +
-      '  [Symbol(flags)]: 4,\n' +
-      '  [Symbol(handle)]: StringDecoder {\n' +
+      '  Symbol(flags): 4,\n' +
+      '  Symbol(handle): StringDecoder {\n' +
       "    encoding: 'utf8',\n" +
-      '    [Symbol(kNativeDecoder)]: <Buffer 00 00 00 00 00 00 01>\n' +
+      '    Symbol(kNativeDecoder): <Buffer 00 00 00 00 00 00 01>\n' +
       '  }\n' +
       '}'
     );

--- a/test/parallel/test-whatwg-url-custom-inspect.js
+++ b/test/parallel/test-whatwg-url-custom-inspect.js
@@ -45,7 +45,7 @@ assert.strictEqual(
   search: '?que=ry',
   searchParams: URLSearchParams { 'que' => 'ry' },
   hash: '#hash',
-  [Symbol(context)]: URLContext {
+  Symbol(context): URLContext {
     href: 'https://username:password@host.name:8080/path/name/?que=ry#hash',
     protocol_end: 6,
     username_end: 16,


### PR DESCRIPTION
The intention of this change is to increase consistency. Before this PR, non-enumerable string properties have square brackets, and all Symbol properties have square brackets - meaning that without color cues, there's no way to determine whether a Symbol is enumerable or not, and it can be confusing whether `[foo]` is indeed bracketed because it's non-enumerable.

Due to the following considerations:
1. minimizing disruption/changes to output
1. square brackets are already used for a number of "special" things, including a data __proto__ property, Symbol.toStringTag values, null objects, etc, so we already wouldn't be able to have square brackets mean only "computed properties"

… we decided to go with "enumerable Symbols do not have square brackets", so that all non-enumerables use square brackets.

Implements https://github.com/orgs/nodejs/discussions/41283#discussioncomment-11188239