### PR TITLE
doc: add example for piping ReadableStream

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -436,6 +436,39 @@ async function* asyncIterableGenerator() {
 })();
 ```
 
+To pipe the resulting {ReadableStream} into a {WritableStream} the {Iterable}
+should yield a sequence of {Buffer}, {TypedArray}, or {DataView} objects.
+
+```mjs
+import { ReadableStream } from 'node:stream/web';
+import { Buffer } from 'node:buffer';
+
+async function* asyncIterableGenerator() {
+  yield Buffer.from('a');
+  yield Buffer.from('b');
+  yield Buffer.from('c');
+}
+
+const stream = ReadableStream.from(asyncIterableGenerator());
+
+stream.pipeTo(createWritableStreamSomehow());
+```
+
+```cjs
+const { ReadableStream } = require('node:stream/web');
+const { Buffer } = require('node:buffer');
+
+async function* asyncIterableGenerator() {
+  yield Buffer.from('a');
+  yield Buffer.from('b');
+  yield Buffer.from('c');
+}
+
+const stream = ReadableStream.from(asyncIterableGenerator());
+
+stream.pipeTo(createWritableStreamSomehow());
+```
+
 ### Class: `ReadableStreamDefaultReader`
 
 <!-- YAML

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -451,7 +451,7 @@ async function* asyncIterableGenerator() {
 
 const stream = ReadableStream.from(asyncIterableGenerator());
 
-stream.pipeTo(createWritableStreamSomehow());
+await stream.pipeTo(createWritableStreamSomehow());
 ```
 
 ```cjs
@@ -466,7 +466,9 @@ async function* asyncIterableGenerator() {
 
 const stream = ReadableStream.from(asyncIterableGenerator());
 
-stream.pipeTo(createWritableStreamSomehow());
+(async () => {
+  await stream.pipeTo(createWritableStreamSomehow());
+})();
 ```
 
 ### Class: `ReadableStreamDefaultReader`


### PR DESCRIPTION
When piping a `ReadableStream` created from an `Iterable` into a `WritableStream`, the sequence of objects in the `Iterable` must consist of either `Buffer`s, `TypedArray`s, or `DataView`s.

Re: https://github.com/nodejs/node/issues/56297

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
