### PR TITLE
tools: update winget manifest on new release

### DIFF
--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -1,0 +1,66 @@
+name: Update WinGet manifest
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+    # wingetcreate is only supported on Windows
+    runs-on: windows-latest
+    # Only submit stable releases
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Submit new version PR using wingetcreate
+        run: |
+          $wingetPackageID = "OpenJS.NodeJS"
+
+          # Get installer info from release event
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
+          $releaseDate = (Get-Date ${{ toJSON(github.event.release.published_at) }}).ToString("yyyy-MM-dd")
+          $x64InstallerUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-x64.msi"
+          $arm64InstallerUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-arm64.msi"
+          $releaseNotesUrl = "https://github.com/nodejs/node/releases/tag/v$packageVersion"
+
+          # Download wingetcreate portable executable
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+          # Update manifest with new version & URLs
+          # Not using --submit flag with update as we want to make manual changes to manifests & then submit
+          .\wingetcreate.exe update $wingetPackageID `
+            --version $packageVersion `
+            --urls $x64InstallerUrl $arm64InstallerUrl `
+            --release-date $releaseDate `
+            --release-notes-url $releaseNotesUrl `
+            --token "${{ secrets.WINGET_GITHUB_TOKEN }}"
+
+          # The update command will output the manifests in the following path
+          $outputRelativePath = "manifests/o/OpenJS/NodeJS/$packageVersion/"
+
+          # Pattern to value map for updating version specific URLs in locale manifests
+          $patternValueMap = @{
+            # Targets PublisherSupportUrl
+            'v([\d.]+)\/\.github\/SUPPORT\.md' = "v$packageVersion/.github/SUPPORT.md"
+
+            # Targets LicenseUrl
+            'v([\d.]+)\/LICENSE' = "v$packageVersion/LICENSE"
+
+            # Targets DocumentUrl
+            'docs\/v([\d.]+)\/api\/' = "docs/v$packageVersion/api/"
+          }
+
+          # Update patterns if they exist in the locale manifests
+          $localeManifests = Get-ChildItem -Path $outputRelativePath -Recurse -Filter "*locale.*.yaml"
+          $localeManifests | ForEach-Object {
+              $localeManifestContent = Get-Content $_.FullName
+              $patternValueMap.Keys | ForEach-Object {
+                  $localeManifestContent = $localeManifestContent -replace $_, $patternValueMap[$_]
+              }
+              Set-Content -Path $_.FullName -Value $localeManifestContent
+          }
+
+          # Submit the updated manifests to winget-pkgs repository
+          .\wingetcreate.exe submit $outputRelativePath `
+            --token "${{ secrets.WINGET_GITHUB_TOKEN }}" `
+            --prtitle "New version: $wingetPackageID version $packageVersion"

--- a/.github/workflows/update-winget.yml
+++ b/.github/workflows/update-winget.yml
@@ -9,6 +9,12 @@ jobs:
     name: Submit to WinGet repository
     # wingetcreate is only supported on Windows
     runs-on: windows-latest
+    permissions:
+      contents: read
+    env:
+      # wingetcreate will read the following environment variable to access the GitHub token needed for submitting a PR
+      # Reference: https://aka.ms/winget-create-token
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
     # Only submit stable releases
     if: ${{ !github.event.release.prerelease }}
     steps:
@@ -19,21 +25,22 @@ jobs:
           # Get installer info from release event
           $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
           $releaseDate = (Get-Date ${{ toJSON(github.event.release.published_at) }}).ToString("yyyy-MM-dd")
-          $x64InstallerUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-x64.msi"
-          $arm64InstallerUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-arm64.msi"
+          $x64MSIUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-x64.msi"
+          $x64PortableUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-win-x64.zip"
+          $arm64MSIUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-arm64.msi"
+          $arm64PortableUrl = "https://nodejs.org/dist/v$packageVersion/node-v$packageVersion-win-arm64.zip"
           $releaseNotesUrl = "https://github.com/nodejs/node/releases/tag/v$packageVersion"
 
           # Download wingetcreate portable executable
-          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
 
           # Update manifest with new version & URLs
           # Not using --submit flag with update as we want to make manual changes to manifests & then submit
           .\wingetcreate.exe update $wingetPackageID `
             --version $packageVersion `
-            --urls $x64InstallerUrl $arm64InstallerUrl `
+            --urls $x64MSIUrl $x64PortableUrl $arm64MSIUrl $arm64PortableUrl `
             --release-date $releaseDate `
-            --release-notes-url $releaseNotesUrl `
-            --token "${{ secrets.WINGET_GITHUB_TOKEN }}"
+            --release-notes-url $releaseNotesUrl
 
           # The update command will output the manifests in the following path
           $outputRelativePath = "manifests/o/OpenJS/NodeJS/$packageVersion/"
@@ -62,5 +69,4 @@ jobs:
 
           # Submit the updated manifests to winget-pkgs repository
           .\wingetcreate.exe submit $outputRelativePath `
-            --token "${{ secrets.WINGET_GITHUB_TOKEN }}" `
             --prtitle "New version: $wingetPackageID version $packageVersion"


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

### Description

This PR proposes to add a GitHub action for submitting the latest stable release to WinGet as it gets published. [microsoft/winget-create](https://github.com/microsoft/winget-create) is used as the tool for generating and submitting the new manifests. The implementation assumes that the Installer URLs at `https://nodejs.org/dist/` are available as soon as the release is published at GitHub.

---

### Steps needed from maintainers

If the maintainers approve of these changes, they will need to do the following before merging this PR:

1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under a personal or bot account. Looking at discussion in PR #34014, I assume this can be done under the bot account @nodejs-github-bot
2. Create a [personal access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the fork exists.
3. Store the created token in a repository secret with the name `WINGET_CREATE_GITHUB_TOKEN`

For reference, maintainers may see similar implemented actions in the following repos:
- [Microsoft PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml)
- [Microsoft Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml)
- [Microsoft Copilot CLI](https://github.com/github/copilot-cli/blob/v0.0.368-2/.github/workflows/winget.yml)
- [Microsoft Edit](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml)
- [WinGet Studio](https://github.com/microsoft/winget-studio/blob/main/.github/workflows/winget.yml)
- [Oh-My-Posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/release.yml)

---

### Validation

Validated the action works as expected in a test repo. See the run https://github.com/mdanish-kh/test-wingetcreate/actions/runs/12976977036/job/36189859568