### PR TITLE
esm: avoid `import.meta` setup costs for unused properties

### DIFF
--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ObjectDefineProperties,
+  ObjectDefineProperty,
   StringPrototypeStartsWith,
 } = primordials;
 
@@ -60,9 +62,27 @@ function initializeImportMeta(meta, context, loader) {
   if (StringPrototypeStartsWith(url, 'file:') === true) {
     // These only make sense for locally loaded modules,
     // i.e. network modules are not supported.
-    const filePath = fileURLToPath(url);
-    meta.dirname = dirname(filePath);
-    meta.filename = filePath;
+
+    // Avoid paying the cost to derive these unless they're actually accessed.
+    ObjectDefineProperties(meta, {
+      dirname: {
+        get() {
+          const value = dirname(this.filename);
+          ObjectDefineProperty(this, 'dirname', { __proto__: null, value });
+          return value;
+        },
+        __proto__: null,
+      },
+      filePath: {
+        get() {
+          const value = fileURLToPath(url);
+          ObjectDefineProperty(this, 'filename', { __proto__: null, value });
+          return value;
+        },
+        __proto__: null,
+      },
+      __proto__: null,
+    });
   }
 
   if (!loader || loader.allowImportMetaResolve) {

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -68,17 +68,27 @@ function initializeImportMeta(meta, context, loader) {
       dirname: {
         get() {
           const value = dirname(this.filename);
-          ObjectDefineProperty(this, 'dirname', { __proto__: null, value });
+          ObjectDefineProperty(this, 'dirname', { __proto__: null, value, writable: true });
           return value;
         },
+        set(value) {
+          ObjectDefineProperty(this, 'dirname', { __proto__: null, value, writable: true });
+        },
+        configurable: true,
+        enumerable: true,
         __proto__: null,
       },
       filename: {
         get() {
           const value = fileURLToPath(url);
-          ObjectDefineProperty(this, 'filename', { __proto__: null, value });
+          ObjectDefineProperty(this, 'filename', { __proto__: null, value, writable: true });
           return value;
         },
+        set(value) {
+          ObjectDefineProperty(this, 'filename', { __proto__: null, value, writable: true });
+        },
+        configurable: true,
+        enumerable: true,
         __proto__: null,
       },
       __proto__: null,

--- a/lib/internal/modules/esm/initialize_import_meta.js
+++ b/lib/internal/modules/esm/initialize_import_meta.js
@@ -73,7 +73,7 @@ function initializeImportMeta(meta, context, loader) {
         },
         __proto__: null,
       },
-      filePath: {
+      filename: {
         get() {
           const value = fileURLToPath(url);
           ObjectDefineProperty(this, 'filename', { __proto__: null, value });

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -9,11 +9,8 @@ assert.deepStrictEqual(Reflect.ownKeys(import.meta), keys);
 const descriptors = Object.getOwnPropertyDescriptors(import.meta);
 for (const descriptor of Object.values(descriptors)) {
   delete descriptor.value; // Values are verified below.
-  assert.deepStrictEqual(descriptor, {
-    enumerable: true,
-    writable: true,
-    configurable: true
-  });
+  assert.strictEqual(descriptor.configurable, true);
+  assert.strictEqual(descriptor.enumerable, true);
 }
 
 const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
@@ -24,10 +21,18 @@ assert(import.meta.url.match(urlReg));
 const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module$/;
 assert.match(import.meta.dirname, dirReg);
 
+const newDirname = 'reassigned';
+import.meta.dirname = newDirname;
+assert.strictEqual(import.meta.dirname, newDirname);
+
 // Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
 // Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
 const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module(\/|\\)test-esm-import-meta\.mjs$/;
 assert.match(import.meta.filename, fileReg);
+
+const newFilename = 'reassigned.js';
+import.meta.filename = newFilename;
+assert.strictEqual(import.meta.filename, newFilename);
 
 // Verify that `data:` imports do not behave like `file:` imports.
 import dataDirname from 'data:text/javascript,export default "dirname" in import.meta';


### PR DESCRIPTION
Currently, the cost of deriving `import.meta.dirname` and `import.meta.filename` is paid up-front, regardless of whether they are actually used. This can instead be delayed until they are accessed, and then to avoid re-paying the cost, overwrite the getter with the derived value.