### PR TITLE
test: use strict mode in global setters test

### DIFF
--- a/test/parallel/test-global-setters.js
+++ b/test/parallel/test-global-setters.js
@@ -1,4 +1,4 @@
-/* eslint-disable strict */
+'use strict';
 require('../common');
 const assert = require('assert');
 const _process = require('process');

--- a/test/parallel/test-global-setters.js
+++ b/test/parallel/test-global-setters.js
@@ -1,3 +1,9 @@
+// When setters and getters were added for global.process and global.Buffer to
+// create a deprecation path for them in ESM, this test was added to make sure
+// the setters and getters behaved as expected.
+// Ref: https://github.com/nodejs/node/pull/26882
+// Ref: https://github.com/nodejs/node/pull/26334
+
 'use strict';
 require('../common');
 const assert = require('assert');


### PR DESCRIPTION
test-global-setters.js was added in
https://github.com/nodejs/node/pull/26882 and hasn't been modified since. It appears that it avoids strict mode so that unscoped identifiers are treated as globals, but that's true in strict mode too. (In sloppy mode, an assignment to an undefined identifier will create a global, but that's not what this test does. In strict mode, those assignments will throw an error, which would seem to be what we would want.)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
