### PR TITLE
child_process: validate options.shell and correctly enforce shell invocation in exec/execSync

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -196,7 +196,12 @@ function normalizeExecArgs(command, options, callback) {
 
   // Make a shallow copy so we don't clobber the user's options object.
   options = { __proto__: null, ...options };
-  options.shell = typeof options.shell === 'string' ? options.shell : true;
+
+  // Validate the shell, if present, and ensure a truthy value.
+  if (options.shell != null) {
+    validateString(options.shell, 'options.shell');
+  }
+  options.shell ||= true;
 
   return {
     file: command,

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -33,7 +33,7 @@ const testCopy = (shellName, shellPath) => {
 const system32 = `${process.env.SystemRoot}\\System32`;
 
 // Test CMD
-test(true);
+test();
 test('cmd');
 testCopy('cmd.exe', `${system32}\\cmd.exe`);
 test('cmd.exe');

--- a/test/parallel/test-child-process-exec-enforce-shell.js
+++ b/test/parallel/test-child-process-exec-enforce-shell.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { exec, execSync } = require('child_process');
+
+const invalidArgTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError'
+};
+
+exec('echo should-be-passed-as-argument', { shell: '' }, common.mustSucceed((stdout, stderr) => {
+  assert.match(stdout, /should-be-passed-as-argument/);
+  assert.ok(!stderr);
+}));
+
+{
+  const ret = execSync('echo should-be-passed-as-argument', { encoding: 'utf-8', shell: '' });
+  assert.match(ret, /should-be-passed-as-argument/);
+}
+
+for (const fn of [exec, execSync]) {
+  assert.throws(() => fn('should-throw-on-boolean-shell-option', { shell: false }), invalidArgTypeError);
+}


### PR DESCRIPTION
Previously opened as #54623, and the PR description there is still valid. Unfortunately this was originally submitted while CI was blocked by the macos test platform issues, and never made it back to request-ci.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
