### PR TITLE
doc: mark `--env-file-if-exists` flag as experimental

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -800,6 +800,8 @@ node --entry-url 'data:text/javascript,console.log("Hello")'
 
 ### `--env-file-if-exists=config`
 
+> Stability: 1.1 - Active development
+
 <!-- YAML
 added: v22.9.0
 -->


### PR DESCRIPTION
As `--env-file` is experimental, this must be marked as experimental as well.

Refs: https://github.com/nodejs/node/issues/56887