### PR TITLE
tools: run macOS test workflow with Xcode 16.1

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -30,6 +30,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.12'
+  XCODE_VERSION: '16.1'
   FLAKY_TESTS: keep_retrying
 
 permissions:
@@ -40,9 +41,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
-      matrix:
-        macos-version: [macos-13, macos-14]
-    runs-on: ${{ matrix.macos-version }}
+    runs-on: macos-14
     env:
       CC: sccache gcc
       CXX: sccache g++
@@ -56,6 +55,8 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Xcode ${{ env.XCODE_VERSION }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@9e326ebed976843c9932b3aa0e021c6f50310eb4  # v0.0.6
         with:


### PR DESCRIPTION
We have to remove `macos-13` as it doesn't have Xcode 16 available.

Refs: https://github.com/nodejs/node/pull/56824

