### PR TITLE
src,lib: handle invalid stdio configuration gracefully

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -427,6 +427,13 @@ ChildProcess.prototype.spawn = function(options) {
 
   for (i = 0; i < stdio.length; i++) {
     const stream = stdio[i];
+    // Never trust the user input/runtime
+    // Refs: https://github.com/nodejs/node/issues/55932
+    if (!stream) {
+      process.nextTick(onErrorNT, this, UV_EINVAL);
+      return UV_EINVAL;
+    }
+
     if (stream.type === 'ignore') continue;
 
     if (stream.ipc) {

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -26,6 +26,7 @@
 #include "stream_wrap.h"
 #include "util-inl.h"
 
+#include <stdio.h>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
@@ -122,6 +123,16 @@ class ProcessWrap : public HandleWrap {
     for (uint32_t i = 0; i < len; i++) {
       Local<Object> stdio =
           stdios->Get(context, i).ToLocalChecked().As<Object>();
+
+      // Never trust the user.
+      // Refs: https://github.com/nodejs/node/issues/55932
+      if (!stdio->IsObject()) {
+        stdio = Object::New(env->isolate());
+        stdio->Set(context,
+                   env->type_string(),
+                   env->ignore_string()).FromJust();
+      }
+
       Local<Value> type =
           stdio->Get(context, env->type_string()).ToLocalChecked();
 

--- a/test/parallel/test-child-process-muted-array-proto.js
+++ b/test/parallel/test-child-process-muted-array-proto.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+
+// The UNIX version of this test is enough.
+if (common.isWindows) {
+  common.skip('This test is enough for Unix-like systems');
+  return;
+}
+
+// Refs: https://github.com/nodejs/node/issues/55932
+Object.defineProperty(Array.prototype, '0', {
+  set() {
+    console.log(123);
+  },
+  get() {
+    return 123;
+  }
+}, { configurable: true, writable: true });
+
+const cp = spawn('ls');
+
+// Can't use common.mustCall() here because array prototype is mutated.
+cp.on('error', (err) => {
+  assert.strictEqual(err.code, 'EINVAL');
+});


### PR DESCRIPTION
Fixes an issue where malformed or unexpected stdio configurations could cause crashes or undefined behavior during child process spawning. This patch ensures robust validation of stdio entries:

Fixes: https://github.com/nodejs/node/issues/55932

---
I don't think we should patch user-space misconfiguration. This is a rare case and, could be extrapolated to different issues. I never faced an issue due to proto mutation. But I personally don't think we should patch that (except for the native layer.)