### PR TITLE
doc: document CLI way to open the nodejs/bluesky PR

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1102,6 +1102,22 @@ The post content can be as simple as:
 > …
 > something here about notable changes
 
+You can create the PR for the release post on nodejs/bluesky with the following:
+
+```sh
+# Create a PR for a post:
+gh workflow run create-pr.yml --repo "https://github.com/nodejs/bluesky" \
+  -F prTitle='vx.x.x release announcement' \
+  -F richText='Node.js vx.x.x is out. Check the blog post at https://nodejs.org/…. TL;DR is
+
+- New feature
+- …'
+
+# Create a PR for a retweet:
+gh workflow run create-pr.yml --repo "https://github.com/nodejs/bluesky" \
+  -F prTitle='Retweet vx.x.x release announcement' -F postURL=…
+```
+
 <details>
 <summary>Security release</summary>
 

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1104,7 +1104,7 @@ The post content can be as simple as:
 
 You can create the PR for the release post on nodejs/bluesky with the following:
 
-```sh
+```bash
 # Create a PR for a post:
 gh workflow run create-pr.yml --repo "https://github.com/nodejs/bluesky" \
   -F prTitle='vx.x.x release announcement' \


### PR DESCRIPTION
With https://github.com/nodejs/bluesky/pull/32, we now have a way to have GHA open the PR for us, as I find the manual workflow to be quite a slowdown when working on post-release stuff.

@nodejs/releasers wdyt?
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
