### PR TITLE
build: fix GN build for ngtcp2

### DIFF
--- a/deps/ngtcp2/unofficial.gni
+++ b/deps/ngtcp2/unofficial.gni
@@ -68,8 +68,7 @@ template("ngtcp2_gn_build") {
       cflags_c = [
         "-Wno-extra-semi",
         "-Wno-implicit-fallthrough",
-        # Remove after https://github.com/ngtcp2/ngtcp2/issues/1050 is fixed.
-        "-Wno-sometimes-uninitialized",
+        "-Wno-unused-function",
       ]
     }
   }


### PR DESCRIPTION
Fix build failure with GN after merging https://github.com/nodejs/node/pull/56258.