### PR TITLE
inspector: fix StringUtil::CharacterCount for unicodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1474,6 +1474,8 @@ LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	src/*/*.h \
 	test/addons/*/*.cc \
 	test/addons/*/*.h \
+	test/cctest/*/*.cc \
+	test/cctest/*/*.h \
 	test/cctest/*.cc \
 	test/cctest/*.h \
 	test/embedding/*.cc \

--- a/node.gyp
+++ b/node.gyp
@@ -432,6 +432,7 @@
       'test/cctest/test_quic_tokens.cc',
     ],
     'node_cctest_inspector_sources': [
+      'test/cctest/inspector/test_node_protocol.cc',
       'test/cctest/test_inspector_socket.cc',
       'test/cctest/test_inspector_socket_server.cc',
     ],
@@ -1209,6 +1210,14 @@
             'HAVE_INSPECTOR=1',
           ],
           'sources': [ '<@(node_cctest_inspector_sources)' ],
+          'include_dirs': [
+            # TODO(legendecas): make node_inspector.gypi a dependable target.
+            '<(SHARED_INTERMEDIATE_DIR)', # for inspector
+            '<(SHARED_INTERMEDIATE_DIR)/src', # for inspector
+          ],
+          'dependencies': [
+            'deps/inspector_protocol/inspector_protocol.gyp:crdtp',
+          ],
         }, {
            'defines': [
              'HAVE_INSPECTOR=0',

--- a/src/inspector/node_string.cc
+++ b/src/inspector/node_string.cc
@@ -85,11 +85,12 @@ const uint8_t* StringUtil::CharactersUTF8(const std::string_view s) {
 }
 
 size_t StringUtil::CharacterCount(const std::string_view s) {
-  // The utf32_length_from_utf8 function calls count_utf8.
-  // The count_utf8 function counts the number of code points
-  // (characters) in the string, assuming that the string is valid Unicode.
-  // TODO(@anonrig): Test to make sure CharacterCount returns correctly.
-  return simdutf::utf32_length_from_utf8(s.data(), s.length());
+  // Return the length of underlying representation storage.
+  // E.g. for std::basic_string_view<char>, return its byte length.
+  // If we adopt a variant underlying store string type, like
+  // `v8_inspector::StringView`, for UTF16, return the length of the
+  // underlying uint16_t store.
+  return s.length();
 }
 
 }  // namespace protocol

--- a/src/inspector/node_string.h
+++ b/src/inspector/node_string.h
@@ -32,6 +32,9 @@ using StringBuilder = std::ostringstream;
 using ProtocolMessage = std::string;
 
 // Implements StringUtil methods used in `inspector_protocol/lib/`.
+// Refer to
+// https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/inspector/v8_inspector_string.h;l=40;drc=2b15d6974a49d3a14d3d67ae099a649d523a828d
+// for more details about the interface.
 struct StringUtil {
   // Convert Utf16 in local endianness to Utf8 if needed.
   static String StringViewToUtf8(v8_inspector::StringView view);

--- a/test/cctest/inspector/test_node_protocol.cc
+++ b/test/cctest/inspector/test_node_protocol.cc
@@ -1,0 +1,33 @@
+#include "crdtp/json.h"
+#include "gtest/gtest.h"
+#include "inspector/node_json.h"
+#include "node/inspector/protocol/Protocol.h"
+
+namespace node {
+namespace inspector {
+namespace protocol {
+namespace {
+
+TEST(InspectorProtocol, Utf8StringSerDes) {
+  constexpr const char* kKey = "unicode_key";
+  constexpr const char* kValue = "CJK 汉字 🍱 🧑‍🧑‍🧒‍🧒";
+  std::unique_ptr<DictionaryValue> val = DictionaryValue::create();
+  val->setString(kKey, kValue);
+
+  std::vector<uint8_t> cbor = val->Serialize();
+  std::string json;
+  crdtp::Status status =
+      crdtp::json::ConvertCBORToJSON(crdtp::SpanFrom(cbor), &json);
+  CHECK(status.ok());
+
+  std::unique_ptr<DictionaryValue> parsed =
+      DictionaryValue::cast(JsonUtil::parseJSON(json));
+  std::string parsed_value;
+  CHECK(parsed->getString(kKey, &parsed_value));
+  CHECK_EQ(parsed_value, std::string(kValue));
+}
+
+}  // namespace
+}  // namespace protocol
+}  // namespace inspector
+}  // namespace node

--- a/test/parallel/test-inspector-network-arbitrary-data.js
+++ b/test/parallel/test-inspector-network-arbitrary-data.js
@@ -1,0 +1,41 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+
+const session = new inspector.Session();
+session.connect();
+
+test('should emit Network.requestWillBeSent with unicode', async () => {
+  await session.post('Network.enable');
+  const expectedValue = 'CJK 汉字 🍱 🧑‍🧑‍🧒‍🧒';
+
+  const requestWillBeSentFuture = waitUntil(session, 'Network.requestWillBeSent')
+    .then(([event]) => {
+      assert.strictEqual(event.params.request.url, expectedValue);
+      assert.strictEqual(event.params.request.method, expectedValue);
+      assert.strictEqual(event.params.request.headers.mKey, expectedValue);
+    });
+
+  Network.requestWillBeSent({
+    requestId: '1',
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url: expectedValue,
+      method: expectedValue,
+      headers: {
+        mKey: expectedValue,
+      },
+    },
+  });
+
+  await requestWillBeSentFuture;
+});


### PR DESCRIPTION
`StringUtil::CharacterCount` should return the length of underlying
representation storage of a protocol string.

`StringUtil::CharacterCount` is only used in DictionaryValue
serialization. Only `Network.Headers` is an object type, represented
with DictionaryValue.