### PR TITLE
bootstrap: expose process._rawDebug as a global function

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -464,7 +464,7 @@ function setupBuffer() {
 }
 
 function setupGlobalDebug() {
-  let _process = process;
+  const _process = process;
   ObjectDefineProperty(globalThis, 'rawDebug', {
     __proto__: null,
     get() {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -86,6 +86,7 @@ setupProcessObject();
 
 setupGlobalProxy();
 setupBuffer();
+setupGlobalDebug();
 
 process.domain = null;
 
@@ -456,6 +457,21 @@ function setupBuffer() {
     },
     set(value) {
       _Buffer = value;
+    },
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+function setupGlobalDebug() {
+  let _process = process;
+  ObjectDefineProperty(globalThis, 'rawDebug', {
+    __proto__: null,
+    get() {
+      return _process._rawDebug;
+    },
+    set(value) {
+      _process._rawDebug = value;
     },
     enumerable: false,
     configurable: true,

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -464,14 +464,14 @@ function setupBuffer() {
 }
 
 function setupGlobalDebug() {
-  const _process = process;
+  let _rawDebug = process._rawDebug;
   ObjectDefineProperty(globalThis, 'rawDebug', {
     __proto__: null,
     get() {
-      return _process._rawDebug;
+      return _rawDebug;
     },
     set(value) {
-      _process._rawDebug = value;
+      _rawDebug = value;
     },
     enumerable: false,
     configurable: true,

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -136,7 +136,7 @@ const nodeGlobals = new Set([
   'Buffer',
   'clearImmediate',
   'setImmediate',
-  'rawDebug'
+  'rawDebug',
 ]);
 
 module.exports = {

--- a/test/common/globals.js
+++ b/test/common/globals.js
@@ -136,6 +136,7 @@ const nodeGlobals = new Set([
   'Buffer',
   'clearImmediate',
   'setImmediate',
+  'rawDebug'
 ]);
 
 module.exports = {

--- a/test/parallel/test-bootstrap-rawdebug.js
+++ b/test/parallel/test-bootstrap-rawdebug.js
@@ -5,3 +5,7 @@ const assert = require('assert');
 
 common.allowGlobals('rawDebug');
 assert.strictEqual(typeof global.rawDebug === 'function', true);
+assert.strictEqual(global.rawDebug === process._rawDebug, true);
+
+global.rawDebug = 42;
+assert.strictEqual(global.rawDebug === 42, true);

--- a/test/parallel/test-bootstrap-rawdebug.js
+++ b/test/parallel/test-bootstrap-rawdebug.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 
 common.allowGlobals('rawDebug');
 assert.strictEqual(typeof global.rawDebug === 'function', true);
-assert.strictEqual(global.rawDebug === process._rawDebug, true);
 
 global.rawDebug = 42;
 assert.strictEqual(global.rawDebug === 42, true);

--- a/test/parallel/test-bootstrap-rawdebug.js
+++ b/test/parallel/test-bootstrap-rawdebug.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+assert.equal(typeof rawDebug === 'function', true);

--- a/test/parallel/test-bootstrap-rawdebug.js
+++ b/test/parallel/test-bootstrap-rawdebug.js
@@ -3,4 +3,5 @@
 const common = require('../common');
 const assert = require('assert');
 
-assert.equal(typeof rawDebug === 'function', true);
+common.allowGlobals('rawDebug');
+assert.strictEqual(typeof global.rawDebug === 'function', true);


### PR DESCRIPTION
The `process._rawDebug` function is very helpful when triaging bugs that cross asynchronous boundaries. It is also quite cumbersome to write out `process._rawDebug` everywhere such a line is needed. So this change exposes it as a global function to facilitate an improved
developer experience.

If we think that a naming collision is possible, maybe it could be named `nodeDebug` or similar.
