### PR TITLE
Revert "path,win: fix bug in resolve and normalize"

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -268,16 +268,10 @@ const win32 = {
                 j++;
               }
               if (j === len || j !== last) {
-                if (firstPart !== '.' && firstPart !== '?') {
-                  // We matched a UNC root
-                  device =
-                    `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-                  rootEnd = j;
-                } else {
-                  // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
-                  device = `\\\\${firstPart}`;
-                  rootEnd = 4;
-                }
+                // We matched a UNC root
+                device =
+                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+                rootEnd = j;
               }
             }
           }
@@ -387,22 +381,17 @@ const win32 = {
                    !isPathSeparator(StringPrototypeCharCodeAt(path, j))) {
               j++;
             }
-            if (j === len || j !== last) {
-              if (firstPart === '.' || firstPart === '?') {
-                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
-                device = `\\\\${firstPart}`;
-                rootEnd = 4;
-              } else if (j === len) {
-                // We matched a UNC root only
-                // Return the normalized version of the UNC root since there
-                // is nothing left to process
-                return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
-              } else {
-                // We matched a UNC root with leftovers
-                device =
-                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-                rootEnd = j;
-              }
+            if (j === len) {
+              // We matched a UNC root only
+              // Return the normalized version of the UNC root since there
+              // is nothing left to process
+              return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
+            }
+            if (j !== last) {
+              // We matched a UNC root with leftovers
+              device =
+                `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+              rootEnd = j;
             }
           }
         }

--- a/src/path.cc
+++ b/src/path.cc
@@ -170,16 +170,9 @@ std::string PathResolve(Environment* env,
               j++;
             }
             if (j == len || j != last) {
-              if (firstPart != "." && firstPart != "?") {
-                // We matched a UNC root
-                device =
-                    "\\\\" + firstPart + "\\" + path.substr(last, j - last);
-                rootEnd = j;
-              } else {
-                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
-                device = "\\\\" + firstPart;
-                rootEnd = 4;
-              }
+              // We matched a UNC root
+              device = "\\\\" + firstPart + "\\" + path.substr(last, j - last);
+              rootEnd = j;
             }
           }
         }

--- a/test/cctest/test_path.cc
+++ b/test/cctest/test_path.cc
@@ -39,10 +39,6 @@ TEST_F(PathTest, PathResolve) {
   EXPECT_EQ(
       PathResolve(*env, {"C:\\foo\\tmp.3\\", "..\\tmp.3\\cycles\\root.js"}),
       "C:\\foo\\tmp.3\\cycles\\root.js");
-  EXPECT_EQ(PathResolve(*env, {"\\\\.\\PHYSICALDRIVE0"}),
-            "\\\\.\\PHYSICALDRIVE0");
-  EXPECT_EQ(PathResolve(*env, {"\\\\?\\PHYSICALDRIVE0"}),
-            "\\\\?\\PHYSICALDRIVE0");
 #else
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "../", "file/"}), "/var/file");
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "/../", "file/"}), "/file");

--- a/test/parallel/test-fs-readdir-pipe.js
+++ b/test/parallel/test-fs-readdir-pipe.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { readdir, readdirSync } = require('fs');
+
+if (!common.isWindows) {
+  common.skip('This test is specific to Windows to test enumerate pipes');
+}
+
+// Ref: https://github.com/nodejs/node/issues/56002
+// This test is specific to Windows.
+
+const pipe = '\\\\.\\pipe';
+
+assert.ok(readdirSync(pipe).length >= 0);
+
+readdir(pipe, common.mustCall((err, files) => {
+  assert.ok(err == null);
+  assert.ok(files.length >= 0);
+}));

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -79,7 +79,7 @@ assert.strictEqual(path.win32.toNamespacedPath('\\\\foo\\bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
 assert.strictEqual(path.win32.toNamespacedPath('//foo//bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
-assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo');
+assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo\\');
 assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\c:\\Windows/System'), '\\\\?\\c:\\Windows\\System');
 assert.strictEqual(path.win32.toNamespacedPath(null), null);
 assert.strictEqual(path.win32.toNamespacedPath(true), true);

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -40,8 +40,6 @@ assert.strictEqual(
   '..\\..\\..\\..\\baz'
 );
 assert.strictEqual(path.win32.normalize('foo/bar\\baz'), 'foo\\bar\\baz');
-assert.strictEqual(path.win32.normalize('\\\\.\\foo'), '\\\\.\\foo');
-assert.strictEqual(path.win32.normalize('\\\\.\\foo\\'), '\\\\.\\foo\\');
 
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
                    'fixtures/b/c.js');

--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -33,8 +33,6 @@ const resolveTests = [
      [['c:/', '///some//dir'], 'c:\\some\\dir'],
      [['C:\\foo\\tmp.3\\', '..\\tmp.3\\cycles\\root.js'],
       'C:\\foo\\tmp.3\\cycles\\root.js'],
-     [['\\\\.\\PHYSICALDRIVE0'], '\\\\.\\PHYSICALDRIVE0'],
-     [['\\\\?\\PHYSICALDRIVE0'], '\\\\?\\PHYSICALDRIVE0'],
     ],
   ],
   [ path.posix.resolve,


### PR DESCRIPTION
This reverts commit 7f68e5466a9c443d3b19a0a0749debe493a8af34.

fixes: #56002
Refs: #55623
Reopens: #54025

Additionally add a test to verify enumeration of windows named pipes works.

---

Seems normalization of path names of devices requires the trailing `\` at least in some cases like debugger.

Not sure if revert is the best way to go, maybe there is a better fix. Happy to close this revert PR in case of a better proposal.

fyi @huseyinacacak-janea


