### PR TITLE
assert: show diff when doing partial comparisons with a custom message

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -604,10 +604,9 @@ function compareBranch(
   // Check if all expected keys and values match
   for (let i = 0; i < keysExpected.length; i++) {
     const key = keysExpected[i];
-    assert(
-      ReflectHas(actual, key),
-      new AssertionError({ message: `Expected key ${String(key)} not found in actual object` }),
-    );
+    if (!ReflectHas(actual, key)) {
+      return false;
+    }
     if (!compareBranch(actual[key], expected[key], comparedObjects)) {
       return false;
     }

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -26,6 +26,7 @@ const { myersDiff, printMyersDiff, printSimpleMyersDiff } = require('internal/as
 
 const kReadableOperator = {
   deepStrictEqual: 'Expected values to be strictly deep-equal:',
+  partialDeepStrictEqual: 'Expected values to be partially and strictly deep-equal:',
   strictEqual: 'Expected values to be strictly equal:',
   strictEqualObject: 'Expected "actual" to be reference-equal to "expected":',
   deepEqual: 'Expected values to be loosely deep-equal:',
@@ -40,6 +41,8 @@ const kReadableOperator = {
 
 const kMaxShortStringLength = 12;
 const kMaxLongStringLength = 512;
+
+const kMethodsWithCustomMessageDiff = ['deepStrictEqual', 'strictEqual', 'partialDeepStrictEqual'];
 
 function copyError(source) {
   const target = ObjectAssign(
@@ -210,8 +213,12 @@ function createErrDiff(actual, expected, operator, customMessage) {
     const checkCommaDisparity = actual != null && typeof actual === 'object';
     const diff = myersDiff(inspectedSplitActual, inspectedSplitExpected, checkCommaDisparity);
 
-    const myersDiffMessage = printMyersDiff(diff);
+    const myersDiffMessage = printMyersDiff(diff, operator);
     message = myersDiffMessage.message;
+
+    if (operator === 'partialDeepStrictEqual') {
+      header = `${colors.gray}${colors.hasColors ? '' : '+ '}actual${colors.white} ${colors.red}- expected${colors.white}`;
+    }
 
     if (myersDiffMessage.skipped) {
       skipped = true;
@@ -255,7 +262,7 @@ class AssertionError extends Error {
     if (isErrorStackTraceLimitWritable()) Error.stackTraceLimit = 0;
 
     if (message != null) {
-      if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
+      if (kMethodsWithCustomMessageDiff.includes(operator)) {
         super(createErrDiff(actual, expected, operator, message));
       } else {
         super(String(message));
@@ -275,7 +282,7 @@ class AssertionError extends Error {
         expected = copyError(expected);
       }
 
-      if (operator === 'deepStrictEqual' || operator === 'strictEqual') {
+      if (kMethodsWithCustomMessageDiff.includes(operator)) {
         super(createErrDiff(actual, expected, operator, message));
       } else if (operator === 'notDeepStrictEqual' ||
         operator === 'notStrictEqual') {

--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -122,7 +122,7 @@ function printSimpleMyersDiff(diff) {
   return `\n${message}`;
 }
 
-function printMyersDiff(diff, simple = false) {
+function printMyersDiff(diff, operator) {
   let message = '';
   let skipped = false;
   let nopCount = 0;
@@ -148,7 +148,11 @@ function printMyersDiff(diff, simple = false) {
     }
 
     if (type === 'insert') {
-      message += `${colors.green}+${colors.white} ${value}\n`;
+      if (operator === 'partialDeepStrictEqual') {
+        message += `${colors.gray}${colors.hasColors ? ' ' : '+'} ${value}${colors.white}\n`;
+      } else {
+        message += `${colors.green}+${colors.white} ${value}\n`;
+      }
     } else if (type === 'delete') {
       message += `${colors.red}-${colors.white} ${value}\n`;
     } else if (type === 'nop') {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1351,6 +1351,17 @@ test('Additional assert', () => {
     }
   );
 
+  assert.throws(
+    () => {
+      assert.partialDeepStrictEqual({ a: true }, { a: false }, 'custom message');
+    },
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError',
+      message: 'custom message\n+ actual - expected\n\n  {\n+   a: true\n-   a: false\n  }\n'
+    }
+  );
+
   {
     let threw = false;
     try {

--- a/test/pseudo-tty/test-assert-colors.js
+++ b/test/pseudo-tty/test-assert-colors.js
@@ -1,11 +1,16 @@
+// Flags: --no-warnings
 'use strict';
 require('../common');
 const assert = require('assert').strict;
 
-assert.throws(() => {
+function setup() {
   process.env.FORCE_COLOR = '1';
   delete process.env.NODE_DISABLE_COLORS;
   delete process.env.NO_COLOR;
+}
+
+assert.throws(() => {
+  setup();
   assert.deepStrictEqual([1, 2, 2, 2, 2], [2, 2, 2, 2, 2]);
 }, (err) => {
   const expected = 'Expected values to be strictly deep-equal:\n' +
@@ -19,6 +24,48 @@ assert.throws(() => {
     '\x1B[39m    2,\n' +
     '\x1B[31m-\x1B[39m   2\n' +
     '\x1B[39m  ]\n';
+
   assert.strictEqual(err.message, expected);
   return true;
 });
+
+{
+  assert.throws(() => {
+    setup();
+    assert.partialDeepStrictEqual({ a: 1, b: 2, c: 3, d: 5 }, { z: 4, b: 5 });
+  }, (err) => {
+    const expected = 'Expected values to be partially and strictly deep-equal:\n' +
+      '\x1B[90mactual\x1B[39m \x1B[31m- expected\x1B[39m\n' +
+      '\n' +
+      '\x1B[39m  {\n' +
+      '\x1B[90m    a: 1,\x1B[39m\n' +
+      '\x1B[90m    b: 2,\x1B[39m\n' +
+      '\x1B[90m    c: 3,\x1B[39m\n' +
+      '\x1B[90m    d: 5\x1B[39m\n' +
+      '\x1B[31m-\x1B[39m   b: 5,\n' +
+      '\x1B[31m-\x1B[39m   z: 4\n' +
+      '\x1B[39m  }\n';
+
+    assert.strictEqual(err.message, expected);
+    return true;
+  });
+
+  assert.throws(() => {
+    setup();
+    assert.partialDeepStrictEqual([1, 2, 3, 5], [4, 5]);
+  }, (err) => {
+    const expected = 'Expected values to be partially and strictly deep-equal:\n' +
+      '\x1B[90mactual\x1B[39m \x1B[31m- expected\x1B[39m\n' +
+      '\n' +
+      '\x1B[39m  [\n' +
+      '\x1B[90m    1,\x1B[39m\n' +
+      '\x1B[90m    2,\x1B[39m\n' +
+      '\x1B[90m    3,\x1B[39m\n' +
+      '\x1B[31m-\x1B[39m   4,\n' +
+      '\x1B[39m    5\n' +
+      '\x1B[39m  ]\n';
+
+    assert.strictEqual(err.message, expected);
+    return true;
+  });
+}

--- a/test/pseudo-tty/test-assert-no-color.js
+++ b/test/pseudo-tty/test-assert-no-color.js
@@ -1,3 +1,4 @@
+// Flags: --no-warnings
 'use strict';
 require('../common');
 const assert = require('assert').strict;
@@ -17,3 +18,19 @@ assert.throws(
       '-   foo: \'bar\'\n' +
       '- }\n',
   });
+
+{
+  assert.throws(
+    () => {
+      assert.partialDeepStrictEqual({}, { foo: 'bar' });
+    },
+    {
+      message: 'Expected values to be partially and strictly deep-equal:\n' +
+        '+ actual - expected\n' +
+        '\n' +
+        '+ {}\n' +
+        '- {\n' +
+        "-   foo: 'bar'\n" +
+        '- }\n',
+    });
+}


### PR DESCRIPTION
following the same reasoning as [this PR](https://github.com/nodejs/node/pull/54759):

right now the method `assert.partialDeepStrictEqual` does not show the diff when the assertion fails.  
With this PR we go from this:

```js
const assert = require('assert');

assert.partialDeepStrictEqual([1, 2, 3, 5], [4, 5]);
```

<img width="791" alt="image" src="https://github.com/user-attachments/assets/777b0ec3-3144-4809-8f1b-e1c4b3664de2" />

to this
<img width="792" alt="image" src="https://github.com/user-attachments/assets/745b619b-a046-4880-b78a-3c54a0cc1737" />

with a custom error message:

<img width="788" alt="image" src="https://github.com/user-attachments/assets/2e870d84-b402-42a9-8656-e87a1e6742fb" />


Relevant changes:

1. enabled the diff when `assert.partialDeepStrictEqual` fails
2. enabled the diff when `assert.partialDeepStrictEqual` fails with a custom error message
3. added different diff style in case `assert.partialDeepStrictEqual` fails:

- properties available in `actual` are gray
- properties in `expected` but not in `actual` are prefixed with the classic red `-`
- properties present in both `actual` and `expected` are white

