### PR TITLE
src: lock the isolate properly in IsolateData destructor

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -615,6 +615,7 @@ IsolateData::IsolateData(Isolate* isolate,
 
 IsolateData::~IsolateData() {
   if (cpp_heap_ != nullptr) {
+    v8::Locker locker(isolate_);
     // The CppHeap must be detached before being terminated.
     isolate_->DetachCppHeap();
     cpp_heap_->Terminate();

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -438,6 +438,7 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
   // This test sets a global variable in the child Environment, and reads it
   // back both through the inspector and inside the child Environment, and
   // makes sure that those correspond to the value that was originally set.
+  v8::Locker locker(isolate_);
   const v8::HandleScope handle_scope(isolate_);
   const Argv argv;
   Env env {handle_scope, argv};
@@ -507,6 +508,7 @@ TEST_F(EnvironmentTest, InspectorMultipleEmbeddedEnvironments) {
     CHECK_NOT_NULL(isolate);
 
     {
+      v8::Locker locker(isolate);
       v8::Isolate::Scope isolate_scope(isolate);
       v8::HandleScope handle_scope(isolate);
 
@@ -630,6 +632,7 @@ TEST_F(NodeZeroIsolateTestFixture, CtrlCWithOnlySafeTerminationTest) {
 
   // Try creating Context + IsolateData + Environment.
   {
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
 

--- a/test/cctest/test_platform.cc
+++ b/test/cctest/test_platform.cc
@@ -78,6 +78,7 @@ TEST_F(NodeZeroIsolateTestFixture, IsolatePlatformDelegateTest) {
 
   // Try creating Context + IsolateData + Environment
   {
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handle_scope(isolate);
 


### PR DESCRIPTION
Otherwise it may fail the DCHECK that uses the locked thread as a fast path to get the current thread.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
