### PR TITLE
test: increase spin for eventloop test on s390

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -48,7 +48,3 @@ test-tls-securepair-client: PASS, FLAKY
 [$arch==arm]
 # https://github.com/nodejs/node/issues/49933
 test-watch-mode-inspect: SKIP
-
-[$arch==s390x]
-# https://github.com/nodejs/node/issues/41286
-test-performance-eventloopdelay: PASS, FLAKY

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -3,6 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+const os = require('os');
 const {
   monitorEventLoopDelay
 } = require('perf_hooks');
@@ -51,9 +52,13 @@ const { sleep } = require('internal/util');
 }
 
 {
+  const s390x = os.arch() === 's390x';
   const histogram = monitorEventLoopDelay({ resolution: 1 });
   histogram.enable();
   let m = 5;
+  if (s390x) {
+    m = m * 2;
+  }
   function spinAWhile() {
     sleep(1000);
     if (--m > 0) {


### PR DESCRIPTION
It was excluded as it was failing intermittently. Likely that s390 was just so fast times were rounded down to 0.

Refs: https://github.com/nodejs/node/issues/41286

Increase the spin time on s390x only.

Stress run of 1000 with no failures with this change - https://ci.nodejs.org/job/node-stress-single-test/nodes=rhel8-s390x/548/console

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
