### PR TITLE
doc: call out import.meta is only supported in ES modules

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -343,7 +343,7 @@ modules it can be used to load ES modules.
 * {Object}
 
 The `import.meta` meta property is an `Object` that contains the following
-properties.
+properties. It is only supported in ES modules.
 
 ### `import.meta.dirname`
 


### PR DESCRIPTION
**Problem**: It is called out that dynamic import is supported in both CJS and ES modules. Nothing is mentioned for leading `import.meta`. This can lead to an incorrect assumption that one can use `import.meta.resolve` to resolve a file path to dynamically import from a CJS module. Using `import.meta` in CJS currently throws an error.

**Solution**: Explicitly call out the environments in which `import.meta` is supported.