### PR TITLE
tools: improve release proposal PR opening

### DIFF
--- a/.github/workflows/create-release-proposal.yml
+++ b/.github/workflows/create-release-proposal.yml
@@ -32,6 +32,7 @@ jobs:
       RELEASE_BRANCH: v${{ inputs.release-line }}.x
       RELEASE_DATE: ${{ inputs.release-date }}
       RELEASE_LINE: ${{ inputs.release-line }}
+      RELEASER: ${{ github.actor }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -79,6 +80,6 @@ jobs:
 
       - name: Start git node release prepare
         run: |
-          ./tools/actions/create-release.sh "${RELEASE_DATE}" "${RELEASE_LINE}"
+          ./tools/actions/create-release.sh "${RELEASE_DATE}" "${RELEASE_LINE}" "${RELEASER}"
         env:
           GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}

--- a/tools/actions/create-release.sh
+++ b/tools/actions/create-release.sh
@@ -4,6 +4,7 @@ set -xe
 
 RELEASE_DATE=$1
 RELEASE_LINE=$2
+RELEASER=$3
 
 if [ -z "$RELEASE_DATE" ] || [ -z "$RELEASE_LINE" ]; then
   echo "Usage: $0 <RELEASE_DATE> <RELEASE_LINE>"
@@ -21,7 +22,7 @@ TITLE=$(awk "/^## ${RELEASE_DATE}/ { print substr(\$0, 4) }" "doc/changelogs/CHA
 # Use a temporary file for the PR body
 TEMP_BODY="$(awk "/## ${RELEASE_DATE}/,/^<a id=/{ if (!/^<a id=/) print }" "doc/changelogs/CHANGELOG_V${RELEASE_LINE}.md")"
 
-PR_URL="$(gh pr create --title "$TITLE" --body "$TEMP_BODY" --base "v$RELEASE_LINE.x")"
+PR_URL="$(gh pr create --draft --title "$TITLE" --body "$TEMP_BODY" --base "v$RELEASE_LINE.x" --assignee "$RELEASER" --label release)"
 
 # Amend commit message so it contains the correct PR-URL trailer.
 AMENDED_COMMIT_MSG="$(git log -1 --pretty=%B | sed "s|PR-URL: TODO|PR-URL: $PR_URL|")"


### PR DESCRIPTION
- Open as draft. The releaser should review the PR and mark it as ready.
- Add the "release" label.
- Assign the releaser to the PR so it's clearer who's in charge and
  they can find it more easily. This will also notify and subscribe
  them to the PR.

