### PR TITLE
test_runner: exclude test files from coverage by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2291,6 +2291,9 @@ This option may be specified multiple times to exclude multiple glob patterns.
 If both `--test-coverage-exclude` and `--test-coverage-include` are provided,
 files must meet **both** criteria to be included in the coverage report.
 
+By default all the matching test files are excluded from the coverage report.
+Specifying this option will override the default behavior.
+
 ### `--test-coverage-functions=threshold`
 
 <!-- YAML

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -476,8 +476,10 @@ all tests have completed. If the [`NODE_V8_COVERAGE`][] environment variable is
 used to specify a code coverage directory, the generated V8 coverage files are
 written to that directory. Node.js core modules and files within
 `node_modules/` directories are, by default, not included in the coverage report.
-However, they can be explicitly included via the [`--test-coverage-include`][] flag. If
-coverage is enabled, the coverage report is sent to any [test reporters][] via
+However, they can be explicitly included via the [`--test-coverage-include`][] flag.
+By default all the matching test files are excluded from the coverage report.
+Exclusions can be overridden by using the [`--test-coverage-exclude`][] flag.
+If coverage is enabled, the coverage report is sent to any [test reporters][] via
 the `'test:coverage'` event.
 
 Coverage can be disabled on a series of lines using the following
@@ -3594,6 +3596,7 @@ Can be used to abort test subtasks when the test has been aborted.
 [`--experimental-test-module-mocks`]: cli.md#--experimental-test-module-mocks
 [`--import`]: cli.md#--importmodule
 [`--test-concurrency`]: cli.md#--test-concurrency
+[`--test-coverage-exclude`]: cli.md#--test-coverage-exclude
 [`--test-coverage-include`]: cli.md#--test-coverage-include
 [`--test-name-pattern`]: cli.md#--test-name-pattern
 [`--test-only`]: cli.md#--test-only

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -650,7 +650,14 @@ class Glob {
   }
 }
 
-function glob(path, pattern, windows) {
+/**
+ * Check if a path matches a glob pattern
+ * @param {string} path the path to check
+ * @param {string} pattern the glob pattern to match
+ * @param {boolean} windows whether the path is on a Windows system, defaults to `isWindows`
+ * @returns {boolean}
+ */
+function matchGlobPattern(path, pattern, windows = isWindows) {
   validateString(path, 'path');
   validateString(pattern, 'pattern');
   return lazyMinimatch().minimatch(path, pattern, {
@@ -668,5 +675,5 @@ function glob(path, pattern, windows) {
 module.exports = {
   __proto__: null,
   Glob,
-  glob,
+  matchGlobPattern,
 };

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -650,7 +650,23 @@ class Glob {
   }
 }
 
+function glob(path, pattern, windows) {
+  validateString(path, 'path');
+  validateString(pattern, 'pattern');
+  return lazyMinimatch().minimatch(path, pattern, {
+    kEmptyObject,
+    nocase: isMacOS || isWindows,
+    windowsPathsNoEscape: true,
+    nonegate: true,
+    nocomment: true,
+    optimizationLevel: 2,
+    platform: windows ? 'win32' : 'posix',
+    nocaseMagicOnly: true,
+  });
+}
+
 module.exports = {
   __proto__: null,
   Glob,
+  glob,
 };

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -25,9 +25,9 @@ const {
   readFileSync,
   rmSync,
 } = require('fs');
-const { setupCoverageHooks } = require('internal/util');
+const { setupCoverageHooks, isWindows, isMacOS } = require('internal/util');
 const { tmpdir } = require('os');
-const { join, resolve, relative, matchesGlob } = require('path');
+const { join, resolve, relative } = require('path');
 const { fileURLToPath } = require('internal/url');
 const { kMappings, SourceMap } = require('internal/source_map/source_map');
 const {
@@ -41,6 +41,25 @@ const kIgnoreRegex = /\/\* node:coverage ignore next (?<count>\d+ )?\*\//;
 const kLineEndingRegex = /\r?\n$/u;
 const kLineSplitRegex = /(?<=\r?\n)/u;
 const kStatusRegex = /\/\* node:coverage (?<status>enable|disable) \*\//;
+
+let minimatch;
+function lazyMinimatch() {
+  minimatch ??= require('internal/deps/minimatch/index');
+  return minimatch;
+}
+
+function glob(path, pattern, windows) {
+  return lazyMinimatch().minimatch(path, pattern, {
+    __proto__: null,
+    nocase: isMacOS || isWindows,
+    windowsPathsNoEscape: true,
+    nonegate: true,
+    nocomment: true,
+    optimizationLevel: 2,
+    platform: windows ? 'win32' : 'posix',
+    nocaseMagicOnly: true,
+  });
+}
 
 class CoverageLine {
   constructor(line, startOffset, src, length = src?.length) {
@@ -464,19 +483,24 @@ class TestCoverage {
       coverageExcludeGlobs: excludeGlobs,
       coverageIncludeGlobs: includeGlobs,
     } = this.options;
+
     // This check filters out files that match the exclude globs.
     if (excludeGlobs?.length > 0) {
       for (let i = 0; i < excludeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, excludeGlobs[i]) ||
-            matchesGlob(absolutePath, excludeGlobs[i])) return true;
+        if (
+          glob(relativePath, excludeGlobs[i]) ||
+          glob(absolutePath, excludeGlobs[i])
+        ) return true;
       }
     }
 
     // This check filters out files that do not match the include globs.
     if (includeGlobs?.length > 0) {
       for (let i = 0; i < includeGlobs.length; ++i) {
-        if (matchesGlob(relativePath, includeGlobs[i]) ||
-            matchesGlob(absolutePath, includeGlobs[i])) return false;
+        if (
+          glob(relativePath, includeGlobs[i]) ||
+          glob(absolutePath, includeGlobs[i])
+        ) return false;
       }
       return true;
     }

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -25,7 +25,7 @@ const {
   readFileSync,
   rmSync,
 } = require('fs');
-const { setupCoverageHooks, isWindows, isMacOS } = require('internal/util');
+const { setupCoverageHooks } = require('internal/util');
 const { tmpdir } = require('os');
 const { join, resolve, relative } = require('path');
 const { fileURLToPath } = require('internal/url');
@@ -36,30 +36,13 @@ const {
     ERR_SOURCE_MAP_MISSING_SOURCE,
   },
 } = require('internal/errors');
+const { glob } = require('internal/fs/glob');
+
 const kCoverageFileRegex = /^coverage-(\d+)-(\d{13})-(\d+)\.json$/;
 const kIgnoreRegex = /\/\* node:coverage ignore next (?<count>\d+ )?\*\//;
 const kLineEndingRegex = /\r?\n$/u;
 const kLineSplitRegex = /(?<=\r?\n)/u;
 const kStatusRegex = /\/\* node:coverage (?<status>enable|disable) \*\//;
-
-let minimatch;
-function lazyMinimatch() {
-  minimatch ??= require('internal/deps/minimatch/index');
-  return minimatch;
-}
-
-function glob(path, pattern, windows) {
-  return lazyMinimatch().minimatch(path, pattern, {
-    __proto__: null,
-    nocase: isMacOS || isWindows,
-    windowsPathsNoEscape: true,
-    nonegate: true,
-    nocomment: true,
-    optimizationLevel: 2,
-    platform: windows ? 'win32' : 'posix',
-    nocaseMagicOnly: true,
-  });
-}
 
 class CoverageLine {
   constructor(line, startOffset, src, length = src?.length) {

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -36,7 +36,7 @@ const {
     ERR_SOURCE_MAP_MISSING_SOURCE,
   },
 } = require('internal/errors');
-const { glob } = require('internal/fs/glob');
+const { matchGlobPattern } = require('internal/fs/glob');
 
 const kCoverageFileRegex = /^coverage-(\d+)-(\d{13})-(\d+)\.json$/;
 const kIgnoreRegex = /\/\* node:coverage ignore next (?<count>\d+ )?\*\//;
@@ -471,8 +471,8 @@ class TestCoverage {
     if (excludeGlobs?.length > 0) {
       for (let i = 0; i < excludeGlobs.length; ++i) {
         if (
-          glob(relativePath, excludeGlobs[i]) ||
-          glob(absolutePath, excludeGlobs[i])
+          matchGlobPattern(relativePath, excludeGlobs[i]) ||
+          matchGlobPattern(absolutePath, excludeGlobs[i])
         ) return true;
       }
     }
@@ -481,8 +481,8 @@ class TestCoverage {
     if (includeGlobs?.length > 0) {
       for (let i = 0; i < includeGlobs.length; ++i) {
         if (
-          glob(relativePath, includeGlobs[i]) ||
-          glob(absolutePath, includeGlobs[i])
+          matchGlobPattern(relativePath, includeGlobs[i]) ||
+          matchGlobPattern(absolutePath, includeGlobs[i])
         ) return false;
       }
       return true;

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -287,6 +287,11 @@ function parseCommandLine() {
 
   if (coverage) {
     coverageExcludeGlobs = getOptionValue('--test-coverage-exclude');
+    if (!coverageExcludeGlobs || coverageExcludeGlobs.length === 0) {
+      // TODO(pmarchini): this default should follow something similar to c8 defaults
+      // Default exclusions should be also exported to be used by other tools / users
+      coverageExcludeGlobs = [kDefaultPattern];
+    }
     coverageIncludeGlobs = getOptionValue('--test-coverage-include');
 
     branchCoverage = getOptionValue('--test-coverage-branches');

--- a/lib/path.js
+++ b/lib/path.js
@@ -52,13 +52,12 @@ const {
 } = require('internal/validators');
 
 const {
-  getLazy,
   emitExperimentalWarning,
   isWindows,
-  isMacOS,
+  getLazy,
 } = require('internal/util');
 
-const lazyMinimatch = getLazy(() => require('internal/deps/minimatch/index'));
+const lazyGlob = getLazy(() => require('internal/fs/glob').glob);
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -162,22 +161,6 @@ function _format(sep, pathObject) {
     return base;
   }
   return dir === pathObject.root ? `${dir}${base}` : `${dir}${sep}${base}`;
-}
-
-function glob(path, pattern, windows) {
-  emitExperimentalWarning('glob');
-  validateString(path, 'path');
-  validateString(pattern, 'pattern');
-  return lazyMinimatch().minimatch(path, pattern, {
-    __proto__: null,
-    nocase: isMacOS || isWindows,
-    windowsPathsNoEscape: true,
-    nonegate: true,
-    nocomment: true,
-    optimizationLevel: 2,
-    platform: windows ? 'win32' : 'posix',
-    nocaseMagicOnly: true,
-  });
 }
 
 const win32 = {
@@ -1140,7 +1123,8 @@ const win32 = {
   },
 
   matchesGlob(path, pattern) {
-    return glob(path, pattern, true);
+    emitExperimentalWarning('glob');
+    return lazyGlob()(path, pattern, true);
   },
 
   sep: '\\',
@@ -1616,7 +1600,8 @@ const posix = {
   },
 
   matchesGlob(path, pattern) {
-    return glob(path, pattern, false);
+    emitExperimentalWarning('glob');
+    return lazyGlob()(path, pattern, false);
   },
 
   sep: '/',

--- a/lib/path.js
+++ b/lib/path.js
@@ -57,7 +57,7 @@ const {
   getLazy,
 } = require('internal/util');
 
-const lazyGlob = getLazy(() => require('internal/fs/glob').glob);
+const lazyMatchGlobPattern = getLazy(() => require('internal/fs/glob').matchGlobPattern);
 
 function isPathSeparator(code) {
   return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -1124,7 +1124,7 @@ const win32 = {
 
   matchesGlob(path, pattern) {
     emitExperimentalWarning('glob');
-    return lazyGlob()(path, pattern, true);
+    return lazyMatchGlobPattern()(path, pattern, true);
   },
 
   sep: '\\',
@@ -1601,7 +1601,7 @@ const posix = {
 
   matchesGlob(path, pattern) {
     emitExperimentalWarning('glob');
-    return lazyGlob()(path, pattern, false);
+    return lazyMatchGlobPattern()(path, pattern, false);
   },
 
   sep: '/',

--- a/test/fixtures/test-runner/coverage-default-exclusion/file-test.js
+++ b/test/fixtures/test-runner/coverage-default-exclusion/file-test.js
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { foo } = require('./logic-file');
+
+test('foo returns 1', () => {
+    assert.strictEqual(foo(), 1);
+});

--- a/test/fixtures/test-runner/coverage-default-exclusion/file.test.mjs
+++ b/test/fixtures/test-runner/coverage-default-exclusion/file.test.mjs
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { foo } from './logic-file.js';
+
+test('foo returns 1', () => {
+    assert.strictEqual(foo(), 1);
+});

--- a/test/fixtures/test-runner/coverage-default-exclusion/file.test.ts
+++ b/test/fixtures/test-runner/coverage-default-exclusion/file.test.ts
@@ -1,0 +1,7 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { foo } from './logic-file.js';
+
+test('foo returns 1', () => {
+    assert.strictEqual(foo(), 1);
+});

--- a/test/fixtures/test-runner/coverage-default-exclusion/logic-file.js
+++ b/test/fixtures/test-runner/coverage-default-exclusion/logic-file.js
@@ -1,0 +1,9 @@
+function foo() {
+    return 1;
+}
+
+function bar() {
+    return 'bar';
+}
+
+module.exports = { foo, bar };

--- a/test/fixtures/test-runner/coverage-default-exclusion/test.cjs
+++ b/test/fixtures/test-runner/coverage-default-exclusion/test.cjs
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { foo } = require('./logic-file.js');
+
+test('foo returns 1', () => {
+    assert.strictEqual(foo(), 1);
+});

--- a/test/fixtures/test-runner/coverage-default-exclusion/test/not-matching-test-name.js
+++ b/test/fixtures/test-runner/coverage-default-exclusion/test/not-matching-test-name.js
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { foo } = require('../logic-file.js');
+
+test('foo returns 1', () => {
+    assert.strictEqual(foo(), 1);
+});

--- a/test/fixtures/test-runner/output/lcov_reporter.js
+++ b/test/fixtures/test-runner/output/lcov_reporter.js
@@ -4,4 +4,13 @@ const fixtures = require('../../../common/fixtures');
 const spawn = require('node:child_process').spawn;
 
 spawn(process.execPath,
-      ['--no-warnings', '--experimental-test-coverage', '--test-reporter', 'lcov', fixtures.path('test-runner/output/output.js')], { stdio: 'inherit' });
+      [
+            '--no-warnings',
+            '--experimental-test-coverage',
+            '--test-coverage-exclude=!test/**',
+            '--test-reporter',
+            'lcov',
+            fixtures.path('test-runner/output/output.js')
+      ],
+      { stdio: 'inherit' }
+);

--- a/test/parallel/test-runner-coverage-default-exclusion.mjs
+++ b/test/parallel/test-runner-coverage-default-exclusion.mjs
@@ -1,0 +1,113 @@
+import '../common/index.mjs';
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import { cp } from 'node:fs/promises';
+import tmpdir from '../common/tmpdir.js';
+import fixtures from '../common/fixtures.js';
+
+tmpdir.refresh();
+
+async function setupFixtures() {
+  const fixtureDir = fixtures.path('test-runner', 'coverage-default-exclusion');
+  await cp(fixtureDir, tmpdir.path, { recursive: true });
+}
+
+describe('test runner coverage default exclusion', () => {
+  before(async () => {
+    await setupFixtures();
+  });
+
+  it('should override default exclusion setting --test-coverage-exclude', async () => {
+    const report = [
+      '# start of coverage report',
+      '# ---------------------------------------------------------------------------',
+      '# file                       | line % | branch % | funcs % | uncovered lines',
+      '# ---------------------------------------------------------------------------',
+      '# file-test.js               | 100.00 |   100.00 |  100.00 | ',
+      '# file.test.mjs              | 100.00 |   100.00 |  100.00 | ',
+      '# logic-file.js              |  66.67 |   100.00 |   50.00 | 5-7',
+      '# test.cjs                   | 100.00 |   100.00 |  100.00 | ',
+      '# test                       |        |          |         | ',
+      '#  not-matching-test-name.js | 100.00 |   100.00 |  100.00 | ',
+      '# ---------------------------------------------------------------------------',
+      '# all files                  |  91.89 |   100.00 |   83.33 | ',
+      '# ---------------------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
+
+
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args, {
+      env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
+      cwd: tmpdir.path
+    });
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
+
+  it('should exclude test files from coverage by default', async () => {
+    const report = [
+      '# start of coverage report',
+      '# --------------------------------------------------------------',
+      '# file          | line % | branch % | funcs % | uncovered lines',
+      '# --------------------------------------------------------------',
+      '# logic-file.js |  66.67 |   100.00 |   50.00 | 5-7',
+      '# --------------------------------------------------------------',
+      '# all files     |  66.67 |   100.00 |   50.00 | ',
+      '# --------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
+
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args, {
+      env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
+      cwd: tmpdir.path
+    });
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
+
+  it('should exclude ts test files when using --experimental-strip-types', async () => {
+    const report = [
+      '# start of coverage report',
+      '# --------------------------------------------------------------',
+      '# file          | line % | branch % | funcs % | uncovered lines',
+      '# --------------------------------------------------------------',
+      '# logic-file.js |  66.67 |   100.00 |   50.00 | 5-7',
+      '# --------------------------------------------------------------',
+      '# all files     |  66.67 |   100.00 |   50.00 | ',
+      '# --------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
+
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--experimental-strip-types',
+      '--disable-warning=ExperimentalWarning',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args, {
+      env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
+      cwd: tmpdir.path
+    });
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
+});

--- a/test/parallel/test-runner-coverage-default-exclusion.mjs
+++ b/test/parallel/test-runner-coverage-default-exclusion.mjs
@@ -5,6 +5,9 @@ import { spawnSync } from 'node:child_process';
 import { cp } from 'node:fs/promises';
 import tmpdir from '../common/tmpdir.js';
 import fixtures from '../common/fixtures.js';
+const skipIfNoInspector = {
+  skip: !process.features.inspector ? 'inspector disabled' : false
+};
 
 tmpdir.refresh();
 
@@ -13,7 +16,7 @@ async function setupFixtures() {
   await cp(fixtureDir, tmpdir.path, { recursive: true });
 }
 
-describe('test runner coverage default exclusion', () => {
+describe('test runner coverage default exclusion', skipIfNoInspector, () => {
   before(async () => {
     await setupFixtures();
   });

--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -20,7 +20,11 @@ function generateReport(report) {
 
 const flags = [
   '--enable-source-maps',
-  '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
+  '--test',
+  '--experimental-test-coverage',
+  '--test-coverage-exclude=!test/**',
+  '--test-reporter',
+  'tap',
 ];
 
 describe('Coverage with source maps', async () => {

--- a/test/parallel/test-runner-coverage-thresholds.js
+++ b/test/parallel/test-runner-coverage-thresholds.js
@@ -61,6 +61,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=25`,
       '--test-reporter', 'tap',
       fixture,
@@ -77,6 +78,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=25`,
       '--test-reporter', reporter,
       fixture,
@@ -92,6 +94,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=99`,
       '--test-reporter', 'tap',
       fixture,
@@ -108,6 +111,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=99`,
       '--test-reporter', reporter,
       fixture,
@@ -123,6 +127,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=101`,
       fixture,
     ]);
@@ -136,6 +141,7 @@ for (const coverage of coverages) {
     const result = spawnSync(process.execPath, [
       '--test',
       '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
       `${coverage.flag}=-1`,
       fixture,
     ]);

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -84,7 +84,11 @@ test('test coverage report', async (t) => {
     }
 
     const fixture = fixtures.path('test-runner', 'coverage.js');
-    const args = ['--experimental-test-coverage', fixture];
+    const args = [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      fixture,
+    ];
     const result = spawnSync(process.execPath, args);
 
     assert(!result.stdout.toString().includes('# start of coverage report'));
@@ -97,7 +101,13 @@ test('test coverage report', async (t) => {
 test('test tap coverage reporter', skipIfNoInspector, async (t) => {
   await t.test('coverage is reported and dumped to NODE_V8_COVERAGE if present', (t) => {
     const fixture = fixtures.path('test-runner', 'coverage.js');
-    const args = ['--experimental-test-coverage', '--test-reporter', 'tap', fixture];
+    const args = [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter',
+      'tap',
+      fixture,
+    ];
     const options = { env: { ...process.env, NODE_V8_COVERAGE: tmpdir.path } };
     const result = spawnSync(process.execPath, args, options);
     const report = getTapCoverageFixtureReport();
@@ -109,7 +119,13 @@ test('test tap coverage reporter', skipIfNoInspector, async (t) => {
 
   await t.test('coverage is reported without NODE_V8_COVERAGE present', (t) => {
     const fixture = fixtures.path('test-runner', 'coverage.js');
-    const args = ['--experimental-test-coverage', '--test-reporter', 'tap', fixture];
+    const args = [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter',
+      'tap',
+      fixture,
+    ];
     const result = spawnSync(process.execPath, args);
     const report = getTapCoverageFixtureReport();
 
@@ -123,7 +139,12 @@ test('test tap coverage reporter', skipIfNoInspector, async (t) => {
 test('test spec coverage reporter', skipIfNoInspector, async (t) => {
   await t.test('coverage is reported and dumped to NODE_V8_COVERAGE if present', (t) => {
     const fixture = fixtures.path('test-runner', 'coverage.js');
-    const args = ['--experimental-test-coverage', '--test-reporter', 'spec', fixture];
+    const args = [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter',
+      'spec',
+      fixture];
     const options = { env: { ...process.env, NODE_V8_COVERAGE: tmpdir.path } };
     const result = spawnSync(process.execPath, args, options);
     const report = getSpecCoverageFixtureReport();
@@ -136,7 +157,12 @@ test('test spec coverage reporter', skipIfNoInspector, async (t) => {
 
   await t.test('coverage is reported without NODE_V8_COVERAGE present', (t) => {
     const fixture = fixtures.path('test-runner', 'coverage.js');
-    const args = ['--experimental-test-coverage', '--test-reporter', 'spec', fixture];
+    const args = [
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter',
+      'spec',
+      fixture];
     const result = spawnSync(process.execPath, args);
     const report = getSpecCoverageFixtureReport();
 
@@ -150,7 +176,12 @@ test('test spec coverage reporter', skipIfNoInspector, async (t) => {
 test('single process coverage is the same with --test', skipIfNoInspector, () => {
   const fixture = fixtures.path('test-runner', 'coverage.js');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap', fixture,
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter',
+    'tap',
+    fixture,
   ];
   const result = spawnSync(process.execPath, args);
   const report = getTapCoverageFixtureReport();
@@ -183,7 +214,11 @@ test('coverage is combined for multiple processes', skipIfNoInspector, () => {
 
   const fixture = fixtures.path('v8-coverage', 'combined_coverage');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter',
+    'tap',
   ];
   const result = spawnSync(process.execPath, args, {
     env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
@@ -221,7 +256,11 @@ test.skip('coverage works with isolation=none', skipIfNoInspector, () => {
 
   const fixture = fixtures.path('v8-coverage', 'combined_coverage');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap', '--experimental-test-isolation=none',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-reporter',
+    'tap',
+    '--experimental-test-isolation=none',
   ];
   const result = spawnSync(process.execPath, args, {
     env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
@@ -236,9 +275,14 @@ test.skip('coverage works with isolation=none', skipIfNoInspector, () => {
 test('coverage reports on lines, functions, and branches', skipIfNoInspector, async (t) => {
   const fixture = fixtures.path('test-runner', 'coverage.js');
   const child = spawnSync(process.execPath,
-                          ['--test', '--experimental-test-coverage', '--test-reporter',
-                           fixtures.fileURL('test-runner/custom_reporters/coverage.mjs'),
-                           fixture]);
+                          [
+                            '--test',
+                            '--experimental-test-coverage',
+                            '--test-coverage-exclude=!test/**',
+                            '--test-reporter',
+                            fixtures.fileURL('test-runner/custom_reporters/coverage.mjs'),
+                            fixture,
+                          ]);
   assert.strictEqual(child.stderr.toString(), '');
   const stdout = child.stdout.toString();
   const coverage = JSON.parse(stdout);
@@ -310,7 +354,14 @@ test('coverage with ESM hook - source irrelevant', skipIfNoInspector, () => {
 
   const fixture = fixtures.path('test-runner', 'coverage-loader');
   const args = [
-    '--import', './register-hooks.js', '--test', '--experimental-test-coverage', '--test-reporter', 'tap', 'virtual.js',
+    '--import',
+    './register-hooks.js',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter',
+    'tap',
+    'virtual.js',
   ];
   const result = spawnSync(process.execPath, args, { cwd: fixture });
 
@@ -341,7 +392,10 @@ test('coverage with ESM hook - source transpiled', skipIfNoInspector, () => {
 
   const fixture = fixtures.path('test-runner', 'coverage-loader');
   const args = [
-    '--import', './register-hooks.js', '--test', '--experimental-test-coverage',
+    '--import', './register-hooks.js',
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
     '--test-reporter', 'tap', 'sum.test.ts',
   ];
   const result = spawnSync(process.execPath, args, { cwd: fixture });
@@ -356,6 +410,7 @@ test('coverage with excluded files', skipIfNoInspector, () => {
   const args = [
     '--experimental-test-coverage', '--test-reporter', 'tap',
     '--test-coverage-exclude=test/*/test-runner/invalid-tap.js',
+    '--test-coverage-exclude=!test/**',
     fixture];
   const result = spawnSync(process.execPath, args);
   const report = [
@@ -391,6 +446,7 @@ test('coverage with included files', skipIfNoInspector, () => {
     '--experimental-test-coverage', '--test-reporter', 'tap',
     '--test-coverage-include=test/fixtures/test-runner/coverage.js',
     '--test-coverage-include=test/fixtures/v8-coverage/throw.js',
+    '--test-coverage-exclude=!test/**',
     fixture,
   ];
   const result = spawnSync(process.execPath, args);
@@ -478,7 +534,12 @@ test('correctly prints the coverage report of files contained in parent director
   }
   const fixture = fixtures.path('test-runner', 'coverage.js');
   const args = [
-    '--test', '--experimental-test-coverage', '--test-reporter', 'tap', fixture,
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter',
+    'tap',
+    fixture,
   ];
   const result = spawnSync(process.execPath, args, {
     env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -171,7 +171,12 @@ const tests = [
     name: 'test-runner/output/source_mapped_locations.mjs',
     flags: ['--test-reporter=tap'],
   },
-  process.features.inspector ? { name: 'test-runner/output/lcov_reporter.js', transform: lcovTransform } : false,
+  process.features.inspector ?
+    {
+      name: 'test-runner/output/lcov_reporter.js',
+      transform: lcovTransform
+    } :
+    false,
   { name: 'test-runner/output/output.js', flags: ['--test-reporter=tap'] },
   { name: 'test-runner/output/output_cli.js' },
   {
@@ -236,7 +241,7 @@ const tests = [
   },
   process.features.inspector ? {
     name: 'test-runner/output/coverage_failure.js',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   {
     name: 'test-runner/output/test-diagnostic-warning-without-test-only-flag.js',
@@ -244,49 +249,51 @@ const tests = [
   },
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-40.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-80.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector && !skipCoverageColors ? {
     name: 'test-runner/output/coverage-width-80-color.mjs',
+    flags: ['--test-coverage-exclude=!test/**'],
     transform: specTransform,
     tty: true
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-100.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-150.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-infinity.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-80-uncovered-lines.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-100-uncovered-lines.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector && !skipCoverageColors ? {
     name: 'test-runner/output/coverage-width-80-uncovered-lines-color.mjs',
+    flags: ['--test-coverage-exclude=!test/**'],
     transform: specTransform,
     tty: true
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-150-uncovered-lines.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
   process.features.inspector ? {
     name: 'test-runner/output/coverage-width-infinity-uncovered-lines.mjs',
-    flags: ['--test-reporter=tap'],
+    flags: ['--test-reporter=tap', '--test-coverage-exclude=!test/**'],
   } : false,
 ]
 .filter(Boolean)


### PR DESCRIPTION
This should address #53508.

I'm opening this PR since #55633 seems to be stale.

This PR contains the feature and some changes to reduce its footprint.

Note: The reason behind `lazyMinimatch` is to avoid experimental warnings related to `matchesGlob`.

I'm not entirely convinced about the change I introduced to the `--test-coverage-exclude` and `--test-coverage-include` flags.

Regarding: 
@cjihrig 
https://github.com/nodejs/node/pull/55633#pullrequestreview-2410163982
> Another thing that is not clear to me: what happens if someone runs a test file, but that test file imports another file that also includes tests? Should we exclude that imported file from the coverage report, or should we only exclude the files that the user specified?

I think we should just exclude the files specified by the user, as it's the most common scenario.
If a user imports other tests from different files, I would expect them to exclude those manually.
WDYT?

