### PR TITLE
dgram: check udp buffer size to avoid fd leak

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -61,6 +61,7 @@ const {
   validateString,
   validateNumber,
   validatePort,
+  validateUint32,
 } = require('internal/validators');
 const { Buffer } = require('buffer');
 const { deprecate, guessHandleType, promisify } = require('internal/util');
@@ -110,6 +111,12 @@ function Socket(type, listener) {
     options = type;
     type = options.type;
     lookup = options.lookup;
+    if (options.recvBufferSize) {
+      validateUint32(options.recvBufferSize, 'options.recvBufferSize');
+    }
+    if (options.sendBufferSize) {
+      validateUint32(options.sendBufferSize, 'options.sendBufferSize');
+    }
     recvBufferSize = options.recvBufferSize;
     sendBufferSize = options.sendBufferSize;
   }

--- a/test/parallel/test-dgram-createSocket-type.js
+++ b/test/parallel/test-dgram-createSocket-type.js
@@ -59,3 +59,16 @@ validTypes.forEach((validType) => {
     socket.close();
   }));
 }
+
+{
+  [
+    { type: 'udp4', recvBufferSize: 'invalid' },
+    { type: 'udp4', sendBufferSize: 'invalid' },
+  ].forEach((options) => {
+    assert.throws(() => {
+      dgram.createSocket(options);
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+    });
+  });
+}


### PR DESCRIPTION
```js
const udp = require('dgram');

// uncaughtException event is triggered
process.on('uncaughtException', () => {});

for (let i = 0; i < 10; i++) {
    const socket = udp.createSocket({type: 'udp4', recvBufferSize: 'x'});
    // error and listening events are not triggered
    socket.on('error', () => {
        socket.close();
    });
    socket.on('listening', () => {
        socket.close();
    });
    socket.bind(0);
}
```
The process will open 10 fds.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)