### PR TITLE
crypto: make generatePrime/checkPrime interruptible

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3940,6 +3940,13 @@ By default, the prime is encoded as a big-endian sequence of octets
 in an {ArrayBuffer}. If the `bigint` option is `true`, then a {bigint}
 is provided.
 
+The `size` of the prime will have a direct impact on how long it takes to
+generate the prime. The larger the size, the longer it will take. Because
+we use OpenSSL's `BN_generate_prime_ex` function, which provides only
+minimal control over our ability to interrupt the generation process,
+it is not recommended to generate overly large primes, as doing so may make
+the process unresponsive.
+
 ### `crypto.generatePrimeSync(size[, options])`
 
 <!-- YAML
@@ -3980,6 +3987,13 @@ if given as an `ArrayBuffer`, `SharedArrayBuffer`, `TypedArray`, `Buffer`, or
 By default, the prime is encoded as a big-endian sequence of octets
 in an {ArrayBuffer}. If the `bigint` option is `true`, then a {bigint}
 is provided.
+
+The `size` of the prime will have a direct impact on how long it takes to
+generate the prime. The larger the size, the longer it will take. Because
+we use OpenSSL's `BN_generate_prime_ex` function, which provides only
+minimal control over our ability to interrupt the generation process,
+it is not recommended to generate overly large primes, as doing so may make
+the process unresponsive.
 
 ### `crypto.getCipherInfo(nameOrNid[, options])`
 


### PR DESCRIPTION
The `generatePrime` and `checkPrime` functions in the `crypto` module are only somewhat interruptible. This change makes it possible to interrupt these more reliably. Note that generating overly large primes can still take a long time and may not be interruptible as this mechanism relies on a callback to check for stopping conditions but OpenSSL may perform a long running operation without calling the callback right away.

Fixes: https://github.com/nodejs/node/issues/56449
