### PR TITLE
doc,lib,src,test: unflag sqlite module

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1065,14 +1065,6 @@ added:
 
 Use this flag to enable [ShadowRealm][] support.
 
-### `--experimental-sqlite`
-
-<!-- YAML
-added: v22.5.0
--->
-
-Enable the experimental [`node:sqlite`][] module.
-
 ### `--experimental-strip-types`
 
 <!-- YAML
@@ -1692,6 +1684,18 @@ changes:
 Disable support for loading a synchronous ES module graph in `require()`.
 
 See [Loading ECMAScript modules using `require()`][].
+
+### `--no-experimental-sqlite`
+
+<!-- YAML
+added: v22.5.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/55890
+    description: SQLite is unflagged but still experimental.
+-->
+
+Disable the experimental [`node:sqlite`][] module.
 
 ### `--no-experimental-websocket`
 
@@ -3043,7 +3047,6 @@ one is included in the list below.
 * `--experimental-require-module`
 * `--experimental-shadow-realm`
 * `--experimental-specifier-resolution`
-* `--experimental-sqlite`
 * `--experimental-strip-types`
 * `--experimental-top-level-await`
 * `--experimental-transform-types`
@@ -3080,6 +3083,7 @@ one is included in the list below.
 * `--no-deprecation`
 * `--no-experimental-global-navigator`
 * `--no-experimental-repl-await`
+* `--no-experimental-sqlite`
 * `--no-experimental-websocket`
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -6,8 +6,7 @@
 added: v22.5.0
 -->
 
-> Stability: 1.1 - Active development. Enable this API with the
-> [`--experimental-sqlite`][] CLI flag.
+> Stability: 1.1 - Active development.
 
 <!-- source_link=lib/sqlite.js -->
 
@@ -412,7 +411,6 @@ The following constants are meant for use with [`database.applyChangeset()`](#da
 
 [Changesets and Patchsets]: https://www.sqlite.org/sessionintro.html#changesets_and_patchsets
 [SQL injection]: https://en.wikipedia.org/wiki/SQL_injection
-[`--experimental-sqlite`]: cli.md#--experimental-sqlite
 [`ATTACH DATABASE`]: https://www.sqlite.org/lang_attach.html
 [`PRAGMA foreign_keys`]: https://www.sqlite.org/pragma.html#pragma_foreign_keys
 [`sqlite3_changes64()`]: https://www.sqlite.org/c3ref/changes.html

--- a/doc/node.1
+++ b/doc/node.1
@@ -182,9 +182,6 @@ Enable the experimental permission model.
 .It Fl -experimental-shadow-realm
 Use this flag to enable ShadowRealm support.
 .
-.It Fl -experimental-sqlite
-Enable the experimental node:sqlite module.
-.
 .It Fl -experimental-test-coverage
 Enable code coverage in the test runner.
 .
@@ -214,6 +211,9 @@ Enable experimental support for the Web Storage API.
 .
 .It Fl -no-experimental-repl-await
 Disable top-level await keyword support in REPL.
+.
+.It Fl -no-experimental-sqlite
+Disable the experimental node:sqlite module.
 .
 .It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -303,7 +303,7 @@ function setupNavigator() {
 }
 
 function setupSQLite() {
-  if (!getOptionValue('--experimental-sqlite')) {
+  if (getOptionValue('--no-experimental-sqlite')) {
     return;
   }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -427,7 +427,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-sqlite",
             "experimental node:sqlite module",
             &EnvironmentOptions::experimental_sqlite,
-            kAllowedInEnvvar);
+            kAllowedInEnvvar,
+            true);
   AddOption("--experimental-webstorage",
             "experimental Web Storage API",
             &EnvironmentOptions::experimental_webstorage,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -123,7 +123,7 @@ class EnvironmentOptions : public Options {
   bool experimental_eventsource = false;
   bool experimental_fetch = true;
   bool experimental_websocket = true;
-  bool experimental_sqlite = false;
+  bool experimental_sqlite = true;
   bool experimental_webstorage = false;
   std::string localstorage_file;
   bool experimental_global_navigator = true;

--- a/test/parallel/test-sqlite-data-types.js
+++ b/test/parallel/test-sqlite-data-types.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-sqlite-named-parameters.js
+++ b/test/parallel/test-sqlite-named-parameters.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-sqlite-transactions.js
+++ b/test/parallel/test-sqlite-transactions.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -1,4 +1,3 @@
-// Flags: --experimental-sqlite
 'use strict';
 const { spawnPromisified } = require('../common');
 const tmpdir = require('../common/tmpdir');
@@ -23,13 +22,14 @@ suite('accessing the node:sqlite module', () => {
     });
   });
 
-  test('cannot be accessed without --experimental-sqlite flag', async (t) => {
+  test('can be disabled with --no-experimental-sqlite flag', async (t) => {
     const {
       stdout,
       stderr,
       code,
       signal,
     } = await spawnPromisified(process.execPath, [
+      '--no-experimental-sqlite',
       '-e',
       'require("node:sqlite")',
     ]);


### PR DESCRIPTION
As requested in #55854...

This commit allows the node:sqlite module to be used without starting Node with a CLI flag. The module is still experimental.

Fixes: https://github.com/nodejs/node/issues/55854

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
