### PR TITLE
sqlite: allow returning `ArrayBufferView`s from user-defined functions

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -518,13 +518,13 @@ more data types than SQLite, only a subset of JavaScript types are supported.
 Attempting to write an unsupported data type to SQLite will result in an
 exception.
 
-| SQLite    | JavaScript           |
-| --------- | -------------------- |
-| `NULL`    | {null}               |
-| `INTEGER` | {number} or {bigint} |
-| `REAL`    | {number}             |
-| `TEXT`    | {string}             |
-| `BLOB`    | {Uint8Array}         |
+| SQLite    | JavaScript                 |
+| --------- | -------------------------- |
+| `NULL`    | {null}                     |
+| `INTEGER` | {number} or {bigint}       |
+| `REAL`    | {number}                   |
+| `TEXT`    | {string}                   |
+| `BLOB`    | {TypedArray} or {DataView} |
 
 ## `sqlite.constants`
 

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -213,7 +213,7 @@ class UserDefinedFunction {
     } else if (result->IsString()) {
       Utf8Value val(isolate, result.As<String>());
       sqlite3_result_text(ctx, *val, val.length(), SQLITE_TRANSIENT);
-    } else if (result->IsUint8Array()) {
+    } else if (result->IsArrayBufferView()) {
       ArrayBufferViewContents<uint8_t> buf(result);
       sqlite3_result_blob(ctx, buf.data(), buf.length(), SQLITE_TRANSIENT);
     } else if (result->IsBigInt()) {

--- a/test/parallel/test-sqlite-custom-functions.js
+++ b/test/parallel/test-sqlite-custom-functions.js
@@ -274,13 +274,18 @@ suite('DatabaseSync.prototype.function()', () => {
       db.function('retString', () => { return 'foo'; });
       db.function('retBigInt', () => { return 5n; });
       db.function('retUint8Array', () => { return new Uint8Array([1, 2, 3]); });
+      db.function('retArrayBufferView', () => {
+        const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+        return new DataView(arrayBuffer);
+      });
       const stmt = db.prepare(`SELECT
         retUndefined() AS retUndefined,
         retNull() AS retNull,
         retNumber() AS retNumber,
         retString() AS retString,
         retBigInt() AS retBigInt,
-        retUint8Array() AS retUint8Array
+        retUint8Array() AS retUint8Array,
+        retArrayBufferView() AS retArrayBufferView
       `);
       assert.deepStrictEqual(stmt.get(), {
         __proto__: null,
@@ -290,6 +295,7 @@ suite('DatabaseSync.prototype.function()', () => {
         retString: 'foo',
         retBigInt: 5,
         retUint8Array: new Uint8Array([1, 2, 3]),
+        retArrayBufferView: new Uint8Array([1, 2, 3]),
       });
     });
 


### PR DESCRIPTION
#56385 widened the valid "blob-equivalent" type from `Uint8Array` to `ArrayBufferView` for bound parameters. This isn't currently reflected in the valid return types for user-defined functions, and it seems sensible to keep things consistent.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
