### PR TITLE
test_runner: error on mocking an already mocked date

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -328,6 +328,9 @@ class MockTimers {
   #createDate() {
     kMock ??= Symbol('MockTimers');
     const NativeDateConstructor = this.#nativeDateDescriptor.value;
+    if (NativeDateConstructor.isMock) {
+      throw new ERR_INVALID_STATE('Date is already being mocked!');
+    }
     /**
      * Function to mock the Date constructor, treats cases as per ECMA-262
      * and returns a Date object with a mocked implementation

--- a/test/parallel/test-runner-mock-timers-date.js
+++ b/test/parallel/test-runner-mock-timers-date.js
@@ -117,4 +117,11 @@ describe('Mock Timers Date Test Suite', () => {
     assert.strictEqual(fn.mock.callCount(), 0);
     clearTimeout(id);
   });
+
+  it((t) => {
+    t.mock.timers.enable();
+    t.test('should throw when a already-mocked Date is mocked', (t2) => {
+      assert.throws(() => t2.mock.timers.enable(), { code: 'ERR_INVALID_STATE' });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #55849

Previously, the properties from the global `Date`, including the not-writable `isMock` and `[kMock]` values, would be copied if the global `Date` was already mocked. This became an issue because the mock setup would attempt overwrite these properties.

Now, `ERR_INVALID_STATE` is thrown, as `Date is already being mocked!`.

## Example

```js
import { test } from 'node:test'

test((outer) => {
    outer.mock.timers.enable()
    test((inner) => inner.mock.timers.enable())
});
```

### Before
```
✖ <anonymous> (0.536701ms)
  TypeError: Cannot redefine property: Symbol(MockTimers)
      at defineProperties (<anonymous>)
      at #createDate (node:internal/test_runner/mock/mock_timers:396:5)
      at Object.Date (node:internal/test_runner/mock/mock_timers:635:45)
      at node:internal/test_runner/mock/mock_timers:659:74
      at Array.forEach (<anonymous>)
      at #toggleEnableTimers (node:internal/test_runner/mock/mock_timers:659:5)
      at MockTimers.enable (node:internal/test_runner/mock/mock_timers:740:29)
      at TestContext.<anonymous> (file:///repro.js:5:39)
      at Test.runInAsyncScope (node:async_hooks:211:14)
      at Test.run (node:internal/test_runner/test:934:25)
```

### After
```
✖ <anonymous> (0.573319ms)
  Error [ERR_INVALID_STATE]: Invalid state: Date is already being mocked!
      at #createDate (node:internal/test_runner/mock/mock_timers:332:13)
      at Object.Date (node:internal/test_runner/mock/mock_timers:638:45)
      at node:internal/test_runner/mock/mock_timers:662:74
      at Array.forEach (<anonymous>)
      at #toggleEnableTimers (node:internal/test_runner/mock/mock_timers:662:5)
      at MockTimers.enable (node:internal/test_runner/mock/mock_timers:743:29)
      at TestContext.<anonymous> (file:///repro.js:5:39)
      at Test.runInAsyncScope (node:async_hooks:211:14)
      at Test.run (node:internal/test_runner/test:934:25)
      at Test.start (node:internal/test_runner/test:833:17) {
    code: 'ERR_INVALID_STATE'
  }
```