### PR TITLE
build: link with Security.framework in GN build

### DIFF
--- a/unofficial.gni
+++ b/unofficial.gni
@@ -173,7 +173,10 @@ template("node_gn_build") {
       libs = [ "psapi.lib" ]
     }
     if (is_mac) {
-      frameworks = [ "CoreFoundation.framework" ]
+      frameworks = [
+        "CoreFoundation.framework",
+        "Security.framework",
+      ]
     }
     if (is_posix) {
       configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]


### PR DESCRIPTION
Update the GN build file to match the changes in https://github.com/nodejs/node/pull/56599.