### PR TITLE
node-api: remove deprecated attribute from napi_module_register

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -90,9 +90,6 @@ EXTERN_C_START
 
 // Deprecated. Replaced by symbol-based registration defined by NAPI_MODULE
 // and NAPI_MODULE_INIT macros.
-#if defined(__cplusplus) && __cplusplus >= 201402L
-[[deprecated]]
-#endif
 NAPI_EXTERN void NAPI_CDECL
 napi_module_register(napi_module* mod);
 


### PR DESCRIPTION
This PR targets to addresses the issue #56153 by removing the `[[deprecated]]` attribute from the `napi_module_register` function.

The code described in the issue does not use the `napi_module_register`  function as it was intended from a module shared library. Instead, it uses it to register modules for embedding scenarios. While it was never the intended use, we currently do not have a better approach to register modules before `Environment` is created until we complete the new embedding API  - PR #54660. 

We discussed the issue in the Node-API meeting on Dec 6th 2024, and decided that the quickest and the least intrusive way to address it is to remove the `[[deprecated]]` attribute from the `napi_module_register` function for now.