### PR TITLE
build: remove explicit linker call to libm on macOS

### DIFF
--- a/deps/brotli/brotli.gyp
+++ b/deps/brotli/brotli.gyp
@@ -59,14 +59,15 @@
           'defines': [
             'OS_MACOSX'
           ]
+        }, {
+          'libraries': [
+            '-lm',
+          ],
         }],
       ],
       'direct_dependent_settings': {
         'include_dirs': [ 'c/include' ]
       },
-      'libraries': [
-        '-lm',
-      ],
       'sources': [
         '<@(brotli_sources)',
       ]

--- a/deps/brotli/unofficial.gni
+++ b/deps/brotli/unofficial.gni
@@ -25,7 +25,7 @@ template("brotli_gn_build") {
     } else if (target_os == "freebsd") {
       defines = [ "OS_FREEBSD" ]
     }
-    if (!is_win) {
+    if (is_linux) {
       libs = [ "m" ]
     }
     if (is_clang || !is_win) {

--- a/deps/uv/unofficial.gni
+++ b/deps/uv/unofficial.gni
@@ -87,11 +87,11 @@ template("uv_gn_build") {
       ]
     }
     if (is_posix) {
-      libs = [ "m" ]
       ldflags = [ "-pthread" ]
     }
     if (is_linux) {
       libs += [
+        "m",
         "dl",
         "rt",
       ]

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -220,7 +220,6 @@
             '<@(uv_sources_posix)',
           ],
           'link_settings': {
-            'libraries': [ '-lm' ],
             'conditions': [
               ['OS=="solaris"', {
                 'ldflags': [ '-pthreads' ],
@@ -230,6 +229,11 @@
               }],
               ['OS != "solaris" and OS != "android" and OS != "zos"', {
                 'ldflags': [ '-pthread' ],
+              }],
+              ['OS!="mac"', {
+                'libraries': [
+                  '-lm'
+                ],
               }],
             ],
           },


### PR DESCRIPTION
`/usr/lib/libm.tbd` is available via `libSystem.*.dylib` and reexports sanitizer symbols. When building for asan or other sanitizers this becomes an issue as the linker will resolve the symbols from the system library rather from `libclang_rt.*`

For V8 that rely on specific version of these symbols that get bundled as part of clang, for ex:
https://source.chromium.org/chromium/chromium/src/+/main:v8/src/heap/cppgc/platform.cc;l=93-97 accepting nullptr for shadow_offset in `asan_get_shadow_mapping`, linking to system version that doesn't support this will lead to a crash.

Clang linker driver eventually links with `-lSystem`
https://github.com/llvm/llvm-project/blob/e82f93890daefeb38fe2a22ee3db87a89948ec57/clang/lib/Driver/ToolChains/Darwin.cpp#L1628-L1631, this is done after linking the sanitizer libraries which ensures right order of resolution for the symbols.

**After:**

```
% nm -m ./out/Release/node | grep asan_get_shadow_mapping
                 (undefined) external ___asan_get_shadow_mapping (from libclang_rt.asan_osx_dynamic)
```

Fixes https://github.com/nodejs/node/issues/55583