### PR TITLE
doc: `sea.getRawAsset(key)` always returns an ArrayBuffer

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -352,7 +352,7 @@ writes to the returned array buffer is likely to result in a crash.
 
 * `key`  {string} the key for the asset in the dictionary specified by the
   `assets` field in the single-executable application configuration.
-* Returns: {string|ArrayBuffer}
+* Returns: {ArrayBuffer}
 
 ### `require(id)` in the injected main script is not file based
 


### PR DESCRIPTION
`sea.getRawAsset(key)` always returns ArrayBuffer, not string. The return type in the documentation is wrong.

https://github.com/nodejs/node/blob/bd3c25cf31282f101196c0808cbf9267fb3f9bcd/src/node_sea.cc#L600

https://github.com/nodejs/node/blob/bd3c25cf31282f101196c0808cbf9267fb3f9bcd/lib/sea.js#L15-L35

cc @nodejs/single-executable