### PR TITLE
src: fix platform shutdown deadlock

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -629,7 +629,7 @@ template <class T>
 void TaskQueue<T>::NotifyOfCompletion() {
   Mutex::ScopedLock scoped_lock(lock_);
   if (--outstanding_tasks_ == 0) {
-    tasks_drained_.Broadcast(scoped_lock);
+    tasks_drained_.Signal(scoped_lock);
   }
 }
 


### PR DESCRIPTION
Fixes #54918

Each worker is signalling its own completion of tasks independently and so should only be signalling for one corresponding drain otherwise the count of outstanding tasks goes out of sync and the process will never stop waiting for tasks when it should be exiting.

It just needs to be calling Signal rather than Broadcast.

Not sure if there was a reason for it to be a broadcast in the first place, but if so then the `outstanding_tasks_` count adjustment needs to factor that in properly.