### PR TITLE
inspector: make dispatching_messages_ atomic

### DIFF
--- a/src/inspector/main_thread_interface.cc
+++ b/src/inspector/main_thread_interface.cc
@@ -243,7 +243,11 @@ void MainThreadInterface::DispatchMessages() {
   bool expected = false;
   // compare_exchange_strong returns true if the value was successfully changed
   // from false to true.
-  if (dispatching_messages_.compare_exchange_strong(expected, true, std::memory_order_acquire, std::memory_order_relaxed)) {
+  if (dispatching_messages_.compare_exchange_strong(
+          expected,
+          true,
+          std::memory_order_acquire,
+          std::memory_order_relaxed)) {
     bool had_messages = false;
     do {
       if (dispatching_message_queue_.empty()) {

--- a/src/inspector/main_thread_interface.h
+++ b/src/inspector/main_thread_interface.h
@@ -94,7 +94,7 @@ class MainThreadInterface :
   // This queue is to maintain the order of the messages for the cases
   // when we reenter the DispatchMessages function.
   MessageQueue dispatching_message_queue_;
-  bool dispatching_messages_ = false;
+  std::atomic<bool> dispatching_messages_ = false;
   // This flag indicates an internal request to exit the loop in
   // WaitForFrontendEvent(). It's set to true by calling
   // StopWaitingForFrontendEvent().


### PR DESCRIPTION
This is in relation with https://github.com/nodejs/node/issues/56925 reported by @targos

Assuming that `DispatchMessages()` is called by several threads, the following is formally unsafe:

```C++
oid MainThreadInterface::DispatchMessages() {
  if (dispatching_messages_)
    return;
  dispatching_messages_ = true;
  ...
}
```
The intention of the code seems to be that just one thread enters into the function. However, it is entirely possible (formally speaking) for the two (or more!) threads to enter `DispatchMessages()` while `dispatching_messages_` is false, and both set `dispatching_messages_` to true. That's what the pattern suggests.

At a minimum, `dispatching_messages_` should be atomic if that is what is meant.  It is what this PR does. We make `dispatching_messages_` atomic.

I have not examined the inside of the if-clause. It remains unchanged.