### PR TITLE
test: remove unnecessary syscall to cpuinfo

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -124,7 +124,7 @@ const isMacOS = process.platform === 'darwin';
 const isASan = process.config.variables.asan === 1;
 const isRiscv64 = process.arch === 'riscv64';
 const isDebug = process.features.debug;
-const isPi = (() => {
+function isPi() {
   try {
     // Normal Raspberry Pi detection is to find the `Raspberry Pi` string in
     // the contents of `/sys/firmware/devicetree/base/model` but that doesn't
@@ -136,7 +136,7 @@ const isPi = (() => {
   } catch {
     return false;
   }
-})();
+}
 
 // When using high concurrency or in the CI we need much more time for each connection attempt
 net.setDefaultAutoSelectFamilyAttemptTimeout(platformTimeout(net.getDefaultAutoSelectFamilyAttemptTimeout() * 10));
@@ -256,7 +256,7 @@ function platformTimeout(ms) {
   if (exports.isAIX || exports.isIBMi)
     return multipliers.two * ms; // Default localhost speed is slower on AIX
 
-  if (isPi)
+  if (isPi())
     return multipliers.two * ms;  // Raspberry Pi devices
 
   if (isRiscv64) {

--- a/test/pummel/test-crypto-dh-hash.js
+++ b/test/pummel/test-crypto-dh-hash.js
@@ -26,7 +26,7 @@ if (!common.hasCrypto) {
   common.skip('node compiled without OpenSSL.');
 }
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-crypto-dh-keys.js
+++ b/test/pummel/test-crypto-dh-keys.js
@@ -26,7 +26,7 @@ if (!common.hasCrypto) {
   common.skip('node compiled without OpenSSL.');
 }
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-dh-regr.js
+++ b/test/pummel/test-dh-regr.js
@@ -26,7 +26,7 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-fs-watch-system-limit.js
+++ b/test/pummel/test-fs-watch-system-limit.js
@@ -9,7 +9,7 @@ if (!common.isLinux) {
   common.skip('The fs watch limit is OS-dependent');
 }
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-hash-seed.js
+++ b/test/pummel/test-hash-seed.js
@@ -3,7 +3,7 @@
 // Check that spawn child doesn't create duplicated entries
 const common = require('../common');
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-heapsnapshot-near-heap-limit-bounded.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit-bounded.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-heapsnapshot-near-heap-limit-by-api.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit-by-api.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-heapsnapshot-near-heap-limit.js
+++ b/test/pummel/test-heapsnapshot-near-heap-limit.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-next-tick-infinite-calls.js
+++ b/test/pummel/test-next-tick-infinite-calls.js
@@ -22,7 +22,7 @@
 'use strict';
 const common = require('../common');
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/pummel/test-webcrypto-derivebits-pbkdf2.js
+++ b/test/pummel/test-webcrypto-derivebits-pbkdf2.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 

--- a/test/sequential/test-child-process-pass-fd.js
+++ b/test/sequential/test-child-process-pass-fd.js
@@ -9,7 +9,7 @@ const common = require('../common');
 // This test is basically `test-cluster-net-send` but creating lots of workers
 // so the issue reproduces on OS X consistently.
 
-if (common.isPi) {
+if (common.isPi()) {
   common.skip('Too slow for Raspberry Pi devices');
 }
 


### PR DESCRIPTION
Before this PR, we made a sys call to /proc/cpuinfo even if we don't need it... let's improve our test runner