### PR TITLE
test: migrate tests to use node:test module for better test structure for zlib empty buffer

### DIFF
--- a/test/parallel/test-zlib-empty-buffer.js
+++ b/test/parallel/test-zlib-empty-buffer.js
@@ -1,26 +1,36 @@
 'use strict';
-const common = require('../common');
-const zlib = require('zlib');
-const { inspect, promisify } = require('util');
-const assert = require('assert');
+
+require('../common');
+
+const { test } = require('node:test');
+const zlib = require('node:zlib');
+const { inspect, promisify } = require('node:util');
+const assert = require('node:assert');
+
 const emptyBuffer = Buffer.alloc(0);
 
-(async function() {
-  for (const [ compress, decompress, method ] of [
-    [ zlib.deflateRawSync, zlib.inflateRawSync, 'raw sync' ],
-    [ zlib.deflateSync, zlib.inflateSync, 'deflate sync' ],
-    [ zlib.gzipSync, zlib.gunzipSync, 'gzip sync' ],
-    [ zlib.brotliCompressSync, zlib.brotliDecompressSync, 'br sync' ],
-    [ promisify(zlib.deflateRaw), promisify(zlib.inflateRaw), 'raw' ],
-    [ promisify(zlib.deflate), promisify(zlib.inflate), 'deflate' ],
-    [ promisify(zlib.gzip), promisify(zlib.gunzip), 'gzip' ],
-    [ promisify(zlib.brotliCompress), promisify(zlib.brotliDecompress), 'br' ],
-  ]) {
-    const compressed = await compress(emptyBuffer);
-    const decompressed = await decompress(compressed);
-    assert.deepStrictEqual(
-      emptyBuffer, decompressed,
-      `Expected ${inspect(compressed)} to match ${inspect(decompressed)} ` +
-      `to match for ${method}`);
+test('zlib compression and decompression with various methods', async (t) => {
+  const methods = [
+    [zlib.deflateRawSync, zlib.inflateRawSync, 'raw sync'],
+    [zlib.deflateSync, zlib.inflateSync, 'deflate sync'],
+    [zlib.gzipSync, zlib.gunzipSync, 'gzip sync'],
+    [zlib.brotliCompressSync, zlib.brotliDecompressSync, 'br sync'],
+    [promisify(zlib.deflateRaw), promisify(zlib.inflateRaw), 'raw'],
+    [promisify(zlib.deflate), promisify(zlib.inflate), 'deflate'],
+    [promisify(zlib.gzip), promisify(zlib.gunzip), 'gzip'],
+    [promisify(zlib.brotliCompress), promisify(zlib.brotliDecompress), 'br'],
+  ];
+
+  for (const [compress, decompress, method] of methods) {
+    await t.test(`should handle ${method} compression and decompression`, async () => {
+      const compressed = await compress(emptyBuffer);
+      const decompressed = await decompress(compressed);
+
+      assert.deepStrictEqual(
+        emptyBuffer,
+        decompressed,
+        `Expected ${inspect(compressed)} to match ${inspect(decompressed)} for ${method}`
+      );
+    });
   }
-})().then(common.mustCall());
+});


### PR DESCRIPTION
Updated zlib-empty-buffer tests to use the node:test module for better structure and maintainability.

this is part of a long pull request: https://github.com/nodejs/node/pull/56024