### PR TITLE
src: fix undefined script name in error source

### DIFF
--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -136,8 +136,13 @@ static std::string GetErrorSource(Isolate* isolate,
 
   // Print (filename):(line number): (message).
   ScriptOrigin origin = message->GetScriptOrigin();
-  node::Utf8Value filename(isolate, message->GetScriptResourceName());
-  const char* filename_string = *filename;
+  std::string filename_string;
+  if (message->GetScriptResourceName()->IsUndefined()) {
+    filename_string = "<anonymous_script>";
+  } else {
+    node::Utf8Value filename(isolate, message->GetScriptResourceName());
+    filename_string = filename.ToString();
+  }
   int linenum = message->GetLineNumber(context).FromJust();
 
   int script_start = (linenum - origin.LineOffset()) == 1

--- a/test/fixtures/errors/throw_in_eval_anonymous.js
+++ b/test/fixtures/errors/throw_in_eval_anonymous.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../../common');
+
+Error.stackTraceLimit = 1;
+eval(`
+
+  throw new Error('error in anonymous script');
+
+`)

--- a/test/fixtures/errors/throw_in_eval_anonymous.snapshot
+++ b/test/fixtures/errors/throw_in_eval_anonymous.snapshot
@@ -1,0 +1,8 @@
+<anonymous_script>:*
+  throw new Error('error in anonymous script');
+  ^
+
+Error: error in anonymous script
+    at eval (eval at <anonymous> (*throw_in_eval_anonymous.js:*:*), <anonymous>:*:*)
+
+Node.js *

--- a/test/fixtures/errors/throw_in_eval_named.js
+++ b/test/fixtures/errors/throw_in_eval_named.js
@@ -1,0 +1,9 @@
+'use strict';
+require('../../common');
+
+Error.stackTraceLimit = 1;
+eval(`
+
+  throw new Error('error in named script');
+
+//# sourceURL=evalscript.js`)

--- a/test/fixtures/errors/throw_in_eval_named.snapshot
+++ b/test/fixtures/errors/throw_in_eval_named.snapshot
@@ -1,0 +1,8 @@
+evalscript.js:*
+  throw new Error('error in named script');
+  ^
+
+Error: error in named script
+    at eval (evalscript.js:*:*)
+
+Node.js *

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -63,6 +63,8 @@ describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
     { name: 'errors/if-error-has-good-stack.js', transform: errTransform },
     { name: 'errors/throw_custom_error.js', transform: errTransform },
     { name: 'errors/throw_error_with_getter_throw.js', transform: errTransform },
+    { name: 'errors/throw_in_eval_anonymous.js', transform: errTransform },
+    { name: 'errors/throw_in_eval_named.js', transform: errTransform },
     { name: 'errors/throw_in_line_with_tabs.js', transform: errTransform },
     { name: 'errors/throw_non_error.js', transform: errTransform },
     { name: 'errors/throw_null.js', transform: errTransform },


### PR DESCRIPTION
If an error is not caught, the file name and source code line where the error was thrown is printed. However, for unnamed eval scripts, a placeholder instead of `undefined` should be print:

```
undefined:3
  throw new Error('error in unnamed script');
  ^

Error: error in unnamed script
    at eval (eval at <anonymous> (/dev/nodejs/node/test/fixtures/errors/throw_in_eval_unnamed.js:5:1), <anonymous>:3:9)
```

This PR prints a placeholder `<anonymous_script>` for such errors:

```
<anonymous_script>:3
  throw new Error('error in anonymous script');
```