### PR TITLE
sqlite: handle exceptions in filter callback database.applyChangeset()

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -241,8 +241,8 @@ added:
 
 * `changeset` {Uint8Array} A binary changeset or patchset.
 * `options` {Object} The configuration options for how the changes will be applied.
-  * `filter` {Function} Skip changes that, when targeted table name is supplied to this function, return a truthy value.
-    By default, all changes are attempted.
+  * `filter` {Function} A table name is provided as an argument to this callback. Returning a truthy value means changes
+    for the table with that table name should be attempted. By default, changes for all tables are attempted.
   * `onConflict` {Function} A function that determines how to handle conflicts. The function receives one argument,
     which can be one of the following values:
 


### PR DESCRIPTION
Resolves #56890

Also adds additional test coverage for filter callback and clarifies behavior in documentation.