### PR TITLE
test: mark test-worker-prof as flaky on smartos

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -32,6 +32,7 @@ test-single-executable-application-empty: PASS, FLAKY
 test-http-server-request-timeouts-mixed: PASS, FLAKY
 
 [$system==solaris] # Also applies to SmartOS
+test-worker-prof: PASS, FLAKY
 
 [$system==freebsd]
 


### PR DESCRIPTION
This has been flaky at least [since Dec 17](https://github.com/nodejs/reliability/blob/main/reports/2024-12-17.md) and has failed [7 PRs in the last 100 CI runs](https://github.com/nodejs/reliability/blob/main/reports/2025-01-13.md). I don't think it would do us any good to keep it flaking on smartos in the CI, and I don't think anyone is looking into it, so mark it as flaky.

cc @nodejs/platform-smartos @nodejs/tsc  this is what I mentioned in https://github.com/nodejs/TSC/issues/1666 about the tier 2 platforms destablizing the CI. It's counting on volunteers, like me, to occasionally care about the overall health of the project enough to look at the reliability reports, triage the flakes, and ping the platform teams. IMO it's fine for tier 1 platforms whose user base make them worthy of this volunteer effort, but not fine for tier 2 platforms which <1% of our users rely on to consume the scarce volunteer energy, and the platform teams should be more proactive in watching the CI results to prevent these platforms from contributing to the instablility. Otherwise this could just continue distablizing for a year or more until any volunteer cares enough to find out who's flaking the CI, all because stakeholders of a niche platform that <1% of our users use want to stick around in node-test-pull-request and assume that they would get free notifications whenever it breaks.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
