### PR TITLE
util: fix Latin1 decoding to return string output

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -286,9 +286,11 @@ void BindingData::DecodeLatin1(const FunctionCallbackInfo<Value>& args) {
         env->isolate(), "The encoded data was not valid for encoding latin1");
   }
 
-  Local<Object> buffer_result =
-      node::Buffer::Copy(env, result.c_str(), written).ToLocalChecked();
-  args.GetReturnValue().Set(buffer_result);
+  Local<String> output =
+      String::NewFromUtf8(
+          env->isolate(), result.c_str(), v8::NewStringType::kNormal, written)
+          .ToLocalChecked();
+  args.GetReturnValue().Set(output);
 }
 
 }  // namespace encoding_binding

--- a/test/cctest/test_encoding_binding.cc
+++ b/test/cctest/test_encoding_binding.cc
@@ -156,7 +156,7 @@ TEST_F(EncodingBindingTest, DecodeLatin1_ReturnsString) {
   Isolate* isolate = env->isolate();
   HandleScope handle_scope(isolate);
 
-  const uint8_t latin1_data[] = {0xC1, 0xE9, 0xF3}; 
+  const uint8_t latin1_data[] = {0xC1, 0xE9, 0xF3};
   Local<ArrayBuffer> ab = ArrayBuffer::New(isolate, sizeof(latin1_data));
   memcpy(ab->GetBackingStore()->Data(), latin1_data, sizeof(latin1_data));
 

--- a/test/cctest/test_encoding_binding.cc
+++ b/test/cctest/test_encoding_binding.cc
@@ -151,5 +151,26 @@ TEST_F(EncodingBindingTest, DecodeLatin1_BOMPresent) {
   EXPECT_STREQ(*utf8_result, "Áéó");
 }
 
+TEST_F(EncodingBindingTest, DecodeLatin1_ReturnsString) {
+  Environment* env = CreateEnvironment();
+  Isolate* isolate = env->isolate();
+  HandleScope handle_scope(isolate);
+
+  const uint8_t latin1_data[] = {0xC1, 0xE9, 0xF3}; 
+  Local<ArrayBuffer> ab = ArrayBuffer::New(isolate, sizeof(latin1_data));
+  memcpy(ab->GetBackingStore()->Data(), latin1_data, sizeof(latin1_data));
+
+  Local<Uint8Array> array = Uint8Array::New(ab, 0, sizeof(latin1_data));
+  Local<Value> args[] = {array};
+
+  Local<Value> result;
+  ASSERT_TRUE(RunDecodeLatin1(env, args, false, false, &result));
+
+  ASSERT_TRUE(result->IsString());
+
+  String::Utf8Value utf8_result(isolate, result);
+  EXPECT_STREQ(*utf8_result, "Áéó");
+}
+
 }  // namespace encoding_binding
 }  // namespace node

--- a/test/cctest/test_encoding_binding.cc
+++ b/test/cctest/test_encoding_binding.cc
@@ -26,7 +26,7 @@ bool RunDecodeLatin1(Environment* env,
     return false;
   }
 
-  *result = try_catch.Exception();
+  *result = args[0];
   return true;
 }
 

--- a/test/parallel/test-util-text-decoder.js
+++ b/test/parallel/test-util-text-decoder.js
@@ -5,9 +5,7 @@ const common = require('../common');
 const test = require('node:test');
 const assert = require('node:assert');
 
-test('TextDecoder correctly decodes windows-1252 encoded data', { skip: !common.hasIntl }, (t) => {
-  }
-
+test('TextDecoder correctly decodes windows-1252 encoded data', { skip: !common.hasIntl }, () => {
   const latin1Bytes = new Uint8Array([0xc1, 0xe9, 0xf3]);
 
   const expectedString = 'Áéó';

--- a/test/parallel/test-util-text-decoder.js
+++ b/test/parallel/test-util-text-decoder.js
@@ -5,9 +5,7 @@ const common = require('../common');
 const test = require('node:test');
 const assert = require('node:assert');
 
-test('TextDecoder correctly decodes windows-1252 encoded data', (t) => {
-  if (!common.hasIntl) {
-    common.skip('missing Intl');
+test('TextDecoder correctly decodes windows-1252 encoded data', { skip: !common.hasIntl }, (t) => {
   }
 
   const latin1Bytes = new Uint8Array([0xc1, 0xe9, 0xf3]);

--- a/test/parallel/test-util-text-decoder.js
+++ b/test/parallel/test-util-text-decoder.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('TextDecoder correctly decodes windows-1252 encoded data', (t) => {
+  const latin1Bytes = new Uint8Array([0xc1, 0xe9, 0xf3]);
+
+  const expectedString = 'Áéó';
+
+  const decoder = new TextDecoder('windows-1252');
+  const decodedString = decoder.decode(latin1Bytes);
+
+  assert.strictEqual(decodedString, expectedString);
+});

--- a/test/parallel/test-util-text-decoder.js
+++ b/test/parallel/test-util-text-decoder.js
@@ -1,11 +1,15 @@
 'use strict';
 
-require('../common');
+const common = require('../common');
 
 const test = require('node:test');
 const assert = require('node:assert');
 
 test('TextDecoder correctly decodes windows-1252 encoded data', (t) => {
+  if (!common.hasIntl) {
+    common.skip('missing Intl');
+  }
+
   const latin1Bytes = new Uint8Array([0xc1, 0xe9, 0xf3]);
 
   const expectedString = 'Áéó';


### PR DESCRIPTION
returned a string instead of a buffer

Fixes: https://github.com/nodejs/node/issues/56219