### PR TITLE
test: improve abort signal dropping test

### DIFF
--- a/test/parallel/test-abortsignal-drop-settled-signals.mjs
+++ b/test/parallel/test-abortsignal-drop-settled-signals.mjs
@@ -134,25 +134,30 @@ it('does not prevent source signal from being GCed if it is short-lived', (t, do
 
 it('drops settled dependant signals when signal is composite', (t, done) => {
   const controllers = Array.from({ length: 2 }, () => new AbortController());
-  const composedSignal1 = AbortSignal.any([controllers[0].signal]);
-  const composedSignalRef = new WeakRef(AbortSignal.any([composedSignal1, controllers[1].signal]));
+
+  // Using WeakRefs to avoid this test to retain information that will make the test fail
+  const composedSignal1 = new WeakRef(AbortSignal.any([controllers[0].signal]));
+  const composedSignalRef = new WeakRef(AbortSignal.any([composedSignal1.deref(), controllers[1].signal]));
 
   const kDependantSignals = Object.getOwnPropertySymbols(controllers[0].signal).find(
     (s) => s.toString() === 'Symbol(kDependantSignals)'
   );
 
+  t.assert.strictEqual(controllers[0].signal[kDependantSignals].size, 2);
+  t.assert.strictEqual(controllers[1].signal[kDependantSignals].size, 1);
+
   setImmediate(() => {
-    global.gc({ execution: 'async' }).then(() => {
-      t.assert.strictEqual(composedSignalRef.deref(), undefined);
-      t.assert.strictEqual(controllers[0].signal[kDependantSignals].size, 2);
-      t.assert.strictEqual(controllers[1].signal[kDependantSignals].size, 1);
+    global.gc({ execution: 'async' }).then(async () => {
+      await gcUntil('all signals are GCed', () => {
+        const totalDependantSignals = Math.max(
+          controllers[0].signal[kDependantSignals].size,
+          controllers[1].signal[kDependantSignals].size
+        );
 
-      setImmediate(() => {
-        t.assert.strictEqual(controllers[0].signal[kDependantSignals].size, 0);
-        t.assert.strictEqual(controllers[1].signal[kDependantSignals].size, 0);
-
-        done();
+        return composedSignalRef.deref() === undefined && totalDependantSignals === 0;
       });
+
+      done();
     });
   });
 });


### PR DESCRIPTION
Refs #56190

This PR does two things in the specific `test` case that is flaky:

- Make the `composedSignal` a weak ref so the test won't hold any reference that could keep that variable from being GCed.
- Add `gcUntil` so it will make more calls to `global.gc`. Precisely, until that condition is reached or a maximum number of attempts is hit.