### PR TITLE
doc: fix deprecation codes

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3786,7 +3786,7 @@ Type: Documentation-only
 Passing non-supported argument types is deprecated and, instead of returning `false`,
 will throw an error in a future version.
 
-### DEP0187: `process.features.ipv6` and `process.features.uv`
+### DEP0188: `process.features.ipv6` and `process.features.uv`
 
 <!-- YAML
 changes:
@@ -3799,7 +3799,7 @@ Type: Documentation-only
 
 These properties are unconditionally `true`. Any checks based on these properties are redundant.
 
-### DEP0188: `process.features.tls_*`
+### DEP0189: `process.features.tls_*`
 
 <!-- YAML
 changes:


### PR DESCRIPTION
https://github.com/nodejs/node/pull/55545 introduced a duplicate deprecation code and because of it [CI is now failing](https://github.com/nodejs/node/actions/workflows/doc.yml)