### PR TITLE
assert: make partialDeepStrictEqual throw when comparing [0] with [-0]

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -56,6 +56,7 @@ const {
   StringPrototypeIndexOf,
   StringPrototypeSlice,
   StringPrototypeSplit,
+  Symbol,
   SymbolIterator,
   TypedArrayPrototypeGetLength,
   Uint8Array,
@@ -497,6 +498,17 @@ function partiallyCompareSets(actual, expected, comparedObjects) {
   return true;
 }
 
+const minusZeroSymbol = Symbol('-0');
+const zeroSymbol = Symbol('0');
+
+// Helper function to get a unique key for 0, -0 to avoid collisions
+function getZeroKey(item) {
+  if (item === 0) {
+    return ObjectIs(item, -0) ? minusZeroSymbol : zeroSymbol;
+  }
+  return item;
+}
+
 function partiallyCompareArrays(actual, expected, comparedObjects) {
   if (expected.length > actual.length) {
     return false;
@@ -506,39 +518,58 @@ function partiallyCompareArrays(actual, expected, comparedObjects) {
 
   // Create a map to count occurrences of each element in the expected array
   const expectedCounts = new SafeMap();
-  for (const expectedItem of expected) {
-    let found = false;
-    for (const { 0: key, 1: count } of expectedCounts) {
-      if (isDeepStrictEqual(key, expectedItem)) {
-        expectedCounts.set(key, count + 1);
-        found = true;
-        break;
+  const safeExpected = new SafeArrayIterator(expected);
+
+  for (const expectedItem of safeExpected) {
+    // Check if the item is a zero or a -0, as these need to be handled separately
+    if (expectedItem === 0) {
+      const zeroKey = getZeroKey(expectedItem);
+      expectedCounts.set(zeroKey, (expectedCounts.get(zeroKey)?.count || 0) + 1);
+    } else {
+      let found = false;
+      for (const { 0: key, 1: count } of expectedCounts) {
+        if (isDeepStrictEqual(key, expectedItem)) {
+          expectedCounts.set(key, count + 1);
+          found = true;
+          break;
+        }
       }
-    }
-    if (!found) {
-      expectedCounts.set(expectedItem, 1);
+      if (!found) {
+        expectedCounts.set(expectedItem, 1);
+      }
     }
   }
 
   const safeActual = new SafeArrayIterator(actual);
 
-  // Create a map to count occurrences of relevant elements in the actual array
   for (const actualItem of safeActual) {
-    for (const { 0: key, 1: count } of expectedCounts) {
-      if (isDeepStrictEqual(key, actualItem)) {
+    // Check if the item is a zero or a -0, as these need to be handled separately
+    if (actualItem === 0) {
+      const zeroKey = getZeroKey(actualItem);
+
+      if (expectedCounts.has(zeroKey)) {
+        const count = expectedCounts.get(zeroKey);
         if (count === 1) {
-          expectedCounts.delete(key);
+          expectedCounts.delete(zeroKey);
         } else {
-          expectedCounts.set(key, count - 1);
+          expectedCounts.set(zeroKey, count - 1);
         }
-        break;
+      }
+    } else {
+      for (const { 0: expectedItem, 1: count } of expectedCounts) {
+        if (isDeepStrictEqual(expectedItem, actualItem)) {
+          if (count === 1) {
+            expectedCounts.delete(expectedItem);
+          } else {
+            expectedCounts.set(expectedItem, count - 1);
+          }
+          break;
+        }
       }
     }
   }
 
-  const { size } = expectedCounts;
-  expectedCounts.clear();
-  return size === 0;
+  return expectedCounts.size === 0;
 }
 
 /**

--- a/test/parallel/test-assert-objects.js
+++ b/test/parallel/test-assert-objects.js
@@ -98,6 +98,41 @@ describe('Object Comparison Tests', () => {
           expected: [1, 'two', false],
         },
         {
+          description: 'throws when comparing [0] with [-0]',
+          actual: [0],
+          expected: [-0],
+        },
+        {
+          description: 'throws when comparing [0, 0, 0] with [0, -0]',
+          actual: [0, 0, 0],
+          expected: [0, -0],
+        },
+        {
+          description: 'throws when comparing ["-0"] with [-0]',
+          actual: ['-0'],
+          expected: [-0],
+        },
+        {
+          description: 'throws when comparing [-0] with [0]',
+          actual: [-0],
+          expected: [0],
+        },
+        {
+          description: 'throws when comparing [-0] with ["-0"]',
+          actual: [-0],
+          expected: ['-0'],
+        },
+        {
+          description: 'throws when comparing ["0"] with [0]',
+          actual: ['0'],
+          expected: [0],
+        },
+        {
+          description: 'throws when comparing [0] with ["0"]',
+          actual: [0],
+          expected: ['0'],
+        },
+        {
           description:
             'throws when comparing two Date objects with different times',
           actual: new Date(0),
@@ -384,6 +419,21 @@ describe('Object Comparison Tests', () => {
         description: 'compares two arrays with identical elements',
         actual: [1, 'two', true],
         expected: [1, 'two', true],
+      },
+      {
+        description: 'compares [0] with [0]',
+        actual: [0],
+        expected: [0],
+      },
+      {
+        description: 'compares [-0] with [-0]',
+        actual: [-0],
+        expected: [-0],
+      },
+      {
+        description: 'compares [0, -0, 0] with [0, 0]',
+        actual: [0, -0, 0],
+        expected: [0, 0],
       },
       {
         description: 'compares two Date objects with the same time',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/56230

`assert.partialDeepStrictEqual` now throws when comparing `[0]` with `[-0]`