### PR TITLE
src: drain platform tasks before taking startup snapshot

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -992,10 +992,6 @@ ExitCode BuildSnapshotWithoutCodeCache(
     // example, a WeakRef may schedule an per-isolate platform task as a GC
     // root, and referencing an object in a context, causing an assertion in
     // the snapshot creator.
-
-    // FIXME(joyeecheung): right now running the loop in the snapshot
-    // builder might introduce inconsistencies in JS land that need to
-    // be synchronized again after snapshot restoration.
     ExitCode exit_code =
         SpinEventLoopInternal(env).FromMaybe(ExitCode::kGenericUserError);
     if (exit_code != ExitCode::kNoFailure) {

--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -973,25 +973,33 @@ ExitCode BuildSnapshotWithoutCodeCache(
       }
     });
 
+    Context::Scope context_scope(setup->context());
+    Environment* env = setup->env();
+
     // Run the custom main script for fully customized snapshots.
     if (snapshot_type == SnapshotMetadata::Type::kFullyCustomized) {
-      Context::Scope context_scope(setup->context());
-      Environment* env = setup->env();
 #if HAVE_INSPECTOR
         env->InitializeInspector({});
 #endif
         if (LoadEnvironment(env, builder_script_content.value()).IsEmpty()) {
           return ExitCode::kGenericUserError;
         }
+    }
 
-        // FIXME(joyeecheung): right now running the loop in the snapshot
-        // builder might introduce inconsistencies in JS land that need to
-        // be synchronized again after snapshot restoration.
-        ExitCode exit_code =
-            SpinEventLoopInternal(env).FromMaybe(ExitCode::kGenericUserError);
-        if (exit_code != ExitCode::kNoFailure) {
-          return exit_code;
-        }
+    // Drain the loop and platform tasks before creating a snapshot. This is
+    // necessary to ensure that the no roots are held by the the platform
+    // tasks, which may reference objects associated with a context. For
+    // example, a WeakRef may schedule an per-isolate platform task as a GC
+    // root, and referencing an object in a context, causing an assertion in
+    // the snapshot creator.
+
+    // FIXME(joyeecheung): right now running the loop in the snapshot
+    // builder might introduce inconsistencies in JS land that need to
+    // be synchronized again after snapshot restoration.
+    ExitCode exit_code =
+        SpinEventLoopInternal(env).FromMaybe(ExitCode::kGenericUserError);
+    if (exit_code != ExitCode::kNoFailure) {
+      return exit_code;
     }
   }
 


### PR DESCRIPTION
Drain the loop and platform tasks before creating a snapshot. This is
necessary to ensure that the no roots are held by the the platform
tasks, which may reference objects associated with a context. For
example, a WeakRef may schedule an per-isolate platform task as a GC
root, and referencing an object in a context, causing an assertion in
the snapshot creator that objects must be serialized with a context.

Refs: https://github.com/nodejs/node/pull/56292