### PR TITLE
assert: optimize partial comparison of two `Set`s

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -414,7 +414,6 @@ function compareBranch(
   }
 
   // Check for Set object equality
-  // TODO(aduh95): switch to `SetPrototypeIsSubsetOf` when it's available
   if (isSet(actual) && isSet(expected)) {
     if (expected.size > actual.size) {
       return false; // `expected` can't be a subset if it has more elements
@@ -422,25 +421,18 @@ function compareBranch(
 
     if (isDeepEqual === undefined) lazyLoadComparison();
 
-    const actualArray = ArrayFrom(actual);
-    const expectedArray = ArrayFrom(expected);
+    const actualArray = ArrayFrom(FunctionPrototypeCall(SafeSet.prototype[SymbolIterator], actual));
+    const expectedIterator = FunctionPrototypeCall(SafeSet.prototype[SymbolIterator], expected);
     const usedIndices = new SafeSet();
 
-    for (let expectedIdx = 0; expectedIdx < expectedArray.length; expectedIdx++) {
-      const expectedItem = expectedArray[expectedIdx];
-      let found = false;
-
+    expectedIteration: for (const expectedItem of expectedIterator) {
       for (let actualIdx = 0; actualIdx < actualArray.length; actualIdx++) {
         if (!usedIndices.has(actualIdx) && isDeepStrictEqual(actualArray[actualIdx], expectedItem)) {
           usedIndices.add(actualIdx);
-          found = true;
-          break;
+          continue expectedIteration;
         }
       }
-
-      if (!found) {
-        return false;
-      }
+      return false;
     }
 
     return true;


### PR DESCRIPTION
We can skip the conversion to an array of the expected items as we're only iterating over them. Using a labelled `continue` should also slightly improve perf as we no longer need to keep a `found` boolean value and check its value.
I'm also removing the `TODO` that no longer applies (I suggested adding it when there were plans for a `assert.includes` method in the PR which have since been abandoned). Lastly I'm using the `SafeSet` methods to iterate over the `Set` instances to be consistent with how we iterate over `Map` instances just a few lines above.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
