### PR TITLE
src: avoid copy by using std::views::keys

### DIFF
--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -126,7 +127,9 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
 
   void CopySourceAndCodeCacheReferenceFrom(const BuiltinLoader* other);
 
-  std::vector<std::string_view> GetBuiltinIds() const;
+  [[nodiscard]] auto GetBuiltinIds() const {
+    return std::views::keys(*source_.read());
+  }
 
   void SetEagerCompile() { should_eager_compile_ = true; }
 

--- a/src/util.h
+++ b/src/util.h
@@ -42,6 +42,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -729,6 +730,12 @@ template <typename T, typename U>
 inline v8::MaybeLocal<v8::Value> ToV8Value(v8::Local<v8::Context> context,
                                            const std::unordered_map<T, U>& map,
                                            v8::Isolate* isolate = nullptr);
+
+template <typename T, std::size_t U>
+inline v8::MaybeLocal<v8::Value> ToV8Value(
+    v8::Local<v8::Context> context,
+    const std::ranges::elements_view<T, U>& vec,
+    v8::Isolate* isolate = nullptr);
 
 // These macros expects a `Isolate* isolate` and a `Local<Context> context`
 // to be in the scope.


### PR DESCRIPTION
We can leverage C++20 and use `std::views::keys()` which returns `std::ranges::elements_view<T, S>` which avoids creating a vector for `GetBuiltinIds()`