### PR TITLE
src: cache negative results in GetPackageJSON

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -100,10 +100,19 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
     return &cache_entry->second;
   }
 
+  auto missing_cache_entry = binding_data->missing_package_configs_.find(path.data());
+  if (missing_cache_entry != binding_data->missing_package_configs_.end()) {
+    return nullptr;
+  }
+
   PackageConfig package_config{};
   package_config.file_path = path;
   // No need to exclude BOM since simdjson will skip it.
   if (ReadFileSync(&package_config.raw_json, path.data()) < 0) {
+    // Cache the failed read so that other queries in the same folder don't
+    // keep probing the file system
+    binding_data->missing_package_configs_.insert(
+      std::string(path));
     return nullptr;
   }
   // In some systems, std::string is annotated to generate an

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -100,8 +100,7 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
     return &cache_entry->second;
   }
 
-  auto missing_cache_entry = binding_data->missing_package_configs_.find(path.data());
-  if (missing_cache_entry != binding_data->missing_package_configs_.end()) {
+  if (!binding_data->missing_package_configs_.contains(path.data())) {
     return nullptr;
   }
 

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -100,7 +100,7 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
     return &cache_entry->second;
   }
 
-  if (!binding_data->missing_package_configs_.contains(path.data())) {
+  if (binding_data->missing_package_configs_.contains(std::string(path))) {
     return nullptr;
   }
 

--- a/src/node_modules.h
+++ b/src/node_modules.h
@@ -74,6 +74,7 @@ class BindingData : public SnapshotableObject {
 
  private:
   std::unordered_map<std::string, PackageConfig> package_configs_;
+  std::unordered_set<std::string> missing_package_configs_;
   simdjson::ondemand::parser json_parser;
   // returns null on error
   static const PackageConfig* GetPackageJSON(


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixes #56821 

Ensure that `GetPackageJSON` caches which `package.json` files do _not_ exist, not just the contents of the ones that do. In packages with at least one subfolder, it is normal for most folders in a package not to contain a `package.json` file, so this will significantly reduce the number of file system reads performed during `GetNearestParentPackageJSON`.