### PR TITLE
fs: fix fs.promises.mkdir to also report ENOSPC correctly

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1821,6 +1821,7 @@ int MKDirpAsync(uv_loop_t* loop,
           break;
         }
         case UV_EACCES:
+        case UV_ENOSPC:
         case UV_ENOTDIR:
         case UV_EPERM: {
           req_wrap->continuation_data()->Done(err);


### PR DESCRIPTION
Continuation of https://github.com/nodejs/node/pull/42811 which fixes https://github.com/nodejs/node/issues/42808 for the async case

Happy to try to write a test but left as is for now seeing as the previous PR also didn't: https://github.com/nodejs/node/pull/42811#pullrequestreview-948610220