### PR TITLE
inspector: add Network.Initiator in inspector protocol

### DIFF
--- a/lib/internal/inspector/network_http.js
+++ b/lib/internal/inspector/network_http.js
@@ -44,11 +44,11 @@ const convertHeaderObject = (headers = {}) => {
 };
 
 /**
- * When a client request starts, emit Network.requestWillBeSent event.
+ * When a client request is created, emit Network.requestWillBeSent event.
  * https://chromedevtools.github.io/devtools-protocol/1-3/Network/#event-requestWillBeSent
  * @param {{ request: import('http').ClientRequest }} event
  */
-function onClientRequestStart({ request }) {
+function onClientRequestCreated({ request }) {
   request[kInspectorRequestId] = getNextRequestId();
 
   const { 0: host, 1: headers } = convertHeaderObject(request.getHeaders());
@@ -115,13 +115,13 @@ function onClientResponseFinish({ request, response }) {
 }
 
 function enable() {
-  dc.subscribe('http.client.request.start', onClientRequestStart);
+  dc.subscribe('http.client.request.created', onClientRequestCreated);
   dc.subscribe('http.client.request.error', onClientRequestError);
   dc.subscribe('http.client.response.finish', onClientResponseFinish);
 }
 
 function disable() {
-  dc.unsubscribe('http.client.request.start', onClientRequestStart);
+  dc.unsubscribe('http.client.request.created', onClientRequestCreated);
   dc.unsubscribe('http.client.request.error', onClientRequestError);
   dc.unsubscribe('http.client.response.finish', onClientResponseFinish);
 }

--- a/lib/internal/inspector/network_undici.js
+++ b/lib/internal/inspector/network_undici.js
@@ -129,10 +129,10 @@ function enable() {
 }
 
 function disable() {
-  dc.subscribe('undici:request:create', onClientRequestStart);
-  dc.subscribe('undici:request:error', onClientRequestError);
-  dc.subscribe('undici:request:headers', onClientResponseHeaders);
-  dc.subscribe('undici:request:trailers', onClientResponseFinish);
+  dc.unsubscribe('undici:request:create', onClientRequestStart);
+  dc.unsubscribe('undici:request:error', onClientRequestError);
+  dc.unsubscribe('undici:request:headers', onClientResponseHeaders);
+  dc.unsubscribe('undici:request:trailers', onClientResponseFinish);
 }
 
 module.exports = {

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -14,7 +14,8 @@ namespace protocol {
 
 class NetworkAgent : public Network::Backend {
  public:
-  explicit NetworkAgent(NetworkInspector* inspector);
+  explicit NetworkAgent(NetworkInspector* inspector,
+                        v8_inspector::V8Inspector* v8_inspector);
 
   void Wire(UberDispatcher* dispatcher);
 
@@ -35,6 +36,7 @@ class NetworkAgent : public Network::Backend {
 
  private:
   NetworkInspector* inspector_;
+  v8_inspector::V8Inspector* v8_inspector_;
   std::shared_ptr<Network::Frontend> frontend_;
   using EventNotifier =
       void (NetworkAgent::*)(std::unique_ptr<protocol::DictionaryValue>);

--- a/src/inspector/network_inspector.cc
+++ b/src/inspector/network_inspector.cc
@@ -3,9 +3,10 @@
 namespace node {
 namespace inspector {
 
-NetworkInspector::NetworkInspector(Environment* env)
+NetworkInspector::NetworkInspector(Environment* env,
+                                   v8_inspector::V8Inspector* v8_inspector)
     : enabled_(false), env_(env) {
-  network_agent_ = std::make_unique<protocol::NetworkAgent>(this);
+  network_agent_ = std::make_unique<protocol::NetworkAgent>(this, v8_inspector);
 }
 NetworkInspector::~NetworkInspector() {
   network_agent_.reset();

--- a/src/inspector/network_inspector.h
+++ b/src/inspector/network_inspector.h
@@ -11,7 +11,8 @@ namespace inspector {
 
 class NetworkInspector {
  public:
-  explicit NetworkInspector(Environment* env);
+  explicit NetworkInspector(Environment* env,
+                            v8_inspector::V8Inspector* v8_inspector);
   ~NetworkInspector();
 
   void Wire(protocol::UberDispatcher* dispatcher);

--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -2,6 +2,7 @@
   'variables': {
     'protocol_tool_path': '../../deps/inspector_protocol',
     'jinja_dir': '../../tools/inspector_protocol',
+    'v8_gypfiles_dir': '../../tools/v8_gypfiles',
     'node_inspector_sources': [
       'src/inspector_agent.cc',
       'src/inspector_io.cc',
@@ -74,6 +75,7 @@
   ],
   'dependencies': [
     '<(protocol_tool_path)/inspector_protocol.gyp:crdtp',
+    '<(v8_gypfiles_dir)/v8.gyp:v8_inspector_headers',
   ],
   'actions': [
     {

--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -97,6 +97,7 @@
       'action_name': 'node_protocol_generated_sources',
       'inputs': [
         'node_protocol_config.json',
+        'node_protocol.pdl',
         '<(SHARED_INTERMEDIATE_DIR)/src/node_protocol.json',
         '<@(node_protocol_files)',
         '<(protocol_tool_path)/code_generator.py',

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -101,6 +101,8 @@ experimental domain NodeWorker
 # Partial support for Network domain of ChromeDevTools Protocol.
 # https://chromedevtools.github.io/devtools-protocol/tot/Network
 experimental domain Network
+  depends on Runtime
+
   # Resource type as it was perceived by the rendering engine.
   type ResourceType extends string
     enum
@@ -131,6 +133,31 @@ experimental domain Network
 
   # Monotonically increasing time in seconds since an arbitrary point in the past.
   type MonotonicTime extends number
+
+  # Information about the request initiator.
+  type Initiator extends object
+    properties
+      # Type of this initiator.
+      enum type
+        parser
+        script
+        preload
+        SignedExchange
+        preflight
+        other
+      # Initiator JavaScript stack trace, set for Script only.
+      # Requires the Debugger domain to be enabled.
+      optional Runtime.StackTrace stack
+      # Initiator URL, set for Parser type or for Script type (when script is importing module) or for SignedExchange type.
+      optional string url
+      # Initiator line number, set for Parser type or for Script type (when script is importing
+      # module) (0-based).
+      optional number lineNumber
+      # Initiator column number, set for Parser type or for Script type (when script is importing
+      # module) (0-based).
+      optional number columnNumber
+      # Set if another request triggered this request (e.g. preflight).
+      optional RequestId requestId
 
   # HTTP request data.
   type Request extends object
@@ -163,6 +190,8 @@ experimental domain Network
       RequestId requestId
       # Request data.
       Request request
+      # Request initiator.
+      Initiator initiator
       # Timestamp.
       MonotonicTime timestamp
       # Timestamp.

--- a/src/inspector/node_protocol_config.json
+++ b/src/inspector/node_protocol_config.json
@@ -5,6 +5,17 @@
         "output": "node/inspector/protocol",
         "namespace": ["node", "inspector", "protocol"]
     },
+    "imported": {
+        "path": "../../deps/v8/include/js_protocol.pdl",
+        "header": "<v8-inspector-protocol.h>",
+        "namespace": ["v8_inspector", "protocol"],
+        "options": [
+            {
+                "domain": "Runtime",
+                "imported": ["StackTrace"]
+            }
+        ]
+    },
     "exported": {
         "package": "include/inspector",
         "output": "../../include/inspector",

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -239,7 +239,8 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
     }
     runtime_agent_ = std::make_unique<protocol::RuntimeAgent>();
     runtime_agent_->Wire(node_dispatcher_.get());
-    network_inspector_ = std::make_unique<NetworkInspector>(env);
+    network_inspector_ =
+        std::make_unique<NetworkInspector>(env, inspector.get());
     network_inspector_->Wire(node_dispatcher_.get());
   }
 

--- a/test/parallel/test-inspector-network-fetch.js
+++ b/test/parallel/test-inspector-network-fetch.js
@@ -65,6 +65,13 @@ const terminate = () => {
   inspector.close();
 };
 
+function findFrameInInitiator(scriptName, initiator) {
+  const frame = initiator.stack.callFrames.find((it) => {
+    return it.url === scriptName;
+  });
+  return frame;
+}
+
 const testHttpGet = () => new Promise((resolve, reject) => {
   session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));
@@ -77,6 +84,10 @@ const testHttpGet = () => new Promise((resolve, reject) => {
     assert.strictEqual(params.request.headers['x-header1'], 'value1, value2');
     assert.strictEqual(typeof params.timestamp, 'number');
     assert.strictEqual(typeof params.wallTime, 'number');
+
+    assert.strictEqual(typeof params.initiator, 'object');
+    assert.strictEqual(params.initiator.type, 'script');
+    assert.ok(findFrameInInitiator(__filename, params.initiator));
   }));
   session.on('Network.responseReceived', common.mustCall(({ params }) => {
     assert.ok(params.requestId.startsWith('node-network-event-'));

--- a/test/parallel/test-inspector-network-http.js
+++ b/test/parallel/test-inspector-network-http.js
@@ -64,6 +64,13 @@ const terminate = () => {
   inspector.close();
 };
 
+function findFrameInInitiator(scriptName, initiator) {
+  const frame = initiator.stack.callFrames.find((it) => {
+    return it.url === scriptName;
+  });
+  return frame;
+}
+
 function verifyRequestWillBeSent({ method, params }, expect) {
   assert.strictEqual(method, 'Network.requestWillBeSent');
 
@@ -77,6 +84,10 @@ function verifyRequestWillBeSent({ method, params }, expect) {
   assert.strictEqual(params.request.headers['x-header1'], 'value1, value2');
   assert.strictEqual(typeof params.timestamp, 'number');
   assert.strictEqual(typeof params.wallTime, 'number');
+
+  assert.strictEqual(typeof params.initiator, 'object');
+  assert.strictEqual(params.initiator.type, 'script');
+  assert.ok(findFrameInInitiator(__filename, params.initiator));
 
   return params;
 }

--- a/tools/v8_gypfiles/inspector.gypi
+++ b/tools/v8_gypfiles/inspector.gypi
@@ -129,51 +129,13 @@
       '<(inspector_protocol_path)/crdtp/span.h',
       '<(inspector_protocol_path)/crdtp/status.cc',
       '<(inspector_protocol_path)/crdtp/status.h',
+
+      '<@(inspector_generated_sources)',
     ],
     'v8_inspector_js_protocol': '<(V8_ROOT)/include/js_protocol.pdl',
   },
   'include_dirs': [
     '<(inspector_generated_output_root)',
     '<(inspector_protocol_path)',
-  ],
-  'actions': [
-    {
-      'action_name': 'protocol_compatibility',
-      'inputs': [
-        '<(v8_inspector_js_protocol)',
-      ],
-      'outputs': [
-        '<@(inspector_generated_output_root)/src/js_protocol.stamp',
-      ],
-      'action': [
-        '<(python)',
-        '<(inspector_protocol_path)/check_protocol_compatibility.py',
-        '--stamp', '<@(_outputs)',
-        '<@(_inputs)',
-      ],
-      'message': 'Checking inspector protocol compatibility',
-    },
-    {
-      'action_name': 'protocol_generated_sources',
-      'inputs': [
-        '<(v8_inspector_js_protocol)',
-        '<(inspector_path)/inspector_protocol_config.json',
-        '<@(inspector_protocol_files)',
-      ],
-      'outputs': [
-        '<@(inspector_generated_sources)',
-      ],
-      'process_outputs_as_sources': 1,
-      'action': [
-        '<(python)',
-        '<(inspector_protocol_path)/code_generator.py',
-        '--jinja_dir', '<(V8_ROOT)/third_party',
-        '--output_base', '<(inspector_generated_output_root)/src/inspector',
-        '--config', '<(inspector_path)/inspector_protocol_config.json',
-        '--config_value', 'protocol.path=<(v8_inspector_js_protocol)',
-        '--inspector_protocol_dir', '<(inspector_protocol_path)',
-      ],
-      'message': 'Generating inspector protocol sources from protocol json',
-    },
   ],
 }

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1018,6 +1018,58 @@
       ],
     },  # v8_compiler_for_mksnapshot
     {
+      'target_name': 'v8_inspector_headers',
+      'type': 'none',
+      'toolsets': ['host', 'target'],
+      'hard_dependency': 1,
+      'includes': ['inspector.gypi'],
+      'direct_dependent_settings': {
+        'include_dirs': [
+          '<(inspector_generated_output_root)/include',
+        ],
+      },
+      'actions': [
+        {
+          'action_name': 'protocol_compatibility',
+          'inputs': [
+            '<(v8_inspector_js_protocol)',
+          ],
+          'outputs': [
+            '<@(inspector_generated_output_root)/src/js_protocol.stamp',
+          ],
+          'action': [
+            '<(python)',
+            '<(inspector_protocol_path)/check_protocol_compatibility.py',
+            '--stamp', '<@(_outputs)',
+            '<@(_inputs)',
+          ],
+          'message': 'Checking inspector protocol compatibility',
+        },
+        {
+          'action_name': 'protocol_generated_sources',
+          'inputs': [
+            '<(v8_inspector_js_protocol)',
+            '<(inspector_path)/inspector_protocol_config.json',
+            '<@(inspector_protocol_files)',
+          ],
+          'outputs': [
+            '<@(inspector_generated_sources)',
+          ],
+          'process_outputs_as_sources': 1,
+          'action': [
+            '<(python)',
+            '<(inspector_protocol_path)/code_generator.py',
+            '--jinja_dir', '<(V8_ROOT)/third_party',
+            '--output_base', '<(inspector_generated_output_root)/src/inspector',
+            '--config', '<(inspector_path)/inspector_protocol_config.json',
+            '--config_value', 'protocol.path=<(v8_inspector_js_protocol)',
+            '--inspector_protocol_dir', '<(inspector_protocol_path)',
+          ],
+          'message': 'Generating inspector protocol sources from protocol json',
+        },
+      ],
+    },  # v8_inspector_headers
+    {
       'target_name': 'v8_base_without_compiler',
       'type': 'static_library',
       'toolsets': ['host', 'target'],
@@ -1026,6 +1078,7 @@
         'v8_bigint',
         'v8_headers',
         'v8_heap_base',
+        'v8_inspector_headers',
         'v8_libbase',
         'v8_shared_internal_headers',
         'v8_version',


### PR DESCRIPTION
#### src: add a hard dependency v8_inspector_headers

A GYP hard dependency instructs GYP to not remove the dependency link
between two static library targets in its generated output. This
allows V8 dependents to include V8 inspector protocol headers.

#### inspector: add Network.Initiator in inspector protocol

Add initiator stack trace in inspector network events, reflecting
the location where the script created the request.

The `http.client.request.created` event is closer to where user code
creates the http request, and correctly reflects which script
initiated the request.

Refs: https://github.com/nodejs/node/issues/53946