### PR TITLE
build: do not put commands in sources variables

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1394,6 +1394,11 @@ def gcc_version_ge(version_checked):
 def configure_node_lib_files(o):
   o['variables']['node_library_files'] = SearchFiles('lib', 'js')
 
+def configure_node_cctest_sources(o):
+  o['variables']['node_cctest_sources'] = [ 'src/node_snapshot_stub.cc' ] + \
+    SearchFiles('test/cctest', 'cc') + \
+    SearchFiles('test/cctest', 'h')
+
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
@@ -2207,6 +2212,7 @@ flavor = GetFlavor(flavor_params)
 
 configure_node(output)
 configure_node_lib_files(output)
+configure_node_cctest_sources(output)
 configure_napi(output)
 configure_library('zlib', output)
 configure_library('http_parser', output)

--- a/node.gyp
+++ b/node.gyp
@@ -402,11 +402,6 @@
       'src/quic/transportparams.h',
       'src/quic/quic.cc',
     ],
-    'node_cctest_sources': [
-      'src/node_snapshot_stub.cc',
-      '<!@("<(python)" tools/search_files.py . test/cctest cc)',
-      '<!@("<(python)" tools/search_files.py . test/cctest h)',
-    ],
     'node_cctest_openssl_sources': [
       'test/cctest/test_crypto_clienthello.cc',
       'test/cctest/test_node_crypto.cc',

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -362,13 +362,26 @@ template("node_gn_build") {
       "$node_simdutf_path",
     ]
 
-    sources = gypi_values.node_cctest_sources
+    sources = [ "src/node_snapshot_stub.cc" ]
+    sources += exec_script("./tools/search_files.py",
+                           [ rebase_path(".", root_build_dir),
+                             rebase_path("test/cctest", root_build_dir),
+                             "cc" ],
+                           "list lines")
+
     if (node_use_openssl) {
       deps += [ "deps/ncrypto" ]
-      sources += gypi_values.node_cctest_openssl_sources
+    } else {
+      sources -= gypi_values.node_cctest_openssl_sources
     }
     if (node_enable_inspector) {
-      sources += gypi_values.node_cctest_inspector_sources
+      deps += [ "src/inspector:crdtp" ]
+      include_dirs = [
+        "$target_gen_dir/src",
+        "$target_gen_dir/src/inspector",
+      ]
+    } else {
+      sources -= gypi_values.node_cctest_inspector_sources
     }
   }
 


### PR DESCRIPTION
The `_sources` variables are also read by GN and putting anything other than filenames in them would end up with GN errors.