### PR TITLE
build: use variable for OpenSSL dep path

### DIFF
--- a/deps/ncrypto/unofficial.gni
+++ b/deps/ncrypto/unofficial.gni
@@ -27,6 +27,6 @@ template("ncrypto_gn_build") {
     forward_variables_from(invoker, "*")
     public_configs = [ ":ncrypto_config" ]
     sources = gypi_values.ncrypto_sources
-    deps = [ "../openssl" ]
+    deps = [ "$node_openssl_path" ]
   }
 }

--- a/node.gni
+++ b/node.gni
@@ -10,6 +10,8 @@ declare_args() {
   # The location of V8, use the one from node's deps by default.
   node_v8_path = "$node_path/deps/v8"
 
+  node_openssl_path = "$node_path/deps/openssl"
+
   # The NODE_MODULE_VERSION defined in node_version.h.
   node_module_version = exec_script("$node_path/tools/getmoduleversion.py", [], "value")
 

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -185,7 +185,7 @@ template("node_gn_build") {
     }
     if (node_use_openssl) {
       deps += [ "deps/ncrypto" ]
-      public_deps += [ "deps/openssl" ]
+      public_deps += [ "$node_openssl_path" ]
       sources += gypi_values.node_crypto_sources
     }
     if (node_enable_inspector) {


### PR DESCRIPTION
Allow customizing the path to Node.js crypto in the GN build

For Electron it'd be e.g. `/third_party/boringssl`.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
