### PR TITLE
test: update test-set-http-max-http-headers to use node:test

### DIFF
--- a/test/parallel/test-set-http-max-http-headers.js
+++ b/test/parallel/test-set-http-max-http-headers.js
@@ -4,17 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 const { spawn } = require('child_process');
 const path = require('path');
+const { suite, test } = require('node:test');
 const testName = path.join(__dirname, 'test-http-max-http-headers.js');
 
-const timeout = common.platformTimeout(100);
-
-const tests = [];
-
-function test(fn) {
-  tests.push(fn);
-}
-
-test(function(cb) {
+test(function(_, cb) {
   console.log('running subtest expecting failure');
 
   // Validate that the test fails if the max header size is too small.
@@ -30,7 +23,7 @@ test(function(cb) {
   }));
 });
 
-test(function(cb) {
+test(function(_, cb) {
   console.log('running subtest expecting success');
 
   const env = Object.assign({}, process.env, {
@@ -54,13 +47,13 @@ test(function(cb) {
   }));
 });
 
-// Next, repeat the same checks using NODE_OPTIONS if it is supported.
-if (!process.config.variables.node_without_node_options) {
+const skip = process.config.variables.node_without_node_options;
+suite('same checks using NODE_OPTIONS if it is supported', { skip }, () => {
   const env = Object.assign({}, process.env, {
     NODE_OPTIONS: '--max-http-header-size=1024'
   });
 
-  test(function(cb) {
+  test(function(_, cb) {
     console.log('running subtest expecting failure');
 
     // Validate that the test fails if the max header size is too small.
@@ -74,7 +67,7 @@ if (!process.config.variables.node_without_node_options) {
     }));
   });
 
-  test(function(cb) {
+  test(function(_, cb) {
     // Validate that the test now passes if the same limit is large enough.
     const args = ['--expose-internals', testName, '1024'];
     const cp = spawn(process.execPath, args, { env, stdio: 'inherit' });
@@ -85,18 +78,4 @@ if (!process.config.variables.node_without_node_options) {
       cb();
     }));
   });
-}
-
-function runTest() {
-  const fn = tests.shift();
-
-  if (!fn) {
-    return;
-  }
-
-  fn(() => {
-    setTimeout(runTest, timeout);
-  });
-}
-
-runTest();
+});


### PR DESCRIPTION
This commit updates test/parallel/test-set-http-max-http-headers.js to use node:test. This test already implemented a test runner, so it makes sense to use the existing public API.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
