### PR TITLE
doc: update history of stream.Readable.toWeb()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3138,6 +3138,11 @@ Returns whether the stream is readable.
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version:
+    - v18.7.0
+    pr-url: https://github.com/nodejs/node/pull/43515
+    description: include strategy options on Readable.
 -->
 
 > Stability: 1 - Experimental


### PR DESCRIPTION
Adds the exact version for when the 2nd `options` argument is available.

Refs: https://github.com/nodejs/node/pull/43515
