### PR TITLE
sqlite: add support for custom functions

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -160,6 +160,31 @@ This method allows one or more SQL statements to be executed without returning
 any results. This method is useful when executing SQL statements read from a
 file. This method is a wrapper around [`sqlite3_exec()`][].
 
+### `database.function(name[, options], function)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `name` {string} The name of the SQLite function to create.
+* `options` {Object} Optional configuration settings for the function. The
+  following properties are supported:
+  * `deterministic` {boolean} If `true`, the [`SQLITE_DETERMINISTIC`][] flag is
+    set on the created function. **Default:** `false`.
+  * `directOnly` {boolean} If `true`, the [`SQLITE_DIRECTONLY`][] flag is set on
+    the created function. **Default:** `false`.
+  * `useBigIntArguments` {boolean} If `true`, integer arguments to `function`
+    are converted to `BigInt`s. If `false`, integer arguments are passed as
+    JavaScript numbers. **Default:** `false`.
+  * `varargs` {boolean} If `true`, `function` can accept a variable number of
+    arguments. If `false`, `function` must be invoked with exactly
+    `function.length` arguments. **Default:** `false`.
+* `function` {Function} The JavaScript function to call when the SQLite
+  function is invoked.
+
+This method is used to create SQLite user-defined functions. This method is a
+wrapper around [`sqlite3_create_function_v2()`][].
+
 ### `database.open()`
 
 <!-- YAML
@@ -490,8 +515,11 @@ The following constants are meant for use with [`database.applyChangeset()`](#da
 [SQL injection]: https://en.wikipedia.org/wiki/SQL_injection
 [`ATTACH DATABASE`]: https://www.sqlite.org/lang_attach.html
 [`PRAGMA foreign_keys`]: https://www.sqlite.org/pragma.html#pragma_foreign_keys
+[`SQLITE_DETERMINISTIC`]: https://www.sqlite.org/c3ref/c_deterministic.html
+[`SQLITE_DIRECTONLY`]: https://www.sqlite.org/c3ref/c_deterministic.html
 [`sqlite3_changes64()`]: https://www.sqlite.org/c3ref/changes.html
 [`sqlite3_close_v2()`]: https://www.sqlite.org/c3ref/close.html
+[`sqlite3_create_function_v2()`]: https://www.sqlite.org/c3ref/create_function.html
 [`sqlite3_exec()`]: https://www.sqlite.org/c3ref/exec.html
 [`sqlite3_expanded_sql()`]: https://www.sqlite.org/c3ref/expanded_sql.html
 [`sqlite3_last_insert_rowid()`]: https://www.sqlite.org/c3ref/last_insert_rowid.html

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -57,6 +57,7 @@ class DatabaseSync : public BaseObject {
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Prepare(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Exec(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CustomFunction(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CreateSession(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ApplyChangeset(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void EnableLoadExtension(

--- a/test/parallel/test-sqlite-custom-functions.js
+++ b/test/parallel/test-sqlite-custom-functions.js
@@ -1,0 +1,373 @@
+'use strict';
+require('../common');
+const assert = require('node:assert');
+const { DatabaseSync } = require('node:sqlite');
+const { suite, test } = require('node:test');
+
+suite('DatabaseSync.prototype.function()', () => {
+  suite('input validation', () => {
+    const db = new DatabaseSync(':memory:');
+
+    test('throws if name is not a string', () => {
+      assert.throws(() => {
+        db.function();
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "name" argument must be a string/,
+      });
+    });
+
+    test('throws if function is not a function', () => {
+      assert.throws(() => {
+        db.function('foo');
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "function" argument must be a function/,
+      });
+    });
+
+    test('throws if options is not an object', () => {
+      assert.throws(() => {
+        db.function('foo', null, () => {});
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "options" argument must be an object/,
+      });
+    });
+
+    test('throws if options.useBigIntArguments is not a boolean', () => {
+      assert.throws(() => {
+        db.function('foo', { useBigIntArguments: null }, () => {});
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "options\.useBigIntArguments" argument must be a boolean/,
+      });
+    });
+
+    test('throws if options.varargs is not a boolean', () => {
+      assert.throws(() => {
+        db.function('foo', { varargs: null }, () => {});
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "options\.varargs" argument must be a boolean/,
+      });
+    });
+
+    test('throws if options.deterministic is not a boolean', () => {
+      assert.throws(() => {
+        db.function('foo', { deterministic: null }, () => {});
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "options\.deterministic" argument must be a boolean/,
+      });
+    });
+
+    test('throws if options.directOnly is not a boolean', () => {
+      assert.throws(() => {
+        db.function('foo', { directOnly: null }, () => {});
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: /The "options\.directOnly" argument must be a boolean/,
+      });
+    });
+  });
+
+  suite('useBigIntArguments', () => {
+    test('converts arguments to BigInts when true', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', { useBigIntArguments: true }, (arg) => {
+        value = arg;
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(5) AS custom').get();
+      assert.strictEqual(value, 5n);
+    });
+
+    test('uses number primitives when false', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', { useBigIntArguments: false }, (arg) => {
+        value = arg;
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(5) AS custom').get();
+      assert.strictEqual(value, 5);
+    });
+
+    test('defaults to false', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', (arg) => {
+        value = arg;
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(5) AS custom').get();
+      assert.strictEqual(value, 5);
+    });
+
+    test('throws if value cannot fit in a number', () => {
+      const db = new DatabaseSync(':memory:');
+      const value = Number.MAX_SAFE_INTEGER + 1;
+      db.function('custom', (arg) => {});
+      assert.throws(() => {
+        db.prepare(`SELECT custom(${value}) AS custom`).get();
+      }, {
+        code: 'ERR_OUT_OF_RANGE',
+        message: /Value is too large to be represented as a JavaScript number: 9007199254740992/,
+      });
+    });
+  });
+
+  suite('varargs', () => {
+    test('supports variable number of arguments when true', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', { varargs: true }, (...args) => {
+        value = args;
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(5, 4, 3, 2, 1) AS custom').get();
+      assert.deepStrictEqual(value, [5, 4, 3, 2, 1]);
+    });
+
+    test('uses function.length when false', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', { varargs: false }, (a, b, c) => {
+        value = [a, b, c];
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(1, 2, 3) AS custom').get();
+      assert.deepStrictEqual(value, [1, 2, 3]);
+    });
+
+    test('defaults to false', () => {
+      const db = new DatabaseSync(':memory:');
+      let value;
+      const r = db.function('custom', (a, b, c) => {
+        value = [a, b, c];
+      });
+      assert.strictEqual(r, undefined);
+      db.prepare('SELECT custom(7, 8, 9) AS custom').get();
+      assert.deepStrictEqual(value, [7, 8, 9]);
+    });
+
+    test('throws if an incorrect number of arguments is provided', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('custom', (a, b, c, d) => {});
+      assert.throws(() => {
+        db.prepare('SELECT custom(1, 2, 3) AS custom').get();
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /wrong number of arguments to function custom\(\)/,
+      });
+    });
+  });
+
+  suite('deterministic', () => {
+    test('creates a deterministic function when true', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('isDeterministic', { deterministic: true }, () => {
+        return 42;
+      });
+      const r = db.exec(`
+        CREATE TABLE t1 (
+          a INTEGER PRIMARY KEY,
+          b INTEGER GENERATED ALWAYS AS (isDeterministic()) VIRTUAL
+        )
+      `);
+      assert.strictEqual(r, undefined);
+    });
+
+    test('creates a non-deterministic function when false', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('isNonDeterministic', { deterministic: false }, () => {
+        return 42;
+      });
+      assert.throws(() => {
+        db.exec(`
+          CREATE TABLE t1 (
+            a INTEGER PRIMARY KEY,
+            b INTEGER GENERATED ALWAYS AS (isNonDeterministic()) VIRTUAL
+          )
+        `);
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /non-deterministic functions prohibited in generated columns/,
+      });
+    });
+
+    test('deterministic defaults to false', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('isNonDeterministic', () => {
+        return 42;
+      });
+      assert.throws(() => {
+        db.exec(`
+          CREATE TABLE t1 (
+            a INTEGER PRIMARY KEY,
+            b INTEGER GENERATED ALWAYS AS (isNonDeterministic()) VIRTUAL
+          )
+        `);
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /non-deterministic functions prohibited in generated columns/,
+      });
+    });
+  });
+
+  suite('directOnly', () => {
+    test('sets SQLite direct only flag when true', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('fn', { deterministic: true, directOnly: true }, () => {
+        return 42;
+      });
+      assert.throws(() => {
+        db.exec(`
+          CREATE TABLE t1 (
+            a INTEGER PRIMARY KEY,
+            b INTEGER GENERATED ALWAYS AS (fn()) VIRTUAL
+          )
+        `);
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /unsafe use of fn\(\)/
+      });
+    });
+
+    test('does not set SQLite direct only flag when false', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('fn', { deterministic: true, directOnly: false }, () => {
+        return 42;
+      });
+      const r = db.exec(`
+        CREATE TABLE t1 (
+          a INTEGER PRIMARY KEY,
+          b INTEGER GENERATED ALWAYS AS (fn()) VIRTUAL
+        )
+      `);
+      assert.strictEqual(r, undefined);
+    });
+
+    test('directOnly defaults to false', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('fn', { deterministic: true }, () => {
+        return 42;
+      });
+      const r = db.exec(`
+        CREATE TABLE t1 (
+          a INTEGER PRIMARY KEY,
+          b INTEGER GENERATED ALWAYS AS (fn()) VIRTUAL
+        )
+      `);
+      assert.strictEqual(r, undefined);
+    });
+  });
+
+  suite('return types', () => {
+    test('supported return types', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('retUndefined', () => {});
+      db.function('retNull', () => { return null; });
+      db.function('retNumber', () => { return 3; });
+      db.function('retString', () => { return 'foo'; });
+      db.function('retBigInt', () => { return 5n; });
+      db.function('retUint8Array', () => { return new Uint8Array([1, 2, 3]); });
+      const stmt = db.prepare(`SELECT
+        retUndefined() AS retUndefined,
+        retNull() AS retNull,
+        retNumber() AS retNumber,
+        retString() AS retString,
+        retBigInt() AS retBigInt,
+        retUint8Array() AS retUint8Array
+      `);
+      assert.deepStrictEqual(stmt.get(), {
+        __proto__: null,
+        retUndefined: null,
+        retNull: null,
+        retNumber: 3,
+        retString: 'foo',
+        retBigInt: 5,
+        retUint8Array: new Uint8Array([1, 2, 3]),
+      });
+    });
+
+    test('throws if returned BigInt is too large for SQLite', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('retBigInt', () => {
+        return BigInt(Number.MAX_SAFE_INTEGER + 1);
+      });
+      const stmt = db.prepare('SELECT retBigInt() AS retBigInt');
+      assert.throws(() => {
+        stmt.get();
+      }, {
+        code: 'ERR_OUT_OF_RANGE',
+      });
+    });
+
+    test('does not support Promise return values', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('retPromise', async () => {});
+      const stmt = db.prepare('SELECT retPromise() AS retPromise');
+      assert.throws(() => {
+        stmt.get();
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /Asynchronous user-defined functions are not supported/,
+      });
+    });
+
+    test('throws on unsupported return types', () => {
+      const db = new DatabaseSync(':memory:');
+      db.function('retFunction', () => {
+        return () => {};
+      });
+      const stmt = db.prepare('SELECT retFunction() AS retFunction');
+      assert.throws(() => {
+        stmt.get();
+      }, {
+        code: 'ERR_SQLITE_ERROR',
+        message: /Returned JavaScript value cannot be converted to a SQLite value/,
+      });
+    });
+  });
+
+  test('supported argument types', () => {
+    const db = new DatabaseSync(':memory:');
+    db.function('arguments', (i, f, s, n, b) => {
+      assert.strictEqual(i, 5);
+      assert.strictEqual(f, 3.14);
+      assert.strictEqual(s, 'foo');
+      assert.strictEqual(n, null);
+      assert.deepStrictEqual(b, new Uint8Array([254]));
+      return 42;
+    });
+    const stmt = db.prepare(
+      'SELECT arguments(5, 3.14, \'foo\', null, x\'fe\') as result'
+    );
+    assert.deepStrictEqual(stmt.get(), { __proto__: null, result: 42 });
+  });
+
+  test('propagates thrown errors', () => {
+    const db = new DatabaseSync(':memory:');
+    const err = new Error('boom');
+    db.function('throws', () => {
+      throw err;
+    });
+    const stmt = db.prepare('SELECT throws()');
+    assert.throws(() => {
+      stmt.get();
+    }, err);
+  });
+
+  test('throws if database is not open', () => {
+    const db = new DatabaseSync(':memory:', { open: false });
+    assert.throws(() => {
+      db.function('foo', () => {});
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /database is not open/,
+    });
+  });
+});


### PR DESCRIPTION
This commit adds support to node:sqlite for defining custom functions that can be invoked from SQL.

Fixes: https://github.com/nodejs/node/issues/54349

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
