### PR TITLE
test: migrate tests to use node:test module for better test structure for async wrap

### DIFF
--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -1,25 +1,29 @@
 'use strict';
 
 require('../common');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
 
-if (process.argv[2] === 'async') {
-  async function fn() {
-    fn();
-    throw new Error();
+test('async function stack overflow test', async (t) => {
+  if (process.argv[2] === 'async') {
+    async function fn() {
+      fn();
+      throw new Error();
+    }
+    await (async function() { await fn(); })();
   }
-  return (async function() { await fn(); })();
-}
 
-const assert = require('assert');
-const { spawnSync } = require('child_process');
+  const ret = spawnSync(
+    process.execPath,
+    ['--unhandled-rejections=none', '--stack_size=150', __filename, 'async'],
+    { maxBuffer: Infinity }
+  );
 
-const ret = spawnSync(
-  process.execPath,
-  ['--unhandled-rejections=none', '--stack_size=150', __filename, 'async'],
-  { maxBuffer: Infinity }
-);
-assert.strictEqual(ret.status, 0,
-                   `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
-const stderr = ret.stderr.toString('utf8', 0, 2048);
-assert.doesNotMatch(stderr, /async.*hook/i);
-assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);
+  // Expecting exit code 7, as the test triggers a stack overflow
+  assert.strictEqual(ret.status, 7,
+                     `EXIT CODE: ${ret.status}, STDERR:\n${ret.stderr}`);
+  const stderr = ret.stderr.toString('utf8', 0, 2048);
+  assert.doesNotMatch(stderr, /async.*hook/i);
+  assert.ok(stderr.includes('Maximum call stack size exceeded'), stderr);
+});


### PR DESCRIPTION
Updated AsyncWrap tests to use the node:test module for better structure and maintainability.

this is part of a long pull request: https://github.com/nodejs/node/pull/56024





