### PR TITLE
src: integrate ContextifyContext to cppgc

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -1085,6 +1085,7 @@ class Environment final : public MemoryRetainer {
                          const char* errmsg);
   void TrackContext(v8::Local<v8::Context> context);
   void UntrackContext(v8::Local<v8::Context> context);
+  void PurgeTrackedEmptyContexts();
 
   std::list<binding::DLib> loaded_addons_;
   v8::Isolate* const isolate_;

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -23,17 +23,73 @@ struct ContextOptions {
   bool vanilla = false;
 };
 
-class ContextifyContext : public BaseObject {
+/**
+ * The memory management of a vm context is as follows:
+ *
+ *                                                          user code
+ *                                                              │
+ *                          As global proxy or                  ▼
+ *     ┌──────────────┐  kSandboxObject embedder data   ┌────────────────┐
+ * ┌─► │  V8 Context  │────────────────────────────────►│ Wrapper holder │
+ * │   └──────────────┘                                 └───────┬────────┘
+ * │         ▲  Object constructor/creation context             │
+ * │         │                                                  │
+ * │  ┌──────┴────────────┐  contextify_context_private_symbol  │
+ * │  │ ContextifyContext │◄────────────────────────────────────┘
+ * │  │   JS Wrapper      │◄──────────► ┌─────────────────────────┐
+ * │  └───────────────────┘  cppgc      │ node::ContextifyContext │
+ * │                                    │       C++ Object        │
+ * └──────────────────────────────────► └─────────────────────────┘
+ *     v8::TracedReference / ContextEmbedderIndex::kContextifyContext
+ *
+ * There are two possibilities for the "wrapper holder":
+ *
+ * 1. When vm.constants.DONT_CONTEXTIFY is used, the wrapper holder is the V8
+ *    context's global proxy object
+ * 2. Otherwise it's the arbitrary "sandbox object" that users pass into
+ *    vm.createContext() or a new empty object created internally if they pass
+ *    undefined.
+ *
+ * In 2, the global object of the new V8 context is created using
+ * global_object_template with interceptors that perform any requested
+ * operations on the global object in the context first on the sandbox object
+ * living outside of the new context, then fall back to the global proxy of the
+ * new context.
+ *
+ * It's critical for the user-accessible wrapper holder to keep the
+ * ContextifyContext wrapper alive via contextify_context_private_symbol
+ * so that the V8 context is always available to the user while they still
+ * hold the vm "context" object alive.
+ *
+ * It's also critical for the V8 context to keep the wrapper holder
+ * (specifically, the "sandbox object") as well as the node::ContextifyContext
+ * C++ object alive, so that when the code runs inside the object and accesses
+ * the global object, the interceptors can still access the "sandbox object"
+ * as well as and perform operations
+ * on them, even if users already relinquish access to the outer
+ * "sandbox object".
+ *
+ * The v8::TracedReference and the ContextEmbedderIndex::kContextifyContext
+ * slot in the context act as shortcuts from the node::ContextifyContext
+ * C++ object to the V8 context.
+ */
+class ContextifyContext final : CPPGC_MIXIN(ContextifyContext) {
  public:
+  SET_CPPGC_NAME(ContextifyContext)
+  void Trace(cppgc::Visitor* visitor) const final;
+
   ContextifyContext(Environment* env,
                     v8::Local<v8::Object> wrapper,
                     v8::Local<v8::Context> v8_context,
                     ContextOptions* options);
-  ~ContextifyContext();
 
-  void MemoryInfo(MemoryTracker* tracker) const override;
-  SET_MEMORY_INFO_NAME(ContextifyContext)
-  SET_SELF_SIZE(ContextifyContext)
+  // The destructors don't need to do anything because when the wrapper is
+  // going away, the context is already going away or otherwise it would've
+  // been holding the wrapper alive, so there's no need to reset the pointers
+  // in the context. Also, any global handles to the context would've been
+  // empty at this point, and the per-Environment context tracking code is
+  // capable of dealing with empty handles from contexts purged elsewhere.
+  ~ContextifyContext() {}
 
   static v8::MaybeLocal<v8::Context> CreateV8Context(
       v8::Isolate* isolate,
@@ -48,7 +104,7 @@ class ContextifyContext : public BaseObject {
       Environment* env, const v8::Local<v8::Object>& wrapper_holder);
 
   inline v8::Local<v8::Context> context() const {
-    return PersistentToLocal::Default(env()->isolate(), context_);
+    return context_.Get(env()->isolate());
   }
 
   inline v8::Local<v8::Object> global_proxy() const {
@@ -75,14 +131,14 @@ class ContextifyContext : public BaseObject {
   static void InitializeGlobalTemplates(IsolateData* isolate_data);
 
  private:
-  static BaseObjectPtr<ContextifyContext> New(Environment* env,
-                                              v8::Local<v8::Object> sandbox_obj,
-                                              ContextOptions* options);
+  static ContextifyContext* New(Environment* env,
+                                v8::Local<v8::Object> sandbox_obj,
+                                ContextOptions* options);
   // Initialize a context created from CreateV8Context()
-  static BaseObjectPtr<ContextifyContext> New(v8::Local<v8::Context> ctx,
-                                              Environment* env,
-                                              v8::Local<v8::Object> sandbox_obj,
-                                              ContextOptions* options);
+  static ContextifyContext* New(v8::Local<v8::Context> ctx,
+                                Environment* env,
+                                v8::Local<v8::Object> sandbox_obj,
+                                ContextOptions* options);
 
   static bool IsStillInitializing(const ContextifyContext* ctx);
   static void MakeContext(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -140,7 +196,7 @@ class ContextifyContext : public BaseObject {
   static void IndexedPropertyEnumeratorCallback(
       const v8::PropertyCallbackInfo<v8::Array>& args);
 
-  v8::Global<v8::Context> context_;
+  v8::TracedReference<v8::Context> context_;
   std::unique_ptr<v8::MicrotaskQueue> microtask_queue_;
 };
 

--- a/src/node_contextify.h
+++ b/src/node_contextify.h
@@ -62,16 +62,16 @@ struct ContextOptions {
  * hold the vm "context" object alive.
  *
  * It's also critical for the V8 context to keep the wrapper holder
- * (specifically, the "sandbox object") as well as the node::ContextifyContext
- * C++ object alive, so that when the code runs inside the object and accesses
- * the global object, the interceptors can still access the "sandbox object"
- * as well as and perform operations
+ * (specifically, the "sandbox object" if users pass one) as well as the
+ * node::ContextifyContext C++ object alive, so that when the code
+ * runs inside the object and accesses the global object, the interceptors
+ * can still access the "sandbox object" and perform operations
  * on them, even if users already relinquish access to the outer
  * "sandbox object".
  *
  * The v8::TracedReference and the ContextEmbedderIndex::kContextifyContext
- * slot in the context act as shortcuts from the node::ContextifyContext
- * C++ object to the V8 context.
+ * slot in the context only act as shortcuts between
+ * the node::ContextifyContext C++ object and the V8 context.
  */
 class ContextifyContext final : CPPGC_MIXIN(ContextifyContext) {
  public:
@@ -89,7 +89,7 @@ class ContextifyContext final : CPPGC_MIXIN(ContextifyContext) {
   // in the context. Also, any global handles to the context would've been
   // empty at this point, and the per-Environment context tracking code is
   // capable of dealing with empty handles from contexts purged elsewhere.
-  ~ContextifyContext() {}
+  ~ContextifyContext() = default;
 
   static v8::MaybeLocal<v8::Context> CreateV8Context(
       v8::Isolate* isolate,

--- a/test/common/gc.js
+++ b/test/common/gc.js
@@ -3,7 +3,8 @@
 const wait = require('timers/promises').setTimeout;
 const assert = require('assert');
 const common = require('../common');
-const { setImmediate } = require('timers/promises');
+// TODO(joyeecheung): rewrite checkIfCollectable to use this too.
+const { setImmediate: setImmediatePromisified } = require('timers/promises');
 const gcTrackerMap = new WeakMap();
 const gcTrackerTag = 'NODE_TEST_COMMON_GC_TRACKER';
 
@@ -50,7 +51,7 @@ function onGC(obj, gcListener) {
  */
 async function gcUntil(name, condition, maxCount = 10, gcOptions) {
   for (let count = 0; count < maxCount; ++count) {
-    await setImmediate();
+    await setImmediatePromisified();
     if (gcOptions) {
       await global.gc(gcOptions);
     } else {

--- a/test/common/gc.js
+++ b/test/common/gc.js
@@ -3,6 +3,7 @@
 const wait = require('timers/promises').setTimeout;
 const assert = require('assert');
 const common = require('../common');
+const { setImmediate } = require('timers/promises');
 const gcTrackerMap = new WeakMap();
 const gcTrackerTag = 'NODE_TEST_COMMON_GC_TRACKER';
 
@@ -40,32 +41,26 @@ function onGC(obj, gcListener) {
 
 /**
  * Repeatedly triggers garbage collection until a specified condition is met or a maximum number of attempts is reached.
+ * This utillity must be run in a Node.js instance that enables --expose-gc.
  * @param {string|Function} [name] - Optional name, used in the rejection message if the condition is not met.
  * @param {Function} condition - A function that returns true when the desired condition is met.
+ * @param {number} maxCount - Maximum number of garbage collections that should be tried.
+ * @param {object} gcOptions - Options to pass into the global gc() function.
  * @returns {Promise} A promise that resolves when the condition is met, or rejects after 10 failed attempts.
  */
-function gcUntil(name, condition) {
-  if (typeof name === 'function') {
-    condition = name;
-    name = undefined;
-  }
-  return new Promise((resolve, reject) => {
-    let count = 0;
-    function gcAndCheck() {
-      setImmediate(() => {
-        count++;
-        global.gc();
-        if (condition()) {
-          resolve();
-        } else if (count < 10) {
-          gcAndCheck();
-        } else {
-          reject(name === undefined ? undefined : 'Test ' + name + ' failed');
-        }
-      });
+async function gcUntil(name, condition, maxCount = 10, gcOptions) {
+  for (let count = 0; count < maxCount; ++count) {
+    await setImmediate();
+    if (gcOptions) {
+      await global.gc(gcOptions);
+    } else {
+      await global.gc();  // Passing in undefined is not the same as empty.
     }
-    gcAndCheck();
-  });
+    if (condition()) {
+      return;
+    }
+  }
+  throw new Error(`Test ${name} failed`);
 }
 
 // This function can be used to check if an object factor leaks or not,

--- a/test/parallel/test-inspector-contexts.js
+++ b/test/parallel/test-inspector-contexts.js
@@ -8,7 +8,7 @@ common.skipIfInspectorDisabled();
 const assert = require('assert');
 const vm = require('vm');
 const { Session } = require('inspector');
-
+const { gcUntil } = require('../common/gc');
 const session = new Session();
 session.connect();
 
@@ -66,8 +66,7 @@ async function testContextCreatedAndDestroyed() {
 
     // GC is unpredictable...
     console.log('Checking/waiting for GC.');
-    while (!contextDestroyed)
-      global.gc();
+    await gcUntil('context destruction', () => contextDestroyed, Infinity, { type: 'major', execution: 'async' });
     console.log('Context destroyed.');
 
     assert.strictEqual(contextDestroyed.params.executionContextId, id,
@@ -98,8 +97,7 @@ async function testContextCreatedAndDestroyed() {
 
     // GC is unpredictable...
     console.log('Checking/waiting for GC again.');
-    while (!contextDestroyed)
-      global.gc();
+    await gcUntil('context destruction', () => contextDestroyed, Infinity, { type: 'major', execution: 'async' });
     console.log('Other context destroyed.');
   }
 
@@ -124,8 +122,7 @@ async function testContextCreatedAndDestroyed() {
 
     // GC is unpredictable...
     console.log('Checking/waiting for GC a third time.');
-    while (!contextDestroyed)
-      global.gc();
+    await gcUntil('context destruction', () => contextDestroyed, Infinity, { type: 'major', execution: 'async' });
     console.log('Context destroyed once again.');
   }
 
@@ -148,8 +145,7 @@ async function testContextCreatedAndDestroyed() {
 
     // GC is unpredictable...
     console.log('Checking/waiting for GC a fourth time.');
-    while (!contextDestroyed)
-      global.gc();
+    await gcUntil('context destruction', () => contextDestroyed, Infinity, { type: 'major', execution: 'async' });
     console.log('Context destroyed a fourth time.');
   }
 }


### PR DESCRIPTION
This simplifies the memory management of ContextifyContext,
making all references visible to V8.

The destructors don't need to do anything because when the wrapper is
going away, the context is already going away or otherwise it would've
been holding the wrapper alive, so there's no need to reset the
pointers in the context. Also, any global handles to the context
would've been empty at this point, and the per-Environment context
tracking code is capable of dealing with empty handles from contexts
purged elsewhere.

To this end, the context tracking code also purges empty handles
from the list now, to prevent keeping too many empty handles around.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
