### PR TITLE
build: test macos-13 on GitHub actions

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -38,7 +38,11 @@ permissions:
 jobs:
   test-macOS:
     if: github.event.pull_request.draft == false
-    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        macos-version: [macos-13, macos-14]
+    runs-on: ${{ matrix.macos-version }}
     env:
       CC: sccache gcc
       CXX: sccache g++


### PR DESCRIPTION
We are in the process of updating macOS to version 13 in the
Jenkins CI, but unfortunately this is taking longer than expected.
Add it to the GitHub actions test matrix so that we have some coverage.

Refs: https://github.com/nodejs/build/issues/3686

