### PR TITLE
child_process: check array readability in spawn

### DIFF
--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -236,18 +236,18 @@ const handleConversion = {
 };
 
 function stdioStringToArray(stdio, channel) {
-  const options = [];
+  let options = [];
 
   switch (stdio) {
     case 'ignore':
     case 'overlapped':
-    case 'pipe': ArrayPrototypePush(options, stdio, stdio, stdio); break;
-    case 'inherit': ArrayPrototypePush(options, 0, 1, 2); break;
+    case 'pipe': options = [stdio, stdio, stdio]; break;
+    case 'inherit': options = [0, 1, 2]; break;
     default:
       throw new ERR_INVALID_ARG_VALUE('stdio', stdio);
   }
 
-  if (channel) ArrayPrototypePush(options, channel);
+  if (channel) options = [channel];
 
   return options;
 }


### PR DESCRIPTION
With previous example issues caused by prototype pollution, I don't think we should add a test, as this PR fixes it from hard crash, but does not guarantee a defined behaviour. For example,
```
const {exec} = require('node:child_process');

Object.defineProperty(Array.prototype, "2", {
  set: function () {},
});

(async function () {
  exec('pwd', (err, stdout, stderr) => {
    console.log(stdout);
  });
})();
```
gives

```
node:internal/util/inspect:2063
      totalLength += output[i].length;
                               ^

TypeError: Cannot read properties of undefined (reading 'length')
    at isBelowBreakLength (node:internal/util/inspect:2063:32)
    at reduceToSingleString (node:internal/util/inspect:2106:13)
    at formatRaw (node:internal/util/inspect:1138:15)
    at formatValue (node:internal/util/inspect:883:10)
    at Object.inspect (node:internal/util/inspect:386:10)
    at TypeError.<anonymous> (node:internal/errors:1441:45)
    at getMessage (node:internal/errors:598:12)
    at new NodeError (node:internal/errors:470:20)
    at stdioStringToArray (node:internal/child_process:253:13)
    at getValidStdio (node:internal/child_process:997:13)

Node.js v24.0.0-pre
```
In case we does check if array is readable in some other modules, the error would likely be different.

Fixes: https://github.com/nodejs/node/issues/56531