### PR TITLE
src,build: add no user defined deduction guides of CTAD check

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -482,6 +482,7 @@
         '-Wno-unused-parameter',
         '-Werror=undefined-inline',
         '-Werror=extra-semi',
+        '-Werror=ctad-maybe-unsupported',
       ],
     },
 

--- a/node.gypi
+++ b/node.gypi
@@ -27,7 +27,11 @@
 
   'conditions': [
     [ 'clang==1', {
-      'cflags': [ '-Werror=undefined-inline', '-Werror=extra-semi']
+      'cflags': [
+        '-Werror=undefined-inline',
+        '-Werror=extra-semi',
+        '-Werror=ctad-maybe-unsupported',
+      ],
     }],
     [ '"<(_type)"=="executable"', {
       'msvs_settings': {

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -1531,7 +1531,7 @@ void Session::EmitDatagram(Store&& datagram, DatagramReceivedFlags flag) {
   DCHECK(!is_destroyed());
   if (!env()->can_call_into_js()) return;
 
-  CallbackScope cbv_scope(this);
+  CallbackScope<Session> cbv_scope(this);
 
   Local<Value> argv[] = {datagram.ToUint8Array(env()),
                          v8::Boolean::New(env()->isolate(), flag.early)};


### PR DESCRIPTION
To our [secondary C++ style guide](https://github.com/nodejs/node/blob/main/doc/contributing/cpp-style-guide.md#guides-and-references):

> Do not use CTAD with a given template unless the template's maintainers have opted into supporting use of CTAD by providing at least one explicit deduction guide (all templates in the std namespace are also presumed to have opted in). This should be enforced with a compiler warning if available.
> 
> Ref: https://google.github.io/styleguide/cppguide.html#CTAD

To use CTAD with a template, it must be defined with at least one deduction guide (`std` templates are defined with guides). Enforcing this rule with compiler checks.