### PR TITLE
module: integrate TypeScript into compile cache

### DIFF
--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -108,8 +108,9 @@ function stripTypeScriptTypes(code, options = kEmptyObject) {
 }
 
 /**
+ * @typedef {'strip-only' | 'transform'} TypeScriptMode
  * @typedef {object} TypeScriptOptions
- * @property {'transform'|'strip-only'} mode Mode.
+ * @property {TypeScriptMode} mode Mode.
  * @property {boolean} sourceMap Whether to generate source maps.
  * @property {string|undefined} filename Filename.
  */
@@ -137,7 +138,7 @@ function processTypeScriptCode(code, options) {
 
 /**
  * Get the type enum used for compile cache.
- * @param {'strip-only'|'transform'} mode Mode of transpilation.
+ * @param {TypeScriptMode} mode Mode of transpilation.
  * @param {boolean} sourceMap Whether source maps are enabled.
  * @returns {number}
  */
@@ -173,6 +174,11 @@ function stripTypeScriptModuleTypes(source, filename, emitWarning = true) {
   // as checking process.env equally involves calling into C++ anyway, and
   // the compile cache can be enabled dynamically.
   const type = getCachedCodeType(mode, sourceMap);
+  // Get a compile cache entry into the native compile cache store,
+  // keyed by the filename. If the cache can already be loaded on disk,
+  // cached.transpiled contains the cached string. Otherwise we should do
+  // the transpilation and save it in the native store later using
+  // saveCompileCacheEntry().
   const cached = (filename ? getCompileCacheEntry(source, filename, type) : undefined);
   if (cached?.transpiled) {  // TODO(joyeecheung): return Buffer here.
     return cached.transpiled;
@@ -186,6 +192,11 @@ function stripTypeScriptModuleTypes(source, filename, emitWarning = true) {
 
   const transpiled = processTypeScriptCode(source, options);
   if (cached) {
+    // cached.external contains a pointer to the native cache entry.
+    // The cached object would be unreachable once it's out of scope,
+    // but the pointer inside cached.external would stay around for reuse until
+    // environment shutdown or when the cache is manually flushed
+    // to disk. Unwrap it in JS before passing into C++ since it's faster.
     saveCompileCacheEntry(cached.external, transpiled);
   }
   return transpiled;

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -20,6 +20,11 @@ const {
 const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
 const { Buffer } = require('buffer');
+const {
+  getCompileCacheEntry,
+  saveCompileCacheEntry,
+  cachedCodeTypes: { kStrippedTypeScript, kTransformedTypeScript, kTransformedTypeScriptWithSourceMaps },
+} = internalBinding('modules');
 
 /**
  * The TypeScript parsing mode, either 'strip-only' or 'transform'.
@@ -103,10 +108,17 @@ function stripTypeScriptTypes(code, options = kEmptyObject) {
 }
 
 /**
+ * @typedef {object} TypeScriptOptions
+ * @property {'transform'|'strip-only'} mode Mode.
+ * @property {boolean} sourceMap Whether to generate source maps.
+ * @property {string|undefined} filename Filename.
+ */
+
+/**
  * Processes TypeScript code by stripping types or transforming.
  * Handles source maps if needed.
  * @param {string} code TypeScript code to process.
- * @param {object} options The configuration object.
+ * @param {TypeScriptOptions} options The configuration object.
  * @returns {string} The processed code.
  */
 function processTypeScriptCode(code, options) {
@@ -121,6 +133,20 @@ function processTypeScriptCode(code, options) {
   }
 
   return transformedCode;
+}
+
+/**
+ * Get the type enum used for compile cache.
+ * @param {'strip-only'|'transform'} mode Mode of transpilation.
+ * @param {boolean} sourceMap Whether source maps are enabled.
+ * @returns {number}
+ */
+function getCachedCodeType(mode, sourceMap) {
+  if (mode === 'transform') {
+    if (sourceMap) { return kTransformedTypeScriptWithSourceMaps; }
+    return kTransformedTypeScript;
+  }
+  return kStrippedTypeScript;
 }
 
 /**
@@ -139,12 +165,30 @@ function stripTypeScriptModuleTypes(source, filename, emitWarning = true) {
   if (isUnderNodeModules(filename)) {
     throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
   }
+  const sourceMap = getOptionValue('--enable-source-maps');
+
+  const mode = getTypeScriptParsingMode();
+
+  // Instead of caching the compile cache status, just go into C++ to fetch it,
+  // as checking process.env equally involves calling into C++ anyway, and
+  // the compile cache can be enabled dynamically.
+  const type = getCachedCodeType(mode, sourceMap);
+  const cached = (filename ? getCompileCacheEntry(source, filename, type) : undefined);
+  if (cached?.transpiled) {  // TODO(joyeecheung): return Buffer here.
+    return cached.transpiled;
+  }
+
   const options = {
-    mode: getTypeScriptParsingMode(),
-    sourceMap: getOptionValue('--enable-source-maps'),
+    mode,
+    sourceMap,
     filename,
   };
-  return processTypeScriptCode(source, options);
+
+  const transpiled = processTypeScriptCode(source, options);
+  if (cached) {
+    saveCompileCacheEntry(cached.external, transpiled);
+  }
+  return transpiled;
 }
 
 /**

--- a/src/compile_cache.cc
+++ b/src/compile_cache.cc
@@ -89,6 +89,8 @@ const char* CompileCacheEntry::type_name() const {
       return "TransformedTypeScript";
     case CachedCodeType::kTransformedTypeScriptWithSourceMaps:
       return "TransformedTypeScriptWithSourceMaps";
+    default:
+      UNREACHABLE();
   }
 }
 

--- a/src/compile_cache.h
+++ b/src/compile_cache.h
@@ -13,10 +13,17 @@
 namespace node {
 class Environment;
 
-// TODO(joyeecheung): move it into a CacheHandler class.
+#define CACHED_CODE_TYPES(V)                                                   \
+  V(kCommonJS, 0)                                                              \
+  V(kESM, 1)                                                                   \
+  V(kStrippedTypeScript, 2)                                                    \
+  V(kTransformedTypeScript, 3)                                                 \
+  V(kTransformedTypeScriptWithSourceMaps, 4)
+
 enum class CachedCodeType : uint8_t {
-  kCommonJS = 0,
-  kESM,
+#define V(type, value) type = value,
+  CACHED_CODE_TYPES(V)
+#undef V
 };
 
 struct CompileCacheEntry {
@@ -34,6 +41,7 @@ struct CompileCacheEntry {
   // Copy the cache into a new store for V8 to consume. Caller takes
   // ownership.
   v8::ScriptCompiler::CachedData* CopyCache() const;
+  const char* type_name() const;
 };
 
 #define COMPILE_CACHE_STATUS(V)                                                \
@@ -70,6 +78,7 @@ class CompileCacheHandler {
   void MaybeSave(CompileCacheEntry* entry,
                  v8::Local<v8::Module> mod,
                  bool rejected);
+  void MaybeSave(CompileCacheEntry* entry, std::string_view transpiled);
   std::string_view cache_dir() { return compile_cache_dir_; }
 
  private:

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -1,6 +1,7 @@
 #include "node_modules.h"
 #include <cstdio>
 #include "base_object-inl.h"
+#include "compile_cache.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
 #include "node_url.h"
@@ -498,6 +499,74 @@ void GetCompileCacheDir(const FunctionCallbackInfo<Value>& args) {
           .ToLocalChecked());
 }
 
+void GetCompileCacheEntry(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  CHECK(args[0]->IsString());  // TODO(joyeecheung): accept buffer.
+  CHECK(args[1]->IsString());
+  CHECK(args[2]->IsUint32());
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+  if (!env->use_compile_cache()) {
+    return;
+  }
+  Local<String> source = args[0].As<String>();
+  Local<String> filename = args[1].As<String>();
+  CachedCodeType type =
+      static_cast<CachedCodeType>(args[2].As<v8::Uint32>()->Value());
+  auto* cache_entry =
+      env->compile_cache_handler()->GetOrInsert(source, filename, type);
+  if (cache_entry == nullptr) {
+    return;
+  }
+
+  v8::LocalVector<v8::Name> names(isolate,
+                                  {FIXED_ONE_BYTE_STRING(isolate, "external")});
+  v8::LocalVector<v8::Value> values(isolate,
+                                    {v8::External::New(isolate, cache_entry)});
+  if (cache_entry->cache != nullptr) {
+    Debug(env,
+          DebugCategory::COMPILE_CACHE,
+          "[compile cache] retrieving transpile cache for %s %s...",
+          cache_entry->type_name(),
+          cache_entry->source_filename);
+
+    std::string_view cache(
+        reinterpret_cast<const char*>(cache_entry->cache->data),
+        cache_entry->cache->length);
+    Local<Value> transpiled;
+    // TODO(joyeecheung): convert with simdutf and into external strings
+    if (!ToV8Value(context, cache).ToLocal(&transpiled)) {
+      Debug(env, DebugCategory::COMPILE_CACHE, "failed\n");
+      return;
+    } else {
+      Debug(env, DebugCategory::COMPILE_CACHE, "success\n");
+    }
+    names.push_back(FIXED_ONE_BYTE_STRING(isolate, "transpiled"));
+    values.push_back(transpiled);
+  } else {
+    Debug(env,
+          DebugCategory::COMPILE_CACHE,
+          "[compile cache] no transpile cache for %s %s\n",
+          cache_entry->type_name(),
+          cache_entry->source_filename);
+  }
+  args.GetReturnValue().Set(Object::New(
+      isolate, v8::Null(isolate), names.data(), values.data(), names.size()));
+}
+
+void SaveCompileCacheEntry(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
+  DCHECK(env->use_compile_cache());
+  CHECK(args[0]->IsExternal());
+  CHECK(args[1]->IsString());  // TODO(joyeecheung): accept buffer.
+  auto* cache_entry =
+      static_cast<CompileCacheEntry*>(args[0].As<v8::External>()->Value());
+  Utf8Value utf8(isolate, args[1].As<String>());
+  env->compile_cache_handler()->MaybeSave(cache_entry, utf8.ToStringView());
+}
+
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
                                              Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
@@ -514,6 +583,8 @@ void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "enableCompileCache", EnableCompileCache);
   SetMethod(isolate, target, "getCompileCacheDir", GetCompileCacheDir);
   SetMethod(isolate, target, "flushCompileCache", FlushCompileCache);
+  SetMethod(isolate, target, "getCompileCacheEntry", GetCompileCacheEntry);
+  SetMethod(isolate, target, "saveCompileCacheEntry", SaveCompileCacheEntry);
 }
 
 void BindingData::CreatePerContextProperties(Local<Object> target,
@@ -530,12 +601,31 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
   compile_cache_status_values.push_back(                                       \
       FIXED_ONE_BYTE_STRING(isolate, #status));
   COMPILE_CACHE_STATUS(V)
+#undef V
 
   USE(target->Set(context,
                   FIXED_ONE_BYTE_STRING(isolate, "compileCacheStatus"),
                   Array::New(isolate,
                              compile_cache_status_values.data(),
                              compile_cache_status_values.size())));
+
+  LocalVector<v8::Name> cached_code_type_keys(isolate);
+  LocalVector<Value> cached_code_type_values(isolate);
+
+#define V(type, value)                                                         \
+  cached_code_type_keys.push_back(FIXED_ONE_BYTE_STRING(isolate, #type));      \
+  cached_code_type_values.push_back(v8::Integer::New(isolate, value));         \
+  DCHECK_EQ(value, cached_code_type_values.size() - 1);
+  CACHED_CODE_TYPES(V)
+#undef V
+
+  USE(target->Set(context,
+                  FIXED_ONE_BYTE_STRING(isolate, "cachedCodeTypes"),
+                  Object::New(isolate,
+                              v8::Null(isolate),
+                              cached_code_type_keys.data(),
+                              cached_code_type_values.data(),
+                              cached_code_type_keys.size())));
 }
 
 void BindingData::RegisterExternalReferences(
@@ -547,6 +637,8 @@ void BindingData::RegisterExternalReferences(
   registry->Register(EnableCompileCache);
   registry->Register(GetCompileCacheDir);
   registry->Register(FlushCompileCache);
+  registry->Register(GetCompileCacheEntry);
+  registry->Register(SaveCompileCacheEntry);
 }
 
 }  // namespace modules

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -22,6 +22,7 @@ namespace modules {
 
 using v8::Array;
 using v8::Context;
+using v8::External;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Integer;
@@ -565,7 +566,7 @@ void SaveCompileCacheEntry(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsExternal());
   CHECK(args[1]->IsString());  // TODO(joyeecheung): accept buffer.
   auto* cache_entry =
-      static_cast<CompileCacheEntry*>(args[0].As<v8::External>()->Value());
+      static_cast<CompileCacheEntry*>(args[0].As<External>()->Value());
   Utf8Value utf8(isolate, args[1].As<String>());
   env->compile_cache_handler()->MaybeSave(cache_entry, utf8.ToStringView());
 }

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -24,10 +24,13 @@ using v8::Array;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
+using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::LocalVector;
+using v8::Name;
 using v8::NewStringType;
+using v8::Null;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::Primitive;
@@ -609,12 +612,12 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
                              compile_cache_status_values.data(),
                              compile_cache_status_values.size())));
 
-  LocalVector<v8::Name> cached_code_type_keys(isolate);
+  LocalVector<Name> cached_code_type_keys(isolate);
   LocalVector<Value> cached_code_type_values(isolate);
 
 #define V(type, value)                                                         \
   cached_code_type_keys.push_back(FIXED_ONE_BYTE_STRING(isolate, #type));      \
-  cached_code_type_values.push_back(v8::Integer::New(isolate, value));         \
+  cached_code_type_values.push_back(Integer::New(isolate, value));             \
   DCHECK_EQ(value, cached_code_type_values.size() - 1);
   CACHED_CODE_TYPES(V)
 #undef V
@@ -622,7 +625,7 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
   USE(target->Set(context,
                   FIXED_ONE_BYTE_STRING(isolate, "cachedCodeTypes"),
                   Object::New(isolate,
-                              v8::Null(isolate),
+                              Null(isolate),
                               cached_code_type_keys.data(),
                               cached_code_type_values.data(),
                               cached_code_type_keys.size())));

--- a/test/parallel/test-compile-cache-typescript-commonjs.js
+++ b/test/parallel/test-compile-cache-typescript-commonjs.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE works for CommonJS with types.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+// Check cache for .ts files that would be run as CommonJS.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'ts', 'test-commonjs-parsing.ts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /saving transpilation cache for StrippedTypeScript .*test-commonjs-parsing\.ts/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-commonjs-parsing\.ts.*success/);
+        assert.match(output, /writing cache for CommonJS .*test-commonjs-parsing\.ts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-commonjs-parsing\.ts.*success/);
+        assert.match(output, /reading cache from .* for CommonJS .*test-commonjs-parsing\.ts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-commonjs-parsing\.ts because cache was the same/);
+        assert.match(output, /V8 code cache for CommonJS .*test-commonjs-parsing\.ts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting CommonJS .*test-commonjs-parsing\.ts because cache was the same/);
+        return true;
+      }
+    });
+}
+
+// Check cache for .cts files that require .cts files.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'cts', 'test-require-commonjs.cts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /writing cache for StrippedTypeScript .*test-require-commonjs\.cts.*success/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-cts-export-foo\.cts.*success/);
+        assert.match(output, /writing cache for CommonJS .*test-require-commonjs\.cts.*success/);
+        assert.match(output, /writing cache for CommonJS .*test-cts-export-foo\.cts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-require-commonjs\.cts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-require-commonjs\.cts because cache was the same/);
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-cts-export-foo\.cts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-cts-export-foo\.cts because cache was the same/);
+
+        assert.match(output, /V8 code cache for CommonJS .*test-require-commonjs\.cts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting CommonJS .*test-require-commonjs\.cts because cache was the same/);
+        assert.match(output, /V8 code cache for CommonJS .*test-cts-export-foo\.cts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting CommonJS .*test-cts-export-foo\.cts because cache was the same/);
+        return true;
+      }
+    });
+}
+
+// Check cache for .cts files that require .mts files.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'cts', 'test-require-mts-module.cts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /writing cache for StrippedTypeScript .*test-require-mts-module\.cts.*success/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-mts-export-foo\.mts.*success/);
+        assert.match(output, /writing cache for CommonJS .*test-require-mts-module\.cts.*success/);
+        assert.match(output, /writing cache for ESM .*test-mts-export-foo\.mts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-require-mts-module\.cts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-require-mts-module\.cts because cache was the same/);
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-mts-export-foo\.mts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-mts-export-foo\.mts because cache was the same/);
+
+        assert.match(output, /V8 code cache for CommonJS .*test-require-mts-module\.cts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting CommonJS .*test-require-mts-module\.cts because cache was the same/);
+        assert.match(output, /V8 code cache for ESM .*test-mts-export-foo\.mts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting ESM .*test-mts-export-foo\.mts because cache was the same/);
+        return true;
+      }
+    });
+}

--- a/test/parallel/test-compile-cache-typescript-esm.js
+++ b/test/parallel/test-compile-cache-typescript-esm.js
@@ -1,0 +1,167 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE works for ESM with types.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+// Check cache for .ts files that would be run as ESM.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'ts', 'test-module-typescript.ts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /saving transpilation cache for StrippedTypeScript .*test-module-typescript\.ts/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-module-typescript\.ts.*success/);
+        assert.match(output, /writing cache for ESM .*test-module-typescript\.ts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-module-typescript\.ts.*success/);
+        assert.match(output, /reading cache from .* for ESM .*test-module-typescript\.ts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-module-typescript\.ts because cache was the same/);
+        assert.match(output, /V8 code cache for ESM .*test-module-typescript\.ts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting ESM .*test-module-typescript\.ts because cache was the same/);
+        return true;
+      }
+    });
+}
+
+// Check cache for .mts files that import .mts files.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'mts', 'test-import-module.mts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /writing cache for StrippedTypeScript .*test-import-module\.mts.*success/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-mts-export-foo\.mts.*success/);
+        assert.match(output, /writing cache for ESM .*test-import-module\.mts.*success/);
+        assert.match(output, /writing cache for ESM .*test-mts-export-foo\.mts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-import-module\.mts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-import-module\.mts because cache was the same/);
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-mts-export-foo\.mts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-mts-export-foo\.mts because cache was the same/);
+
+        assert.match(output, /V8 code cache for ESM .*test-import-module\.mts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting ESM .*test-import-module\.mts because cache was the same/);
+        assert.match(output, /V8 code cache for ESM .*test-mts-export-foo\.mts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting ESM .*test-mts-export-foo\.mts because cache was the same/);
+        return true;
+      }
+    });
+}
+
+
+// Check cache for .mts files that import .cts files.
+{
+  tmpdir.refresh();
+  const dir = tmpdir.resolve('.compile_cache_dir');
+  const script = fixtures.path('typescript', 'mts', 'test-import-commonjs.mts');
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /writing cache for StrippedTypeScript .*test-import-commonjs\.mts.*success/);
+        assert.match(output, /writing cache for StrippedTypeScript .*test-cts-export-foo\.cts.*success/);
+        assert.match(output, /writing cache for ESM .*test-import-commonjs\.mts.*success/);
+        assert.match(output, /writing cache for CommonJS .*test-cts-export-foo\.cts.*success/);
+        return true;
+      }
+    });
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: dir
+      },
+      cwd: tmpdir.path
+    },
+    {
+      stderr(output) {
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-import-commonjs\.mts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-import-commonjs\.mts because cache was the same/);
+        assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-cts-export-foo\.cts.*success/);
+        assert.match(output, /skip persisting StrippedTypeScript .*test-cts-export-foo\.cts because cache was the same/);
+
+        assert.match(output, /V8 code cache for ESM .*test-import-commonjs\.mts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting ESM .*test-import-commonjs\.mts because cache was the same/);
+        assert.match(output, /V8 code cache for CommonJS .*test-cts-export-foo\.cts was accepted, keeping the in-memory entry/);
+        assert.match(output, /skip persisting CommonJS .*test-cts-export-foo\.cts because cache was the same/);
+        return true;
+      }
+    });
+}

--- a/test/parallel/test-compile-cache-typescript-strip-miss.js
+++ b/test/parallel/test-compile-cache-typescript-strip-miss.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE can handle cache invalidation
+// between strip-only TypeScript and transformed TypeScript.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+tmpdir.refresh();
+const dir = tmpdir.resolve('.compile_cache_dir');
+const script = fixtures.path('typescript', 'ts', 'test-typescript.ts');
+
+spawnSyncAndAssert(
+  process.execPath,
+  [script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /saving transpilation cache for StrippedTypeScript .*test-typescript\.ts/);
+      assert.match(output, /writing cache for StrippedTypeScript .*test-typescript\.ts.*success/);
+      assert.match(output, /writing cache for CommonJS .*test-typescript\.ts.*success/);
+      return true;
+    }
+  });
+
+// Reloading with transform should miss the cache generated without transform.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      // Both the transpile cache and the code cache should be missed.
+      assert.match(output, /no transpile cache for TransformedTypeScriptWithSourceMaps .*test-typescript\.ts/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-typescript\.ts.*mismatch/);
+      // New cache with source map should be generated.
+      assert.match(output, /writing cache for TransformedTypeScriptWithSourceMaps .*test-typescript\.ts.*success/);
+      assert.match(output, /writing cache for CommonJS .*test-typescript\.ts.*success/);
+      return true;
+    }
+  });
+
+// Reloading with transform should hit the cache generated with transform.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /retrieving transpile cache for TransformedTypeScriptWithSourceMaps .*test-typescript\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-typescript\.ts.*success/);
+      assert.match(output, /skip persisting TransformedTypeScriptWithSourceMaps .*test-typescript\.ts because cache was the same/);
+      assert.match(output, /V8 code cache for CommonJS .*test-typescript\.ts was accepted, keeping the in-memory entry/);
+      assert.match(output, /skip persisting CommonJS .*test-typescript\.ts because cache was the same/);
+      return true;
+    }
+  });
+
+// Reloading without transform should hit the co-existing transpile cache generated without transform,
+// but miss the code cache generated with transform.
+spawnSyncAndAssert(
+  process.execPath,
+  [script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-typescript\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-typescript\.ts.*mismatch/);
+      assert.match(output, /skip persisting StrippedTypeScript .*test-typescript\.ts because cache was the same/);
+      assert.match(output, /writing cache for CommonJS .*test-typescript\.ts.*success/);
+      return true;
+    }
+  });

--- a/test/parallel/test-compile-cache-typescript-strip-sourcemaps.js
+++ b/test/parallel/test-compile-cache-typescript-strip-sourcemaps.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE can be used for type stripping and ignores
+// --enable-source-maps as there's no difference in the code generated.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+tmpdir.refresh();
+const dir = tmpdir.resolve('.compile_cache_dir');
+const script = fixtures.path('typescript', 'ts', 'test-typescript.ts');
+
+spawnSyncAndAssert(
+  process.execPath,
+  [script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /saving transpilation cache for StrippedTypeScript .*test-typescript\.ts/);
+      assert.match(output, /writing cache for StrippedTypeScript .*test-typescript\.ts.*success/);
+      assert.match(output, /writing cache for CommonJS .*test-typescript\.ts.*success/);
+      return true;
+    }
+  });
+
+// Reloading with source maps should hit the cache generated without source maps, because for
+// type stripping, only sourceURL is added regardless of whether source map is enabled.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--enable-source-maps', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      // Both the transpile cache and the code cache should be missed.
+      assert.match(output, /retrieving transpile cache for StrippedTypeScript .*test-typescript\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-typescript\.ts.*success/);
+      assert.match(output, /skip persisting StrippedTypeScript .*test-typescript\.ts because cache was the same/);
+      assert.match(output, /V8 code cache for CommonJS .*test-typescript\.ts was accepted, keeping the in-memory entry/);
+      assert.match(output, /skip persisting CommonJS .*test-typescript\.ts because cache was the same/);
+      return true;
+    }
+  });

--- a/test/parallel/test-compile-cache-typescript-transform.js
+++ b/test/parallel/test-compile-cache-typescript-transform.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE works with --experimental-transform-types.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+
+
+tmpdir.refresh();
+const dir = tmpdir.resolve('.compile_cache_dir');
+const script = fixtures.path('typescript', 'ts', 'transformation', 'test-enum.ts');
+
+// Check --experimental-transform-types which enables source maps by default.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /saving transpilation cache for TransformedTypeScriptWithSourceMaps .*test-enum\.ts/);
+      assert.match(output, /writing cache for TransformedTypeScriptWithSourceMaps .*test-enum\.ts.*success/);
+      assert.match(output, /writing cache for CommonJS .*test-enum\.ts.*success/);
+      return true;
+    }
+  });
+
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /retrieving transpile cache for TransformedTypeScriptWithSourceMaps .*test-enum\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-enum\.ts.*success/);
+      assert.match(output, /skip persisting TransformedTypeScriptWithSourceMaps .*test-enum\.ts because cache was the same/);
+      assert.match(output, /V8 code cache for CommonJS .*test-enum\.ts was accepted, keeping the in-memory entry/);
+      assert.match(output, /skip persisting CommonJS .*test-enum\.ts because cache was the same/);
+      return true;
+    }
+  });
+
+// Reloading without source maps should miss the cache generated with source maps.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', '--no-enable-source-maps', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      // Both the transpile cache and the code cache should be missed.
+      assert.match(output, /no transpile cache for TransformedTypeScript .*test-enum\.ts/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-enum\.ts.*mismatch/);
+      // New cache without source map should be generated.
+      assert.match(output, /writing cache for TransformedTypeScript .*test-enum\.ts.*success/);
+      assert.match(output, /writing cache for CommonJS .*test-enum\.ts.*success/);
+      return true;
+    }
+  });
+
+// Reloading without source maps again should hit the cache generated without source maps.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', '--no-enable-source-maps', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /retrieving transpile cache for TransformedTypeScript .*test-enum\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-enum\.ts.*success/);
+      assert.match(output, /skip persisting TransformedTypeScript .*test-enum\.ts because cache was the same/);
+      assert.match(output, /V8 code cache for CommonJS .*test-enum\.ts was accepted, keeping the in-memory entry/);
+      assert.match(output, /skip persisting CommonJS .*test-enum\.ts because cache was the same/);
+      return true;
+    }
+  });
+
+// Reloading with source maps again should hit the co-existing transpile cache with source
+// maps, but miss the code cache generated without source maps.
+spawnSyncAndAssert(
+  process.execPath,
+  ['--experimental-transform-types', script],
+  {
+    env: {
+      ...process.env,
+      NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+      NODE_COMPILE_CACHE: dir
+    },
+    cwd: tmpdir.path
+  },
+  {
+    stderr(output) {
+      assert.match(output, /retrieving transpile cache for TransformedTypeScriptWithSourceMaps .*test-enum\.ts.*success/);
+      assert.match(output, /reading cache from .* for CommonJS .*test-enum\.ts.*mismatch/);
+      assert.match(output, /skip persisting TransformedTypeScriptWithSourceMaps .*test-enum\.ts because cache was the same/);
+      assert.match(output, /writing cache for CommonJS .*test-enum\.ts.*success/);
+      return true;
+    }
+  });


### PR DESCRIPTION
This integrates TypeScript into the compile cache by caching the transpilation (either type-stripping or transforming) output in addition to the V8 code cache that's generated from the transpilation output.

Locally this speeds up loading with type stripping of `benchmark/fixtures/strip-types-benchmark.ts` by ~65% and loading with type transforms of
`fixtures/transform-types-benchmark.ts` by ~128%.

When comparing loading .ts and loading pre-transpiled .js on-disk with the compile cache enabled, previously .ts loaded 46% slower with type-stripping and 66% slower with transforms compared to loading .js files directly.
After this patch, .ts loads 12% slower with type-stripping and 22% slower with transforms compared to .js.

(Note that the numbers are based on microbenchmark fixtures and do not necessarily represent real-world workloads, though with bigger real-world files, the speed up should be more significant, as it's not exactly linear - it just skips transpilation altogether if it's already cached, so the more complex the file is, the more will be saved).

There are some TODOs left for avoiding the excessive UTF8 transcoding, which depends on https://github.com/swc-project/swc/issues/9851 though the numbers are already good enough that I think that can be done as a follow-up..when swc actually supports it.

With compile cache enabled via `export NODE_COMPILE_CACHE=/tmp`:

```
                                                                                                                        confidence improvement accuracy (*)    (**)   (***)
ts/strip-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/strip-types-benchmark.js'                         2.31 %       ±3.44%  ±4.62%  ±6.10%
ts/strip-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/strip-types-benchmark.ts'                ***     65.37 %       ±3.99%  ±5.35%  ±7.03%
ts/transform-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/transform-types-benchmark.js'                 0.37 %       ±1.37%  ±1.82%  ±2.37%
ts/transform-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/transform-types-benchmark.ts'        ***    128.86 %       ±7.94% ±10.69% ±14.17%
```

Without compile cache (i.e. there should be no regression when it's not enabled):

```
                                                                                                                        confidence improvement accuracy (*)   (**)  (***)
ts/strip-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/strip-types-benchmark.js'                        -0.94 %       ±4.40% ±5.86% ±7.63%
ts/strip-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/strip-types-benchmark.ts'                        -0.58 %       ±1.50% ±1.99% ±2.59%
ts/transform-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/transform-types-benchmark.js'                 1.54 %       ±2.41% ±3.20% ±4.17%
ts/transform-typescript.js n=1000 filepath='/Users/joyee/projects/node/benchmark/fixtures/transform-types-benchmark.ts'                 0.04 %       ±2.28% ±3.04% ±3.95%
```

Fixes: https://github.com/nodejs/node/issues/54741

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
