### PR TITLE
src: replace NoArrayBufferZeroFillScope with v8 option

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -15,6 +15,7 @@ namespace encoding_binding {
 
 using v8::ArrayBuffer;
 using v8::BackingStore;
+using v8::BackingStoreInitializationMode;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
@@ -124,9 +125,8 @@ void BindingData::EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
 
   Local<ArrayBuffer> ab;
   {
-    NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
-    std::unique_ptr<BackingStore> bs =
-        ArrayBuffer::NewBackingStore(isolate, length);
+    std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+        isolate, length, BackingStoreInitializationMode::kUninitialized);
 
     CHECK(bs);
 

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -19,6 +19,7 @@ namespace node {
 using v8::Array;
 using v8::ArrayBuffer;
 using v8::BackingStore;
+using v8::BackingStoreInitializationMode;
 using v8::ConstructorBehavior;
 using v8::Context;
 using v8::DontDelete;
@@ -243,8 +244,8 @@ int StreamBase::Writev(const FunctionCallbackInfo<Value>& args) {
 
   std::unique_ptr<BackingStore> bs;
   if (storage_size > 0) {
-    NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
-    bs = ArrayBuffer::NewBackingStore(isolate, storage_size);
+    bs = ArrayBuffer::NewBackingStore(
+        isolate, storage_size, BackingStoreInitializationMode::kUninitialized);
   }
 
   offset = 0;
@@ -398,14 +399,14 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
 
   if (try_write) {
     // Copy partial data
-    NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
-    bs = ArrayBuffer::NewBackingStore(isolate, buf.len);
+    bs = ArrayBuffer::NewBackingStore(
+        isolate, buf.len, BackingStoreInitializationMode::kUninitialized);
     memcpy(static_cast<char*>(bs->Data()), buf.base, buf.len);
     data_size = buf.len;
   } else {
     // Write it
-    NoArrayBufferZeroFillScope no_zero_fill_scope(env->isolate_data());
-    bs = ArrayBuffer::NewBackingStore(isolate, storage_size);
+    bs = ArrayBuffer::NewBackingStore(
+        isolate, storage_size, BackingStoreInitializationMode::kUninitialized);
     data_size = StringBytes::Write(isolate,
                                    static_cast<char*>(bs->Data()),
                                    storage_size,


### PR DESCRIPTION
NoArrayBufferZeroFillScope was added before the v8 option to create uninitialized backing stores was added. We can start moving away from it.

There are a handful of remaining instances in src/crypto that I remove in a separate PR. Once both of these land we can remove the `NoArrayBufferZeroFillScope` class entirely.

