### PR TITLE
module: add --experimental-strip-input-types

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -995,6 +995,18 @@ added:
 
 Use this flag to enable [ShadowRealm][] support.
 
+### `--experimental-strip-input-types`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.1 - Active development
+
+Enable experimental type-stripping for `--eval`.
+Implies [`--experimental-strip-types`][].
+For more information, see the [TypeScript type-stripping][] documentation.
+
 ### `--experimental-strip-types`
 
 <!-- YAML
@@ -3054,6 +3066,7 @@ one is included in the list below.
 * `--experimental-require-module`
 * `--experimental-shadow-realm`
 * `--experimental-specifier-resolution`
+* `--experimental-strip-input-types`
 * `--experimental-strip-types`
 * `--experimental-top-level-await`
 * `--experimental-transform-types`

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -153,7 +153,7 @@ import { fn, FnParams } from './fn.ts';
 
 ### Non-file forms of input
 
-Type stripping can be enabled for `--eval`. The module system
+Type stripping can be enabled for `--eval` by using the flag [`--experimental-strip-input-types`][]. The module system
 will be determined by `--input-type`, as it is for JavaScript.
 
 TypeScript syntax is unsupported in the REPL, STDIN input, `--print`, `--check`, and
@@ -181,6 +181,7 @@ with `#`.
 [CommonJS]: modules.md
 [ES Modules]: esm.md
 [Full TypeScript support]: #full-typescript-support
+[`--experimental-strip-input-types`]: cli.md#--experimental-strip-input-types
 [`--experimental-strip-types`]: cli.md#--experimental-strip-types
 [`--experimental-transform-types`]: cli.md#--experimental-transform-types
 [`tsconfig` "paths"]: https://www.typescriptlang.org/tsconfig/#paths

--- a/doc/node.1
+++ b/doc/node.1
@@ -186,6 +186,9 @@ Configures the type of test isolation used in the test runner.
 .It Fl -experimental-test-module-mocks
 Enable module mocking in the test runner.
 .
+.It Fl -experimental-strip-input-types
+Enable experimental type-stripping for eval input.
+.
 .It Fl -experimental-strip-types
 Enable experimental type-stripping for TypeScript files.
 .

--- a/lib/internal/main/eval_string.js
+++ b/lib/internal/main/eval_string.js
@@ -23,7 +23,7 @@ addBuiltinLibsToObject(globalThis, '<eval>');
 markBootstrapComplete();
 
 const code = getOptionValue('--eval');
-const source = getOptionValue('--experimental-strip-types') ?
+const source = getOptionValue('--experimental-strip-input-types') ?
   stripTypeScriptModuleTypes(code) :
   code;
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -449,7 +449,6 @@ function initializeCJS() {
 
   const tsEnabled = getOptionValue('--experimental-strip-types');
   if (tsEnabled) {
-    emitExperimentalWarning('Type Stripping');
     Module._extensions['.cts'] = loadCTS;
     Module._extensions['.ts'] = loadTS;
   }

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -250,7 +250,6 @@ translators.set('require-commonjs', (url, source, isMain) => {
 // Handle CommonJS modules referenced by `require` calls.
 // This translator function must be sync, as `require` is sync.
 translators.set('require-commonjs-typescript', (url, source, isMain) => {
-  emitExperimentalWarning('Type Stripping');
   assert(cjsParse);
   const code = stripTypeScriptModuleTypes(stringify(source), url);
   return createCJSModuleWrap(url, code, isMain, 'commonjs-typescript');
@@ -464,7 +463,6 @@ translators.set('wasm', async function(url, source) {
 
 // Strategy for loading a commonjs TypeScript module
 translators.set('commonjs-typescript', function(url, source) {
-  emitExperimentalWarning('Type Stripping');
   assertBufferSource(source, true, 'load');
   const code = stripTypeScriptModuleTypes(stringify(source), url);
   debug(`Translating TypeScript ${url}`);
@@ -473,7 +471,6 @@ translators.set('commonjs-typescript', function(url, source) {
 
 // Strategy for loading an esm TypeScript module
 translators.set('module-typescript', function(url, source) {
-  emitExperimentalWarning('Type Stripping');
   assertBufferSource(source, true, 'load');
   const code = stripTypeScriptModuleTypes(stringify(source), url);
   debug(`Translating TypeScript ${url}`);

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -115,6 +115,7 @@ function processTypeScriptCode(code, options) {
  * @returns {TransformOutput} The stripped TypeScript code.
  */
 function stripTypeScriptModuleTypes(source, filename) {
+  emitExperimentalWarning('Type Stripping');
   assert(typeof source === 'string');
   if (isUnderNodeModules(filename)) {
     throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -844,6 +844,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "ES module to preload (option can be repeated)",
             &EnvironmentOptions::preload_esm_modules,
             kAllowedInEnvvar);
+  AddOption("--experimental-strip-input-types",
+            "Experimental type-stripping for eval",
+            &EnvironmentOptions::experimental_strip_input_types,
+            kAllowedInEnvvar);
   AddOption("--experimental-strip-types",
             "Experimental type-stripping for TypeScript files.",
             &EnvironmentOptions::experimental_strip_types,
@@ -855,6 +859,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvvar);
   Implies("--experimental-transform-types", "--experimental-strip-types");
   Implies("--experimental-transform-types", "--enable-source-maps");
+  Implies("--experimental-strip-input-types", "--experimental-strip-types");
   AddOption("--interactive",
             "always enter the REPL even if stdin does not appear "
             "to be a terminal",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -247,6 +247,7 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> preload_esm_modules;
 
   bool experimental_strip_types = false;
+  bool experimental_strip_input_types = false;
   bool experimental_transform_types = false;
 
   std::vector<std::string> user_argv;

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -6,7 +6,7 @@ if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--eval',
     `import util from 'node:util'
     const text: string = 'Hello, TypeScript!'
@@ -19,7 +19,7 @@ test('eval TypeScript ESM syntax', async () => {
 
 test('eval TypeScript ESM syntax with input-type module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--input-type=module',
     '--eval',
     `import util from 'node:util'
@@ -33,7 +33,7 @@ test('eval TypeScript ESM syntax with input-type module', async () => {
 
 test('eval TypeScript CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--eval',
     `const util = require('node:util');
     const text: string = 'Hello, TypeScript!'
@@ -46,7 +46,7 @@ test('eval TypeScript CommonJS syntax', async () => {
 
 test('eval TypeScript CommonJS syntax with input-type commonjs', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--input-type=commonjs',
     '--eval',
     `const util = require('node:util');
@@ -60,7 +60,7 @@ test('eval TypeScript CommonJS syntax with input-type commonjs', async () => {
 
 test('eval TypeScript CommonJS syntax by default', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--eval',
     `const util = require('node:util');
     const text: string = 'Hello, TypeScript!'
@@ -74,7 +74,7 @@ test('eval TypeScript CommonJS syntax by default', async () => {
 
 test('TypeScript ESM syntax not specified', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--eval',
     `import util from 'node:util'
     const text: string = 'Hello, TypeScript!'
@@ -86,7 +86,7 @@ test('TypeScript ESM syntax not specified', async () => {
 
 test('expect fail eval TypeScript CommonJS syntax with input-type module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--input-type=module',
     '--eval',
     `const util = require('node:util');
@@ -100,7 +100,7 @@ test('expect fail eval TypeScript CommonJS syntax with input-type module', async
 
 test('expect fail eval TypeScript ESM syntax with input-type commonjs', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--input-type=commonjs',
     '--eval',
     `import util from 'node:util'
@@ -113,10 +113,24 @@ test('expect fail eval TypeScript ESM syntax with input-type commonjs', async ()
 
 test('check syntax error is thrown when passing invalid syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
+    '--experimental-strip-input-types',
     '--eval',
     'enum Foo { A, B, C }']);
   strictEqual(result.stdout, '');
   match(result.stderr, /ERR_INVALID_TYPESCRIPT_SYNTAX/);
+  strictEqual(result.code, 1);
+});
+
+test('eval TypeScript without --experimental-strip-input-types but --experimental-strip-types', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-strip-types',
+    '--input-type=module',
+    '--eval',
+    `import util from 'node:util'
+    const text: string = 'Hello, TypeScript!'
+    console.log(util.styleText('red', text));`]);
+
+  match(result.stderr, /SyntaxError: Missing initializer in const declaration/);
+  strictEqual(result.stdout, '');
   strictEqual(result.code, 1);
 });


### PR DESCRIPTION
Refs: https://github.com/nodejs/typescript/issues/17
We cannot unflag `--experimental-strip-types` as it is because when using `--eval` it will ALWAYS emit an experimental warning and treat the input as `typescript` regardless.
This flag specifically enables the input of `--eval` to be treated as typescript that otherwise will be treated as javascript.
Once `--experimental-strip-types` is stable we can unflag this too.
I tested this PR with `--experimental-strip-types` unflagged and it goes smoothly.


This is a breaking change (it's experimental so it should not matter too much but still) since now `--experimental-strip-types` is no longer sufficient for input 🤷🏼‍♂️ but I don't see another way.