### PR TITLE
build: ignore changes in docs

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,6 +15,8 @@ on:
       - v[0-9]+.x
     paths-ignore:
       - README.md
+      - doc/**/*.md
+      - !doc/api/cli.md
       - .github/**
       - '!.github/workflows/test-linux.yml'
 


### PR DESCRIPTION
When only documentation is changed, running tests may not be necessary. Perhaps we could consider skipping them in such cases.