### PR TITLE
doc: correct max-semi-space-size statement

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3553,8 +3553,8 @@ improvement depends on your workload (see [#42511][]).
 
 The default value depends on the memory limit. For example, on 64-bit systems
 with a memory limit of 512 MiB, the max size of a semi-space defaults to 1 MiB.
-On 64-bit systems with a memory limit of 2 GiB, the max size of a semi-space
-defaults to 16 MiB.
+For memory limits up to and including 2GiB, the default max size of a
+semi-space will be less than 16 MiB on 64-bit systems.
 
 To get the best configuration for your application, you should try different
 max-semi-space-size values when running benchmarks for your application.


### PR DESCRIPTION
Corrects #55495 re. the `--max-semi-space-size` default behavior change after Node 18

This relates to Node 19+ so please label [dont-land-on-v18.x](https://github.com/nodejs/node/labels/dont-land-on-v18.x)

Correction: The default `max-semi-space-size` doesn't reach 16MiB until the memory limit _exceeds_ 2GiB:

```shell
docker run -it -m 2048m \
  -e NODE_OPTIONS="--max-old-space-size=1536" \
  node:20 node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'
```

=> 1560 - 1536 = 24MB = 3x max-semi-space = 8MB

```shell
docker run -it -m 2049m \
  -e NODE_OPTIONS="--max-old-space-size=1536" \
  node:20 node -e 'console.log(v8.getHeapStatistics().heap_size_limit/(1024*1024))'
```

=> 1584 - 1536 = 48MB = 3x max-semi-space = 16MB

(Relates #55487 - Please excuse the churn!)