### PR TITLE
test: add fast api tests for getLibuvNow()

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -1,5 +1,7 @@
 #include "timers.h"
+
 #include "env-inl.h"
+#include "node_debug.h"
 #include "node_external_reference.h"
 #include "util-inl.h"
 #include "v8.h"
@@ -35,6 +37,7 @@ void BindingData::SlowGetLibuvNow(const FunctionCallbackInfo<Value>& args) {
 
 double BindingData::FastGetLibuvNow(Local<Object> unused,
                                     Local<Object> receiver) {
+  TRACK_V8_FAST_API_CALL("timers.getLibuvNow");
   return GetLibuvNowImpl(FromJSObject<BindingData>(receiver));
 }
 

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -1,11 +1,32 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
 'use strict';
-// Flags: --expose-internals
 
-require('../common');
-const assert = require('assert');
+const common = require('../common');
+const assert = require('node:assert');
 const { internalBinding } = require('internal/test/binding');
 const binding = internalBinding('timers');
 
 // Return value of getLibuvNow() should easily fit in a SMI after start-up.
 // We need to use the binding as the receiver for fast API calls.
 assert(binding.getLibuvNow() < 0x3ffffff);
+
+{
+  // V8 Fast API
+  function optimized() { // eslint-disable-line no-unused-vars
+    return binding.getLibuvNow();
+  }
+
+  function testFastPaths() {
+    assert(binding.getLibuvNow() < 0x3ffffff);
+  }
+
+  eval('%PrepareFunctionForOptimization(optimized)');
+  testFastPaths();
+  eval('%OptimizeFunctionOnNextCall(optimized)');
+  testFastPaths();
+
+  if (common.isDebug) {
+    const { getV8FastApiCallCount } = internalBinding('debug');
+    assert.strictEqual(getV8FastApiCallCount('timers.getLibuvNow'), 1);
+  }
+}


### PR DESCRIPTION
Adds a V8 fast api test for `binding.getLibuvNow()` function.

cc @nodejs/cpp-reviewers 