### PR TITLE
build: build v8 with -fvisibility=hidden on macOS

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -41,14 +41,18 @@
         'AdditionalOptions': ['/utf-8']
       }
     },
-    # Hide symbols that are not explicitly exported with V8_EXPORT.
-    # TODO(joyeecheung): enable it on other platforms. Currently gcc times out
-    # or run out of memory with -fvisibility=hidden on some machines in the CI.
-    'xcode_settings': {
-      'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
-    },
-    'defines': [
-      'BUILDING_V8_SHARED',  # Make V8_EXPORT visible.
+    'conditions': [
+      ['OS=="mac"', {
+        # Hide symbols that are not explicitly exported with V8_EXPORT.
+        # TODO(joyeecheung): enable it on other platforms. Currently gcc times out
+        # or run out of memory with -fvisibility=hidden on some machines in the CI.
+        'xcode_settings': {
+          'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
+        },
+        'defines': [
+          'BUILDING_V8_SHARED',  # Make V8_EXPORT visible.
+        ],
+      }],
     ],
   },
   'targets': [

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -41,6 +41,15 @@
         'AdditionalOptions': ['/utf-8']
       }
     },
+    # Hide symbols that are not explicitly exported with V8_EXPORT.
+    # TODO(joyeecheung): enable it on other platforms. Currently gcc times out
+    # or run out of memory with -fvisibility=hidden on some machines in the CI.
+    'xcode_settings': {
+      'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
+    },
+    'defines': [
+      'BUILDING_V8_SHARED',  # Make V8_EXPORT visible.
+    ],
   },
   'targets': [
     {


### PR DESCRIPTION
V8 should be built with -fvisibility=hidden, otherwise the resulting binary would contain unnecessary symbols. In particular, on macOS, this leads to 5000+ weak symbols resolved at runtime, leading to a startup regression.

On macOS this also reduces the binary size about ~10MB.  On Linux the size reduction is around 8MB.

```
$ DYLD_PRINT_BINDINGS=1 ./node-c4aa34aa --version 2>&1 | grep "looking for weak-def symbol" | wc -l
    7317
$ DYLD_PRINT_BINDINGS=1 out/Release/node --version 2>&1 | grep "looking for weak-def symbol" | wc -l
    1755

$ hyperfine "./node-c4aa34aa --version" "out/Release/node --version" --warmup 10
Benchmark 1: ./node-c4aa34aa --version
  Time (mean ± σ):      28.9 ms ±   1.0 ms    [User: 26.5 ms, System: 1.9 ms]
  Range (min … max):    28.1 ms …  32.2 ms    89 runs

Benchmark 2: out/Release/node --version
  Time (mean ± σ):      12.4 ms ±   1.0 ms    [User: 9.1 ms, System: 1.9 ms]
  Range (min … max):    11.6 ms …  16.2 ms    148 runs

Summary
  'out/Release/node --version' ran
    2.33 ± 0.20 times faster than './node-c4aa34aa --version'

$ ls -lah out/Release/node
-rwxr-xr-x  1 joyee  staff   108M Dec 16 22:39 out/Release/node
$ ls -lah ./node-c4aa34aa
-rwxr-xr-x  1 joyee  staff   118M Dec  5 12:39 ./node-c4aa34aa
```

On Linux the performance is mostly the same as Linux's ld doesn't resolve the weak symbols like macOS's dyld does in the first place, so there was no regression to fix. This does however makes the binary a bit smaller. EDIT: split out the non-macOS settings to https://github.com/nodejs/node/pull/56290 since it seems to cause gcc to time out or run out of memory on some machines in the CI, possibly because it invalidates the ccache on too many machines.

```
$ hyperfine "./node-hidden ./test/fixtures/empty.js" "./node-main ./test/fixtures/empty.js" --warmup=10
Benchmark 1: ./node-hidden ./test/fixtures/empty.js
  Time (mean ± σ):      18.0 ms ±   0.3 ms    [User: 10.0 ms, System: 8.4 ms]
  Range (min … max):    17.2 ms …  18.7 ms    165 runs

Benchmark 2: ./node-main ./test/fixtures/empty.js
  Time (mean ± σ):      18.4 ms ±   0.3 ms    [User: 9.8 ms, System: 8.9 ms]
  Range (min … max):    17.7 ms …  19.1 ms    158 runs

Summary
  './node-hidden ./test/fixtures/empty.js' ran
    1.02 ± 0.02 times faster than './node-main ./test/fixtures/empty.js'

$ ls -lah ./node-main ./node-hidden
-rwxrwxr-x 1 ubuntu ubuntu 113M Dec 16 23:05 ./node-hidden
-rwxrwxr-x 1 ubuntu ubuntu 121M Dec 16 23:59 ./node-main
```

Fixes: https://github.com/nodejs/performance/issues/180

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
