### PR TITLE
doc: fix eslint check with prefixed builtin modules

### DIFF
--- a/doc/eslint.config_partial.mjs
+++ b/doc/eslint.config_partial.mjs
@@ -6,6 +6,7 @@ import {
 import { builtinModules as builtin } from 'node:module';
 
 const globals = requireEslintTool('globals');
+const noSchemeBuiltins = builtin.filter((id) => !id.startsWith('node:'));
 
 export default [
   {
@@ -18,7 +19,7 @@ export default [
         ...noRestrictedSyntaxCommonAll,
         ...noRestrictedSyntaxCommonLib,
         {
-          selector: `CallExpression[callee.name="require"][arguments.0.type="Literal"]:matches(${builtin.map((name) => `[arguments.0.value="${name}"]`).join(',')}),ImportDeclaration:matches(${builtin.map((name) => `[source.value="${name}"]`).join(',')})`,
+          selector: `CallExpression[callee.name="require"][arguments.0.type="Literal"]:matches(${noSchemeBuiltins.map((name) => `[arguments.0.value="${name}"]`).join(',')}),ImportDeclaration:matches(${noSchemeBuiltins.map((name) => `[source.value="${name}"]`).join(',')})`,
           message: 'Use `node:` prefix.',
         },
       ],


### PR DESCRIPTION
With https://github.com/nodejs/node/pull/56185, when running `make lint-js` with locally built `node` binary, it complains about "Use `node:` prefix." on codes like `require('node:sea')`.