### PR TITLE
doc: update websocket link to avoid linking to self

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -4256,7 +4256,7 @@ A browser-compatible implementation of [`WebSocket`][].
 [`Headers`]: globals.md#class-headers
 [`TypeError`]: errors.md#class-typeerror
 [`URL`]: url.md#the-whatwg-url-api
-[`WebSocket`]: #websocket
+[`WebSocket`]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
 [`agent.createConnection()`]: #agentcreateconnectionoptions-callback
 [`agent.getName()`]: #agentgetnameoptions
 [`destroy()`]: #agentdestroy


### PR DESCRIPTION
The link `WebSocket` is pointing to the section itself.

https://github.com/nodejs/node/blob/793c7936c394aba54875f84b135684e38a30ff94/doc/api/http.md?plain=1#L4241
