### PR TITLE
build: use more aggressive LTO on gcc

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -13,6 +13,7 @@
     'enable_pgo_generate%': '0',
     'enable_pgo_use%': '0',
     'python%': 'python',
+    'enable_lto': 'true',
 
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,

--- a/common.gypi
+++ b/common.gypi
@@ -187,7 +187,7 @@
             ['clang==1', {
               'lto': ' -flto ', # Clang
             }, {
-              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
+              'lto': ' -flto=4 -fuse-linker-plugin -fno-fat-lto-objects -flto-partition=one -ffunction-sections -fdata-sections ', # GCC
             }],
           ],
         },

--- a/common.gypi
+++ b/common.gypi
@@ -188,7 +188,7 @@
             ['clang==1', {
               'lto': ' -flto ', # Clang
             }, {
-              'lto': ' -flto=4 -fuse-linker-plugin -fno-fat-lto-objects -flto-partition=one -ffunction-sections -fdata-sections ', # GCC
+              'lto': ' -flto=auto -fuse-linker-plugin -fno-fat-lto-objects -flto-partition=one -ffunction-sections -fdata-sections ', # GCC
             }],
           ],
         },


### PR DESCRIPTION
> Please validate locally before landing this pull-request. This is an area that I'm not familiar with.

Using more aggressive LTO, the startup time of Node.js can be reduced from 38ms to 28ms.

## Before

```
➜  node git:(main) ✗ hyperfine 'out/Release/node index.js' --warmup 30
Benchmark 1: out/Release/node index.js
  Time (mean ± σ):      38.7 ms ±   0.8 ms    [User: 27.1 ms, System: 8.1 ms]
  Range (min … max):    37.9 ms …  42.2 ms    70 runs
```

## After

```
➜  node git:(main) ✗ hyperfine 'out/Release/node index.js' --warmup 30
Benchmark 1: out/Release/node index.js
  Time (mean ± σ):      32.0 ms ±   2.7 ms    [User: 26.7 ms, System: 5.3 ms]
  Range (min … max):    28.5 ms …  42.3 ms    53 runs
```