### PR TITLE
cli: fix negated boolean options not removing implied options

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -421,20 +421,20 @@ void OptionsParser<Options>::Parse(
     }
 
     {
-      std::string implied_name = name;
-      if (is_negation) {
-        // Implications for negated options are defined with "--no-".
-        implied_name.insert(2, "no-");
-      }
-      auto [f, l] = implications_.equal_range(implied_name);
+      auto [f, l] = implications_.equal_range(name);
       std::ranges::for_each(std::ranges::subrange(f, l) | std::views::values,
                             [&](const auto& value) {
                               if (value.type == kV8Option) {
                                 v8_args->push_back(value.name);
                               } else {
+                                bool target_value = value.target_value;
+                                if (is_negation && value.type == kBoolean) {
+                                  target_value = !value.target_value;
+                                }
                                 *value.target_field->template Lookup<bool>(
-                                    options) = value.target_value;
+                                    options) = target_value;
                               }
+                                
                             });
     }
 

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -434,7 +434,6 @@ void OptionsParser<Options>::Parse(
                                 *value.target_field->template Lookup<bool>(
                                     options) = target_value;
                               }
-                                
                             });
     }
 

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <ranges>
+#include <unordered_map>
 #include "node_options.h"
 #include "util.h"
 
@@ -334,6 +335,8 @@ void OptionsParser<Options>::Parse(
   if (v8_args->empty())
     v8_args->push_back(args.program_name());
 
+  std::unordered_map<std::string, bool> default_field_map = {};
+
   while (!args.empty() && errors->empty()) {
     if (args.first().size() <= 1 || args.first()[0] != '-') break;
 
@@ -428,8 +431,13 @@ void OptionsParser<Options>::Parse(
                                 v8_args->push_back(value.name);
                               } else {
                                 bool target_value = value.target_value;
+                                if (!default_field_map.contains(value.name)) {
+                                  default_field_map[value.name] =
+                                      *value.target_field
+                                           ->template Lookup<bool>(options);
+                                }
                                 if (is_negation && value.type == kBoolean) {
-                                  target_value = !value.target_value;
+                                  target_value = default_field_map[value.name];
                                 }
                                 *value.target_field->template Lookup<bool>(
                                     options) = target_value;

--- a/test/parallel/test-negative-and-implies-options.js
+++ b/test/parallel/test-negative-and-implies-options.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { describe, it } = require('node:test');
+
+describe('negative and implies options', () => {
+  it('should remove --inspect option when --no-inspect-brk is specified', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      ['--inspect-brk=0', '--no-inspect-brk', '-e', "console.log('inspect-brk')"]);
+    assert.strictEqual(stdout, 'inspect-brk\n');
+    assert.strictEqual(stderr, '');
+  });
+
+  it('should remove --inspect option when --no-inspect-wait is specified', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      ['--inspect-wait=0', '--no-inspect-wait', '-e', "console.log('inspect-wait')"]);
+    assert.strictEqual(stdout, 'inspect-wait\n');
+    assert.strictEqual(stderr, '');
+  });
+
+  it('should remove --trace-env option when --no-trace-env-js-stack is specified', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      ['--trace-env-js-stack', '--no-trace-env-js-stack', '-e', "console.log('trace-env-js-stack')"]);
+    assert.strictEqual(stdout, 'trace-env-js-stack\n');
+    assert.strictEqual(stderr, '');
+  });
+
+  it('should remove --trace-env option when --no-trace-env-native-stack is specified', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      ['--trace-env-native-stack', '--no-trace-env-native-stack', '-e', "console.log('trace-env-native-stack')"]);
+    assert.strictEqual(stdout, 'trace-env-native-stack\n');
+    assert.strictEqual(stderr, '');
+  });
+
+  it('should remove implies options when --no-experimental-transform-types is specified',
+     async () => {
+       {
+         const { stdout, stderr } = await common.spawnPromisified(
+           process.execPath,
+           ['--experimental-transform-types',
+            '--no-experimental-transform-types',
+            '-e',
+            "console.log('experimental-transform-types')"]);
+         assert.strictEqual(stdout, 'experimental-transform-types\n');
+         assert.strictEqual(stderr, '');
+       }
+       {
+         const { stderr } = await common.spawnPromisified(
+           process.execPath,
+           ['--experimental-transform-types',
+            '--no-experimental-transform-types',
+            '../fixtures/source-map/throw-async.mjs']);
+         assert.doesNotMatch(
+           stderr,
+           /at Throw \([^)]+throw-async\.ts:4:9\)/
+         );
+       }
+     });
+  it('should remove shadow-realm option when negate shadow-realm options are specified', async () => {
+    {
+      const { stdout, stderr } = await common.spawnPromisified(
+        process.execPath,
+        ['--experimental-shadow-realm',
+         '--no-experimental-shadow-realm',
+         '-e',
+         "new ShadowRealm().eval('console.log(1)')",
+        ]);
+      assert.strictEqual(stdout, '');
+      assert.match(stderr, /Error: Not supported/);
+    }
+    {
+      const { stdout, stderr } = await common.spawnPromisified(
+        process.execPath,
+        ['--harmony-shadow-realm', '--no-harmony-shadow-realm', '-e', "new ShadowRealm().eval('console.log(1)')"]);
+      assert.strictEqual(stdout, '');
+      assert.match(stderr, /ReferenceError: ShadowRealm is not defined/);
+    }
+    {
+      const { stdout, stderr } = await common.spawnPromisified(
+        process.execPath,
+        ['--harmony-shadow-realm', '--no-experimental-shadow-realm', '-e', "new ShadowRealm().eval('console.log(1)')"]);
+      assert.strictEqual(stdout, '');
+      assert.match(stderr, /Error: Not supported/);
+    }
+    {
+      const { stdout, stderr } = await common.spawnPromisified(
+        process.execPath,
+        ['--experimental-shadow-realm', '--no-harmony-shadow-realm', '-e', "new ShadowRealm().eval('console.log(1)')"]);
+      assert.strictEqual(stdout, '');
+      assert.match(stderr, /ReferenceError: ShadowRealm is not defined/);
+    }
+  });
+
+
+  it('should not affect with only negation option', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      ['--no-inspect-brk', '-e', "console.log('inspect-brk')"]);
+    assert.strictEqual(stdout, 'inspect-brk\n');
+    assert.strictEqual(stderr, '');
+  });
+
+  it('should throw no boolean option error', async () => {
+    const { stdout, stderr } = await common.spawnPromisified(
+      process.execPath,
+      [`--env-file=../fixtures/dotenv/.env`, '--no-env-file', '-e', 'const foo = 1'],
+      { cwd: __dirname });
+
+    assert.strictEqual(stdout, '');
+    assert.match(stderr, /--no-env-file is an invalid negation because it is not a boolean option/);
+  });
+});

--- a/test/parallel/test-negative-and-implies-options.js
+++ b/test/parallel/test-negative-and-implies-options.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
 const assert = require('assert');
 const { describe, it } = require('node:test');
 


### PR DESCRIPTION
When using negated options for boolean options that imply other options (e.g., --inspect-brk), the implied options are not removed as expected. This causes the implied option to remain active, leading to unexpected behavior.

``` sh
shimaryuuheinoMac-mini:node shimaryuuhei$ node --inspect-brk --no-inspect-brk -e "console.log(\"foo\")"
Debugger listening on ws://127.0.0.1:9229/67479127-5d17-4027-b514-70217b2fe102
For help, see: https://nodejs.org/en/docs/inspector
foo
```
When using --no-inspect-brk, only the effect of the --inspect option remains.

This change ensures that when a negated option (e.g., --no-...) is used, any implied options are also removed. After this fix, the above example will no longer activate the implied options.

### Alternative
Currently, the negated options affected by this change are not documented in the official CLI documentation: https://nodejs.org/api/cli.html

An alternative approach could be to remove these undocumented negated options entirely, ensuring no unexpected behavior arises from their usage.
