### PR TITLE
doc: add restrictions around node:test usage

### DIFF
--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -153,7 +153,7 @@ These dependencies are:
 - `node:async_hooks`
 - `node:child_process`
 - `node:fs`
-- ReadableStream in `node:streams`
+- `node:streams` with the exception of WebStreams
 - `node:vm`
 
 #### Caveats

--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -143,8 +143,8 @@ request. Interesting things to notice:
 
 ### Usage of `node:test`
 
-It is recommended to use `node:test` in tests outside of testing the `node:test`
-module, if particular functionality that's tested is not a dependency of
+It is optional to use `node:test` in tests outside of testing the `node:test`
+module, as long as the functionality being tested is not a dependency of the
 `node:test` module. This ensures that a bug in the test runner doesn't impact
 the outcome of the underlying dependencies' test results.
 

--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -150,6 +150,7 @@ the outcome of the underlying dependencies' test results.
 
 These dependencies are:
 
+- `node:events`
 - `node:async_hooks`
 - `node:child_process`
 - `node:fs`

--- a/doc/contributing/writing-tests.md
+++ b/doc/contributing/writing-tests.md
@@ -141,6 +141,26 @@ request. Interesting things to notice:
 
 ## General recommendations
 
+### Usage of `node:test`
+
+It is recommended to use `node:test` in tests outside of testing the `node:test`
+module, if particular functionality that's tested is not a dependency of
+`node:test` module. This ensures that a bug in the test runner doesn't impact
+the outcome of the underlying dependencies' test results.
+
+These dependencies are:
+
+- `node:async_hooks`
+- `node:child_process`
+- `node:fs`
+- ReadableStream in `node:streams`
+- `node:vm`
+
+#### Caveats
+
+* `node:url` is excluded due to the extensive testing on web-platform tests.
+* `node:path` and `node:os` is excluded due to being used by both test runners.
+
 ### Timers
 
 Avoid timers unless the test is specifically testing timers. There are multiple


### PR DESCRIPTION
Adds a contributing guideline around the usage of `node:test` in `tests/` folder. This pull-request is open as a result of last weeks TSC meeting.

Potentially unblocks https://github.com/nodejs/node/pull/55716

cc @nodejs/tsc 