### PR TITLE
lib: filter node:quic from builtinModules when flag not used

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -435,7 +435,11 @@ Module.isBuiltin = BuiltinModule.isBuiltin;
 function initializeCJS() {
   // This need to be done at runtime in case --expose-internals is set.
 
-  Module.builtinModules = ObjectFreeze(BuiltinModule.getAllBuiltinModuleIds());
+  let modules = Module.builtinModules = BuiltinModule.getAllBuiltinModuleIds();
+  if (!getOptionValue('--experimental-quic')) {
+    modules = modules.filter((i) => i !== 'node:quic');
+  }
+  Module.builtinModules = ObjectFreeze(modules);
 
   initializeCjsConditions();
 


### PR DESCRIPTION
Make sure `node:quic` is not included in `module.builtinModules` when the `--experimental-quic` flat is not used.