### PR TITLE
Enable ccache on Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -573,6 +573,20 @@ export CC="ccache cc"          # add to ~/.zshrc or other shell config file
 export CXX="ccache c++"        # add to ~/.zshrc or other shell config file
 ```
 
+On Windows:
+
+Tips: follow <https://github.com/ccache/ccache/wiki/MS-Visual-Studio>, and you
+should notice that obj file will be bigger the normal one.
+
+First, install ccache, assume ccache install to c:\ccache, copy
+c:\ccache\ccache.exe to c:\ccache\cl.exe
+
+When building Node.js provide a path to your ccache via the option
+
+```powershell
+.\vcbuild.bat ccache c:\ccache\
+```
+
 This will allow for near-instantaneous rebuilds when switching branches back
 and forth that were built with cache.
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -483,6 +483,9 @@
           'NOMINMAX',
         ],
       }],
+      ['ccache_used == 1', {
+        'defines': ['CCACHE_USED',],
+      }],
       [ 'OS in "linux freebsd openbsd solaris aix os400"', {
         'cflags': [ '-pthread' ],
         'ldflags': [ '-pthread' ],

--- a/configure.py
+++ b/configure.py
@@ -989,6 +989,11 @@ parser.add_argument('--clang-cl',
     default=None,
     help='Configure for clang-cl on Windows. This flag sets the GYP "clang" ' +
          'variable to 1 and "llvm_version" to the specified value.')
+parser.add_argument('--ccache-used',
+    action='store_true',
+    dest='ccache_used',
+    default=None,
+    help='Ccache is used in compulation on Windows.')
 
 (options, args) = parser.parse_known_args()
 
@@ -1165,6 +1170,8 @@ def get_gas_version(cc):
 # check involves checking the build number against an allowlist.  I'm not
 # quite prepared to go that far yet.
 def check_compiler(o):
+  o['variables']['ccache_used'] = 0
+
   if sys.platform == 'win32':
     if options.clang_cl:
       o['variables']['clang'] = 1
@@ -1172,6 +1179,9 @@ def check_compiler(o):
     else:
       o['variables']['clang'] = 0
       o['variables']['llvm_version'] = '0.0'
+
+    if options.ccache_used:
+      o['variables']['ccache_used'] = 1
 
     if not options.openssl_no_asm and options.dest_cpu in ('x86', 'x64'):
       nasm_version = get_nasm_version('nasm')

--- a/deps/v8/src/builtins/generate-bytecodes-builtins-list.cc
+++ b/deps/v8/src/builtins/generate-bytecodes-builtins-list.cc
@@ -41,6 +41,14 @@ void WriteBytecode(std::ofstream& out, Bytecode bytecode,
 void WriteHeader(const char* header_filename) {
   std::ofstream out(header_filename);
 
+#ifdef CCACHE_USED
+  // Write a cache invalidator to ensure that ccache does not cache this file.
+  out << "#ifndef CACHE_INVALIDATOR\n"
+      << "#define CACHE_INVALIDATOR\n"
+      << "inline const char* cache_invalidator = __TIME__;\n"
+      << "#endif\n\n";
+#endif
+
   out << "// Automatically generated from interpreter/bytecodes.h\n"
       << "// The following list macro is used to populate the builtins list\n"
       << "// with the bytecode handlers\n\n"

--- a/tools/msvs/props_4_ccache.props
+++ b/tools/msvs/props_4_ccache.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <UseMultiToolTask>true</UseMultiToolTask>
+    <TrackFileAccess>false</TrackFileAccess>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <!-- /Z7 of cl.exe, ref: https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format -->
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -28,6 +28,7 @@ set target_env=
 set noprojgen=
 set projgen=
 set clang_cl=
+set ccache_path=
 set nobuild=
 set sign=
 set nosnapshot=
@@ -87,6 +88,7 @@ if /i "%1"=="vs2022"        set target_env=vs2022&goto arg-ok
 if /i "%1"=="noprojgen"     set noprojgen=1&goto arg-ok
 if /i "%1"=="projgen"       set projgen=1&goto arg-ok
 if /i "%1"=="clang-cl"      set clang_cl=1&goto arg-ok
+if /i "%1"=="ccache"        set "ccache_path=%2%"&goto arg-ok-2
 if /i "%1"=="nobuild"       set nobuild=1&goto arg-ok
 if /i "%1"=="nosign"        set "sign="&echo Note: vcbuild no longer signs by default. "nosign" is redundant.&goto arg-ok
 if /i "%1"=="sign"          set sign=1&goto arg-ok
@@ -206,6 +208,7 @@ if defined debug_nghttp2    set configure_flags=%configure_flags% --debug-nghttp
 if defined openssl_no_asm   set configure_flags=%configure_flags% --openssl-no-asm
 if defined no_shared_roheap set configure_flags=%configure_flags% --disable-shared-readonly-heap
 if defined DEBUG_HELPER     set configure_flags=%configure_flags% --verbose
+if defined ccache_path      set configure_flags=%configure_flags% --ccache-used
 if defined compile_commands set configure_flags=%configure_flags% -C
 
 if "%target_arch%"=="x86" (
@@ -364,6 +367,7 @@ if "%target%"=="Build" (
 if "%target%"=="node" if exist "%config%\cctest.exe" del "%config%\cctest.exe"
 if "%target%"=="node" if exist "%config%\embedtest.exe" del "%config%\embedtest.exe"
 if defined msbuild_args set "extra_msbuild_args=%extra_msbuild_args% %msbuild_args%"
+if defined ccache_path set "extra_msbuild_args=%extra_msbuild_args% /p:TrackFileAccess=false /p:CLToolPath=%ccache_path% /p:ForceImportAfterCppProps=%CD%\tools\msvs\props_4_ccache.props"
 @rem Setup env variables to use multiprocessor build
 set UseMultiToolTask=True
 set EnforceProcessCountAcrossBuilds=True
@@ -800,7 +804,7 @@ set exit_code=1
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [clang-cl] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [nocorepack] [ltcg] [licensetf] [sign] [x64/arm64] [vs2022] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [format-md] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
+echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [ignore-flaky] [static/dll] [noprojgen] [projgen] [clang-cl] [ccache path-to-ccache] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [nocorepack] [ltcg] [licensetf] [sign] [x64/arm64] [vs2022] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [format-md] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
 echo Examples:
 echo   vcbuild.bat                          : builds release build
 echo   vcbuild.bat debug                    : builds debug build
@@ -811,6 +815,7 @@ echo   vcbuild.bat enable-vtune             : builds Node.js with Intel VTune pr
 echo   vcbuild.bat link-module my_module.js : bundles my_module as built-in module
 echo   vcbuild.bat lint                     : runs the C++, documentation and JavaScript linter
 echo   vcbuild.bat no-cctest                : skip building cctest.exe
+echo   vcbuild.bat ccache c:\ccache\        : use ccache to speed build
 goto exit
 
 :exit


### PR DESCRIPTION
This PR continues an effort to enable Clang in the CI. While based on initial tests, it works, we want to make it as fast as possible. For that reason, this PR enables using ccache on Windows. The current cache we have in the CI, the clcache, is not compatible with Clang and is obsolete, so we could move fully to ccache in the CI in the future, but for Clang it is mandatory.

The initial work on this was done in https://github.com/nodejs/node/pull/52126 and https://github.com/nodejs/node/pull/52255 and that is the cornerstone of the changes suggested here. The main change is adding a new vcbuild option ccache which should be the path to the directory where ccache is installed (ccache.exe also needs to be renamed to cl.exe as explained in the docs).

When testing this, I noticed that one of the .h files, generated by V8 during the compilation was causing issues for ccache as its last modification time was later than cached PCH modification times. As a result, I made a simple patch to disable caching that file by using `__TIME__`.
NOTE TO REVIEWERS - I know this is far from optimal, but was the only way I found to enable ccache on at least a part of the project. I'm looking forward to any suggestions on how to improve it. Thanks in advance.