### PR TITLE
report: fix typos in memory limit units

### DIFF
--- a/doc/api/report.md
+++ b/doc/api/report.md
@@ -35,7 +35,7 @@ is provided below for reference.
 ```json
 {
   "header": {
-    "reportVersion": 4,
+    "reportVersion": 5,
     "event": "exception",
     "trigger": "Exception",
     "filename": "report.20181221.005011.8974.0.001.json",
@@ -392,7 +392,7 @@ is provided below for reference.
       "soft": "",
       "hard": "unlimited"
     },
-    "data_seg_size_kbytes": {
+    "data_seg_size_bytes": {
       "soft": "unlimited",
       "hard": "unlimited"
     },
@@ -404,7 +404,7 @@ is provided below for reference.
       "soft": "unlimited",
       "hard": 65536
     },
-    "max_memory_size_kbytes": {
+    "max_memory_size_bytes": {
       "soft": "unlimited",
       "hard": "unlimited"
     },
@@ -424,7 +424,7 @@ is provided below for reference.
       "soft": "unlimited",
       "hard": 4127290
     },
-    "virtual_memory_kbytes": {
+    "virtual_memory_bytes": {
       "soft": "unlimited",
       "hard": "unlimited"
     }
@@ -587,6 +587,41 @@ when new key is added or removed, or the data type of a value is changed.
 Report version definitions are consistent across LTS releases.
 
 ### Version history
+
+#### Version 5
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56068
+    description: Fix typos in the memory limit units.
+-->
+
+Replace the keys `data_seg_size_kbytes`, `max_memory_size_kbytes`, and `virtual_memory_kbytes`
+with `data_seg_size_bytes`, `max_memory_size_bytes`, and `virtual_memory_bytes`
+respectively in the `userLimits` section, as these values are given in bytes.
+
+```json
+{
+  "userLimits": {
+    // Skip some keys ...
+    "data_seg_size_bytes": { // replacing data_seg_size_kbytes
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    // ...
+    "max_memory_size_bytes": { // replacing max_memory_size_kbytes
+      "soft": "unlimited",
+      "hard": "unlimited"
+    },
+    // ...
+    "virtual_memory_bytes": { // replacing virtual_memory_kbytes
+      "soft": "unlimited",
+      "hard": "unlimited"
+    }
+  }
+}
+```
 
 #### Version 4
 

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -23,7 +23,7 @@
 #include <cwctype>
 #include <fstream>
 
-constexpr int NODE_REPORT_VERSION = 4;
+constexpr int NODE_REPORT_VERSION = 5;
 constexpr int NANOS_PER_SEC = 1000 * 1000 * 1000;
 constexpr double SEC_PER_MICROS = 1e-6;
 constexpr int MAX_FRAME_COUNT = node::kMaxFrameCountForLogging;
@@ -732,13 +732,13 @@ static void PrintSystemInformation(JSONWriter* writer) {
     int id;
   } rlimit_strings[] = {
     {"core_file_size_blocks", RLIMIT_CORE},
-    {"data_seg_size_kbytes", RLIMIT_DATA},
+    {"data_seg_size_bytes", RLIMIT_DATA},
     {"file_size_blocks", RLIMIT_FSIZE},
 #if !(defined(_AIX) || defined(__sun))
     {"max_locked_memory_bytes", RLIMIT_MEMLOCK},
 #endif
 #ifndef __sun
-    {"max_memory_size_kbytes", RLIMIT_RSS},
+    {"max_memory_size_bytes", RLIMIT_RSS},
 #endif
     {"open_files", RLIMIT_NOFILE},
     {"stack_size_bytes", RLIMIT_STACK},
@@ -747,7 +747,7 @@ static void PrintSystemInformation(JSONWriter* writer) {
     {"max_user_processes", RLIMIT_NPROC},
 #endif
 #ifndef __OpenBSD__
-    {"virtual_memory_kbytes", RLIMIT_AS}
+    {"virtual_memory_bytes", RLIMIT_AS}
 #endif
   };
 

--- a/test/common/report.js
+++ b/test/common/report.js
@@ -110,7 +110,7 @@ function _validateContent(report, fields = []) {
                         'glibcVersionRuntime', 'glibcVersionCompiler', 'cwd',
                         'reportVersion', 'networkInterfaces', 'threadId'];
   checkForUnknownFields(header, headerFields);
-  assert.strictEqual(header.reportVersion, 4);  // Increment as needed.
+  assert.strictEqual(header.reportVersion, 5);  // Increment as needed.
   assert.strictEqual(typeof header.event, 'string');
   assert.strictEqual(typeof header.trigger, 'string');
   assert(typeof header.filename === 'string' || header.filename === null);
@@ -309,11 +309,11 @@ function _validateContent(report, fields = []) {
 
   // Verify the format of the userLimits section on non-Windows platforms.
   if (!isWindows) {
-    const userLimitsFields = ['core_file_size_blocks', 'data_seg_size_kbytes',
+    const userLimitsFields = ['core_file_size_blocks', 'data_seg_size_bytes',
                               'file_size_blocks', 'max_locked_memory_bytes',
-                              'max_memory_size_kbytes', 'open_files',
+                              'max_memory_size_bytes', 'open_files',
                               'stack_size_bytes', 'cpu_time_seconds',
-                              'max_user_processes', 'virtual_memory_kbytes'];
+                              'max_user_processes', 'virtual_memory_bytes'];
     checkForUnknownFields(report.userLimits, userLimitsFields);
     for (const [type, limits] of Object.entries(report.userLimits)) {
       assert.strictEqual(typeof type, 'string');


### PR DESCRIPTION
Replace typos "kbytes" with "bytes" in `PrintSystemInformation()` in `src/node_report.cc` for `"data_seg_size_kbytes"`, `"max_memory_size_kbytes"` and `"virtual_memory_kbytes"`, as `RLIMIT_DATA`, `RLIMIT_RSS` and `RLIMIT_AS` from `<sys/resource.h>` are given in bytes. ([ref](https://www.ibm.com/docs/en/aix/7.3?topic=k-kgetrlimit64-kernel-service))

I found this problem when I was testing the limit of virtual memory. When I set it to 32GB, the report showed
```
"virtual_memory_kbytes": {
  "soft": 34359738368,
  "hard": 34359738368
}
```
After checking the source codes, I think that it should be in `bytes`, not `kbytes`.

Refs: https://www.ibm.com/docs/en/aix/7.3?topic=k-kgetrlimit64-kernel-service

### **Update:**
**The keys with `*_kbytes` are replaced by `*_bytes`, and the report version is bumped from 4 to 5.**

This is my first contribution (first PR) to a public, well-known repository. Thanks the members for the guidance.
Although it is just a tiny fix, this means a lot for me.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
