### PR TITLE
test: skip `test-sqlite-extensions` when it is missing

### DIFF
--- a/test/sqlite/test-sqlite-extensions.mjs
+++ b/test/sqlite/test-sqlite-extensions.mjs
@@ -11,13 +11,19 @@ if (process.config.variables.node_shared_sqlite) {
   common.skip('Missing libsqlite_extension binary');
 }
 
-// Lib extension binary is named differently on different platforms
-function resolveBuiltBinary(binary) {
-  const targetFile = fs.readdirSync(path.dirname(process.execPath)).find((file) => file.startsWith(binary));
-  return path.join(path.dirname(process.execPath), targetFile);
+const binDir = path.dirname(process.execPath);
+let binary;
+for await (const { name } of await fs.promises.opendir(binDir)) {
+  // Lib extension binary is named differently on different platforms
+  if (name.startsWith('libsqlite_extension')) {
+    binary = path.join(binDir, name);
+    break;
+  }
 }
 
-const binary = resolveBuiltBinary('libsqlite_extension');
+if (binary == null) {
+  common.skip('Missing libsqlite_extension binary');
+}
 
 test('should load extension successfully', () => {
   const db = new sqlite.DatabaseSync(':memory:', {


### PR DESCRIPTION
49acdc8748fe9fe83bc1b444e24c456dff00ecc5 disabled the test when building with `--shared-sqlite`, but there are more cases where the extension is not built, and IMO we should not report it as failure and instead skip the test.

Fixes: https://github.com/nodejs/node/issues/56453
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
