### PR TITLE
assert: make partialDeepStrictEqual work with urls and File prototypes

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -94,6 +94,7 @@ const CallTracker = require('internal/assert/calltracker');
 const {
   validateFunction,
 } = require('internal/validators');
+const { isURL } = require('internal/url');
 
 let isDeepEqual;
 let isDeepStrictEqual;
@@ -382,7 +383,7 @@ function isSpecial(obj) {
 }
 
 const typesToCallDeepStrictEqualWith = [
-  isKeyObject, isWeakSet, isWeakMap, Buffer.isBuffer, isSharedArrayBuffer,
+  isKeyObject, isWeakSet, isWeakMap, Buffer.isBuffer, isSharedArrayBuffer, isURL,
 ];
 
 function partiallyCompareMaps(actual, expected, comparedObjects) {
@@ -465,7 +466,7 @@ function partiallyCompareArrayBuffersOrViews(actual, expected) {
   }
 
   for (let i = 0; i < expectedViewLength; i++) {
-    if (actualView[i] !== expectedView[i]) {
+    if (!ObjectIs(actualView[i], expectedView[i])) {
       return false;
     }
   }
@@ -555,6 +556,10 @@ function compareBranch(
   expected,
   comparedObjects,
 ) {
+  // Checking for the simplest case possible.
+  if (actual === expected) {
+    return true;
+  }
   // Check for Map object equality
   if (isMap(actual) && isMap(expected)) {
     return partiallyCompareMaps(actual, expected, comparedObjects);

--- a/test/parallel/test-assert-objects.js
+++ b/test/parallel/test-assert-objects.js
@@ -272,6 +272,16 @@ describe('Object Comparison Tests', () => {
           expected: { dataView: new DataView(new ArrayBuffer(3)) },
         },
         {
+          description: 'throws when comparing Float32Array([+0.0]) with Float32Array([-0.0])',
+          actual: new Float32Array([+0.0]),
+          expected: new Float32Array([-0.0]),
+        },
+        {
+          description: 'throws when comparing two different urls',
+          actual: new URL('http://foo'),
+          expected: new URL('http://bar'),
+        },
+        {
           description: 'throws when comparing SharedArrayBuffers when expected has different elements actual',
           actual: (() => {
             const sharedBuffer = new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT);
@@ -727,6 +737,21 @@ describe('Object Comparison Tests', () => {
           'compares one subset array with another',
         actual: [1, 2, 3],
         expected: [2],
+      },
+      {
+        description: 'ensures that File extends Blob',
+        actual: Object.getPrototypeOf(File.prototype),
+        expected: Blob.prototype
+      },
+      {
+        description: 'compares NaN with NaN',
+        actual: NaN,
+        expected: NaN,
+      },
+      {
+        description: 'compares two identical urls',
+        actual: new URL('http://foo'),
+        expected: new URL('http://foo'),
       },
     ].forEach(({ description, actual, expected }) => {
       it(description, () => {

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -101,10 +101,15 @@ suite('notEqualArrayPairs', () => {
         makeBlock(assert.deepStrictEqual, arrayPair[0], arrayPair[1]),
         assert.AssertionError
       );
+      // TODO(puskin94): remove emitWarning override once the partialDeepStrictEqual method is not experimental anymore
+      // Suppress warnings, necessary otherwise the tools/pseudo-tty.py runner will fail
+      const originalEmitWarning = process.emitWarning;
+      process.emitWarning = () => {};
       assert.throws(
         makeBlock(assert.partialDeepStrictEqual, arrayPair[0], arrayPair[1]),
         assert.AssertionError
       );
+      process.emitWarning = originalEmitWarning; // Restore original process.emitWarning
     });
   }
 });


### PR DESCRIPTION
this PR should close the gap between `assert.deepStrictEqual` and `assert.partialDeepStrictEqual` even more.

Found a couple more cases that were not properly working:

- URLs were not properly compared
- it was not passing when comparing `Object.getPrototypeOf(File.prototype)` and `Blob.prototype`
- `new Float32Array([+0.0])` and `new Float32Array([-0.0])` were considered equal, which is not the case