### PR TITLE
assert: support inequalities

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -551,6 +551,30 @@ added: v0.5.9
 
 An alias of [`assert.ok()`][].
 
+## `assert.atLeast(actual, expected[, message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `actual` {number}
+* `expected` {number}
+* `message` {string|Error}
+
+Expects the `actual` input to be greater than or equal to the `expected` value.
+
+## `assert.atMost(actual, expected[, message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `actual` {number}
+* `expected` {number}
+* `message` {string|Error}
+
+Expects the `actual` input to be less than or equal to the `expected` value.
+
 ## `assert.deepEqual(actual, expected[, message])`
 
 <!-- YAML
@@ -1311,6 +1335,18 @@ parameter is undefined, a default error message is assigned. If the `message`
 parameter is an instance of an [`Error`][] then it will be thrown instead of the
 `AssertionError`.
 
+## `assert.greaterThan(actual, expected[, message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `actual` {number}
+* `expected` {number}
+* `message` {string|Error}
+
+Expects the `actual` input to be greater than the `expected` value.
+
 ## `assert.fail([message])`
 
 <!-- YAML
@@ -1449,6 +1485,18 @@ suppressFrame();
 //     at ContextifyScript.Script.runInThisContext (vm.js:44:33)
 //     ...
 ```
+
+## `assert.lessThan(actual, expected[, message])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `actual` {number}
+* `expected` {number}
+* `message` {string|Error}
+
+Expects the `actual` input to be less than the `expected` value.
 
 ## `assert.ifError(value)`
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -551,7 +551,7 @@ added: v0.5.9
 
 An alias of [`assert.ok()`][].
 
-## `assert.atLeast(actual, expected[, message])`
+## `assert.greaterThanOrEqualTo(actual, expected[, message])`
 
 <!-- YAML
 added: REPLACEME
@@ -563,7 +563,7 @@ added: REPLACEME
 
 Expects the `actual` input to be greater than or equal to the `expected` value.
 
-## `assert.atMost(actual, expected[, message])`
+## `assert.lessThanOrEqualTo(actual, expected[, message])`
 
 <!-- YAML
 added: REPLACEME

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -791,6 +791,78 @@ assert.doesNotMatch = function doesNotMatch(string, regexp, message) {
   internalMatch(string, regexp, message, doesNotMatch);
 };
 
+/**
+ * Asserts that the first number is greater than the second number.
+ * @param {number} actual
+ * @param {number} expected
+ * @param {string | Error} [message]
+ */
+assert.greaterThan = function greaterThan(actual, expected, message = `Expected ${actual} to be greater than ${expected}`) {
+  if (actual <= expected) {
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '>',
+      stackStartFn: greaterThan,
+    });
+  }
+};
+
+/**
+ * Asserts that the first number is greater than or equal to the second number.
+ * @param {number} actual
+ * @param {number} expected
+ * @param {string | Error} [message]
+ */
+assert.atLeast = function atLeast(actual, expected, message = `Expected ${actual} to be greater than or equal to ${expected}`) {
+  if (actual < expected) {
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '>=',
+      stackStartFn: atLeast,
+    });
+  }
+};
+
+/**
+ * Asserts that the first number is less than the second number.
+ * @param {number} actual
+ * @param {number} expected
+ * @param {string | Error} [message]
+ */
+assert.lessThan = function lessThan(actual, expected, message = `Expected ${actual} to be less than ${expected}`) {
+  if (actual >= expected) {
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '<',
+      stackStartFn: lessThan,
+    });
+  }
+};
+
+/**
+ * Asserts that the first number is less than or equal to the second number.
+ * @param {number} actual
+ * @param {number} expected
+ * @param {string | Error} [message]
+ */
+assert.atMost = function atMost(actual, expected, message = `Expected ${actual} to be less than or equal to ${expected}`) {
+  if (actual > expected) {
+    innerFail({
+      actual,
+      expected,
+      message,
+      operator: '<=',
+      stackStartFn: atMost,
+    });
+  }
+};
+
 assert.CallTracker = deprecate(CallTracker, 'assert.CallTracker is deprecated.', 'DEP0173');
 
 /**

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -821,7 +821,7 @@ assert.atLeast = function atLeast(actual, expected, message = `Expected ${actual
       actual,
       expected,
       message,
-      operator: '>=',
+      operator: '\u2265',
       stackStartFn: atLeast,
     });
   }
@@ -839,7 +839,7 @@ assert.lessThan = function lessThan(actual, expected, message = `Expected ${actu
       actual,
       expected,
       message,
-      operator: '<',
+      operator: '\u2264',
       stackStartFn: lessThan,
     });
   }

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -815,14 +815,14 @@ assert.greaterThan = function greaterThan(actual, expected, message = `Expected 
  * @param {number} expected
  * @param {string | Error} [message]
  */
-assert.atLeast = function atLeast(actual, expected, message = `Expected ${actual} to be greater than or equal to ${expected}`) {
+assert.greaterThanOrEqualTo = function greaterThanOrEqualTo(actual, expected, message = `Expected ${actual} to be greater than or equal to ${expected}`) {
   if (actual < expected) {
     innerFail({
       actual,
       expected,
       message,
       operator: '\u2265',
-      stackStartFn: atLeast,
+      stackStartFn: greaterThanOrEqualTo,
     });
   }
 };
@@ -851,14 +851,14 @@ assert.lessThan = function lessThan(actual, expected, message = `Expected ${actu
  * @param {number} expected
  * @param {string | Error} [message]
  */
-assert.atMost = function atMost(actual, expected, message = `Expected ${actual} to be less than or equal to ${expected}`) {
+assert.lessThanOrEqualTo = function lessThanOrEqualTo(actual, expected, message = `Expected ${actual} to be less than or equal to ${expected}`) {
   if (actual > expected) {
     innerFail({
       actual,
       expected,
       message,
       operator: '\u2264',
-      stackStartFn: atMost,
+      stackStartFn: lessThanOrEqualTo,
     });
   }
 };

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -839,7 +839,7 @@ assert.lessThan = function lessThan(actual, expected, message = `Expected ${actu
       actual,
       expected,
       message,
-      operator: '\u2264',
+      operator: '<',
       stackStartFn: lessThan,
     });
   }
@@ -857,7 +857,7 @@ assert.atMost = function atMost(actual, expected, message = `Expected ${actual} 
       actual,
       expected,
       message,
-      operator: '<=',
+      operator: '\u2264',
       stackStartFn: atMost,
     });
   }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -105,6 +105,8 @@ function lazyAssertObject(harness) {
     assertObj = new SafeMap();
     const assert = require('assert');
     const methodsToCopy = [
+      'atLeast',
+      'atMost',
       'deepEqual',
       'deepStrictEqual',
       'doesNotMatch',
@@ -112,7 +114,9 @@ function lazyAssertObject(harness) {
       'doesNotThrow',
       'equal',
       'fail',
+      'greaterThan',
       'ifError',
+      'lessThan',
       'match',
       'notDeepEqual',
       'notDeepStrictEqual',

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -105,8 +105,8 @@ function lazyAssertObject(harness) {
     assertObj = new SafeMap();
     const assert = require('assert');
     const methodsToCopy = [
-      'atLeast',
-      'atMost',
+      'greaterThanOrEqualTo',
+      'lessThanOrEqualTo',
       'deepEqual',
       'deepStrictEqual',
       'doesNotMatch',

--- a/test/parallel/test-assert-inequalities.js
+++ b/test/parallel/test-assert-inequalities.js
@@ -10,7 +10,7 @@ const testCases = {
     { actual: 3, expected: 3, shouldPass: false },
     { actual: 2, expected: 3, shouldPass: false },
   ],
-  atLeast: [
+  greaterThanOrEqualTo: [
     { actual: 5, expected: 3, shouldPass: true },
     { actual: 3, expected: 3, shouldPass: true },
     { actual: 2, expected: 3, shouldPass: false },
@@ -20,7 +20,7 @@ const testCases = {
     { actual: 3, expected: 3, shouldPass: false },
     { actual: 4, expected: 3, shouldPass: false },
   ],
-  atMost: [
+  lessThanOrEqualTo: [
     { actual: 2, expected: 3, shouldPass: true },
     { actual: 3, expected: 3, shouldPass: true },
     { actual: 4, expected: 3, shouldPass: false },
@@ -29,9 +29,9 @@ const testCases = {
 
 const comparison = {
   greaterThan: 'greater than',
-  atLeast: 'greater than or equal to',
+  greaterThanOrEqualTo: 'greater than or equal to',
   lessThan: 'less than',
-  atMost: 'less than or equal to'
+  lessThanOrEqualTo: 'less than or equal to'
 };
 
 const methods = Object.keys(testCases);

--- a/test/parallel/test-assert-inequalities.js
+++ b/test/parallel/test-assert-inequalities.js
@@ -1,0 +1,50 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const { describe, it } = require('node:test');
+
+const testCases = {
+  greaterThan: [
+    { actual: 5, expected: 3, shouldPass: true },
+    { actual: 3, expected: 3, shouldPass: false },
+    { actual: 2, expected: 3, shouldPass: false },
+  ],
+  atLeast: [
+    { actual: 5, expected: 3, shouldPass: true },
+    { actual: 3, expected: 3, shouldPass: true },
+    { actual: 2, expected: 3, shouldPass: false },
+  ],
+  lessThan: [
+    { actual: 2, expected: 3, shouldPass: true },
+    { actual: 3, expected: 3, shouldPass: false },
+    { actual: 4, expected: 3, shouldPass: false },
+  ],
+  atMost: [
+    { actual: 2, expected: 3, shouldPass: true },
+    { actual: 3, expected: 3, shouldPass: true },
+    { actual: 4, expected: 3, shouldPass: false },
+  ]
+};
+
+const comparison = {
+  greaterThan: 'greater than',
+  atLeast: 'greater than or equal to',
+  lessThan: 'less than',
+  atMost: 'less than or equal to'
+};
+
+const methods = Object.keys(testCases);
+
+for (const method of methods) {
+  describe(`assert.${method}`, () => {
+    for (const { actual, expected, shouldPass } of testCases[method]) {
+      it(`should ${shouldPass ? 'pass' : 'fail'} with (${actual}, ${expected})`, () => {
+        assert[shouldPass ? 'doesNotThrow' : 'throws'](
+          () => assert[method](actual, expected),
+          new RegExp(`Expected ${actual} to be ${comparison[method]} ${expected}`)
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
This PR introduces four new assertion methods

### Motivation

These methods align with the capabilities provided by other popular testing libraries, such as:

- **Jest**: [toBeGreaterThan](https://jestjs.io/docs/expect#tobegreaterthannumber--bigint)
- **Chai**: [above](https://www.chaijs.com/api/bdd/#method_above)
- **Vitest**: [isAbove](https://vitest.dev/api/assert.html#isabove)

While it’s possible to use standard assertions like `assert(x > y)`, dedicated methods offer more informative error messages by including displaying the values of `x` and `y` in the failure output. This saves time and effort, particularly when working with large test suites, as there’s no need to manually format output with ``assert(x > y, `${x} > ${y}`)``.