### PR TITLE
src: use std::string_view for process emit fns

### DIFF
--- a/src/node_process.h
+++ b/src/node_process.h
@@ -24,25 +24,27 @@ void CreateEnvProxyTemplate(IsolateData* isolate_data);
 void RawDebug(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 v8::MaybeLocal<v8::Value> ProcessEmit(Environment* env,
-                                      const char* event,
+                                      std::string_view event,
                                       v8::Local<v8::Value> message);
 
 v8::Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
-                                          const char* warning,
-                                          const char* type = nullptr,
-                                          const char* code = nullptr);
+                                          std::string_view warning,
+                                          std::string_view type = "",
+                                          std::string_view code = "");
 
 template <typename... Args>
 inline v8::Maybe<bool> ProcessEmitWarning(Environment* env,
                                           const char* fmt,
                                           Args&&... args);
 
-v8::Maybe<bool> ProcessEmitWarningSync(Environment* env, const char* message);
+v8::Maybe<bool> ProcessEmitWarningSync(Environment* env,
+                                       std::string_view message);
 v8::Maybe<bool> ProcessEmitExperimentalWarning(Environment* env,
-                                              const char* warning);
-v8::Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
-                                              const char* warning,
-                                              const char* deprecation_code);
+                                               const std::string& warning);
+v8::Maybe<bool> ProcessEmitDeprecationWarning(
+    Environment* env,
+    const std::string& warning,
+    std::string_view deprecation_code);
 
 v8::MaybeLocal<v8::Object> CreateProcessObject(Realm* env);
 void PatchProcessObject(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -18,10 +18,11 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-Maybe<bool> ProcessEmitWarningSync(Environment* env, const char* message) {
+Maybe<bool> ProcessEmitWarningSync(Environment* env, std::string_view message) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
-  Local<String> message_string = OneByteString(isolate, message);
+  Local<String> message_string =
+      OneByteString(isolate, message.data(), message.size());
 
   Local<Value> argv[] = {message_string};
   Local<Function> emit_function = env->process_emit_warning_sync();
@@ -37,13 +38,14 @@ Maybe<bool> ProcessEmitWarningSync(Environment* env, const char* message) {
 }
 
 MaybeLocal<Value> ProcessEmit(Environment* env,
-                              const char* event,
+                              std::string_view event,
                               Local<Value> message) {
   Isolate* isolate = env->isolate();
 
-  Local<String> event_string;
-  if (!String::NewFromOneByte(isolate, reinterpret_cast<const uint8_t*>(event))
-      .ToLocal(&event_string)) return MaybeLocal<Value>();
+  Local<Value> event_string;
+  if (!ToV8Value(env->context(), event).ToLocal(&event_string)) {
+    return MaybeLocal<Value>();
+  }
 
   Local<Object> process = env->process_object();
   Local<Value> argv[] = {event_string, message};
@@ -51,10 +53,12 @@ MaybeLocal<Value> ProcessEmit(Environment* env,
 }
 
 Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
-                                      const char* warning,
-                                      const char* type,
-                                      const char* code) {
-  if (!env->can_call_into_js()) return Just(false);
+                                      std::string_view warning,
+                                      std::string_view type,
+                                      std::string_view code) {
+  if (!env->can_call_into_js()) {
+    return Just(false);
+  }
 
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
@@ -73,19 +77,16 @@ Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
 
   // The caller has to be able to handle a failure anyway, so we might as well
   // do proper error checking for string creation.
-  if (!String::NewFromUtf8(env->isolate(), warning).ToLocal(&args[argc++]))
+  if (!ToV8Value(env->context(), warning).ToLocal(&args[argc++])) {
     return Nothing<bool>();
+  }
 
-  if (type != nullptr) {
-    if (!String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(type))
-             .ToLocal(&args[argc++])) {
+  if (!type.empty()) {
+    if (!ToV8Value(env->context(), type).ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }
-    if (code != nullptr &&
-        !String::NewFromOneByte(env->isolate(),
-                                reinterpret_cast<const uint8_t*>(code))
-             .ToLocal(&args[argc++])) {
+    if (!code.empty() &&
+        !ToV8Value(env->context(), code).ToLocal(&args[argc++])) {
       return Nothing<bool>();
     }
   }
@@ -100,13 +101,11 @@ Maybe<bool> ProcessEmitWarningGeneric(Environment* env,
   return Just(true);
 }
 
-
 std::set<std::string> experimental_warnings;
 
 Maybe<bool> ProcessEmitExperimentalWarning(Environment* env,
-                                          const char* warning) {
-  if (experimental_warnings.find(warning) != experimental_warnings.end())
-    return Nothing<bool>();
+                                           const std::string& warning) {
+  if (experimental_warnings.contains(warning)) return Nothing<bool>();
 
   experimental_warnings.insert(warning);
   std::string message(warning);
@@ -115,8 +114,8 @@ Maybe<bool> ProcessEmitExperimentalWarning(Environment* env,
 }
 
 Maybe<bool> ProcessEmitDeprecationWarning(Environment* env,
-                                          const char* warning,
-                                          const char* deprecation_code) {
+                                          const std::string& warning,
+                                          std::string_view deprecation_code) {
   return ProcessEmitWarningGeneric(
       env, warning, "DeprecationWarning", deprecation_code);
 }


### PR DESCRIPTION
We should use `std::string_view` instead of `const char*` because we need the length for better creating a string in V8.