### PR TITLE
sqlite: allow passing conflict resolution handler function

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -251,7 +251,8 @@ added:
       `SQLITE_CHANGESET_DATA` or `SQLITE_CHANGESET_CONFLICT` conflicts).
     * `SQLITE_CHANGESET_ABORT`: Abort on conflict and roll back the database.
 
-    When an error is thrown in the conflict handler, applying the changeset is aborted and the database is rolled back.
+    When an error is thrown in the conflict handler or when any other value is returned from the handler,
+    applying the changeset is aborted and the database is rolled back.
 
     **Default**: A function that returns `SQLITE_CHANGESET_ABORT`.
 * Returns: {boolean} Whether the changeset was applied succesfully without being aborted.

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -514,7 +514,9 @@ The following constants are exported by the `sqlite.constants` object.
 
 #### Conflict resolution constants
 
-One of the following constants is available as an argument to the `onConflict` conflict resolution handler passed to [`database.applyChangeset()`](#databaseapplychangesetchangeset-options)). See also [Constants Passed To The Conflict Handler](https://www.sqlite.org/session/c_changeset_conflict.html) in the SQLite documentation.
+One of the following constants is available as an argument to the `onConflict`
+conflict resolution handler passed to [`database.applyChangeset()`][]. See also
+[Constants Passed To The Conflict Handler]() in the SQLite documentation.
 
 <table>
   <tr>
@@ -535,7 +537,7 @@ One of the following constants is available as an argument to the `onConflict` c
   </tr>
   <tr>
     <td><code>SQLITE_CHANGESET_CONSTRAINT</code></td>
-    <td>If foreign key handling is enabled, and applying a changeset leaves the database in a state containing foreign key violations, the conflict handler is invoked with this constant exactly once before the changeset is committed. If the conflict handler returns SQLITE_CHANGESET_OMIT, the changes, including those that caused the foreign key constraint violation, are committed. Or, if it returns SQLITE_CHANGESET_ABORT, the changeset is rolled back.</td>
+    <td>If foreign key handling is enabled, and applying a changeset leaves the database in a state containing foreign key violations, the conflict handler is invoked with this constant exactly once before the changeset is committed. If the conflict handler returns <code>SQLITE_CHANGESET_OMIT</code>, the changes, including those that caused the foreign key constraint violation, are committed. Or, if it returns <code>SQLITE_CHANGESET_ABORT</code>, the changeset is rolled back.</td>
   </tr>
   <tr>
     <td><code>SQLITE_CHANGESET_FOREIGN_KEY</code></td>
@@ -543,7 +545,9 @@ One of the following constants is available as an argument to the `onConflict` c
   </tr>
 </table>
 
-One of the following constants must be returned from the `onConflict` conflict resolution handler passed to [`database.applyChangeset()`](#databaseapplychangesetchangeset-options). See also [Constants Returned From The Conflict Handler](https://www.sqlite.org/session/c_changeset_abort.html) in the SQLite documentation.
+One of the following constants must be returned from the `onConflict` conflict
+resolution handler passed to [`database.applyChangeset()`][]. See also
+[Constants Returned From The Conflict Handler][] in the SQLite documentation.
 
 <table>
   <tr>
@@ -556,7 +560,7 @@ One of the following constants must be returned from the `onConflict` conflict r
   </tr>
   <tr>
     <td><code>SQLITE_CHANGESET_REPLACE</code></td>
-    <td>Conflicting changes replace existing values. Note that this value can only be returned when the type of conflict is either `SQLITE_CHANGESET_DATA` or `SQLITE_CHANGESET_CONFLICT`.</td>
+    <td>Conflicting changes replace existing values. Note that this value can only be returned when the type of conflict is either <code>SQLITE_CHANGESET_DATA</code> or <code>SQLITE_CHANGESET_CONFLICT</code>.</td>
   </tr>
   <tr>
     <td><code>SQLITE_CHANGESET_ABORT</code></td>
@@ -565,6 +569,9 @@ One of the following constants must be returned from the `onConflict` conflict r
 </table>
 
 [Changesets and Patchsets]: https://www.sqlite.org/sessionintro.html#changesets_and_patchsets
+[`database.applyChangeset()`]: #databaseapplychangesetchangeset-options
+[Constants Passed To The Conflict Handler]: https://www.sqlite.org/session/c_changeset_conflict.html
+[Constants Returned From The Conflict Handler]: https://www.sqlite.org/session/c_changeset_abort.html
 [SQL injection]: https://en.wikipedia.org/wiki/SQL_injection
 [`ATTACH DATABASE`]: https://www.sqlite.org/lang_attach.html
 [`PRAGMA foreign_keys`]: https://www.sqlite.org/pragma.html#pragma_foreign_keys

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -251,6 +251,8 @@ added:
       `SQLITE_CHANGESET_DATA` or `SQLITE_CHANGESET_CONFLICT` conflicts).
     * `SQLITE_CHANGESET_ABORT`: Abort on conflict and roll back the database.
 
+    When an error is thrown in the conflict handler, applying the changeset is aborted and the database is rolled back.
+
     **Default**: A function that returns `SQLITE_CHANGESET_ABORT`.
 * Returns: {boolean} Whether the changeset was applied succesfully without being aborted.
 

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -517,7 +517,7 @@ The following constants are exported by the `sqlite.constants` object.
 
 One of the following constants is available as an argument to the `onConflict`
 conflict resolution handler passed to [`database.applyChangeset()`][]. See also
-[Constants Passed To The Conflict Handler]() in the SQLite documentation.
+[Constants Passed To The Conflict Handler][] in the SQLite documentation.
 
 <table>
   <tr>
@@ -570,7 +570,6 @@ resolution handler passed to [`database.applyChangeset()`][]. See also
 </table>
 
 [Changesets and Patchsets]: https://www.sqlite.org/sessionintro.html#changesets_and_patchsets
-[`database.applyChangeset()`]: #databaseapplychangesetchangeset-options
 [Constants Passed To The Conflict Handler]: https://www.sqlite.org/session/c_changeset_conflict.html
 [Constants Returned From The Conflict Handler]: https://www.sqlite.org/session/c_changeset_abort.html
 [SQL injection]: https://en.wikipedia.org/wiki/SQL_injection
@@ -578,6 +577,7 @@ resolution handler passed to [`database.applyChangeset()`][]. See also
 [`PRAGMA foreign_keys`]: https://www.sqlite.org/pragma.html#pragma_foreign_keys
 [`SQLITE_DETERMINISTIC`]: https://www.sqlite.org/c3ref/c_deterministic.html
 [`SQLITE_DIRECTONLY`]: https://www.sqlite.org/c3ref/c_deterministic.html
+[`database.applyChangeset()`]: #databaseapplychangesetchangeset-options
 [`sqlite3_changes64()`]: https://www.sqlite.org/c3ref/changes.html
 [`sqlite3_close_v2()`]: https://www.sqlite.org/c3ref/close.html
 [`sqlite3_create_function_v2()`]: https://www.sqlite.org/c3ref/create_function.html

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -144,10 +144,13 @@
   V(entry_type_string, "entryType")                                            \
   V(env_pairs_string, "envPairs")                                              \
   V(env_var_settings_string, "envVarSettings")                                 \
+  V(err_sqlite_error_string, "ERR_SQLITE_ERROR")                               \
+  V(errcode_string, "errcode")                                                 \
   V(errno_string, "errno")                                                     \
   V(error_string, "error")                                                     \
-  V(events, "events")                                                          \
+  V(errstr_string, "errstr")                                                   \
   V(events_waiting, "eventsWaiting")                                           \
+  V(events, "events")                                                          \
   V(exchange_string, "exchange")                                               \
   V(expire_string, "expire")                                                   \
   V(exponent_string, "exponent")                                               \

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -94,9 +94,7 @@ inline MaybeLocal<Object> CreateSQLiteError(Isolate* isolate, sqlite3* db) {
              env->errcode_string(),
              Integer::New(isolate, errcode))
           .IsNothing() ||
-      e->Set(isolate->GetCurrentContext(),
-             env->errstr_string(),
-             js_errmsg)
+      e->Set(isolate->GetCurrentContext(), env->errstr_string(), js_errmsg)
           .IsNothing()) {
     return MaybeLocal<Object>();
   }
@@ -122,9 +120,10 @@ inline void THROW_ERR_SQLITE_ERROR(Isolate* isolate, int errcode) {
 
   Environment* env = Environment::GetCurrent(isolate);
   auto error = CreateSQLiteError(isolate, errstr).ToLocalChecked();
-  error->Set(isolate->GetCurrentContext(),
-          env->errcode_string(),
-          Integer::New(isolate, errcode))
+  error
+      ->Set(isolate->GetCurrentContext(),
+            env->errcode_string(),
+            Integer::New(isolate, errcode))
       .ToChecked();
   isolate->ThrowException(error);
 }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -9,7 +9,6 @@
 #include "node_mem-inl.h"
 #include "sqlite3.h"
 #include "util-inl.h"
-#include "v8-exception.h"
 
 #include <cinttypes>
 

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -73,7 +73,7 @@ inline MaybeLocal<Object> CreateSQLiteError(Isolate* isolate,
            ->ToObject(isolate->GetCurrentContext())
            .ToLocal(&e) ||
       e->Set(isolate->GetCurrentContext(),
-             env->error_string(),
+             env->code_string(),
              env->err_sqlite_error_string())
           .IsNothing()) {
     return MaybeLocal<Object>();

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -805,6 +805,8 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
           try_catch.ReThrow();
           return SQLITE_CHANGESET_ABORT;
         }
+        constexpr auto invalid_value = -1;
+        if (!result->IsInt32()) return invalid_value;
         return result->Int32Value(env->context()).FromJust();
       };
     }

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -324,21 +324,24 @@ suite('conflict resolution', () => {
   });
 
   test('conflict resolution handler returns invalid value', (t) => {
-    const invalidValues = [-1, {}, null];
+    const invalidHandlers = [
+      () => -1,
+      () => ({}),
+      () => null,
+      async () => constants.SQLITE_CHANGESET_ABORT
+    ];
 
-    for (const invalidValue of invalidValues) {
+    for (const invalidHandler of invalidHandlers) {
       const { database2, changeset } = prepareConflict();
       t.assert.throws(() => {
         database2.applyChangeset(changeset, {
-          onConflict: () => {
-            return invalidValue;
-          }
+          onConflict: invalidHandler
         });
       }, {
         name: 'Error',
         message: 'bad parameter or other API misuse',
         errcode: 21
-      }, `Did not throw expected exception when returning '${invalidValue}' from conflict handler`);
+      }, `Did not throw expected exception when returning '${invalidHandler}' from conflict handler`);
     }
   });
 

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -323,7 +323,7 @@ suite('conflict resolution', () => {
     deepStrictEqual(t)(database2.prepare('SELECT key, value from data').all(), [{ key: 2, value: 'hello' }]);
   });
 
-  test("conflict resolution handler returns invalid value", (t) => {
+  test('conflict resolution handler returns invalid value', (t) => {
     const { database2, changeset } = prepareConflict();
     t.assert.throws(() => {
       database2.applyChangeset(changeset, {
@@ -334,6 +334,20 @@ suite('conflict resolution', () => {
     }, {
       name: 'Error',
       message: 'bad parameter or other API misuse'
+    });
+  });
+
+  test('conflict resolution handler throws', (t) => {
+    const { database2, changeset } = prepareConflict();
+    t.assert.throws(() => {
+      database2.applyChangeset(changeset, {
+        onConflict: () => {
+          throw new Error('some error');
+        }
+      });
+    }, {
+      name: 'Error',
+      message: 'some error'
     });
   });
 });

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -328,7 +328,7 @@ suite('conflict resolution', () => {
       () => -1,
       () => ({}),
       () => null,
-      async () => constants.SQLITE_CHANGESET_ABORT
+      async () => constants.SQLITE_CHANGESET_ABORT,
     ];
 
     for (const invalidHandler of invalidHandlers) {
@@ -340,7 +340,8 @@ suite('conflict resolution', () => {
       }, {
         name: 'Error',
         message: 'bad parameter or other API misuse',
-        errcode: 21
+        errcode: 21,
+        code: 'ERR_SQLITE_ERROR'
       }, `Did not throw expected exception when returning '${invalidHandler}' from conflict handler`);
     }
   });

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -128,15 +128,15 @@ test('database.createSession() - use table option to track specific table', (t) 
 });
 
 suite('conflict resolution', () => {
+  const createDataTableSql = `CREATE TABLE data (
+      key INTEGER PRIMARY KEY,
+      value TEXT UNIQUE
+    ) STRICT`;
+
   const prepareConflict = () => {
     const database1 = new DatabaseSync(':memory:');
     const database2 = new DatabaseSync(':memory:');
 
-    const createDataTableSql = `CREATE TABLE data (
-        key INTEGER PRIMARY KEY,
-        value TEXT
-      ) STRICT
-      `;
     database1.exec(createDataTableSql);
     database2.exec(createDataTableSql);
 
@@ -151,7 +151,91 @@ suite('conflict resolution', () => {
     };
   };
 
-  test('database.applyChangeset() - conflict with default behavior (abort)', (t) => {
+  const prepareDataConflict = () => {
+    const database1 = new DatabaseSync(':memory:');
+    const database2 = new DatabaseSync(':memory:');
+
+    database1.exec(createDataTableSql);
+    database2.exec(createDataTableSql);
+
+    const insertSql = 'INSERT INTO data (key, value) VALUES (?, ?)';
+    database1.prepare(insertSql).run(1, 'hello');
+    database2.prepare(insertSql).run(1, 'othervalue');
+    const session = database1.createSession();
+    database1.prepare('UPDATE data SET value = ? WHERE key = ?').run('foo', 1);
+    return {
+      database2,
+      changeset: session.changeset()
+    };
+  };
+
+  const prepareNotFoundConflict = () => {
+    const database1 = new DatabaseSync(':memory:');
+    const database2 = new DatabaseSync(':memory:');
+
+    database1.exec(createDataTableSql);
+    database2.exec(createDataTableSql);
+
+    const insertSql = 'INSERT INTO data (key, value) VALUES (?, ?)';
+    database1.prepare(insertSql).run(1, 'hello');
+    const session = database1.createSession();
+    database1.prepare('DELETE FROM data WHERE key = 1').run();
+    return {
+      database2,
+      changeset: session.changeset()
+    };
+  };
+
+  const prepareFkConflict = () => {
+    const database1 = new DatabaseSync(':memory:');
+    const database2 = new DatabaseSync(':memory:');
+
+    database1.exec(createDataTableSql);
+    database2.exec(createDataTableSql);
+    const fkTableSql = `CREATE TABLE other (
+      key INTEGER PRIMARY KEY,
+      ref REFERENCES data(key)
+    )`;
+    database1.exec(fkTableSql);
+    database2.exec(fkTableSql);
+
+    const insertDataSql = 'INSERT INTO data (key, value) VALUES (?, ?)';
+    const insertOtherSql = 'INSERT INTO other (key, ref) VALUES (?, ?)';
+    database1.prepare(insertDataSql).run(1, 'hello');
+    database2.prepare(insertDataSql).run(1, 'hello');
+    database1.prepare(insertOtherSql).run(1, 1);
+    database2.prepare(insertOtherSql).run(1, 1);
+
+    database1.exec('DELETE FROM other WHERE key = 1');  // So we don't get a fk violation in database1
+    const session = database1.createSession();
+    database1.prepare('DELETE FROM data WHERE key = 1').run(); // Changeset with fk violation
+    database2.exec('PRAGMA foreign_keys = ON');  // Needs to be supported, otherwise will fail here
+
+    return {
+      database2,
+      changeset: session.changeset()
+    };
+  };
+
+  const prepareConstraintConflict = () => {
+    const database1 = new DatabaseSync(':memory:');
+    const database2 = new DatabaseSync(':memory:');
+
+    database1.exec(createDataTableSql);
+    database2.exec(createDataTableSql);
+
+    const insertSql = 'INSERT INTO data (key, value) VALUES (?, ?)';
+    const session = database1.createSession();
+    database1.prepare(insertSql).run(1, 'hello');
+    database2.prepare(insertSql).run(2, 'hello');  // database2 already constains hello
+
+    return {
+      database2,
+      changeset: session.changeset()
+    };
+  };
+
+  test('database.applyChangeset() - SQLITE_CHANGESET_CONFLICT conflict with default behavior (abort)', (t) => {
     const { database2, changeset } = prepareConflict();
     // When changeset is aborted due to a conflict, applyChangeset should return false
     t.assert.strictEqual(database2.applyChangeset(changeset), false);
@@ -160,40 +244,83 @@ suite('conflict resolution', () => {
       [{ value: 'world' }]);  // unchanged
   });
 
-  test('database.applyChangeset() - conflict with SQLITE_CHANGESET_ABORT', (t) => {
+  test('database.applyChangeset() - SQLITE_CHANGESET_CONFLICT conflict handled with SQLITE_CHANGESET_ABORT', (t) => {
     const { database2, changeset } = prepareConflict();
+    let conflictType = null;
     const result = database2.applyChangeset(changeset, {
-      onConflict: constants.SQLITE_CHANGESET_ABORT
+      onConflict: (conflictType_) => {
+        conflictType = conflictType_;
+        return constants.SQLITE_CHANGESET_ABORT;
+      }
     });
     // When changeset is aborted due to a conflict, applyChangeset should return false
     t.assert.strictEqual(result, false);
+    t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_CONFLICT);
     deepStrictEqual(t)(
       database2.prepare('SELECT value from data').all(),
       [{ value: 'world' }]);  // unchanged
   });
 
-  test('database.applyChangeset() - conflict with SQLITE_CHANGESET_REPLACE', (t) => {
-    const { database2, changeset } = prepareConflict();
+  test('database.applyChangeset() - SQLITE_CHANGESET_DATA conflict handled with SQLITE_CHANGESET_REPLACE', (t) => {
+    const { database2, changeset } = prepareDataConflict();
+    let conflictType = null;
     const result = database2.applyChangeset(changeset, {
-      onConflict: constants.SQLITE_CHANGESET_REPLACE
+      onConflict: (conflictType_) => {
+        conflictType = conflictType_;
+        return constants.SQLITE_CHANGESET_REPLACE;
+      }
     });
     // Not aborted due to conflict, so should return true
     t.assert.strictEqual(result, true);
+    t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_DATA);
     deepStrictEqual(t)(
       database2.prepare('SELECT value from data ORDER BY key').all(),
-      [{ value: 'hello' }, { value: 'foo' }]);  // replaced
+      [{ value: 'foo' }]);  // replaced
   });
 
-  test('database.applyChangeset() - conflict with SQLITE_CHANGESET_OMIT', (t) => {
-    const { database2, changeset } = prepareConflict();
+  test('database.applyChangeset() - SQLITE_CHANGESET_NOTFOUND conflict with SQLITE_CHANGESET_OMIT', (t) => {
+    const { database2, changeset } = prepareNotFoundConflict();
+    let conflictType = null;
     const result = database2.applyChangeset(changeset, {
-      onConflict: constants.SQLITE_CHANGESET_OMIT
+      onConflict: (conflictType_) => {
+        conflictType = conflictType_;
+        return constants.SQLITE_CHANGESET_OMIT;
+      }
     });
     // Not aborted due to conflict, so should return true
     t.assert.strictEqual(result, true);
-    deepStrictEqual(t)(
-      database2.prepare('SELECT value from data ORDER BY key ASC').all(),
-      [{ value: 'world' }, { value: 'foo' }]);  // Conflicting change omitted
+    t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_NOTFOUND);
+    deepStrictEqual(t)(database2.prepare('SELECT value from data').all(), []);
+  });
+
+  test('database.applyChangeset() - SQLITE_CHANGESET_FOREIGN_KEY conflict', (t) => {
+    const { database2, changeset } = prepareFkConflict();
+    let conflictType = null;
+    const result = database2.applyChangeset(changeset, {
+      onConflict: (conflictType_) => {
+        conflictType = conflictType_;
+        return constants.SQLITE_CHANGESET_OMIT;
+      }
+    });
+    // Not aborted due to conflict, so should return true
+    t.assert.strictEqual(result, true);
+    t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_FOREIGN_KEY);
+    deepStrictEqual(t)(database2.prepare('SELECT value from data').all(), []);
+  });
+
+  test('database.applyChangeset() - SQLITE_CHANGESET_CONSTRAINT conflict', (t) => {
+    const { database2, changeset } = prepareConstraintConflict();
+    let conflictType = null;
+    const result = database2.applyChangeset(changeset, {
+      onConflict: (conflictType_) => {
+        conflictType = conflictType_;
+        return constants.SQLITE_CHANGESET_OMIT;
+      }
+    });
+    // Not aborted due to conflict, so should return true
+    t.assert.strictEqual(result, true);
+    t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_CONSTRAINT);
+    deepStrictEqual(t)(database2.prepare('SELECT key, value from data').all(), [{ key: 2, value: 'hello' }]);
   });
 });
 
@@ -299,7 +426,7 @@ test('database.applyChangeset() - wrong arguments', (t) => {
     }, null);
   }, {
     name: 'TypeError',
-    message: 'The "options.onConflict" argument must be a number.'
+    message: 'The "options.onConflict" argument must be a function.'
   });
 });
 

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -324,17 +324,22 @@ suite('conflict resolution', () => {
   });
 
   test('conflict resolution handler returns invalid value', (t) => {
-    const { database2, changeset } = prepareConflict();
-    t.assert.throws(() => {
-      database2.applyChangeset(changeset, {
-        onConflict: () => {
-          return -1;
-        }
-      });
-    }, {
-      name: 'Error',
-      message: 'bad parameter or other API misuse'
-    });
+    const invalidValues = [-1, {}, null];
+
+    for (const invalidValue of invalidValues) {
+      const { database2, changeset } = prepareConflict();
+      t.assert.throws(() => {
+        database2.applyChangeset(changeset, {
+          onConflict: () => {
+            return invalidValue;
+          }
+        });
+      }, {
+        name: 'Error',
+        message: 'bad parameter or other API misuse',
+        errcode: 21
+      }, `Did not throw expected exception when returning '${invalidValue}' from conflict handler`);
+    }
   });
 
   test('conflict resolution handler throws', (t) => {

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -322,6 +322,20 @@ suite('conflict resolution', () => {
     t.assert.strictEqual(conflictType, constants.SQLITE_CHANGESET_CONSTRAINT);
     deepStrictEqual(t)(database2.prepare('SELECT key, value from data').all(), [{ key: 2, value: 'hello' }]);
   });
+
+  test("conflict resolution handler returns invalid value", (t) => {
+    const { database2, changeset } = prepareConflict();
+    t.assert.throws(() => {
+      database2.applyChangeset(changeset, {
+        onConflict: () => {
+          return -1;
+        }
+      });
+    }, {
+      name: 'Error',
+      message: 'bad parameter or other API misuse'
+    });
+  });
 });
 
 test('database.createSession() - filter changes', (t) => {

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -342,7 +342,7 @@ suite('conflict resolution', () => {
         message: 'bad parameter or other API misuse',
         errcode: 21,
         code: 'ERR_SQLITE_ERROR'
-      }, `Did not throw expected exception when returning '${invalidHandler}' from conflict handler`);
+      }, `Did not throw expected exception when using invalid onConflict handler: ${invalidHandler}`);
     }
   });
 


### PR DESCRIPTION
Resolves #56210 by allowing to pass a conflict resolution handler that returns a conflict resolution type instead of just a conflict resolution type.

As @Renegade334 points out in that issue, it does not make sense to pass `SQLITE_CHANGESET_REPLACE` because this conflict resolution type is only valid for certain conflict types. Therefore an API where the conflict-resolution handler receives the conflict type makes sense, so the user can return a valid conflict resolution type for a particular conflict type.

An API where an individual (conflicting) change can be inspected ([as is possible with the SQLite C conflict handler](https://www.sqlite.org/session/sqlite3changeset_apply.html)) would be a good follow-up. This would then be added as a second argument to the conflict handler.

Note that this is a breaking change, but since the SQLite module is experimental I don't think that is an issue.

Note: some of the documentation I added comes pretty much verbatim from the SQLite Documentation, but this is not an issue because the SQLite documentation is dedicated to the [public domain](https://www.sqlite.org/copyright.html). Also I linked to the SQLite documentation.