### PR TITLE
module: unflag --experimental-strip-types

### DIFF
--- a/benchmark/ts/strip-typescript.js
+++ b/benchmark/ts/strip-typescript.js
@@ -12,7 +12,7 @@ const bench = common.createBenchmark(main, {
   filepath: [ts, js],
   n: [1e4],
 }, {
-  flags: ['--experimental-strip-types', '--disable-warning=ExperimentalWarning'],
+  flags: ['--disable-warning=ExperimentalWarning'],
 });
 
 async function main({ n, filepath }) {

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -780,7 +780,7 @@ Any query parameter or hash in the URL will be accessible via [`import.meta.url`
 
 ```bash
 node --entry-url 'file:///path/to/file.js?queryparams=work#and-hashes-too'
-node --entry-url --experimental-strip-types 'file.ts?query#hash'
+node --entry-url 'file.ts?query#hash'
 node --entry-url 'data:text/javascript,console.log("Hello")'
 ```
 
@@ -880,8 +880,8 @@ On Windows, using `cmd.exe` a single quote will not work correctly because it
 only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
 and `"` are usable.
 
-It is possible to run code containing inline types by passing
-[`--experimental-strip-types`][].
+It is possible to run code containing inline types unless the
+[`--no-experimental-strip-types`][] flag is provided.
 
 ### `--experimental-addon-modules`
 
@@ -1008,17 +1008,6 @@ added:
 
 Use this flag to enable [ShadowRealm][] support.
 
-### `--experimental-strip-types`
-
-<!-- YAML
-added: v22.6.0
--->
-
-> Stability: 1.1 - Active development
-
-Enable experimental type-stripping for TypeScript files.
-For more information, see the [TypeScript type-stripping][] documentation.
-
 ### `--experimental-test-coverage`
 
 <!-- YAML
@@ -1059,7 +1048,7 @@ added: v22.7.0
 > Stability: 1.1 - Active development
 
 Enables the transformation of TypeScript-only syntax into JavaScript code.
-Implies `--experimental-strip-types` and `--enable-source-maps`.
+Implies `--enable-source-maps`.
 
 ### `--experimental-vm-modules`
 
@@ -1370,10 +1359,10 @@ added: v12.0.0
 
 This configures Node.js to interpret `--eval` or `STDIN` input as CommonJS or
 as an ES module. Valid values are `"commonjs"`, `"module"`, `"module-typescript"` and `"commonjs-typescript"`.
-The `"-typescript"` values are available only in combination with the flag `--experimental-strip-types`.
+The `"-typescript"` values are not available with the flag `--no-experimental-strip-types`.
 The default is `"commonjs"`.
 
-If `--experimental-strip-types` is enabled and `--input-type` is not provided,
+If `--input-type` is not provided,
 Node.js will try to detect the syntax with the following steps:
 
 1. Run the input as CommonJS.
@@ -1662,6 +1651,21 @@ changes:
 -->
 
 Disable the experimental [`node:sqlite`][] module.
+
+### `--no-experimental-strip-types`
+
+<!-- YAML
+added: v22.6.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56350
+    description: Type stripping is enabled by default.
+-->
+
+> Stability: 1.1 - Active development
+
+Disable experimental type-stripping for TypeScript files.
+For more information, see the [TypeScript type-stripping][] documentation.
 
 ### `--no-experimental-websocket`
 
@@ -3089,7 +3093,6 @@ one is included in the list below.
 * `--experimental-require-module`
 * `--experimental-shadow-realm`
 * `--experimental-specifier-resolution`
-* `--experimental-strip-types`
 * `--experimental-test-isolation`
 * `--experimental-top-level-await`
 * `--experimental-transform-types`
@@ -3127,6 +3130,7 @@ one is included in the list below.
 * `--no-experimental-global-navigator`
 * `--no-experimental-repl-await`
 * `--no-experimental-sqlite`
+* `--no-experimental-strip-types`
 * `--no-experimental-websocket`
 * `--no-extra-info-on-fatal-exception`
 * `--no-force-async-hooks-checks`
@@ -3651,10 +3655,10 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--env-file`]: #--env-fileconfig
 [`--experimental-addon-modules`]: #--experimental-addon-modules
 [`--experimental-sea-config`]: single-executable-applications.md#generating-single-executable-preparation-blobs
-[`--experimental-strip-types`]: #--experimental-strip-types
 [`--experimental-wasm-modules`]: #--experimental-wasm-modules
 [`--heap-prof-dir`]: #--heap-prof-dir
 [`--import`]: #--importmodule
+[`--no-experimental-strip-types`]: #--no-experimental-strip-types
 [`--openssl-config`]: #--openssl-configfile
 [`--preserve-symlinks`]: #--preserve-symlinks
 [`--print`]: #-p---print-script

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2025,8 +2025,9 @@ added:
 
 * {boolean|string}
 
-A value that is `"strip"` if Node.js is run with `--experimental-strip-types`,
-`"transform"` if Node.js is run with `--experimental-transform-types`, and `false` otherwise.
+A value that is `"strip"` by default,
+`"transform"` if Node.js is run with `--experimental-transform-types`, and `false` if
+Node.js is run with `--no-experimental-strip-types`.
 
 ## `process.features.uv`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -420,8 +420,8 @@ By default, Node.js will run all files matching these patterns:
 * `**/test.{cjs,mjs,js}`
 * `**/test/**/*.{cjs,mjs,js}`
 
-When [`--experimental-strip-types`][] is supplied, the following
-additional patterns are matched:
+Unless [`--no-experimental-strip-types`][] is supplied, the following
+additional patterns are also matched:
 
 * `**/*.test.{cts,mts,ts}`
 * `**/*-test.{cts,mts,ts}`
@@ -3591,10 +3591,10 @@ added:
 Can be used to abort test subtasks when the test has been aborted.
 
 [TAP]: https://testanything.org/
-[`--experimental-strip-types`]: cli.md#--experimental-strip-types
 [`--experimental-test-coverage`]: cli.md#--experimental-test-coverage
 [`--experimental-test-module-mocks`]: cli.md#--experimental-test-module-mocks
 [`--import`]: cli.md#--importmodule
+[`--no-experimental-strip-types`]: cli.md#--no-experimental-strip-types
 [`--test-concurrency`]: cli.md#--test-concurrency
 [`--test-coverage-exclude`]: cli.md#--test-coverage-exclude
 [`--test-coverage-include`]: cli.md#--test-coverage-include

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -2,6 +2,9 @@
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56350
+    description: Type stripping is enabled by default.
   - version: v22.7.0
     pr-url: https://github.com/nodejs/node/pull/54283
     description: Added `--experimental-transform-types` flag.
@@ -52,7 +55,7 @@ added: v22.6.0
 
 > Stability: 1.1 - Active development
 
-The flag [`--experimental-strip-types`][] enables Node.js to run TypeScript
+The flag [`--no-experimental-strip-types`][] prevents Node.js from running TypeScript
 files. By default Node.js will execute only files that contain no
 TypeScript features that require transformation, such as enums or namespaces.
 Node.js will replace inline type annotations with whitespace,
@@ -181,8 +184,8 @@ with `#`.
 [CommonJS]: modules.md
 [ES Modules]: esm.md
 [Full TypeScript support]: #full-typescript-support
-[`--experimental-strip-types`]: cli.md#--experimental-strip-types
 [`--experimental-transform-types`]: cli.md#--experimental-transform-types
+[`--no-experimental-strip-types`]: cli.md#--no-experimental-strip-types
 [`tsconfig` "paths"]: https://www.typescriptlang.org/tsconfig/#paths
 [`tsx`]: https://tsx.is/
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax

--- a/doc/node.1
+++ b/doc/node.1
@@ -186,9 +186,6 @@ Enable code coverage in the test runner.
 .It Fl -experimental-test-module-mocks
 Enable module mocking in the test runner.
 .
-.It Fl -experimental-strip-types
-Enable experimental type-stripping for TypeScript files.
-.
 .It Fl -experimental-transform-types
 Enable transformation of TypeScript-only syntax into JavaScript code.
 .
@@ -206,6 +203,9 @@ Disable top-level await keyword support in REPL.
 .
 .It Fl -no-experimental-sqlite
 Disable the experimental node:sqlite module.
+.
+.It Fl -no-experimental-strip-types
+Disable experimental type-stripping for TypeScript files.
 .
 .It Fl -experimental-vm-modules
 Enable experimental ES module support in VM module.

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -857,7 +857,8 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-strip-types",
             "Experimental type-stripping for TypeScript files.",
             &EnvironmentOptions::experimental_strip_types,
-            kAllowedInEnvvar);
+            kAllowedInEnvvar,
+            true);
   AddOption("--experimental-transform-types",
             "enable transformation of TypeScript-only"
             "syntax into JavaScript code",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -247,7 +247,7 @@ class EnvironmentOptions : public Options {
 
   std::vector<std::string> preload_esm_modules;
 
-  bool experimental_strip_types = false;
+  bool experimental_strip_types = true;
   bool experimental_transform_types = false;
 
   std::vector<std::string> user_argv;

--- a/test/es-module/test-esm-loader-entry-url.mjs
+++ b/test/es-module/test-esm-loader-entry-url.mjs
@@ -84,7 +84,7 @@ describe('--entry-url', { concurrency: true }, () => {
 
     for (const url of typescriptUrls) {
       await assertSpawnedProcess(
-        ['--entry-url', '--experimental-strip-types', fixtures.fileURL(url)],
+        ['--entry-url', fixtures.fileURL(url)],
         {},
         {
           ...experimentalFeatureWarning,

--- a/test/es-module/test-esm-resolve-type.mjs
+++ b/test/es-module/test-esm-resolve-type.mjs
@@ -186,7 +186,7 @@ try {
     [ 'qmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v'],
     [ 'hmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '#Key'],
     [ 'qhmod', 'index.js', 'imp.js', 'commonjs', 'module', 'module', '?k=v#h'],
-    [ 'ts-mod-com', 'index.js', 'imp.ts', 'module', 'commonjs', undefined],
+    [ 'ts-mod-com', 'index.js', 'imp.ts', 'module', 'commonjs', 'commonjs-typescript'],
   ].forEach((testVariant) => {
     const [
       moduleName,

--- a/test/es-module/test-typescript-commonjs.mjs
+++ b/test/es-module/test-typescript-commonjs.mjs
@@ -7,7 +7,6 @@ if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('require a .ts file with explicit extension succeeds', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'require("./test-typescript.ts")',
     '--no-warnings',
@@ -22,7 +21,6 @@ test('require a .ts file with explicit extension succeeds', async () => {
 
 test('eval require a .ts file with implicit extension fails', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'require("./test-typescript")',
     '--no-warnings',
@@ -37,7 +35,6 @@ test('eval require a .ts file with implicit extension fails', async () => {
 
 test('eval require a .cts file with implicit extension fails', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'require("./test-cts-typescript")',
     '--no-warnings',
@@ -52,7 +49,6 @@ test('eval require a .cts file with implicit extension fails', async () => {
 
 test('require a .ts file with implicit extension fails', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/cts/test-extensionless-require.ts'),
   ]);
@@ -64,7 +60,6 @@ test('require a .ts file with implicit extension fails', async () => {
 
 test('expect failure of an .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/cts/test-cts-but-module-syntax.cts'),
   ]);
 
@@ -75,7 +70,6 @@ test('expect failure of an .mts file with CommonJS syntax', async () => {
 
 test('execute a .cts file importing a .cts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/cts/test-require-commonjs.cts'),
   ]);
@@ -87,7 +81,6 @@ test('execute a .cts file importing a .cts file', async () => {
 
 test('execute a .cts file importing a .ts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/cts/test-require-ts-file.cts'),
   ]);
@@ -99,7 +92,6 @@ test('execute a .cts file importing a .ts file export', async () => {
 
 test('execute a .cts file importing a .mts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-experimental-require-module',
     fixtures.path('typescript/cts/test-require-mts-module.cts'),
   ]);
@@ -111,7 +103,6 @@ test('execute a .cts file importing a .mts file export', async () => {
 
 test('execute a .cts file importing a .mts file export', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--experimental-require-module',
     fixtures.path('typescript/cts/test-require-mts-module.cts'),
   ]);
@@ -122,7 +113,6 @@ test('execute a .cts file importing a .mts file export', async () => {
 
 test('expect failure of a .cts file in node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/cts/test-cts-node_modules.cts'),
   ]);
 
@@ -133,7 +123,6 @@ test('expect failure of a .cts file in node_modules', async () => {
 
 test('expect failure of a .ts file in node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/cts/test-ts-node_modules.cts'),
   ]);
 
@@ -144,7 +133,6 @@ test('expect failure of a .ts file in node_modules', async () => {
 
 test('expect failure of a .cts requiring esm without default type module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-experimental-require-module',
     fixtures.path('typescript/cts/test-mts-node_modules.cts'),
   ]);
@@ -156,7 +144,6 @@ test('expect failure of a .cts requiring esm without default type module', async
 
 test('expect failure of a .cts file requiring esm in node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--experimental-require-module',
     fixtures.path('typescript/cts/test-mts-node_modules.cts'),
   ]);

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -6,7 +6,6 @@ if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('eval TypeScript ESM syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `import util from 'node:util'
     const text: string = 'Hello, TypeScript!'
@@ -19,7 +18,6 @@ test('eval TypeScript ESM syntax', async () => {
 
 test('eval TypeScript ESM syntax with input-type module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=module-typescript',
     '--eval',
     `import util from 'node:util'
@@ -33,7 +31,6 @@ test('eval TypeScript ESM syntax with input-type module', async () => {
 
 test('eval TypeScript CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `const util = require('node:util');
     const text: string = 'Hello, TypeScript!'
@@ -45,7 +42,6 @@ test('eval TypeScript CommonJS syntax', async () => {
 
 test('eval TypeScript CommonJS syntax with input-type commonjs-typescript', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=commonjs-typescript',
     '--eval',
     `const util = require('node:util');
@@ -59,7 +55,6 @@ test('eval TypeScript CommonJS syntax with input-type commonjs-typescript', asyn
 
 test('eval TypeScript CommonJS syntax by default', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `const util = require('node:util');
     const text: string = 'Hello, TypeScript!'
@@ -73,7 +68,6 @@ test('eval TypeScript CommonJS syntax by default', async () => {
 
 test('TypeScript ESM syntax not specified', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `import util from 'node:util'
     const text: string = 'Hello, TypeScript!'
@@ -85,7 +79,6 @@ test('TypeScript ESM syntax not specified', async () => {
 
 test('expect fail eval TypeScript CommonJS syntax with input-type module-typescript', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=module-typescript',
     '--eval',
     `const util = require('node:util');
@@ -99,7 +92,6 @@ test('expect fail eval TypeScript CommonJS syntax with input-type module-typescr
 
 test('expect fail eval TypeScript ESM syntax with input-type commonjs-typescript', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=commonjs-typescript',
     '--eval',
     `import util from 'node:util'
@@ -112,7 +104,6 @@ test('expect fail eval TypeScript ESM syntax with input-type commonjs-typescript
 
 test('check syntax error is thrown when passing invalid syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'enum Foo { A, B, C }']);
   strictEqual(result.stdout, '');
@@ -123,7 +114,6 @@ test('check syntax error is thrown when passing invalid syntax', async () => {
 
 test('check syntax error is thrown when passing invalid syntax with --input-type=module-typescript', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=module-typescript',
     '--eval',
     'enum Foo { A, B, C }']);
@@ -134,7 +124,6 @@ test('check syntax error is thrown when passing invalid syntax with --input-type
 
 test('check syntax error is thrown when passing invalid syntax with --input-type=commonjs-typescript', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=commonjs-typescript',
     '--eval',
     'enum Foo { A, B, C }']);
@@ -145,7 +134,6 @@ test('check syntax error is thrown when passing invalid syntax with --input-type
 
 test('should not parse TypeScript with --type-module=commonjs', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=commonjs',
     '--eval',
     `enum Foo {}`]);
@@ -158,7 +146,6 @@ test('should not parse TypeScript with --type-module=commonjs', async () => {
 
 test('should not parse TypeScript with --type-module=module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--input-type=module',
     '--eval',
     `enum Foo {}`]);
@@ -171,7 +158,6 @@ test('should not parse TypeScript with --type-module=module', async () => {
 
 test('check warning is emitted when eval TypeScript CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `const util = require('node:util');
     const text: string = 'Hello, TypeScript!'
@@ -183,7 +169,6 @@ test('check warning is emitted when eval TypeScript CommonJS syntax', async () =
 
 test('code is throwing a non Error is rethrown', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `throw null;`]);
   doesNotMatch(result.stderr, /node:internal\/process\/execution/);
@@ -193,7 +178,6 @@ test('code is throwing a non Error is rethrown', async () => {
 
 test('code is throwing an error with customized accessors', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `throw Object.defineProperty(new Error, "stack", { set() {throw this} });`]);
 
@@ -205,7 +189,6 @@ test('code is throwing an error with customized accessors', async () => {
 
 test('typescript code is throwing an error', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     `const foo: string =  'Hello, TypeScript!'; throw new Error(foo);`]);
 
@@ -216,7 +199,6 @@ test('typescript code is throwing an error', async () => {
 
 test('typescript ESM code is throwing a syntax error at runtime', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'import util from "node:util"; function foo(){}; throw new SyntaxError(foo<Number>(1));']);
   // Trick by passing ambiguous syntax to see if evaluated in TypeScript or JavaScript
@@ -230,7 +212,6 @@ test('typescript ESM code is throwing a syntax error at runtime', async () => {
 
 test('typescript CJS code is throwing a syntax error at runtime', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--eval',
     'const util = require("node:util"); function foo(){}; throw new SyntaxError(foo<Number>(1));']);
   // Trick by passing ambiguous syntax to see if evaluated in TypeScript or JavaScript

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -7,7 +7,6 @@ if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('expect failure of a .mts file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/mts/test-mts-but-commonjs-syntax.mts'),
   ]);
 
@@ -18,7 +17,6 @@ test('expect failure of a .mts file with CommonJS syntax', async () => {
 
 test('execute an .mts file importing an .mts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/mts/test-import-module.mts'),
   ]);
 
@@ -29,7 +27,6 @@ test('execute an .mts file importing an .mts file', async () => {
 
 test('execute an .mts file importing a .ts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/mts/test-import-ts-file.mts'),
   ]);
@@ -41,7 +38,6 @@ test('execute an .mts file importing a .ts file', async () => {
 
 test('execute an .mts file importing a .cts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/mts/test-import-commonjs.mts'),
   ]);
@@ -53,7 +49,6 @@ test('execute an .mts file importing a .cts file', async () => {
 
 test('execute an .mts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/mts/test-mts-node_modules.mts'),
   ]);
 
@@ -64,7 +59,6 @@ test('execute an .mts file from node_modules', async () => {
 
 test('execute a .cts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/mts/test-cts-node_modules.mts'),
   ]);
 
@@ -75,7 +69,6 @@ test('execute a .cts file from node_modules', async () => {
 
 test('execute a .ts file from node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/mts/test-ts-node_modules.mts'),
   ]);
 
@@ -86,7 +79,6 @@ test('execute a .ts file from node_modules', async () => {
 
 test('execute an empty .ts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-empty-file.ts'),
   ]);
@@ -98,7 +90,6 @@ test('execute an empty .ts file', async () => {
 
 test('execute .ts file importing a module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-import-fs.ts'),
   ]);

--- a/test/es-module/test-typescript.mjs
+++ b/test/es-module/test-typescript.mjs
@@ -3,15 +3,15 @@ import * as fixtures from '../common/fixtures.mjs';
 import { match, strictEqual } from 'node:assert';
 import { test } from 'node:test';
 
-test('expect process.features.typescript to be \'strip\' when --experimental-strip-types', async () => {
+test('expect process.features.typescript to be false when --no-experimental-strip-types ', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--no-warnings',
-    '--experimental-strip-types',
+    '--no-experimental-strip-types',
     fixtures.path('typescript/echo-process-features-typescript.cjs'),
   ]);
 
   strictEqual(result.stderr, '');
-  strictEqual(result.stdout, process.config.variables.node_use_amaro ? 'strip\n' : 'false\n');
+  strictEqual(result.stdout, 'false\n');
   strictEqual(result.code, 0);
 });
 
@@ -32,7 +32,6 @@ if (!process.config.variables.node_use_amaro) skip('Requires Amaro');
 
 test('execute a TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-typescript.ts'),
   ]);
 
@@ -43,7 +42,6 @@ test('execute a TypeScript file', async () => {
 
 test('execute a TypeScript file with imports', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-import-foo.ts'),
   ]);
@@ -67,7 +65,6 @@ test('execute a TypeScript file with imports', async () => {
 
 test('execute a TypeScript file with node_modules', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-typescript-node-modules.ts'),
   ]);
@@ -79,7 +76,6 @@ test('execute a TypeScript file with node_modules', async () => {
 
 test('expect error when executing a TypeScript file with imports with no extensions', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-import-no-extension.ts'),
   ]);
 
@@ -90,7 +86,6 @@ test('expect error when executing a TypeScript file with imports with no extensi
 
 test('expect error when executing a TypeScript file with enum', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-enums.ts'),
   ]);
 
@@ -102,7 +97,6 @@ test('expect error when executing a TypeScript file with enum', async () => {
 
 test('expect error when executing a TypeScript file with experimental decorators', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-experimental-decorators.ts'),
   ]);
   // This error should be thrown at runtime
@@ -113,7 +107,6 @@ test('expect error when executing a TypeScript file with experimental decorators
 
 test('expect error when executing a TypeScript file with namespaces', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-namespaces.ts'),
   ]);
   // This error should be thrown during transformation
@@ -124,7 +117,6 @@ test('expect error when executing a TypeScript file with namespaces', async () =
 
 test('execute a TypeScript file with type definition', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-import-types.ts'),
   ]);
@@ -136,7 +128,6 @@ test('execute a TypeScript file with type definition', async () => {
 
 test('execute a TypeScript file with type definition but no type keyword', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-import-no-type-keyword.ts'),
   ]);
 
@@ -147,7 +138,6 @@ test('execute a TypeScript file with type definition but no type keyword', async
 
 test('execute a TypeScript file with CommonJS syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-commonjs-parsing.ts'),
   ]);
@@ -158,7 +148,6 @@ test('execute a TypeScript file with CommonJS syntax', async () => {
 
 test('execute a TypeScript file with ES module syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-module-typescript.ts'),
   ]);
@@ -170,7 +159,6 @@ test('execute a TypeScript file with ES module syntax', async () => {
 
 test('expect failure of a TypeScript file requiring ES module syntax', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--experimental-require-module',
     fixtures.path('typescript/ts/test-require-module.ts'),
   ]);
@@ -181,7 +169,6 @@ test('expect failure of a TypeScript file requiring ES module syntax', async () 
 
 test('expect stack trace of a TypeScript file to be correct', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-whitespacing.ts'),
   ]);
 
@@ -192,7 +179,6 @@ test('expect stack trace of a TypeScript file to be correct', async () => {
 
 test('execute CommonJS TypeScript file from node_modules with require-module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-import-ts-node-modules.ts'),
   ]);
 
@@ -203,7 +189,6 @@ test('execute CommonJS TypeScript file from node_modules with require-module', a
 
 test('execute a TypeScript file with CommonJS syntax requiring .cts', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-require-cts.ts'),
   ]);
@@ -215,7 +200,6 @@ test('execute a TypeScript file with CommonJS syntax requiring .cts', async () =
 
 test('execute a TypeScript file with CommonJS syntax requiring .mts', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-require-mts.ts'),
   ]);
 
@@ -225,7 +209,6 @@ test('execute a TypeScript file with CommonJS syntax requiring .mts', async () =
 
 test('execute a TypeScript file with CommonJS syntax requiring .mts using require-module', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--experimental-require-module',
     fixtures.path('typescript/ts/test-require-mts.ts'),
   ]);
@@ -236,7 +219,6 @@ test('execute a TypeScript file with CommonJS syntax requiring .mts using requir
 
 test('execute a TypeScript file with CommonJS syntax requiring .cts using commonjs', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-require-cts.ts'),
   ]);
@@ -249,7 +231,6 @@ test('execute a TypeScript file with CommonJS syntax requiring .cts using common
 test('execute a TypeScript file with CommonJS syntax requiring .mts with require-module',
      async () => {
        const result = await spawnPromisified(process.execPath, [
-         '--experimental-strip-types',
          '--no-warnings',
          fixtures.path('typescript/ts/test-require-cts.ts'),
        ]);
@@ -261,7 +242,6 @@ test('execute a TypeScript file with CommonJS syntax requiring .mts with require
 
 test('execute a JavaScript file importing a cjs TypeScript file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/issue-54457.mjs'),
   ]);
@@ -277,7 +257,6 @@ test('execute a TypeScript test mocking module', { skip: isWindows && process.ar
   const result = await spawnPromisified(process.execPath, [
     '--test',
     '--experimental-test-module-mocks',
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-mock-module.ts'),
   ]);
@@ -287,13 +266,12 @@ test('execute a TypeScript test mocking module', { skip: isWindows && process.ar
   strictEqual(result.code, 0);
 });
 
-test('expect process.features.typescript to be false without type-stripping', async () => {
-  strictEqual(process.features.typescript, false);
+test('expect process.features.typescript to be strip', async () => {
+  strictEqual(process.features.typescript, 'strip');
 });
 
 test('execute a TypeScript file with union types', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     fixtures.path('typescript/ts/test-union-types.ts'),
   ]);
@@ -311,7 +289,6 @@ test('execute a TypeScript file with union types', async () => {
 
 test('expect error when executing a TypeScript file with generics', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     fixtures.path('typescript/ts/test-parameter-properties.ts'),
   ]);
 
@@ -326,7 +303,6 @@ test('expect error when executing a TypeScript file with generics', async () => 
 
 test('execute a TypeScript loader and a .ts file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     '--import',
     fixtures.fileURL('typescript/ts/test-loader.ts'),
@@ -339,7 +315,6 @@ test('execute a TypeScript loader and a .ts file', async () => {
 
 test('execute a TypeScript loader and a .js file', async () => {
   const result = await spawnPromisified(process.execPath, [
-    '--experimental-strip-types',
     '--no-warnings',
     '--import',
     fixtures.fileURL('typescript/ts/test-loader.ts'),

--- a/test/fixtures/eval/eval_messages.snapshot
+++ b/test/fixtures/eval/eval_messages.snapshot
@@ -2,11 +2,17 @@
 [eval]:1
 with(this){__filename}
 ^^^^
+  x The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
+   ,----
+ 1 | with(this){__filename}
+   : ^^^^
+   `----
+
+
+Caused by:
+    failed to parse
 
 SyntaxError: Strict mode code may not include a with statement
-
-
-
 
 
 

--- a/test/module-hooks/test-module-hooks-preload.js
+++ b/test/module-hooks/test-module-hooks-preload.js
@@ -16,7 +16,6 @@ spawnSyncAndAssert(process.execPath,
 
 spawnSyncAndAssert(process.execPath,
                    [
-                     '--experimental-strip-types',
                      '--no-experimental-transform-types',
                      '--require',
                      fixtures.path('module-hooks', 'register-typescript-hooks.js'),
@@ -38,7 +37,6 @@ spawnSyncAndAssert(process.execPath,
 
 spawnSyncAndAssert(process.execPath,
                    [
-                     '--experimental-strip-types',
                      '--no-experimental-transform-types',
                      '--import',
                      fixtures.fileURL('module-hooks', 'register-typescript-hooks.js'),

--- a/test/module-hooks/test-module-hooks-resolve-load-import-inline-typescript-override.mjs
+++ b/test/module-hooks/test-module-hooks-resolve-load-import-inline-typescript-override.mjs
@@ -1,4 +1,4 @@
-// Flags: --experimental-strip-types --no-experimental-transform-types
+// Flags: --no-experimental-transform-types
 // This tests that a mini TypeScript loader works with resolve and
 // load hooks when overriding --experimental-strip-types in ESM.
 import '../common/index.mjs';

--- a/test/module-hooks/test-module-hooks-resolve-load-require-inline-typescript-override.js
+++ b/test/module-hooks/test-module-hooks-resolve-load-require-inline-typescript-override.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --experimental-strip-types --no-experimental-transform-types
+// Flags: --no-experimental-transform-types
 // This tests that a mini TypeScript loader works with resolve and
 // load hooks when overriding --experimental-strip-types in CJS.
 

--- a/test/parallel/test-inspector-strip-types.js
+++ b/test/parallel/test-inspector-strip-types.js
@@ -12,7 +12,7 @@ const scriptPath = fixtures.path('typescript/ts/test-typescript.ts');
 
 async function runTest() {
   const child = new NodeInstance(
-    ['--inspect-brk=0', '--experimental-strip-types'],
+    ['--inspect-brk=0'],
     undefined,
     scriptPath);
 

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -46,6 +46,7 @@ for (const isolation of ['none', 'process']) {
   {
     // Should match files with "-test.(c|m)js" suffix.
     const args = ['--test', '--test-reporter=tap',
+                  `--no-experimental-strip-types`,
                   `--test-isolation=${isolation}`];
     const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'matching-patterns') });
 

--- a/test/parallel/test-runner-coverage-default-exclusion.mjs
+++ b/test/parallel/test-runner-coverage-default-exclusion.mjs
@@ -45,6 +45,7 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
       '--experimental-test-coverage',
       '--test-coverage-exclude=!test/**',
       '--test-reporter=tap',
+      '--no-experimental-strip-types',
     ];
     const result = spawnSync(process.execPath, args, {
       env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
@@ -70,6 +71,7 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
     ].join('\n');
 
     const args = [
+      '--no-experimental-strip-types',
       '--test',
       '--experimental-test-coverage',
       '--test-reporter=tap',
@@ -84,7 +86,7 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
     assert.strictEqual(result.status, 0);
   });
 
-  it('should exclude ts test files when using --experimental-strip-types', async () => {
+  it('should exclude ts test files', async () => {
     const report = [
       '# start of coverage report',
       '# --------------------------------------------------------------',
@@ -100,7 +102,6 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
     const args = [
       '--test',
       '--experimental-test-coverage',
-      '--experimental-strip-types',
       '--disable-warning=ExperimentalWarning',
       '--test-reporter=tap',
     ];

--- a/test/parallel/test-runner-coverage-source-map.js
+++ b/test/parallel/test-runner-coverage-source-map.js
@@ -25,6 +25,7 @@ const flags = [
   '--test-coverage-exclude=!test/**',
   '--test-reporter',
   'tap',
+  '--no-experimental-strip-types',
 ];
 
 describe('Coverage with source maps', async () => {


### PR DESCRIPTION
It's time to enable it by default to catch some more bugs, currently there are no open issues.
I think it's a semver minor change.

Fixes: https://github.com/nodejs/typescript/issues/17

@nodejs/tsc for visibility

Notable change section:

This change enables the flag `--experimental-strip-types` by default.
Node.js will be able to execute TypeScript files without additional configuration. Note that there are some limitations in the supported syntax documented at https://nodejs.org/api/typescript.html#type-stripping
This feature is experimental and is subject to change.