### PR TITLE
deps: macro ENODATA is deprecated in libc++

### DIFF
--- a/deps/uv/unofficial.gni
+++ b/deps/uv/unofficial.gni
@@ -7,6 +7,11 @@
 template("uv_gn_build") {
   config("uv_external_config") {
     include_dirs = [ "include" ]
+    if (is_clang || !is_win) {
+      cflags_cc = [
+        "-Wno-deprecated-pragma",  # for using ENODATA in errno.h
+      ]
+    }
   }
 
   config("uv_internal_config") {


### PR DESCRIPTION
The `ENODATA` macro, which is used by uv's public header`errno.h`, has been deprecated in libc++.