### PR TITLE
src: fix accessing empty string

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -156,7 +156,7 @@ void Dotenv::ParseContent(const std::string_view input) {
     key = trim_spaces(key);
 
     // If the value is not present (e.g. KEY=) set is to an empty string
-    if (content.front() == '\n') {
+    if (content.empty() || content.front() == '\n') {
       store_.insert_or_assign(std::string(key), "");
       continue;
     }


### PR DESCRIPTION
Fix an assertion caused by accessing empty string:

```
(lldb) run -e "process.loadEnvFile('./test/fixtures/dotenv/eof-without-value.env')"
../../third_party/gn/third_party/libc++/src/include/string_view:411: assertion !empty() failed: string_view::front(): string is empty
(lldb) bt
* thread #1, name = 'MainThread', queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007ff81b4dfc52 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007ff81b519f85 libsystem_pthread.dylib`pthread_kill + 262
    frame #2: 0x00007ff81b43ab19 libsystem_c.dylib`abort + 126
    frame #3: 0x0000000101b96cb2 node`std::__Cr::__libcpp_verbose_abort(format=<unavailable>) at verbose_abort.cpp:74:3 [opt]
    frame #4: 0x00000001000fe088 node`node::Dotenv::ParseContent(std::__Cr::basic_string_view<char, std::__Cr::char_traits<char>>) [inlined] std::__Cr::basic_string_view<char, std::__Cr::char_traits<char>>::front(this=<unavailable>) const at string_view:411:12 [opt]
    frame #5: 0x00000001000fe073 node`node::Dotenv::ParseContent(this=0x00007ff7bfefd670, input=<unavailable>) at node_dotenv.cc:159:17 [opt]
    frame #6: 0x00000001000fe4dd node`node::Dotenv::ParsePath(this=0x00007ff7bfefd670, path=<unavailable>) at node_dotenv.cc:296:3 [opt]
    frame #7: 0x000000010018f3e7 node`node::LoadEnvFile(args=0x00007ff7bfefdac8) at node_process_methods.cc:488:18 [opt]
```