### PR TITLE
[v22.x backport] lib: ensure FORCE_COLOR forces color output in non-TTY environments

### DIFF
--- a/lib/internal/util/colors.js
+++ b/lib/internal/util/colors.js
@@ -24,18 +24,16 @@ module.exports = {
         stream.getColorDepth() > 2 : true);
   },
   refresh() {
-    if (process.stderr.isTTY) {
-      const hasColors = module.exports.shouldColorize(process.stderr);
-      module.exports.blue = hasColors ? '\u001b[34m' : '';
-      module.exports.green = hasColors ? '\u001b[32m' : '';
-      module.exports.white = hasColors ? '\u001b[39m' : '';
-      module.exports.yellow = hasColors ? '\u001b[33m' : '';
-      module.exports.red = hasColors ? '\u001b[31m' : '';
-      module.exports.gray = hasColors ? '\u001b[90m' : '';
-      module.exports.clear = hasColors ? '\u001bc' : '';
-      module.exports.reset = hasColors ? '\u001b[0m' : '';
-      module.exports.hasColors = hasColors;
-    }
+    const hasColors = module.exports.shouldColorize(process.stderr);
+    module.exports.blue = hasColors ? '\u001b[34m' : '';
+    module.exports.green = hasColors ? '\u001b[32m' : '';
+    module.exports.white = hasColors ? '\u001b[39m' : '';
+    module.exports.yellow = hasColors ? '\u001b[33m' : '';
+    module.exports.red = hasColors ? '\u001b[31m' : '';
+    module.exports.gray = hasColors ? '\u001b[90m' : '';
+    module.exports.clear = hasColors ? '\u001bc' : '';
+    module.exports.reset = hasColors ? '\u001b[0m' : '';
+    module.exports.hasColors = hasColors;
   },
 };
 

--- a/test/fixtures/test-runner/output/assertion-color-tty.mjs
+++ b/test/fixtures/test-runner/output/assertion-color-tty.mjs
@@ -1,0 +1,6 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+test('failing assertion', () => {
+  assert.strictEqual('!Hello World', 'Hello World!')
+})

--- a/test/fixtures/test-runner/output/assertion-color-tty.snapshot
+++ b/test/fixtures/test-runner/output/assertion-color-tty.snapshot
@@ -1,0 +1,37 @@
+[31m✖ failing assertion [90m(*ms)[39m[39m
+  [AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  [32mactual[39m [31mexpected[39m
+  
+  [39m'[39m[32m![39m[39mH[39m[39me[39m[39ml[39m[39ml[39m[39mo[39m[39m [39m[39mW[39m[39mo[39m[39mr[39m[39ml[39m[39md[39m[31m![39m[39m'[39m
+  ] {
+    generatedMessage: [33mtrue[39m,
+    code: [32m'ERR_ASSERTION'[39m,
+    actual: [32m'!Hello World'[39m,
+    expected: [32m'Hello World!'[39m,
+    operator: [32m'strictEqual'[39m
+  }
+
+[34mℹ tests 1[39m
+[34mℹ suites 0[39m
+[34mℹ pass 0[39m
+[34mℹ fail 1[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms *[39m
+
+[31m✖ failing tests:[39m
+
+*
+[31m✖ failing assertion [90m(*ms)[39m[39m
+  [AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+  [32mactual[39m [31mexpected[39m
+  
+  [39m'[39m[32m![39m[39mH[39m[39me[39m[39ml[39m[39ml[39m[39mo[39m[39m [39m[39mW[39m[39mo[39m[39mr[39m[39ml[39m[39md[39m[31m![39m[39m'[39m
+  ] {
+    generatedMessage: [33mtrue[39m,
+    code: [32m'ERR_ASSERTION'[39m,
+    actual: [32m'!Hello World'[39m,
+    expected: [32m'Hello World!'[39m,
+    operator: [32m'strictEqual'[39m
+  }

--- a/test/fixtures/test-runner/output/non-tty-forced-color-output.js
+++ b/test/fixtures/test-runner/output/non-tty-forced-color-output.js
@@ -1,0 +1,6 @@
+'use strict';
+
+process.env.FORCE_COLOR = 1;
+
+const test = require('node:test');
+test('passing test', () => {});

--- a/test/fixtures/test-runner/output/non-tty-forced-color-output.snapshot
+++ b/test/fixtures/test-runner/output/non-tty-forced-color-output.snapshot
@@ -1,0 +1,9 @@
+[32m✔ passing test [90m(*ms)[39m[39m
+[34mℹ tests 1[39m
+[34mℹ suites 0[39m
+[34mℹ pass 1[39m
+[34mℹ fail 0[39m
+[34mℹ cancelled 0[39m
+[34mℹ skipped 0[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms *[39m

--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -204,6 +204,17 @@ const tests = [
     flags: ['--test-reporter=tap'],
   },
   {
+    name: 'test-runner/output/non-tty-forced-color-output.js',
+    flags: ['--test-reporter=spec'],
+    transform: specTransform,
+  },
+  canColorize ? {
+    name: 'test-runner/output/assertion-color-tty.mjs',
+    flags: ['--test', '--stack-trace-limit=0'],
+    transform: specTransform,
+    tty: true,
+  } : false,
+  {
     name: 'test-runner/output/async-test-scheduling.mjs',
     flags: ['--test-reporter=tap'],
   },


### PR DESCRIPTION
This PR should backport #55404, as a manual backport is required, and also addresses #52249 in this version