### PR TITLE
test_runner: print coverage threshold errors in red

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -69,6 +69,7 @@ const { TIMEOUT_MAX } = require('internal/timers');
 const { fileURLToPath } = require('internal/url');
 const { availableParallelism } = require('os');
 const { innerOk } = require('internal/assert/utils');
+const { red, reset } = require('internal/util/colors');
 const { bigint: hrtime } = process.hrtime;
 const kCallbackAndPromisePresent = 'callbackAndPromisePresent';
 const kCancelledByParent = 'cancelledByParent';
@@ -1089,7 +1090,10 @@ class Test extends AsyncResource {
           if (actual < threshold) {
             harness.success = false;
             process.exitCode = kGenericUserError;
-            reporter.diagnostic(nesting, loc, `Error: ${NumberPrototypeToFixed(actual, 2)}% ${name} coverage does not meet threshold of ${threshold}%.`);
+            reporter.diagnostic(nesting,
+                                loc,
+                                `${red}Error: ${NumberPrototypeToFixed(actual, 2)}% ${name} ` +
+                                `coverage does not meet threshold of ${threshold}%.${reset}`);
           }
         }
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/help/issues/4504 by printing coverage threshold errors in **red**.