### PR TITLE
[v20.x backport] deps: V8: backport 9ab40592f697

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/riscv/cpu-riscv.cc
+++ b/deps/v8/src/codegen/riscv/cpu-riscv.cc
@@ -15,12 +15,12 @@ namespace internal {
 void CpuFeatures::FlushICache(void* start, size_t size) {
 #if !defined(USE_SIMULATOR)
   char* end = reinterpret_cast<char*>(start) + size;
-  // The definition of this syscall is
-  // SYSCALL_DEFINE3(riscv_flush_icache, uintptr_t, start,
-  //                 uintptr_t, end, uintptr_t, flags)
-  // The flag here is set to be SYS_RISCV_FLUSH_ICACHE_LOCAL, which is
-  // defined as 1 in the Linux kernel.
-  syscall(SYS_riscv_flush_icache, start, end, 1);
+  // SYS_riscv_flush_icache is a symbolic constant used in user-space code to
+  // identify the flush_icache system call, while __NR_riscv_flush_icache is the
+  // corresponding system call number used in the kernel to dispatch the system
+  // call.
+  // The flag set to zero will flush all cpu cores.
+  syscall(__NR_riscv_flush_icache, start, end, 0);
 #endif  // !USE_SIMULATOR.
 }
 


### PR DESCRIPTION
Manual backport for v20.x of #56781

Original commit message:

    [riscv] Flush icache in both local and remote harts

    Fix the I-Cache flush flag according to the implementation of flush_icache_mm in Linux kernel.

    Change-Id: I6e6b1f56c377c2c0a629e170737bfac6c357ce8d
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6080611
    Commit-Queue: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#97673}

Refs: https://github.com/v8/v8/commit/9ab40592f697795f13e71325a18ecbe8cf5857ed

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
