### PR TITLE
Fixing leak from short_path not being freed for win fs watch

### DIFF
--- a/deps/uv/src/win/fs-event.c
+++ b/deps/uv/src/win/fs-event.c
@@ -252,9 +252,9 @@ short_path_done:
       goto error;
     }
 
+    dir_to_watch = dir;
     uv__free(short_path);
     short_path = NULL;
-    dir_to_watch = dir;
     uv__free(pathw);
     pathw = NULL;
   }

--- a/deps/uv/src/win/fs-event.c
+++ b/deps/uv/src/win/fs-event.c
@@ -252,6 +252,8 @@ short_path_done:
       goto error;
     }
 
+    uv__free(short_path);
+    short_path = NULL;
     dir_to_watch = dir;
     uv__free(pathw);
     pathw = NULL;


### PR DESCRIPTION
Fixes bug number: #52769
short_path was being leaked causing the memory leak from the bug above.  This PR frees the memory and fixes the leak.
