### PR TITLE
src,test: expand test coverage for urlpattern and fix error

### DIFF
--- a/src/node_url_pattern.cc
+++ b/src/node_url_pattern.cc
@@ -103,13 +103,14 @@ URLPatternRegexProvider::regex_search(std::string_view input,
       return std::nullopt;
     }
 
+    // V8 checks that the regexp exec result is one of the correct types.
+    DCHECK_IMPLIES(!entry->IsUndefined(), entry->IsString());
+
     if (entry->IsUndefined()) {
       result.emplace_back(std::nullopt);
     } else if (entry->IsString()) {
       Utf8Value utf8_entry(isolate, entry.As<String>());
       result.emplace_back(utf8_entry.ToString());
-    } else {
-      UNREACHABLE("v8::RegExp::Exec return a non-string, non-undefined value.");
     }
   }
   return result;
@@ -184,7 +185,8 @@ void URLPattern::New(const FunctionCallbackInfo<Value>& args) {
         return;
       }
     } else {
-      THROW_ERR_MISSING_ARGS(env, "baseURL or options must be provided");
+      THROW_ERR_INVALID_ARG_TYPE(env,
+                                 "second argument must be a string or object");
       return;
     }
 

--- a/test/parallel/test-urlpattern-types.js
+++ b/test/parallel/test-urlpattern-types.js
@@ -1,0 +1,46 @@
+'use strict';
+
+require('../common');
+
+const { URLPattern } = require('url');
+const { throws } = require('assert');
+
+// Verifies that calling URLPattern with no new keyword throws.
+throws(() => URLPattern(), {
+  code: 'ERR_CONSTRUCT_CALL_REQUIRED',
+});
+
+// Verifies that type checks are performed on the arguments.
+throws(() => new URLPattern(1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => new URLPattern({}, 1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => new URLPattern({}, '', 1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => new URLPattern({}, { ignoreCase: '' }), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+const pattern = new URLPattern();
+
+throws(() => pattern.exec(1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => pattern.exec('', 1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => pattern.test(1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+throws(() => pattern.test('', 1), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});


### PR DESCRIPTION
Improve test coverage for URLPattern, fixup a typecheck error, and eliminate an unnecessary `UNREACHABLE` branch.