### PR TITLE
tools: fix update-undici script

### DIFF
--- a/tools/dep_updaters/update-undici.sh
+++ b/tools/dep_updaters/update-undici.sh
@@ -80,7 +80,7 @@ cd "$ROOT"
 
   # Rebuild components from source
   rm lib/llhttp/llhttp*.*
-  "$NODE" "$NPM" install --no-bin-link --ignore-scripts
+  "$NODE" "$NPM" install --ignore-scripts
   "$NODE" "$NPM" run build:wasm > lib/llhttp/wasm_build_env.txt
   "$NODE" "$NPM" run build:node
   "$NODE" "$NPM" prune --production


### PR DESCRIPTION
The `build:node` npm script now expects esbuild to be installed and
bin-linked.

Closes: https://github.com/nodejs/node/issues/56061

