### PR TITLE
test: adjust check to use OpenSSL sec level

### DIFF
--- a/test/parallel/test-tls-client-mindhsize.js
+++ b/test/parallel/test-tls-client-mindhsize.js
@@ -1,9 +1,15 @@
+// Flags: --expose-internals
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const { hasOpenSSL } = require('../common/crypto');
+// OpenSSL has a set of security levels which affect what algorithms
+// are available by default. Different OpenSSL veresions have different
+// default security levels and we use this value to adjust what a test
+// expects based on the security level. You can read more in
+// https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_security_level/#default-callback-behaviour
+const secLevel = require('internal/crypto/util').getOpenSSLSecLevel();
 const assert = require('assert');
 const tls = require('tls');
 const fixtures = require('../common/fixtures');
@@ -38,8 +44,9 @@ function test(size, err, next) {
   server.listen(0, function() {
     // Client set minimum DH parameter size to 2048 or 3072 bits
     // so that it fails when it makes a connection to the tls
-    // server where is too small
-    const minDHSize = hasOpenSSL(3, 2) ? 3072 : 2048;
+    // server where is too small. This depends on the openssl
+    // security level
+    const minDHSize = (secLevel > 1) ? 3072 : 2048;
     const client = tls.connect({
       minDHSize: minDHSize,
       port: this.address().port,
@@ -77,8 +84,8 @@ function testDHE3072() {
   test(3072, false, null);
 }
 
-if (hasOpenSSL(3, 2)) {
-  // Minimum size for OpenSSL 3.2 is 2048 by default
+if (secLevel > 1) {
+  // Minimum size for OpenSSL security level 2 and above is 2048 by default
   testDHE2048(true, testDHE3072);
 } else {
   testDHE1024();


### PR DESCRIPTION
Some checks should use the sec level instead of the OpenSSL version, adjust test-tls-client-mindhsize.js

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
