### PR TITLE
test: make test-crypto-hash compatible with OpenSSL > 3.4.0

### DIFF
--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
 
+const { hasOpenSSL } = common;
 const fixtures = require('../common/fixtures');
 
 let cryptoType;
@@ -182,19 +183,21 @@ assert.throws(
 
 // Test XOF hash functions and the outputLength option.
 {
-  // Default outputLengths.
-  assert.strictEqual(crypto.createHash('shake128').digest('hex'),
-                     '7f9c2ba4e88f827d616045507605853e');
-  assert.strictEqual(crypto.createHash('shake128', null).digest('hex'),
-                     '7f9c2ba4e88f827d616045507605853e');
-  assert.strictEqual(crypto.createHash('shake256').digest('hex'),
-                     '46b9dd2b0ba88d13233b3feb743eeb24' +
-                     '3fcd52ea62b81b82b50c27646ed5762f');
-  assert.strictEqual(crypto.createHash('shake256', { outputLength: 0 })
-                           .copy()  // Default outputLength.
-                           .digest('hex'),
-                     '46b9dd2b0ba88d13233b3feb743eeb24' +
-                     '3fcd52ea62b81b82b50c27646ed5762f');
+  // Default outputLengths. Since OpenSSL 3.4 an outputLength is mandatory
+  if (!hasOpenSSL(3, 4)) {
+    assert.strictEqual(crypto.createHash('shake128').digest('hex'),
+                       '7f9c2ba4e88f827d616045507605853e');
+    assert.strictEqual(crypto.createHash('shake128', null).digest('hex'),
+                       '7f9c2ba4e88f827d616045507605853e');
+    assert.strictEqual(crypto.createHash('shake256').digest('hex'),
+                       '46b9dd2b0ba88d13233b3feb743eeb24' +
+                       '3fcd52ea62b81b82b50c27646ed5762f');
+    assert.strictEqual(crypto.createHash('shake256', { outputLength: 0 })
+                             .copy()  // Default outputLength.
+                             .digest('hex'),
+                       '46b9dd2b0ba88d13233b3feb743eeb24' +
+                       '3fcd52ea62b81b82b50c27646ed5762f');
+  }
 
   // Short outputLengths.
   assert.strictEqual(crypto.createHash('shake128', { outputLength: 0 })

--- a/test/parallel/test-crypto-oneshot-hash.js
+++ b/test/parallel/test-crypto-oneshot-hash.js
@@ -31,6 +31,9 @@ const methods = crypto.getHashes();
 const input = fs.readFileSync(fixtures.path('utf8_test_text.txt'));
 
 for (const method of methods) {
+  // Skip failing tests on OpenSSL 3.4.0
+  if (method.startsWith('shake') && common.hasOpenSSL(3, 4))
+    continue;
   for (const outputEncoding of ['buffer', 'hex', 'base64', undefined]) {
     const oldDigest = crypto.createHash(method).update(input).digest(outputEncoding || 'hex');
     const digestFromBuffer = crypto.hash(method, input, outputEncoding);


### PR DESCRIPTION
OpenSSL 3.4 has a breaking change where the outputLength is now mandatory for shake* hash algorithms.

https://github.com/openssl/openssl/commit/b911fef216d1386210ec24e201d54d709528abb4

---

This only fixes one of the tree issues with OpenSSL 3.4. and it doesn't fix `crypto.createHash()` which likely should be adjusted to be compatible with the new OpenSSL behaviour but I am unsure how that is done. I assume it should raise an InvalidArgumentError now.

Refs: https://github.com/nodejs/node/issues/56159