### PR TITLE
Added <cstdint> for uint64_t support

### DIFF
--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <cstdint>
 
 namespace node {
 namespace inspector {


### PR DESCRIPTION
src: Adding `#include <cstdint>` to worker_inspector. h for gcc v15

Added cstdint to worker_inspector as on more recent version of gcc
the build was failing due to changes to libstdc++ and the removal
of transitive includes

Fixes: https://github.com/nodejs/node/issues/56731
