### PR TITLE
fs: remove `fs.F_OK`, `fs.R_OK`, `fs.W_OK`, `fs.X_OK`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3578,6 +3578,9 @@ The [`util.toUSVString()`][] API is deprecated. Please use
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/49686
     description: Runtime deprecation.
   - version: v20.8.0
@@ -3585,10 +3588,10 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-`F_OK`, `R_OK`, `W_OK` and `X_OK` getters exposed directly on `node:fs` are
-deprecated. Get them from `fs.constants` or `fs.promises.constants` instead.
+`F_OK`, `R_OK`, `W_OK` and `X_OK` getters exposed directly on `node:fs` were
+removed. Get them from `fs.constants` or `fs.promises.constants` instead.
 
 ### DEP0177: `util.types.isWebAssemblyCompiledModule`
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3578,7 +3578,7 @@ The [`util.toUSVString()`][] API is deprecated. Please use
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/55862
     description: End-of-Life.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/49686

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1920,6 +1920,10 @@ concurrent modifications on the same file or data corruption may occur.
 <!-- YAML
 added: v0.11.15
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: The constants `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`
+                 which were present directly on `fs` are removed.
   - version: v20.8.0
     pr-url: https://github.com/nodejs/node/pull/49683
     description: The constants `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1921,7 +1921,7 @@ concurrent modifications on the same file or data corruption may occur.
 added: v0.11.15
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/55862
     description: The constants `fs.F_OK`, `fs.R_OK`, `fs.W_OK` and `fs.X_OK`
                  which were present directly on `fs` are removed.
   - version: v20.8.0

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -52,9 +52,6 @@ const {
   S_IFREG,
   S_IFSOCK,
   F_OK,
-  R_OK,
-  W_OK,
-  X_OK,
   O_WRONLY,
   O_SYMLINK,
 } = constants;
@@ -87,7 +84,6 @@ const {
 const { toPathIfFileURL } = require('internal/url');
 const {
   customPromisifyArgs: kCustomPromisifyArgsSymbol,
-  deprecate,
   emitExperimentalWarning,
   getLazy,
   kEmptyObject,
@@ -3275,50 +3271,6 @@ defineLazyProperties(
 );
 
 ObjectDefineProperties(fs, {
-  F_OK: {
-    __proto__: null,
-    enumerable: false,
-    get: deprecate(
-      function get() {
-        return F_OK || 0;
-      },
-      'fs.F_OK is deprecated, use fs.constants.F_OK instead',
-      'DEP0176',
-    ),
-  },
-  R_OK: {
-    __proto__: null,
-    enumerable: false,
-    get: deprecate(
-      function get() {
-        return R_OK || 0;
-      },
-      'fs.R_OK is deprecated, use fs.constants.R_OK instead',
-      'DEP0176',
-    ),
-  },
-  W_OK: {
-    __proto__: null,
-    enumerable: false,
-    get: deprecate(
-      function get() {
-        return W_OK || 0;
-      },
-      'fs.W_OK is deprecated, use fs.constants.W_OK instead',
-      'DEP0176',
-    ),
-  },
-  X_OK: {
-    __proto__: null,
-    enumerable: false,
-    get: deprecate(
-      function get() {
-        return X_OK || 0;
-      },
-      'fs.X_OK is deprecated, use fs.constants.X_OK instead',
-      'DEP0176',
-    ),
-  },
   constants: {
     __proto__: null,
     configurable: false,

--- a/test/parallel/test-fs-constants.js
+++ b/test/parallel/test-fs-constants.js
@@ -1,27 +1,8 @@
 'use strict';
-const { expectWarning } = require('../common');
+require('../common');
 const fs = require('fs');
 const assert = require('assert');
 
 // Check if the two constants accepted by chmod() on Windows are defined.
 assert.notStrictEqual(fs.constants.S_IRUSR, undefined);
 assert.notStrictEqual(fs.constants.S_IWUSR, undefined);
-
-// Check for runtime deprecation warning, there should be no setter
-const { F_OK, R_OK, W_OK, X_OK } = fs.constants;
-
-assert.throws(() => { fs.F_OK = 'overwritten'; }, { name: 'TypeError' });
-assert.throws(() => { fs.R_OK = 'overwritten'; }, { name: 'TypeError' });
-assert.throws(() => { fs.W_OK = 'overwritten'; }, { name: 'TypeError' });
-assert.throws(() => { fs.X_OK = 'overwritten'; }, { name: 'TypeError' });
-
-expectWarning(
-  'DeprecationWarning',
-  'fs.F_OK is deprecated, use fs.constants.F_OK instead',
-  'DEP0176'
-);
-
-assert.strictEqual(fs.F_OK, F_OK);
-assert.strictEqual(fs.R_OK, R_OK);
-assert.strictEqual(fs.W_OK, W_OK);
-assert.strictEqual(fs.X_OK, X_OK);


### PR DESCRIPTION
Follow-up from: https://github.com/nodejs/node/pull/49686 (runtime deprecation)