### PR TITLE
sqlite: fix coverity warnings related to backup()

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -171,9 +171,9 @@ class BackupJob : public ThreadPoolWork {
         env_(env),
         source_(source),
         pages_(pages),
-        source_db_(source_db),
-        destination_name_(destination_name),
-        dest_db_(dest_db) {
+        source_db_(std::move(source_db)),
+        destination_name_(std::move(destination_name)),
+        dest_db_(std::move(dest_db)) {
     resolver_.Reset(env->isolate(), resolver);
     progressFunc_.Reset(env->isolate(), progressFunc);
   }
@@ -314,7 +314,7 @@ class BackupJob : public ThreadPoolWork {
   sqlite3* dest_ = nullptr;
   sqlite3_backup* backup_ = nullptr;
   int pages_;
-  int backup_status_;
+  int backup_status_ = SQLITE_OK;
   std::string source_db_;
   std::string destination_name_;
   std::string dest_db_;
@@ -1078,8 +1078,14 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(resolver->GetPromise());
 
-  BackupJob* job = new BackupJob(
-      env, db, resolver, source_db, *dest_path, dest_db, rate, progressFunc);
+  BackupJob* job = new BackupJob(env,
+                                 db,
+                                 resolver,
+                                 std::move(source_db),
+                                 *dest_path,
+                                 std::move(dest_db),
+                                 rate,
+                                 progressFunc);
   db->AddBackup(job);
   job->ScheduleBackup();
 }


### PR DESCRIPTION
This commit fixes several coverity warnings related to the recently landed backup() API.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
