### PR TITLE
Revert "build: avoid compiling with VS v17.12"

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -292,18 +292,9 @@ goto exit
 @rem Visual Studio v17.10 has a bug that causes the build to fail.
 @rem Check if the version is v17.10 and exit if it is.
 echo %VSCMD_VER% | findstr /b /c:"17.10" >nul
-if %errorlevel% neq 1 (
+if %errorlevel% neq 1  (
   echo Node.js doesn't compile with Visual Studio 17.10 Please use a different version.
   goto exit
-)
-@rem Same applies to v17.12 for MSVC.
-echo %VSCMD_VER% | findstr /b /c:"17.12" >nul
-if %errorlevel% neq 1 (
-  @rem Clang 18.1.8 Provided with VS 17.12 works fine.
-  if not defined clang_cl (
-    echo Node.js doesn't compile with Visual Studio 17.12 Please use a different version.
-    goto exit
-  )
 )
 
 @rem check if the clang-cl build is requested


### PR DESCRIPTION
This reverts commit 542f252d3672f586db07112fe2d844a5d1417e3a.

---

VS 17.12.2 and 17.12.3 work therefore no longer needed to stop build for 17.12.

fyi @nodejs/platform-windows @nodejs/build @StefanStojanovic 

Refs: https://github.com/nodejs/build/issues/3963
Refs: https://github.com/nodejs/node/pull/55930

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
