### PR TITLE
util: inspect: do not crash on an Error stack that contains a Symbol

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1287,8 +1287,14 @@ function identicalSequenceRange(a, b) {
   return { len: 0, offset: 0 };
 }
 
-function getStackString(error) {
-  return error.stack ? String(error.stack) : ErrorPrototypeToString(error);
+function getStackString(ctx, error) {
+  if (error.stack) {
+    if (typeof error.stack === 'string') {
+      return error.stack;
+    }
+    return formatValue(ctx, error.stack);
+  }
+  return ErrorPrototypeToString(error);
 }
 
 function getStackFrames(ctx, err, stack) {
@@ -1303,7 +1309,7 @@ function getStackFrames(ctx, err, stack) {
 
   // Remove stack frames identical to frames in cause.
   if (cause != null && isError(cause)) {
-    const causeStack = getStackString(cause);
+    const causeStack = getStackString(ctx, cause);
     const causeStackStart = StringPrototypeIndexOf(causeStack, '\n    at');
     if (causeStackStart !== -1) {
       const causeFrames = StringPrototypeSplit(StringPrototypeSlice(causeStack, causeStackStart + 1), '\n');
@@ -1426,7 +1432,7 @@ function safeGetCWD() {
 
 function formatError(err, constructor, tag, ctx, keys) {
   const name = err.name != null ? err.name : 'Error';
-  let stack = getStackString(err);
+  let stack = getStackString(ctx, err);
 
   removeDuplicateErrorKeys(ctx, keys, err, stack);
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -777,16 +777,18 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
   [undefined, 'RangeError: foo', '[RangeError: foo]'],
   [false, 'false [RangeError]: foo', '[RangeError: foo]'],
   ['', 'foo', '[RangeError: foo]'],
-  [[1, 2, 3], '1,2,3 [RangeError]: foo', '[1,2,3]'],
+  [[1, 2, 3], '1,2,3 [RangeError]: foo', '[[\n  1,\n  2,\n  3\n]]'],
 ].forEach(([value, outputStart, stack]) => {
   let err = new RangeError('foo');
   err.name = value;
+  const result = util.inspect(err);
   assert(
-    util.inspect(err).startsWith(outputStart),
+    result.startsWith(outputStart),
     util.format(
-      'The name set to %o did not result in the expected output "%s"',
+      'The name set to %o did not result in the expected output "%s", got "%s"',
       value,
-      outputStart
+      outputStart,
+      result.split('\n')[0]
     )
   );
 
@@ -3446,5 +3448,15 @@ assert.strictEqual(
     util.inspect(error),
     `${re} [EvalError]
 ${error.stack.split('\n').slice(1).join('\n')}`,
+  );
+}
+
+{
+  const error = new Error();
+  error.stack = [Symbol('foo')];
+
+  assert.strictEqual(
+    inspect(error),
+    '[[\n  Symbol(foo)\n]]'
   );
 }


### PR DESCRIPTION
See #56570 - this avoids a crash when an Error's `stack` property contains a Symbol inside an array