### PR TITLE
doc: improve GN build documentation a bit

### DIFF
--- a/doc/contributing/gn-build.md
+++ b/doc/contributing/gn-build.md
@@ -28,27 +28,33 @@ Node.js contains following GN build files:
 
 Unlike GYP, the GN tool does not include any built-in rules for compiling a
 project, which means projects building with GN must provide their own build
-configurations for things like how to invoke a C++ compiler. Chromium related
-projects like V8 and skia choose to reuse Chromium's build configurations, and
-V8's Node.js integration testing repository
-([node-ci](https://chromium.googlesource.com/v8/node-ci/)) can be reused for
-building Node.js.
+configurations for things like how to invoke a C++ compiler.
+
+Chromium related projects like V8 and skia choose to reuse Chromium's build
+configurations, and V8's Node.js integration testing repository
+[`node-ci`][node-ci] can be reused for building Node.js.
 
 ### 1. Install `depot_tools`
 
-The `depot_tools` is a set of tools used by Chromium related projects for
-checking out code and managing dependencies, and since this guide is reusing the
-infra of V8, it needs to be installed and added to `PATH`:
+You'll need to install [`depot_tools`][depot-tools] the toolset
+used for fetching Chromium and its dependencies.
 
 ```bash
 git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 export PATH=/path/to/depot_tools:$PATH
 ```
 
-You can also follow the [official tutorial of
-`depot_tools`](https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html).
+You can ensure `depot_tools` is correctly added to your PATH by running
+`which gn` and confirming that it returns `/path/to/depot_tools/gn`.
 
-### 2. Check out code of Node.js
+**NOTE:** On Windows you'll also need to set the environment variable
+`DEPOT_TOOLS_WIN_TOOLCHAIN=0`. To do so, open `Control Panel` → `System and
+Security` → `System` → `Advanced system settings` and add a system variable
+`DEPOT_TOOLS_WIN_TOOLCHAIN` with value `0`. This tells `depot_tools` to use
+your locally installed version of Visual Studio (by default, `depot_tools` will
+try to download a Google-internal version that only Googlers have access to).
+
+### 2. Checkout Node.js Source Code
 
 To check out the latest main branch of Node.js for building, use the `fetch`
 tool from `depot_tools`:
@@ -91,9 +97,9 @@ out at `node_gn/node/node`.
 
 ### 3. Build
 
-GN only supports [`ninja`](https://ninja-build.org) for building, so to build
-Node.js with GN, `ninja` build files should be generated first, and then
-`ninja` can be invoked to do the building.
+GN only supports [`ninja`](https://ninja-build.org) for building. To build
+Node.js with GN you'll first need to generate `ninja` build files and then invoke
+`ninja` to perform the build.
 
 The `node-ci` repository provides a script for calling GN:
 
@@ -103,9 +109,10 @@ cd node  # Enter `node_gn/node` which contains a node-ci checkout
 ```
 
 which writes `ninja` build files into the `out/Release` directory under
-`node_gn/node`.
+`node_gn/node`. To see all possible configurable options, run
+`tools/gn-gen.py --help`.
 
-And then you can execute `ninja`:
+When `gn-gen.py` has executed successfully, you can then execute `ninja`:
 
 ```bash
 ninja -C out/Release node
@@ -116,10 +123,12 @@ After the build is completed, the compiled Node.js executable can be found in
 
 ## Status of the GN build
 
-Currently the GN build of Node.js is not fully functioning. It builds for macOS
-and Linux, while the Windows build is still a work in progress. And some tests
-are still failing with the GN build.
+Currently the GN build of Node.js is not fully functioning. Some tests
+are still failing with the GN build, and there may be other small pitfall
+for certain configuration options.
 
-There are also efforts on making GN build work without using `depot_tools`,
-which is tracked in the issue
-[#51689](https://github.com/nodejs/node/issues/51689).
+An effort is currently underway to make GN build work without using `depot_tools`,
+which is tracked in [#51689](https://github.com/nodejs/node/issues/51689).
+
+[depot-tools]: https://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up
+[node-ci]: https://chromium.googlesource.com/v8/node-ci


### PR DESCRIPTION
As in title. With my last few commits as well as some i've made upstream to `node-ci`, the GN build now compiles on Windows:

```
NORTHAMERICA+cavohr@CODEBYTERE-WIN-WORK CLANGARM64 ~/Developer/node_gn/node ((95ad75b...))
$ ./out/Release/node.exe
Welcome to Node.js v24.0.0-pre.
Type ".help" for more information.
>
```

This adds some Windows-specific notes to documentation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
