### PR TITLE
sqlite: disable memstatus APIs at build time

### DIFF
--- a/deps/sqlite/sqlite.gyp
+++ b/deps/sqlite/sqlite.gyp
@@ -13,6 +13,7 @@
         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
       },
       'defines': [
+        'SQLITE_DEFAULT_MEMSTATUS=0',
         'SQLITE_ENABLE_MATH_FUNCTIONS',
         'SQLITE_ENABLE_SESSION',
         'SQLITE_ENABLE_PREUPDATE_HOOK'


### PR DESCRIPTION
This commit defines `SQLITE_DEFAULT_MEMSTATUS=0` for the SQLite build. This setting disables several currently unused C APIs in SQLite, which can yield noticeable performance improvements. This setting is also used by better-sqlite, and is one of the recommended compile-time options in the SQLite docs.

The disabled APIs are used to report statistics about SQLite's memory usage. The drawback to this change is that those APIs could possibly be useful one day. I think the perf tradeoff and prior art make this change worth it.

Refs: https://sqlite.org/compile.html

<details>
I tested this code against main, this PR, and better-sqlite by changing the `require()` calls. On my machine, this PR was the fastest (6.4 seconds), followed by better-sqlite (6.7 seconds), followed by main (7.6 seconds).

```js
'use strict';
const { strictEqual } = require('node:assert');
const { DatabaseSync: Database } = require('node:sqlite');
// const Database = require('better-sqlite3');
const N = 1_000_000;
const db = new Database(':memory:');

db.exec('PRAGMA journal_mode = WAL');
db.exec('CREATE TABLE data(key INTEGER PRIMARY KEY, created_at TEXT DEFAULT CURRENT_TIMESTAMP) STRICT');

const start = performance.now();

for (let i = 0; i < N; ++i) {
  const insert = db.prepare('INSERT INTO data (key) values (?)');
  strictEqual(insert.run(i).lastInsertRowid, i);
  const query = db.prepare('SELECT created_at FROM data WHERE key = ?');
  strictEqual(typeof query.get(i).created_at, 'string');
}

const end = performance.now();
db.close();
console.log('elapsed:', end - start);
```
</details>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
