### PR TITLE
test: openssl 3.4 compatibility

### DIFF
--- a/test/parallel/test-crypto-oneshot-hash.js
+++ b/test/parallel/test-crypto-oneshot-hash.js
@@ -32,12 +32,14 @@ const input = fs.readFileSync(fixtures.path('utf8_test_text.txt'));
 
 for (const method of methods) {
   for (const outputEncoding of ['buffer', 'hex', 'base64', undefined]) {
-    const oldDigest = crypto.createHash(method).update(input).digest(outputEncoding || 'hex');
-    const digestFromBuffer = crypto.hash(method, input, outputEncoding);
-    assert.deepStrictEqual(digestFromBuffer, oldDigest,
-                           `different result from ${method} with encoding ${outputEncoding}`);
-    const digestFromString = crypto.hash(method, input.toString(), outputEncoding);
-    assert.deepStrictEqual(digestFromString, oldDigest,
-                           `different result from ${method} with encoding ${outputEncoding}`);
+    if (method !== 'shake128' && method !== 'shake256' || !common.hasOpenSSL(3, 4)) {
+      const oldDigest = crypto.createHash(method).update(input).digest(outputEncoding || 'hex');
+      const digestFromBuffer = crypto.hash(method, input, outputEncoding);
+      assert.deepStrictEqual(digestFromBuffer, oldDigest,
+                             `different result from ${method} with encoding ${outputEncoding}`);
+      const digestFromString = crypto.hash(method, input.toString(), outputEncoding);
+      assert.deepStrictEqual(digestFromString, oldDigest,
+                             `different result from ${method} with encoding ${outputEncoding}`);
+    }
   }
 }

--- a/test/parallel/test-tls-psk-circuit.js
+++ b/test/parallel/test-tls-psk-circuit.js
@@ -66,7 +66,11 @@ const expectedHandshakeErr = common.hasOpenSSL(3, 2) ?
   'ERR_SSL_SSL/TLS_ALERT_HANDSHAKE_FAILURE' : 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE';
 test({ psk: USERS.UserB, identity: 'UserC' }, {}, expectedHandshakeErr);
 // Recognized user but incorrect secret should fail handshake
-const expectedIllegalParameterErr = common.hasOpenSSL(3, 2) ?
-  'ERR_SSL_SSL/TLS_ALERT_ILLEGAL_PARAMETER' : 'ERR_SSL_SSLV3_ALERT_ILLEGAL_PARAMETER';
+const expectedIllegalParameterErr =
+  common.hasOpenSSL(3, 4)
+  ? 'ERR_SSL_TLSV1_ALERT_DECRYPT_ERROR'
+  : (common.hasOpenSSL(3, 2)
+    ? 'ERR_SSL_SSL/TLS_ALERT_ILLEGAL_PARAMETER'
+    : 'ERR_SSL_SSLV3_ALERT_ILLEGAL_PARAMETER');
 test({ psk: USERS.UserA, identity: 'UserB' }, {}, expectedIllegalParameterErr);
 test({ psk: USERS.UserB, identity: 'UserB' });


### PR DESCRIPTION
This PR fixes two issues in the testsuite caused by changes in openssl 3.4:
- using SHAKE128 and SHAKE256 requires explicitely setting an output length,
- the error code for one of the failure mode in TLS 1.3 was off-spec.

In addition to https://github.com/nodejs/node/pull/56160 , this should fix
the build of nodejs with openssl 3.4 for Ubuntu 25.04 (Plucky).