### PR TITLE
test_runner: introduce NODE_TEST_WORKER_ID for improved concurrent te…

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3306,6 +3306,12 @@ If `value` equals `'child'`, test reporter options will be overridden and test
 output will be sent to stdout in the TAP format. If any other value is provided,
 Node.js makes no guarantees about the reporter format used or its stability.
 
+### `NODE_TEST_WORKER_ID`
+
+This environment variable is set by the test runner. When using process-level test
+isolation, each worker process is assigned a unique ID, starting at `1`. This is
+set to 1 for all tests when test isolation is disabled.
+
 ### `NODE_TLS_REJECT_UNAUTHORIZED=value`
 
 If `value` equals `'0'`, certificate validation is disabled for TLS connections.

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -358,14 +358,14 @@ class FileTest extends Test {
   }
 }
 
-function runTestFile(path, filesWatcher, opts) {
+function runTestFile(path, filesWatcher, opts, workerId = 1) {
   const watchMode = filesWatcher != null;
   const testPath = path === kIsolatedProcessName ? '' : path;
   const testOpts = { __proto__: null, signal: opts.signal };
   const subtest = opts.root.createSubtest(FileTest, testPath, testOpts, async (t) => {
     const args = getRunArgs(path, opts);
     const stdio = ['pipe', 'pipe', 'pipe'];
-    const env = { __proto__: null, ...process.env, NODE_TEST_CONTEXT: 'child-v8' };
+    const env = { __proto__: null, ...process.env, NODE_TEST_CONTEXT: 'child-v8', NODE_TEST_WORKER_ID: workerId };
     if (watchMode) {
       stdio.push('ipc');
       env.WATCH_REPORT_DEPENDENCIES = '1';
@@ -724,8 +724,10 @@ function run(options = kEmptyObject) {
     runFiles = () => {
       root.harness.bootstrapPromise = null;
       root.harness.buildPromise = null;
+      let workerId = 1;
       return SafePromiseAllSettledReturnVoid(testFiles, (path) => {
-        const subtest = runTestFile(path, filesWatcher, opts);
+        const subtest = runTestFile(path, filesWatcher, opts, workerId);
+        workerId++;
         filesWatcher?.runningSubtests.set(path, subtest);
         return subtest;
       });
@@ -766,6 +768,7 @@ function run(options = kEmptyObject) {
 
             root.entryFile = resolve(testFile);
             debug('loading test file:', fileURL.href);
+            process.env.NODE_TEST_WORKER_ID = 1;
             try {
               await cascadedLoader.import(fileURL, parent, { __proto__: null });
             } catch (err) {

--- a/test/fixtures/test-runner/worker-id/1.test.js
+++ b/test/fixtures/test-runner/worker-id/1.test.js
@@ -1,0 +1,5 @@
+const test = require('node:test');
+
+test('test1', t => {
+    console.log('NODE_TEST_WORKER_ID', process.env.NODE_TEST_WORKER_ID)
+});

--- a/test/fixtures/test-runner/worker-id/2.test.js
+++ b/test/fixtures/test-runner/worker-id/2.test.js
@@ -1,0 +1,5 @@
+const test = require('node:test');
+
+test('test2', t => {
+    console.log('NODE_TEST_WORKER_ID', process.env.NODE_TEST_WORKER_ID)
+});

--- a/test/fixtures/test-runner/worker-id/3.test.js
+++ b/test/fixtures/test-runner/worker-id/3.test.js
@@ -1,0 +1,5 @@
+const test = require('node:test');
+
+test('test3', t => {
+    console.log('NODE_TEST_WORKER_ID', process.env.NODE_TEST_WORKER_ID)
+});

--- a/test/parallel/test-runner-worker-id.js
+++ b/test/parallel/test-runner-worker-id.js
@@ -1,0 +1,100 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const test = require('node:test');
+const { spawnSync, spawn } = require('child_process');
+const { join } = require('path');
+const fixtures = require('../common/fixtures');
+const testFixtures = fixtures.path('test-runner');
+
+test('testing with isolation enabled', () => {
+  const args = ['--test', '--experimental-test-isolation=process'];
+  const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'worker-id') });
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+
+  assert.match(stdout, /NODE_TEST_WORKER_ID 1/);
+  assert.match(stdout, /NODE_TEST_WORKER_ID 2/);
+  assert.match(stdout, /NODE_TEST_WORKER_ID 3/);
+
+  assert.strictEqual(child.status, 0);
+});
+
+test('testing with isolation disabled', () => {
+  const args = ['--test', '--experimental-test-isolation=none'];
+  const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'worker-id') });
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+  const regex = /NODE_TEST_WORKER_ID 1/g;
+  const result = stdout.match(regex);
+
+  assert.strictEqual(result.length, 3);
+  assert.strictEqual(child.status, 0);
+});
+
+
+test('testing with isolation enabled in watch mode', async () => {
+  const args = ['--watch', '--test', '--experimental-test-isolation=process'];
+
+  const child = spawn(process.execPath, args, { cwd: join(testFixtures, 'worker-id') });
+
+  let outputData = '';
+  let errorData = '';
+
+  child.stdout.on('data', (data) => {
+    outputData += data.toString();
+  });
+
+  child.stderr.on('data', (data) => {
+    errorData += data.toString();
+  });
+
+  setTimeout(() => {
+    child.kill();
+
+    assert.strictEqual(errorData, '');
+    assert.match(outputData, /NODE_TEST_WORKER_ID 1/);
+    assert.match(outputData, /NODE_TEST_WORKER_ID 2/);
+    assert.match(outputData, /NODE_TEST_WORKER_ID 3/);
+
+    if (child.exitCode !== null) {
+      assert.strictEqual(child.exitCode, null); // Since we killed it manually
+    }
+  }, 1000);
+
+});
+
+test('testing with isolation disabled in watch mode', async () => {
+  const args = ['--watch', '--test', '--experimental-test-isolation=none'];
+
+  const child = spawn(process.execPath, args, { cwd: join(testFixtures, 'worker-id') });
+
+  let outputData = '';
+  let errorData = '';
+
+  child.stdout.on('data', (data) => {
+    outputData += data.toString();
+  });
+
+  child.stderr.on('data', (data) => {
+    errorData += data.toString();
+  });
+
+  setTimeout(() => {
+    child.kill();
+
+    assert.strictEqual(errorData, '');
+    const regex = /NODE_TEST_WORKER_ID 1/g;
+    const result = outputData.match(regex);
+
+    assert.strictEqual(result.length, 3);
+
+    if (child.exitCode !== null) {
+      assert.strictEqual(child.exitCode, null);
+    }
+  }, 1000);
+
+});


### PR DESCRIPTION
ref: #55842 
 
Added a new environment variable, `NODE_TEST_WORKER_ID`, which ranges from 1 to N when `--experimental-test-isolation=process` is enabled and defaults to 1 when `--experimental-test-isolation=none` is used.

Before merging, I want to add some tests but haven't come up with a good approach yet. Here's what I aim to test:  
- When `--experimental-test-isolation=process` is enabled, verify that `NODE_TEST_WORKER_ID` ranges from 1 to N.  
- When `--experimental-test-isolation=none` is used, ensure that `NODE_TEST_WORKER_ID` is set to 1.  

Any suggestions on how to create such tests would be greatly appreciated!