### PR TITLE
watch: reload env file for --env-file-if-exists

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -33,7 +33,7 @@ markBootstrapComplete();
 // TODO(MoLow): Make kill signal configurable
 const kKillSignal = 'SIGTERM';
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
-const kEnvFile = getOptionValue('--env-file');
+const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);


### PR DESCRIPTION
While using watch mode with --env-file-if-exists, reload env correctly

ref: https://github.com/nodejs/node/issues/49148#issuecomment-2585886195