### PR TITLE
crypto: check for nullptr before dereferencing identity_buf

### DIFF
--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1558,7 +1558,7 @@ unsigned int TLSWrap::PskClientCallback(
 
   Utf8Value identity_buf(env->isolate(), identity_val);
 
-  if (identity_buf.length() > max_identity_len)
+  if (*identity_buf == nullptr || identity_buf.length() > max_identity_len)
     return 0;
 
   memcpy(identity, *identity_buf, identity_buf.length());

--- a/test/parallel/test-tls-psk-identity-null.js
+++ b/test/parallel/test-tls-psk-identity-null.js
@@ -14,7 +14,7 @@ const tls = require('tls');
     }
   });
 
-  server.listen(0, common.mustCall(() => {
+  server.listen(0, () => {
     const client = tls.connect({
       port: server.address().port,
       pskIdentity: 'test',
@@ -23,11 +23,11 @@ const tls = require('tls');
       }
     });
 
-    client.on('error', common.mustCall((err) => {
+    client.on('error', (err) => {
       assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
       server.close();
-    }));
-  }));
+    });
+  });
 }
 
 {
@@ -37,7 +37,7 @@ const tls = require('tls');
     }
   });
 
-  server.listen(0, common.mustCall(() => {
+  server.listen(0, () => {
     const client = tls.connect({
       port: server.address().port,
       pskIdentity: 'test',
@@ -46,9 +46,9 @@ const tls = require('tls');
       }
     });
 
-    client.on('error', common.mustCall((err) => {
+    client.on('error', (err) => {
       assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
       server.close();
-    }));
-  }));
+    });
+  });
 }

--- a/test/parallel/test-tls-psk-identity-null.js
+++ b/test/parallel/test-tls-psk-identity-null.js
@@ -1,0 +1,54 @@
+'use strict';
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+
+{
+  const server = tls.createServer({
+    pskCallback: (socket, identity) => {
+      return undefined;
+    }
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const client = tls.connect({
+      port: server.address().port,
+      pskIdentity: 'test',
+      pskCallback: () => {
+        return undefined;
+      }
+    });
+
+    client.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
+      server.close();
+    }));
+  }));
+}
+
+{
+  const server = tls.createServer({
+    pskCallback: (socket, identity) => {
+      return null;
+    }
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const client = tls.connect({
+      port: server.address().port,
+      pskIdentity: 'test',
+      pskCallback: () => {
+        return null;
+      }
+    });
+
+    client.on('error', common.mustCall((err) => {
+      assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
+      server.close();
+    }));
+  }));
+}

--- a/test/parallel/test-tls-psk-identity-null.js
+++ b/test/parallel/test-tls-psk-identity-null.js
@@ -8,13 +8,10 @@ const assert = require('assert');
 const tls = require('tls');
 
 {
-  const server = tls.createServer({
-    pskCallback: (socket, identity) => {
-      return undefined;
-    }
-  });
+  const pskCallback = () => undefined;
+  const server = tls.createServer({ pskCallback });
 
-  server.listen(0, () => {
+  server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
       pskIdentity: 'test',
@@ -27,17 +24,14 @@ const tls = require('tls');
       assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
       server.close();
     });
-  });
+  }));
 }
 
 {
-  const server = tls.createServer({
-    pskCallback: (socket, identity) => {
-      return null;
-    }
-  });
+  const pskCallback = () => null;
+  const server = tls.createServer({ pskCallback });
 
-  server.listen(0, () => {
+  server.listen(0, common.mustCall(() => {
     const client = tls.connect({
       port: server.address().port,
       pskIdentity: 'test',
@@ -50,5 +44,5 @@ const tls = require('tls');
       assert.strictEqual(err.code, 'ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE');
       server.close();
     });
-  });
+  }));
 }


### PR DESCRIPTION
The js-side already checks for this so the test already passes, so I don't think it's a vulnerability

Just in case, added the check for future

Fix https://github.com/nodejs/node/issues/56665