### PR TITLE
test: update test-child-process-bad-stdio to use node:test

### DIFF
--- a/test/parallel/test-child-process-bad-stdio.js
+++ b/test/parallel/test-child-process-bad-stdio.js
@@ -1,21 +1,23 @@
 'use strict';
 // Flags: --expose-internals
 const common = require('../common');
-const assert = require('assert');
-const cp = require('child_process');
 
 if (process.argv[2] === 'child') {
   setTimeout(() => {}, common.platformTimeout(100));
   return;
 }
 
+const assert = require('node:assert');
+const cp = require('node:child_process');
+const { mock, test } = require('node:test');
+const { ChildProcess } = require('internal/child_process');
+
 // Monkey patch spawn() to create a child process normally, but destroy the
 // stdout and stderr streams. This replicates the conditions where the streams
 // cannot be properly created.
-const ChildProcess = require('internal/child_process').ChildProcess;
 const original = ChildProcess.prototype.spawn;
 
-ChildProcess.prototype.spawn = function() {
+mock.method(ChildProcess.prototype, 'spawn', function() {
   const err = original.apply(this, arguments);
 
   this.stdout.destroy();
@@ -24,7 +26,7 @@ ChildProcess.prototype.spawn = function() {
   this.stderr = null;
 
   return err;
-};
+});
 
 function createChild(options, callback) {
   const [cmd, opts] = common.escapePOSIXShell`"${process.execPath}" "${__filename}" child`;
@@ -33,32 +35,32 @@ function createChild(options, callback) {
   return cp.exec(cmd, options, common.mustCall(callback));
 }
 
-// Verify that normal execution of a child process is handled.
-{
+test('normal execution of a child process is handled', (_, done) => {
   createChild({}, (err, stdout, stderr) => {
     assert.strictEqual(err, null);
     assert.strictEqual(stdout, '');
     assert.strictEqual(stderr, '');
+    done();
   });
-}
+});
 
-// Verify that execution with an error event is handled.
-{
+test('execution with an error event is handled', (_, done) => {
   const error = new Error('foo');
   const child = createChild({}, (err, stdout, stderr) => {
     assert.strictEqual(err, error);
     assert.strictEqual(stdout, '');
     assert.strictEqual(stderr, '');
+    done();
   });
 
   child.emit('error', error);
-}
+});
 
-// Verify that execution with a killed process is handled.
-{
+test('execution with a killed process is handled', (_, done) => {
   createChild({ timeout: 1 }, (err, stdout, stderr) => {
     assert.strictEqual(err.killed, true);
     assert.strictEqual(stdout, '');
     assert.strictEqual(stderr, '');
+    done();
   });
-}
+});


### PR DESCRIPTION
This commit updates test/parallel/test-child-process-bad-stdio.js to use node:test. This change prevents multiple child processes from being spawned in parallel, which can be problematic in the CI.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
