### PR TITLE
worker: flush stdout and stderr on exit

### DIFF
--- a/lib/internal/bootstrap/switches/is_not_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_not_main_thread.js
@@ -33,11 +33,22 @@ process.removeListener('removeListener', stopListeningIfSignal);
 
 const {
   createWorkerStdio,
+  kStdioWantsMoreDataCallback,
 } = require('internal/worker/io');
 
 let workerStdio;
 function lazyWorkerStdio() {
-  return workerStdio ??= createWorkerStdio();
+  if (workerStdio === undefined) {
+    workerStdio = createWorkerStdio();
+    process.on('exit', flushSync);
+  }
+
+  return workerStdio;
+}
+
+function flushSync() {
+  workerStdio.stdout[kStdioWantsMoreDataCallback]();
+  workerStdio.stderr[kStdioWantsMoreDataCallback]();
 }
 
 function getStdout() { return lazyWorkerStdio().stdout; }

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -294,10 +294,11 @@ class WritableWorkerStdio extends Writable {
     });
     if (process._exiting) {
       cb()
+    } else {
+      ArrayPrototypePush(this[kWritableCallbacks], cb);
+      if (this[kPort][kWaitingStreams]++ === 0)
+        this[kPort].ref();
     }
-    ArrayPrototypePush(this[kWritableCallbacks], cb);
-    if (this[kPort][kWaitingStreams]++ === 0)
-      this[kPort].ref();
   }
 
   _final(cb) {

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -292,6 +292,9 @@ class WritableWorkerStdio extends Writable {
       chunks: ArrayPrototypeMap(chunks,
                                 ({ chunk, encoding }) => ({ chunk, encoding })),
     });
+    if (process._exiting) {
+      cb()
+    }
     ArrayPrototypePush(this[kWritableCallbacks], cb);
     if (this[kPort][kWaitingStreams]++ === 0)
       this[kPort].ref();

--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -293,7 +293,7 @@ class WritableWorkerStdio extends Writable {
                                 ({ chunk, encoding }) => ({ chunk, encoding })),
     });
     if (process._exiting) {
-      cb()
+      cb();
     } else {
       ArrayPrototypePush(this[kWritableCallbacks], cb);
       if (this[kPort][kWaitingStreams]++ === 0)

--- a/test/parallel/test-worker-stdio-flush-inflight.js
+++ b/test/parallel/test-worker-stdio-flush-inflight.js
@@ -1,27 +1,24 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fs = require('fs');
-const util = require('util');
-const { Writable } = require('stream');
 const { Worker, isMainThread } = require('worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename, { stdout: true });
-  const expected = 'hello world'
+  const expected = 'hello world';
 
-  let data = ''
-  w.stdout.setEncoding('utf8')
+  let data = '';
+  w.stdout.setEncoding('utf8');
   w.stdout.on('data', (chunk) => {
-    data += chunk
-  })
+    data += chunk;
+  });
 
   w.on('exit', common.mustCall(() => {
-    assert.strictEqual(data, expected)
+    assert.strictEqual(data, expected);
   }));
 } else {
-  process.stdout.write('hello')
-  process.stdout.write(' ')
-  process.stdout.write('world')
-  process.exit(0)
+  process.stdout.write('hello');
+  process.stdout.write(' ');
+  process.stdout.write('world');
+  process.exit(0);
 }

--- a/test/parallel/test-worker-stdio-flush-inflight.js
+++ b/test/parallel/test-worker-stdio-flush-inflight.js
@@ -1,0 +1,27 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const util = require('util');
+const { Writable } = require('stream');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const w = new Worker(__filename, { stdout: true });
+  const expected = 'hello world'
+
+  let data = ''
+  w.stdout.setEncoding('utf8')
+  w.stdout.on('data', (chunk) => {
+    data += chunk
+  })
+
+  w.on('exit', common.mustCall(() => {
+    assert.strictEqual(data, expected)
+  }));
+} else {
+  process.stdout.write('hello')
+  process.stdout.write(' ')
+  process.stdout.write('world')
+  process.exit(0)
+}

--- a/test/parallel/test-worker-stdio-flush.js
+++ b/test/parallel/test-worker-stdio-flush.js
@@ -1,28 +1,25 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const fs = require('fs');
-const util = require('util');
-const { Writable } = require('stream');
 const { Worker, isMainThread } = require('worker_threads');
 
 if (isMainThread) {
   const w = new Worker(__filename, { stdout: true });
-  const expected = 'hello world'
+  const expected = 'hello world';
 
-  let data = ''
-  w.stdout.setEncoding('utf8')
+  let data = '';
+  w.stdout.setEncoding('utf8');
   w.stdout.on('data', (chunk) => {
-    data += chunk
-  })
+    data += chunk;
+  });
 
   w.on('exit', common.mustCall(() => {
-    assert.strictEqual(data, expected)
+    assert.strictEqual(data, expected);
   }));
 } else {
   process.on('exit', () => {
-    process.stdout.write(' ')
-    process.stdout.write('world')
-  })
-  process.stdout.write('hello')
+    process.stdout.write(' ');
+    process.stdout.write('world');
+  });
+  process.stdout.write('hello');
 }

--- a/test/parallel/test-worker-stdio-flush.js
+++ b/test/parallel/test-worker-stdio-flush.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const util = require('util');
+const { Writable } = require('stream');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  const w = new Worker(__filename, { stdout: true });
+  const expected = 'hello world'
+
+  let data = ''
+  w.stdout.setEncoding('utf8')
+  w.stdout.on('data', (chunk) => {
+    data += chunk
+  })
+
+  w.on('exit', common.mustCall(() => {
+    assert.strictEqual(data, expected)
+  }));
+} else {
+  process.stdout.write('hello')
+  process.on('exit', () => {
+    process.stdout.write(' ')
+    process.stdout.write('world')
+  })
+}

--- a/test/parallel/test-worker-stdio-flush.js
+++ b/test/parallel/test-worker-stdio-flush.js
@@ -20,9 +20,9 @@ if (isMainThread) {
     assert.strictEqual(data, expected)
   }));
 } else {
-  process.stdout.write('hello')
   process.on('exit', () => {
     process.stdout.write(' ')
     process.stdout.write('world')
   })
+  process.stdout.write('hello')
 }


### PR DESCRIPTION
This fix an old problem I had since forever when using worker threads, stdout log lines being cut if the thread exited. This PR fixes it by bypassing backpressure if the thread is exiting. 