### PR TITLE
module: do not warn when require(esm) comes from node_modules

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -70,6 +70,7 @@ const {
     module_export_private_symbol,
     module_parent_private_symbol,
   },
+  isInsideNodeModules,
 } = internalBinding('util');
 
 const { kEvaluated, createRequiredModuleFacade } = internalBinding('module_wrap');
@@ -131,6 +132,7 @@ const {
   setOwnProperty,
   getLazy,
   isWindows,
+  isUnderNodeModules,
 } = require('internal/util');
 const {
   makeContextifyScript,
@@ -1328,6 +1330,7 @@ Module.prototype.require = function(id) {
   }
 };
 
+let emittedRequireModuleWarning = false;
 /**
  * Resolve and evaluate it synchronously as ESM if it's ESM.
  * @param {Module} mod CJS module instance
@@ -1347,29 +1350,46 @@ function loadESMFromCJS(mod, filename, format, source) {
     setOwnProperty(process, 'mainModule', undefined);
   } else {
     const parent = mod[kModuleParent];
-    let messagePrefix;
-    if (parent) {
-      // In the case of the module calling `require()`, it's more useful to know its absolute path.
-      let from = parent.filename || parent.id;
-      // In the case of the module being require()d, it's more useful to know the id passed into require().
-      const to = mod.id || mod.filename;
-      if (from === 'internal/preload') {
-        from = '--require';
-      } else if (from === '<repl>') {
-        from = 'The REPL';
-      } else if (from === '.') {
-        from = 'The entry point';
-      } else {
-        from &&= `CommonJS module ${from}`;
+
+    if (!emittedRequireModuleWarning) {
+      let shouldEmitWarning = false;
+      // Check if the require() comes from node_modules.
+      if (parent) {
+        shouldEmitWarning = !isUnderNodeModules(parent.filename);
+      } else if (mod[kIsCachedByESMLoader]) {
+        // It comes from the require() built for `import cjs` and doesn't have a parent recorded
+        // in the CJS module instance. Inspect the stack trace to see if the require()
+        // comes from node_modules and reduce the noise. If there are more than 100 frames,
+        // just give up and assume it is under node_modules.
+        shouldEmitWarning = !isInsideNodeModules(100, true);
       }
-      if (from && to) {
-        messagePrefix = `${from} is loading ES Module ${to} using require().\n`;
+      if (shouldEmitWarning) {
+        let messagePrefix;
+        if (parent) {
+          // In the case of the module calling `require()`, it's more useful to know its absolute path.
+          let from = parent.filename || parent.id;
+          // In the case of the module being require()d, it's more useful to know the id passed into require().
+          const to = mod.id || mod.filename;
+          if (from === 'internal/preload') {
+            from = '--require';
+          } else if (from === '<repl>') {
+            from = 'The REPL';
+          } else if (from === '.') {
+            from = 'The entry point';
+          } else {
+            from &&= `CommonJS module ${from}`;
+          }
+          if (from && to) {
+            messagePrefix = `${from} is loading ES Module ${to} using require().\n`;
+          }
+        }
+        emitExperimentalWarning('Support for loading ES Module in require()',
+                                messagePrefix,
+                                undefined,
+                                parent?.require);
+        emittedRequireModuleWarning = true;
       }
     }
-    emitExperimentalWarning('Support for loading ES Module in require()',
-                            messagePrefix,
-                            undefined,
-                            parent?.require);
     const {
       wrap,
       namespace,

--- a/test/es-module/test-require-node-modules-warning.js
+++ b/test/es-module/test-require-node-modules-warning.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// This checks the experimental warning for require(esm) is disabled when the
+// require() comes from node_modules.
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const fixtures = require('../common/fixtures');
+
+const warningRE = /Support for loading ES Module in require\(\)/;
+
+// The fixtures are placed in a directory that includes "node_modules" in its name
+// to check false negatives.
+
+// require() in non-node_modules -> esm in node_modules should warn.
+spawnSyncAndAssert(
+  process.execPath,
+  [fixtures.path('es-modules', 'test_node_modules', 'require-esm.js')],
+  {
+    trim: true,
+    stderr: warningRE,
+    stdout: 'world',
+  }
+);
+
+// require() in non-node_modules -> require() in node_modules -> esm in node_modules
+// should not warn.
+spawnSyncAndAssert(
+  process.execPath,
+  [fixtures.path('es-modules', 'test_node_modules', 'require-require-esm.js')],
+  {
+    trim: true,
+    stderr: '',
+    stdout: 'world',
+  }
+);
+
+// Import in non-node_modules -> require() in node_modules -> esm in node_modules
+// should not warn.
+spawnSyncAndAssert(
+  process.execPath,
+  [fixtures.path('es-modules', 'test_node_modules', 'import-require-esm.mjs')],
+  {
+    trim: true,
+    stderr: '',
+    stdout: 'world',
+  }
+);
+
+// Import in non-node_modules -> import in node_modules ->
+// require() in node_modules -> esm in node_modules should not warn.
+spawnSyncAndAssert(
+  process.execPath,
+  [fixtures.path('es-modules', 'test_node_modules', 'import-import-require-esm.mjs')],
+  {
+    trim: true,
+    stderr: '',
+    stdout: 'world',
+  }
+);

--- a/test/fixtures/es-modules/test_node_modules/import-import-require-esm.mjs
+++ b/test/fixtures/es-modules/test_node_modules/import-import-require-esm.mjs
@@ -1,0 +1,2 @@
+import mod from 'import-require-esm';
+console.log(mod.hello);

--- a/test/fixtures/es-modules/test_node_modules/import-require-esm.mjs
+++ b/test/fixtures/es-modules/test_node_modules/import-require-esm.mjs
@@ -1,0 +1,2 @@
+import mod from 'require-esm';
+console.log(mod.hello);

--- a/test/fixtures/es-modules/test_node_modules/node_modules/esm/index.js
+++ b/test/fixtures/es-modules/test_node_modules/node_modules/esm/index.js
@@ -1,0 +1,1 @@
+export const hello = 'world';

--- a/test/fixtures/es-modules/test_node_modules/node_modules/esm/package.json
+++ b/test/fixtures/es-modules/test_node_modules/node_modules/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/fixtures/es-modules/test_node_modules/node_modules/import-require-esm/index.js
+++ b/test/fixtures/es-modules/test_node_modules/node_modules/import-require-esm/index.js
@@ -1,0 +1,2 @@
+import mod from 'require-esm';
+export default mod;

--- a/test/fixtures/es-modules/test_node_modules/node_modules/import-require-esm/package.json
+++ b/test/fixtures/es-modules/test_node_modules/node_modules/import-require-esm/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/fixtures/es-modules/test_node_modules/node_modules/require-esm/index.js
+++ b/test/fixtures/es-modules/test_node_modules/node_modules/require-esm/index.js
@@ -1,0 +1,2 @@
+module.exports = require('esm');
+

--- a/test/fixtures/es-modules/test_node_modules/require-esm.js
+++ b/test/fixtures/es-modules/test_node_modules/require-esm.js
@@ -1,0 +1,2 @@
+const { hello } = require('esm');
+console.log(hello);

--- a/test/fixtures/es-modules/test_node_modules/require-require-esm.js
+++ b/test/fixtures/es-modules/test_node_modules/require-require-esm.js
@@ -1,0 +1,2 @@
+const { hello } = require('require-esm');
+console.log(hello);


### PR DESCRIPTION
As part of the standard experimental feature graduation policy, when we unflagged require(esm) we moved the experimental warning to be emitted when require() is actually used to load ESM, which previously was an error. However, some packages in the ecosystem have already being using try-catch to load require(esm) to e.g. resolve optional dependency, and emitting warning from there instead of throwing directly could break the CLI output.

To reduce the disruption for releases, as a compromise, this patch skips the warning if require(esm) comes from node_modules, where users typically don't have much control over the code. This warning will be eventually removed when require(esm) becomes stable.

This patch was originally intended for the LTS releases, though it seems there's appetite for it on v23.x as well so it's re-targeted to the main branch.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
