### PR TITLE
util: inspect: do not crash on Symbol function names

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -989,7 +989,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
     keys = getKeys(value, ctx.showHidden);
     braces = ['{', '}'];
     if (typeof value === 'function') {
-      base = getFunctionBase(value, constructor, tag);
+      base = getFunctionBase(ctx, value, constructor, tag);
       if (keys.length === 0 && protoProps === undefined)
         return ctx.stylize(base, 'special');
     } else if (constructor === 'Object') {
@@ -1223,7 +1223,7 @@ function getClassBase(value, constructor, tag) {
   return `[${base}]`;
 }
 
-function getFunctionBase(value, constructor, tag) {
+function getFunctionBase(ctx, value, constructor, tag) {
   const stringified = FunctionPrototypeToString(value);
   if (StringPrototypeStartsWith(stringified, 'class') && stringified[stringified.length - 1] === '}') {
     const slice = StringPrototypeSlice(stringified, 5, -1);
@@ -1250,7 +1250,7 @@ function getFunctionBase(value, constructor, tag) {
   if (value.name === '') {
     base += ' (anonymous)';
   } else {
-    base += `: ${value.name}`;
+    base += `: ${typeof value.name === 'string' ? value.name : formatValue(ctx, value.name)}`;
   }
   base += ']';
   if (constructor !== type && constructor !== null) {

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3426,3 +3426,13 @@ assert.strictEqual(
     Object.defineProperty(BuiltinPrototype, 'constructor', desc);
   }
 }
+
+{
+  function f() {}
+  Object.defineProperty(f, 'name', { value: Symbol('f') });
+
+  assert.strictEqual(
+    util.inspect(f),
+    '[Function: Symbol(f)]',
+  );
+}


### PR DESCRIPTION
See #56570 - this avoids a crash when a Function name is a Symbol.