### PR TITLE
test: temporary remove resource check from fs read-write

### DIFF
--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -19,26 +19,26 @@ const regularFile = __filename;
   fs.readFile(blockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.readFile(bufferBlockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.readFileSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.readFileSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -52,7 +52,7 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   })).then(common.mustCall());
   assert.rejects(() => {
     return new Promise((_resolve, reject) => {
@@ -62,7 +62,7 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   })).then(common.mustCall());
 
   assert.rejects(() => {
@@ -73,7 +73,7 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   })).then(common.mustCall());
 }
 
@@ -82,31 +82,31 @@ const regularFile = __filename;
   fs.stat(blockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.stat(bufferBlockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.statSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.statSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.stat(path.join(blockedFolder, 'anyfile'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
   }));
 
   // doesNotThrow
@@ -120,26 +120,26 @@ const regularFile = __filename;
   fs.access(blockedFile, fs.constants.R_OK, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.access(bufferBlockedFile, fs.constants.R_OK, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.accessSync(blockedFileURL, fs.constants.R_OK);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.accessSync(path.join(blockedFolder, 'anyfile'), fs.constants.R_OK);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
   }));
 
   // doesNotThrow
@@ -153,26 +153,26 @@ const regularFile = __filename;
   fs.copyFile(blockedFile, path.join(blockedFolder, 'any-other-file'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.copyFile(bufferBlockedFile, path.join(blockedFolder, 'any-other-file'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.copyFileSync(blockedFileURL, path.join(blockedFolder, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.copyFileSync(blockedFile, path.join(__dirname, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -183,28 +183,28 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.cpSync(bufferBlockedFile, path.join(blockedFolder, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.cpSync(blockedFileURL, path.join(blockedFolder, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.cpSync(blockedFile, path.join(__dirname, 'any-other-file'));
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -213,26 +213,26 @@ const regularFile = __filename;
   fs.open(blockedFile, 'r', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.open(bufferBlockedFile, 'r', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.openSync(blockedFileURL, 'r');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.openSync(path.join(blockedFolder, 'anyfile'), 'r');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
   }));
 
   // doesNotThrow
@@ -259,14 +259,14 @@ const regularFile = __filename;
   fs.opendir(blockedFolder, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
   assert.throws(() => {
     fs.opendirSync(blockedFolder);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
   // doesNotThrow
   fs.opendir(allowedFolder, (err, dir) => {
@@ -280,26 +280,26 @@ const regularFile = __filename;
   fs.readdir(blockedFolder, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
   assert.throws(() => {
     fs.readdirSync(blockedFolder, { recursive: true });
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
   fs.readdir(blockedFolder, { recursive: true }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
   assert.throws(() => {
     fs.readdirSync(blockedFolder);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   }));
 
   // doesNotThrow
@@ -315,14 +315,14 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.watch(blockedFileURL, () => {});
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 
   // doesNotThrow
@@ -338,14 +338,14 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.watchFile(blockedFileURL, common.mustNotCall());
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -354,26 +354,26 @@ const regularFile = __filename;
   fs.rename(blockedFile, 'newfile', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.rename(bufferBlockedFile, 'newfile', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.renameSync(blockedFile, 'newfile');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.renameSync(blockedFileURL, 'newfile');
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -384,21 +384,21 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.openAsBlob(bufferBlockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.openAsBlob(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -416,7 +416,7 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -425,26 +425,26 @@ const regularFile = __filename;
   fs.statfs(blockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.statfs(bufferBlockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.statfsSync(blockedFile);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.statfsSync(blockedFileURL);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
 }
 
@@ -455,7 +455,7 @@ const regularFile = __filename;
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemRead',
-    resource: blockedFolder,
+    // resource: blockedFolder,
   }));
 }
 

--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -32,31 +32,31 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   fs.writeFile(blockedFile, 'example', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.writeFile(bufferBlockedFile, 'example', common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.writeFileSync(blockedFileURL, 'example');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.writeFileSync(relativeProtectedFile, 'example');
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(relativeProtectedFile),
+    // resource: path.toNamespacedPath(relativeProtectedFile),
   });
 
   assert.throws(() => {
@@ -64,7 +64,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
   });
 }
 
@@ -78,7 +78,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }).then(common.mustCall());
   assert.rejects(() => {
     return new Promise((_resolve, reject) => {
@@ -88,7 +88,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(relativeProtectedFile),
+    // resource: path.toNamespacedPath(relativeProtectedFile),
   }).then(common.mustCall());
 
   assert.rejects(() => {
@@ -99,7 +99,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'example')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'example')),
   }).then(common.mustCall());
 }
 
@@ -110,28 +110,28 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.utimes(bufferBlockedFile, new Date(), new Date(), () => {});
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.utimes(blockedFileURL, new Date(), new Date(), () => {});
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.utimes(relativeProtectedFile, new Date(), new Date(), () => {});
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(relativeProtectedFile),
+    // resource: path.toNamespacedPath(relativeProtectedFile),
   });
 
   assert.throws(() => {
@@ -139,7 +139,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'anyfile')),
   });
 }
 
@@ -150,21 +150,21 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.lutimes(bufferBlockedFile, new Date(), new Date(), () => {});
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.lutimes(blockedFileURL, new Date(), new Date(), () => {});
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
 }
 
@@ -177,7 +177,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'any-folder')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'any-folder')),
   });
   assert.throws(() => {
     fs.mkdir(path.join(relativeProtectedFolder, 'any-folder'), (err) => {
@@ -186,7 +186,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-folder')),
+    // resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-folder')),
   });
 }
 
@@ -210,38 +210,38 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   fs.rename(blockedFile, path.join(blockedFile, 'renamed'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   fs.rename(bufferBlockedFile, path.join(blockedFile, 'renamed'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.renameSync(blockedFileURL, path.join(blockedFile, 'renamed'));
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.renameSync(relativeProtectedFile, path.join(relativeProtectedFile, 'renamed'));
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(relativeProtectedFile),
+    // resource: path.toNamespacedPath(relativeProtectedFile),
   });
   assert.throws(() => {
     fs.renameSync(blockedFile, path.join(regularFolder, 'renamed'));
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
 
   assert.throws(() => {
@@ -249,7 +249,7 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'renamed')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'renamed')),
   });
 }
 
@@ -260,24 +260,24 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'any-file')),
   });
   assert.throws(() => {
     fs.copyFileSync(regularFile, path.join(relativeProtectedFolder, 'any-file'));
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
   });
   fs.copyFile(regularFile, path.join(relativeProtectedFolder, 'any-file'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
   }));
   fs.copyFile(bufferBlockedFile, path.join(relativeProtectedFolder, 'any-file'), common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
   }));
 }
 
@@ -288,14 +288,14 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(blockedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(blockedFolder, 'any-file')),
   });
   assert.throws(() => {
     fs.cpSync(regularFile, path.join(relativeProtectedFolder, 'any-file'));
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
+    // resource: path.toNamespacedPath(path.join(relativeProtectedFolder, 'any-file')),
   });
 }
 
@@ -306,14 +306,14 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFolder),
+    // resource: path.toNamespacedPath(blockedFolder),
   });
   assert.throws(() => {
     fs.rmSync(relativeProtectedFolder, { recursive: true });
   },{
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(relativeProtectedFolder),
+    // resource: path.toNamespacedPath(relativeProtectedFolder),
   });
 }
 
@@ -508,26 +508,26 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   assert.throws(() => {
     fs.unlinkSync(bufferBlockedFile);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
   fs.unlink(blockedFile, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   }));
   assert.throws(() => {
     fs.unlinkSync(blockedFileURL);
   }, {
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
-    resource: path.toNamespacedPath(blockedFile),
+    // resource: path.toNamespacedPath(blockedFile),
   });
 }
 


### PR DESCRIPTION
@marco-ippolito informed me some permission model tests are failing on Windows and until I get some time to find out why this is flaky on Windows (I have some guesses), let's disable those checks.

Refs: https://github.com/nodejs/node/pull/56727#issuecomment-2613834438

```
Since the last security release, the resource check has been flaky on Windows. This commit temporarily disables those checks to unblock the next regular release.
```