### PR TITLE
doc: fix history info for URLSearchParams

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -771,9 +771,21 @@ console.log(myURL.href);
 
 #### `new URLSearchParams()`
 
+<!-- YAML
+added:
+  - v7.5.0
+  - v6.13.0
+-->
+
 Instantiate a new empty `URLSearchParams` object.
 
 #### `new URLSearchParams(string)`
+
+<!-- YAML
+added:
+  - v7.5.0
+  - v6.13.0
+-->
 
 * `string` {string} A query string
 
@@ -881,6 +893,12 @@ new URLSearchParams([
 
 #### `urlSearchParams.append(name, value)`
 
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
+
 * `name` {string}
 * `value` {string}
 
@@ -889,6 +907,9 @@ Append a new name-value pair to the query string.
 #### `urlSearchParams.delete(name[, value])`
 
 <!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
 changes:
   - version:
       - v20.2.0
@@ -907,6 +928,12 @@ If `value` is not provided, removes all name-value pairs whose name is `name`.
 
 #### `urlSearchParams.entries()`
 
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
+
 * Returns: {Iterator}
 
 Returns an ES6 `Iterator` over each of the name-value pairs in the query.
@@ -918,6 +945,9 @@ Alias for [`urlSearchParams[@@iterator]()`][`urlSearchParams@@iterator()`].
 #### `urlSearchParams.forEach(fn[, thisArg])`
 
 <!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
 changes:
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
@@ -943,6 +973,12 @@ myURL.searchParams.forEach((value, name, searchParams) => {
 
 #### `urlSearchParams.get(name)`
 
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
+
 * `name` {string}
 * Returns: {string | null} A string or `null` if there is no name-value pair
   with the given `name`.
@@ -951,6 +987,12 @@ Returns the value of the first name-value pair whose name is `name`. If there
 are no such pairs, `null` is returned.
 
 #### `urlSearchParams.getAll(name)`
+
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
 
 * `name` {string}
 * Returns: {string\[]}
@@ -961,6 +1003,9 @@ no such pairs, an empty array is returned.
 #### `urlSearchParams.has(name[, value])`
 
 <!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
 changes:
   - version:
       - v20.2.0
@@ -984,6 +1029,12 @@ pair whose name is `name`.
 
 #### `urlSearchParams.keys()`
 
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
+
 * Returns: {Iterator}
 
 Returns an ES6 `Iterator` over the names of each name-value pair.
@@ -999,6 +1050,12 @@ for (const name of params.keys()) {
 ```
 
 #### `urlSearchParams.set(name, value)`
+
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
 
 * `name` {string}
 * `value` {string}
@@ -1055,6 +1112,12 @@ console.log(params.toString());
 
 #### `urlSearchParams.toString()`
 
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
+
 * Returns: {string}
 
 Returns the search parameters serialized as a string, with characters
@@ -1062,11 +1125,23 @@ percent-encoded where necessary.
 
 #### `urlSearchParams.values()`
 
+<!-- YAML
+added:
+  - v7.3.0
+  - v6.13.0
+-->
+
 * Returns: {Iterator}
 
 Returns an ES6 `Iterator` over the values of each name-value pair.
 
 #### `urlSearchParams[Symbol.iterator]()`
+
+<!-- YAML
+added:
+  - v7.0.0
+  - v6.13.0
+-->
 
 * Returns: {Iterator}
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/17365
Refs: https://github.com/nodejs/node/pull/9484
Refs: https://github.com/nodejs/node/pull/7448
Refs: https://github.com/nodejs/node/pull/10801
Refs: https://github.com/mdn/browser-compat-data/pull/24998

Add version table for:

- `new URLSearchParams(string)`
  - added in v7.5.0, taken from [bcd](https://github.com/mdn/browser-compat-data/blob/main/api/URLSearchParams.json#L119)
  - backlogged to v6.13.0, see https://github.com/nodejs/node/pull/17365
- `URLSearchParams.prototype.{entries,forEach,keys,values}`
  - added in v7.3.0, see https://github.com/nodejs/node/pull/9484
  - backlogged to v6.13.0, see https://github.com/nodejs/node/pull/17365
- other methods & properties
  - mostly added (if doesn't have version table previously) in v7.0.0, see https://github.com/nodejs/node/pull/7448, and then backlogged to v6.13.0


Test screenshots taken from https://github.com/mdn/browser-compat-data/pull/24998:

![image](https://github.com/user-attachments/assets/326c27db-4051-4113-a4c3-10306c0a9071)

![image](https://github.com/user-attachments/assets/169c96fe-ea72-460b-8ae0-0cfa307fee71)

![image](https://github.com/user-attachments/assets/1f08dad7-8c30-401c-ba66-31b984fa6c6d)

![image](https://github.com/user-attachments/assets/2d1903e4-27d6-409c-ab5a-6e704f0c677a)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
