### PR TITLE
test: clarify fork inherit permission flags

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -174,18 +174,17 @@ node:internal/child_process:388
                            ^
 Error: Access to this API has been restricted
     at ChildProcess.spawn (node:internal/child_process:388:28)
-    at Object.spawn (node:child_process:723:9)
-    at Object.<anonymous> (/home/index.js:3:14)
-    at Module._compile (node:internal/modules/cjs/loader:1120:14)
-    at Module._extensions..js (node:internal/modules/cjs/loader:1174:10)
-    at Module.load (node:internal/modules/cjs/loader:998:32)
-    at Module._load (node:internal/modules/cjs/loader:839:12)
-    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
     at node:internal/main/run_main_module:17:47 {
   code: 'ERR_ACCESS_DENIED',
   permission: 'ChildProcess'
 }
 ```
+
+Unlike `child_process.spawn`, the `child_process.fork` API copies the execution
+arguments from the parent process. This means that if you start Node.js with the
+Permission Model enabled and include the `--allow-child-process` flag, calling
+`child_process.fork()` will propagate all Permission Model flags to the child
+process.
 
 ### `--allow-fs-read`
 

--- a/test/parallel/test-permission-allow-child-process-cli.js
+++ b/test/parallel/test-permission-allow-child-process-cli.js
@@ -5,8 +5,15 @@ const common = require('../common');
 common.skipIfWorker();
 const assert = require('assert');
 const childProcess = require('child_process');
+const fs = require('fs');
 
 if (process.argv[2] === 'child') {
+  assert.throws(() => {
+    fs.writeFileSync(__filename, 'should not write');
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
   process.exit(0);
 }
 
@@ -21,6 +28,7 @@ if (process.argv[2] === 'child') {
   // doesNotThrow
   childProcess.spawnSync(process.execPath, ['--version']);
   childProcess.execSync(...common.escapePOSIXShell`"${process.execPath}" --version`);
-  childProcess.fork(__filename, ['child']);
+  const child = childProcess.fork(__filename, ['child']);
+  child.on('close', common.mustCall());
   childProcess.execFileSync(process.execPath, ['--version']);
 }


### PR DESCRIPTION
This commit updates the documentation and includes a test to ensure that permission model flags
will be passed to the child process if `fork` is called