### PR TITLE
src: initialize FSReqWrapSync in path that uses it

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2482,7 +2482,6 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
     }
   } else {  // write(fd, string, pos, enc, undefined, ctx)
     CHECK_EQ(argc, 6);
-    FSReqWrapSync req_wrap_sync;
     FSReqBase::FSReqBuffer stack_buffer;
     if (buf == nullptr) {
       if (!StringBytes::StorageSize(isolate, value, enc).To(&len))
@@ -2496,6 +2495,7 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
       buf = *stack_buffer;
     }
     uv_buf_t uvbuf = uv_buf_init(buf, len);
+    FSReqWrapSync req_wrap_sync("write");
     FS_SYNC_TRACE_BEGIN(write);
     int bytesWritten = SyncCall(env, args[5], &req_wrap_sync, "write",
                                 uv_fs_write, fd, &uvbuf, 1, pos);


### PR DESCRIPTION
The goal is to fix this error reported by Coverity:

![image](https://github.com/user-attachments/assets/4a4bf96d-1be0-41d0-b2bd-9929f6248b07)
