### PR TITLE
module: use more defensive code when handling SWC errors

### DIFF
--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const {
+  ObjectPrototypeHasOwnProperty,
+} = primordials;
+const {
   validateBoolean,
   validateOneOf,
   validateObject,
@@ -12,7 +15,6 @@ const { assertTypeScript,
         isUnderNodeModules,
         kEmptyObject } = require('internal/util');
 const {
-  ERR_INTERNAL_ASSERTION,
   ERR_INVALID_TYPESCRIPT_SYNTAX,
   ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING,
   ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX,
@@ -55,15 +57,16 @@ function parseTypeScript(source, options) {
      * Amaro v0.3.0 (from SWC v1.10.7) throws an object with `message` and `code` properties.
      * It allows us to distinguish between invalid syntax and unsupported syntax.
      */
-    switch (error.code) {
+    switch (error?.code) {
       case 'UnsupportedSyntax':
         throw new ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX(error.message);
       case 'InvalidSyntax':
         throw new ERR_INVALID_TYPESCRIPT_SYNTAX(error.message);
       default:
-        // SWC will throw strings when something goes wrong.
-        // Check if has the `message` property or treat it as a string.
-        throw new ERR_INTERNAL_ASSERTION(error.message ?? error);
+        // SWC may throw strings when something goes wrong.
+        if (typeof error === 'string') { assert.fail(error); }
+        assert(error != null && ObjectPrototypeHasOwnProperty(error, 'message'));
+        assert.fail(error.message);
     }
   }
 }


### PR DESCRIPTION
In case the thrown error is not of the shape we expect, we get a `TypeError` but an `ERR_INTERNAL_ASSERTION`

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
