### PR TITLE
url: use resolved path to convert to `fileURL`

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1516,7 +1516,7 @@ function pathToFileURL(filepath, options = kEmptyObject) {
   let resolved = isUNC ?
     filepath :
     (windows ? path.win32.resolve(filepath) : path.posix.resolve(filepath));
-  if (isUNC || windows && StringPrototypeStartsWith(resolved, '\\\\')) {
+  if (isUNC || (windows && StringPrototypeStartsWith(resolved, '\\\\'))) {
     // UNC path format: \\server\share\resource
     // Handle extended UNC path and standard UNC path
     // "\\?\UNC\" path prefix should be ignored.

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1512,32 +1512,32 @@ function fileURLToPath(path, options = kEmptyObject) {
 
 function pathToFileURL(filepath, options = kEmptyObject) {
   const windows = options?.windows ?? isWindows;
-  if (windows && StringPrototypeStartsWith(filepath, '\\\\')) {
+  let resolved = windows ? path.win32.resolve(filepath) : path.posix.resolve(filepath);
+  if (windows && StringPrototypeStartsWith(resolved, '\\\\')) {
     // UNC path format: \\server\share\resource
     // Handle extended UNC path and standard UNC path
     // "\\?\UNC\" path prefix should be ignored.
     // Ref: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-    const isExtendedUNC = StringPrototypeStartsWith(filepath, '\\\\?\\UNC\\');
+    const isExtendedUNC = StringPrototypeStartsWith(resolved, '\\\\?\\UNC\\');
     const prefixLength = isExtendedUNC ? 8 : 2;
-    const hostnameEndIndex = StringPrototypeIndexOf(filepath, '\\', prefixLength);
+    const hostnameEndIndex = StringPrototypeIndexOf(resolved, '\\', prefixLength);
     if (hostnameEndIndex === -1) {
       throw new ERR_INVALID_ARG_VALUE(
         'path',
-        filepath,
+        resolved,
         'Missing UNC resource path',
       );
     }
     if (hostnameEndIndex === 2) {
       throw new ERR_INVALID_ARG_VALUE(
         'path',
-        filepath,
+        resolved,
         'Empty UNC servername',
       );
     }
-    const hostname = StringPrototypeSlice(filepath, prefixLength, hostnameEndIndex);
-    return new URL(StringPrototypeSlice(filepath, hostnameEndIndex), hostname, kCreateURLFromWindowsPathSymbol);
+    const hostname = StringPrototypeSlice(resolved, prefixLength, hostnameEndIndex);
+    return new URL(StringPrototypeSlice(resolved, hostnameEndIndex), hostname, kCreateURLFromWindowsPathSymbol);
   }
-  let resolved = windows ? path.win32.resolve(filepath) : path.posix.resolve(filepath);
   // path.resolve strips trailing slashes so we must add them back
   const filePathLast = StringPrototypeCharCodeAt(filepath,
                                                  filepath.length - 1);

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1512,8 +1512,11 @@ function fileURLToPath(path, options = kEmptyObject) {
 
 function pathToFileURL(filepath, options = kEmptyObject) {
   const windows = options?.windows ?? isWindows;
-  let resolved = windows ? path.win32.resolve(filepath) : path.posix.resolve(filepath);
-  if (windows && StringPrototypeStartsWith(resolved, '\\\\')) {
+  const isUNC = windows && StringPrototypeStartsWith(filepath, '\\\\');
+  let resolved = isUNC ?
+    filepath :
+    (windows ? path.win32.resolve(filepath) : path.posix.resolve(filepath));
+  if (isUNC || windows && StringPrototypeStartsWith(resolved, '\\\\')) {
     // UNC path format: \\server\share\resource
     // Handle extended UNC path and standard UNC path
     // "\\?\UNC\" path prefix should be ignored.


### PR DESCRIPTION
Only matters if the CWD is a UNC path, which is hard to write a test for.

Fixes: https://github.com/nodejs/node/issues/56262
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
