### PR TITLE
doc: fixing the crc32 function on documentation

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -696,7 +696,67 @@ The `zlib.bytesWritten` property specifies the number of bytes written to
 the engine, before the bytes are processed (compressed or decompressed,
 as appropriate for the derived class).
 
-### `zlib.crc32(data[, value])`
+### `zlib.close([callback])`
+
+<!-- YAML
+added: v0.9.4
+-->
+
+* `callback` {Function}
+
+Close the underlying handle.
+
+### `zlib.flush([kind, ]callback)`
+
+<!-- YAML
+added: v0.5.8
+-->
+
+* `kind` **Default:** `zlib.constants.Z_FULL_FLUSH` for zlib-based streams,
+  `zlib.constants.BROTLI_OPERATION_FLUSH` for Brotli-based streams.
+* `callback` {Function}
+
+Flush pending data. Don't call this frivolously, premature flushes negatively
+impact the effectiveness of the compression algorithm.
+
+Calling this only flushes data from the internal `zlib` state, and does not
+perform flushing of any kind on the streams level. Rather, it behaves like a
+normal call to `.write()`, i.e. it will be queued up behind other pending
+writes and will only produce output when data is being read from the stream.
+
+### `zlib.params(level, strategy, callback)`
+
+<!-- YAML
+added: v0.11.4
+-->
+
+* `level` {integer}
+* `strategy` {integer}
+* `callback` {Function}
+
+This function is only available for zlib-based streams, i.e. not Brotli.
+
+Dynamically update the compression level and compression strategy.
+Only applicable to deflate algorithm.
+
+### `zlib.reset()`
+
+<!-- YAML
+added: v0.7.0
+-->
+
+Reset the compressor/decompressor to factory defaults. Only applicable to
+the inflate and deflate algorithms.
+
+## `zlib.constants`
+
+<!-- YAML
+added: v7.0.0
+-->
+
+Provides an object enumerating Zlib-related constants.
+
+## `zlib.crc32(data[, value])`
 
 <!-- YAML
 added:
@@ -758,66 +818,6 @@ crc = zlib.crc32('world', crc);  // 4192936109
 crc = zlib.crc32(Buffer.from('hello', 'utf16le'));  // 1427272415
 crc = zlib.crc32(Buffer.from('world', 'utf16le'), crc);  // 4150509955
 ```
-
-### `zlib.close([callback])`
-
-<!-- YAML
-added: v0.9.4
--->
-
-* `callback` {Function}
-
-Close the underlying handle.
-
-### `zlib.flush([kind, ]callback)`
-
-<!-- YAML
-added: v0.5.8
--->
-
-* `kind` **Default:** `zlib.constants.Z_FULL_FLUSH` for zlib-based streams,
-  `zlib.constants.BROTLI_OPERATION_FLUSH` for Brotli-based streams.
-* `callback` {Function}
-
-Flush pending data. Don't call this frivolously, premature flushes negatively
-impact the effectiveness of the compression algorithm.
-
-Calling this only flushes data from the internal `zlib` state, and does not
-perform flushing of any kind on the streams level. Rather, it behaves like a
-normal call to `.write()`, i.e. it will be queued up behind other pending
-writes and will only produce output when data is being read from the stream.
-
-### `zlib.params(level, strategy, callback)`
-
-<!-- YAML
-added: v0.11.4
--->
-
-* `level` {integer}
-* `strategy` {integer}
-* `callback` {Function}
-
-This function is only available for zlib-based streams, i.e. not Brotli.
-
-Dynamically update the compression level and compression strategy.
-Only applicable to deflate algorithm.
-
-### `zlib.reset()`
-
-<!-- YAML
-added: v0.7.0
--->
-
-Reset the compressor/decompressor to factory defaults. Only applicable to
-the inflate and deflate algorithms.
-
-## `zlib.constants`
-
-<!-- YAML
-added: v7.0.0
--->
-
-Provides an object enumerating Zlib-related constants.
 
 ## `zlib.createBrotliCompress([options])`
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

In this PR I'm adjusing the documentation of zlib. The crc32 is not a method of ZlibBase. It is a standalone function of the module.
Mentioned in [55800](https://github.com/nodejs/node/issues/55800)

@RedYetiDev @ErickWendel @aduh95