### PR TITLE
build: set DESTCPU correctly for 'make binary' on loongarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,7 +934,11 @@ else
 ifeq ($(findstring riscv64,$(UNAME_M)),riscv64)
 DESTCPU ?= riscv64
 else
+ifeq ($(findstring loongarch64,$(UNAME_M)),loongarch64)
+DESTCPU ?= loong64
+else
 DESTCPU ?= x86
+endif
 endif
 endif
 endif
@@ -971,7 +975,11 @@ else
 ifeq ($(DESTCPU),riscv64)
 ARCH=riscv64
 else
+ifeq ($(DESTCPU),loong64)
+ARCH=loong64
+else
 ARCH=x86
+endif
 endif
 endif
 endif


### PR DESCRIPTION
- https://github.com/nodejs/unofficial-builds/pull/157

When running on `loongarch64`, `DESTCPU` in the `Makefile` does not seem to be set correctly, so I get the following error when building the openssl `make -j8 binary `

```bash
make -j8 binary V= VARIATION=musl DISTTYPE=release CUSTOMTAG= DATESTRING= COMMIT= RELEASE_URLBASE=https://unofficial-builds.nodejs.org/download/release/ CONFIG_FLAGS=--openssl-no-asm
/bin/sh: git: not found
rm -f -r node-v23.3.0-linux-x86-musl
rm -f -r out/deps out/Release
python3 ./configure \
	--prefix=/ \
	--dest-cpu=x86 \
	--tag= \
	--release-urlbase=https://unofficial-builds.nodejs.org/download/release/ \
	--openssl-no-asm --download=all --with-intl=full-icu
Node.js configure: Found Python 3.12.8...
WARNING: --openssl-no-asm will result in binaries that do not take advantage
         of modern CPU cryptographic instructions and will therefore be slower.
         Please refer to BUILDING.md
WARNING: warnings were emitted in the configure phase
INFO: configure completed successfully
make install DESTDIR=node-v23.3.0-linux-x86-musl V= PORTABLE=1
make -C out BUILDTYPE=Release V=
```
```log
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/d1_lib.o] Error 1
make[2]: *** Waiting for unfinished jobs....
gcc: error: unrecognized command-line option '-m32'
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/d1_msg.o] Error 1
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/bio_ssl.o] Error 1
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/d1_srtp.o] Error 1
gcc: error: unrecognized command-line option '-m32'
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/methods.o] Error 1
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/pqueue.o] Error 1
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/s3_enc.o] Error 1
gcc: error: unrecognized command-line option '-m32'
make[2]: *** [deps/openssl/openssl.target.mk:1103: /home/node/node-v23.3.0/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/s3_lib.o] Error 1
make[1]: *** [Makefile:135: node] Error 2
make: *** [Makefile:1278: node-v23.3.0-linux-x86-musl.tar] Error 2
```