### PR TITLE
test_runner: refactor primordial-based Promise chains

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -17,7 +17,6 @@ const {
   ArrayPrototypeSort,
   ObjectAssign,
   PromisePrototypeThen,
-  PromiseResolve,
   PromiseWithResolvers,
   SafeMap,
   SafePromiseAll,
@@ -801,9 +800,17 @@ function run(options = kEmptyObject) {
     }
   }
 
-  const setupPromise = PromiseResolve(setup?.(root.reporter));
-  PromisePrototypeThen(PromisePrototypeThen(PromisePrototypeThen(setupPromise, runFiles), postRun), teardown);
+  const runChain = async () => {
+    if (typeof setup === 'function') {
+      await setup(root.reporter);
+    }
 
+    await runFiles();
+    postRun?.();
+    teardown?.();
+  };
+
+  runChain();
   return root.reporter;
 }
 

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -24,7 +24,6 @@ const {
   SafeMap,
   SafePromiseAll,
   SafePromiseAllReturnVoid,
-  SafePromisePrototypeFinally,
   SafePromiseRace,
   SafeSet,
   StringPrototypeStartsWith,
@@ -1259,27 +1258,20 @@ class Suite extends Test {
       this.skipped = false;
     }
 
+    this.buildSuite = this.createBuild();
+    this.fn = noop;
+  }
+
+  async createBuild() {
     try {
       const { ctx, args } = this.getRunArgs();
       const runArgs = [this.fn, ctx];
       ArrayPrototypePushApply(runArgs, args);
-      this.buildSuite = SafePromisePrototypeFinally(
-        PromisePrototypeThen(
-          PromiseResolve(ReflectApply(this.runInAsyncScope, this, runArgs)),
-          undefined,
-          (err) => {
-            this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
-          }),
-        () => this.postBuild(),
-      );
+      await ReflectApply(this.runInAsyncScope, this, runArgs);
     } catch (err) {
       this.fail(new ERR_TEST_FAILURE(err, kTestCodeFailure));
-      this.postBuild();
     }
-    this.fn = noop;
-  }
 
-  postBuild() {
     this.buildPhaseFinished = true;
   }
 


### PR DESCRIPTION
This PR refactors two Promise chains in the test runner to use async/await style syntax instead. IMO this makes these two pieces of code significantly more readable (largely because of primordials), and will make some planned changes easier to implement.

##### test_runner: refactor build Promise in Suite()

This commit refactors the buildSuite Promise logic in the Suite
constructor to use an async function instead of creating an
awkward primordial-based Promise chain.

##### test_runner: refactor Promise chain in run()

This commit refactors the chain of functions in run() to use an
async function instead of creating an awkward primordial-based
Promise chain.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
