### PR TITLE
Fixed an issue that caused a segmentation fault when resolving a module in certain environments

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -340,12 +340,14 @@ void BindingData::GetNearestParentPackageJSON(
   ToNamespacedPath(realm->env(), &path_value);
 
   std::string path_value_str = path_value.ToString();
+  auto path_value_u8str =
+      std::u8string(path_value_str.begin(), path_value_str.end());
   if (slashCheck) {
-    path_value_str.push_back(kPathSeparator);
+    path_value_u8str.push_back(kPathSeparator);
   }
 
   auto package_json =
-      TraverseParent(realm, std::filesystem::path(path_value_str));
+      TraverseParent(realm, std::filesystem::path(path_value_u8str));
 
   if (package_json != nullptr) {
     args.GetReturnValue().Set(package_json->Serialize(realm));
@@ -366,12 +368,14 @@ void BindingData::GetNearestParentPackageJSONType(
   ToNamespacedPath(realm->env(), &path_value);
 
   std::string path_value_str = path_value.ToString();
+  auto path_value_u8str =
+    std::u8string(path_value_str.begin(), path_value_str.end());
   if (slashCheck) {
-    path_value_str.push_back(kPathSeparator);
+    path_value_u8str.push_back(kPathSeparator);
   }
 
   auto package_json =
-      TraverseParent(realm, std::filesystem::path(path_value_str));
+      TraverseParent(realm, std::filesystem::path(path_value_u8str));
 
   if (package_json == nullptr) {
     return;

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -369,7 +369,7 @@ void BindingData::GetNearestParentPackageJSONType(
 
   std::string path_value_str = path_value.ToString();
   auto path_value_u8str =
-    std::u8string(path_value_str.begin(), path_value_str.end());
+      std::u8string(path_value_str.begin(), path_value_str.end());
   if (slashCheck) {
     path_value_u8str.push_back(kPathSeparator);
   }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fix: https://github.com/nodejs/node/issues/56650

This PR fixes a problem that caused a segmentation fault in module resolution when creating a require object with multibyte characters in a non-English environment.

Since the issue occurred when generating a std::filesystem::path object, some patches were applied to the changed areas in the following PR.

https://github.com/nodejs/node/commit/a7dad43d159df199e17bcc0c64e6f02a07fb7d9e


### Caution

It cannot be reproduced by using `chcp` command in a Windows environment, and it is necessary to change the locale in the OS settings...