### PR TITLE
process: remove support for undocumented symbol

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -420,15 +420,17 @@ function toggleTraceCategoryState(asyncHooksEnabled) {
 
 const { arch, platform, version } = process;
 
+let refSymbol;
 function ref(maybeRefable) {
-  const fn = maybeRefable?.[SymbolFor('nodejs.ref')] || maybeRefable?.[SymbolFor('node:ref')] || maybeRefable?.ref;
+  if (maybeRefable == null) return;
+  const fn = maybeRefable[refSymbol ??= SymbolFor('nodejs.ref')] || maybeRefable.ref;
   if (typeof fn === 'function') FunctionPrototypeCall(fn, maybeRefable);
 }
 
+let unrefSymbol;
 function unref(maybeRefable) {
-  const fn = maybeRefable?.[SymbolFor('nodejs.unref')] ||
-             maybeRefable?.[SymbolFor('node:unref')] ||
-             maybeRefable?.unref;
+  if (maybeRefable == null) return;
+  const fn = maybeRefable[unrefSymbol ??= SymbolFor('nodejs.unref')] || maybeRefable.unref;
   if (typeof fn === 'function') FunctionPrototypeCall(fn, maybeRefable);
 }
 

--- a/test/parallel/test-process-ref-unref.js
+++ b/test/parallel/test-process-ref-unref.js
@@ -33,37 +33,20 @@ class Foo2 {
   }
 }
 
-// TODO(aduh95): remove support for undocumented symbol
-class Foo3 {
-  refCalled = 0;
-  unrefCalled = 0;
-  [Symbol.for('node:ref')]() {
-    this.refCalled++;
-  }
-  [Symbol.for('node:unref')]() {
-    this.unrefCalled++;
-  }
-}
-
 describe('process.ref/unref work as expected', () => {
   it('refs...', () => {
     // Objects that implement the new Symbol-based API
     // just work.
     const foo1 = new Foo();
     const foo2 = new Foo2();
-    const foo3 = new Foo3();
     process.ref(foo1);
     process.unref(foo1);
     process.ref(foo2);
     process.unref(foo2);
-    process.ref(foo3);
-    process.unref(foo3);
     strictEqual(foo1.refCalled, 1);
     strictEqual(foo1.unrefCalled, 1);
     strictEqual(foo2.refCalled, 1);
     strictEqual(foo2.unrefCalled, 1);
-    strictEqual(foo3.refCalled, 1);
-    strictEqual(foo3.unrefCalled, 1);
 
     // Objects that implement the legacy API also just work.
     const i = setInterval(() => {}, 1000);


### PR DESCRIPTION
The symbol was undocumented in https://github.com/nodejs/node/pull/56517, but left in the code to avoid a breaking change. This PR makes the breaking change, I suggest we skip landing it on 23.x and directly backport it to 22.x so that release line only receive support for the documented symbol.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
