### PR TITLE
sqlite: expose backup api

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -132,8 +132,8 @@ added: REPLACEME
     pages.
 * Returns: {Promise} A promise that resolves when the backup is completed and rejects if an error occurs.
 
-This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][] and
-[`sqlite3_backup_finish()`][] functions.
+This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][]
+and [`sqlite3_backup_finish()`][] functions.
 
 ### `database.close()`
 

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -126,13 +126,13 @@ added: REPLACEME
 * `options` {Object} Optional configuration for the backup. The
   following properties are supported:
   * `source` {string} Name of the source database. **Default:** `'main'`.
-  * `target` {string} NAme of the target database. **Default:** `'main'`.
+  * `target` {string} Name of the target database. **Default:** `'main'`.
   * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
   * `progress` {Function} Callback function that will be called with the number of pages copied and the total number of
     pages.
+* Returns: {Promise} A promise that resolves when the backup is completed and rejects if an error occurs.
 
-This method makes a backup of the database. The returned {Promise} will resolve when the backup is completed and will
-reject if an error occurs. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][] and
+This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][] and
 [`sqlite3_backup_finish()`][] functions.
 
 ### `database.close()`

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -115,26 +115,6 @@ added: v22.5.0
 
 Constructs a new `DatabaseSync` instance.
 
-### `database.backup(destination[, options])`
-
-<!-- YAML
-added: REPLACEME
--->
-
-* `destination` {string} The path where the backup will be created. If the file already exists, the contents will be
-  overwritten.
-* `options` {Object} Optional configuration for the backup. The
-  following properties are supported:
-  * `source` {string} Name of the source database. **Default:** `'main'`.
-  * `target` {string} Name of the target database. **Default:** `'main'`.
-  * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
-  * `progress` {Function} Callback function that will be called with the number of pages copied and the total number of
-    pages.
-* Returns: {Promise} A promise that resolves when the backup is completed and rejects if an error occurs.
-
-This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][]
-and [`sqlite3_backup_finish()`][] functions.
-
 ### `database.close()`
 
 <!-- YAML
@@ -545,6 +525,27 @@ exception.
 | `REAL`    | {number}                   |
 | `TEXT`    | {string}                   |
 | `BLOB`    | {TypedArray} or {DataView} |
+
+## `sqlite.backup(sourceDb, destination[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `sourceDb` {DatabaseSync} The database to backup. The source database must be open.
+* `destination` {string} The path where the backup will be created. If the file already exists, the contents will be
+  overwritten.
+* `options` {Object} Optional configuration for the backup. The
+  following properties are supported:
+  * `source` {string} Name of the source database. **Default:** `'main'`.
+  * `target` {string} Name of the target database. **Default:** `'main'`.
+  * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
+  * `progress` {Function} Callback function that will be called with the number of pages copied and the total number of
+    pages.
+* Returns: {Promise} A promise that resolves when the backup is completed and rejects if an error occurs.
+
+This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][]
+and [`sqlite3_backup_finish()`][] functions.
 
 ## `sqlite.constants`
 

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -537,8 +537,10 @@ added: REPLACEME
   overwritten.
 * `options` {Object} Optional configuration for the backup. The
   following properties are supported:
-  * `source` {string} Name of the source database. **Default:** `'main'`.
-  * `target` {string} Name of the target database. **Default:** `'main'`.
+  * `source` {string} Name of the source database. This can be `'main'` (the default primary database) or any other
+    database that have been added with [`ATTACH DATABASE`][] **Default:** `'main'`.
+  * `target` {string} Name of the target database. This can be `'main'` (the default primary database) or any other
+    database that have been added with [`ATTACH DATABASE`][] **Default:** `'main'`.
   * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
   * `progress` {Function} Callback function that will be called with the number of pages copied and the total number of
     pages.
@@ -546,6 +548,42 @@ added: REPLACEME
 
 This method makes a database backup. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][]
 and [`sqlite3_backup_finish()`][] functions.
+
+The backed-up database can be used normally during the backup process. Mutations coming from the same connection - same
+{DatabaseSync} - object will be reflected in the backup right away. However, mutations from other connections will cause
+the backup process to restart.
+
+```cjs
+const { backup, DatabaseSync } = require('node:sqlite');
+
+const sourceDb = new DatabaseSync('source.db');
+backup(sourceDb, 'backup.db', {
+  rate: 1, // Copy one page at a time.
+  progress: ({ totalPages, remainingPages }) => {
+    console.log('Backup in progress', { totalPages, remainingPages });
+  },
+}).then(() => {
+  console.log('Backup completed');
+}).catch((err) => {
+  console.error('Backup failed', err);
+});
+```
+
+```mjs
+import { backup, DatabaseSync } from 'node:sqlite';
+
+const sourceDb = new DatabaseSync('source.db');
+backup(sourceDb, 'backup.db', {
+  rate: 1, // Copy one page at a time.
+  progress: ({ totalPages, remainingPages }) => {
+    console.log('Backup in progress', { totalPages, remainingPages });
+  },
+}).then(() => {
+  console.log('Backup completed');
+}).catch((err) => {
+  console.error('Backup failed', err);
+});
+```
 
 ## `sqlite.constants`
 

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -115,6 +115,26 @@ added: v22.5.0
 
 Constructs a new `DatabaseSync` instance.
 
+### `database.backup(destination[, options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `destination` {string} The path where the backup will be created. If the file already exists, the contents will be
+  overwritten.
+* `options` {Object} Optional configuration for the backup. The
+  following properties are supported:
+  * `source` {string} Name of the source database. **Default:** `'main'`.
+  * `target` {string} NAme of the target database. **Default:** `'main'`.
+  * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
+  * `progress` {Function} Callback function that will be called with the number of pages copied and the total number of
+    pages.
+
+This method makes a backup of the database. The returned {Promise} will resolve when the backup is completed and will
+reject if an error occurs. This method abstracts the [`sqlite3_backup_init()`][], [`sqlite3_backup_step()`][] and
+[`sqlite3_backup_finish()`][] functions.
+
 ### `database.close()`
 
 <!-- YAML
@@ -609,6 +629,9 @@ resolution handler passed to [`database.applyChangeset()`][]. See also
 [`SQLITE_DIRECTONLY`]: https://www.sqlite.org/c3ref/c_deterministic.html
 [`SQLITE_MAX_FUNCTION_ARG`]: https://www.sqlite.org/limits.html#max_function_arg
 [`database.applyChangeset()`]: #databaseapplychangesetchangeset-options
+[`sqlite3_backup_finish()`]: https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupfinish
+[`sqlite3_backup_init()`]: https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupinit
+[`sqlite3_backup_step()`]: https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep
 [`sqlite3_changes64()`]: https://www.sqlite.org/c3ref/changes.html
 [`sqlite3_close_v2()`]: https://www.sqlite.org/c3ref/close.html
 [`sqlite3_create_function_v2()`]: https://www.sqlite.org/c3ref/create_function.html

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -556,33 +556,31 @@ the backup process to restart.
 ```cjs
 const { backup, DatabaseSync } = require('node:sqlite');
 
-const sourceDb = new DatabaseSync('source.db');
-backup(sourceDb, 'backup.db', {
-  rate: 1, // Copy one page at a time.
-  progress: ({ totalPages, remainingPages }) => {
-    console.log('Backup in progress', { totalPages, remainingPages });
-  },
-}).then(() => {
-  console.log('Backup completed');
-}).catch((err) => {
-  console.error('Backup failed', err);
-});
+(async () => {
+  const sourceDb = new DatabaseSync('source.db');
+  const totalPagesTransferred = await backup(sourceDb, 'backup.db', {
+    rate: 1, // Copy one page at a time.
+    progress: ({ totalPages, remainingPages }) => {
+      console.log('Backup in progress', { totalPages, remainingPages });
+    },
+  });
+
+  console.log('Backup completed', totalPagesTransferred);
+})();
 ```
 
 ```mjs
 import { backup, DatabaseSync } from 'node:sqlite';
 
 const sourceDb = new DatabaseSync('source.db');
-backup(sourceDb, 'backup.db', {
+const totalPagesTransferred = await backup(sourceDb, 'backup.db', {
   rate: 1, // Copy one page at a time.
   progress: ({ totalPages, remainingPages }) => {
     console.log('Backup in progress', { totalPages, remainingPages });
   },
-}).then(() => {
-  console.log('Backup completed');
-}).catch((err) => {
-  console.error('Backup failed', err);
 });
+
+console.log('Backup completed', totalPagesTransferred);
 ```
 
 ## `sqlite.constants`

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -71,6 +71,9 @@
   V(__dirname_string, "__dirname")                                             \
   V(ack_string, "ack")                                                         \
   V(address_string, "address")                                                 \
+  V(source_db_string, "sourceDb")                                              \
+  V(target_db_string, "targetDb")                                              \
+  V(progress_string, "progress")                                               \
   V(aliases_string, "aliases")                                                 \
   V(alpn_callback_string, "ALPNCallback")                                      \
   V(args_string, "args")                                                       \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -71,8 +71,6 @@
   V(__dirname_string, "__dirname")                                             \
   V(ack_string, "ack")                                                         \
   V(address_string, "address")                                                 \
-  V(source_db_string, "sourceDb")                                              \
-  V(target_db_string, "targetDb")                                              \
   V(total_pages_string, "totalPages")                                          \
   V(remaining_pages_string, "remainingPages")                                  \
   V(progress_string, "progress")                                               \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -77,6 +77,7 @@
   V(asn1curve_string, "asn1Curve")                                             \
   V(async_ids_stack_string, "async_ids_stack")                                 \
   V(attributes_string, "attributes")                                           \
+  V(backup_string, "backup")                                                   \
   V(base_string, "base")                                                       \
   V(base_url_string, "baseURL")                                                \
   V(bits_string, "bits")                                                       \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -73,6 +73,8 @@
   V(address_string, "address")                                                 \
   V(source_db_string, "sourceDb")                                              \
   V(target_db_string, "targetDb")                                              \
+  V(total_pages_string, "totalPages")                                          \
+  V(remaining_pages_string, "remainingPages")                                  \
   V(progress_string, "progress")                                               \
   V(aliases_string, "aliases")                                                 \
   V(alpn_callback_string, "ALPNCallback")                                      \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -71,9 +71,6 @@
   V(__dirname_string, "__dirname")                                             \
   V(ack_string, "ack")                                                         \
   V(address_string, "address")                                                 \
-  V(total_pages_string, "totalPages")                                          \
-  V(remaining_pages_string, "remainingPages")                                  \
-  V(progress_string, "progress")                                               \
   V(aliases_string, "aliases")                                                 \
   V(alpn_callback_string, "ALPNCallback")                                      \
   V(args_string, "args")                                                       \
@@ -305,6 +302,7 @@
   V(primordials_string, "primordials")                                         \
   V(priority_string, "priority")                                               \
   V(process_string, "process")                                                 \
+  V(progress_string, "progress")                                               \
   V(promise_string, "promise")                                                 \
   V(protocol_string, "protocol")                                               \
   V(prototype_string, "prototype")                                             \
@@ -319,6 +317,7 @@
   V(reason_string, "reason")                                                   \
   V(refresh_string, "refresh")                                                 \
   V(regexp_string, "regexp")                                                   \
+  V(remaining_pages_string, "remainingPages")                                  \
   V(rename_string, "rename")                                                   \
   V(replacement_string, "replacement")                                         \
   V(required_module_facade_url_string,                                         \
@@ -372,6 +371,7 @@
   V(time_to_first_byte_sent_string, "timeToFirstByteSent")                     \
   V(time_to_first_header_string, "timeToFirstHeader")                          \
   V(tls_ticket_string, "tlsTicket")                                            \
+  V(total_pages_string, "totalPages")                                          \
   V(transfer_string, "transfer")                                               \
   V(transfer_unsupported_type_str,                                             \
     "Cannot transfer object of unsupported type.")                             \

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -179,7 +179,10 @@ class BackupJob : public ThreadPoolWork {
   void ScheduleBackup() {
     Isolate* isolate = env()->isolate();
     HandleScope handle_scope(isolate);
-    backup_status_ = sqlite3_open(destination_name_.c_str(), &dest_);
+    backup_status_ = sqlite3_open_v2(destination_name_.c_str(),
+                                     &dest_,
+                                     SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                                     nullptr);
     Local<Promise::Resolver> resolver =
         Local<Promise::Resolver>::New(env()->isolate(), resolver_);
     if (backup_status_ != SQLITE_OK) {
@@ -271,7 +274,7 @@ class BackupJob : public ThreadPoolWork {
 
     if (dest_) {
       backup_status_ = sqlite3_errcode(dest_);
-      sqlite3_close(dest_);
+      sqlite3_close_v2(dest_);
       dest_ = nullptr;
     }
   }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -278,18 +278,20 @@ class BackupJob : public ThreadPoolWork {
       return;
     }
 
-    Local<String> message =
-        String::NewFromUtf8(
-            env()->isolate(), "Backup completed", NewStringType::kNormal)
-            .ToLocalChecked();
+    Local<Object> e;
+    if (!CreateSQLiteError(env()->isolate(), pDest_).ToLocal(&e)) {
+      Finalize();
 
-    Local<Object> e =
-        CreateSQLiteError(env()->isolate(), pDest_).ToLocalChecked();
+      return;
+    }
 
     Finalize();
 
     if (backup_status_ == SQLITE_OK) {
-      resolver->Resolve(env()->context(), message).ToChecked();
+      resolver
+          ->Resolve(env()->context(),
+                    Integer::New(env()->isolate(), total_pages))
+          .ToChecked();
     } else {
       resolver->Reject(env()->context(), e).ToChecked();
     }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -256,6 +256,7 @@ class BackupJob : public ThreadPoolWork {
       return;
     }
 
+    Finalize();
     resolver
         ->Resolve(env()->context(), Integer::New(env()->isolate(), total_pages))
         .ToChecked();
@@ -477,9 +478,10 @@ void DatabaseSync::DeleteSessions() {
 }
 
 DatabaseSync::~DatabaseSync() {
+  FinalizeBackups();
+
   if (IsOpen()) {
     FinalizeStatements();
-    FinalizeBackups();
     DeleteSessions();
     sqlite3_close_v2(connection_);
     connection_ = nullptr;

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -778,8 +778,8 @@ void DatabaseSync::Exec(const FunctionCallbackInfo<Value>& args) {
   CHECK_ERROR_OR_THROW(env->isolate(), db, r, SQLITE_OK, void());
 }
 
-// database.backup(path, { sourceDb, targetDb, rate, progress: (total,
-// remaining) => {} )
+// database.backup(path, { source, target, rate, progress: ({ totalPages,
+// remainingPages }) => {} )
 void DatabaseSync::Backup(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
 
@@ -827,7 +827,7 @@ void DatabaseSync::Backup(const FunctionCallbackInfo<Value>& args) {
     }
 
     Local<Value> sourceDbValue;
-    if (!options->Get(env->context(), env->source_db_string())
+    if (!options->Get(env->context(), env->source_string())
              .ToLocal(&sourceDbValue)) {
       return;
     }
@@ -836,7 +836,7 @@ void DatabaseSync::Backup(const FunctionCallbackInfo<Value>& args) {
       if (!sourceDbValue->IsString()) {
         THROW_ERR_INVALID_ARG_TYPE(
             env->isolate(),
-            "The \"options.sourceDb\" argument must be a string.");
+            "The \"options.source\" argument must be a string.");
         return;
       }
 
@@ -845,7 +845,7 @@ void DatabaseSync::Backup(const FunctionCallbackInfo<Value>& args) {
     }
 
     Local<Value> targetDbValue;
-    if (!options->Get(env->context(), env->target_db_string())
+    if (!options->Get(env->context(), env->target_string())
              .ToLocal(&targetDbValue)) {
       return;
     }

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -43,6 +43,7 @@ class DatabaseOpenConfiguration {
 };
 
 class StatementSync;
+class BackupJob;
 
 class DatabaseSync : public BaseObject {
  public:
@@ -57,6 +58,7 @@ class DatabaseSync : public BaseObject {
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Prepare(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Exec(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Backup(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CustomFunction(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CreateSession(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ApplyChangeset(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -64,6 +66,8 @@ class DatabaseSync : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoadExtension(const v8::FunctionCallbackInfo<v8::Value>& args);
   void FinalizeStatements();
+  void RemoveBackup(BackupJob* backup);
+  void FinalizeBackups();
   void UntrackStatement(StatementSync* statement);
   bool IsOpen();
   sqlite3* Connection();
@@ -89,6 +93,7 @@ class DatabaseSync : public BaseObject {
   sqlite3* connection_;
   bool ignore_next_sqlite_error_;
 
+  std::set<BackupJob*> backups_;
   std::set<sqlite3_session*> sessions_;
   std::unordered_set<StatementSync*> statements_;
 

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -58,7 +58,6 @@ class DatabaseSync : public BaseObject {
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Prepare(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Exec(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void Backup(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CustomFunction(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void CreateSession(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ApplyChangeset(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -67,6 +66,7 @@ class DatabaseSync : public BaseObject {
   static void LoadExtension(const v8::FunctionCallbackInfo<v8::Value>& args);
   void FinalizeStatements();
   void RemoveBackup(BackupJob* backup);
+  void AddBackup(BackupJob* backup);
   void FinalizeBackups();
   void UntrackStatement(StatementSync* statement);
   bool IsOpen();

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -1,9 +1,9 @@
-import * as common from '../common/index.mjs';
+import '../common/index.mjs';
 import tmpdir from '../common/tmpdir.js';
-import { join } from 'path';
+import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
-import { writeFileSync } from 'fs';
+import { writeFileSync } from 'node:fs';
 
 let cnt = 0;
 
@@ -36,77 +36,70 @@ describe('DatabaseSync.prototype.backup()', () => {
   test('throws if path is not a string', async (t) => {
     const database = makeSourceDb();
 
-    t.assert.rejects(async () => {
-      await database.backup();
-    }, common.expectsError({
+    t.assert.throws(() => {
+      database.backup();
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "destination" argument must be a string.'
-    }));
+    });
 
-    t.assert.rejects(async () => {
-      await database.backup({});
-    }, common.expectsError({
+    t.assert.rejects(() => {
+      database.backup({});
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "destination" argument must be a string.'
-    }));
+    });
   });
 
-  test('throws if options is not an object', async (t) => {
+  test('throws if options is not an object', (t) => {
     const database = makeSourceDb();
 
-    t.assert.rejects(async () => {
-      await database.backup('hello.db', 'invalid');
-    }, common.expectsError({
+    t.assert.rejects(() => {
+      database.backup('hello.db', 'invalid');
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options" argument must be an object.'
-    }));
-
-    t.assert.rejects(async () => {
-      await database.backup({});
-    }, common.expectsError({
-      code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "destination" argument must be a string.'
-    }));
+    });
   });
 
-  test('throws if any of provided options is invalid', async (t) => {
+  test('throws if any of provided options is invalid', (t) => {
     const database = makeSourceDb();
 
-    t.assert.rejects(async () => {
-      await database.backup('hello.db', {
+    t.assert.rejects(() => {
+      database.backup('hello.db', {
         sourceDb: 42
       });
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.sourceDb" argument must be a string.'
-    }));
+    });
 
-    t.assert.rejects(async () => {
-      await database.backup('hello.db', {
+    t.assert.rejects(() => {
+      database.backup('hello.db', {
         targetDb: 42
       });
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.targetDb" argument must be a string.'
-    }));
+    });
 
-    t.assert.rejects(async () => {
-      await database.backup('hello.db', {
+    t.assert.rejects(() => {
+      database.backup('hello.db', {
         rate: 'invalid'
       });
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.rate" argument must be an integer.'
-    }));
+    });
 
-    t.assert.rejects(async () => {
-      await database.backup('hello.db', {
+    t.assert.rejects(() => {
+      database.backup('hello.db', {
         progress: 'invalid'
       });
-    }, common.expectsError({
+    }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.progress" argument must be a function.'
-    }));
+    });
   });
 });
 
@@ -155,16 +148,16 @@ test('database backup in a single call', async (t) => {
 });
 
 test('throws exception when trying to start backup from a closed database', async (t) => {
-  t.assert.rejects(async () => {
+  t.assert.throws(() => {
     const database = new DatabaseSync(':memory:');
 
     database.close();
 
-    await database.backup('backup.db');
-  }, common.expectsError({
+    database.backup('backup.db');
+  }, {
     code: 'ERR_INVALID_STATE',
     message: 'database is not open'
-  }));
+  });
 });
 
 test('database backup fails when dest file is not writable', (t) => {
@@ -175,10 +168,10 @@ test('database backup fails when dest file is not writable', (t) => {
 
   t.assert.rejects(async () => {
     await database.backup(readonlyDestDb);
-  }, common.expectsError({
+  }, {
     code: 'ERR_SQLITE_ERROR',
     message: 'attempt to write a readonly database'
-  }));
+  });
 });
 
 test('backup fails when progress function throws', async (t) => {
@@ -194,28 +187,23 @@ test('backup fails when progress function throws', async (t) => {
       rate: 1,
       progress: progressFn,
     });
-  }, common.expectsError({
+  }, {
     message: 'progress error'
-  }));
+  });
 });
 
-test('backup fails source db is invalid', async (t) => {
+test('backup fails when source db is invalid', async (t) => {
   const database = makeSourceDb();
   const destDb = nextDb();
-
-  const progressFn = t.mock.fn(() => {
-    throw new Error('progress error');
-  });
 
   t.assert.rejects(async () => {
     await database.backup(destDb, {
       rate: 1,
-      progress: progressFn,
       sourceDb: 'invalid',
     });
-  }, common.expectsError({
+  }, {
     message: 'unknown database invalid'
-  }));
+  });
 });
 
 test('backup fails when destination cannot be opened', async (t) => {
@@ -223,7 +211,7 @@ test('backup fails when destination cannot be opened', async (t) => {
 
   t.assert.rejects(async () => {
     await database.backup('/invalid/path/to/db.sqlite');
-  }, common.expectsError({
+  }, {
     message: 'unable to open database file'
-  }));
+  });
 });

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -1,0 +1,130 @@
+import * as common from '../common/index.mjs';
+import tmpdir from '../common/tmpdir.js';
+import { join } from 'path';
+import { DatabaseSync } from 'node:sqlite';
+import { test } from 'node:test';
+import { writeFileSync } from 'fs';
+
+let cnt = 0;
+
+tmpdir.refresh();
+
+function nextDb() {
+  return join(tmpdir.path, `database-${cnt++}.db`);
+}
+
+function makeSourceDb() {
+  const database = new DatabaseSync(':memory:');
+
+  database.exec(`
+    CREATE TABLE data(
+      key INTEGER PRIMARY KEY,
+      value TEXT
+    ) STRICT
+  `);
+
+  const insert = database.prepare('INSERT INTO data (key, value) VALUES (?, ?)');
+
+  for (let i = 1; i <= 2; i++) {
+    insert.run(i, `value-${i}`);
+  }
+
+  return database;
+}
+
+test('throws exception when trying to start backup from a closed database', async (t) => {
+  t.assert.rejects(async () => {
+    const database = new DatabaseSync(':memory:');
+
+    database.close();
+
+    await database.backup('backup.db');
+  }, common.expectsError({
+    code: 'ERR_INVALID_STATE',
+    message: 'database is not open'
+  }));
+});
+
+test('database backup', async (t) => {
+  const progressFn = t.mock.fn();
+  const database = makeSourceDb();
+  const destDb = nextDb();
+
+  await database.backup(destDb, {
+    rate: 1,
+    progress: progressFn,
+  });
+
+  const backup = new DatabaseSync(destDb);
+  const rows = backup.prepare('SELECT * FROM data').all();
+
+  // The source database has two pages - using the default page size -,
+  // so the progress function should be called once (the last call is not made since
+  // the promise resolves)
+  t.assert.strictEqual(progressFn.mock.calls.length, 1);
+  t.assert.deepStrictEqual(rows, [
+    { __proto__: null, key: 1, value: 'value-1' },
+    { __proto__: null, key: 2, value: 'value-2' },
+  ]);
+});
+
+test('database backup fails when dest file is not writable', (t) => {
+  const readonlyDestDb = nextDb();
+  writeFileSync(readonlyDestDb, '', { mode: 0o444 });
+
+  const database = makeSourceDb();
+
+  t.assert.rejects(async () => {
+    await database.backup(readonlyDestDb);
+  }, common.expectsError({
+    code: 'ERR_SQLITE_ERROR',
+    message: 'attempt to write a readonly database'
+  }));
+});
+
+test('backup fails when progress function throws', async (t) => {
+  const database = makeSourceDb();
+  const destDb = nextDb();
+
+  const progressFn = t.mock.fn(() => {
+    throw new Error('progress error');
+  });
+
+  t.assert.rejects(async () => {
+    await database.backup(destDb, {
+      rate: 1,
+      progress: progressFn,
+    });
+  }, common.expectsError({
+    message: 'progress error'
+  }));
+});
+
+test('backup fails source db is invalid', async (t) => {
+  const database = makeSourceDb();
+  const destDb = nextDb();
+
+  const progressFn = t.mock.fn(() => {
+    throw new Error('progress error');
+  });
+
+  t.assert.rejects(async () => {
+    await database.backup(destDb, {
+      rate: 1,
+      progress: progressFn,
+      sourceDb: 'invalid',
+    });
+  }, common.expectsError({
+    message: 'unknown database invalid'
+  }));
+});
+
+test('backup fails when destination cannot be opened', async (t) => {
+  const database = makeSourceDb();
+
+  t.assert.rejects(async () => {
+    await database.backup('/invalid/path/to/db.sqlite');
+  }, common.expectsError({
+    message: 'unable to open database file'
+  }));
+});

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -134,6 +134,11 @@ test('database backup', async (t) => {
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },
   ]);
+
+  t.after(() => {
+    database.close();
+    backupDb.close();
+  });
 });
 
 test('database backup in a single call', async (t) => {
@@ -154,9 +159,14 @@ test('database backup in a single call', async (t) => {
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },
   ]);
+
+  t.after(() => {
+    database.close();
+    backupDb.close();
+  });
 });
 
-test('throws exception when trying to start backup from a closed database', async (t) => {
+test('throws exception when trying to start backup from a closed database', (t) => {
   t.assert.throws(() => {
     const database = new DatabaseSync(':memory:');
 

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -80,7 +80,7 @@ describe('DatabaseSync.prototype.backup()', () => {
       });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.targetDb" argument must be a string.'
+      message: 'The "options.target" argument must be a string.'
     });
 
     t.assert.throws(() => {

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -210,7 +210,7 @@ test('backup fails when destination cannot be opened', async (t) => {
   const database = makeSourceDb();
 
   t.assert.rejects(async () => {
-    await database.backup('/invalid/path/to/db.sqlite');
+    await database.backup(`${tmpdir.path}/invalid/backup.db`);
   }, {
     message: 'unable to open database file'
   });

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -43,7 +43,7 @@ describe('DatabaseSync.prototype.backup()', () => {
       message: 'The "destination" argument must be a string.'
     });
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup({});
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
@@ -54,7 +54,7 @@ describe('DatabaseSync.prototype.backup()', () => {
   test('throws if options is not an object', (t) => {
     const database = makeSourceDb();
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup('hello.db', 'invalid');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
@@ -65,25 +65,25 @@ describe('DatabaseSync.prototype.backup()', () => {
   test('throws if any of provided options is invalid', (t) => {
     const database = makeSourceDb();
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup('hello.db', {
-        sourceDb: 42
+        source: 42
       });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "options.sourceDb" argument must be a string.'
+      message: 'The "options.source" argument must be a string.'
     });
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup('hello.db', {
-        targetDb: 42
+        target: 42
       });
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.targetDb" argument must be a string.'
     });
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup('hello.db', {
         rate: 'invalid'
       });
@@ -92,7 +92,7 @@ describe('DatabaseSync.prototype.backup()', () => {
       message: 'The "options.rate" argument must be an integer.'
     });
 
-    t.assert.rejects(() => {
+    t.assert.throws(() => {
       database.backup('hello.db', {
         progress: 'invalid'
       });
@@ -199,7 +199,7 @@ test('backup fails when source db is invalid', async (t) => {
   t.assert.rejects(async () => {
     await database.backup(destDb, {
       rate: 1,
-      sourceDb: 'invalid',
+      source: 'invalid',
     });
   }, {
     message: 'unknown database invalid'

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -127,6 +127,27 @@ test('database backup', async (t) => {
   // so the progress function should be called once (the last call is not made since
   // the promise resolves)
   t.assert.strictEqual(progressFn.mock.calls.length, 1);
+  t.assert.deepStrictEqual(progressFn.mock.calls[0].arguments, [{ totalPages: 2, remainingPages: 1 }]);
+  t.assert.deepStrictEqual(rows, [
+    { __proto__: null, key: 1, value: 'value-1' },
+    { __proto__: null, key: 2, value: 'value-2' },
+  ]);
+});
+
+test('database backup in a single call', async (t) => {
+  const progressFn = t.mock.fn();
+  const database = makeSourceDb();
+  const destDb = nextDb();
+
+  // Let rate to be default (100) to backup in a single call
+  await database.backup(destDb, {
+    progress: progressFn,
+  });
+
+  const backup = new DatabaseSync(destDb);
+  const rows = backup.prepare('SELECT * FROM data').all();
+
+  t.assert.strictEqual(progressFn.mock.calls.length, 0);
   t.assert.deepStrictEqual(rows, [
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -160,13 +160,13 @@ test('throws exception when trying to start backup from a closed database', asyn
   });
 });
 
-test('database backup fails when dest file is not writable', (t) => {
+test('database backup fails when dest file is not writable', async (t) => {
   const readonlyDestDb = nextDb();
   writeFileSync(readonlyDestDb, '', { mode: 0o444 });
 
   const database = makeSourceDb();
 
-  t.assert.rejects(async () => {
+  await t.assert.rejects(async () => {
     await database.backup(readonlyDestDb);
   }, {
     code: 'ERR_SQLITE_ERROR',
@@ -182,7 +182,7 @@ test('backup fails when progress function throws', async (t) => {
     throw new Error('progress error');
   });
 
-  t.assert.rejects(async () => {
+  await t.assert.rejects(async () => {
     await database.backup(destDb, {
       rate: 1,
       progress: progressFn,
@@ -196,7 +196,7 @@ test('backup fails when source db is invalid', async (t) => {
   const database = makeSourceDb();
   const destDb = nextDb();
 
-  t.assert.rejects(async () => {
+  await t.assert.rejects(async () => {
     await database.backup(destDb, {
       rate: 1,
       source: 'invalid',
@@ -209,7 +209,7 @@ test('backup fails when source db is invalid', async (t) => {
 test('backup fails when destination cannot be opened', async (t) => {
   const database = makeSourceDb();
 
-  t.assert.rejects(async () => {
+  await t.assert.rejects(async () => {
     await database.backup(`${tmpdir.path}/invalid/backup.db`);
   }, {
     message: 'unable to open database file'

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -112,6 +112,7 @@ const customTypesMap = {
   'Channel': 'diagnostics_channel.html#class-channel',
   'TracingChannel': 'diagnostics_channel.html#class-tracingchannel',
 
+  'DatabaseSync': 'sqlite.html#class-databasesync',
   'Domain': 'domain.html#class-domain',
 
   'errors.Error': 'errors.html#class-error',


### PR DESCRIPTION
Closes #55413

This PR exposes the [SQLite Online Backup API](https://www.sqlite.org/backup.html), which allows database backup.

The API is inspired by better-sqlite3 https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#backupdestination-options---promise.

### Multithreading caveats

As long as writes come from the same process and handle (`sqlite*`), the backup will continue progressing as expected. Other than that, it can cause the backup process to restart. From docs:

> ...If the source database is not an in-memory database, and the write is performed from within the same process as the backup operation and uses the same database handle (pDb), then the destination database (the one opened using connection pFile) is automatically updated along with the source.

> Writes to an in-memory source database, or writes to a file-based source database by an external process or thread using a database connection other than pDb are significantly more expensive than writes made to a file-based source database using pDb (as the entire backup operation must be restarted...)