### PR TITLE
doc: fix color contrast issue in light mode

### DIFF
--- a/doc/api_assets/hljs.css
+++ b/doc/api_assets/hljs.css
@@ -49,7 +49,7 @@
     color: #808080;
   }
   .hljs-attr {
-    color: #f00;
+    color: #d00;
   }
   .hljs-symbol,
   .hljs-bullet,


### PR DESCRIPTION
Attributes are being highlighted as #f00 on a background of #f2f2f2 in light mode. That's a color contrast of 3.98:1, failing to meet the 4.5:1 requirement of WCAG 2.1 AA. This changes the attribute color to #d00, which has a color contrast of 5.09:1 meeting the 4.5:1 requirement.

By the way, I'm not sure if we document it anywhere, but it would probably be useful to document that we strive for WCAG 2.1 AA compliance (and not AAA compliance which might not even be possible, or some other WCAG version compliance). 

Before:

![image](https://github.com/user-attachments/assets/38923bd7-aa2e-418f-a186-b5263a0eeeca)


After:

![image](https://github.com/user-attachments/assets/ebc7e508-36ec-4ec5-b3ee-e95334f03313)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
