### PR TITLE
test: remove unnecessary code

### DIFF
--- a/test/parallel/test-https-client-renegotiation-limit.js
+++ b/test/parallel/test-https-client-renegotiation-limit.js
@@ -25,12 +25,6 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-const { opensslCli } = require('../common/crypto');
-
-if (!opensslCli) {
-  common.skip('node compiled without OpenSSL CLI.');
-}
-
 const assert = require('assert');
 const tls = require('tls');
 const https = require('https');

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -8,12 +8,7 @@ if (!common.hasCrypto) {
 const {
   hasOpenSSL,
   hasOpenSSL3,
-  opensslCli,
 } = require('../common/crypto');
-
-if (!opensslCli) {
-  common.skip('node compiled without OpenSSL CLI');
-}
 
 const assert = require('assert');
 const net = require('net');

--- a/test/parallel/test-tls-ocsp-callback.js
+++ b/test/parallel/test-tls-ocsp-callback.js
@@ -26,12 +26,6 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-const { opensslCli } = require('../common/crypto');
-
-if (!opensslCli) {
-  common.skip('node compiled without OpenSSL CLI.');
-}
-
 const crypto = require('crypto');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');


### PR DESCRIPTION
The following tests

- `test/parallel/test-https-client-renegotiation-limit.js`
- `test/parallel/test-tls-alert-handling.js`
- `test/parallel/test-tls-ocsp-callback.js`

no longer use the OpenSSL CLI.

Refs: https://github.com/nodejs/node/pull/56714#discussion_r1926486581

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
