### PR TITLE
zlib: use modern class syntax for zstd classes

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -842,45 +842,44 @@ const zstdDefaultOpts = {
   finishFlush: ZSTD_e_end,
   fullFlush: ZSTD_e_flush,
 };
-function Zstd(opts, mode, initParamsArray, maxParam) {
-  assert(mode === ZSTD_COMPRESS || mode === ZSTD_DECOMPRESS);
+class Zstd extends ZlibBase {
+  constructor(opts, mode, initParamsArray, maxParam) {
+    assert(mode === ZSTD_COMPRESS || mode === ZSTD_DECOMPRESS);
 
-  initParamsArray.fill(-1);
-  if (opts?.params) {
-    ObjectKeys(opts.params).forEach((origKey) => {
-      const key = +origKey;
-      if (NumberIsNaN(key) || key < 0 || key > maxParam ||
-          (initParamsArray[key] | 0) !== -1) {
-        throw new ERR_ZSTD_INVALID_PARAM(origKey);
-      }
+    initParamsArray.fill(-1);
+    if (opts?.params) {
+      ObjectKeys(opts.params).forEach((origKey) => {
+        const key = +origKey;
+        if (NumberIsNaN(key) || key < 0 || key > maxParam ||
+            (initParamsArray[key] | 0) !== -1) {
+          throw new ERR_ZSTD_INVALID_PARAM(origKey);
+        }
 
-      const value = opts.params[origKey];
-      if (typeof value !== 'number' && typeof value !== 'boolean') {
-        throw new ERR_INVALID_ARG_TYPE('options.params[key]',
-                                       'number', opts.params[origKey]);
-      }
-      initParamsArray[key] = value;
-    });
+        const value = opts.params[origKey];
+        if (typeof value !== 'number' && typeof value !== 'boolean') {
+          throw new ERR_INVALID_ARG_TYPE('options.params[key]',
+                                         'number', opts.params[origKey]);
+        }
+        initParamsArray[key] = value;
+      });
+    }
+
+    const handle = mode === ZSTD_COMPRESS ?
+      new binding.ZstdCompress() : new binding.ZstdDecompress();
+
+    const pledgedSrcSize = opts?.pledgedSrcSize ?? undefined;
+
+    const writeState = new Uint32Array(2);
+    handle.init(
+      initParamsArray,
+      pledgedSrcSize,
+      writeState,
+      processCallback,
+    );
+    super(opts, mode, handle, zstdDefaultOpts);
+    this._writeState = writeState;
   }
-
-  const handle = mode === ZSTD_COMPRESS ?
-    new binding.ZstdCompress() : new binding.ZstdDecompress();
-
-  const pledgedSrcSize = opts?.pledgedSrcSize ?? undefined;
-
-  this._writeState = new Uint32Array(2);
-  handle.init(
-    initParamsArray,
-    pledgedSrcSize,
-    this._writeState,
-    processCallback,
-  );
-
-  ReflectApply(ZlibBase, this, [opts, mode, handle, zstdDefaultOpts]);
 }
-ObjectSetPrototypeOf(Zstd.prototype, ZlibBase.prototype);
-ObjectSetPrototypeOf(Zstd, ZlibBase);
-
 
 const kMaxZstdCParam = MathMax(...ObjectKeys(constants).map(
   (key) => (key.startsWith('ZSTD_c_') ?
@@ -890,16 +889,11 @@ const kMaxZstdCParam = MathMax(...ObjectKeys(constants).map(
 
 const zstdInitCParamsArray = new Uint32Array(kMaxZstdCParam + 1);
 
-function ZstdCompress(opts) {
-  if (!(this instanceof ZstdCompress))
-    return new ZstdCompress(opts);
-
-  ReflectApply(Zstd, this,
-               [opts, ZSTD_COMPRESS, zstdInitCParamsArray, kMaxZstdCParam]);
+class ZstdCompress extends Zstd {
+  constructor(opts) {
+    super(opts, ZSTD_COMPRESS, zstdInitCParamsArray, kMaxZstdCParam);
+  }
 }
-ObjectSetPrototypeOf(ZstdCompress.prototype, Zstd.prototype);
-ObjectSetPrototypeOf(ZstdCompress, Zstd);
-
 
 const kMaxZstdDParam = MathMax(...ObjectKeys(constants).map(
   (key) => (key.startsWith('ZSTD_d_') ?
@@ -909,16 +903,11 @@ const kMaxZstdDParam = MathMax(...ObjectKeys(constants).map(
 
 const zstdInitDParamsArray = new Uint32Array(kMaxZstdDParam + 1);
 
-function ZstdDecompress(opts) {
-  if (!(this instanceof ZstdDecompress))
-    return new ZstdDecompress(opts);
-
-  ReflectApply(Zstd, this,
-               [opts, ZSTD_DECOMPRESS, zstdInitDParamsArray, kMaxZstdDParam]);
+class ZstdDecompress extends Zstd {
+  constructor(opts) {
+    super(opts, ZSTD_DECOMPRESS, zstdInitDParamsArray, kMaxZstdDParam);
+  }
 }
-ObjectSetPrototypeOf(ZstdDecompress.prototype, Zstd.prototype);
-ObjectSetPrototypeOf(ZstdDecompress, Zstd);
-
 
 function createProperty(ctor) {
   return {

--- a/test/parallel/test-zlib-invalid-input.js
+++ b/test/parallel/test-zlib-invalid-input.js
@@ -40,7 +40,7 @@ const unzips = [
   zlib.Inflate(),
   zlib.InflateRaw(),
   zlib.BrotliDecompress(),
-  zlib.ZstdDecompress(),
+  new zlib.ZstdDecompress(),
 ];
 
 nonStringInputs.forEach(common.mustCall((input) => {

--- a/test/parallel/test-zlib-zero-byte.js
+++ b/test/parallel/test-zlib-zero-byte.js
@@ -36,7 +36,7 @@ test('zlib should properly handle zero byte input', async () => {
 
   for (const [Compressor, expected] of compressors) {
     const { promise, resolve, reject } = Promise.withResolvers();
-    const gz = Compressor();
+    const gz = new Compressor();
     const emptyBuffer = Buffer.alloc(0);
     let received = 0;
     gz.on('data', function(c) {


### PR DESCRIPTION
All other classes in zlib has deprecated the usage of calling them without the new qualifier. Since this API is extremely new and experimental, let's remove them.