### PR TITLE
doc: fix styles of the expandable TOC

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -562,38 +562,26 @@ hr {
 }
 
 .toc ul {
-  margin: 0
+  margin: 0;
 }
-
-.toc li a::before {
-  content: "■";
-  color: var(--color-text-primary);
-  padding-right: 1em;
-  font-size: 0.9em;
+.toc>ul:first-child {
+  margin-left: 1rem;
+}
+.toc li {
+  display: list-item;
+  list-style: square;
+}
+.toc li a {
+  display: inline;
+  padding-left: 0;
 }
 
 .toc li a:hover::before {
   color: var(--white);
 }
 
-.toc ul ul a {
+.toc ul {
   padding-left: 1rem;
-}
-
-.toc ul ul ul a {
-  padding-left: 2rem;
-}
-
-.toc ul ul ul ul a {
-  padding-left: 3rem;
-}
-
-.toc ul ul ul ul ul a {
-  padding-left: 4rem;
-}
-
-.toc ul ul ul ul ul ul a {
-  padding-left: 5rem;
 }
 
 #toc .stability_0::after,


### PR DESCRIPTION
The current CSS uses `::before` to build custom list markers, which causes them to appear underlined. This PR undoes that to use plain old list marker instead.

<details open><summary>Before</summary>

![screenshot of the expanded Table of Contents from the current website](https://github.com/user-attachments/assets/78abfd06-13a7-471e-bec5-3000c8cae2b9)

</details>
<details open><summary>After</summary>

![screenshot of the expanded Table of Contents from this PR](https://github.com/user-attachments/assets/b5d007c0-9f32-493b-9d8d-029e2a2f378f)

</details>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
