### PR TITLE
test: update test-child-process-windows-hide to use node:test

### DIFF
--- a/test/parallel/test-child-process-windows-hide.js
+++ b/test/parallel/test-child-process-windows-hide.js
@@ -3,49 +3,48 @@
 const common = require('../common');
 const assert = require('assert');
 const cp = require('child_process');
+const { test } = require('node:test');
 const internalCp = require('internal/child_process');
 const cmd = process.execPath;
 const args = ['-p', '42'];
 const options = { windowsHide: true };
 
-// Since windowsHide isn't really observable, monkey patch spawn() and
-// spawnSync() to verify that the flag is being passed through correctly.
-const originalSpawn = internalCp.ChildProcess.prototype.spawn;
-const originalSpawnSync = internalCp.spawnSync;
+// Since windowsHide isn't really observable, this test relies on monkey
+// patching spawn() and spawnSync() to verify that the flag is being passed
+// through correctly.
 
-internalCp.ChildProcess.prototype.spawn = common.mustCall(function(options) {
-  assert.strictEqual(options.windowsHide, true);
-  return originalSpawn.apply(this, arguments);
-}, 2);
-
-internalCp.spawnSync = common.mustCall(function(options) {
-  assert.strictEqual(options.windowsHide, true);
-  return originalSpawnSync.apply(this, arguments);
-});
-
-{
+test('spawnSync() passes windowsHide correctly', (t) => {
+  const spy = t.mock.method(internalCp, 'spawnSync');
   const child = cp.spawnSync(cmd, args, options);
 
   assert.strictEqual(child.status, 0);
   assert.strictEqual(child.signal, null);
   assert.strictEqual(child.stdout.toString().trim(), '42');
   assert.strictEqual(child.stderr.toString().trim(), '');
-}
+  assert.strictEqual(spy.mock.calls.length, 1);
+  assert.strictEqual(spy.mock.calls[0].arguments[0].windowsHide, true);
+});
 
-{
+test('spawn() passes windowsHide correctly', (t, done) => {
+  const spy = t.mock.method(internalCp.ChildProcess.prototype, 'spawn');
   const child = cp.spawn(cmd, args, options);
 
   child.on('exit', common.mustCall((code, signal) => {
     assert.strictEqual(code, 0);
     assert.strictEqual(signal, null);
+    assert.strictEqual(spy.mock.calls.length, 1);
+    assert.strictEqual(spy.mock.calls[0].arguments[0].windowsHide, true);
+    done();
   }));
-}
+});
 
-{
-  const callback = common.mustSucceed((stdout, stderr) => {
+test('execFile() passes windowsHide correctly', (t, done) => {
+  const spy = t.mock.method(internalCp.ChildProcess.prototype, 'spawn');
+  cp.execFile(cmd, args, options, common.mustSucceed((stdout, stderr) => {
     assert.strictEqual(stdout.trim(), '42');
     assert.strictEqual(stderr.trim(), '');
-  });
-
-  cp.execFile(cmd, args, options, callback);
-}
+    assert.strictEqual(spy.mock.calls.length, 1);
+    assert.strictEqual(spy.mock.calls[0].arguments[0].windowsHide, true);
+    done();
+  }));
+});


### PR DESCRIPTION
This commit updates test/parallel/test-child-process-windows-hide.js to use node:test. This allows the test to use the built in mocking functionality instead of managing spies manually. It also prevents multiple child processes from being spawned in parallel, which can be problematic in the CI.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
