### PR TITLE
src: add check for Bignum in GroupOrderSize

### DIFF
--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -937,6 +937,7 @@ size_t GroupOrderSize(const EVPKeyPointer& key) {
   const EC_KEY* ec = key;
   CHECK_NOT_NULL(ec);
   auto order = BignumPointer::New();
+  CHECK(order);
   CHECK(EC_GROUP_get_order(ECKeyPointer::GetGroup(ec), order.get(), nullptr));
   return order.byteLength();
 }


### PR DESCRIPTION
I think it's missed, cause in this file we have example of checking result of BignumPointer::new

Fixes: https://github.com/nodejs/node/issues/56692
