### PR TITLE
tools: replace pull_request_target to pull_request

### DIFF
--- a/.github/workflows/comment-labeled.yml
+++ b/.github/workflows/comment-labeled.yml
@@ -2,7 +2,7 @@ name: Comment on issues and PRs when labeled
 on:
   issues:
     types: [labeled]
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 env:
@@ -35,7 +35,7 @@ jobs:
   fast-track:
     permissions:
       pull-requests: write
-    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request_target' && github.event.label.name == 'fast-track'
+    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request' && github.event.label.name == 'fast-track'
     runs-on: ubuntu-latest
     steps:
       - name: Request Fast-Track
@@ -46,7 +46,7 @@ jobs:
   notable-change:
     permissions:
       pull-requests: write
-    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request_target' && github.event.label.name == 'notable-change'
+    if: github.repository == 'nodejs/node' && github.event_name == 'pull_request' && github.event.label.name == 'notable-change'
     runs-on: ubuntu-latest
     steps:
       - name: Add notable change description

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: Label PRs
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 permissions:

--- a/.github/workflows/notify-on-review-wanted.yml
+++ b/.github/workflows/notify-on-review-wanted.yml
@@ -2,7 +2,7 @@ name: Notify on Review Wanted
 on:
   issues:
     types: [labeled]
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 permissions:

--- a/doc/contributing/commit-queue.md
+++ b/doc/contributing/commit-queue.md
@@ -71,7 +71,7 @@ reasons:
    the last one to finish will fail because the local branch will be out of
    sync with the remote after the first Action pushes. `issue_comment` event
    has the same limitation.
-2. `pull_request_target` will only run if the Action exists on the base commit
+2. `pull_request` will only run if the Action exists on the base commit
    of a pull request, and it will run the Action version present on that
    commit, meaning we wouldn't be able to use it for already opened PRs
    without rebasing them first.


### PR DESCRIPTION
`pull_request_target` trigger is risky as it permits anyone without validation to run the workflow when a PR is opened (see https://docs.github.com/fr/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target).

Also https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/