### PR TITLE
build: fix GN build of uv

### DIFF
--- a/deps/uv/unofficial.gni
+++ b/deps/uv/unofficial.gni
@@ -90,7 +90,7 @@ template("uv_gn_build") {
       ldflags = [ "-pthread" ]
     }
     if (is_linux) {
-      libs += [
+      libs = [
         "m",
         "dl",
         "rt",


### PR DESCRIPTION
Which was broken after 756a24242ed6dd99be7ccaed68346c3b9fd1bbea.