### PR TITLE
esm: unflag --experimental-wasm-modules for 24

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -48,7 +48,6 @@ entry point, the `node` command will accept as input only files with `.js`,
 `.mjs`, or `.cjs` extensions. With the following flags, additional file
 extensions are enabled:
 
-* [`--experimental-wasm-modules`][] for files with `.wasm` extension.
 * [`--experimental-addon-modules`][] for files with `.node` extension.
 
 ## Options
@@ -1123,14 +1122,6 @@ changes:
 -->
 
 Enable experimental WebAssembly System Interface (WASI) support.
-
-### `--experimental-wasm-modules`
-
-<!-- YAML
-added: v12.3.0
--->
-
-Enable experimental WebAssembly module support.
 
 ### `--experimental-webstorage`
 
@@ -3198,7 +3189,6 @@ one is included in the list below.
 * `--experimental-transform-types`
 * `--experimental-vm-modules`
 * `--experimental-wasi-unstable-preview1`
-* `--experimental-wasm-modules`
 * `--experimental-webstorage`
 * `--force-context-aware`
 * `--force-fips`
@@ -3758,7 +3748,6 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`--env-file`]: #--env-fileconfig
 [`--experimental-addon-modules`]: #--experimental-addon-modules
 [`--experimental-sea-config`]: single-executable-applications.md#generating-single-executable-preparation-blobs
-[`--experimental-wasm-modules`]: #--experimental-wasm-modules
 [`--heap-prof-dir`]: #--heap-prof-dir
 [`--import`]: #--importmodule
 [`--no-experimental-strip-types`]: #--no-experimental-strip-types

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -667,10 +667,17 @@ imported from the same path.
 
 ## Wasm modules
 
+<!-- YAML
+changes:
+  - version:
+    - v24.0.0
+    pr-url: https://github.com/nodejs/node/pull/57038
+    description: Wasm modules no longer require the `--experimental-wasm-modules` flag.
+-->
+
 > Stability: 1 - Experimental
 
-Importing WebAssembly modules is supported under the
-`--experimental-wasm-modules` flag, allowing any `.wasm` files to be
+Importing WebAssembly modules is supported, allowing any `.wasm` files to be
 imported as normal modules while also supporting their module imports.
 
 This integration is in line with the
@@ -686,7 +693,7 @@ console.log(M);
 executed under:
 
 ```bash
-node --experimental-wasm-modules index.mjs
+node index.mjs
 ```
 
 would provide the exports interface for the instantiation of `module.wasm`.

--- a/doc/node.1
+++ b/doc/node.1
@@ -214,9 +214,6 @@ Enable experimental ES module support in VM module.
 Enable experimental WebAssembly System Interface support. This
 flag is no longer required as WASI is enabled by default.
 .
-.It Fl -experimental-wasm-modules
-Enable experimental WebAssembly module support.
-.
 .It Fl -experimental-quic
 Enable the experimental QUIC support.
 .

--- a/lib/internal/modules/esm/formats.js
+++ b/lib/internal/modules/esm/formats.js
@@ -9,7 +9,6 @@ const { getValidatedPath } = require('internal/fs/utils');
 const fsBindings = internalBinding('fs');
 const { fs: fsConstants } = internalBinding('constants');
 
-const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const experimentalAddonModules = getOptionValue('--experimental-addon-modules');
 
 const extensionFormatMap = {
@@ -18,11 +17,8 @@ const extensionFormatMap = {
   '.js': 'module',
   '.json': 'json',
   '.mjs': 'module',
+  '.wasm': 'wasm',
 };
-
-if (experimentalWasmModules) {
-  extensionFormatMap['.wasm'] = 'wasm';
-}
 
 if (experimentalAddonModules) {
   extensionFormatMap['.node'] = 'addon';
@@ -46,7 +42,7 @@ function mimeToFormat(mime) {
     ) !== null
   ) { return 'module'; }
   if (mime === 'application/json') { return 'json'; }
-  if (experimentalWasmModules && mime === 'application/wasm') { return 'wasm'; }
+  if (mime === 'application/wasm') { return 'wasm'; }
   return null;
 }
 
@@ -57,7 +53,6 @@ function mimeToFormat(mime) {
  * @param {URL} url
  */
 function getFormatOfExtensionlessFile(url) {
-  if (!experimentalWasmModules) { return 'module'; }
   const path = getValidatedPath(url);
   switch (fsBindings.getFormatOfExtensionlessFile(path)) {
     case fsConstants.EXTENSIONLESS_FORMAT_WASM:

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -466,10 +466,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvvar);
   AddAlias("--loader", "--experimental-loader");
   AddOption("--experimental-modules", "", NoOp{}, kAllowedInEnvvar);
-  AddOption("--experimental-wasm-modules",
-            "experimental ES Module support for webassembly modules",
-            &EnvironmentOptions::experimental_wasm_modules,
-            kAllowedInEnvvar);
+  AddOption("--experimental-wasm-modules", "", NoOp{}, kAllowedInEnvvar);
   AddOption("--experimental-import-meta-resolve",
             "experimental ES Module import.meta.resolve() parentURL support",
             &EnvironmentOptions::experimental_import_meta_resolve,

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -8,8 +8,6 @@ import { describe, it } from 'node:test';
 describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should load exports', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-wasm-modules',
       '--input-type=module',
       '--eval',
       [
@@ -31,8 +29,6 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
 
   it('should not allow code injection through export names', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-wasm-modules',
       '--input-type=module',
       '--eval',
       `import * as wasmExports from ${JSON.stringify(fixtures.fileURL('es-modules/export-name-code-injection.wasm'))};`,
@@ -45,8 +41,6 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
 
   it('should allow non-identifier export names', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-wasm-modules',
       '--input-type=module',
       '--eval',
       [
@@ -63,8 +57,6 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
 
   it('should properly escape import names as well', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
-      '--no-warnings',
-      '--experimental-wasm-modules',
       '--input-type=module',
       '--eval',
       [
@@ -81,7 +73,6 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
 
   it('should emit experimental warning', async () => {
     const { code, signal, stderr } = await spawnPromisified(execPath, [
-      '--experimental-wasm-modules',
       fixtures.path('es-modules/wasm-modules.mjs'),
     ]);
 

--- a/test/module-hooks/test-module-hooks-import-wasm.mjs
+++ b/test/module-hooks/test-module-hooks-import-wasm.mjs
@@ -1,6 +1,6 @@
 // Flags: --no-experimental-wasm-modules
 // This tests that module.registerHooks() can be used to support unknown formats, like
-// import(wasm) (without --experimental-wasm-modules).
+// import(wasm)
 import '../common/index.mjs';
 
 import assert from 'node:assert';

--- a/test/module-hooks/test-module-hooks-require-wasm.js
+++ b/test/module-hooks/test-module-hooks-require-wasm.js
@@ -1,8 +1,7 @@
-// Flags: --no-experimental-wasm-modules
 'use strict';
 
 // This tests that module.registerHooks() can be used to support unknown formats, like
-// require(wasm) and import(wasm) (without --experimental-wasm-modules).
+// require(wasm) and import(wasm)
 const common = require('../common');
 
 const assert = require('assert');


### PR DESCRIPTION
This unflags `--experimental-wasm-modules` for Node.js 24, while keeping the implementation experimental for now.

This should land after https://github.com/nodejs/node/pull/56919, but is posted as a separate PR to get approval separately.

The proposal is currently at Phase 3 in the WebAssembly proposal process, and the spec and design is considered stable at this point.

By unflagging, this will enable build tools to target source phase imports for Node.js as an output format, which will be much more useful for consumers if the implementation is available unflagged.