### PR TITLE
benchmarks: add simple parse and test benchmarks for URLPattern

### DIFF
--- a/benchmark/url/urlpattern-parse.js
+++ b/benchmark/url/urlpattern-parse.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common.js');
+const { URLPattern } = require('url');
+const { ok } = require('assert');
+
+const tests = [
+  'https://(sub.)?example(.com/)foo',
+  { 'hostname': 'xn--caf-dma.com' },
+  { 'pathname': '/foo', 'search': 'bar', 'hash': 'baz',
+    'baseURL': 'https://example.com:8080' },
+  { 'pathname': '/([[a-z]--a])' },
+];
+
+const bench = common.createBenchmark(main, {
+  pattern: tests.map(JSON.stringify),
+  n: [1e5],
+});
+
+function main({ pattern, n }) {
+  const inputPattern = JSON.parse(pattern);
+  let deadcode;
+  bench.start();
+  for (let i = 0; i < n; i += 1) {
+    deadcode = new URLPattern(inputPattern);
+  }
+  bench.end(n);
+  ok(deadcode);
+}

--- a/benchmark/url/urlpattern-test.js
+++ b/benchmark/url/urlpattern-test.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common.js');
+const { URLPattern } = require('url');
+const { notStrictEqual } = require('assert');
+
+const tests = [
+  'https://(sub.)?example(.com/)foo',
+  { 'hostname': 'xn--caf-dma.com' },
+  { 'pathname': '/foo', 'search': 'bar', 'hash': 'baz',
+    'baseURL': 'https://example.com:8080' },
+  { 'pathname': '/([[a-z]--a])' },
+];
+
+const bench = common.createBenchmark(main, {
+  pattern: tests.map(JSON.stringify),
+  n: [1e5],
+});
+
+function main({ pattern, n }) {
+  const inputPattern = JSON.parse(pattern);
+  const urlpattern = new URLPattern(inputPattern);
+
+  let deadcode;
+  bench.start();
+  for (let i = 0; i < n; i += 1) {
+    deadcode = urlpattern.test('https://sub.example.com/foo');
+  }
+  bench.end(n);
+  notStrictEqual(deadcode, undefined);  // We don't care if it is true or false.
+}


### PR DESCRIPTION
Add a couple of simple benchmarks for `URLPattern` that we can use to help judge performance improvements.