### PR TITLE
build: fix C string encoding for `PRODUCT_DIR_ABS`

### DIFF
--- a/deps/openssl/openssl.gyp
+++ b/deps/openssl/openssl.gyp
@@ -5,19 +5,13 @@
     'nasm_version%': '0.0',
     'openssl-cli': '<(PRODUCT_DIR)/<(EXECUTABLE_PREFIX)openssl-cli<(EXECUTABLE_SUFFIX)',
     'conditions': [
-      ['OS == "win"', {
-        'obj_dir_abs': '<(PRODUCT_DIR_ABS)/obj',
-      }],
       ['GENERATOR == "ninja"', {
-        'obj_dir_abs': '<(PRODUCT_DIR_ABS)/obj',
-        'modules_dir': '<(PRODUCT_DIR_ABS)/obj/lib/openssl-modules',
+        'modules_dir': '<(PRODUCT_DIR_ABS_CSTR)/obj/lib/openssl-modules',
       }, {
-        'obj_dir_abs%': '<(PRODUCT_DIR_ABS)/obj.target',
-        'modules_dir': '<(PRODUCT_DIR_ABS)/obj.target/deps/openssl/lib/openssl-modules',
+        'modules_dir': '<(PRODUCT_DIR_ABS_CSTR)/obj.target/deps/openssl/lib/openssl-modules',
       }],
       ['OS=="mac"', {
-        'obj_dir_abs%': '<(PRODUCT_DIR_ABS)/obj.target',
-        'modules_dir': '<(PRODUCT_DIR_ABS)/obj.target/deps/openssl/lib/openssl-modules',
+        'modules_dir': '<(PRODUCT_DIR_ABS_CSTR)/obj.target/deps/openssl/lib/openssl-modules',
       }],
     ],
   },

--- a/tools/gyp/CHANGELOG.md
+++ b/tools/gyp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.19.1](https://github.com/nodejs/gyp-next/compare/v0.19.0...v0.19.1) (2024-12-09)
+
+
+### Bug Fixes
+
+* fixup for break in EscapeForCString ([#274](https://github.com/nodejs/gyp-next/issues/274)) ([610f661](https://github.com/nodejs/gyp-next/commit/610f661da877a358c8b3cbc106b528fb1d0b8095))
+
 ## [0.19.0](https://github.com/nodejs/gyp-next/compare/v0.18.3...v0.19.0) (2024-12-03)
 
 

--- a/tools/gyp/pylib/gyp/__init__.py
+++ b/tools/gyp/pylib/gyp/__init__.py
@@ -29,7 +29,7 @@ def EscapeForCString(string: bytes | str) -> str:
         string = string.encode(encoding='utf8')
 
     backslash_or_double_quote = {ord('\\'), ord('"')}
-    result = []
+    result = ''
     for char in string:
         if char in backslash_or_double_quote or not 32 <= char < 127:
             result += '\\%03o' % char

--- a/tools/gyp/pyproject.toml
+++ b/tools/gyp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gyp-next"
-version = "0.19.0"
+version = "0.19.1"
 authors = [
   { name="Node.js contributors", email="ryzokuken@disroot.org" },
 ]


### PR DESCRIPTION
Since the `PRODUCT_DIR_ABS` gyp variable is meant to be used in a C string in the OpenSSL config, provide a version of it that actually provides it in a way that is always usable as a C string. Otherwise, unescaped characters in the path can mess with the string definitions; for example, building in paths on Windows whose directories start with valid or invalid escape sequences (e.g.: `C:\...\x61foobar\...` or `C:\...\456789\...`) can result in failing builds or incorrect paths provided to OpenSSL.

Needs: https://github.com/nodejs/gyp-next/pull/271

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
