### PR TITLE
test_runner: simplify hook running logic

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -2,7 +2,6 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypePushApply,
-  ArrayPrototypeReduce,
   ArrayPrototypeShift,
   ArrayPrototypeSlice,
   ArrayPrototypeSome,
@@ -845,13 +844,14 @@ class Test extends AsyncResource {
   async runHook(hook, args) {
     validateOneOf(hook, 'hook name', kHookNames);
     try {
-      await ArrayPrototypeReduce(this.hooks[hook], async (prev, hook) => {
-        await prev;
+      const hooks = this.hooks[hook];
+      for (let i = 0; i < hooks.length; ++i) {
+        const hook = hooks[i];
         await hook.run(args);
         if (hook.error) {
           throw hook.error;
         }
-      }, PromiseResolve());
+      }
     } catch (err) {
       const error = new ERR_TEST_FAILURE(`failed running ${hook} hook`, kHookFailure);
       error.cause = isTestFailureError(err) ? err.cause : err;

--- a/test/fixtures/test-runner/output/abort_hooks.snapshot
+++ b/test/fixtures/test-runner/output/abort_hooks.snapshot
@@ -101,7 +101,7 @@ not ok 2 - 2 after describe
         *
         *
         *
-        async Promise.all (index 0)
+        *
       ...
     # Subtest: test 2
     not ok 2 - test 2
@@ -122,7 +122,7 @@ not ok 2 - 2 after describe
         *
         *
         *
-        async Promise.all (index 0)
+        *
       ...
     1..2
 not ok 3 - 3 beforeEach describe

--- a/test/fixtures/test-runner/output/global_after_should_fail_the_test.snapshot
+++ b/test/fixtures/test-runner/output/global_after_should_fail_the_test.snapshot
@@ -21,7 +21,6 @@ not ok 2 - /test/fixtures/test-runner/output/global_after_should_fail_the_test.j
     *
     *
     *
-    *
   ...
 1..1
 # tests 1

--- a/test/fixtures/test-runner/output/hooks.snapshot
+++ b/test/fixtures/test-runner/output/hooks.snapshot
@@ -77,7 +77,6 @@ not ok 3 - before throws
     *
     *
     *
-    *
   ...
 # Subtest: before throws - no subtests
 not ok 4 - before throws - no subtests
@@ -89,7 +88,6 @@ not ok 4 - before throws - no subtests
   error: 'before'
   code: 'ERR_TEST_FAILURE'
   stack: |-
-    *
     *
     *
     *
@@ -129,6 +127,7 @@ not ok 5 - after throws
     *
     *
     *
+    *
   ...
 # Subtest: after throws - no subtests
 not ok 6 - after throws - no subtests
@@ -140,6 +139,7 @@ not ok 6 - after throws - no subtests
   error: 'after'
   code: 'ERR_TEST_FAILURE'
   stack: |-
+    *
     *
     *
     *
@@ -167,9 +167,9 @@ not ok 6 - after throws - no subtests
         *
         *
         *
-        async Promise.all (index 0)
         *
         *
+        new Promise (<anonymous>)
       ...
     # Subtest: 2
     not ok 2 - 2
@@ -188,6 +188,8 @@ not ok 6 - after throws - no subtests
         *
         *
         *
+        *
+        async Promise.all (index 0)
       ...
     1..2
 not ok 7 - beforeEach throws
@@ -482,7 +484,6 @@ not ok 15 - t.after throws
     *
     *
     *
-    *
   ...
 # Subtest: t.after throws - no subtests
 not ok 16 - t.after throws - no subtests
@@ -493,7 +494,6 @@ not ok 16 - t.after throws - no subtests
   error: 'after'
   code: 'ERR_TEST_FAILURE'
   stack: |-
-    *
     *
     *
     *
@@ -757,7 +757,6 @@ not ok 24 - run after when before throws
   error: 'before'
   code: 'ERR_TEST_FAILURE'
   stack: |-
-    *
     *
     *
     *

--- a/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
+++ b/test/fixtures/test-runner/output/hooks_spec_reporter.snapshot
@@ -26,11 +26,9 @@
       *
       *
       *
-      *
 
  before throws - no subtests (*ms)
   Error: before
-      *
       *
       *
       *
@@ -55,9 +53,11 @@
       *
       *
       *
+      *
 
  after throws - no subtests (*ms)
   Error: after
+      *
       *
       *
       *
@@ -78,9 +78,9 @@
         *
         *
         *
-        at async Promise.all (index 0)
         *
         *
+        at new Promise (<anonymous>)
 
    2 (*ms)
     Error: beforeEach
@@ -92,6 +92,8 @@
         *
         *
         *
+        *
+        at async Promise.all (index 0)
 
  beforeEach throws (*ms)
  afterEach throws
@@ -242,11 +244,9 @@
       *
       *
       *
-      *
 
  t.after throws - no subtests (*ms)
   Error: after
-      *
       *
       *
       *
@@ -390,7 +390,6 @@
       *
       *
       *
-      *
 
  test hooks - async
    1 (*ms)
@@ -430,7 +429,6 @@
       *
       *
       *
-      *
 
 *
  before throws - no subtests (*ms)
@@ -443,11 +441,11 @@
       *
       *
       *
-      *
 
 *
  after throws (*ms)
   Error: after
+      *
       *
       *
       *
@@ -470,6 +468,7 @@
       *
       *
       *
+      *
 
 *
  1 (*ms)
@@ -481,9 +480,9 @@
       *
       *
       *
-      at async Promise.all (index 0)
       *
       *
+      at new Promise (<anonymous>)
 
 *
  2 (*ms)
@@ -496,6 +495,8 @@
       *
       *
       *
+      *
+      at async Promise.all (index 0)
 
 *
  1 (*ms)
@@ -633,12 +634,10 @@
       *
       *
       *
-      *
 
 *
  t.after throws - no subtests (*ms)
   Error: after
-      *
       *
       *
       *
@@ -768,7 +767,6 @@
 *
  run after when before throws (*ms)
   Error: before
-      *
       *
       *
       *


### PR DESCRIPTION
This commit removes some asynchronous logic from the `runHook()` method and replaces `ArrayPrototypeReduce()` with a `for` loop.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
