### PR TITLE
tls: change TLSWrap::GetProtocol to fix #56935

### DIFF
--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -2098,6 +2098,12 @@ void TLSWrap::GetProtocol(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+
+  if (w->kind_ == Kind::kServer) {
+    args.GetReturnValue().SetNull();
+    return;
+  }
+
   args.GetReturnValue().Set(
       OneByteString(env->isolate(), SSL_get_version(w->ssl_.get())));
 }

--- a/test/parallel/test-tls-min-max-version.js
+++ b/test/parallel/test-tls-min-max-version.js
@@ -84,7 +84,7 @@ function test(cmin, cmax, cprot, smin, smax, sprot, proto, cerr, serr) {
     assert(pair.server.conn);
     assert(pair.client.conn);
     assert.strictEqual(pair.client.conn.getProtocol(), proto);
-    assert.strictEqual(pair.server.conn.getProtocol(), proto);
+    assert.strictEqual(pair.server.conn.getProtocol(), null);
     return cleanup();
   }));
 }


### PR DESCRIPTION
tls: change tlsSocket.getProtocol() to return null for server sockets

I updated TLSWrap::GetProtocol to return null for server sockets.
I updated a test to ensure that the returned protocol is indeed null for 
server sockets.

Fixes: https://github.com/nodejs/node/issues/56935 

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
