### PR TITLE
http: return `Content-Length` header for `HEAD`s

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -547,7 +547,7 @@ function _storeHeader(firstLine, headers) {
   }
 
   if (!state.contLen && !state.te) {
-    if (!this._hasBody) {
+    if (!this._hasBody && this.req.method !== 'HEAD') {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
       this.chunkedEncoding = false;
     } else if (!this.useChunkedEncodingByDefault) {
@@ -932,7 +932,7 @@ function strictContentLength(msg) {
   return (
     msg.strictContentLength &&
     msg._contentLength != null &&
-    msg._hasBody &&
+    (msg._hasBody || msg.req.method === 'HEAD') &&
     !msg._removedContLen &&
     !msg.chunkedEncoding &&
     !msg.hasHeader('transfer-encoding')

--- a/test/parallel/test-http-head-response-correct-raw.js
+++ b/test/parallel/test-http-head-response-correct-raw.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+const net = require('net');
+
+// This test is to make sure that when the HTTP server
+// responds to a HEAD request, it returns the correct
+// raw response.
+
+// Body that should be sent if the request were GET.
+const body = 'Test body';
+
+// Regex to test that the raw response is correct.
+// Date can change.
+const regex = new RegExp(
+  `HTTP/1[.]1 200 OK\\r\\nContent-Type: text/plain\\r\\nDate: .+\\r\\nConnection: keep-alive\\r\\nKeep-Alive: timeout=5\\r\\nContent-Length: ${body.length}\\r\\n\\r\\n`
+);
+
+const server = http.createServer(function(req, res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/plain');
+  res.end(body);
+});
+
+server.listen(0);
+
+server.on('listening', common.mustCall(function() {
+  const s = new net.Socket();
+  s.connect(this.address().port, this.address().host);
+  s.write(`HEAD / HTTP/1.1\r\nHost: ${this.address()}:${this.address().port}\r\n\r\n`);
+  s.on('data', function(d) {
+    assert(regex.test(d.toString()));
+    s.end();
+    server.close();
+  });
+}));

--- a/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
+++ b/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
@@ -19,7 +19,11 @@ server.on('listening', common.mustCall(function() {
     method: 'HEAD',
     path: '/'
   }, common.mustCall(function(res) {
-    assert.notStrictEqual(res.headers['content-length'], undefined, 'Expected Content-Length header to be present');
+    assert.strictEqual(
+      res.headers['content-length'],
+      '4',
+      new Error('Expected Content-Length header to be of length 4')
+    );
 
     res.on('end', common.mustCall(function() {
       server.close();

--- a/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
+++ b/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
@@ -19,7 +19,7 @@ server.on('listening', common.mustCall(function() {
     method: 'HEAD',
     path: '/'
   }, common.mustCall(function(res) {
-    assert(res.headers['content-length'] !== undefined, 'Content-Length header is missing');
+    assert.notStrictEqual(res.headers['content-length'], undefined, 'Expected Content-Length header to be present');
 
     res.on('end', common.mustCall(function() {
       server.close();

--- a/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
+++ b/test/parallel/test-http-head-response-has-no-body-end-implicit-headers.js
@@ -1,6 +1,7 @@
 'use strict';
 const common = require('../common');
 const http = require('http');
+const assert = require('assert');
 
 // This test is to make sure that when the HTTP server
 // responds to a HEAD request with data to res.end,
@@ -18,6 +19,8 @@ server.on('listening', common.mustCall(function() {
     method: 'HEAD',
     path: '/'
   }, common.mustCall(function(res) {
+    assert(res.headers['content-length'] !== undefined, 'Content-Length header is missing');
+
     res.on('end', common.mustCall(function() {
       server.close();
     }));


### PR DESCRIPTION
In the current http library, all responses without body will not return the Content-Length header.

Fixes: https://github.com/nodejs/node/issues/56680

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
