### PR TITLE
src,lib: use uv_thread_setname to a better multi-thread debugging

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1229,9 +1229,16 @@ changes:
       used for generated code.
     * `stackSizeMb` {number} The default maximum stack size for the thread.
       Small values may lead to unusable Worker instances. **Default:** `4`.
-  * `name` {string} An optional `name` to be appended to the worker title
-    for debugging/identification purposes, making the final title as
-    `[worker ${id}] ${name}`. **Default:** `''`.
+  * `name` {string} An optional `name` to be replaced in the thread name
+    and to the worker title for debugging/identification purposes,
+    making the final title as `[worker ${id}] ${name}`.
+    This parameter has a maximum allowed size, depending on the operating
+    system. If the provided name exceeds the limit, it will be truncated
+    * Maximum sizes:
+      * Windows: 32,767 characters
+      * macOS: 64 characters
+      * Other systems: 16 characters
+        **Default:** `'WorkerThread'`.
 
 ### Event: `'error'`
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1237,7 +1237,9 @@ changes:
     * Maximum sizes:
       * Windows: 32,767 characters
       * macOS: 64 characters
-      * Other systems: 16 characters
+      * Linux: 16 characters
+      * NetBSD: limited to `PTHREAD_MAX_NAMELEN_NP`
+      * FreeBSD and OpenBSD: limited to `MAXCOMLEN`
         **Default:** `'WorkerThread'`.
 
 ### Event: `'error'`

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -204,7 +204,7 @@ class Worker extends EventEmitter {
         options.env);
     }
 
-    let name = '';
+    let name = 'WorkerThread';
     if (options.name) {
       validateString(options.name, 'options.name');
       name = StringPrototypeTrim(options.name);

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -86,6 +86,7 @@ static void StartIoThreadWakeup(int signo, siginfo_t* info, void* ucontext) {
 }
 
 inline void* StartIoThreadMain(void* unused) {
+  uv_thread_setname("SignalInspector");
   for (;;) {
     uv_sem_wait(&start_io_thread_semaphore);
     Mutex::ScopedLock lock(start_io_thread_async_mutex);

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -283,6 +283,11 @@ void InspectorIo::ThreadMain(void* io) {
 }
 
 void InspectorIo::ThreadMain() {
+  int thread_name_error = uv_thread_setname("InspectorIo");
+  if (!thread_name_error) [[unlikely]] {
+    per_process::Debug(node::DebugCategory::INSPECTOR_SERVER,
+        "Failed to set thread name for Inspector\n");
+  }
   uv_loop_t loop;
   loop.data = nullptr;
   int err = uv_loop_init(&loop);

--- a/src/inspector_io.cc
+++ b/src/inspector_io.cc
@@ -286,7 +286,7 @@ void InspectorIo::ThreadMain() {
   int thread_name_error = uv_thread_setname("InspectorIo");
   if (!thread_name_error) [[unlikely]] {
     per_process::Debug(node::DebugCategory::INSPECTOR_SERVER,
-        "Failed to set thread name for Inspector\n");
+                       "Failed to set thread name for Inspector\n");
   }
   uv_loop_t loop;
   loop.data = nullptr;

--- a/src/node.cc
+++ b/src/node.cc
@@ -1165,6 +1165,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
   }
 
   if (!(flags & ProcessInitializationFlags::kNoInitializeNodeV8Platform)) {
+    uv_thread_setname("MainThread");
     per_process::v8_platform.Initialize(
         static_cast<int>(per_process::cli_options->v8_thread_pool_size));
     result->platform_ = per_process::v8_platform.Platform();

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -25,6 +25,7 @@ struct PlatformWorkerData {
 };
 
 static void PlatformWorkerThread(void* data) {
+  uv_thread_setname("V8Worker");
   std::unique_ptr<PlatformWorkerData>
       worker_data(static_cast<PlatformWorkerData*>(data));
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -740,6 +740,7 @@ void Worker::StartThread(const FunctionCallbackInfo<Value>& args) {
     Worker* w = static_cast<Worker*>(arg);
     const uintptr_t stack_top = reinterpret_cast<uintptr_t>(&arg);
 
+    uv_thread_setname(w->name_.c_str());
     // Leave a few kilobytes just to make sure we're within limits and have
     // some space to do work in C++ land.
     w->stack_base_ = stack_top - (w->stack_size_ - kStackBufferSize);

--- a/test/addons/uv-thread-name/binding.cc
+++ b/test/addons/uv-thread-name/binding.cc
@@ -1,0 +1,29 @@
+#include <node.h>
+#include <uv.h>
+#include <v8.h>
+
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::String;
+using v8::Value;
+
+void GetThreadName(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  uv_thread_t thread;
+  char thread_name[16];
+#ifdef _WIN32
+  /* uv_thread_self isn't defined for the main thread on Windows. */
+  thread = GetCurrentThread();
+#else
+  thread = uv_thread_self();
+#endif
+  uv_thread_getname(&thread, thread_name, sizeof(thread_name));
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(isolate, thread_name).ToLocalChecked());
+}
+
+void init(v8::Local<v8::Object> exports) {
+  NODE_SET_METHOD(exports, "getThreadName", GetThreadName);
+}
+
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, init)

--- a/test/addons/uv-thread-name/binding.gyp
+++ b/test/addons/uv-thread-name/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/uv-thread-name/test.js
+++ b/test/addons/uv-thread-name/test.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../../common');
+
+if (common.isAIX) {
+  common.skip('AIX is not supported by libuv');
+}
+
+const assert = require('node:assert');
+const { parentPort, Worker, isMainThread } = require('node:worker_threads');
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
+
+if (isMainThread) {
+  assert.strictEqual(binding.getThreadName(), 'MainThread');
+
+  const worker = new Worker(__filename);
+  worker.on('message', common.mustCall((data) => {
+    assert.strictEqual(data, 'WorkerThread');
+  }));
+  worker.on('error', common.mustNotCall());
+  worker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+
+  const namedWorker = new Worker(__filename, { name: 'NamedThread' });
+  namedWorker.on('message', common.mustCall((data) => {
+    assert.strictEqual(data, 'NamedThread');
+  }));
+  namedWorker.on('error', common.mustNotCall());
+  namedWorker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+} else {
+  parentPort.postMessage(binding.getThreadName());
+}

--- a/test/parallel/test-trace-events-worker-metadata.js
+++ b/test/parallel/test-trace-events-worker-metadata.js
@@ -23,7 +23,7 @@ if (isMainThread) {
       assert(traces.length > 0);
       assert(traces.some((trace) =>
         trace.cat === '__metadata' && trace.name === 'thread_name' &&
-          trace.args.name === '[worker 1]'));
+          trace.args.name === '[worker 1] WorkerThread'));
     }));
   }));
 } else {


### PR DESCRIPTION
Note: This PR depends https://github.com/libuv/libuv/pull/4599 to be released by libuv team.

TODO:

- [x] Work on tests

* ~I'm also patching uv to set the default thread name, but it's up to them to accept it, I don't know if there's a way from Node.js to access their thread or call an API to change their default thread name~ Done in https://github.com/libuv/libuv/pull/4664
* A default thread name for the inspector thread has been added
* A default thread nathe me for signal inspector has been added
* A default thread name for each one of the Node Platform Workers has been added
* I'm using `worker.name` to set the thread name when a worker thread gets created (it defaults to `WorkerThread`). 

cc: @santigimeno 

---

With this PR users will be able to get a more meaningful diagnostic when looking at Node.js threads, for instance, they will be able to see on which thread their app is spending more time (libuv, workers, main thread...). See the image:

Consider the following server (please do not run it in production):

```cjs
const http = require('http')
const fs = require('node:fs')
const { Worker, isMainThread } = require('node:worker_threads')

if (!isMainThread) {
  console.log('Done :)')
  setTimeout(() => {
    process.exit(0);
  }, 5 * 1000);
  return;
}

let i = 0;
http.createServer((req, res) => {
  fs.readFile(__filename, () => {
    res.end('hello')
  })
  new Worker(__filename, { name: `RafaelGSS (${++i})` });
}).listen(3000)
```

On Node.js startup if you monitor using `htop` you should be able to see:

![image](https://github.com/user-attachments/assets/e2343986-bb7d-40a0-a624-1ea9b7d0bd16)

Then once it gets a request:

![image](https://github.com/user-attachments/assets/729a6935-d5ba-4704-bd73-9e64af19270d)

> `V8Worker` and `libuv` threads number depends on the parameters & environments


