### PR TITLE
doc: update macOS and Xcode versions for releases

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -162,8 +162,8 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 | Binary package          | Platform and Toolchain                                                                                        |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------- |
 | aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                                                                       |
-| darwin-x64              | macOS 11, Xcode 13 with -mmacosx-version-min=11.0                                                             |
-| darwin-arm64 (and .pkg) | macOS 11 (arm64), Xcode 13 with -mmacosx-version-min=11.0                                                     |
+| darwin-x64              | macOS 13, Xcode 16 with -mmacosx-version-min=11.0                                                             |
+| darwin-arm64 (and .pkg) | macOS 13 (arm64), Xcode 14 with -mmacosx-version-min=11.0                                                     |
 | linux-arm64             | RHEL 8 with gcc-toolset-12[^6]                                                                                |
 | linux-armv7l            | Cross-compiled on RHEL 9 x64 with a [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)[^7] |
 | linux-ppc64le           | RHEL 8 with gcc-toolset-12[^6]                                                                                |


### PR DESCRIPTION
This is just documenting the current state, not changing it.

Refs:
- https://ci-release.nodejs.org/job/iojs+release/10689/nodes=osx13-x64-release-tar/consoleFull
  Apple clang version 16.0.0 (clang-1600.0.26.3)
- https://ci-release.nodejs.org/job/iojs+release/10689/nodes=osx13-arm64-release-tar/consoleFull
  Apple clang version 14.0.3 (clang-1403.0.22.14.1)
