### PR TITLE
fs: cache ReadFileContext after lazy loading

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -164,6 +164,7 @@ let ReadStream;
 let WriteStream;
 let rimraf;
 let kResistStopPropagation;
+let ReadFileContext;
 
 // These have to be separate because of how graceful-fs happens to do it's
 // monkeypatching.
@@ -365,7 +366,7 @@ function readFile(path, options, callback) {
   callback ||= options;
   validateFunction(callback, 'cb');
   options = getOptions(options, { flag: 'r' });
-  const ReadFileContext = require('internal/fs/read/context');
+  ReadFileContext ??= require('internal/fs/read/context');
   const context = new ReadFileContext(callback, options.encoding);
   context.isUserFd = isFd(path); // File descriptor ownership
 


### PR DESCRIPTION
Not sure why it's `require`d at every call, I think we can cache it after the lazy load

All tests pass on my end