### PR TITLE
test: use --permission instead of --experimental-permission

### DIFF
--- a/test/parallel/test-permission-dc-worker-threads.js
+++ b/test/parallel/test-permission-dc-worker-threads.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-permission --allow-fs-read=* --experimental-test-module-mocks
+// Flags: --permission --allow-fs-read=* --experimental-test-module-mocks
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-runner-module-mocking.js
+++ b/test/parallel/test-runner-module-mocking.js
@@ -655,7 +655,7 @@ test('should throw ERR_ACCESS_DENIED when permission model is enabled', async (t
   const cwd = fixtures.path('test-runner');
   const fixture = fixtures.path('test-runner', 'mock-nm.js');
   const args = [
-    '--experimental-permission',
+    '--permission',
     '--allow-fs-read=*',
     '--experimental-test-module-mocks',
     fixture,
@@ -674,7 +674,7 @@ test('should work when --allow-worker is passed and permission model is enabled'
   const cwd = fixtures.path('test-runner');
   const fixture = fixtures.path('test-runner', 'mock-nm.js');
   const args = [
-    '--experimental-permission',
+    '--permission',
     '--allow-fs-read=*',
     '--allow-worker',
     '--experimental-test-module-mocks',


### PR DESCRIPTION
This PR fixes main. I've cherry-picked the v23.x security release commits into main and I forgot we've removed `--experimental-permission` in main. 