### PR TITLE
Revert "src: modernize cleanup queue to use c++20"

### DIFF
--- a/src/cleanup_queue-inl.h
+++ b/src/cleanup_queue-inl.h
@@ -3,8 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <compare>
-
 #include "cleanup_queue.h"
 #include "util.h"
 
@@ -29,18 +27,6 @@ void CleanupQueue::Add(Callback cb, void* arg) {
 void CleanupQueue::Remove(Callback cb, void* arg) {
   CleanupHookCallback search{cb, arg, 0};
   cleanup_hooks_.erase(search);
-}
-
-constexpr std::strong_ordering CleanupQueue::CleanupHookCallback::operator<=>(
-    const CleanupHookCallback& other) const noexcept {
-  if (insertion_order_counter_ > other.insertion_order_counter_) {
-    return std::strong_ordering::greater;
-  }
-
-  if (insertion_order_counter_ < other.insertion_order_counter_) {
-    return std::strong_ordering::less;
-  }
-  return std::strong_ordering::equivalent;
 }
 
 }  // namespace node

--- a/src/cleanup_queue.cc
+++ b/src/cleanup_queue.cc
@@ -1,6 +1,5 @@
 #include "cleanup_queue.h"  // NOLINT(build/include_inline)
 #include <algorithm>
-#include <ranges>
 #include <vector>
 #include "cleanup_queue-inl.h"
 
@@ -9,20 +8,27 @@ namespace node {
 std::vector<CleanupQueue::CleanupHookCallback> CleanupQueue::GetOrdered()
     const {
   // Copy into a vector, since we can't sort an unordered_set in-place.
-  std::vector callbacks(cleanup_hooks_.begin(), cleanup_hooks_.end());
+  std::vector<CleanupHookCallback> callbacks(cleanup_hooks_.begin(),
+                                             cleanup_hooks_.end());
   // We can't erase the copied elements from `cleanup_hooks_` yet, because we
   // need to be able to check whether they were un-scheduled by another hook.
 
-  // Sort in descending order so that the most recently inserted callbacks are
-  // run first.
-  std::ranges::sort(callbacks, std::greater());
+  std::sort(callbacks.begin(),
+            callbacks.end(),
+            [](const CleanupHookCallback& a, const CleanupHookCallback& b) {
+              // Sort in descending order so that the most recently inserted
+              // callbacks are run first.
+              return a.insertion_order_counter_ > b.insertion_order_counter_;
+            });
 
   return callbacks;
 }
 
 void CleanupQueue::Drain() {
-  for (const CleanupHookCallback& cb : GetOrdered()) {
-    if (!cleanup_hooks_.contains(cb)) {
+  std::vector<CleanupHookCallback> callbacks = GetOrdered();
+
+  for (const CleanupHookCallback& cb : callbacks) {
+    if (cleanup_hooks_.count(cb) == 0) {
       // This hook was removed from the `cleanup_hooks_` set during another
       // hook that was run earlier. Nothing to do here.
       continue;

--- a/src/cleanup_queue.h
+++ b/src/cleanup_queue.h
@@ -3,7 +3,6 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <unordered_set>
@@ -41,9 +40,6 @@ class CleanupQueue : public MemoryRetainer {
         : fn_(fn),
           arg_(arg),
           insertion_order_counter_(insertion_order_counter) {}
-
-    constexpr std::strong_ordering operator<=>(
-        const CleanupHookCallback& other) const noexcept;
 
     // Only hashes `arg_`, since that is usually enough to identify the hook.
     struct Hash {


### PR DESCRIPTION
This reverts commit 581b44421ac399c0b9ed051b1779e69f5b2457df.

Refs: https://github.com/nodejs/node/pull/56063

---

Fixes [failing Test Linux workflow](https://github.com/nodejs/node/actions/runs/13073721954/job/36480723623).

```
../src/cleanup_queue.cc:18:32: error: 'greater' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
   18 |   std::ranges::sort(callbacks, std::greater());
      |                                ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/bits/stl_function.h:390:12: note: add a deduction guide to suppress this warning
  390 |     struct greater : public binary_function<_Tp, _Tp, bool>
      |            ^
1 error generated.
```


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
