### PR TITLE
punycode: limit deprecation warning

### DIFF
--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -1,11 +1,16 @@
 'use strict';
+const {
+  isInsideNodeModules,
+} = internalBinding('util');
 
-process.emitWarning(
-  'The `punycode` module is deprecated. Please use a userland ' +
-  'alternative instead.',
-  'DeprecationWarning',
-  'DEP0040',
-);
+if (!isInsideNodeModules(100, true)) {
+	process.emitWarning(
+		'The `punycode` module is deprecated. Please use a userland ' +
+		'alternative instead.',
+		'DeprecationWarning',
+		'DEP0040',
+	);
+}
 
 /** Highest positive signed 32-bit float value */
 const maxInt = 2147483647; // aka. 0x7FFFFFFF or 2^31-1

--- a/test/fixtures/errors/core_line_numbers.snapshot
+++ b/test/fixtures/errors/core_line_numbers.snapshot
@@ -1,10 +1,10 @@
-node:punycode:49
+node:punycode:54
 	throw new RangeError(errors[type]);
 	^
 
 RangeError: Invalid input
-    at error (node:punycode:49:8)
-    at Object.decode (node:punycode:242:5)
+    at error (node:punycode:54:8)
+    at Object.decode (node:punycode:247:5)
     at Object.<anonymous> (*core_line_numbers.js:13:10)
 
 Node.js *


### PR DESCRIPTION
DEP0040 is an extremely annoying warning. Most of the people seeing it cannot do anything about it. This commit updates the warning logic to only emit outside of node_modules. This is similar to other warnings such as the Buffer() constructor warning.

Ideally, this should be backported to Node 22.

Refs: https://github.com/nodejs/node/pull/47202

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
