### PR TITLE
test: remove flakiness on macOS test

### DIFF
--- a/test/parallel/test-net-write-fully-async-buffer.js
+++ b/test/parallel/test-net-write-fully-async-buffer.js
@@ -23,7 +23,7 @@ const server = net.createServer(common.mustCall(function(conn) {
       }
 
       while (conn.write(Buffer.from(data)));
-      globalThis.gc({ type: 'minor' });
+      globalThis.gc({ type: 'major' });
       // The buffer allocated above should still be alive.
     }
 

--- a/test/parallel/test-net-write-fully-async-hex-string.js
+++ b/test/parallel/test-net-write-fully-async-hex-string.js
@@ -21,7 +21,7 @@ const server = net.createServer(common.mustCall(function(conn) {
       }
 
       while (conn.write(data, 'hex'));
-      globalThis.gc({ type: 'minor' });
+      globalThis.gc({ type: 'major' });
       // The buffer allocated inside the .write() call should still be alive.
     }
 


### PR DESCRIPTION
Locally I could reproduce this on macOS M4 machine using `tools/test.py --repeat 10000 test/parallel/test-net-write-fully-async-hex-string.js` after this change I couldn't reproduce it.

Ref: https://github.com/nodejs/node/actions/runs/13220154720/job/36904132463?pr=56970