### PR TITLE
Chore/remove test reporter duplicate

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -105,4 +105,4 @@ jobs:
       - name: Test
         run: |
           cd $TAR_DIR
-          make run-ci -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9"
+          make run-ci -j4 V=1 TEST_CI_ARGS="-p dots  --measure-flakiness 9"

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -68,7 +68,7 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots  --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage
         env:

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -68,7 +68,7 @@ jobs:
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Test
-        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots --node-args='--test-reporter=./test/common/test-error-reporter.js' --measure-flakiness 9" || exit 0
+        run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots  --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage
         env:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -40,4 +40,4 @@ jobs:
           name: docs
           path: out/doc
       - name: Test
-        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -40,4 +40,4 @@ jobs:
           name: docs
           path: out/doc
       - name: Test
-        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: NODE=$(command -v node) make test-doc-ci TEST_CI_ARGS="-p actions --measure-flakiness 9"

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Build
         run: make build-ci -j4 V=1
       - name: Test
-        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"

--- a/.github/workflows/test-asan.yml
+++ b/.github/workflows/test-asan.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Build
         run: make build-ci -j4 V=1
       - name: Test
-        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions -t 300 --measure-flakiness 9"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: make -C node build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
-        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: make -C node build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
-        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Free Space After Build
         run: df -h
       - name: Test
-        run: make -C node run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make -C node run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Free Space After Build
         run: df -h
       - name: Test
-        run: make -C node run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' --measure-flakiness 9"
+        run: make -C node run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"

--- a/.github/workflows/test-ubsan.yml
+++ b/.github/workflows/test-ubsan.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions --node-args='--test-reporter=./test/common/test-error-reporter.js' --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"

--- a/.github/workflows/test-ubsan.yml
+++ b/.github/workflows/test-ubsan.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Build
         run: make build-ci -j2 V=1
       - name: Test
-        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions  --node-args='--test-reporter-destination=stdout' -t 300 --measure-flakiness 9"
+        run: make run-ci -j2 V=1 TEST_CI_ARGS="-p actions -t 300 --measure-flakiness 9"


### PR DESCRIPTION
Currently the test reporter is specified both in workflow files and `test.py`. This PR removes it from the formers to avoid duplication

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
