### PR TITLE
src: add default value for RSACipherConfig mode field

### DIFF
--- a/src/crypto/crypto_rsa.h
+++ b/src/crypto/crypto_rsa.h
@@ -77,7 +77,7 @@ struct RSAKeyExportTraits final {
 using RSAKeyExportJob = KeyExportJob<RSAKeyExportTraits>;
 
 struct RSACipherConfig final : public MemoryRetainer {
-  CryptoJobMode mode;
+  CryptoJobMode mode = kCryptoJobAsync;
   ByteSource label;
   int padding = 0;
   const EVP_MD* digest = nullptr;


### PR DESCRIPTION
Using default init of enum is UB
Refs: https://github.com/nodejs/node/issues/56693

