### PR TITLE
tls: fix error stack conversion in cryptoErrorListToException()

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -237,7 +237,8 @@ MaybeLocal<Value> cryptoErrorListToException(
   if (errors.size() > 1) {
     CHECK(exception->IsObject());
     Local<Object> exception_obj = exception.As<Object>();
-    LocalVector<Value> stack(env->isolate(), errors.size() - 1);
+    LocalVector<Value> stack(env->isolate());
+    stack.reserve(errors.size() - 1);
 
     // Iterate over all but the last error in the list.
     auto current = errors.begin();
@@ -255,9 +256,9 @@ MaybeLocal<Value> cryptoErrorListToException(
     Local<v8::Array> stackArray =
         v8::Array::New(env->isolate(), stack.data(), stack.size());
 
-    if (!exception_obj
-             ->Set(env->context(), env->openssl_error_stack(), stackArray)
-             .IsNothing()) {
+    if (exception_obj
+            ->Set(env->context(), env->openssl_error_stack(), stackArray)
+            .IsNothing()) {
       return {};
     }
   }

--- a/test/parallel/test-tls-error-stack.js
+++ b/test/parallel/test-tls-error-stack.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// This tests that the crypto error stack can be correctly converted.
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+assert.throws(() => {
+  tls.createSecureContext({ clientCertEngine: 'x' });
+}, (err) => {
+  return err.name === 'Error' &&
+         /could not load the shared library/.test(err.message) &&
+         Array.isArray(err.opensslErrorStack) &&
+        err.opensslErrorStack.length > 0;
+});


### PR DESCRIPTION
The ncrypto move introduced regressions in
cryptoErrorListToException() by passing in the size of the vector unnecessarily into the vector constructor and then use push_back() (which would result in a crash on dereferencing empty handles during later iteration) and having incorrect logic for checking the presence of an exception. This patch fixes it.

Fixes: https://github.com/nodejs/node/issues/56375
Refs: https://github.com/nodejs/node/pull/53803

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
