### PR TITLE
module: use buffer.toString base64

### DIFF
--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -13,12 +13,12 @@ const noRestrictedSyntax = [
     selector: "CallExpression[callee.object.name='assert']:not([callee.property.name='ok']):not([callee.property.name='fail']):not([callee.property.name='ifError'])",
     message: 'Only use simple assertions',
   },
-  // Forbids usages of `btoa` like:
-  // ```
-  // const { btoa } = internalBinding('buffer');
-  // btoa('...');
-  // ```
   {
+    // Forbids usages of `btoa` that are not caught by no-restricted-globals, like:
+    // ```
+    // const { btoa } = internalBinding('buffer');
+    // btoa('...');
+    // ```
     selector: "CallExpression[callee.property.name='btoa'], CallExpression[callee.name='btoa']",
     message: "`btoa` supports only latin-1 charset, use Buffer.from(str).toString('base64') instead",
   },

--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -13,6 +13,15 @@ const noRestrictedSyntax = [
     selector: "CallExpression[callee.object.name='assert']:not([callee.property.name='ok']):not([callee.property.name='fail']):not([callee.property.name='ifError'])",
     message: 'Only use simple assertions',
   },
+  // Forbids usages of `btoa` like:
+  // ```
+  // const { btoa } = internalBinding('buffer');
+  // btoa('...');
+  // ```
+  {
+    selector: "CallExpression[callee.property.name='btoa'], CallExpression[callee.name='btoa']",
+    message: "`btoa` supports only latin-1 charset, use Buffer.from(str).toString('base64') instead",
+  },
   {
     selector: 'NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError|AbortError|NodeAggregateError)$/])',
     message: "Use an error exported by 'internal/errors' instead.",

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -17,6 +17,7 @@ const {
 } = require('internal/errors').codes;
 const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
+const { Buffer } = require('buffer');
 
 /**
  * The TypeScript parsing mode, either 'strip-only' or 'transform'.
@@ -134,9 +135,10 @@ function stripTypeScriptModuleTypes(source, filename) {
  * @returns {string} The code with the source map attached.
  */
 function addSourceMap(code, sourceMap) {
-  // TODO(@marco-ippolito) When Buffer.transcode supports utf8 to
-  // base64 transformation, we should change this line.
-  const base64SourceMap = internalBinding('buffer').btoa(sourceMap);
+  // The base64 encoding should be https://datatracker.ietf.org/doc/html/rfc4648#section-4,
+  // not base64url https://datatracker.ietf.org/doc/html/rfc4648#section-5. See data url
+  // spec https://tools.ietf.org/html/rfc2397#section-2.
+  const base64SourceMap = Buffer.from(sourceMap).toString('base64');
   return `${code}\n\n//# sourceMappingURL=data:application/json;base64,${base64SourceMap}`;
 }
 


### PR DESCRIPTION
`btoa` only supports latin-1 charset and produces invalid source mapping urls.

This also forbids usage of `btoa` in `lib/` without particular reasons.

Refs: https://github.com/nodejs/node/issues/56296