### PR TITLE
test: lazily load modules on test runner

### DIFF
--- a/test/common/crypto.js
+++ b/test/common/crypto.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const common = require('../common');
-if (!common.hasCrypto) {
-  common.skip('missing crypto');
+const { hasCrypto, skip } = require('../common');
+if (!hasCrypto) {
+  skip('missing crypto');
 }
 
 const assert = require('assert');
-const crypto = require('crypto');
 const {
   createSign,
   createVerify,
@@ -14,7 +13,7 @@ const {
   privateDecrypt,
   sign,
   verify,
-} = crypto;
+} = require('crypto');  /* eslint-disable-line node-core/crypto-check */
 
 // The values below (modp2/modp2buf) are for a 1024 bits long prime from
 // RFC 2412 E.2, see https://tools.ietf.org/html/rfc2412. */
@@ -109,7 +108,7 @@ const opensslVersionNumber = (major = 0, minor = 0, patch = 0) => {
 
 let OPENSSL_VERSION_NUMBER;
 const hasOpenSSL = (major = 0, minor = 0, patch = 0) => {
-  if (!common.hasCrypto) return false;
+  if (!hasCrypto) return false;
   if (OPENSSL_VERSION_NUMBER === undefined) {
     const regexp = /(?<m>\d+)\.(?<n>\d+)\.(?<p>\d+)/;
     const { m, n, p } = process.versions.openssl.match(regexp).groups;

--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -1,6 +1,6 @@
 'use strict';
-const common = require('../common');
-const spawn = require('child_process').spawn;
+const { isWindows, platformTimeout } = require('../common');
+const { spawn } = require('child_process');
 
 const BREAK_MESSAGE = new RegExp('(?:' + [
   'assert', 'break', 'break on start', 'debugCommand',
@@ -8,12 +8,12 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
 ].join('|') + ') in', 'i');
 
 // Some macOS machines require more time to receive the outputs from the client.
-let TIMEOUT = common.platformTimeout(10000);
-if (common.isWindows) {
+let TIMEOUT = platformTimeout(10000);
+if (isWindows) {
   // Some of the windows machines in the CI need more time to receive
   // the outputs from the client.
   // https://github.com/nodejs/build/issues/3014
-  TIMEOUT = common.platformTimeout(15000);
+  TIMEOUT = platformTimeout(15000);
 }
 
 function isPreBreak(output) {

--- a/test/common/dns.js
+++ b/test/common/dns.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const os = require('os');
-const { isIP } = require('net');
+let endianness;
+let isIP;
 
 const types = {
   A: 1,
@@ -284,11 +284,13 @@ function writeDNSPacket(parsed) {
     }
   }
 
+  endianness ??= require('os').endianness();
+
   return Buffer.concat(buffers.map((typedArray) => {
     const buf = Buffer.from(typedArray.buffer,
                             typedArray.byteOffset,
                             typedArray.byteLength);
-    if (os.endianness() === 'LE') {
+    if (endianness === 'LE') {
       if (typedArray.BYTES_PER_ELEMENT === 2) buf.swap16();
       if (typedArray.BYTES_PER_ELEMENT === 4) buf.swap32();
     }
@@ -311,6 +313,7 @@ function errorLookupMock(code = mockedErrorCode, syscall = mockedSysCall) {
 }
 
 function createMockedLookup(...addresses) {
+  isIP ??= require('net').isIP;
   addresses = addresses.map((address) => ({ address: address, family: isIP(address) }));
 
   // Create a DNS server which replies with a AAAA and a A record for the same host

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -1,6 +1,6 @@
 'use strict';
 const assert = require('assert');
-const util = require('util');
+const { inspect } = require('util');
 
 let _buildEmbedderGraph;
 function buildEmbedderGraph() {
@@ -91,7 +91,7 @@ function readHeapInfo(raw, fields, types, strings) {
 }
 
 function inspectNode(snapshot) {
-  return util.inspect(snapshot, { depth: 4 });
+  return inspect(snapshot, { depth: 4 });
 }
 
 function isEdge(edge, { node_name, edge_name }) {
@@ -144,7 +144,7 @@ class State {
           if (!hasChild) {
             throw new Error(
               'expected to find child ' +
-              `${util.inspect(expectedEdge)} in ${inspectNode(rootNodes)}`);
+              `${inspect(expectedEdge)} in ${inspectNode(rootNodes)}`);
           }
         }
       }
@@ -196,7 +196,7 @@ class State {
           if (!hasChild) {
             throw new Error(
               'expected to find child ' +
-              `${util.inspect(expectedEdge)} in ${inspectNode(rootNodes)}`);
+              `${inspect(expectedEdge)} in ${inspectNode(rootNodes)}`);
           }
         }
       }
@@ -269,7 +269,7 @@ function findByRetainingPath(rootName, retainingPath) {
     }
 
     if (newHaystack.length === 0) {
-      const format = (val) => util.inspect(val, { breakLength: 128, depth: 3 });
+      const format = (val) => inspect(val, { breakLength: 128, depth: 3 });
       console.error('#');
       console.error('# Retaining path to search for:');
       for (let j = 0; j < retainingPath.length; ++j) {

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -24,7 +24,10 @@ const process = globalThis.process;  // Some tests tamper with the process globa
 
 const assert = require('assert');
 const fs = require('fs');
-const net = require('net');
+const {
+  getDefaultAutoSelectFamilyAttemptTimeout,
+  setDefaultAutoSelectFamilyAttemptTimeout,
+} = require('net');
 // Do not require 'os' until needed so that test-os-checked-function can
 // monkey patch it. If 'os' is required here, that test will fail.
 const path = require('path');
@@ -139,8 +142,8 @@ function isPi() {
 }
 
 // When using high concurrency or in the CI we need much more time for each connection attempt
-net.setDefaultAutoSelectFamilyAttemptTimeout(platformTimeout(net.getDefaultAutoSelectFamilyAttemptTimeout() * 10));
-const defaultAutoSelectFamilyAttemptTimeout = net.getDefaultAutoSelectFamilyAttemptTimeout();
+const defaultAutoSelectFamilyAttemptTimeout = platformTimeout(getDefaultAutoSelectFamilyAttemptTimeout() * 10);
+setDefaultAutoSelectFamilyAttemptTimeout(defaultAutoSelectFamilyAttemptTimeout);
 
 const buildType = process.config.target_defaults ?
   process.config.target_defaults.default_configuration :

--- a/test/common/inspector-helper.js
+++ b/test/common/inspector-helper.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const http = require('http');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
-const { URL, pathToFileURL } = require('url');
+const { pathToFileURL } = require('url');
 const { EventEmitter, once } = require('events');
 
 const _MAINSCRIPT = fixtures.path('loop.js');

--- a/test/common/measure-memory.js
+++ b/test/common/measure-memory.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const common = require('./');
+let expectWarning;
 
 // The formats could change when V8 is updated, then the tests should be
 // updated accordingly.
@@ -43,7 +43,8 @@ function assertSingleDetailedShape(result) {
 }
 
 function expectExperimentalWarning() {
-  common.expectWarning(
+  expectWarning ??= require('./').expectWarning;
+  expectWarning(
     'ExperimentalWarning',
     'vm.measureMemory is an experimental feature and might change at any time',
   );

--- a/test/common/net.js
+++ b/test/common/net.js
@@ -1,11 +1,11 @@
 'use strict';
-const net = require('net');
-
 const options = { port: 0, reusePort: true };
+let createServer;
 
 function checkSupportReusePort() {
+  createServer ??= require('net').createServer;
   return new Promise((resolve, reject) => {
-    const server = net.createServer().listen(options);
+    const server = createServer().listen(options);
     server.on('listening', () => {
       server.close(resolve);
     });

--- a/test/common/tls.js
+++ b/test/common/tls.js
@@ -2,11 +2,11 @@
 
 'use strict';
 const crypto = require('crypto');
-const net = require('net');
+const { Socket } = require('net');
 
 exports.ccs = Buffer.from('140303000101', 'hex');
 
-class TestTLSSocket extends net.Socket {
+class TestTLSSocket extends Socket {
   constructor(server_cert) {
     super();
     this.server_cert = server_cert;

--- a/test/common/udp.js
+++ b/test/common/udp.js
@@ -1,21 +1,21 @@
 'use strict';
-const dgram = require('dgram');
+const { createSocket } = require('dgram');
 
 const options = { type: 'udp4', reusePort: true };
 
 function checkSupportReusePort() {
-  return new Promise((resolve, reject) => {
-    const socket = dgram.createSocket(options);
-    socket.bind(0);
-    socket.on('listening', () => {
-      socket.close(resolve);
-    });
-    socket.on('error', (err) => {
-      console.log('The `reusePort` option is not supported:', err.message);
-      socket.close();
-      reject(err);
-    });
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = createSocket(options);
+  socket.bind(0);
+  socket.on('listening', () => {
+    socket.close(resolve);
   });
+  socket.on('error', (err) => {
+    console.log('The `reusePort` option is not supported:', err.message);
+    socket.close();
+    reject(err);
+  });
+  return promise;
 }
 
 module.exports = {

--- a/test/common/v8.js
+++ b/test/common/v8.js
@@ -1,15 +1,16 @@
 'use strict';
 const assert = require('assert');
-const { GCProfiler } = require('v8');
+let GCProfiler;
 
 function collectGCProfile({ duration }) {
-  return new Promise((resolve) => {
-    const profiler = new GCProfiler();
-    profiler.start();
-    setTimeout(() => {
-      resolve(profiler.stop());
-    }, duration);
-  });
+  GCProfiler ??= require('v8').GCProfiler;
+  const { promise, resolve } = Promise.withResolvers();
+  const profiler = new GCProfiler();
+  profiler.start();
+  setTimeout(() => {
+    resolve(profiler.stop());
+  }, duration);
+  return promise;
 }
 
 function checkGCProfile(data) {


### PR DESCRIPTION
Small refactor to lazy load as much as possible. Most tests doesn't even use all of these... Also, try to destruct the require on the declaration to see which functionality we are using from the required module.