### PR TITLE
util: rename CallSite.column to columnNumber

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -372,6 +372,9 @@ util.formatWithOptions({ colors: true }, 'See object %O', { foo: 42 });
 added: v22.9.0
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56584
+    description: Property `column` is deprecated in favor of `columnNumber`.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/56551
     description: Property `CallSite.scriptId` is exposed.
   - version:
@@ -391,8 +394,8 @@ changes:
   * `scriptName` {string} Returns the name of the resource that contains the script for the
     function for this call site.
   * `scriptId` {string} Returns the unique id of the script, as in Chrome DevTools protocol [`Runtime.ScriptId`][].
-  * `lineNumber` {number} Returns the number, 1-based, of the line for the associate function call.
-  * `column` {number} Returns the 1-based column offset on the line for the associated function call.
+  * `lineNumber` {number} Returns the JavaScript script line number (1-based).
+  * `columnNumber` {number} Returns the JavaScript script column number (1-based).
 
 Returns an array of call site objects containing the stack of
 the caller function.
@@ -409,7 +412,7 @@ function exampleFunction() {
     console.log(`Function Name: ${callSite.functionName}`);
     console.log(`Script Name: ${callSite.scriptName}`);
     console.log(`Line Number: ${callSite.lineNumber}`);
-    console.log(`Column Number: ${callSite.column}`);
+    console.log(`Column Number: ${callSite.columnNumber}`);
   });
   // CallSite 1:
   // Function Name: exampleFunction

--- a/lib/util.js
+++ b/lib/util.js
@@ -348,10 +348,10 @@ const lazySourceMap = getLazy(() => require('internal/source_map/source_map_cach
  * @returns {CallSite | undefined} // The reconstructed call site object
  */
 function reconstructCallSite(callSite) {
-  const { scriptName, lineNumber, column } = callSite;
+  const { scriptName, lineNumber, columnNumber } = callSite;
   const sourceMap = lazySourceMap().findSourceMap(scriptName);
   if (!sourceMap) return;
-  const entry = sourceMap.findEntry(lineNumber - 1, column - 1);
+  const entry = sourceMap.findEntry(lineNumber - 1, columnNumber - 1);
   if (!entry?.originalSource) return;
   return {
     __proto__: null,
@@ -360,6 +360,7 @@ function reconstructCallSite(callSite) {
     scriptName: entry.originalSource,
     lineNumber: entry.originalLine + 1,
     column: entry.originalColumn + 1,
+    columnNumber: entry.originalColumn + 1,
   };
 }
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -99,6 +99,7 @@
     "transferList")                                                            \
   V(clone_untransferable_str, "Found invalid value in transferList.")          \
   V(code_string, "code")                                                       \
+  V(column_number_string, "columnNumber")                                      \
   V(column_string, "column")                                                   \
   V(commonjs_string, "commonjs")                                               \
   V(config_string, "config")                                                   \

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -282,6 +282,8 @@ static void GetCallSites(const FunctionCallbackInfo<Value>& args) {
         env->script_id_string(),
         env->script_name_string(),
         env->line_number_string(),
+        env->column_number_string(),
+        // TODO(legendecas): deprecate CallSite.column.
         env->column_string(),
     };
     Local<Value> values[] = {
@@ -289,6 +291,8 @@ static void GetCallSites(const FunctionCallbackInfo<Value>& args) {
         OneByteString(isolate, script_id),
         script_name,
         Integer::NewFromUnsigned(isolate, stack_frame->GetLineNumber()),
+        Integer::NewFromUnsigned(isolate, stack_frame->GetColumn()),
+        // TODO(legendecas): deprecate CallSite.column.
         Integer::NewFromUnsigned(isolate, stack_frame->GetColumn()),
     };
     Local<Object> obj = Object::New(

--- a/test/parallel/test-util-getcallsites.js
+++ b/test/parallel/test-util-getcallsites.js
@@ -133,6 +133,7 @@ const assert = require('node:assert');
   assert.strictEqual(stderr.toString(), '');
   assert.match(output, /lineNumber: 8/);
   assert.match(output, /column: 18/);
+  assert.match(output, /columnNumber: 18/);
   assert.match(output, /test-get-callsite\.ts/);
   assert.strictEqual(status, 0);
 }
@@ -150,6 +151,7 @@ const assert = require('node:assert');
   // Line should be wrong when sourcemaps are disable
   assert.match(output, /lineNumber: 2/);
   assert.match(output, /column: 18/);
+  assert.match(output, /columnNumber: 18/);
   assert.match(output, /test-get-callsite\.ts/);
   assert.strictEqual(status, 0);
 }
@@ -166,6 +168,7 @@ const assert = require('node:assert');
   assert.strictEqual(stderr.toString(), '');
   assert.match(output, /lineNumber: 2/);
   assert.match(output, /column: 18/);
+  assert.match(output, /columnNumber: 18/);
   assert.match(output, /test-get-callsite-explicit\.ts/);
   assert.strictEqual(status, 0);
 }


### PR DESCRIPTION
Align the property names `lineNumber` and `columnNumber`.

The name should either be `line` and `column`, or `lineNumber` and `columnNumber`, but not mixing up. This leads confusing doc like https://github.com/nodejs/node/blob/db7a31e2766ae3c800f6e879ec0f3d08e0759198/lib/util.js#L337-L344
