### PR TITLE
events: getMaxListeners detects 0 listeners

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -939,7 +939,7 @@ function getEventListeners(emitterOrTarget, type) {
 function getMaxListeners(emitterOrTarget) {
   if (typeof emitterOrTarget?.getMaxListeners === 'function') {
     return _getMaxListeners(emitterOrTarget);
-  } else if (emitterOrTarget?.[kMaxEventTargetListeners]) {
+  } else if (typeof emitterOrTarget?.[kMaxEventTargetListeners] === 'number') {
     return emitterOrTarget[kMaxEventTargetListeners];
   }
 

--- a/test/parallel/test-events-getmaxlisteners.js
+++ b/test/parallel/test-events-getmaxlisteners.js
@@ -17,3 +17,8 @@ const { getMaxListeners, EventEmitter, defaultMaxListeners, setMaxListeners } = 
   setMaxListeners(101, et);
   assert.strictEqual(getMaxListeners(et), 101);
 }
+
+{
+  const ac = new AbortController();
+  assert.strictEqual(getMaxListeners(ac.signal), 0);
+}


### PR DESCRIPTION
With the removal of the max listeners warning from AbortSignal, a bug was surfaced with getMaxListeners.

```js
> events.getMaxListeners(new AbortController().signal)
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "emitter" argument must be an instance of EventEmitter or EventTarget. Received an instance of AbortSignal
    at Function.getMaxListeners (node:events:946:9) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

This causes performance issues for undici.

Refs: https://github.com/nodejs/undici/issues/4032
Refs: https://github.com/nodejs/node/commit/c1ccade02f29fd5585601bd496d4fb615a55b682

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
