### PR TITLE
Enhance `openDir` to Respect Buffer Size

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -43,6 +43,10 @@ class Dir {
   // Either `null` or an Array of pending operations (= functions to be called
   // once the current operation is done).
   #operationQueue = null;
+  #handlerQueue = [];
+  #isProcessing = false;
+
+
 
   constructor(handle, path, options) {
     if (handle == null) throw new ERR_MISSING_ARGS('handle');
@@ -82,27 +86,38 @@ class Dir {
 
     validateFunction(callback, 'callback');
 
-    if (this.#operationQueue !== null) {
-      ArrayPrototypePush(this.#operationQueue, () => {
+    if (this.#isProcessing) {
+      this.#handlerQueue.push(() => {
         this.#readImpl(maybeSync, callback);
       });
       return;
     }
+
+    this.#isProcessing = true;
 
     if (this.#bufferedEntries.length > 0) {
       try {
         const dirent = ArrayPrototypeShift(this.#bufferedEntries);
 
         if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+          this.#queueDirectoryRead(dirent);
         }
 
-        if (maybeSync)
-          process.nextTick(callback, null, dirent);
-        else
+        if (maybeSync) {
+          process.nextTick(() => {
+            this.#isProcessing = false;
+            this.#processNextHandler();
+            callback(null, dirent);
+          });
+        } else {
+          this.#isProcessing = false;
+          this.#processNextHandler();
           callback(null, dirent);
+        }
         return;
       } catch (error) {
+        this.#isProcessing = false;
+        this.#processNextHandler();
         return callback(error);
       }
     }
@@ -110,33 +125,74 @@ class Dir {
     const req = new FSReqCallback();
     req.oncomplete = (err, result) => {
       process.nextTick(() => {
-        const queue = this.#operationQueue;
-        this.#operationQueue = null;
-        for (const op of queue) op();
-      });
+        this.#isProcessing = false;
 
-      if (err || result === null) {
-        return callback(err, result);
-      }
-
-      try {
-        this.processReadResult(this.#path, result);
-        const dirent = ArrayPrototypeShift(this.#bufferedEntries);
-        if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+        if (err || result === null) {
+          this.#processNextHandler();
+          return callback(err, result);
         }
-        callback(null, dirent);
-      } catch (error) {
-        callback(error);
-      }
+
+        try {
+          this.processReadResult(this.#path, result);
+          const dirent = ArrayPrototypeShift(this.#bufferedEntries);
+          if (this.#options.recursive && dirent.isDirectory()) {
+            this.#queueDirectoryRead(dirent);
+          }
+          this.#processNextHandler();
+          callback(null, dirent);
+        } catch (error) {
+          this.#processNextHandler();
+          callback(error);
+        }
+      });
     };
 
-    this.#operationQueue = [];
     this.#handle.read(
       this.#options.encoding,
       this.#options.bufferSize,
       req,
     );
+  }
+
+  #queueDirectoryRead(dirent) {
+    const path = pathModule.join(dirent.parentPath, dirent.name);
+    const handle = dirBinding.opendir(
+      path,
+      this.#options.encoding,
+    );
+
+    if (handle === undefined) {
+      return;
+    }
+
+    const readNext = () => {
+      const result = handle.read(
+        this.#options.encoding,
+        this.#options.bufferSize,
+      );
+      
+      if (result) {
+        this.processReadResult(path, result);
+        this.#handlerQueue.push(readNext);
+      } else {
+        handle.close();
+      }
+    };
+
+    this.#handlerQueue.push(readNext);
+  }
+
+  #processNextHandler() {
+    if (this.#handlerQueue.length > 0 && !this.#isProcessing) {
+      this.#isProcessing = true;
+      const nextHandler = this.#handlerQueue.shift();
+      try {
+        nextHandler();
+      } finally {
+        this.#isProcessing = false;
+        process.nextTick(() => this.#processNextHandler());
+      }
+    }
   }
 
   processReadResult(path, result) {


### PR DESCRIPTION
### Issue #55764

The current `openDir` implementation does not fully respect the buffer size. This PR introduces an initial solution based on suggestions from @Ethan-Arrowood. Feedback on the concept would be appreciated.

#### PR Status
- [ ] Ready for merge? (Pending feedback)
- [ ] Is passing all the tests

#### Proposed Solution

I am currently working on a `#handlerQueue` that stores a `readNext` function. `readNext` calls `handler.read`, and if the return value is not `null`, it re-adds itself to the queue for continued processing.

**Note:** This solution might be modified or scrapped, but the aim here is to get the conversation started. And just get the work done.

#### Current Challenges
1. `handler.read` does not always populate `this.#bufferedEntries`—for instance, when a directory is empty. This creates issues with triggering `this.processNextHandler` after every yield, as it may yield nothing.
2. Determining the appropriate point to return all remaining items.
3. Handling `readSync` 
