### PR TITLE
build: allow unbundling of Node.js dependencies

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -62,6 +62,12 @@ declare_args() {
 
   # Build with Amaro (TypeScript utils).
   node_use_amaro = true
+
+  # Allows downstream packagers (eg. Linux distributions) to build against system shared libraries.
+  use_system_cares = false
+  use_system_nghttp2 = false
+  use_system_llhttp = false
+  use_system_histogram = false
 }
 
 assert(!node_enable_inspector || node_use_openssl,

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -150,9 +150,6 @@ template("node_gn_build") {
     ]
     deps = [
       ":run_node_js2c",
-      "deps/brotli",
-      "deps/cares",
-      "deps/histogram",
       "deps/nbytes",
       "deps/nghttp2",
       "deps/ngtcp2",

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -153,7 +153,6 @@ template("node_gn_build") {
       "deps/brotli",
       "deps/cares",
       "deps/histogram",
-      "deps/llhttp",
       "deps/nbytes",
       "deps/nghttp2",
       "deps/ngtcp2",
@@ -179,7 +178,17 @@ template("node_gn_build") {
       configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
       configs += [ "//build/config/gcc:symbol_visibility_default" ]
     }
-
+    if (use_system_llhttp) {
+      libs += [ "llhttp" ]
+    } else {
+      deps += [ "deps/llhttp" ]
+    }
+    if (use_system_histogram) {
+      libs += [ "hdr_histogram" ]
+      include_dirs += [ "/usr/include/hdr" ]
+    } else {
+      deps += [ "deps/histogram" ]
+    }
     if (v8_enable_i18n_support) {
       deps += [ "//third_party/icu" ]
     }
@@ -205,6 +214,19 @@ template("node_gn_build") {
           [ "src/inspector/node_inspector.gypi" ])
       sources += node_inspector.node_inspector_sources +
                  node_inspector.node_inspector_generated_sources
+    }
+    if (is_linux) {
+      import("//build/config/linux/pkg_config.gni")
+        if (use_system_cares) {
+          pkg_config("cares") {
+            packages = [ "libcares" ]
+          }
+        }
+      if (use_system_nghttp2) {
+        pkg_config("nghttp2") {
+          packages = [ "libnghttp2" ]
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Refs https://github.com/electron/electron/issues/44691

Linux distributions have guidelines on using distro-provided dependencies, rather than compiling them in statically - Electron already did this via https://github.com/electron/electron/pull/34841 until we ingested Node.js' GN support, which didn't contain this. 

This PR this enables downstream packagers to unbundle these dependencies. We don't need to do this for zlib, as the existing gn workflow uses the same `//third_party/zlib`, so unbundling zlib with Chromium tools in `//build/linux/unbundle` works already. This adds support for some of the others.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
