### PR TITLE
doc: add esm examples to `node:tls`

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2354,7 +2354,7 @@ openssl req -x509 -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' \
   -keyout server-key.pem -out server-cert.pem
 ```
 
-Then, to generate the `server-cert.pem` certificate for this example, run:
+Then, to generate the `client-cert.pem` certificate for this example, run:
 
 ```bash
 openssl pkcs12 -certpbe AES-256-CBC -export -out client-cert.pem \


### PR DESCRIPTION
This PR adds the missing `ESM` counterparts of the `CJS` examples for [the TLS (SSL) documentation](https://nodejs.org/api/tls.html).

While I normally try not to touch the current `CJS` examples, this time I went ahead and destructured the (`require`)  imports following a feedback I had received in [a previous PR](https://github.com/nodejs/node/pull/55335) so that examples from both `CJS` and `ESM` are as similar as possible so new users don't get confused.

I've also taken the liberty to add a snippet to explain how to generate the necessary files for both [the client](https://nodejs.org/api/tls.html#tlsconnectoptions-callback) and [the echo server](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener) examples similar to what I had done for the [`https.createServer`](https://nodejs.org/api/https.html#httpscreateserveroptions-requestlistener) example so new users can try them _out of the box_ sorta speak, or at least without having to search for the extra-steps.

I've tested every single example and they all work/behave as expected but tell me what you think and I can update them!

Best regards!