### PR TITLE
doc: move stability index after history section for consistency

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -590,13 +590,13 @@ Disable the ability of starting a debugging session by sending a
 
 ### `--disable-warning=code-or-type`
 
-> Stability: 1.1 - Active development
-
 <!-- YAML
 added:
   - v21.3.0
   - v20.11.0
 -->
+
+> Stability: 1.1 - Active development
 
 Disable specific process warnings by `code` or `type`.
 
@@ -800,18 +800,16 @@ node --entry-url 'data:text/javascript,console.log("Hello")'
 
 ### `--env-file-if-exists=config`
 
-> Stability: 1.1 - Active development
-
 <!-- YAML
 added: v22.9.0
 -->
+
+> Stability: 1.1 - Active development
 
 Behavior is the same as [`--env-file`][], but an error is not thrown if the file
 does not exist.
 
 ### `--env-file=config`
-
-> Stability: 1.1 - Active development
 
 <!-- YAML
 added: v20.6.0
@@ -822,6 +820,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/51289
     description: Add support to multi-line values.
 -->
+
+> Stability: 1.1 - Active development
 
 Loads environment variables from a file relative to the current directory,
 making them available to applications on `process.env`. The [environment

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -31,11 +31,11 @@ const inspector = require('node:inspector');
 
 ## Promises API
 
-> Stability: 1 - Experimental
-
 <!-- YAML
 added: v19.0.0
 -->
+
+> Stability: 1 - Experimental
 
 ### Class: `inspector.Session`
 

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -716,11 +716,11 @@ if `input` is not a valid.
 
 ### Class: `URLPattern`
 
-> Stability: 1 - Experimental
-
 <!-- YAML
 added: REPLACEME
 -->
+
+> Stability: 1 - Experimental
 
 The `URLPattern` API provides an interface to match URLs or parts of URLs
 against a pattern.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -366,8 +366,6 @@ util.formatWithOptions({ colors: true }, 'See object %O', { foo: 42 });
 
 ## `util.getCallSites(frameCountOrOptions, [options])`
 
-> Stability: 1.1 - Active development
-
 <!-- YAML
 added: v22.9.0
 changes:
@@ -383,6 +381,8 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/55626
     description: The API is renamed from `util.getCallSite` to `util.getCallSites()`.
 -->
+
+> Stability: 1.1 - Active development
 
 * `frameCount` {number} Optional number of frames to capture as call site objects.
   **Default:** `10`. Allowable range is between 1 and 200.
@@ -1725,13 +1725,13 @@ $ node negate.js --no-logfile --logfile=test.log --color --no-color
 
 ## `util.parseEnv(content)`
 
-> Stability: 1.1 - Active development
-
 <!-- YAML
 added:
   - v21.7.0
   - v20.12.0
 -->
+
+> Stability: 1.1 - Active development
 
 * `content` {string}
 
@@ -1925,8 +1925,6 @@ console.log(util.stripVTControlCharacters('\u001B[4mvalue\u001B[0m'));
 ```
 
 ## `util.styleText(format, text[, options])`
-
-> Stability: 2 - Stable.
 
 <!-- YAML
 added:


### PR DESCRIPTION
The vast majority of our docs put the stability index after the history table, except for those 8 which this PR is fixing. I didn't bother putting back `> Stability: 2 - Stable.` back for `util.styleText` since it inherit the stable status from the parent level https://nodejs.org/api/util.html#util.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
