### PR TITLE
Enabling ClangCL compilation testing

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/create-config-gypi.js
+++ b/deps/npm/node_modules/node-gyp/lib/create-config-gypi.js
@@ -96,6 +96,9 @@ async function getCurrentConfigGypi ({ gyp, nodeDir, vsInfo, python }) {
       }
     }
     variables.msbuild_path = vsInfo.msBuild
+    if (config.variables.clang === 1) {
+      config.variables.clang = 0
+    }
   }
 
   // loop through the rest of the opts and add the unknown ones as variables.

--- a/deps/v8/include/v8config.h
+++ b/deps/v8/include/v8config.h
@@ -581,10 +581,14 @@ path. Add it with -I<path> to the command line
 // functions.
 // Use like:
 //   V8_NOINLINE V8_PRESERVE_MOST void UnlikelyMethod();
+#if V8_OS_WIN
+# define V8_PRESERVE_MOST
+#else
 #if V8_HAS_ATTRIBUTE_PRESERVE_MOST
 # define V8_PRESERVE_MOST __attribute__((preserve_most))
 #else
 # define V8_PRESERVE_MOST /* NOT SUPPORTED */
+#endif
 #endif
 
 


### PR DESCRIPTION
This PR is a draft to discuss the changes needed to run test jobs in the CI for the ClangCL-produced binaries. It is not expected to land like this, just to discuss before opening production-ready PRs:

1. Enforce MSVC to be used for node-gyp. As far as I can tell, this is the intended way of using node-gyp on Windows. The issue with running the native suites is that now we use Clang to compile Node.js, so `config.variables.clang` is set to 1, which makes node-gyp generate project files for ClangCL. While we'd like to enable this, that is currently not the priority so for now enforcing MSVC would be the way to go the way I see it. The changes in `create-config-gypi.js` would be done as a PR in node-gyp and then floated in Node.js until the next node-gyp update.
2. Disable `V8_PRESERVE_MOST` on Windows. We already have something similar for `V8_NODISCARD` as a floating patch, so it should not be a problem as I see it. If left, this results in functions that use it having `__swift_2` calling conventions rather than the expected `__cdecl`. This was noticed in `cppgc-object` native suites test. This change, if agreed upon, would be come one of our V8 floating patches we use on each V8 update.

Tagging relative teams/people: @nodejs/platform-windows @nodejs/node-gyp @targos