### PR TITLE
build: implement node_use_amaro flag in GN build

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -59,6 +59,9 @@ declare_args() {
   #   1. cross-os compilation is not supported.
   #   2. node_mksnapshot crashes when cross-compiling for x64 from arm64.
   node_use_node_snapshot = (host_os == target_os) && !(host_cpu == "arm64" && target_cpu == "x64")
+
+  # Build with Amaro (TypeScript utils).
+  node_use_amaro = true
 }
 
 assert(!node_enable_inspector || node_use_openssl,

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -61,6 +61,7 @@ def translate_config(out_dir, config, v8_config):
           eval(config['node_builtin_shareable_builtins']),
       'node_module_version': int(config['node_module_version']),
       'node_use_openssl': config['node_use_openssl'],
+      'node_use_amaro': config['node_use_amaro'],
       'node_use_node_code_cache': config['node_use_node_code_cache'],
       'node_use_node_snapshot': config['node_use_node_snapshot'],
       'v8_enable_inspector':  # this is actually a node misnomer

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -22,6 +22,11 @@ template("node_gn_build") {
     } else {
       defines += [ "HAVE_OPENSSL=0" ]
     }
+    if (node_use_amaro) {
+      defines += [ "HAVE_AMARO=1" ]
+    } else {
+      defines += [ "HAVE_AMARO=0" ]
+    }
     if (node_use_v8_platform) {
       defines += [ "NODE_USE_V8_PLATFORM=1" ]
     } else {


### PR DESCRIPTION
Implement the `node_use_amaro` flag in GN build, which was added to GYP build in https://github.com/nodejs/node/pull/54136.

Refs: https://github.com/nodejs/node/pull/54136