### PR TITLE
doc: correct definition of v8.getHeapStatistics().heap_size_limit

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -219,7 +219,8 @@ does not include memory that has been allocated but not yet used.
 
 `heap_size_limit` The value of heap\_size\_limit is the maximum size of the V8
 heap, in bytes (either the default limit, determined by system resources, or
-the value passed to the `--max-old-space-size` option).
+the value passed to the `--max-old-space-size` option plus heap's semi space plus
+heap's young generation space).
 
 `malloced_memory` The value of malloced\_memory is the number of bytes allocated
 through `malloc` by V8.

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -219,7 +219,7 @@ does not include memory that has been allocated but not yet used.
 
 `heap_size_limit` The value of heap\_size\_limit is the maximum size of the V8
 heap, in bytes (either the default limit, determined by system resources, or
-the value passed to the `--max_old_space_size` option).
+the value passed to the `--max-old-space-size` option).
 
 `malloced_memory` The value of malloced\_memory is the number of bytes allocated
 through `malloc` by V8.


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
