### PR TITLE
test_runner: remove unused errors

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2821,25 +2821,6 @@ An unspecified or non-specific system error has occurred within the Node.js
 process. The error object will have an `err.info` object property with
 additional details.
 
-<a id="ERR_TAP_LEXER_ERROR"></a>
-
-### `ERR_TAP_LEXER_ERROR`
-
-An error representing a failing lexer state.
-
-<a id="ERR_TAP_PARSER_ERROR"></a>
-
-### `ERR_TAP_PARSER_ERROR`
-
-An error representing a failing parser state. Additional information about
-the token causing the error is available via the `cause` property.
-
-<a id="ERR_TAP_VALIDATION_ERROR"></a>
-
-### `ERR_TAP_VALIDATION_ERROR`
-
-This error represents a failed TAP validation.
-
 <a id="ERR_TEST_FAILURE"></a>
 
 ### `ERR_TEST_FAILURE`
@@ -3874,6 +3855,25 @@ removed: v10.0.0
 
 Used when an attempt is made to use a readable stream that has not implemented
 [`readable._read()`][].
+
+<a id="ERR_TAP_LEXER_ERROR"></a>
+
+### `ERR_TAP_LEXER_ERROR`
+
+An error representing a failing lexer state.
+
+<a id="ERR_TAP_PARSER_ERROR"></a>
+
+### `ERR_TAP_PARSER_ERROR`
+
+An error representing a failing parser state. Additional information about
+the token causing the error is available via the `cause` property.
+
+<a id="ERR_TAP_VALIDATION_ERROR"></a>
+
+### `ERR_TAP_VALIDATION_ERROR`
+
+This error represents a failed TAP validation.
 
 <a id="ERR_TLS_RENEGOTIATION_FAILED"></a>
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1739,21 +1739,6 @@ E('ERR_STREAM_WRAP', 'Stream has StringDecoder set or is in objectMode', Error);
 E('ERR_STREAM_WRITE_AFTER_END', 'write after end', Error);
 E('ERR_SYNTHETIC', 'JavaScript Callstack', Error);
 E('ERR_SYSTEM_ERROR', 'A system error occurred', SystemError, HideStackFramesError);
-E('ERR_TAP_LEXER_ERROR', function(errorMsg) {
-  hideInternalStackFrames(this);
-  return errorMsg;
-}, Error);
-E('ERR_TAP_PARSER_ERROR', function(errorMsg, details, tokenCausedError, source) {
-  hideInternalStackFrames(this);
-  this.cause = tokenCausedError;
-  const { column, line, start, end } = tokenCausedError.location;
-  const errorDetails = `${details} at line ${line}, column ${column} (start ${start}, end ${end})`;
-  return errorMsg + errorDetails;
-}, SyntaxError);
-E('ERR_TAP_VALIDATION_ERROR', function(errorMsg) {
-  hideInternalStackFrames(this);
-  return errorMsg;
-}, Error);
 E('ERR_TEST_FAILURE', function(error, failureType) {
   hideInternalStackFrames(this);
   assert(typeof failureType === 'string' || typeof failureType === 'symbol',


### PR DESCRIPTION
It seems that `ERR_TAP_PARSER_ERROR`,`ERR_TAP_LEXER_ERROR` and `ERR_TAP_VALIDATION_ERROR` are no longer used in the codebase.
Does it make sense to perform some housekeeping by removing them?