### PR TITLE
tools: add a backport queue cron action

### DIFF
--- a/.github/workflows/backport-queue.yml
+++ b/.github/workflows/backport-queue.yml
@@ -1,0 +1,170 @@
+name: Backport Commit Queue
+
+on:
+  schedule:
+    # Run twice a week at 00:15 AM UTC on Sunday and Thursday.
+    - cron: 15 0 * * 0,4
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}
+
+env:
+  NODE_VERSION: lts/*
+  PYTHON_VERSION: '3.12'
+  FLAKY_TESTS: keep_retrying
+  CC: sccache clang
+  CXX: sccache clang++
+  SCCACHE_GHA_ENABLED: 'true'
+
+permissions:
+  contents: read
+
+jobs:
+  commitQueue:
+    runs-on: ubuntu-latest
+    if: github.repository == 'nodejs/node' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - { release-line: v23.x, base-branch: main }
+          - { release-line: v22.x, base-branch: v23.x }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          # Needs the whole git history for ncu to work
+          # See https://github.com/nodejs/node-core-utils/pull/486
+          fetch-depth: 0
+          ref: ${{ matrix.branch.release-line }}-staging
+          # A personal token is required because pushing changes to `.github`
+          # with default token will be blocked. It needs
+          # to be set here because `checkout` configures GitHub authentication
+          # for push as well.
+          token: ${{ secrets.GH_USER_TOKEN }}
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Install dependencies
+      - name: Install Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install branch-diff
+        run: npm install -g branch-diff
+
+      - name: Setup git author
+        run: |
+          git config --local user.email "github-bot@iojs.org"
+          git config --local user.name "Node.js GitHub Bot"
+
+      - name: Set up ghauth config (Ubuntu)
+        run: |
+          mkdir -p "${XDG_CONFIG_HOME:-~/.config}/changelog-maker"
+          echo '{}' | jq '{user: env.USERNAME, token: env.TOKEN}' > "${XDG_CONFIG_HOME:-~/.config}/changelog-maker/config.json"
+        env:
+          USERNAME: ${{ secrets.JENKINS_USER }}
+          TOKEN: ${{ github.token }}
+
+      - name: Fetch base branch
+        run: |
+          git remote set-branches --add origin "$BASE_BRANCH"
+          git fetch origin "$BASE_BRANCH"
+        env:
+          BASE_BRANCH: ${{ matrix.branch.base-branch }}
+
+      - name: Fetch auto-backport branch if it exists
+        id: fetch
+        run: |
+          if git fetch origin "$BACKPORT_BRANCH"; then
+            STAGING_BRANCH_TIP="$(git rev-parse HEAD)"
+            WORKING_BRANCH_TIP="$(git rev-parse FETCH_HEAD)"
+            echo "WORKING_BRANCH_TIP=$WORKING_BRANCH_TIP" >> "$GITHUB_OUTPUT"
+            if [ "$WORKING_BRANCH_TIP" != "$STAGING_BRANCH_TIP" ]; then
+                git reset  "$WORKING_BRANCH_TIP" --hard
+                git rebase "$STAGING_BRANCH_TIP" --empty=drop || git reset "$STAGING_BRANCH_TIP" --hard
+            fi
+          else
+            echo "Branch doesn't exist yet"
+          fi
+        env:
+          BACKPORT_BRANCH: ${{ matrix.branch.release-line }}-staging-auto-backport
+
+      - name: Run the queue
+        id: queue
+        run: |
+          set -xe
+
+          NODE="$(command -v node)"
+
+          backport() {
+            git cherry-pick "$1" && \
+            make lint-js NODE="$NODE" && \
+            make test-doc -j4 NODE="$NODE"
+          }
+
+          mkdir -p out/Release
+          ln -s "$NODE" out/Release/node
+
+          branch-diff "${CURRENT_RELEASE_LINE}-staging" "$BASE_REF" \
+            --exclude-label="semver-major,dont-land-on-${CURRENT_RELEASE_LINE},backport-requested-${CURRENT_RELEASE_LINE},backport-blocked-${CURRENT_RELEASE_LINE},backport-open-${CURRENT_RELEASE_LINE},backported-to-${CURRENT_RELEASE_LINE}"\
+            --filter-release --format=sha --reverse | while read -r COMMIT ; do
+            if backport "$COMMIT" 2>&1 >output; then
+              MAX_COMMITS="$((MAX_COMMITS-1))"
+            else
+              {
+                EOF="$(node -p 'crypto.randomUUID()')"
+                echo "$COMMIT<<$EOF"
+                echo "…"
+                tail output # Cutting the output to avoid exceeding memory.
+                echo "$EOF"
+              } >> "$GITHUB_OUTPUT"
+              git cherry-pick --skip || git reset HEAD^ --hard
+            fi
+            cat output
+            [ "$MAX_COMMITS" = "0" ] && break || true
+          done
+          rm -f output
+        env:
+          MAX_COMMITS: 99 # backport commits 99 at a time to limit the risk of timeout
+          CURRENT_RELEASE_LINE: ${{ matrix.branch.release-line }}
+          BASE_REF: origin/${{ matrix.branch.base-branch }}
+          BACKPORT_BRANCH: ${{ matrix.branch.release-line }}-staging-auto-backport
+
+      - name: Get local HEAD
+        id: head
+        run: echo "HEAD=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Push to working branch
+        if: ${{ steps.fetch.outputs.WORKING_BRANCH_TIP != steps.head.outputs.HEAD }}
+        run: git push origin "HEAD:refs/heads/$BACKPORT_BRANCH" --force
+        env:
+          BACKPORT_BRANCH: ${{ matrix.branch.release-line }}-staging-auto-backport
+
+      - name: Report errors
+        if: ${{ 
+            steps.fetch.outputs.WORKING_BRANCH_TIP != steps.head.outputs.HEAD &&
+            toJson(steps.queue.outputs) != '{}'
+            }}
+        run: |
+          node -<<'EOF' | gh issue create --repo "$GITHUB_REPOSITORY_OWNER/Release"\
+            -t "Autobackport is failing on $CURRENT_RELEASE_LINE" \
+            --label 'Release-agenda' --body-file -
+          console.log(`Workflow URL: <${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}>`);
+          console.log('\n<ul>');
+          for (const [sha, output] of Object.entries(JSON.parse(process.env.FAILED_BACKPORTS))) {
+            console.log('<li><details>');
+            console.log(`<summary><code>${sha}</code></summary>`);
+            console.log(`\n${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/commit/${sha}\n\n${'```'}\n${output}\n${'```'}\n`);
+            console.log('</details></li>');
+          }
+          console.log('</ul>');
+          console.log('Try to cherry-pick the commit manually or add `backport-requested` label and leave a comment on the associated PR.')
+          EOF
+        env:
+          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          FAILED_BACKPORTS: ${{ toJson(steps.queue.outputs) }}
+          CURRENT_RELEASE_LINE: ${{ matrix.branch.release-line }}
+

--- a/.github/workflows/backport-queue.yml
+++ b/.github/workflows/backport-queue.yml
@@ -144,7 +144,7 @@ jobs:
           BACKPORT_BRANCH: ${{ matrix.branch.release-line }}-staging-auto-backport
 
       - name: Report errors
-        if: ${{ 
+        if: ${{
             steps.fetch.outputs.WORKING_BRANCH_TIP != steps.head.outputs.HEAD &&
             toJson(steps.queue.outputs) != '{}'
             }}
@@ -167,4 +167,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
           FAILED_BACKPORTS: ${{ toJson(steps.queue.outputs) }}
           CURRENT_RELEASE_LINE: ${{ matrix.branch.release-line }}
-


### PR DESCRIPTION
This should help the Release team to keep up with backports, by getting notified sooner when there's a backport conflict. 

I've tried compiling and running tests as part of the workflow but it's not reliable and would force us to limit the number of commits to avoid timeouts.

I'm using a different branch, I don't think we want the automation to push to the staging branches because:

- It's only able to work with commits that cleanly apply to the staging branch, which is trivial for a human to do.
- No matter how small of a conflict, as soon as a commit doesn't backport it is skipped, and having out of order backports makes branches diverge more and more, making future backport harder.
- Releasers sign their backport commits. Because commits that land on staging branch receive much fewer attention than the one on `main`, we don't want anyone to be tempted to introduce subtle backdoor when backporting, having the signature puts the releaser reputation at stake. I don't think we could have the same system with a bot while making sure no one can impersonate the bot.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
