### PR TITLE
src: fix process exit listeners not receiving unsettled tla codes

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1893,8 +1893,16 @@ A number which will be the process exit code, when the process either
 exits gracefully, or is exited via [`process.exit()`][] without specifying
 a code.
 
-Specifying a code to [`process.exit(code)`][`process.exit()`] will override any
-previous setting of `process.exitCode`.
+The value of `process.exitCode` can be updated by either setting the value
+directly (e.g. `process.exitCode = 9`), or by specifying a code to
+[`process.exit(code)`][`process.exit()`] (the latter takes
+precedence and will override any previous setting of `process.exitCode`).
+
+The value can also be set implicitly by Node.js when unrecoverable errors occur (e.g.
+such as the encountering of an unsettled top-level await). However explicit
+manipulations of the exit code always take precedence over implicit ones (meaning that
+for example updating `process.exitCode` to `9` guarantees that the program's exit code
+will be `9` regardless on other errors Node.js might encounter).
 
 ## `process.features.cached_builtins`
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1907,9 +1907,14 @@ $ node -e 'process.exitCode = 9; process.exit(42)'; echo $?
 
 The value can also be set implicitly by Node.js when unrecoverable errors occur (e.g.
 such as the encountering of an unsettled top-level await). However explicit
-manipulations of the exit code always take precedence over implicit ones (meaning that
-for example updating `process.exitCode` to `9` guarantees that the program's exit code
-will be `9` regardless on other errors Node.js might encounter).
+manipulations of the exit code always take precedence over implicit ones:
+
+```console
+$ node --input-type=module -e 'await new Promise(() => {})'; echo $?
+13
+$ node --input-type=module -e 'process.exitCode = 9; await new Promise(() => {})'; echo $?
+9
+```
 
 ## `process.features.cached_builtins`
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1893,10 +1893,17 @@ A number which will be the process exit code, when the process either
 exits gracefully, or is exited via [`process.exit()`][] without specifying
 a code.
 
-The value of `process.exitCode` can be updated by either setting the value
-directly (e.g. `process.exitCode = 9`), or by specifying a code to
-[`process.exit(code)`][`process.exit()`] (the latter takes
-precedence and will override any previous setting of `process.exitCode`).
+The value of `process.exitCode` can be updated by either assigning a value to
+`process.exitCode` or by passing an argument to [`process.exit()`][]:
+
+```console
+$ node -e 'process.exitCode = 9'; echo $?
+9
+$ node -e 'process.exit(42)'; echo $?
+42
+$ node -e 'process.exitCode = 9; process.exit(42)'; echo $?
+42
+```
 
 The value can also be set implicitly by Node.js when unrecoverable errors occur (e.g.
 such as the encountering of an unsettled top-level await). However explicit

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -108,7 +108,15 @@ process.domain = null;
   ObjectDefineProperty(process, 'exitCode', {
     __proto__: null,
     get() {
-      return exitCode;
+      if (exitCode !== undefined) {
+        return exitCode;
+      }
+
+      if (fields[kHasExitCode] !== 0) {
+        return fields[kExitCode];
+      }
+
+      return undefined;
     },
     set(code) {
       if (code !== null && code !== undefined) {

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -104,19 +104,10 @@ process.domain = null;
     configurable: true,
   });
 
-  let exitCode;
   ObjectDefineProperty(process, 'exitCode', {
     __proto__: null,
     get() {
-      if (exitCode !== undefined) {
-        return exitCode;
-      }
-
-      if (fields[kHasExitCode] !== 0) {
-        return fields[kExitCode];
-      }
-
-      return undefined;
+      return fields[kHasExitCode] ? fields[kExitCode] : undefined;
     },
     set(code) {
       if (code !== null && code !== undefined) {
@@ -131,7 +122,6 @@ process.domain = null;
       } else {
         fields[kHasExitCode] = 0;
       }
-      exitCode = code;
     },
     enumerable: true,
     configurable: false,

--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -73,20 +73,7 @@ Maybe<ExitCode> SpinEventLoopInternal(Environment* env) {
 
   env->PrintInfoForSnapshotIfDebug();
   env->ForEachRealm([](Realm* realm) { realm->VerifyNoStrongBaseObjects(); });
-  Maybe<ExitCode> exit_code = EmitProcessExitInternal(env);
-  if (exit_code.FromMaybe(ExitCode::kGenericUserError) !=
-      ExitCode::kNoFailure) {
-    return exit_code;
-  }
-
-  auto unsettled_tla = env->CheckUnsettledTopLevelAwait();
-  if (unsettled_tla.IsNothing()) {
-    return Nothing<ExitCode>();
-  }
-  if (!unsettled_tla.FromJust()) {
-    return Just(ExitCode::kUnsettledTopLevelAwait);
-  }
-  return Just(ExitCode::kNoFailure);
+  return EmitProcessExitInternal(env);
 }
 
 struct CommonEnvironmentSetup::Impl {

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -75,14 +75,14 @@ Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {
   // the exit code wasn't already set, so let's check for unsettled tlas
   if (exit_code == ExitCode::kNoFailure) {
     auto unsettled_tla = env->CheckUnsettledTopLevelAwait();
-
-    exit_code = !unsettled_tla.FromJust()
-         ? ExitCode::kUnsettledTopLevelAwait
-         : ExitCode::kNoFailure;
+    if (!unsettled_tla.FromJust()) {
+      exit_code = ExitCode::kUnsettledTopLevelAwait;
+      env->set_exit_code(exit_code);
+    }
   }
 
-  Local<Integer> exit_code_int = Integer::New(
-      isolate, static_cast<int32_t>(exit_code));
+  Local<Integer> exit_code_int =
+      Integer::New(isolate, static_cast<int32_t>(exit_code));
 
   if (ProcessEmit(env, "exit", exit_code_int).IsEmpty()) {
     return Nothing<ExitCode>();

--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -70,14 +70,26 @@ Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {
     return Nothing<ExitCode>();
   }
 
-  Local<Integer> exit_code = Integer::New(
-      isolate, static_cast<int32_t>(env->exit_code(ExitCode::kNoFailure)));
+  ExitCode exit_code = env->exit_code(ExitCode::kNoFailure);
 
-  if (ProcessEmit(env, "exit", exit_code).IsEmpty()) {
+  // the exit code wasn't already set, so let's check for unsettled tlas
+  if (exit_code == ExitCode::kNoFailure) {
+    auto unsettled_tla = env->CheckUnsettledTopLevelAwait();
+
+    exit_code = !unsettled_tla.FromJust()
+         ? ExitCode::kUnsettledTopLevelAwait
+         : ExitCode::kNoFailure;
+  }
+
+  Local<Integer> exit_code_int = Integer::New(
+      isolate, static_cast<int32_t>(exit_code));
+
+  if (ProcessEmit(env, "exit", exit_code_int).IsEmpty()) {
     return Nothing<ExitCode>();
   }
+
   // Reload exit code, it may be changed by `emit('exit')`
-  return Just(env->exit_code(ExitCode::kNoFailure));
+  return Just(env->exit_code(exit_code));
 }
 
 Maybe<int> EmitProcessExit(Environment* env) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -341,6 +341,11 @@ inline ExitCode Environment::exit_code(const ExitCode default_code) const {
              : static_cast<ExitCode>(exit_info_[kExitCode]);
 }
 
+inline void Environment::set_exit_code(const ExitCode code) {
+  exit_info_[kExitCode] = static_cast<int>(code);
+  exit_info_[kHasExitCode] = 1;
+}
+
 inline AliasedInt32Array& Environment::exit_info() {
   return exit_info_;
 }

--- a/src/env.h
+++ b/src/env.h
@@ -739,6 +739,8 @@ class Environment final : public MemoryRetainer {
   bool exiting() const;
   inline ExitCode exit_code(const ExitCode default_code) const;
 
+  inline void set_exit_code(const ExitCode code);
+
   // This stores whether the --abort-on-uncaught-exception flag was passed
   // to Node.
   inline bool abort_on_uncaught_exception() const;

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -76,9 +76,9 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
-    assert.strictEqual(stdout, 'the exit listener received code: 13\n');
     assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:5\b/);
     assert.match(stderr, /await new Promise/);
+    assert.strictEqual(stdout, 'the exit listener received code: 13\n');
     assert.strictEqual(code, 13);
   });
 
@@ -169,11 +169,11 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
         fixtures.path('es-modules/tla/unresolved-with-listener.mjs'),
       ]);
 
+      assert.match(stderr, /Warning: Detected unsettled top-level await at/);
       assert.strictEqual(stdout,
                          'the exit listener received code: 13\n' +
                          'process.exitCode inside the exist listener: 13\n'
       );
-      assert.match(stderr, /Warning: Detected unsettled top-level await at/);
       assert.strictEqual(code, 13);
     });
 

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -72,7 +72,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise with warning', async () => {
-    const { code, stdout, stderr } = await spawnPromisified(execPath, [
+    const { code, stderr, stdout } = await spawnPromisified(execPath, [
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
@@ -83,7 +83,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise without warning', async () => {
-    const { code, stdout, stderr } = await spawnPromisified(execPath, [
+    const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
@@ -107,7 +107,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise and respect explicit exit code via stdin', async () => {
-    const { code, stdout, stderr } = await spawnPromisified(execPath, [
+    const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
     ]);
@@ -118,7 +118,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
-    const { code, stdout, stderr } = await spawnPromisified(execPath, [
+    const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
     ]);
@@ -176,7 +176,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
 
   describe('with exit listener', () => {
     it('the process exit event should provide the correct code', async () => {
-      const { code, stdout, stderr } = await spawnPromisified(execPath, [
+      const { code, stderr, stdout } = await spawnPromisified(execPath, [
         fixtures.path('es-modules/tla/unresolved-with-listener.mjs'),
       ]);
 
@@ -189,7 +189,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
     });
 
     it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
-      const { code, stdout, stderr } = await spawnPromisified(execPath, [
+      const { code, stderr, stdout } = await spawnPromisified(execPath, [
         '--no-warnings',
         fixtures.path('es-modules/tla/unresolved-withexitcode-and-listener.mjs'),
       ]);

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -72,24 +72,31 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise with warning', async () => {
-    const { code, stderr, stdout } = await spawnPromisified(execPath, [
+    const { code, stderr } = await spawnPromisified(execPath, [
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
-    assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:1/);
+    assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:5/);
     assert.match(stderr, /await new Promise/);
-    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 13);
+  });
+
+  it('the process exit event should provide the correct code for an unsettled TLA promise', async () => {
+    const { code, stdout } = await spawnPromisified(execPath, [
+      fixtures.path('es-modules/tla/unresolved.mjs'),
+    ]);
+
+    assert.strictEqual(stdout, 'the exit listener received code: 13\n');
     assert.strictEqual(code, 13);
   });
 
   it('should exit for an unsettled TLA promise without warning', async () => {
-    const { code, stderr, stdout } = await spawnPromisified(execPath, [
+    const { code, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
     assert.strictEqual(stderr, '');
-    assert.strictEqual(stdout, '');
     assert.strictEqual(code, 13);
   });
 
@@ -105,13 +112,22 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise and respect explicit exit code via stdin', async () => {
-    const { code, stderr, stdout } = await spawnPromisified(execPath, [
+    const { code, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
     ]);
 
     assert.strictEqual(stderr, '');
-    assert.strictEqual(stdout, '');
+    assert.strictEqual(code, 42);
+  });
+
+  it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
+    const { code, stdout } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
+    ]);
+
+    assert.strictEqual(stdout, 'the exit listener received code: 42\n');
     assert.strictEqual(code, 42);
   });
 

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -72,32 +72,27 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise with warning', async () => {
-    const { code, stderr } = await spawnPromisified(execPath, [
+    const { code, stdout, stderr } = await spawnPromisified(execPath, [
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
+    assert.strictEqual(stdout, 'the exit listener received code: 13\n');
     assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:5/);
     assert.match(stderr, /await new Promise/);
     assert.strictEqual(code, 13);
   });
 
-  it('the process exit event should provide the correct code for an unsettled TLA promise', async () => {
-    const { code, stdout } = await spawnPromisified(execPath, [
-      fixtures.path('es-modules/tla/unresolved.mjs'),
-    ]);
-
-    assert.strictEqual(stdout, 'the exit listener received code: 13\n');
-    assert.strictEqual(code, 13);
-  });
-
   it('should exit for an unsettled TLA promise without warning', async () => {
-    const { code, stderr } = await spawnPromisified(execPath, [
+    const { code, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved.mjs'),
     ]);
 
-    assert.strictEqual(stderr, '');
-    assert.strictEqual(code, 13);
+    assert.deepStrictEqual({ code, stdout, stderr }, {
+      code: 13,
+      stdout: 'the exit listener received code: 13\n',
+      stderr: '',
+    });
   });
 
   it('should throw for a rejected TLA promise via stdin', async () => {
@@ -112,23 +107,27 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
   });
 
   it('should exit for an unsettled TLA promise and respect explicit exit code via stdin', async () => {
-    const { code, stderr } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
-    ]);
-
-    assert.strictEqual(stderr, '');
-    assert.strictEqual(code, 42);
-  });
-
-  it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
-    const { code, stdout } = await spawnPromisified(execPath, [
+    const { code, stdout, stderr } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
     ]);
 
     assert.strictEqual(stdout, 'the exit listener received code: 42\n');
+    assert.strictEqual(stderr, '');
     assert.strictEqual(code, 42);
+  });
+
+  it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
+    const { code, stdout, stderr } = await spawnPromisified(execPath, [
+      '--no-warnings',
+      fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
+    ]);
+
+    assert.deepStrictEqual({ code, stdout, stderr }, {
+      code: 42,
+      stdout: 'the exit listener received code: 42\n',
+      stderr: '',
+    });
   });
 
   it('should throw for a rejected TLA promise and ignore explicit exit code via stdin', async () => {
@@ -177,7 +176,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
 
   describe('with exit listener', () => {
     it('the process exit event should provide the correct code', async () => {
-      const { code, stdout } = await spawnPromisified(execPath, [
+      const { code, stdout, stderr } = await spawnPromisified(execPath, [
         fixtures.path('es-modules/tla/unresolved-with-listener.mjs'),
       ]);
 
@@ -185,20 +184,22 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
                          'the exit listener received code: 13\n' +
                          'process.exitCode inside the exist listener: 13\n'
       );
+      assert.match(stderr, /Warning: Detected unsettled top-level await at/);
       assert.strictEqual(code, 13);
     });
 
     it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
-      const { code, stdout } = await spawnPromisified(execPath, [
+      const { code, stdout, stderr } = await spawnPromisified(execPath, [
         '--no-warnings',
         fixtures.path('es-modules/tla/unresolved-withexitcode-and-listener.mjs'),
       ]);
 
-      assert.strictEqual(stdout,
-                         'the exit listener received code: 42\n' +
-                         'process.exitCode inside the exist listener: 42\n'
-      );
-      assert.strictEqual(code, 42);
+      assert.deepStrictEqual({ code, stdout, stderr }, {
+        code: 42,
+        stdout: 'the exit listener received code: 42\n' +
+                'process.exitCode inside the exist listener: 42\n',
+        stderr: '',
+      });
     });
   });
 });

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -174,4 +174,31 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
     assert.strictEqual(stdout, '');
     assert.strictEqual(code, 13);
   });
+
+  describe('with exit listener', () => {
+    it('the process exit event should provide the correct code', async () => {
+      const { code, stdout } = await spawnPromisified(execPath, [
+        fixtures.path('es-modules/tla/unresolved-with-listener.mjs'),
+      ]);
+
+      assert.strictEqual(stdout,
+                         'the exit listener received code: 13\n' +
+                         'process.exitCode inside the exist listener: 13\n'
+      );
+      assert.strictEqual(code, 13);
+    });
+
+    it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
+      const { code, stdout } = await spawnPromisified(execPath, [
+        '--no-warnings',
+        fixtures.path('es-modules/tla/unresolved-withexitcode-and-listener.mjs'),
+      ]);
+
+      assert.strictEqual(stdout,
+                         'the exit listener received code: 42\n' +
+                         'process.exitCode inside the exist listener: 42\n'
+      );
+      assert.strictEqual(code, 42);
+    });
+  });
 });

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -106,18 +106,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
     assert.strictEqual(code, 1);
   });
 
-  it('should exit for an unsettled TLA promise and respect explicit exit code via stdin', async () => {
-    const { code, stderr, stdout } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),
-    ]);
-
-    assert.strictEqual(stdout, 'the exit listener received code: 42\n');
-    assert.strictEqual(stderr, '');
-    assert.strictEqual(code, 42);
-  });
-
-  it('should exit for an unsettled TLA promise and respect explicit exit code in process exit event', async () => {
+  it('should exit for an unsettled TLA promise and respect explicit exit code', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       fixtures.path('es-modules/tla/unresolved-withexitcode.mjs'),

--- a/test/es-module/test-esm-tla-unfinished.mjs
+++ b/test/es-module/test-esm-tla-unfinished.mjs
@@ -77,7 +77,7 @@ describe('ESM: unsettled and rejected promises', { concurrency: !process.env.TES
     ]);
 
     assert.strictEqual(stdout, 'the exit listener received code: 13\n');
-    assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:5/);
+    assert.match(stderr, /Warning: Detected unsettled top-level await at.+unresolved\.mjs:5\b/);
     assert.match(stderr, /await new Promise/);
     assert.strictEqual(code, 13);
   });

--- a/test/fixtures/es-modules/tla/unresolved-with-listener.mjs
+++ b/test/fixtures/es-modules/tla/unresolved-with-listener.mjs
@@ -1,0 +1,6 @@
+process.on('exit', (exitCode) => {
+    console.log(`the exit listener received code: ${exitCode}`);
+    console.log(`process.exitCode inside the exist listener: ${process.exitCode}`);
+})
+
+await new Promise(() => {});

--- a/test/fixtures/es-modules/tla/unresolved-withexitcode-and-listener.mjs
+++ b/test/fixtures/es-modules/tla/unresolved-withexitcode-and-listener.mjs
@@ -1,0 +1,8 @@
+process.on('exit', (exitCode) => {
+    console.log(`the exit listener received code: ${exitCode}`);
+    console.log(`process.exitCode inside the exist listener: ${process.exitCode}`);
+});
+
+process.exitCode = 42;
+
+await new Promise(() => {});

--- a/test/fixtures/es-modules/tla/unresolved-withexitcode.mjs
+++ b/test/fixtures/es-modules/tla/unresolved-withexitcode.mjs
@@ -1,2 +1,7 @@
+process.on('exit', (exitCode) => {
+    console.log(`the exit listener received code: ${exitCode}`);
+});
+
 process.exitCode = 42;
+
 await new Promise(() => {});

--- a/test/fixtures/es-modules/tla/unresolved.mjs
+++ b/test/fixtures/es-modules/tla/unresolved.mjs
@@ -1,1 +1,5 @@
+process.on('exit', (exitCode) => {
+    console.log(`the exit listener received code: ${exitCode}`);
+})
+
 await new Promise(() => {});


### PR DESCRIPTION
fix listeners registered via `process.on('exit', ...` not receiving error code 13 when an unsettled top-level-await is encountered in the code

Fixes: https://github.com/nodejs/node/issues/53551

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
