### PR TITLE
deps: cherry-pick 88260bf from node-gyp upstream

### DIFF
--- a/deps/npm/node_modules/node-gyp/lib/create-config-gypi.js
+++ b/deps/npm/node_modules/node-gyp/lib/create-config-gypi.js
@@ -96,6 +96,9 @@ async function getCurrentConfigGypi ({ gyp, nodeDir, vsInfo, python }) {
       }
     }
     variables.msbuild_path = vsInfo.msBuild
+    if (config.variables.clang === 1) {
+      config.variables.clang = 0
+    }
   }
 
   // loop through the rest of the opts and add the unknown ones as variables.


### PR DESCRIPTION
This change cherry-picks a small change from node-gyp needed for running native tests on ClangCL compiled binaries. The change was already approved [here](https://github.com/nodejs/node/pull/55784), so this is just the official port after the changes landed in node-gyp. Next is the part of the description regarding this change from the original PR:

_Enforce MSVC to be used for node-gyp. As far as I can tell, this is the intended way of using node-gyp on Windows. The issue with running the native suites is that now we use Clang to compile Node.js, so config.variables.clang is set to 1, which makes node-gyp generate project files for ClangCL. While we'd like to enable this, that is currently not the priority so for now enforcing MSVC would be the way to go the way I see it. The changes in create-config-gypi.js would be done as a PR in node-gyp and then floated in Node.js until the next node-gyp update._

Tagging relative teams: @nodejs/platform-windows @nodejs/node-gyp

P.S. Since it's already reviewed, I'll request fast-tracking and I'm planning to land it after the first approval.

Refs: https://github.com/nodejs/node-gyp/pull/3098
Refs: https://github.com/nodejs/node/pull/55784