### PR TITLE
src: improve node::Dotenv trimming

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -120,10 +120,6 @@ std::string_view trim_spaces(std::string_view input) {
     return input.substr(pos_start);
   }
 
-  if (pos_start == pos_end) {
-    return "";
-  }
-
   return input.substr(pos_start, pos_end - pos_start + 1);
 }
 

--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -105,15 +105,26 @@ Local<Object> Dotenv::ToObject(Environment* env) const {
   return result;
 }
 
+// Removes space characters (spaces, tabs and newlines) from
+// the start and end of a given input string
 std::string_view trim_spaces(std::string_view input) {
   if (input.empty()) return "";
-  if (input.front() == ' ') {
-    input.remove_prefix(input.find_first_not_of(' '));
+
+  auto pos_start = input.find_first_not_of(" \t\n");
+  if (pos_start == std::string_view::npos) {
+    return "";
   }
-  if (!input.empty() && input.back() == ' ') {
-    input = input.substr(0, input.find_last_not_of(' ') + 1);
+
+  auto pos_end = input.find_last_not_of(" \t\n");
+  if (pos_end == std::string_view::npos) {
+    return input.substr(pos_start);
   }
-  return input;
+
+  if (pos_start == pos_end) {
+    return "";
+  }
+
+  return input.substr(pos_start, pos_end - pos_start + 1);
 }
 
 void Dotenv::ParseContent(const std::string_view input) {

--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -154,6 +154,13 @@ void Dotenv::ParseContent(const std::string_view input) {
     key = content.substr(0, equal);
     content.remove_prefix(equal + 1);
     key = trim_spaces(key);
+
+    // If the value is not present (e.g. KEY=) set is to an empty string
+    if (content.front() == '\n') {
+      store_.insert_or_assign(std::string(key), "");
+      continue;
+    }
+
     content = trim_spaces(content);
 
     if (key.empty()) {

--- a/test/fixtures/dotenv/lines-with-only-spaces.env
+++ b/test/fixtures/dotenv/lines-with-only-spaces.env
@@ -1,0 +1,8 @@
+
+EMPTY_LINE='value after an empty line'
+      
+SPACES_LINE='value after a line with just some spaces'
+				
+TABS_LINE='value after a line with just some tabs'
+	    			
+SPACES_TABS_LINE='value after a line with just some spaces and tabs'

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -137,6 +137,25 @@ describe('.env supports edge cases', () => {
     assert.strictEqual(child.code, 0);
   });
 
+  it('should handle lines that come after lines with only spaces (and tabs)', async () => {
+    // Ref: https://github.com/nodejs/node/issues/56686
+    const code = `
+      process.loadEnvFile('./lines-with-only-spaces.env');
+      assert.strictEqual(process.env.EMPTY_LINE, 'value after an empty line');
+      assert.strictEqual(process.env.SPACES_LINE, 'value after a line with just some spaces');
+      assert.strictEqual(process.env.TABS_LINE, 'value after a line with just some tabs');
+      assert.strictEqual(process.env.SPACES_TABS_LINE, 'value after a line with just some spaces and tabs');
+    `.trim();
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--eval', code ],
+      { cwd: fixtures.path('dotenv') },
+    );
+    assert.strictEqual(child.stdout, '');
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
   it('should handle when --env-file is passed along with --', async () => {
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
the trimming functionality that the dotenv parsing uses currently only takes into consideration plain spaces (' '), other type of space characters such as tabs and newlines are not trimmed, this can cause subtle bugs, so the changes here make sure that such characters get trimmed as well

Fixes #56686 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
