### PR TITLE
doc: allow request for TSC reviews via the GitHub UI

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -523,7 +523,6 @@ deprecation level of an API.
 Collaborators can opt to elevate pull requests or issues to the [TSC][].
 Do this if a pull request or issue:
 
-* Is labeled `semver-major`, or
 * Has a significant impact on the codebase, or
 * Is controversial, or
 * Is at an impasse among collaborators who are participating in the discussion.
@@ -531,6 +530,9 @@ Do this if a pull request or issue:
 @-mention the `@nodejs/tsc` GitHub team if you want to elevate an issue to the
 [TSC][]. Do not use the GitHub UI on the right-hand side to assign to
 `@nodejs/tsc` or request a review from `@nodejs/tsc`.
+
+If a pull request is labeled `semver-major`, you can request a review from the
+`@nodejs/tsc` GitHub team.
 
 The TSC serves as the final arbiter where required.
 


### PR DESCRIPTION
I might be missing some context on why we’re not doing that, but IMO it would make perfect sense for semver-major PRs, as it’s basically the only time where TSC voting members reviews have a different weight. Requesting a review from the team would allow GH UI to highlight those reviews (useful for newcomers who are less likely to have all the TSC members handles in mind). It would require us to give the `@nodejs/TSC` team Triage role on the repo, which should not change anything as TSC voting members are already collaborators (which have Write role on the repo).

EDIT: from my understanding of https://github.com/nodejs/node/pull/22759, it seems the rule was put in place because of the lack of support for filtering/filtering out notifications coming from team reviews, which was problematic for folks using GitHub professionally and couldn't/wouldn't involve Node.js collaboration during paid hours. It looks like the issue still exists, I have to say it's kind of crazy GitHub doesn't even support filtering out an org from the notification feed – but it does support that when searching for PRs. However, I'd still be open to trying it out again, even if GitHub notification feed filtering hasn't changed much since 2018, the Node.js project has, so it might just work for the current project members.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
