### PR TITLE
tools: enable type checking within the `internal/modules` directory

### DIFF
--- a/lib/internal/modules/tsconfig.json
+++ b/lib/internal/modules/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  },
+  "include": [
+    "./",
+    "../../../typings",
+  ]
+}


### PR DESCRIPTION
This enables us to find the current type issues within the modules subsystem. There are quite a few.

Not sure if we should:
* merge this now and then fix (it could get annoying to see all the red, which is perhaps some dark UX to encourage people to fix them)
* fix all the type issues as part of this
* leave this open to the side whilst we merge in type fixes piecemeal, then merge this once they're all done

Perhaps we can eventually make this a CI check.