### PR TITLE
lib: remove redundant global RegExps

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -173,7 +173,7 @@ function formatTime(ms) {
 }
 
 function safeTraceLabel(label) {
-  return label.replace(/\\/g, '\\\\').replaceAll('"', '\\"');
+  return label.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
 /**

--- a/lib/url.js
+++ b/lib/url.js
@@ -704,7 +704,7 @@ Url.prototype.format = function format() {
     }
   }
 
-  search = search.replace(/#/g, '%23');
+  search = search.replaceAll('#', '%23');
 
   if (hash && hash.charCodeAt(0) !== CHAR_HASH)
     hash = '#' + hash;


### PR DESCRIPTION
Small PR that replaces RegExps with `.replaceAll` when possible