### PR TITLE
doc: add esm examples to `node:timers`

### DIFF
--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -292,7 +292,23 @@ returned Promises will be rejected with an `'AbortError'`.
 
 For `setImmediate()`:
 
-```js
+```mjs
+import { setImmediate as setImmediatePromise } from 'node:timers/promises';
+
+const ac = new AbortController();
+const signal = ac.signal;
+
+setImmediatePromise('foobar', { signal })
+  .then(console.log)
+  .catch((err) => {
+    if (err.name === 'AbortError')
+      console.error('The immediate was aborted');
+  });
+
+ac.abort();
+```
+
+```cjs
 const { setImmediate: setImmediatePromise } = require('node:timers/promises');
 
 const ac = new AbortController();
@@ -310,7 +326,23 @@ ac.abort();
 
 For `setTimeout()`:
 
-```js
+```mjs
+import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
+
+const ac = new AbortController();
+const signal = ac.signal;
+
+setTimeoutPromise(1000, 'foobar', { signal })
+  .then(console.log)
+  .catch((err) => {
+    if (err.name === 'AbortError')
+      console.error('The timeout was aborted');
+  });
+
+ac.abort();
+```
+
+```cjs
 const { setTimeout: setTimeoutPromise } = require('node:timers/promises');
 
 const ac = new AbortController();

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -298,6 +298,7 @@ import { setImmediate as setImmediatePromise } from 'node:timers/promises';
 const ac = new AbortController();
 const signal = ac.signal;
 
+// We do not `await` the promise so `ac.abort()` is called concurrently.
 setImmediatePromise('foobar', { signal })
   .then(console.log)
   .catch((err) => {

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -333,6 +333,7 @@ import { setTimeout as setTimeoutPromise } from 'node:timers/promises';
 const ac = new AbortController();
 const signal = ac.signal;
 
+// We do not `await` the promise so `ac.abort()` is called concurrently.
 setTimeoutPromise(1000, 'foobar', { signal })
   .then(console.log)
   .catch((err) => {


### PR DESCRIPTION
The two examples for [Cancelling timers](https://nodejs.org/api/timers.html#cancelling-timers) in the Timers docs are missing their `ESM` counterparts.

This PR adds them.

Best regards :heart_hands: 

Edit: With this change all current `node:timers` examples would have their `ESM` counterparts, there are no more left