### PR TITLE
test: improve timeout duration for debugger events

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -7,7 +7,8 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
   'exception', 'other', 'promiseRejection', 'step',
 ].join('|') + ') in', 'i');
 
-let TIMEOUT = common.platformTimeout(5000);
+// Some macOS machines require more time to receive the outputs from the client.
+let TIMEOUT = common.platformTimeout(10000);
 if (common.isWindows) {
   // Some of the windows machines in the CI need more time to receive
   // the outputs from the client.


### PR DESCRIPTION
Apparently, 5 seconds is not enough for some cases and causes flakiness on Github CI. 

Example: https://github.com/nodejs/node/actions/runs/13218322573/job/36900266760?pr=56962

cc @nodejs/inspector 