### PR TITLE
tools: filter release keys to reduce interactivity

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -58,7 +58,7 @@ echo "# Selecting GPG key ..."
 if [ -z "$allPGPKeys" ]; then
   gpgkey="$(awk '{
     if ($1 == "gpg" && $2 == "--keyserver" && $4 == "--recv-keys" && (1 == 2'"$(
-      gpg --list-secret-keys | awk -F' = ' '/^ +Key fingerprint/{ print " || $5 == \"" $2 "\"" }' | tr -d ' ' || true
+      gpg --list-secret-keys | awk -F' = ' '/^ +Key fingerprint/{ gsub(/ /,"",$2); print " || $5 == \"" $2 "\"" }' || true
     )"')) { print substr($5, 33) }
   }' "$readmePath")"
 else
@@ -87,7 +87,7 @@ elif [ "$keycount" -ne 1 ]; then
   gpgkey=$(echo "$gpgkey" | sed -n "${keynum}p")
 fi
 
-gpgfing=$(gpg --keyid-format 0xLONG --fingerprint "$gpgkey" | grep 'Key fingerprint =' | awk -F' = ' '{print $2}' | tr -d ' ')
+gpgfing=$(gpg --keyid-format 0xLONG --fingerprint "$gpgkey" | awk -F' = ' '/^ +Key fingerprint/{gsub(/ /,"",$2);print $2}')
 
 grep -q "$gpgfing" "$readmePath" || {
   echo "Error: this GPG key fingerprint is not listed in $readmePath"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -58,7 +58,7 @@ echo "# Selecting GPG key ..."
 if [ -z "$allPGPKeys" ]; then
   gpgkey="$(awk '{
     if ($1 == "gpg" && $2 == "--keyserver" && $4 == "--recv-keys" && (1 == 2'"$(
-      gpg --list-secret-keys | grep 'Key fingerprint =' | awk -F' = ' '{ print " || $5 == \"" $2 "\"" }' | tr -d ' '
+      gpg --list-secret-keys | awk -F' = ' '/^ +Key fingerprint/{ print " || $5 == \"" $2 "\"" }' | tr -d ' ' || true
     )"')) { print substr($5, 33) }
   }' "$readmePath")"
 else


### PR DESCRIPTION
I might be wrong, but I think most releasers use the primary key that's listed in the README, so we can make the script autoselect it by default, reducing the need for the releaser to interact with the script when selecting the key.

/cc @nodejs/releasers 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
