### PR TITLE
sqlite,test,doc: accept Buffer and URL as paths

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -80,21 +80,21 @@ added: v22.5.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/56991
-    description: The `location` argument now supports Buffer and URL objects.
+    description: The `path` argument now supports Buffer and URL objects.
 -->
 
 This class represents a single [connection][] to a SQLite database. All APIs
 exposed by this class execute synchronously.
 
-### `new DatabaseSync(location[, options])`
+### `new DatabaseSync(path[, options])`
 
 <!-- YAML
 added: v22.5.0
 -->
 
-* `location` {string | Buffer | URL} The location of the database. A SQLite database can be
+* `path` {string | Buffer | URL} The path of the database. A SQLite database can be
   stored in a file or completely [in memory][]. To use a file-backed database,
-  the location should be a file path. To use an in-memory database, the location
+  the path should be a file path. To use an in-memory database, the path
   should be the special name `':memory:'`.
 * `options` {Object} Configuration options for the database connection. The
   following options are supported:
@@ -204,7 +204,7 @@ wrapper around [`sqlite3_create_function_v2()`][].
 added: v22.5.0
 -->
 
-Opens the database specified in the `location` argument of the `DatabaseSync`
+Opens the database specified in the `path` argument of the `DatabaseSync`
 constructor. This method should only be used when the database is not opened via
 the constructor. An exception is thrown if the database is already open.
 
@@ -538,18 +538,18 @@ exception.
 | `TEXT`    | {string}                   |
 | `BLOB`    | {TypedArray} or {DataView} |
 
-## `sqlite.backup(sourceDb, destination[, options])`
+## `sqlite.backup(sourceDb, path[, options])`
 
 <!-- YAML
 added: v23.8.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/56991
-    description: The `destination` argument now supports Buffer and URL objects.
+    description: The `path` argument now supports Buffer and URL objects.
 -->
 
 * `sourceDb` {DatabaseSync} The database to backup. The source database must be open.
-* `destination` {string | Buffer | URL} The path where the backup will be created. If the file already exists,
+* `path` {string | Buffer | URL} The path where the backup will be created. If the file already exists,
   the contents will be overwritten.
 * `options` {Object} Optional configuration for the backup. The
   following properties are supported:

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -88,7 +88,7 @@ exposed by this class execute synchronously.
 added: v22.5.0
 -->
 
-* `location` {string} The location of the database. A SQLite database can be
+* `location` {string} | {Buffer} | {URL} The location of the database. A SQLite database can be
   stored in a file or completely [in memory][]. To use a file-backed database,
   the location should be a file path. To use an in-memory database, the location
   should be the special name `':memory:'`.
@@ -541,8 +541,8 @@ added: v23.8.0
 -->
 
 * `sourceDb` {DatabaseSync} The database to backup. The source database must be open.
-* `destination` {string} The path where the backup will be created. If the file already exists, the contents will be
-  overwritten.
+* `destination` {string} | {Buffer} | {URL} The path where the backup will be created. If the file already exists,
+  the contents will be overwritten.
 * `options` {Object} Optional configuration for the backup. The
   following properties are supported:
   * `source` {string} Name of the source database. This can be `'main'` (the default primary database) or any other

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -77,6 +77,10 @@ console.log(query.all());
 
 <!-- YAML
 added: v22.5.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56991
+    description: The `location` argument now supports Buffer and URL objects.
 -->
 
 This class represents a single [connection][] to a SQLite database. All APIs
@@ -88,7 +92,7 @@ exposed by this class execute synchronously.
 added: v22.5.0
 -->
 
-* `location` {string} | {Buffer} | {URL} The location of the database. A SQLite database can be
+* `location` {string | Buffer | URL} The location of the database. A SQLite database can be
   stored in a file or completely [in memory][]. To use a file-backed database,
   the location should be a file path. To use an in-memory database, the location
   should be the special name `':memory:'`.
@@ -538,10 +542,14 @@ exception.
 
 <!-- YAML
 added: v23.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/56991
+    description: The `destination` argument now supports Buffer and URL objects.
 -->
 
 * `sourceDb` {DatabaseSync} The database to backup. The source database must be open.
-* `destination` {string} | {Buffer} | {URL} The path where the backup will be created. If the file already exists,
+* `destination` {string | Buffer | URL} The path where the backup will be created. If the file already exists,
   the contents will be overwritten.
 * `options` {Object} Optional configuration for the backup. The
   following properties are supported:

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -194,6 +194,7 @@
   V(host_string, "host")                                                       \
   V(hostmaster_string, "hostmaster")                                           \
   V(hostname_string, "hostname")                                               \
+  V(href_string, "href")                                                       \
   V(http_1_1_string, "http/1.1")                                               \
   V(id_string, "id")                                                           \
   V(identity_string, "identity")                                               \

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -640,12 +640,9 @@ bool HandleDatabaseLocationFromURL(Environment* env,
   Local<Object> url = path.As<Object>();
   Local<Value> href;
   Local<Value> protocol;
-  if (!url->Get(env->context(), FIXED_ONE_BYTE_STRING(env->isolate(), "href"))
-           .ToLocal(&href) ||
+  if (!url->Get(env->context(), env->href_string()).ToLocal(&href) ||
       !href->IsString() ||
-      !url->Get(env->context(),
-                FIXED_ONE_BYTE_STRING(env->isolate(), "protocol"))
-           .ToLocal(&protocol) ||
+      !url->Get(env->context(), env->protocol_string()).ToLocal(&protocol) ||
       !protocol->IsString()) {
     return false;
   }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1048,7 +1048,7 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&db, args[0].As<Object>());
   THROW_AND_RETURN_ON_BAD_STATE(env, !db->IsOpen(), "database is not open");
   std::optional<std::string> dest_path =
-      ValidateDatabasePath(env, args[1], "destination");
+      ValidateDatabasePath(env, args[1], "path");
   if (!dest_path.has_value()) {
     return;
   }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1073,6 +1073,11 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
+  if (url_protocol != "" && url_protocol != "file:") {
+    THROW_ERR_INVALID_URL_SCHEME(env->isolate());
+    return;
+  }
+
   int rate = 100;
   std::string source_db = "main";
   std::string dest_db = "main";

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -635,7 +635,12 @@ std::optional<std::string> ValidateDatabasePath(Environment* env,
       if (!has_null_bytes(location)) {
         auto file_url = ada::parse(location);
         CHECK(file_url);
-        return url::FileURLToPath(env, *file_url);
+        if (file_url->type != ada::scheme::FILE) {
+          THROW_ERR_INVALID_URL_SCHEME(env->isolate());
+          return std::nullopt;
+        }
+
+        return location;
       }
     }
   }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -591,7 +591,8 @@ bool DatabaseSync::ShouldIgnoreSQLiteError() {
 
 bool ValidateDatabasePath(Environment* env,
                           Local<Value> path,
-                          std::string* location) {
+                          std::string* location,
+                          std::string field_name) {
   if (path->IsString()) {
     *location = Utf8Value(env->isolate(), path.As<String>()).ToString();
     return true;
@@ -637,10 +638,10 @@ bool ValidateDatabasePath(Environment* env,
     }
   }
 
-  THROW_ERR_INVALID_ARG_TYPE(env->isolate(),
-                             "The \"path\" argument must be a string, "
-                             "Uint8Array, or URL without null bytes.");
-
+  std::string error_message =
+      "The \"" + field_name +
+      "\" argument must be a string, Uint8Array, or URL without null bytes.";
+  THROW_ERR_INVALID_ARG_TYPE(env->isolate(), error_message.c_str());
   return false;
 }
 
@@ -652,7 +653,7 @@ void DatabaseSync::New(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::string location;
-  if (!ValidateDatabasePath(env, args[0], &location)) {
+  if (!ValidateDatabasePath(env, args[0], &location, "path")) {
     return;
   }
 
@@ -1038,7 +1039,7 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&db, args[0].As<Object>());
   THROW_AND_RETURN_ON_BAD_STATE(env, !db->IsOpen(), "database is not open");
   std::string dest_path;
-  if (!ValidateDatabasePath(env, args[1], &dest_path)) {
+  if (!ValidateDatabasePath(env, args[1], &dest_path, "destination")) {
     return;
   }
 

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -50,32 +50,32 @@ describe('backup()', () => {
       backup(database);
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "destination" argument must be a string, Uint8Array, or URL without null bytes.'
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.'
     });
 
     t.assert.throws(() => {
       backup(database, {});
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "destination" argument must be a string, Uint8Array, or URL without null bytes.'
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.'
     });
   });
 
-  test('throws if the database destination contains null bytes', (t) => {
+  test('throws if the database path contains null bytes', (t) => {
     const database = makeSourceDb();
 
     t.assert.throws(() => {
       backup(database, Buffer.from('l\0cation'));
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "destination" argument must be a string, Uint8Array, or URL without null bytes.'
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.'
     });
 
     t.assert.throws(() => {
       backup(database, 'l\0cation');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "destination" argument must be a string, Uint8Array, or URL without null bytes.'
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.'
     });
   });
 
@@ -297,7 +297,7 @@ test('backup fails when source db is invalid', async (t) => {
   });
 });
 
-test('backup fails when destination cannot be opened', async (t) => {
+test('backup fails when path cannot be opened', async (t) => {
   const database = makeSourceDb();
 
   await t.assert.rejects(async () => {

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -143,23 +143,14 @@ test('database backup', async (t) => {
 });
 
 test('backup database using location as URL', async (t) => {
-  const progressFn = t.mock.fn();
   const database = makeSourceDb();
   const destDb = pathToFileURL(nextDb());
 
-  await backup(database, destDb, {
-    rate: 1,
-    progress: progressFn,
-  });
+  await backup(database, destDb);
 
   const backupDb = new DatabaseSync(destDb);
   const rows = backupDb.prepare('SELECT * FROM data').all();
 
-  // The source database has two pages - using the default page size -,
-  // so the progress function should be called once (the last call is not made since
-  // the promise resolves)
-  t.assert.strictEqual(progressFn.mock.calls.length, 1);
-  t.assert.deepStrictEqual(progressFn.mock.calls[0].arguments, [{ totalPages: 2, remainingPages: 1 }]);
   t.assert.deepStrictEqual(rows, [
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },
@@ -172,23 +163,14 @@ test('backup database using location as URL', async (t) => {
 });
 
 test('backup database using location as Buffer', async (t) => {
-  const progressFn = t.mock.fn();
   const database = makeSourceDb();
   const destDb = Buffer.from(nextDb());
 
-  await backup(database, destDb, {
-    rate: 1,
-    progress: progressFn,
-  });
+  await backup(database, destDb);
 
   const backupDb = new DatabaseSync(destDb);
   const rows = backupDb.prepare('SELECT * FROM data').all();
 
-  // The source database has two pages - using the default page size -,
-  // so the progress function should be called once (the last call is not made since
-  // the promise resolves)
-  t.assert.strictEqual(progressFn.mock.calls.length, 1);
-  t.assert.deepStrictEqual(progressFn.mock.calls[0].arguments, [{ totalPages: 2, remainingPages: 1 }]);
   t.assert.deepStrictEqual(rows, [
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -220,6 +220,21 @@ test('throws exception when trying to start backup from a closed database', (t) 
   });
 });
 
+test('throws if URL is not file: scheme', (t) => {
+  const database = new DatabaseSync(':memory:');
+
+  t.assert.throws(() => {
+    backup(database, new URL('http://example.com/backup.db'));
+  }, {
+    code: 'ERR_INVALID_URL_SCHEME',
+    message: 'The URL must be of scheme file:',
+  });
+
+  t.after(() => {
+    database.close();
+  });
+});
+
 test('database backup fails when dest file is not writable', async (t) => {
   const readonlyDestDb = nextDb();
   writeFileSync(readonlyDestDb, '', { mode: 0o444 });

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -146,6 +146,11 @@ test('backup database using location as URL', async (t) => {
   const database = makeSourceDb();
   const destDb = pathToFileURL(nextDb());
 
+  t.after(() => {
+    database.close();
+    backupDb.close();
+  });
+
   await backup(database, destDb);
 
   const backupDb = new DatabaseSync(destDb);
@@ -155,17 +160,17 @@ test('backup database using location as URL', async (t) => {
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },
   ]);
-
-  t.after(() => {
-    database.close();
-    backupDb.close();
-  });
 });
 
 test('backup database using location as Buffer', async (t) => {
   const database = makeSourceDb();
   const destDb = Buffer.from(nextDb());
 
+  t.after(() => {
+    database.close();
+    backupDb.close();
+  });
+
   await backup(database, destDb);
 
   const backupDb = new DatabaseSync(destDb);
@@ -175,11 +180,6 @@ test('backup database using location as Buffer', async (t) => {
     { __proto__: null, key: 1, value: 'value-1' },
     { __proto__: null, key: 2, value: 'value-2' },
   ]);
-
-  t.after(() => {
-    database.close();
-    backupDb.close();
-  });
 });
 
 test('database backup in a single call', async (t) => {
@@ -223,15 +223,13 @@ test('throws exception when trying to start backup from a closed database', (t) 
 test('throws if URL is not file: scheme', (t) => {
   const database = new DatabaseSync(':memory:');
 
+  t.after(() => { database.close(); });
+
   t.assert.throws(() => {
     backup(database, new URL('http://example.com/backup.db'));
   }, {
     code: 'ERR_INVALID_URL_SCHEME',
     message: 'The URL must be of scheme file:',
-  });
-
-  t.after(() => {
-    database.close();
   });
 });
 

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -28,7 +28,7 @@ suite('DatabaseSync() constructor', () => {
       new DatabaseSync();
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
-      message: /The "path" argument must be a string/,
+      message: /The "path" argument must be a string, Uint8Array, or URL without null bytes/,
     });
   });
 

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -256,6 +256,15 @@ suite('DatabaseSync.prototype.exec()', () => {
     });
   });
 
+  test('throws if the URL does not have the file: scheme', (t) => {
+    t.assert.throws(() => {
+      new DatabaseSync(new URL('http://example.com'));
+    }, {
+      code: 'ERR_INVALID_URL_SCHEME',
+      message: 'The URL must be of scheme file:',
+    });
+  });
+
   test('throws if database is not open', (t) => {
     const db = new DatabaseSync(nextDb(), { open: false });
 

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -23,12 +23,30 @@ suite('DatabaseSync() constructor', () => {
     });
   });
 
-  test('throws if database path is not a string', (t) => {
+  test('throws if database path is not a string, Uint8Array, or URL', (t) => {
     t.assert.throws(() => {
       new DatabaseSync();
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: /The "path" argument must be a string, Uint8Array, or URL without null bytes/,
+    });
+  });
+
+  test('throws if the database location as Buffer contains null bytes', (t) => {
+    t.assert.throws(() => {
+      new DatabaseSync(Buffer.from('l\0cation'));
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.',
+    });
+  });
+
+  test('throws if the database location as string contains null bytes', (t) => {
+    t.assert.throws(() => {
+      new DatabaseSync('l\0cation');
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "path" argument must be a string, Uint8Array, or URL without null bytes.',
     });
   });
 

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -143,7 +143,6 @@ test('URL is supported as the database path', (t) => {
   );
 });
 
-
 test('URL query params are supported', (t) => {
   const url = pathToFileURL(nextDb());
   const db = new DatabaseSync(url);

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -4,6 +4,8 @@ const tmpdir = require('../common/tmpdir');
 const { join } = require('node:path');
 const { DatabaseSync, constants } = require('node:sqlite');
 const { suite, test } = require('node:test');
+const { pathToFileURL } = require('node:url');
+
 let cnt = 0;
 
 tmpdir.refresh();
@@ -109,5 +111,32 @@ test('math functions are enabled', (t) => {
   t.assert.deepStrictEqual(
     db.prepare('SELECT PI() AS pi').get(),
     { __proto__: null, pi: 3.141592653589793 },
+  );
+});
+
+test('Buffer is supported as the database location', (t) => {
+  const db = new DatabaseSync(Buffer.from(nextDb()));
+  db.exec(`
+    CREATE TABLE data(key INTEGER PRIMARY KEY);
+    INSERT INTO data (key) VALUES (1);
+  `);
+
+  t.assert.deepStrictEqual(
+    db.prepare('SELECT * FROM data').all(),
+    [{ __proto__: null, key: 1 }]
+  );
+});
+
+test('URL is supported as the database location', (t) => {
+  const url = pathToFileURL(nextDb());
+  const db = new DatabaseSync(url);
+  db.exec(`
+    CREATE TABLE data(key INTEGER PRIMARY KEY);
+    INSERT INTO data (key) VALUES (1);
+  `);
+
+  t.assert.deepStrictEqual(
+    db.prepare('SELECT * FROM data').all(),
+    [{ __proto__: null, key: 1 }]
   );
 });


### PR DESCRIPTION
Closes #56940

This PR adds the capability to the sqlite module to accept Buffer and URL as the database location.