### PR TITLE
src: adding #include <cstdint> to worker_inspector. h for gcc v15

### DIFF
--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -5,6 +5,7 @@
 #error("This header can only be used when inspector is enabled")
 #endif
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Added `cstdint` to `worker_inspector.h `as on new version of gcc
(v15) the build was failing due to changes to **libstdc++** and
the removal of transitive includes. Build then now fails due to
the usage of uint64_t in worker_inspector.h.
**Output of build:**
`../../src/inspector/worker_inspector.h:63:7: **error: ‘uint64_t’ has not been declared**
   63 |       uint64_t thread_id, const std::string& url, const std::string& name) {
      |       ^~~~~~~~

../../src/inspector/worker_inspector.h:12:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   11 | #include <unordered_set>
  +++ |+#include <cstdint>`

Fixes: https://github.com/nodejs/node/issues/56731
