### PR TITLE
crypto: fix missing `OPENSSL_NO_ENGINE` guard

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -34,7 +34,9 @@ using ncrypto::BIOPointer;
 using ncrypto::ClearErrorOnReturn;
 using ncrypto::CryptoErrorList;
 using ncrypto::DHPointer;
+#ifndef OPENSSL_NO_ENGINE
 using ncrypto::EnginePointer;
+#endif  // !OPENSSL_NO_ENGINE
 using ncrypto::EVPKeyPointer;
 using ncrypto::MarkPopErrorOnReturn;
 using ncrypto::SSLPointer;

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -30,7 +30,9 @@ using ncrypto::BignumPointer;
 using ncrypto::BIOPointer;
 using ncrypto::CryptoErrorList;
 using ncrypto::DataPointer;
+#ifndef OPENSSL_NO_ENGINE
 using ncrypto::EnginePointer;
+#endif  // !OPENSSL_NO_ENGINE
 using ncrypto::EVPKeyCtxPointer;
 using ncrypto::SSLCtxPointer;
 using ncrypto::SSLPointer;


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/56526.

Fixes compilation failure when `OPENSSL_NO_ENGINE` is defined:

```
../../third_party/electron_node/src/crypto/crypto_util.cc:32:16: error: no member named 'EnginePointer' in namespace 'ncrypto'; did you mean 'ECPointPointer'?
   32 | using ncrypto::EnginePointer;
      |       ~~~~~~~~~^~~~~~~~~~~~~
      |                ECPointPointer
../../third_party/electron_node/deps/ncrypto/ncrypto.h:889:7: note: 'ECPointPointer' declared here
  889 | class ECPointPointer final {
      |       ^
1 error generated.
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
