### PR TITLE
src: remove workaround for container-overflow

### DIFF
--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -110,7 +110,8 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   simdjson::ondemand::document document;
   simdjson::ondemand::object main_object;
   simdjson::error_code error =
-      binding_data->json_parser.iterate(simdjson::pad(package_config.raw_json)).get(document);
+      binding_data->json_parser.iterate(simdjson::pad(package_config.raw_json))
+          .get(document);
 
   const auto throw_invalid_package_config = [error_context, path, realm]() {
     if (error_context == nullptr) {

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -106,23 +106,11 @@ const BindingData::PackageConfig* BindingData::GetPackageJSON(
   if (ReadFileSync(&package_config.raw_json, path.data()) < 0) {
     return nullptr;
   }
-  // In some systems, std::string is annotated to generate an
-  // AddressSanitizer: container-overflow error when reading beyond the end of
-  // the string even when we are still within the capacity of the string.
-  // https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
-  // https://github.com/nodejs/node/issues/55584
-  // The next lines are a workaround to avoid this false positive.
-  size_t json_length = package_config.raw_json.size();
-  package_config.raw_json.append(simdjson::SIMDJSON_PADDING, ' ');
-  simdjson::padded_string_view json_view(package_config.raw_json.data(),
-                                         json_length,
-                                         package_config.raw_json.size());
-  // End of workaround
 
   simdjson::ondemand::document document;
   simdjson::ondemand::object main_object;
   simdjson::error_code error =
-      binding_data->json_parser.iterate(json_view).get(document);
+      binding_data->json_parser.iterate(simdjson::pad(package_config.raw_json)).get(document);
 
   const auto throw_invalid_package_config = [error_context, path, realm]() {
     if (error_context == nullptr) {


### PR DESCRIPTION
In PR https://github.com/nodejs/node/pull/55591, I added a workaround for issue https://github.com/nodejs/node/issues/55584

This PR stated the following:

> With some glue code, this PR should work around this issue. It somewhat ugly code. In a future release of simdjson, we will provide a more convenient function that avoids such ugly workaround. A future PR will make the code prettier.


It is now time to make the code pretty again. We are removing a blob of hard-to-understand C++ code.

The workaround is no longer needed.

This PR does not change the functionality, it only makes the code nicer.