### PR TITLE
test: migrate tests to use node:test module for better test structure for sequential

### DIFF
--- a/test/sequential/test-debugger-custom-port.js
+++ b/test/sequential/test-debugger-custom-port.js
@@ -1,28 +1,31 @@
 'use strict';
 const common = require('../common');
-
-common.skipIfInspectorDisabled();
-
 const fixtures = require('../common/fixtures');
 const startCLI = require('../common/debugger');
+const assert = require('node:assert');
+const { test } = require('node:test');
 
-const assert = require('assert');
+// Skip if the inspector is disabled
+common.skipIfInspectorDisabled();
 
-// Custom port.
-const script = fixtures.path('debugger', 'three-lines.js');
+test('should start CLI debugger with custom port and validate output', async (t) => {
+  const script = fixtures.path('debugger', 'three-lines.js');
+  const cli = startCLI([`--port=${common.PORT}`, script]);
 
-const cli = startCLI([`--port=${common.PORT}`, script]);
-(async function() {
-  try {
+  await t.test('validate debugger prompt and output', async () => {
     await cli.waitForInitialBreak();
     await cli.waitForPrompt();
+
     assert.match(cli.output, /debug>/, 'prints a prompt');
     assert.match(
       cli.output,
       new RegExp(`< Debugger listening on [^\n]*${common.PORT}`),
-      'forwards child output');
-  } finally {
+      'forwards child output'
+    );
+  });
+
+  await t.test('ensure CLI exits with code 0', async () => {
     const code = await cli.quit();
     assert.strictEqual(code, 0);
-  }
-})().then(common.mustCall());
+  });
+});

--- a/test/sequential/test-worker-heapsnapshot-options.js
+++ b/test/sequential/test-worker-heapsnapshot-options.js
@@ -1,11 +1,14 @@
 // Flags: --expose-internals
 'use strict';
-const common = require('../common');
-const { recordState, getHeapSnapshotOptionTests } = require('../common/heap');
-const { Worker } = require('worker_threads');
-const { once } = require('events');
 
-(async function() {
+require('../common');
+
+const { recordState, getHeapSnapshotOptionTests } = require('../common/heap');
+const { Worker } = require('node:worker_threads');
+const { once } = require('node:events');
+const { test } = require('node:test');
+
+test('should handle heap snapshot options correctly in Worker threads', async () => {
   const tests = getHeapSnapshotOptionTests();
   const w = new Worker(tests.fixtures);
 
@@ -18,4 +21,4 @@ const { once } = require('events');
   }
 
   await w.terminate();
-})().then(common.mustCall());
+});


### PR DESCRIPTION
Refactored test-debugger-custom-port and test-worker-heapsnapshot to use the node:test module for improved structure and maintainability.

this is part of a long pull request: https://github.com/nodejs/node/pull/56024