### PR TITLE
test: print test errors only when finished

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -52,7 +52,7 @@ class SpecReporter extends Transform {
       hasChildren = true;
     }
     const indentation = indent(data.nesting);
-    return `${formatTestReport(type, data, prefix, indentation, hasChildren)}\n`;
+    return `${formatTestReport(type, data, prefix, indentation, hasChildren, true)}\n`;
   }
   #handleEvent({ type, data }) {
     switch (type) {

--- a/lib/internal/test_runner/reporter/utils.js
+++ b/lib/internal/test_runner/reporter/utils.js
@@ -59,7 +59,7 @@ function formatError(error, indent) {
   return `\n${indent}  ${message}\n`;
 }
 
-function formatTestReport(type, data, prefix = '', indent = '', hasChildren = false) {
+function formatTestReport(type, data, prefix = '', indent = '', hasChildren = false, avoidError = false) {
   let color = reporterColorMap[type] ?? colors.white;
   let symbol = reporterUnicodeSymbolMap[type] ?? ' ';
   const { skip, todo } = data;
@@ -71,10 +71,13 @@ function formatTestReport(type, data, prefix = '', indent = '', hasChildren = fa
   } else if (todo !== undefined) {
     title += ` # ${typeof todo === 'string' && todo.length ? todo : 'TODO'}`;
   }
-  const error = formatError(data.details?.error, indent);
-  const err = hasChildren ?
-    (!error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`) :
-    error;
+  let err = "";
+  if (!avoidError) {
+    const error = formatError(data.details?.error, indent);
+    err = hasChildren ?
+      (!error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`) :
+      error;
+  }
   if (skip !== undefined) {
     color = colors.gray;
     symbol = reporterUnicodeSymbolMap['hyphen:minus'];


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/56316

TODO: Add/modify tests (will do later, just pushing this to validate that this is the way to go for changes like this).

I just added a flag to make a conditional output. Is this the usual way to go with NodeJS @pmarchini ? 

About the feature, I'm not sure if everyone will like it like this. Maybe add an opt-in flag to format the errors before the report has finished? (like it was before, but now is opt-in). Or maybe don't add a flag now, and maybe add the opt-in flag later if we receive complaints?