### PR TITLE
src: use `std::ranges::greater` instead of `std::greater`

### DIFF
--- a/src/cleanup_queue.cc
+++ b/src/cleanup_queue.cc
@@ -15,7 +15,7 @@ std::vector<CleanupQueue::CleanupHookCallback> CleanupQueue::GetOrdered()
 
   // Sort in descending order so that the most recently inserted callbacks are
   // run first.
-  std::ranges::sort(callbacks, std::greater());
+  std::ranges::sort(callbacks, std::ranges::greater());
 
   return callbacks;
 }


### PR DESCRIPTION
Blind tentative to fix https://github.com/nodejs/node/pull/56063#issuecomment-2627481292

Based on the example from https://en.cppreference.com/w/cpp/algorithm/ranges/sort