### PR TITLE
Fixes for building when the path to the repo contains spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ V ?= 0
 
 # Use -e to double check in case it's a broken link
 available-node = \
-	if [ -x "$(NODE)" ] && [ -e "$(NODE)" ]; then \
-		"$(NODE)" $(1); \
+	if [ -x $(NODE) ] && [ -e $(NODE) ]; then \
+		$(NODE) $(1); \
 	elif [ -x `command -v node` ] && [ -e `command -v node` ] && [ `command -v node` ]; then \
 		`command -v node` $(1); \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -788,7 +788,7 @@ out/doc/api/assets/%: doc/api_assets/% | out/doc/api/assets
 	@cp $< $@ ; $(RM) out/doc/api/assets/README.md
 
 
-run-npm-ci = $(PWD)/$(NPM) ci
+run-npm-ci = "$(PWD)/$(NPM)" ci
 
 LINK_DATA = out/doc/apilinks.json
 VERSIONS_DATA = out/previous-doc-versions.json


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

[The “Building Node.js” guide says:](https://github.com/nodejs/node/blob/67b647edc72f56ac5e554160116f7fcbf6b32b5e/BUILDING.md#building-nodejs-1)

> If the path to your build directory contains a space, the build will likely
> fail.

This pull request contains a few fixes that are directed at that problem. I still haven’t been able to successfully build and test Node.js while it’s stored in a path that contains spaces, but the changes in this pull request have gotten me closer to being able to do that.

Unfortunately, in order to test one of the commits in this pull request, a vendored dependency of a vendored dependency of a vendored dependency needs to be patched. I’m going to mark this pull request as a draft until the following has happened:

- [x] [I have submitted a nodejs/gyp-next pull request with the required changes.](https://github.com/nodejs/gyp-next/pull/280)
- [ ] That pull request gets merged.
- [ ] There’s a new release of [nodejs/gyp-next](https://github.com/nodejs/gyp-next) that contains the changes from that pull request.
- [ ] Someone submits a [nodejs/node-gyp](https://github.com/nodejs/node-gyp) pull request that updates nodejs/node-gyp’s version of nodejs/gyp-next.
- [ ] That pull request gets merged.
- [ ] There’s a new release of nodejs/node-gyp that contains the new version of nodejs/gyp-next.
- [ ] Someone submits an [npm/cli](https://github.com/npm/cli) pull request that updates npm/cli’s version of nodejs/node-gyp.
- [ ] That pull request gets merged.
- [ ] There’s a new release of npm/cli that contains the new version of nodejs/node-gyp.
- [ ] Someone submits a [nodejs/node](https://github.com/nodejs/node) pull request that updates nodejs/node’s version of npm/cli.
- [ ] That pull request gets merged.
- [ ] I rebase this current pull request on nodejs/node’s main branch.
- [ ] I add testing instructions to this current pull request.