### PR TITLE
test_runner: add level-based diagnostic handling for reporter

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -44,15 +44,27 @@ class SpecReporter extends Transform {
       assert(parent.type === 'test:start');
       const msg = parent.data;
       ArrayPrototypeUnshift(this.#reported, msg);
-      prefix += `${indent(msg.nesting)}${reporterUnicodeSymbolMap['arrow:right']}${msg.name}\n`;
+      prefix += `${indent(msg.nesting)}${
+        reporterUnicodeSymbolMap['arrow:right']
+      }${msg.name}\n`;
     }
     let hasChildren = false;
-    if (this.#reported[0] && this.#reported[0].nesting === data.nesting && this.#reported[0].name === data.name) {
+    if (
+      this.#reported[0] &&
+      this.#reported[0].nesting === data.nesting &&
+      this.#reported[0].name === data.name
+    ) {
       ArrayPrototypeShift(this.#reported);
       hasChildren = true;
     }
     const indentation = indent(data.nesting);
-    return `${formatTestReport(type, data, prefix, indentation, hasChildren)}\n`;
+    return `${formatTestReport(
+      type,
+      data,
+      prefix,
+      indentation,
+      hasChildren
+    )}\n`;
   }
   #handleEvent({ type, data }) {
     switch (type) {
@@ -70,10 +82,19 @@ class SpecReporter extends Transform {
       case 'test:stdout':
         return data.message;
       case 'test:diagnostic':
-        return `${reporterColorMap[type]}${indent(data.nesting)}${reporterUnicodeSymbolMap[type]}${data.message}${colors.white}\n`;
+        const diagnosticColor =
+          reporterColorMap[data.level] || reporterColorMap['test:diagnostic'];
+        return `${diagnosticColor}${indent(data.nesting)}${
+          reporterUnicodeSymbolMap[type]
+        }${data.message}${colors.white}\n`;
       case 'test:coverage':
-        return getCoverageReport(indent(data.nesting), data.summary,
-                                 reporterUnicodeSymbolMap['test:coverage'], colors.blue, true);
+        return getCoverageReport(
+          indent(data.nesting),
+          data.summary,
+          reporterUnicodeSymbolMap['test:coverage'],
+          colors.blue,
+          true
+        );
     }
   }
   _transform({ type, data }, encoding, callback) {
@@ -84,7 +105,9 @@ class SpecReporter extends Transform {
       callback(null, '');
       return;
     }
-    const results = [`\n${reporterColorMap['test:fail']}${reporterUnicodeSymbolMap['test:fail']}failing tests:${colors.white}\n`];
+    const results = [
+      `\n${reporterColorMap['test:fail']}${reporterUnicodeSymbolMap['test:fail']}failing tests:${colors.white}\n`,
+    ];
     for (let i = 0; i < this.#failedTests.length; i++) {
       const test = this.#failedTests[i];
       const formattedErr = formatTestReport('test:fail', test);

--- a/lib/internal/test_runner/reporter/utils.js
+++ b/lib/internal/test_runner/reporter/utils.js
@@ -17,7 +17,7 @@ const inspectOptions = {
 };
 
 const reporterUnicodeSymbolMap = {
-  '__proto__': null,
+  __proto__: null,
   'test:fail': '\u2716 ',
   'test:pass': '\u2714 ',
   'test:diagnostic': '\u2139 ',
@@ -27,7 +27,7 @@ const reporterUnicodeSymbolMap = {
 };
 
 const reporterColorMap = {
-  '__proto__': null,
+  __proto__: null,
   get 'test:fail'() {
     return colors.red;
   },
@@ -36,6 +36,18 @@ const reporterColorMap = {
   },
   get 'test:diagnostic'() {
     return colors.blue;
+  },
+  get info() {
+    return colors.blue;
+  },
+  get debug() {
+    return colors.gray;
+  },
+  get warn() {
+    return colors.yellow;
+  },
+  get error() {
+    return colors.red;
   },
 };
 
@@ -54,16 +66,26 @@ function formatError(error, indent) {
   const message = ArrayPrototypeJoin(
     RegExpPrototypeSymbolSplit(
       hardenRegExp(/\r?\n/),
-      inspectWithNoCustomRetry(err, inspectOptions),
-    ), `\n${indent}  `);
+      inspectWithNoCustomRetry(err, inspectOptions)
+    ),
+    `\n${indent}  `
+  );
   return `\n${indent}  ${message}\n`;
 }
 
-function formatTestReport(type, data, prefix = '', indent = '', hasChildren = false) {
+function formatTestReport(
+  type,
+  data,
+  prefix = '',
+  indent = '',
+  hasChildren = false
+) {
   let color = reporterColorMap[type] ?? colors.white;
   let symbol = reporterUnicodeSymbolMap[type] ?? ' ';
   const { skip, todo } = data;
-  const duration_ms = data.details?.duration_ms ? ` ${colors.gray}(${data.details.duration_ms}ms)${colors.white}` : '';
+  const duration_ms = data.details?.duration_ms
+    ? ` ${colors.gray}(${data.details.duration_ms}ms)${colors.white}`
+    : '';
   let title = `${data.name}${duration_ms}`;
 
   if (skip !== undefined) {
@@ -72,9 +94,11 @@ function formatTestReport(type, data, prefix = '', indent = '', hasChildren = fa
     title += ` # ${typeof todo === 'string' && todo.length ? todo : 'TODO'}`;
   }
   const error = formatError(data.details?.error, indent);
-  const err = hasChildren ?
-    (!error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`) :
-    error;
+  const err = hasChildren
+    ? !error || data.details?.error?.failureType === 'subtestsFailed'
+      ? ''
+      : `\n${error}`
+    : error;
   if (skip !== undefined) {
     color = colors.gray;
     symbol = reporterUnicodeSymbolMap['hyphen:minus'];

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -33,17 +33,16 @@ const {
   SymbolDispose,
 } = primordials;
 const { getCallerLocation } = internalBinding('util');
-const { exitCodes: { kGenericUserError } } = internalBinding('errors');
+const {
+  exitCodes: { kGenericUserError },
+} = internalBinding('errors');
 const { addAbortListener } = require('internal/events/abort_listener');
 const { queueMicrotask } = require('internal/process/task_queues');
 const { AsyncResource } = require('async_hooks');
 const { AbortController } = require('internal/abort_controller');
 const {
   AbortError,
-  codes: {
-    ERR_INVALID_ARG_TYPE,
-    ERR_TEST_FAILURE,
-  },
+  codes: { ERR_INVALID_ARG_TYPE, ERR_TEST_FAILURE },
 } = require('internal/errors');
 const { MockTracker } = require('internal/test_runner/mock/mock');
 const { TestsStream } = require('internal/test_runner/tests_stream');
@@ -53,10 +52,7 @@ const {
   isTestFailureError,
   reporterScope,
 } = require('internal/test_runner/utils');
-const {
-  kEmptyObject,
-  once: runOnce,
-} = require('internal/util');
+const { kEmptyObject, once: runOnce } = require('internal/util');
 const { isPromise } = require('internal/util/types');
 const {
   validateAbortSignal,
@@ -83,8 +79,10 @@ const noop = FunctionPrototype;
 const kShouldAbort = Symbol('kShouldAbort');
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
 const kUnwrapErrors = new SafeSet()
-  .add(kTestCodeFailure).add(kHookFailure)
-  .add('uncaughtException').add('unhandledRejection');
+  .add(kTestCodeFailure)
+  .add(kHookFailure)
+  .add('uncaughtException')
+  .add('unhandledRejection');
 let kResistStopPropagation;
 let assertObj;
 let findSourceMap;
@@ -127,7 +125,9 @@ function lazyAssertObject(harness) {
       assertObj.set(methodsToCopy[i], assert[methodsToCopy[i]]);
     }
 
-    harness.snapshotManager = new SnapshotManager(harness.config.updateSnapshots);
+    harness.snapshotManager = new SnapshotManager(
+      harness.config.updateSnapshots
+    );
     assertObj.set('snapshot', harness.snapshotManager.createAssert());
   }
   return assertObj;
@@ -152,7 +152,7 @@ function stopTest(timeout, signal) {
       value: PromisePrototypeThen(deferred.promise, () => {
         throw new ERR_TEST_FAILURE(
           `test timed out after ${timeout}ms`,
-          kTestTimeoutFailure,
+          kTestTimeoutFailure
         );
       }),
     });
@@ -173,15 +173,21 @@ function stopTest(timeout, signal) {
 }
 
 function testMatchesPattern(test, patterns) {
-  const matchesByNameOrParent = ArrayPrototypeSome(patterns, (re) =>
-    RegExpPrototypeExec(re, test.name) !== null,
-  ) || (test.parent && testMatchesPattern(test.parent, patterns));
+  const matchesByNameOrParent =
+    ArrayPrototypeSome(
+      patterns,
+      (re) => RegExpPrototypeExec(re, test.name) !== null
+    ) ||
+    (test.parent && testMatchesPattern(test.parent, patterns));
   if (matchesByNameOrParent) return true;
 
-  const testNameWithAncestors = StringPrototypeTrim(test.getTestNameWithAncestors());
+  const testNameWithAncestors = StringPrototypeTrim(
+    test.getTestNameWithAncestors()
+  );
 
-  return ArrayPrototypeSome(patterns, (re) =>
-    RegExpPrototypeExec(re, testNameWithAncestors) !== null,
+  return ArrayPrototypeSome(
+    patterns,
+    (re) => RegExpPrototypeExec(re, testNameWithAncestors) !== null
   );
 }
 
@@ -196,7 +202,7 @@ class TestPlan {
     if (this.actual !== this.expected) {
       throw new ERR_TEST_FAILURE(
         `plan expected ${this.expected} assertions but received ${this.actual}`,
-        kTestCodeFailure,
+        kTestCodeFailure
       );
     }
   }
@@ -242,7 +248,7 @@ class TestContext {
     if (this.#test.plan !== null) {
       throw new ERR_TEST_FAILURE(
         'cannot set plan more than once',
-        kTestCodeFailure,
+        kTestCodeFailure
       );
     }
 
@@ -308,7 +314,11 @@ class TestContext {
 
     const subtest = this.#test.createSubtest(
       // eslint-disable-next-line no-use-before-define
-      Test, name, options, fn, overrides,
+      Test,
+      name,
+      options,
+      fn,
+      overrides
     );
 
     return subtest.start();
@@ -388,7 +398,17 @@ class Test extends AsyncResource {
     super('Test');
 
     let { fn, name, parent } = options;
-    const { concurrency, entryFile, loc, only, timeout, todo, skip, signal, plan } = options;
+    const {
+      concurrency,
+      entryFile,
+      loc,
+      only,
+      timeout,
+      todo,
+      skip,
+      signal,
+      plan,
+    } = options;
 
     if (typeof fn !== 'function') {
       fn = noop;
@@ -424,9 +444,10 @@ class Test extends AsyncResource {
       this.timeout = kDefaultTimeout;
       this.entryFile = entryFile;
     } else {
-      const nesting = parent.parent === null ? parent.nesting :
-        parent.nesting + 1;
-      const { config, isFilteringByName, isFilteringByOnly } = parent.root.harness;
+      const nesting =
+        parent.parent === null ? parent.nesting : parent.nesting + 1;
+      const { config, isFilteringByName, isFilteringByOnly } =
+        parent.root.harness;
 
       this.root = parent.root;
       this.harness = null;
@@ -443,7 +464,11 @@ class Test extends AsyncResource {
       if (isFilteringByName) {
         this.filteredByName = this.willBeFilteredByName();
         if (!this.filteredByName) {
-          for (let t = this.parent; t !== null && t.filteredByName; t = t.parent) {
+          for (
+            let t = this.parent;
+            t !== null && t.filteredByName;
+            t = t.parent
+          ) {
             t.filteredByName = false;
           }
         }
@@ -457,7 +482,11 @@ class Test extends AsyncResource {
           this.parent.runOnlySubtests = true;
 
           if (this.parent === this.root || this.parent.startTime === null) {
-            for (let t = this.parent; t !== null && !t.hasOnlyTests; t = t.parent) {
+            for (
+              let t = this.parent;
+              t !== null && !t.hasOnlyTests;
+              t = t.parent
+            ) {
               t.hasOnlyTests = true;
             }
           }
@@ -479,8 +508,8 @@ class Test extends AsyncResource {
 
       case 'boolean':
         if (concurrency) {
-          this.concurrency = parent === null ?
-            MathMax(availableParallelism() - 1, 1) : Infinity;
+          this.concurrency =
+            parent === null ? MathMax(availableParallelism() - 1, 1) : Infinity;
         } else {
           this.concurrency = 1;
         }
@@ -488,7 +517,11 @@ class Test extends AsyncResource {
 
       default:
         if (concurrency != null)
-          throw new ERR_INVALID_ARG_TYPE('options.concurrency', ['boolean', 'number'], concurrency);
+          throw new ERR_INVALID_ARG_TYPE(
+            'options.concurrency',
+            ['boolean', 'number'],
+            concurrency
+          );
     }
 
     if (timeout != null && timeout !== Infinity) {
@@ -506,14 +539,14 @@ class Test extends AsyncResource {
 
     validateAbortSignal(signal, 'options.signal');
     if (signal) {
-      kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+      kResistStopPropagation ??=
+        require('internal/event_target').kResistStopPropagation;
     }
 
-    this.outerSignal?.addEventListener(
-      'abort',
-      this.#abortHandler,
-      { __proto__: null, [kResistStopPropagation]: true },
-    );
+    this.outerSignal?.addEventListener('abort', this.#abortHandler, {
+      __proto__: null,
+      [kResistStopPropagation]: true,
+    });
 
     this.fn = fn;
     this.mock = null;
@@ -526,8 +559,8 @@ class Test extends AsyncResource {
     this.endTime = null;
     this.passed = false;
     this.error = null;
-    this.message = typeof skip === 'string' ? skip :
-      typeof todo === 'string' ? todo : null;
+    this.message =
+      typeof skip === 'string' ? skip : typeof todo === 'string' ? todo : null;
     this.activeSubtests = 0;
     this.pendingSubtests = [];
     this.readySubtests = new SafeMap();
@@ -581,10 +614,16 @@ class Test extends AsyncResource {
       return;
     }
 
-    if (this.root.harness.isFilteringByOnly && !this.only && !this.hasOnlyTests) {
-      if (this.parent.runOnlySubtests ||
-          this.parent.hasOnlyTests ||
-          this.only === false) {
+    if (
+      this.root.harness.isFilteringByOnly &&
+      !this.only &&
+      !this.hasOnlyTests
+    ) {
+      if (
+        this.parent.runOnlySubtests ||
+        this.parent.hasOnlyTests ||
+        this.only === false
+      ) {
         this.filtered = true;
       }
     }
@@ -691,7 +730,14 @@ class Test extends AsyncResource {
       }
     }
 
-    const test = new Factory({ __proto__: null, fn, name, parent, ...options, ...overrides });
+    const test = new Factory({
+      __proto__: null,
+      fn,
+      name,
+      parent,
+      ...options,
+      ...overrides,
+    });
 
     if (parent.waitingOn === 0) {
       parent.waitingOn = test.childNumber;
@@ -701,8 +747,8 @@ class Test extends AsyncResource {
       test.fail(
         new ERR_TEST_FAILURE(
           'test could not be started because its parent finished',
-          kParentAlreadyFinished,
-        ),
+          kParentAlreadyFinished
+        )
       );
     }
 
@@ -711,7 +757,8 @@ class Test extends AsyncResource {
   }
 
   #abortHandler = () => {
-    const error = this.outerSignal?.reason || new AbortError('The test was aborted');
+    const error =
+      this.outerSignal?.reason || new AbortError('The test was aborted');
     error.failureType = kAborted;
     this.#cancel(error);
   };
@@ -721,11 +768,12 @@ class Test extends AsyncResource {
       return;
     }
 
-    this.fail(error ||
-      new ERR_TEST_FAILURE(
-        'test did not finish before its parent and was cancelled',
-        kCancelledByParent,
-      ),
+    this.fail(
+      error ||
+        new ERR_TEST_FAILURE(
+          'test did not finish before its parent and was cancelled',
+          kCancelledByParent
+        )
     );
     this.cancelled = true;
     this.abortController.abort();
@@ -735,13 +783,14 @@ class Test extends AsyncResource {
     if (this.parent.hooks.beforeEach.length > 0) {
       ArrayPrototypeUnshiftApply(
         this.hooks.beforeEach,
-        ArrayPrototypeSlice(this.parent.hooks.beforeEach),
+        ArrayPrototypeSlice(this.parent.hooks.beforeEach)
       );
     }
 
     if (this.parent.hooks.afterEach.length > 0) {
       ArrayPrototypePushApply(
-        this.hooks.afterEach, ArrayPrototypeSlice(this.parent.hooks.afterEach),
+        this.hooks.afterEach,
+        ArrayPrototypeSlice(this.parent.hooks.afterEach)
       );
     }
   }
@@ -765,7 +814,12 @@ class Test extends AsyncResource {
       // afterEach hooks for the current test should run in the order that they
       // are created. However, the current test's afterEach hooks should run
       // prior to any ancestor afterEach hooks.
-      ArrayPrototypeSplice(this.hooks[name], this.hooks.ownAfterEachCount, 0, hook);
+      ArrayPrototypeSplice(
+        this.hooks[name],
+        this.hooks.ownAfterEachCount,
+        0,
+        hook
+      );
       this.hooks.ownAfterEachCount++;
     } else {
       ArrayPrototypePush(this.hooks[name], hook);
@@ -845,15 +899,22 @@ class Test extends AsyncResource {
   async runHook(hook, args) {
     validateOneOf(hook, 'hook name', kHookNames);
     try {
-      await ArrayPrototypeReduce(this.hooks[hook], async (prev, hook) => {
-        await prev;
-        await hook.run(args);
-        if (hook.error) {
-          throw hook.error;
-        }
-      }, PromiseResolve());
+      await ArrayPrototypeReduce(
+        this.hooks[hook],
+        async (prev, hook) => {
+          await prev;
+          await hook.run(args);
+          if (hook.error) {
+            throw hook.error;
+          }
+        },
+        PromiseResolve()
+      );
     } catch (err) {
-      const error = new ERR_TEST_FAILURE(`failed running ${hook} hook`, kHookFailure);
+      const error = new ERR_TEST_FAILURE(
+        `failed running ${hook} hook`,
+        kHookFailure
+      );
       error.cause = isTestFailureError(err) ? err.cause : err;
       throw error;
     }
@@ -918,10 +979,12 @@ class Test extends AsyncResource {
         const ret = ReflectApply(this.runInAsyncScope, this, runArgs);
 
         if (isPromise(ret)) {
-          this.fail(new ERR_TEST_FAILURE(
-            'passed a callback but also returned a Promise',
-            kCallbackAndPromisePresent,
-          ));
+          this.fail(
+            new ERR_TEST_FAILURE(
+              'passed a callback but also returned a Promise',
+              kCallbackAndPromisePresent
+            )
+          );
           await SafePromiseRace([ret, stopPromise]);
         } else {
           await SafePromiseRace([PromiseResolve(promise), stopPromise]);
@@ -947,8 +1010,16 @@ class Test extends AsyncResource {
       } else {
         this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
       }
-      try { await afterEach(); } catch { /* test is already failing, let's ignore the error */ }
-      try { await after(); } catch { /* Ignore error. */ }
+      try {
+        await afterEach();
+      } catch {
+        /* test is already failing, let's ignore the error */
+      }
+      try {
+        await after();
+      } catch {
+        /* Ignore error. */
+      }
     } finally {
       stopPromise?.[SymbolDispose]();
 
@@ -979,15 +1050,21 @@ class Test extends AsyncResource {
       for (let i = 0; i < reporterScope.reporters.length; i++) {
         const { destination } = reporterScope.reporters[i];
 
-        ArrayPrototypePush(promises, new Promise((resolve) => {
-          destination.on('unpipe', () => {
-            if (!destination.closed && typeof destination.close === 'function') {
-              destination.close(resolve);
-            } else {
-              resolve();
-            }
-          });
-        }));
+        ArrayPrototypePush(
+          promises,
+          new Promise((resolve) => {
+            destination.on('unpipe', () => {
+              if (
+                !destination.closed &&
+                typeof destination.close === 'function'
+              ) {
+                destination.close(resolve);
+              } else {
+                resolve();
+              }
+            });
+          })
+        );
       }
 
       this.harness.teardown();
@@ -1033,7 +1110,14 @@ class Test extends AsyncResource {
         const report = this.getReportDetails();
         report.details.passed = this.passed;
         this.testNumber ||= ++this.parent.outputSubtestCount;
-        this.reporter.complete(this.nesting, this.loc, this.testNumber, this.name, report.details, report.directive);
+        this.reporter.complete(
+          this.nesting,
+          this.loc,
+          this.testNumber,
+          this.name,
+          report.details,
+          report.directive
+        );
         this.parent.activeSubtests--;
       }
 
@@ -1041,13 +1125,7 @@ class Test extends AsyncResource {
       this.parent.processReadySubtestRange(false);
       this.parent.processPendingSubtests();
     } else if (!this.reported) {
-      const {
-        diagnostics,
-        harness,
-        loc,
-        nesting,
-        reporter,
-      } = this;
+      const { diagnostics, harness, loc, nesting, reporter } = this;
 
       this.reported = true;
       reporter.plan(nesting, loc, harness.counters.topLevel);
@@ -1064,21 +1142,37 @@ class Test extends AsyncResource {
       reporter.diagnostic(nesting, loc, `suites ${harness.counters.suites}`);
       reporter.diagnostic(nesting, loc, `pass ${harness.counters.passed}`);
       reporter.diagnostic(nesting, loc, `fail ${harness.counters.failed}`);
-      reporter.diagnostic(nesting, loc, `cancelled ${harness.counters.cancelled}`);
+      reporter.diagnostic(
+        nesting,
+        loc,
+        `cancelled ${harness.counters.cancelled}`
+      );
       reporter.diagnostic(nesting, loc, `skipped ${harness.counters.skipped}`);
       reporter.diagnostic(nesting, loc, `todo ${harness.counters.todo}`);
       reporter.diagnostic(nesting, loc, `duration_ms ${duration}`);
 
       if (coverage) {
         const coverages = [
-          { __proto__: null, actual: coverage.totals.coveredLinePercent,
-            threshold: this.config.lineCoverage, name: 'line' },
+          {
+            __proto__: null,
+            actual: coverage.totals.coveredLinePercent,
+            threshold: this.config.lineCoverage,
+            name: 'line',
+          },
 
-          { __proto__: null, actual: coverage.totals.coveredBranchPercent,
-            threshold: this.config.branchCoverage, name: 'branch' },
+          {
+            __proto__: null,
+            actual: coverage.totals.coveredBranchPercent,
+            threshold: this.config.branchCoverage,
+            name: 'branch',
+          },
 
-          { __proto__: null, actual: coverage.totals.coveredFunctionPercent,
-            threshold: this.config.functionCoverage, name: 'function' },
+          {
+            __proto__: null,
+            actual: coverage.totals.coveredFunctionPercent,
+            threshold: this.config.functionCoverage,
+            name: 'function',
+          },
         ];
 
         for (let i = 0; i < coverages.length; i++) {
@@ -1086,7 +1180,15 @@ class Test extends AsyncResource {
           if (actual < threshold) {
             harness.success = false;
             process.exitCode = kGenericUserError;
-            reporter.diagnostic(nesting, loc, `Error: ${NumberPrototypeToFixed(actual, 2)}% ${name} coverage does not meet threshold of ${threshold}%.`);
+            reporter.diagnostic(
+              nesting,
+              loc,
+              `Error: ${NumberPrototypeToFixed(
+                actual,
+                2
+              )}% ${name} coverage does not meet threshold of ${threshold}%.`,
+              'error'
+            );
           }
         }
 
@@ -1094,7 +1196,11 @@ class Test extends AsyncResource {
       }
 
       reporter.summary(
-        nesting, loc?.file, harness.success, harness.counters, duration,
+        nesting,
+        loc?.file,
+        harness.success,
+        harness.counters,
+        duration
       );
 
       if (harness.watching) {
@@ -1108,10 +1214,11 @@ class Test extends AsyncResource {
   }
 
   isClearToSend() {
-    return this.parent === null ||
-      (
-        this.parent.waitingOn === this.childNumber && this.parent.isClearToSend()
-      );
+    return (
+      this.parent === null ||
+      (this.parent.waitingOn === this.childNumber &&
+        this.parent.isClearToSend())
+    );
   }
 
   finalize() {
@@ -1130,8 +1237,10 @@ class Test extends AsyncResource {
     this.parent.waitingOn++;
     this.finished = true;
 
-    if (this.parent === this.root &&
-        this.root.waitingOn > this.root.subtests.length) {
+    if (
+      this.parent === this.root &&
+      this.root.waitingOn > this.root.subtests.length
+    ) {
       // At this point all of the tests have finished running. However, there
       // might be ref'ed handles keeping the event loop alive. This gives the
       // global after() hook a chance to clean them up. The user may also
@@ -1167,16 +1276,34 @@ class Test extends AsyncResource {
   report() {
     countCompletedTest(this);
     if (this.outputSubtestCount > 0) {
-      this.reporter.plan(this.subtests[0].nesting, this.loc, this.outputSubtestCount);
+      this.reporter.plan(
+        this.subtests[0].nesting,
+        this.loc,
+        this.outputSubtestCount
+      );
     } else {
       this.reportStarted();
     }
     const report = this.getReportDetails();
 
     if (this.passed) {
-      this.reporter.ok(this.nesting, this.loc, this.testNumber, this.name, report.details, report.directive);
+      this.reporter.ok(
+        this.nesting,
+        this.loc,
+        this.testNumber,
+        this.name,
+        report.details,
+        report.directive
+      );
     } else {
-      this.reporter.fail(this.nesting, this.loc, this.testNumber, this.name, report.details, report.directive);
+      this.reporter.fail(
+        this.nesting,
+        this.loc,
+        this.testNumber,
+        this.name,
+        report.details,
+        report.directive
+      );
     }
 
     for (let i = 0; i < this.diagnostics.length; i++) {
@@ -1237,11 +1364,18 @@ class TestHook extends Test {
       }
 
       this.endTime ??= hrtime();
-      parent.reporter.fail(0, loc, parent.subtests.length + 1, loc.file, {
-        __proto__: null,
-        duration_ms: this.duration(),
-        error,
-      }, undefined);
+      parent.reporter.fail(
+        0,
+        loc,
+        parent.subtests.length + 1,
+        loc.file,
+        {
+          __proto__: null,
+          duration_ms: this.duration(),
+          error,
+        },
+        undefined
+      );
     }
   }
 }
@@ -1251,9 +1385,11 @@ class Suite extends Test {
   constructor(options) {
     super(options);
 
-    if (this.config.testNamePatterns !== null &&
-        this.config.testSkipPatterns !== null &&
-        !options.skip) {
+    if (
+      this.config.testNamePatterns !== null &&
+      this.config.testSkipPatterns !== null &&
+      !options.skip
+    ) {
       this.fn = options.fn || this.fn;
       this.skipped = false;
     }
@@ -1268,8 +1404,9 @@ class Suite extends Test {
           undefined,
           (err) => {
             this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
-          }),
-        () => this.postBuild(),
+          }
+        ),
+        () => this.postBuild()
       );
     } catch (err) {
       this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
@@ -1292,7 +1429,10 @@ class Suite extends Test {
     const hookArgs = this.getRunArgs();
 
     let stopPromise;
-    const after = runOnce(() => this.runHook('after', hookArgs), kRunOnceOptions);
+    const after = runOnce(
+      () => this.runHook('after', hookArgs),
+      kRunOnceOptions
+    );
     try {
       this.parent.activeSubtests++;
       await this.buildSuite;
@@ -1319,7 +1459,11 @@ class Suite extends Test {
 
       this.pass();
     } catch (err) {
-      try { await after(); } catch { /* suite is already failing */ }
+      try {
+        await after();
+      } catch {
+        /* suite is already failing */
+      }
       if (isTestFailureError(err)) {
         this.fail(err);
       } else {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -114,11 +114,12 @@ class TestsStream extends Readable {
     });
   }
 
-  diagnostic(nesting, loc, message) {
+  diagnostic(nesting, loc, message, level = 'info') {
     this[kEmitMessage]('test:diagnostic', {
       __proto__: null,
       nesting,
       message,
+      level,
       ...loc,
     });
   }


### PR DESCRIPTION
This fixes #55922 

## Change summary
Updated the reporter.diagnostic to accept level parameter like this
```js
  diagnostic(nesting, loc, message, level = 'info') {
    this[kEmitMessage]('test:diagnostic', {
      __proto__: null,
      nesting,
      message,
      level,
      ...loc,
    });
  }
```

Then I updated `#handleEvent` like this
```js
 #handleEvent({ type, data }) {
    switch (type) {
      case 'test:fail':
        if (data.details?.error?.failureType !== kSubtestsFailed) {
          ArrayPrototypePush(this.#failedTests, data);
        }
        return this.#handleTestReportEvent(type, data);
      case 'test:pass':
        return this.#handleTestReportEvent(type, data);
      case 'test:start':
        ArrayPrototypeUnshift(this.#stack, { __proto__: null, data, type });
        break;
      case 'test:stderr':
      case 'test:stdout':
        return data.message;
      case 'test:diagnostic':  // Here I added logic
        const diagnosticColor =
          reporterColorMap[data.level] || reporterColorMap['test:diagnostic'];
        return `${diagnosticColor}${indent(data.nesting)}${
          reporterUnicodeSymbolMap[type]
        }${data.message}${colors.white}\n`;
      case 'test:coverage':
        return getCoverageReport(
          indent(data.nesting),
          data.summary,
          reporterUnicodeSymbolMap['test:coverage'],
          colors.blue,
          true
        );
    }
  }
```

And I am Updated `reporterColorMap` like this
```js
const reporterColorMap = {
  __proto__: null,
  get 'test:fail'() {
    return colors.red;
  },
  get 'test:pass'() {
    return colors.green;
  },
  get 'test:diagnostic'() {
    return colors.blue;
  },
  get info() {
    return colors.blue;
  },
  get debug() {
    return colors.gray;
  },
  get warn() {
    return colors.yellow;
  },
  get error() {
    return colors.red;
  },
};
```

and color already contain logic for this colors

I also set the reporter.diagnostic call from test.js like this (level="Error")
```js

if (actual < threshold) {
            harness.success = false;
            process.exitCode = kGenericUserError;
            reporter.diagnostic(
              nesting,
              loc,
              `Error: ${NumberPrototypeToFixed(
                actual,
                2
              )}% ${name} coverage does not meet threshold of ${threshold}%.`,
              'error'  // Level is set to error for red color
            );
          }
```

Here is Demo output:
![image](https://github.com/user-attachments/assets/6e5ed480-90a9-46b8-82f0-cfbe1025bab9)
