### PR TITLE
module: mark evaluation rejection in require(esm) as handled

### DIFF
--- a/test/es-module/test-require-module-error-catching.js
+++ b/test/es-module/test-require-module-error-catching.js
@@ -1,0 +1,21 @@
+// This tests synchronous errors in ESM from require(esm) can be caught.
+
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// Runtime errors from throw should be caught.
+assert.throws(() => {
+  require('../fixtures/es-modules/runtime-error-esm.js');
+}, {
+  message: 'hello'
+});
+
+// References errors should be caught too.
+assert.throws(() => {
+  require('../fixtures/es-modules/reference-error-esm.js');
+}, {
+  name: 'ReferenceError',
+  message: 'exports is not defined'
+});

--- a/test/es-module/test-require-module-synchronous-rejection-handling.js
+++ b/test/es-module/test-require-module-synchronous-rejection-handling.js
@@ -1,0 +1,13 @@
+// This synchronous rejections from require(esm) still go to the unhandled rejection
+// handler.
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+process.on('unhandledRejection', common.mustCall((reason, promise) => {
+  assert.strictEqual(reason, 'reject!');
+}));
+
+require('../fixtures/es-modules/synchronous-rejection-esm.js');

--- a/test/fixtures/es-modules/reference-error-esm.js
+++ b/test/fixtures/es-modules/reference-error-esm.js
@@ -1,0 +1,5 @@
+// This module is invalid in both ESM and CJS, because
+// 'exports' are not defined in ESM, while require cannot be
+// redeclared in CJS.
+Object.defineProperty(exports, "__esModule", { value: true });
+const require = () => {};

--- a/test/fixtures/es-modules/runtime-error-esm.js
+++ b/test/fixtures/es-modules/runtime-error-esm.js
@@ -1,0 +1,2 @@
+import 'node:fs';  // Forces it to be recognized as ESM.
+throw new Error('hello');

--- a/test/fixtures/es-modules/synchronous-rejection-esm.js
+++ b/test/fixtures/es-modules/synchronous-rejection-esm.js
@@ -1,0 +1,2 @@
+import 'node:fs';  // Forces it to be recognized as ESM.
+Promise.reject('reject!');


### PR DESCRIPTION
Previously the implemention of require(esm) only converted the rejected promise from module evaluation into an error, but the rejected promise was still treated as a pending unhandled rejection by the promise rejection callback, because the promise is created by V8 internals and we don't get a chance to mark it as handled, so the rejection incorrectly marked as unhandled would still go through unhandled rejection handling (if no global listener is set, the default handling would print a warning and make the Node.js instance exit with 1).

This patch fixes it by calling into the JS promise rejection callback to mark the evalaution rejection handled so that it doesn't go through unhandled rejection handling.

Fixes: https://github.com/nodejs/node/issues/56115

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
