### PR TITLE
doc: fix c++ addon hello world sample

### DIFF
--- a/doc/api/addons.md
+++ b/doc/api/addons.md
@@ -72,6 +72,7 @@ namespace demo {
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::NewStringType;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -79,7 +80,7 @@ using v8::Value;
 void Method(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   args.GetReturnValue().Set(String::NewFromUtf8(
-      isolate, "world").ToLocalChecked());
+      isolate, "world", NewStringType::kNormal).ToLocalChecked());
 }
 
 void Initialize(Local<Object> exports) {


### PR DESCRIPTION
Fixes #56173
Refs: #56173

This PR updates the sample provided at https://nodejs.org/api/addons.html#hello-world so it builds successfully with `node-gyp` [1]. 

[1]: https://v8docs.nodesource.com/node-4.8/d2/db3/classv8_1_1_string.html