### PR TITLE
build: use variable for simdutf path

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -7,10 +7,14 @@ declare_args() {
   # The location of Node.js in source code tree.
   node_path = "//node"
 
-  # The location of V8, use the one from node's deps by default.
+  # The location of V8 - use the one from node's deps by default.
   node_v8_path = "$node_path/deps/v8"
 
+  # The location of OpenSSL - use the one from node's deps by default.
   node_openssl_path = "$node_path/deps/openssl"
+
+  # The location of simdutf - use the one from node's deps by default.
+  node_simdutf_path = "$node_path/deps/simdutf"
 
   # The NODE_MODULE_VERSION defined in node_version.h.
   node_module_version = exec_script("$node_path/tools/getmoduleversion.py", [], "value")

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -158,10 +158,10 @@ template("node_gn_build") {
       "deps/nghttp2",
       "deps/ngtcp2",
       "deps/postject",
-      "deps/simdutf",
       "deps/sqlite",
       "deps/uvwasi",
       "//third_party/zlib",
+      "$node_simdutf_path",
       "$node_v8_path:v8_libplatform",
     ]
 
@@ -300,8 +300,8 @@ template("node_gn_build") {
 
   executable("node_js2c") {
     deps = [
-      "deps/simdutf",
       "deps/uv",
+      "$node_simdutf_path",
     ]
     sources = [
       "tools/js2c.cc",
@@ -358,7 +358,7 @@ template("node_gn_build") {
       "deps/googletest",
       "deps/googletest:gtest_main",
       "deps/nbytes",
-      "deps/simdutf",
+      "$node_simdutf_path",
     ]
 
     sources = gypi_values.node_cctest_sources


### PR DESCRIPTION
Similar to https://github.com/nodejs/node/pull/55928 - as of https://chromium-review.googlesource.com/c/chromium/src/+/6054817 Chromium includes simdutf and so there's a conflict if both are used. This allows customizing the one Node.js uses so Electron can use Chromium's in Node.js
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
