### PR TITLE
http: be more generational GC friendly

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -1218,6 +1218,8 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   // Refs: https://github.com/nodejs/node/pull/30958
   for (let i = 0; i < outputLength; i++) {
     const { data, encoding, callback } = outputData[i];
+    // avoid any potential ref to Buffer in new generation from old generation
+    outputData[i].data = null; 
     ret = socket.write(data, encoding, callback);
   }
   socket.uncork();

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -1218,8 +1218,8 @@ OutgoingMessage.prototype._flushOutput = function _flushOutput(socket) {
   // Refs: https://github.com/nodejs/node/pull/30958
   for (let i = 0; i < outputLength; i++) {
     const { data, encoding, callback } = outputData[i];
-    // avoid any potential ref to Buffer in new generation from old generation
-    outputData[i].data = null; 
+    // Avoid any potential ref to Buffer in new generation from old generation
+    outputData[i].data = null;
     ret = socket.write(data, encoding, callback);
   }
   socket.uncork();


### PR DESCRIPTION
Avoid any potential ref to Buffer in new generation from old generation. Otherwise, the lightweight Minor GC could not collect Buffer, as a result, the heavy Major GC may be invoked more frequently

Similar tricks are used in Writable and Readable

https://github.com/nodejs/node/blob/ce6a62872081d720734d82bf975653a322795288/lib/internal/streams/writable.js#L779

https://github.com/nodejs/node/blob/ce6a62872081d720734d82bf975653a322795288/lib/internal/streams/readable.js#L1598

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
