### PR TITLE
[v22.x backport] lib: convert transfer sequence to array in js

### DIFF
--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -32,8 +32,11 @@ const {
 } = require('internal/process/task_queues');
 defineOperation(globalThis, 'queueMicrotask', queueMicrotask);
 
-const { structuredClone } = internalBinding('messaging');
-defineOperation(globalThis, 'structuredClone', structuredClone);
+defineLazyProperties(
+  globalThis,
+  'internal/worker/js_transferable',
+  ['structuredClone'],
+);
 defineLazyProperties(globalThis, 'buffer', ['atob', 'btoa']);
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts

--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -31,7 +31,7 @@ const {
   },
 } = require('internal/errors');
 
-const { structuredClone } = internalBinding('messaging');
+const { structuredClone } = require('internal/worker/js_transferable');
 const {
   lazyDOMException,
   kEnumerableProperty,

--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -36,6 +36,16 @@ converters.any = (V) => {
   return V;
 };
 
+converters.object = (V, opts = kEmptyObject) => {
+  if (type(V) !== 'Object') {
+    throw makeException(
+      'is not an object',
+      kEmptyObject,
+    );
+  }
+  return V;
+};
+
 // https://webidl.spec.whatwg.org/#abstract-opdef-integerpart
 const integerPart = MathTrunc;
 
@@ -186,6 +196,8 @@ converters.DOMString = function DOMString(V) {
 
   return String(V);
 };
+
+converters['sequence<object>'] = createSequenceConverter(converters.object);
 
 function codedTypeError(message, errorProperties = kEmptyObject) {
   // eslint-disable-next-line no-restricted-syntax

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -74,6 +74,7 @@ const {
   kTransfer,
   kTransferList,
   markTransferMode,
+  structuredClone,
 } = require('internal/worker/js_transferable');
 
 const {
@@ -87,8 +88,6 @@ const {
   kIsClosedPromise,
   kControllerErrorFunction,
 } = require('internal/streams/utils');
-
-const { structuredClone } = internalBinding('messaging');
 
 const {
   ArrayBufferViewGetBuffer,

--- a/lib/internal/worker/js_transferable.js
+++ b/lib/internal/worker/js_transferable.js
@@ -4,6 +4,13 @@ const {
   StringPrototypeSplit,
 } = primordials;
 const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_MISSING_ARGS,
+  },
+} = require('internal/errors');
+const webidl = require('internal/webidl');
+const {
   messaging_deserialize_symbol,
   messaging_transfer_symbol,
   messaging_clone_symbol,
@@ -11,6 +18,7 @@ const {
 } = internalBinding('symbols');
 const {
   setDeserializerCreateObjectFunction,
+  structuredClone: nativeStructuredClone,
 } = internalBinding('messaging');
 const {
   privateSymbols: {
@@ -90,9 +98,38 @@ function markTransferMode(obj, cloneable = false, transferable = false) {
   obj[transfer_mode_private_symbol] = mode;
 }
 
+function structuredClone(value, options) {
+  if (arguments.length === 0) {
+    throw new ERR_MISSING_ARGS('The value argument must be specified');
+  }
+
+  // TODO(jazelly): implement generic webidl dictionary converter
+  const prefix = 'Options';
+  const optionsType = webidl.type(options);
+  if (optionsType !== 'Undefined' && optionsType !== 'Null' && optionsType !== 'Object') {
+    throw new ERR_INVALID_ARG_TYPE(
+      prefix,
+      ['object', 'null', 'undefined'],
+      options,
+    );
+  }
+  const key = 'transfer';
+  const idlOptions = { __proto__: null, [key]: [] };
+  if (options != null && key in options && options[key] !== undefined) {
+    idlOptions[key] = webidl.converters['sequence<object>'](options[key], {
+      __proto__: null,
+      context: 'Transfer',
+    });
+  }
+
+  const serializedData = nativeStructuredClone(value, idlOptions);
+  return serializedData;
+}
+
 module.exports = {
   markTransferMode,
   setup,
+  structuredClone,
   kClone: messaging_clone_symbol,
   kDeserialize: messaging_deserialize_symbol,
   kTransfer: messaging_transfer_symbol,

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1578,28 +1578,21 @@ static void StructuredClone(const FunctionCallbackInfo<Value>& args) {
   Realm* realm = Realm::GetCurrent(context);
   Environment* env = realm->env();
 
-  if (args.Length() == 0) {
-    return THROW_ERR_MISSING_ARGS(env, "The value argument must be specified");
-  }
-
   Local<Value> value = args[0];
 
   TransferList transfer_list;
-  if (!args[1]->IsNullOrUndefined()) {
-    if (!args[1]->IsObject()) {
-      return THROW_ERR_INVALID_ARG_TYPE(
-          env, "The options argument must be either an object or undefined");
-    }
-    Local<Object> options = args[1].As<Object>();
-    Local<Value> transfer_list_v;
-    if (!options->Get(context, env->transfer_string())
-             .ToLocal(&transfer_list_v)) {
-      return;
-    }
+  Local<Object> options = args[1].As<Object>();
+  Local<Value> transfer_list_v;
+  if (!options->Get(context, env->transfer_string())
+           .ToLocal(&transfer_list_v)) {
+    return;
+  }
 
-    // TODO(joyeecheung): implement this in JS land to avoid the C++ -> JS
-    // cost to convert a sequence into an array.
-    if (!GetTransferList(env, context, transfer_list_v, &transfer_list)) {
+  Local<Array> arr = transfer_list_v.As<Array>();
+  size_t length = arr->Length();
+  transfer_list.AllocateSufficientStorage(length);
+  for (size_t i = 0; i < length; i++) {
+    if (!arr->Get(context, i).ToLocal(&transfer_list[i])) {
       return;
     }
   }


### PR DESCRIPTION
This commit lets `tranfer` passed to `structuredClone` get validated at JS layer by doing webidl conversion. This avoids the C++ to JS function call overhead in the native implementaiton of `structuredClone`

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
