### PR TITLE
stream: validate undefined sizeAlgorithm in WritableStream

### DIFF
--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -1176,9 +1176,18 @@ function writableStreamDefaultControllerGetDesiredSize(controller) {
 }
 
 function writableStreamDefaultControllerGetChunkSize(controller, chunk) {
+  const {
+    stream,
+    sizeAlgorithm,
+  } = controller[kState];
+  if (sizeAlgorithm === undefined) {
+    assert(stream[kState].state === 'errored' || stream[kState].state === 'erroring');
+    return 1;
+  }
+
   try {
     return FunctionPrototypeCall(
-      controller[kState].sizeAlgorithm,
+      sizeAlgorithm,
       undefined,
       chunk);
   } catch (error) {


### PR DESCRIPTION
No test was added since it was covered by existing WPT, and the spec change did not introduce WPT updates

Fixes: https://github.com/nodejs/node/issues/56014
Refs: https://github.com/whatwg/streams/pull/1333