### PR TITLE
build: remove defaults for create-release-proposal

### DIFF
--- a/.github/workflows/create-release-proposal.yml
+++ b/.github/workflows/create-release-proposal.yml
@@ -11,12 +11,10 @@ on:
       release-line:
         required: true
         type: number
-        default: 23
         description: 'The release line (without dots or prefix). e.g: 22'
       release-date:
         required: true
         type: string
-        default: YYYY-MM-DD
         description: The release date in YYYY-MM-DD format
 
 concurrency: ${{ github.workflow }}


### PR DESCRIPTION
To prevent users from executing the workflow via CLI without passing the desired inputs.

cc: @nodejs/releasers 