### PR TITLE
doc: fix Node.js 23 column in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
   <th title="LTS Until 2025-04"><a href="doc/changelogs/CHANGELOG_V18.md">18</a> (LTS)</th>
 </tr>
 <tr>
+  <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V23.md#23.3.0">23.3.0</a></b><br/>
 <a href="doc/changelogs/CHANGELOG_V23.md#23.2.0">23.2.0</a><br/>
 <a href="doc/changelogs/CHANGELOG_V23.md#23.1.0">23.1.0</a><br/>


### PR DESCRIPTION
The column for Node.js 23 in `CHANGELOG.md` is missing an opening `<td>` tag so was not correctly rendering.

---

* Before
![image](https://github.com/user-attachments/assets/ba337565-7b5d-4efe-8127-0a31b400c48f)

* After
![image](https://github.com/user-attachments/assets/3ebd177d-65fc-4b9c-aca3-02fd1a289e76)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
