### PR TITLE
fs: make mutating `options` in `readdir()` not affect results

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1531,6 +1531,9 @@ function readdir(path, options, callback) {
   }
 
   if (options.recursive) {
+    // Make shallow copy to prevent mutating options from affecting results
+    options = copyObject(options);
+
     readdirRecursive(path, options, callback);
     return;
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -944,6 +944,10 @@ async function readdirRecursive(originalPath, options) {
 
 async function readdir(path, options) {
   options = getOptions(options);
+
+  // Make shallow copy to prevent mutating options from affecting results
+  options = copyObject(options);
+
   path = getValidatedPath(path);
   if (options.recursive) {
     return readdirRecursive(path, options);

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -78,6 +78,14 @@ fs.readdir(readdirDir, {
   assertDirents(dirents);
 })().then(common.mustCall());
 
+// Check that mutating options doesn't affect results
+(async () => {
+  const options = { withFileTypes: true };
+  const direntsPromise = fs.promises.readdir(readdirDir, options);
+  options.withFileTypes = false;
+  assertDirents(await direntsPromise);
+})().then(common.mustCall());
+
 // Check for correct types when the binding returns unknowns
 const UNKNOWN = constants.UV_DIRENT_UNKNOWN;
 const oldReaddir = binding.readdir;

--- a/test/parallel/test-fs-readdir-types.js
+++ b/test/parallel/test-fs-readdir-types.js
@@ -86,6 +86,14 @@ fs.readdir(readdirDir, {
   assertDirents(await direntsPromise);
 })().then(common.mustCall());
 
+{
+  const options = { recursive: true, withFileTypes: true };
+  fs.readdir(readdirDir, options, common.mustSucceed((dirents) => {
+    assertDirents(dirents);
+  }));
+  options.withFileTypes = false;
+}
+
 // Check for correct types when the binding returns unknowns
 const UNKNOWN = constants.UV_DIRENT_UNKNOWN;
 const oldReaddir = binding.readdir;


### PR DESCRIPTION
The callback version is implemented in sync way (see https://github.com/nodejs/node/issues/56006), so its test should pass without adjustments.