### PR TITLE
lib: clean up persisted signals when they are settled

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -276,9 +276,7 @@ class AbortSignal extends EventTarget {
         resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
         dependantSignalsCleanupRegistry.register(resultSignal, signalWeakRef);
-        // when the source signal - coming from the controller - is gced, we need to remove it from the dependant
-        // signals of the composite signal
-        finalizer.register(signal, { sourceSignalRef: signalWeakRef, composedSignalRef: resultSignalWeakRef});
+        finalizer.register(signal, { sourceSignalRef: signalWeakRef, composedSignalRef: resultSignalWeakRef });
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -98,7 +98,7 @@ const dependantSignalsCleanupRegistry = new SafeFinalizationRegistry((signalWeak
 
 const gcPersistentSignals = new SafeSet();
 
-const finalizer = new SafeFinalizationRegistry(({ sourceSignalRef, composedSignalRef }) => {
+const sourceSignalsCleanupRegistry = new SafeFinalizationRegistry(({ sourceSignalRef, composedSignalRef }) => {
   const composedSignal = composedSignalRef.deref();
   if (composedSignal !== undefined) {
     composedSignal[kSourceSignals].delete(sourceSignalRef);
@@ -271,7 +271,10 @@ class AbortSignal extends EventTarget {
         resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
         dependantSignalsCleanupRegistry.register(resultSignal, signalWeakRef);
-        finalizer.register(signal, { sourceSignalRef: signalWeakRef, composedSignalRef: resultSignalWeakRef });
+        sourceSignalsCleanupRegistry.register(signal, {
+          sourceSignalRef: signalWeakRef,
+          composedSignalRef: resultSignalWeakRef,
+        });
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {
@@ -289,6 +292,10 @@ class AbortSignal extends EventTarget {
           resultSignal[kSourceSignals].add(sourceSignalWeakRef);
           sourceSignal[kDependantSignals].add(resultSignalWeakRef);
           dependantSignalsCleanupRegistry.register(resultSignal, sourceSignalWeakRef);
+          sourceSignalsCleanupRegistry.register(signal, {
+            sourceSignalRef: sourceSignalWeakRef,
+            composedSignalRef: resultSignalWeakRef,
+          });
         }
       }
     }

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -95,7 +95,24 @@ const dependantSignalsCleanupRegistry = new SafeFinalizationRegistry((signalWeak
     }
   });
 });
+
 const gcPersistentSignals = new SafeSet();
+
+const finalizer = new SafeFinalizationRegistry(({ sourceSignalRef, composedSignalRef }) => {
+  // TODO: remove ref from source signal
+  // TODO: remove composed signal from gcPersistentSignals
+  const composedSignal = composedSignalRef.deref();
+  if (composedSignal !== undefined) {
+    composedSignal[kSourceSignals].delete(sourceSignalRef);
+    gcPersistentSignals.delete(composedSignal);
+  }
+
+  // TODO: remove ref from dependant signal
+  const sourceSignal = sourceSignalRef.deref();
+  if (sourceSignal !== undefined) {
+    sourceSignal[kDependantSignals].delete(composedSignalRef);
+  }
+});
 
 const kAborted = Symbol('kAborted');
 const kReason = Symbol('kReason');
@@ -258,6 +275,9 @@ class AbortSignal extends EventTarget {
         resultSignal[kSourceSignals].add(signalWeakRef);
         signal[kDependantSignals].add(resultSignalWeakRef);
         dependantSignalsCleanupRegistry.register(resultSignal, signalWeakRef);
+        // when the source signal - coming from the controller - is gced, we need to remove it from the dependant
+        // signals of the composite signal
+        finalizer.register(signal, { sourceSignalRef: signalWeakRef, composedSignalRef: resultSignalWeakRef});
       } else if (!signal[kSourceSignals]) {
         continue;
       } else {
@@ -293,6 +313,7 @@ class AbortSignal extends EventTarget {
       // listener, then we don't want it to be gc'd while the listener
       // is attached and the timer still hasn't fired. So, we retain a
       // strong ref that is held for as long as the listener is registered.
+
       gcPersistentSignals.add(this);
     }
   }
@@ -434,6 +455,7 @@ class AbortController {
    */
   get signal() {
     this.#signal ??= new AbortSignal(kDontThrowSymbol);
+
     return this.#signal;
   }
 

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -99,15 +99,16 @@ const dependantSignalsCleanupRegistry = new SafeFinalizationRegistry((signalWeak
 const gcPersistentSignals = new SafeSet();
 
 const finalizer = new SafeFinalizationRegistry(({ sourceSignalRef, composedSignalRef }) => {
-  // TODO: remove ref from source signal
-  // TODO: remove composed signal from gcPersistentSignals
   const composedSignal = composedSignalRef.deref();
   if (composedSignal !== undefined) {
     composedSignal[kSourceSignals].delete(sourceSignalRef);
-    gcPersistentSignals.delete(composedSignal);
+
+    if (composedSignal[kSourceSignals].size === 0) {
+      // This signal will no longer abort. There's no need to keep it in the gcPersistentSignals set.
+      gcPersistentSignals.delete(composedSignal);
+    }
   }
 
-  // TODO: remove ref from dependant signal
   const sourceSignal = sourceSignalRef.deref();
   if (sourceSignal !== undefined) {
     sourceSignal[kDependantSignals].delete(composedSignalRef);

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -108,11 +108,6 @@ const finalizer = new SafeFinalizationRegistry(({ sourceSignalRef, composedSigna
       gcPersistentSignals.delete(composedSignal);
     }
   }
-
-  const sourceSignal = sourceSignalRef.deref();
-  if (sourceSignal !== undefined) {
-    sourceSignal[kDependantSignals].delete(composedSignalRef);
-  }
 });
 
 const kAborted = Symbol('kAborted');
@@ -312,7 +307,6 @@ class AbortSignal extends EventTarget {
       // listener, then we don't want it to be gc'd while the listener
       // is attached and the timer still hasn't fired. So, we retain a
       // strong ref that is held for as long as the listener is registered.
-
       gcPersistentSignals.add(this);
     }
   }


### PR DESCRIPTION
Refs #55328
Fixes #55328

This PR adds a finalizer to the non-composed signals used in `AbortSignal.any`. With that finalizer, those settled signals can be removed from `gcPersistentSignals`.

## Comparison

This comparison shows that settled signals are being collected.

![image](https://github.com/user-attachments/assets/55e94a90-c444-4b97-978a-62bea2008f07)

