### PR TITLE
test: fix invalid common.mustSucceed() usage

### DIFF
--- a/test/parallel/test-http-server-headers-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-delayed-headers.js
@@ -38,16 +38,18 @@ server.listen(0, common.mustCall(() => {
     response += chunk;
   }));
 
-  const errOrEnd = common.mustSucceed(function(err) {
+  client.on('error', () => {
+    // Ignore errors like 'write EPIPE' that might occur while the request is
+    // sent.
+  });
+
+  client.on('close', common.mustCall(() => {
     assert.strictEqual(
       response,
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
-  });
-
-  client.on('end', errOrEnd);
-  client.on('error', errOrEnd);
+  }));
 
   client.resume();
 

--- a/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-headers-timeout-interrupted-headers.js
@@ -38,16 +38,18 @@ server.listen(0, common.mustCall(() => {
     response += chunk;
   }));
 
-  const errOrEnd = common.mustSucceed(function(err) {
+  client.on('error', () => {
+    // Ignore errors like 'write EPIPE' that might occur while the request is
+    // sent.
+  });
+
+  client.on('close', common.mustCall(() => {
     assert.strictEqual(
       response,
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
-  });
-
-  client.on('end', errOrEnd);
-  client.on('error', errOrEnd);
+  }));
 
   client.resume();
   client.write('GET / HTTP/1.1\r\n');

--- a/test/parallel/test-http-server-request-timeout-delayed-headers.js
+++ b/test/parallel/test-http-server-request-timeout-delayed-headers.js
@@ -33,16 +33,18 @@ server.listen(0, common.mustCall(() => {
     response += chunk;
   }));
 
-  const errOrEnd = common.mustSucceed(function(err) {
+  client.on('error', () => {
+    // Ignore errors like 'write EPIPE' that might occur while the request is
+    // sent.
+  });
+
+  client.on('close', common.mustCall(() => {
     assert.strictEqual(
       response,
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
-  });
-
-  client.on('end', errOrEnd);
-  client.on('error', errOrEnd);
+  }));
 
   client.resume();
 

--- a/test/parallel/test-http-server-request-timeout-interrupted-body.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-body.js
@@ -45,16 +45,18 @@ server.listen(0, common.mustCall(() => {
     response += chunk;
   }));
 
-  const errOrEnd = common.mustSucceed(function(err) {
+  client.on('error', () => {
+    // Ignore errors like 'write EPIPE' that might occur while the request is
+    // sent.
+  });
+
+  client.on('close', common.mustCall(() => {
     assert.strictEqual(
       response,
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
-  });
-
-  client.on('error', errOrEnd);
-  client.on('end', errOrEnd);
+  }));
 
   client.resume();
   client.write('POST / HTTP/1.1\r\n');

--- a/test/parallel/test-http-server-request-timeout-interrupted-headers.js
+++ b/test/parallel/test-http-server-request-timeout-interrupted-headers.js
@@ -33,16 +33,18 @@ server.listen(0, common.mustCall(() => {
     response += chunk;
   }));
 
-  const errOrEnd = common.mustSucceed(function(err) {
+  client.on('error', () => {
+    // Ignore errors like 'write EPIPE' that might occur while the request is
+    // sent.
+  });
+
+  client.on('close', common.mustCall(() => {
     assert.strictEqual(
       response,
       'HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n'
     );
     server.close();
-  });
-
-  client.on('end', errOrEnd);
-  client.on('error', errOrEnd);
+  }));
 
   client.resume();
   client.write('GET / HTTP/1.1\r\n');


### PR DESCRIPTION
By its own nature, the function returned by `common.mustSucceed()` cannot be used as a listener for `'error'` events.

Write errors like `read ECONNRESET` or `write EPIPE`, should be ignored because the socket might be closed by the other peer while the request is sent.

Refs: https://github.com/nodejs/node/commit/3caa2c1a005652fdb3e8

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
