### PR TITLE
module: fix jsdoc for `format` parameter in cjs/loader

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1682,7 +1682,8 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
  * `exports`) to the file. Returns exception, if any.
  * @param {string} content The source code of the module
  * @param {string} filename The file path of the module
- * @param {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} format Intended format of the module.
+ * @param {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} format
+ * Intended format of the module.
  */
 Module.prototype._compile = function(content, filename, format) {
   if (format === 'commonjs-typescript' || format === 'module-typescript' || format === 'typescript') {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1682,9 +1682,7 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
  * `exports`) to the file. Returns exception, if any.
  * @param {string} content The source code of the module
  * @param {string} filename The file path of the module
- * @param {
- *    'module'|'commonjs'|'commonjs-typescript'|'module-typescript'
- * } format Intended format of the module.
+ * @param {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} format Intended format of the module.
  */
 Module.prototype._compile = function(content, filename, format) {
   if (format === 'commonjs-typescript' || format === 'module-typescript' || format === 'typescript') {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1109,9 +1109,13 @@ function resolveForCJSWithHooks(specifier, parent, isMain) {
  */
 
 /**
+ * @typedef {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} ModuleFormat;
+ */
+
+/**
  * Load the source code of a module based on format.
  * @param {string} filename Filename of the module.
- * @param {string|undefined|null} format Format of the module.
+ * @param {ModuleFormat|undefined|null} format Format of the module.
  * @returns {string|null}
  */
 function defaultLoadImpl(filename, format) {
@@ -1682,7 +1686,7 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
  * `exports`) to the file. Returns exception, if any.
  * @param {string} content The source code of the module
  * @param {string} filename The file path of the module
- * @param {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} format Intended format of the module.
+ * @param {ModuleFormat} format Intended format of the module.
  */
 Module.prototype._compile = function(content, filename, format) {
   if (format === 'commonjs-typescript' || format === 'module-typescript' || format === 'typescript') {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1109,13 +1109,9 @@ function resolveForCJSWithHooks(specifier, parent, isMain) {
  */
 
 /**
- * @typedef {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} ModuleFormat;
- */
-
-/**
  * Load the source code of a module based on format.
  * @param {string} filename Filename of the module.
- * @param {ModuleFormat|undefined|null} format Format of the module.
+ * @param {string|undefined|null} format Format of the module.
  * @returns {string|null}
  */
 function defaultLoadImpl(filename, format) {
@@ -1686,7 +1682,7 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
  * `exports`) to the file. Returns exception, if any.
  * @param {string} content The source code of the module
  * @param {string} filename The file path of the module
- * @param {ModuleFormat} format Intended format of the module.
+ * @param {'module'|'commonjs'|'commonjs-typescript'|'module-typescript'|'typescript'} format Intended format of the module.
  */
 Module.prototype._compile = function(content, filename, format) {
   if (format === 'commonjs-typescript' || format === 'module-typescript' || format === 'typescript') {


### PR DESCRIPTION
Before:
<img width="930" alt="Snipaste_2025-01-07_20-27-10-resized" src="https://github.com/user-attachments/assets/812eebcc-c5f0-4366-9860-dd59fcaeb695" />

After:
<img width="920" alt="Snipaste_2025-01-07_21-11-58-resized" src="https://github.com/user-attachments/assets/87c36174-6665-4885-91b3-0e60df29d9ed" />

