### PR TITLE
src: disallow copy/move fns/constructors

### DIFF
--- a/src/debug_utils-inl.h
+++ b/src/debug_utils-inl.h
@@ -50,7 +50,7 @@ struct ToStringHelper {
   template <unsigned BASE_BITS,
             typename T,
             typename = std::enable_if_t<!std::is_integral_v<T>>>
-  static std::string BaseConvert(T value) {
+  static std::string BaseConvert(T& value) {  // NOLINT(runtime/references)
     return Convert(std::forward<T>(value));
   }
 };

--- a/src/util.h
+++ b/src/util.h
@@ -388,15 +388,11 @@ constexpr size_t strsize(const T (&)[N]) {
 template <typename T, size_t kStackStorageSize = 1024>
 class MaybeStackBuffer {
  public:
-  // Disallow move constructor
-  MaybeStackBuffer(MaybeStackBuffer&&) = delete;
   // Disallow copy constructor
   MaybeStackBuffer(const MaybeStackBuffer&) = delete;
-  // Disallow move assignment operator
-  MaybeStackBuffer& operator=(MaybeStackBuffer&& other) = delete;
   // Disallow copy assignment operator
   MaybeStackBuffer&
-    operator=(MaybeStackBuffer& other) = delete;  // NOLINT(runtime/references)
+    operator=(const MaybeStackBuffer& other) = delete;
 
   const T* out() const {
     return buf_;

--- a/src/util.h
+++ b/src/util.h
@@ -388,6 +388,16 @@ constexpr size_t strsize(const T (&)[N]) {
 template <typename T, size_t kStackStorageSize = 1024>
 class MaybeStackBuffer {
  public:
+  // Disallow move constructor
+  MaybeStackBuffer(MaybeStackBuffer&&) = delete;
+  // Disallow copy constructor
+  MaybeStackBuffer(const MaybeStackBuffer&) = delete;
+  // Disallow move assignment operator
+  MaybeStackBuffer& operator=(MaybeStackBuffer&& other) = delete;
+  // Disallow copy assignment operator
+  MaybeStackBuffer&
+    operator=(MaybeStackBuffer& other) = delete;  // NOLINT(runtime/references)
+
   const T* out() const {
     return buf_;
   }

--- a/src/util.h
+++ b/src/util.h
@@ -391,8 +391,7 @@ class MaybeStackBuffer {
   // Disallow copy constructor
   MaybeStackBuffer(const MaybeStackBuffer&) = delete;
   // Disallow copy assignment operator
-  MaybeStackBuffer&
-    operator=(const MaybeStackBuffer& other) = delete;
+  MaybeStackBuffer& operator=(const MaybeStackBuffer& other) = delete;
 
   const T* out() const {
     return buf_;


### PR DESCRIPTION
Following @addaleax's recommendation on https://github.com/nodejs/node/pull/56452#discussion_r1932994017, let's disallow copy/move functions and constructors on MaybeStackBuffer.