### PR TITLE
doc: fix history info for URLSearchParams

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -775,6 +775,12 @@ Instantiate a new empty `URLSearchParams` object.
 
 #### `new URLSearchParams(string)`
 
+<!-- YAML
+added:
+  - v7.5.0
+  - v6.13.0
+-->
+
 * `string` {string} A query string
 
 Parse the `string` as a query string, and use it to instantiate a new
@@ -907,6 +913,12 @@ If `value` is not provided, removes all name-value pairs whose name is `name`.
 
 #### `urlSearchParams.entries()`
 
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
+
 * Returns: {Iterator}
 
 Returns an ES6 `Iterator` over each of the name-value pairs in the query.
@@ -918,6 +930,9 @@ Alias for [`urlSearchParams[@@iterator]()`][`urlSearchParams@@iterator()`].
 #### `urlSearchParams.forEach(fn[, thisArg])`
 
 <!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
 changes:
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
@@ -983,6 +998,12 @@ If `value` is not provided, returns `true` if there is at least one name-value
 pair whose name is `name`.
 
 #### `urlSearchParams.keys()`
+
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
 
 * Returns: {Iterator}
 
@@ -1061,6 +1082,12 @@ Returns the search parameters serialized as a string, with characters
 percent-encoded where necessary.
 
 #### `urlSearchParams.values()`
+
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
 
 * Returns: {Iterator}
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/55806
Refs: https://github.com/nodejs/node/pull/17365
Refs: https://github.com/nodejs/node/pull/9484
Refs: https://github.com/mdn/browser-compat-data/pull/24997
Refs: https://github.com/mdn/browser-compat-data/pull/24998

Add version table for:

- `new URLSearchParams(string)`
  - added in v7.5.0
  - backlogged to v6.13.0, see https://github.com/nodejs/node/pull/17365
- `URLSearchParams.prototype.{entries,forEach,keys,values}`
  - added in v7.3.0, see https://github.com/nodejs/node/pull/9484
  - backlogged to v6.13.0, see https://github.com/nodejs/node/pull/17365

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
