### PR TITLE
deps: define V8_PRESERVE_MOST as no-op on Windows

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8config.h
+++ b/deps/v8/include/v8config.h
@@ -581,10 +581,14 @@ path. Add it with -I<path> to the command line
 // functions.
 // Use like:
 //   V8_NOINLINE V8_PRESERVE_MOST void UnlikelyMethod();
+#if V8_OS_WIN
+# define V8_PRESERVE_MOST
+#else
 #if V8_HAS_ATTRIBUTE_PRESERVE_MOST
 # define V8_PRESERVE_MOST __attribute__((preserve_most))
 #else
 # define V8_PRESERVE_MOST /* NOT SUPPORTED */
+#endif
 #endif
 
 


### PR DESCRIPTION
When compiling with ClangCL, it's causing linker errors with node.lib in node-gyp and potentially breaks other 3rd party tools.

This was already reviewed in another PR where it was grouped with other changes. Here is the part of the description from that PR regarding this change:

_Disable V8_PRESERVE_MOST on Windows. We already have something similar for V8_NODISCARD as a floating patch, so it should not be a problem as I see it. If left, this results in functions that use it having `__swift_2` calling conventions rather than the expected `__cdecl`. This was noticed in `cppgc-object` native suites test. This change, if agreed upon, would be come one of our V8 floating patches we use on each V8 update._

Refs: https://github.com/nodejs/node/pull/55784