### PR TITLE
test: migrate tests to use node:test module for better test structure for eventtarget once twice

### DIFF
--- a/test/parallel/test-eventtarget-once-twice.js
+++ b/test/parallel/test-eventtarget-once-twice.js
@@ -1,14 +1,26 @@
 'use strict';
 const common = require('../common');
-const { once } = require('events');
+const { once } = require('node:events');
+const { test } = require('node:test');
 
-const et = new EventTarget();
-(async function() {
-  await once(et, 'foo');
-  await once(et, 'foo');
-})().then(common.mustCall());
+test('EventTarget test', async () => {
+  const et = new EventTarget();
 
-et.dispatchEvent(new Event('foo'));
-setImmediate(() => {
+  // Use `once` to listen for the 'foo' event twice
+  const promise1 = once(et, 'foo');
+  const promise2 = once(et, 'foo');
+
+  // Dispatch the first event
   et.dispatchEvent(new Event('foo'));
-});
+
+  // Dispatch the second event in the next tick to ensure it's awaited properly
+  setImmediate(() => {
+    et.dispatchEvent(new Event('foo'));
+  });
+
+  // Await both promises to ensure both 'foo' events are captured
+  await promise1;
+  await promise2;
+
+  // Test automatically completes after all asynchronous operations finish
+}).then(common.mustCall());


### PR DESCRIPTION
Updated eventtarget-once-twice tests to use the node:test module for improved structure and consistency.

this is part of a long pull request: https://github.com/nodejs/node/pull/56024