### PR TITLE
src: use v8::LocalVector consistently with other minor cleanups

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -59,6 +59,7 @@ namespace cares_wrap {
 using v8::Array;
 using v8::Context;
 using v8::EscapableHandleScope;
+using v8::Exception;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
@@ -68,6 +69,7 @@ using v8::Isolate;
 using v8::Just;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::Nothing;
 using v8::Null;
@@ -159,7 +161,7 @@ void ares_sockstate_cb(void* data, ares_socket_t sock, int read, int write) {
 Local<Array> HostentToNames(Environment* env, struct hostent* host) {
   EscapableHandleScope scope(env->isolate());
 
-  std::vector<Local<Value>> names;
+  LocalVector<Value> names(env->isolate());
 
   for (uint32_t i = 0; host->h_aliases[i] != nullptr; ++i)
     names.emplace_back(OneByteString(env->isolate(), host->h_aliases[i]));
@@ -1577,7 +1579,7 @@ void ConvertIpv6StringToBuffer(const FunctionCallbackInfo<Value>& args) {
   unsigned char dst[16];  // IPv6 addresses are 128 bits (16 bytes)
 
   if (uv_inet_pton(AF_INET6, *ip, dst) != 0) {
-    isolate->ThrowException(v8::Exception::Error(
+    isolate->ThrowException(Exception::Error(
         String::NewFromUtf8(isolate, "Invalid IPv6 address").ToLocalChecked()));
     return;
   }

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -20,6 +20,7 @@ using v8::HandleScope;
 using v8::Int32;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::Object;
 using v8::Uint32;
 using v8::Value;
@@ -222,7 +223,7 @@ void CipherBase::GetSSLCiphers(const FunctionCallbackInfo<Value>& args) {
   };
 
   const int n = sk_SSL_CIPHER_num(ciphers);
-  std::vector<Local<Value>> arr(n + arraysize(TLS13_CIPHERS));
+  LocalVector<Value> arr(env->isolate(), n + arraysize(TLS13_CIPHERS));
 
   for (int i = 0; i < n; ++i) {
     const SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -28,6 +28,7 @@ using v8::Int32;
 using v8::Isolate;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Nothing;
@@ -95,7 +96,7 @@ void ECDH::GetCurves(const FunctionCallbackInfo<Value>& args) {
   std::vector<EC_builtin_curve> curves(num_curves);
   CHECK_EQ(EC_get_builtin_curves(curves.data(), num_curves), num_curves);
 
-  std::vector<Local<Value>> arr(num_curves);
+  LocalVector<Value> arr(env->isolate(), num_curves);
   std::transform(curves.begin(), curves.end(), arr.begin(), [env](auto& curve) {
     return OneByteString(env->isolate(), OBJ_nid2sn(curve.nid));
   });

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -19,6 +19,7 @@ using v8::Isolate;
 using v8::Just;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Name;
@@ -144,9 +145,9 @@ void Hash::GetCachedAliases(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = args.GetIsolate()->GetCurrentContext();
   Environment* env = Environment::GetCurrent(context);
-  std::vector<Local<Name>> names;
-  std::vector<Local<Value>> values;
   size_t size = env->alias_to_md_id_map.size();
+  LocalVector<Name> names(isolate);
+  LocalVector<Value> values(isolate);
 #if OPENSSL_VERSION_MAJOR >= 3
   names.reserve(size);
   values.reserve(size);

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -36,6 +36,7 @@ using v8::HandleScope;
 using v8::Isolate;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::NewStringType;
@@ -236,7 +237,7 @@ MaybeLocal<Value> cryptoErrorListToException(
   if (errors.size() > 1) {
     CHECK(exception->IsObject());
     Local<Object> exception_obj = exception.As<Object>();
-    std::vector<Local<Value>> stack(errors.size() - 1);
+    LocalVector<Value> stack(env->isolate(), errors.size() - 1);
 
     // Iterate over all but the last error in the list.
     auto current = errors.begin();
@@ -252,7 +253,7 @@ MaybeLocal<Value> cryptoErrorListToException(
     }
 
     Local<v8::Array> stackArray =
-        v8::Array::New(env->isolate(), &stack[0], stack.size());
+        v8::Array::New(env->isolate(), stack.data(), stack.size());
 
     if (!exception_obj
              ->Set(env->context(), env->openssl_error_stack(), stackArray)

--- a/src/internal_only_v8.cc
+++ b/src/internal_only_v8.cc
@@ -10,6 +10,7 @@ using v8::FunctionCallbackInfo;
 using v8::Global;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::Object;
 using v8::Value;
 
@@ -56,7 +57,7 @@ void QueryObjects(const FunctionCallbackInfo<Value>& args) {
   PrototypeChainHas prototype_chain_has(context, proto.As<Object>());
   std::vector<Global<Object>> out;
   isolate->GetHeapProfiler()->QueryObjects(context, &prototype_chain_has, &out);
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(out.size());
   for (size_t i = 0; i < out.size(); ++i) {
     result.push_back(out[i].Get(isolate));

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -59,6 +59,7 @@ using v8::Isolate;
 using v8::JustVoid;
 using v8::KeyCollectionMode;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::MeasureMemoryExecution;
@@ -831,7 +832,7 @@ void ContextifyContext::IndexedPropertyEnumeratorCallback(
   }
 
   // Filter out non-number property names.
-  std::vector<Local<Value>> indices;
+  LocalVector<Value> indices(isolate);
   for (uint32_t i = 0; i < properties->Length(); i++) {
     Local<Value> prop = properties_vec[i].Get(isolate);
     if (!prop->IsNumber()) {
@@ -1790,20 +1791,20 @@ static void CompileFunctionForCJSLoader(
   }
 
   Local<Value> undefined = v8::Undefined(isolate);
-  std::vector<Local<Name>> names = {
+  Local<Name> names[] = {
       env->cached_data_rejected_string(),
       env->source_map_url_string(),
       env->function_string(),
       FIXED_ONE_BYTE_STRING(isolate, "canParseAsESM"),
   };
-  std::vector<Local<Value>> values = {
+  Local<Value> values[] = {
       Boolean::New(isolate, cache_rejected),
       fn.IsEmpty() ? undefined : fn->GetScriptOrigin().SourceMapUrl(),
       fn.IsEmpty() ? undefined : fn.As<Value>(),
       Boolean::New(isolate, can_parse_as_esm),
   };
   Local<Object> result = Object::New(
-      isolate, v8::Null(isolate), names.data(), values.data(), names.size());
+      isolate, v8::Null(isolate), &names[0], &values[0], arraysize(names));
   args.GetReturnValue().Set(result);
 }
 

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -21,6 +21,7 @@ using v8::Intercepted;
 using v8::Isolate;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Name;
@@ -273,7 +274,7 @@ void MapKVStore::Delete(Isolate* isolate, Local<String> key) {
 
 Local<Array> MapKVStore::Enumerate(Isolate* isolate) const {
   Mutex::ScopedLock lock(mutex_);
-  std::vector<Local<Value>> values;
+  LocalVector<Value> values(isolate);
   values.reserve(map_.size());
   for (const auto& pair : map_) {
     values.emplace_back(

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -73,6 +73,7 @@ using v8::Integer;
 using v8::Isolate;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Nothing;
@@ -902,8 +903,8 @@ void AfterScanDir(uv_fs_t* req) {
   Local<Value> error;
   int r;
 
-  std::vector<Local<Value>> name_v;
-  std::vector<Local<Value>> type_v;
+  LocalVector<Value> name_v(isolate);
+  LocalVector<Value> type_v(isolate);
 
   const bool with_file_types = req_wrap->with_file_types();
 
@@ -2045,8 +2046,8 @@ static void ReadDir(const FunctionCallbackInfo<Value>& args) {
     }
 
     int r;
-    std::vector<Local<Value>> name_v;
-    std::vector<Local<Value>> type_v;
+    LocalVector<Value> name_v(isolate);
+    LocalVector<Value> type_v(isolate);
 
     for (;;) {
       uv_dirent_t ent;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -37,6 +37,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Number;
@@ -1606,7 +1607,7 @@ void Http2Session::HandleOriginFrame(const nghttp2_frame* frame) {
   nghttp2_ext_origin* origin = static_cast<nghttp2_ext_origin*>(ext.payload);
 
   size_t nov = origin->nov;
-  std::vector<Local<Value>> origin_v(nov);
+  LocalVector<Value> origin_v(isolate, nov);
 
   for (size_t i = 0; i < nov; ++i) {
     const nghttp2_origin_entry& entry = origin->ov[i];

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -63,6 +63,7 @@ using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::Number;
 using v8::Object;
@@ -1091,7 +1092,7 @@ void ConnectionsList::All(const FunctionCallbackInfo<Value>& args) {
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(list->all_connections_.size());
   for (auto parser : list->all_connections_) {
     result.emplace_back(parser->object());
@@ -1108,7 +1109,7 @@ void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(list->all_connections_.size());
   for (auto parser : list->all_connections_) {
     if (parser->last_message_start_ == 0) {
@@ -1127,7 +1128,7 @@ void ConnectionsList::Active(const FunctionCallbackInfo<Value>& args) {
 
   ASSIGN_OR_RETURN_UNWRAP(&list, args.This());
 
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(list->active_connections_.size());
   for (auto parser : list->active_connections_) {
     result.emplace_back(parser->object());
@@ -1176,7 +1177,7 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   auto iter = list->active_connections_.begin();
   auto end = list->active_connections_.end();
 
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(list->active_connections_.size());
   while (iter != end) {
     Parser* parser = *iter;
@@ -1335,8 +1336,8 @@ void CreatePerContextProperties(Local<Object> target,
   BindingData* const binding_data = realm->AddBindingData<BindingData>(target);
   if (binding_data == nullptr) return;
 
-  std::vector<Local<Value>> methods_val;
-  std::vector<Local<Value>> all_methods_val;
+  LocalVector<Value> methods_val(isolate);
+  LocalVector<Value> all_methods_val(isolate);
 
 #define V(num, name, string)                                                   \
   methods_val.push_back(FIXED_ONE_BYTE_STRING(isolate, #string));

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -25,6 +25,7 @@ using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::NewStringType;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -477,11 +478,11 @@ void EnableCompileCache(const FunctionCallbackInfo<Value>& args) {
   }
   Utf8Value value(isolate, args[0]);
   CompileCacheEnableResult result = env->EnableCompileCache(*value);
-  std::vector<Local<Value>> values = {
+  Local<Value> values[] = {
       v8::Integer::New(isolate, static_cast<uint8_t>(result.status)),
       ToV8Value(context, result.message).ToLocalChecked(),
       ToV8Value(context, result.cache_directory).ToLocalChecked()};
-  args.GetReturnValue().Set(Array::New(isolate, values.data(), values.size()));
+  args.GetReturnValue().Set(Array::New(isolate, &values[0], arraysize(values)));
 }
 
 void GetCompileCacheDir(const FunctionCallbackInfo<Value>& args) {
@@ -522,8 +523,8 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
   Realm* realm = Realm::GetCurrent(context);
   realm->AddBindingData<BindingData>(target);
 
-  std::vector<Local<Value>> compile_cache_status_values;
   Isolate* isolate = context->GetIsolate();
+  LocalVector<Value> compile_cache_status_values(isolate);
 
 #define V(status)                                                              \
   compile_cache_status_values.push_back(                                       \

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -23,6 +23,7 @@ using v8::FunctionCallbackInfo;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::Map;
 using v8::Name;
 using v8::Null;
@@ -1312,8 +1313,8 @@ void GetCLIOptionsValues(const FunctionCallbackInfo<Value>& args) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
   IterateCLIOptionsScope s(env);
 
-  std::vector<Local<Name>> option_names;
-  std::vector<Local<Value>> option_values;
+  LocalVector<Name> option_names(isolate);
+  LocalVector<Value> option_values(isolate);
   option_names.reserve(_ppop_instance.options_.size() * 2);
   option_values.reserve(_ppop_instance.options_.size() * 2);
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -48,6 +48,7 @@ using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Null;
@@ -112,7 +113,7 @@ static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
   // assemble them into objects in JS than to call Object::Set() repeatedly
   // The array is in the format
   // [model, speed, (5 entries of cpu_times), model2, speed2, ...]
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(count * 7);
   for (int i = 0; i < count; i++) {
     uv_cpu_info_t* ci = cpu_infos + i;
@@ -193,7 +194,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
   }
 
   Local<Value> no_scope_id = Integer::New(isolate, -1);
-  std::vector<Local<Value>> result;
+  LocalVector<Value> result(isolate);
   result.reserve(count * 7);
   for (i = 0; i < count; i++) {
     const char* const raw_name = interfaces[i].name;

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -20,6 +20,7 @@ using v8::FunctionTemplate;
 using v8::Int32;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::Object;
 using v8::Uint32;
@@ -498,15 +499,14 @@ std::string SocketAddressBlockList::SocketAddressMaskRule::ToString() {
 
 MaybeLocal<Array> SocketAddressBlockList::ListRules(Environment* env) {
   Mutex::ScopedLock lock(mutex_);
-  std::vector<Local<Value>> rules;
+  LocalVector<Value> rules(env->isolate());
   if (!ListRules(env, &rules))
     return MaybeLocal<Array>();
   return Array::New(env->isolate(), rules.data(), rules.size());
 }
 
-bool SocketAddressBlockList::ListRules(
-    Environment* env,
-    std::vector<v8::Local<v8::Value>>* rules) {
+bool SocketAddressBlockList::ListRules(Environment* env,
+                                       LocalVector<Value>* rules) {
   if (parent_ && !parent_->ListRules(env, rules))
     return false;
   for (const auto& rule : rules_) {

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -315,9 +315,7 @@ class SocketAddressBlockList : public MemoryRetainer {
   SET_SELF_SIZE(SocketAddressBlockList)
 
  private:
-  bool ListRules(
-      Environment* env,
-      std::vector<v8::Local<v8::Value>>* vec);
+  bool ListRules(Environment* env, v8::LocalVector<v8::Value>* vec);
 
   std::shared_ptr<SocketAddressBlockList> parent_;
   std::list<std::unique_ptr<Rule>> rules_;

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -26,6 +26,7 @@ using v8::Intercepted;
 using v8::Isolate;
 using v8::JustVoid;
 using v8::Local;
+using v8::LocalVector;
 using v8::Map;
 using v8::Maybe;
 using v8::MaybeLocal;
@@ -255,7 +256,7 @@ MaybeLocal<Array> Storage::Enumerate() {
   int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Local<Array>());
   auto stmt = stmt_unique_ptr(s);
-  std::vector<Local<Value>> values;
+  LocalVector<Value> values(env()->isolate());
   Local<Value> value;
   while ((r = sqlite3_step(stmt.get())) == SQLITE_ROW) {
     CHECK(sqlite3_column_type(stmt.get(), 0) == SQLITE_BLOB);


### PR DESCRIPTION
V8 introduced `v8::LocalVector` somewhat recently as an alternative to using `std::vector<v8::Local<T>>` to help ensure that Local handles are handled correctly. This updates most (but not all) of our uses of `std::vector<v8::Local<T>>` to use `v8::LocalVector<T>` with a few other minor cleanups encountered along the way.

