### PR TITLE
process: improve error message for process.cwd() when directory is deleted

### DIFF
--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -147,6 +147,5 @@ function wrappedCwd() {
   Use process.chdir() to switch to a valid directory.`);
       }
     }
-    
   return cachedCwd;
 }

--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -139,6 +139,13 @@ function wrappedUmask(mask) {
 
 function wrappedCwd() {
   if (cachedCwd === '')
-    cachedCwd = rawMethods.cwd();
+    if (cachedCwd === '') {
+      try {
+        cachedCwd = rawMethods.cwd();
+      } catch (err) {
+        throw new Error(`process.cwd() failed: The current working directory was deleted.
+  Use process.chdir() to switch to a valid directory.`);
+      }
+    }
   return cachedCwd;
 }

--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -147,5 +147,6 @@ function wrappedCwd() {
   Use process.chdir() to switch to a valid directory.`);
       }
     }
+    
   return cachedCwd;
 }

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -136,9 +136,11 @@ static void Cwd(const FunctionCallbackInfo<Value>& args) {
   char buf[PATH_MAX_BYTES];
   size_t cwd_len = sizeof(buf);
   int err = uv_cwd(buf, &cwd_len);
-  if (err)
-    return env->ThrowUVException(err, "uv_cwd");
-
+  if (err) {
+    // Improved error message
+    return env->ThrowError("process.cwd() failed: The current working directory no longer exists. "
+                           "Use process.chdir() to change to a valid directory before calling process.cwd().");
+  }
   Local<String> cwd = String::NewFromUtf8(env->isolate(),
                                           buf,
                                           NewStringType::kNormal,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixed issue #57045 
### **Improve error message for `process.cwd()` when directory is deleted**  

#### **Problem**  
When the current working directory is deleted, calling `process.cwd()` throws a cryptic error:  

```
Error: ENOENT: no such file or directory, uv_cwd
    at process.wrappedCwd [as cwd] (node:internal/bootstrap/switches/does_own_process_state:142:28)
```

- The error message does not explicitly mention `process.cwd()`, making it unclear where the failure originates.  
- This can be especially confusing in large codebases where `process.cwd()` is called deep within dependencies.  

#### **Fix**  
This PR improves the error message by modifying both the **C++ layer** (`Cwd` function in `node_process_methods.cc`) and the **JavaScript layer** (`does_own_process_state.js`):  

1. **C++ Layer (`node_process_methods.cc`)**
   - If `uv_cwd()` fails, return a clearer error message:  
     ```
     process.cwd() failed: The current working directory no longer exists.
     Use process.chdir() to switch to a valid directory.
     ```

2. **JavaScript Layer (`does_own_process_state.js`)**
   - Wrap `process.cwd()` in a `try/catch` block and throw a clearer error if it fails.

#### **Steps to Reproduce**  
To trigger the bug:  
```sh
mkdir test-dir && cd test-dir
rm -rf ../test-dir
node -p "process.cwd()"
```

#### **Expected Behavior After Fix**  
Instead of the generic `uv_cwd` error, Node.js will now return:  
```
Error: process.cwd() failed: The current working directory was deleted.
Use process.chdir() to switch to a valid directory.
```

#### **Impact**  
- Provides a **more descriptive** error message for developers.  
- Improves **debugging experience** when `process.cwd()` fails.  
- Ensures consistency between the **C++ and JavaScript layers** of Node.js.  

#### **Checklist**  
- Updated **C++ layer** (`node_process_methods.cc`)  
- Updated **JavaScript layer** (`does_own_process_state.js`)  
- Built and tested changes locally  