### PR TITLE
module: avoid throwing when `findPackageJSON` is called on nonexistent

### DIFF
--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -296,6 +296,7 @@ function findPackageJSON(specifier, base = 'data:') {
     return packageJSONPath;
   }
 
+  /** @type {string} */
   let resolvedTarget;
   cascadedLoader ??= require('internal/modules/esm/loader').getOrInitializeCascadedLoader();
 
@@ -308,6 +309,8 @@ function findPackageJSON(specifier, base = 'data:') {
       throw err;
     }
   }
+
+  if (resolvedTarget == null) { return; }
 
   const pkg = getNearestParentPackageJSON(fileURLToPath(resolvedTarget));
 


### PR DESCRIPTION
The edge-case occurs when ESMLoader can't resolve the target.

The documented behaviour is already for it to return `undefined`, so this fixes a small bug.