### PR TITLE
[v18.x] tools: fix failing GHA workflows

### DIFF
--- a/tools/dep_updaters/update-openssl.sh
+++ b/tools/dep_updaters/update-openssl.sh
@@ -97,6 +97,8 @@ main() {
     * )
       echo "unknown command: $1"
       help 1
+
+      # shellcheck disable=SC2317
       exit 1
     ;;
   esac


### PR DESCRIPTION
The fix landed on `main` with an unrelated commit (https://github.com/nodejs/node/commit/021cf912084005f4ecd7db06e0bad75353067a46#diff-0d4336c14130a2e69ae463aa9dc439815825ee04ce8419ca65b3428d2af83f17), it seems better to make a new PR for it than to attempt to cherry-pick the original commit.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
