### PR TITLE
test: migrate tests to use node:test module for better test structure for worker test

### DIFF
--- a/test/parallel/test-worker-message-port-transfer-filehandle.js
+++ b/test/parallel/test-worker-message-port-transfer-filehandle.js
@@ -1,105 +1,107 @@
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const fs = require('fs').promises;
-const vm = require('vm');
-const { MessageChannel, moveMessagePortToContext } = require('worker_threads');
-const { once } = require('events');
 
-(async function() {
-  const fh = await fs.open(__filename);
+require('../common');
 
-  const { port1, port2 } = new MessageChannel();
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs').promises;
+const vm = require('node:vm');
+const { MessageChannel, moveMessagePortToContext } = require('node:worker_threads');
+const { once } = require('node:events');
 
-  assert.throws(() => {
-    port1.postMessage(fh);
-  }, {
-    constructor: DOMException,
-    name: 'DataCloneError',
-    code: 25,
+test('FileHandle transfer behavior', async (t) => {
+  await t.test('should throw when posting a FileHandle without transferring', async () => {
+    const fh = await fs.open(__filename);
+    const { port1 } = new MessageChannel();
+
+    assert.throws(() => {
+      port1.postMessage(fh);
+    }, {
+      constructor: DOMException,
+      name: 'DataCloneError',
+      code: 25,
+    });
+
+    await fh.close();
   });
 
-  // Check that transferring FileHandle instances works.
-  assert.notStrictEqual(fh.fd, -1);
-  port1.postMessage(fh, [ fh ]);
-  assert.strictEqual(fh.fd, -1);
+  await t.test('should transfer a FileHandle successfully', async () => {
+    const fh = await fs.open(__filename);
+    const { port1, port2 } = new MessageChannel();
 
-  const [ fh2 ] = await once(port2, 'message');
-  assert.strictEqual(Object.getPrototypeOf(fh2), Object.getPrototypeOf(fh));
-
-  assert.deepStrictEqual(await fh2.readFile(), await fs.readFile(__filename));
-  await fh2.close();
-
-  await assert.rejects(() => fh.readFile(), { code: 'EBADF' });
-})().then(common.mustCall());
-
-(async function() {
-  // Check that there is no crash if the message is never read.
-  const fh = await fs.open(__filename);
-
-  const { port1 } = new MessageChannel();
-
-  assert.notStrictEqual(fh.fd, -1);
-  port1.postMessage(fh, [ fh ]);
-  assert.strictEqual(fh.fd, -1);
-})().then(common.mustCall());
-
-(async function() {
-  // Check that in the case of a context mismatch the message is discarded.
-  const fh = await fs.open(__filename);
-
-  const { port1, port2 } = new MessageChannel();
-
-  const ctx = vm.createContext();
-  const port2moved = moveMessagePortToContext(port2, ctx);
-  port2moved.onmessage = common.mustCall((msgEvent) => {
-    assert.strictEqual(msgEvent.data, 'second message');
-    port1.close();
-  });
-  // TODO(addaleax): Switch this to a 'messageerror' event once MessagePort
-  // implements EventTarget fully and in a cross-context manner.
-  port2moved.onmessageerror = common.mustCall((event) => {
-    assert.strictEqual(event.data.code,
-                       'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE');
-  });
-  port2moved.start();
-
-  assert.notStrictEqual(fh.fd, -1);
-  port1.postMessage(fh, [ fh ]);
-  assert.strictEqual(fh.fd, -1);
-
-  port1.postMessage('second message');
-})().then(common.mustCall());
-
-(async function() {
-  // Check that a FileHandle with a read in progress cannot be transferred.
-  const fh = await fs.open(__filename);
-
-  const { port1 } = new MessageChannel();
-
-  const readPromise = fh.readFile();
-  assert.throws(() => {
+    assert.notStrictEqual(fh.fd, -1);
     port1.postMessage(fh, [fh]);
-  }, {
-    message: 'Cannot transfer FileHandle while in use',
-    name: 'DataCloneError'
+    assert.strictEqual(fh.fd, -1);
+
+    const [fh2] = await once(port2, 'message');
+    assert.strictEqual(Object.getPrototypeOf(fh2), Object.getPrototypeOf(fh));
+
+    assert.deepStrictEqual(await fh2.readFile(), await fs.readFile(__filename));
+    await fh2.close();
+
+    await assert.rejects(() => fh.readFile(), { code: 'EBADF' });
   });
 
-  assert.deepStrictEqual(await readPromise, await fs.readFile(__filename));
-})().then(common.mustCall());
+  await t.test('should not crash if the message is never read', async () => {
+    const fh = await fs.open(__filename);
+    const { port1 } = new MessageChannel();
 
-(async function() {
-  // Check that filehandles with a close in progress cannot be transferred.
-  const fh = await fs.open(__filename);
-
-  const { port1 } = new MessageChannel();
-
-  const closePromise = fh.close();
-  assert.throws(() => {
+    assert.notStrictEqual(fh.fd, -1);
     port1.postMessage(fh, [fh]);
-  }, {
-    message: 'Cannot transfer FileHandle while in use',
-    name: 'DataCloneError'
+    assert.strictEqual(fh.fd, -1);
   });
-  await closePromise;
-})().then(common.mustCall());
+
+  await t.test('should discard message with context mismatch', async () => {
+    const fh = await fs.open(__filename);
+    const { port1, port2 } = new MessageChannel();
+
+    const ctx = vm.createContext();
+    const port2moved = moveMessagePortToContext(port2, ctx);
+    port2moved.onmessage = (msgEvent) => {
+      assert.strictEqual(msgEvent.data, 'second message');
+      port1.close();
+    };
+    port2moved.onmessageerror = (event) => {
+      assert.strictEqual(
+        event.data.code,
+        'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE'
+      );
+    };
+    port2moved.start();
+
+    assert.notStrictEqual(fh.fd, -1);
+    port1.postMessage(fh, [fh]);
+    assert.strictEqual(fh.fd, -1);
+
+    port1.postMessage('second message');
+  });
+
+  await t.test('should not transfer FileHandle with read in progress', async () => {
+    const fh = await fs.open(__filename);
+    const { port1 } = new MessageChannel();
+
+    const readPromise = fh.readFile();
+    assert.throws(() => {
+      port1.postMessage(fh, [fh]);
+    }, {
+      message: 'Cannot transfer FileHandle while in use',
+      name: 'DataCloneError',
+    });
+
+    assert.deepStrictEqual(await readPromise, await fs.readFile(__filename));
+  });
+
+  await t.test('should not transfer FileHandle with close in progress', async () => {
+    const fh = await fs.open(__filename);
+    const { port1 } = new MessageChannel();
+
+    const closePromise = fh.close();
+    assert.throws(() => {
+      port1.postMessage(fh, [fh]);
+    }, {
+      message: 'Cannot transfer FileHandle while in use',
+      name: 'DataCloneError',
+    });
+    await closePromise;
+  });
+});

--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -1,63 +1,75 @@
 'use strict';
-const common = require('../common');
-const assert = require('assert');
-const { once } = require('events');
-const v8 = require('v8');
-const { Worker } = require('worker_threads');
 
-// Verify that Workers don't care about --stack-size, as they have their own
-// fixed and known stack sizes.
+require('../common');
+
+const { test } = require('node:test');
+const { once } = require('node:events');
+const assert = require('node:assert');
+const v8 = require('node:v8');
+const { Worker } = require('node:worker_threads');
 
 async function runWorker(options = {}) {
   const empiricalStackDepth = new Uint32Array(new SharedArrayBuffer(4));
-  const worker = new Worker(`
-  const { workerData: { empiricalStackDepth } } = require('worker_threads');
-  function f() {
-    empiricalStackDepth[0]++;
-    f();
-  }
-  f();`, {
-    eval: true,
-    workerData: { empiricalStackDepth },
-    ...options
-  });
+  const worker = new Worker(
+    `
+    const { workerData: { empiricalStackDepth } } = require('worker_threads');
+    function f() {
+      empiricalStackDepth[0]++;
+      f();
+    }
+    f();`,
+    {
+      eval: true,
+      workerData: { empiricalStackDepth },
+      ...options,
+    },
+  );
 
-  const [ error ] = await once(worker, 'error');
+  const [error] = await once(worker, 'error');
   if (!options.skipErrorCheck) {
-    common.expectsError({
-      constructor: RangeError,
-      message: 'Maximum call stack size exceeded'
-    })(error);
+    const expectedErrorMessage = 'Expected a RangeError';
+    const unexpectedErrorMessage = 'Unexpected error message';
+
+    assert.strictEqual(error.constructor, RangeError, expectedErrorMessage);
+    assert.match(
+      error.message,
+      /Maximum call stack size exceeded/,
+      unexpectedErrorMessage,
+    );
   }
 
   return empiricalStackDepth[0];
 }
 
-(async function() {
-  {
+test('Worker threads stack size tests', async (t) => {
+  await t.test('Workers are unaffected by --stack-size flag', async () => {
     v8.setFlagsFromString('--stack-size=500');
     const w1stack = await runWorker();
     v8.setFlagsFromString('--stack-size=1000');
     const w2stack = await runWorker();
-    // Make sure the two stack sizes are within 10 % of each other, i.e. not
-    // affected by the different `--stack-size` settings.
-    assert(Math.max(w1stack, w2stack) / Math.min(w1stack, w2stack) < 1.1,
-           `w1stack = ${w1stack}, w2stack = ${w2stack} are too far apart`);
-  }
 
-  {
+    assert(
+      Math.max(w1stack, w2stack) / Math.min(w1stack, w2stack) < 1.1,
+      `w1stack = ${w1stack}, w2stack = ${w2stack} are too far apart`,
+    );
+  });
+
+  await t.test('Workers respect resourceLimits.stackSizeMb', async () => {
     const w1stack = await runWorker({ resourceLimits: { stackSizeMb: 0.5 } });
     const w2stack = await runWorker({ resourceLimits: { stackSizeMb: 1.0 } });
-    // Make sure the two stack sizes are at least 40 % apart from each other,
-    // i.e. affected by the different `stackSizeMb` settings.
-    assert(w2stack > w1stack * 1.4,
-           `w1stack = ${w1stack}, w2stack = ${w2stack} are too close`);
-  }
 
-  // Test that various low stack sizes result in an 'error' event.
-  // Currently the stack size needs to be at least 0.3MB for the worker to be
-  // bootstrapped properly.
-  for (const stackSizeMb of [ 0.3, 0.5, 1 ]) {
-    await runWorker({ resourceLimits: { stackSizeMb }, skipErrorCheck: true });
-  }
-})().then(common.mustCall());
+    assert(
+      w2stack > w1stack * 1.4,
+      `w1stack = ${w1stack}, w2stack = ${w2stack} are too close`,
+    );
+  });
+
+  await t.test('Low stack sizes result in error events', async () => {
+    for (const stackSizeMb of [0.3, 0.5, 1]) {
+      await runWorker({
+        resourceLimits: { stackSizeMb },
+        skipErrorCheck: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
This update refactors the test structure to use the node:test module, aiming to improve consistency and maintainability across the codebase.

this is part of a long pull request: https://github.com/nodejs/node/pull/56024