### PR TITLE
doc: update announce documentation for releases

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1384,7 +1384,6 @@ take place once a new LTS line has been released.
 [Build issue tracker]: https://github.com/nodejs/build/issues/new
 [CI lockdown procedure]: https://github.com/nodejs/build/blob/HEAD/doc/jenkins-guide.md#restricting-access-for-security-releases
 [Node.js Snap management repository]: https://github.com/nodejs/snap
-[Partner Communities]: https://github.com/nodejs/community-committee/blob/HEAD/governance/PARTNER_COMMUNITIES.md
 [Snap]: https://snapcraft.io/node
 [build-infra team]: https://github.com/orgs/nodejs/teams/build-infra
 [expected assets]: https://github.com/nodejs/build/tree/HEAD/ansible/www-standalone/tools/promote/expected_assets

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1081,7 +1081,7 @@ on offical slack channel.
 Node.js is also available on Bluesky and a release announcement can be
 reposted using [nodejs/bluesky](https://github.com/nodejs/bluesky) repository.
 
-The post content should be similar to:
+The post content can be as simple as:
 
 > v5.8.0 of @nodejs is out: <https://nodejs.org/en/blog/release/v5.8.0/>
 > …

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1075,7 +1075,7 @@ This script will use the promoted builds and changelog to generate the post. Run
 ### 19. Announce
 
 The nodejs.org website will automatically rebuild and include the new version.
-To announce the build on social media, please refer to ping @nodejs-social-team
+To announce the build on social media, please ping the @nodejs-social-team
 on offical slack channel.
 
 Node.js is also available on Bluesky and a release announcement can be

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1075,19 +1075,17 @@ This script will use the promoted builds and changelog to generate the post. Run
 ### 19. Announce
 
 The nodejs.org website will automatically rebuild and include the new version.
-To announce the build on Twitter through the official @nodejs account, email
-<pr@nodejs.org> with a message such as:
+To announce the build on social media, please refer to ping @nodejs-social-team
+on offical slack channel.
+
+Node.js is also available on Bluesky and a release announcement can be
+reposted using [nodejs/bluesky](https://github.com/nodejs/bluesky) repository.
+
+The post content should be similar to:
 
 > v5.8.0 of @nodejs is out: <https://nodejs.org/en/blog/release/v5.8.0/>
 > …
 > something here about notable changes
-
-To ensure communication goes out with the timing of the blog post, please allow
-24 hour prior notice. If known, please include the date and time the release
-will be shared with the community in the email to coordinate these
-announcements.
-
-Ping the IRC ops and the other [Partner Communities][] liaisons.
 
 <details>
 <summary>Security release</summary>


### PR DESCRIPTION
This updates the announce section to match the current process of announcing releases on Node.js. This also mentions the latest Bluesky automation.

cc: @nodejs/releasers @nodejs/social 