### PR TITLE
build: avoid compiling with VS v17.12

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -292,9 +292,18 @@ goto exit
 @rem Visual Studio v17.10 has a bug that causes the build to fail.
 @rem Check if the version is v17.10 and exit if it is.
 echo %VSCMD_VER% | findstr /b /c:"17.10" >nul
-if %errorlevel% neq 1  (
+if %errorlevel% neq 1 (
   echo Node.js doesn't compile with Visual Studio 17.10 Please use a different version.
   goto exit
+)
+@rem Same applies to v17.12 for MSVC.
+echo %VSCMD_VER% | findstr /b /c:"17.12" >nul
+if %errorlevel% neq 1 (
+  @rem Clang 18.1.8 Provided with VS 17.12 works fine.
+  if not defined clang_cl (
+    echo Node.js doesn't compile with Visual Studio 17.12 Please use a different version.
+    goto exit
+  )
 )
 
 @rem check if the clang-cl build is requested


### PR DESCRIPTION
Visual Studio v17.12 has a bug that produces a compilation error. Since ClangCL is now supported as a compiler for Node.js on Windows, and Clang 18.1.8, provided with VS 17.12, works fine, Only MSVC is disabled.

cc @nodejs/platform-windows @nodejs/build @huseyinacacak-janea 

Refs: https://github.com/nodejs/build/issues/3963
Refs: https://github.com/nodejs/node/pull/53863