### PR TITLE
test: ensure that CLI options are alphabetical

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -706,25 +706,6 @@ Make built-in language features like `eval` and `new Function` that generate
 code from strings throw an exception instead. This does not affect the Node.js
 `node:vm` module.
 
-### `--expose-gc`
-
-<!-- YAML
-added:
-  - v22.3.0
-  - v20.18.0
--->
-
-> Stability: 1 - Experimental. This flag is inherited from V8 and is subject to
-> change upstream.
-
-This flag will expose the gc extension from V8.
-
-```js
-if (globalThis.gc) {
-  globalThis.gc();
-}
-```
-
 ### `--dns-result-order=order`
 
 <!-- YAML
@@ -962,17 +943,6 @@ files with no extension will be treated as WebAssembly if they begin with the
 WebAssembly magic number (`\0asm`); otherwise they will be treated as ES module
 JavaScript.
 
-### `--experimental-transform-types`
-
-<!-- YAML
-added: v22.7.0
--->
-
-> Stability: 1.1 - Active development
-
-Enables the transformation of TypeScript-only syntax into JavaScript code.
-Implies `--experimental-strip-types` and `--enable-source-maps`.
-
 ### `--experimental-eventsource`
 
 <!-- YAML
@@ -1051,6 +1021,18 @@ following permissions are restricted:
 * Worker Threads - manageable through [`--allow-worker`][] flag
 * WASI - manageable through [`--allow-wasi`][] flag
 * Addons - manageable through [`--allow-addons`][] flag
+
+### `--experimental-print-required-tla`
+
+<!-- YAML
+added:
+  - v22.0.0
+  - v20.17.0
+-->
+
+If the ES module being `require()`'d contains top-level `await`, this flag
+allows Node.js to evaluate the module, try to locate the
+top-level awaits, and print their location to help users find them.
 
 ### `--experimental-require-module`
 
@@ -1166,6 +1148,17 @@ added: v22.3.0
 
 Enable [snapshot testing][] in the test runner.
 
+### `--experimental-transform-types`
+
+<!-- YAML
+added: v22.7.0
+-->
+
+> Stability: 1.1 - Active development
+
+Enables the transformation of TypeScript-only syntax into JavaScript code.
+Implies `--experimental-strip-types` and `--enable-source-maps`.
+
 ### `--experimental-vm-modules`
 
 <!-- YAML
@@ -1210,6 +1203,26 @@ added: v22.4.0
 -->
 
 Enable experimental [`Web Storage`][] support.
+
+
+### `--expose-gc`
+
+<!-- YAML
+added:
+  - v22.3.0
+  - v20.18.0
+-->
+
+> Stability: 1 - Experimental. This flag is inherited from V8 and is subject to
+> change upstream.
+
+This flag will expose the gc extension from V8.
+
+```js
+if (globalThis.gc) {
+  globalThis.gc();
+}
+```
 
 ### `--force-context-aware`
 
@@ -1918,18 +1931,6 @@ changes:
 -->
 
 Identical to `-e` but prints the result.
-
-### `--experimental-print-required-tla`
-
-<!-- YAML
-added:
-  - v22.0.0
-  - v20.17.0
--->
-
-If the ES module being `require()`'d contains top-level `await`, this flag
-allows Node.js to evaluate the module, try to locate the
-top-level awaits, and print their location to help users find them.
 
 ### `--prof`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1204,7 +1204,6 @@ added: v22.4.0
 
 Enable experimental [`Web Storage`][] support.
 
-
 ### `--expose-gc`
 
 <!-- YAML

--- a/test/parallel/test-cli-node-options-docs.js
+++ b/test/parallel/test-cli-node-options-docs.js
@@ -129,9 +129,10 @@ for (const [, envVar, config] of nodeOptionsCC.matchAll(addOptionRE)) {
   const end = /^## Environment variables/m;
   const filteredCLIText = cliText.slice(cliText.search(start), cliText.search(end)).trim();
   const cliOptionPattern = /^### `(--[a-zA-Z0-9-]+)`/mg;
-  const options = Array.from(filteredCLIText.matchAll(cliOptionPattern)).map(match => match[1]);
+  const options = Array.from(filteredCLIText.matchAll(cliOptionPattern)).map((match) => match[1]);
 
   const sortedOptions = [...options].sort();
+  /* eslint-disable no-restricted-syntax */
   assert.deepStrictEqual(options, sortedOptions, 'CLI options are not in alphabetical order');
 
 }

--- a/test/parallel/test-cli-node-options-docs.js
+++ b/test/parallel/test-cli-node-options-docs.js
@@ -123,6 +123,19 @@ for (const [, envVar, config] of nodeOptionsCC.matchAll(addOptionRE)) {
   }
 }
 
+{
+
+  const start = /^## Options/m;
+  const end = /^## Environment variables/m;
+  const filteredCLIText = cliText.slice(cliText.search(start), cliText.search(end)).trim();
+  const cliOptionPattern = /^### `(--[a-zA-Z0-9-]+)`/mg;
+  const options = Array.from(filteredCLIText.matchAll(cliOptionPattern)).map(match => match[1]);
+
+  const sortedOptions = [...options].sort();
+  assert.deepStrictEqual(options, sortedOptions, 'CLI options are not in alphabetical order');
+
+}
+
 // add alias handling
 manPagesOptions.delete('-trace-events-enabled');
 


### PR DESCRIPTION
~~Blocked by #55788~~

This PR ensures that all options documented in CLI.md are in alphabetical order.