### PR TITLE
worker: fix crash when a worker joins after exit

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -449,6 +449,9 @@ void Worker::JoinThread() {
 
   env()->remove_sub_worker_context(this);
 
+  // Join may happen after the worker exits and disposes the isolate
+  if (!env()->can_call_into_js()) return;
+
   {
     HandleScope handle_scope(env()->isolate());
     Context::Scope context_scope(env()->context());


### PR DESCRIPTION
If a worker has not already joined before running to completion it will join in a SetImmediateThreadsafe which could occur after the worker has already ended by other means. Mutating a JS object at that point would fail because the isolate is already disposed.

Fixes #56020 (Note that this issue is not reproducible on 22+, but is likely still technically present on later versions as it appears to be a race condition which just happened to be reproducible in the specific conditions described in the issue. The originating code has not been changed in a long time, so it's likely just a very rare condition.)

cc @addaleax I would greatly appreciate a review from you as you're the last person to touch this code...even if it's been many years now. 😅 