### PR TITLE
doc: clarify path.isAbsolute is not enough for mitigating path traversals

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -317,27 +317,27 @@ added: v0.11.2
 * `path` {string}
 * Returns: {boolean}
 
-The `path.isAbsolute()` method determines if the literal (non-resolved) `path` is an
-absolute path. Therefore, it’s likely that you want to run it through `path.normalize()`
-if your plan is to use it as a subpath in order to mitigate path traversals. For example:
+The `path.isAbsolute()` method determines if the literal `path` is absolute.
+Therefore, it’s not safe for mitigating path traversals without normalizing it.
 
 ```js
-// Normalizing the subpath mitigates traversing above the mount directory.
-const mySubpath = path.normalize('/foo/../..');
-if (path.isAbsolute(mySubpath)) {
-  const myPath = path.join(MOUNT_DIR, mySubpath)
+// Normalizing the subpath mitigates traversing above the mount directory
+const subpath = '/foo/../..'
+if (!path.isAbsolute(path.normalize(subpath))) {
+  throw 'FORBIDDEN'
 }
+const myPath = path.join(MOUNT_DIR, subpath)
 ```
 
 
 If the given `path` is a zero-length string, `false` will be returned.
 
-For example, on POSIX:
+On POSIX:
 
 ```js
 path.isAbsolute('/foo/bar');   // true
 path.isAbsolute('/baz/..');    // true
-path.isAbsolute('/baz/../..'); // true (doesn’t resolve)
+path.isAbsolute('/baz/../..'); // true
 path.isAbsolute('qux/');       // false
 path.isAbsolute('.');          // false
 ```

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -317,9 +317,18 @@ added: v0.11.2
 * `path` {string}
 * Returns: {boolean}
 
-The `path.isAbsolute()` method determines if the literal (non-resolved) `path`
-is an absolute path. Therefore, it’s likely that you want to run it through
-`path.normalize()` before using it in `path.join()` or `path.isAbsolute()`.
+The `path.isAbsolute()` method determines if the literal (non-resolved) `path` is an
+absolute path. Therefore, it’s likely that you want to run it through `path.normalize()`
+if your plan is to use it as a subpath in order to mitigate path traversals. For example:
+
+```js
+// Normalizing the subpath mitigates traversing above the mount directory.
+const mySubpath = path.normalize('/foo/../..');
+if (path.isAbsolute(mySubpath)) {
+  const myPath = path.join(MOUNT_DIR, mySubpath)
+}
+```
+
 
 If the given `path` is a zero-length string, `false` will be returned.
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -317,17 +317,20 @@ added: v0.11.2
 * `path` {string}
 * Returns: {boolean}
 
-The `path.isAbsolute()` method determines if `path` is an absolute path.
+The `path.isAbsolute()` method determines if the literal (non-resolved) `path`
+is an absolute path. Therefore, it’s likely that you want to run it through
+`path.normalize()` before using it in `path.join()` or `path.isAbsolute()`.
 
 If the given `path` is a zero-length string, `false` will be returned.
 
 For example, on POSIX:
 
 ```js
-path.isAbsolute('/foo/bar'); // true
-path.isAbsolute('/baz/..');  // true
-path.isAbsolute('qux/');     // false
-path.isAbsolute('.');        // false
+path.isAbsolute('/foo/bar');   // true
+path.isAbsolute('/baz/..');    // true
+path.isAbsolute('/baz/../..'); // true (doesn’t resolve)
+path.isAbsolute('qux/');       // false
+path.isAbsolute('.');          // false
 ```
 
 On Windows:

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -318,21 +318,11 @@ added: v0.11.2
 * Returns: {boolean}
 
 The `path.isAbsolute()` method determines if the literal `path` is absolute.
-Therefore, it’s not safe for mitigating path traversals without normalizing it.
-
-```js
-// Normalizing the subpath mitigates traversing above the mount directory
-const subpath = '/foo/../..'
-if (!path.isAbsolute(path.normalize(subpath))) {
-  throw 'FORBIDDEN'
-}
-const myPath = path.join(MOUNT_DIR, subpath)
-```
-
+Therefore, it’s not safe for mitigating path traversals.
 
 If the given `path` is a zero-length string, `false` will be returned.
 
-On POSIX:
+For example, on POSIX:
 
 ```js
 path.isAbsolute('/foo/bar');   // true


### PR DESCRIPTION
Since `path.isAbsolute()` it’s likely used for mitigating path traversals, I’m documentating that it doesn’t resolve paths.

I didn’t test its usages but for example it looks that it’s used for that here: https://github.com/nodejs/node/blob/47ae886e43537365ccc54beff0b1ac08a5a5aa19/lib/fs.js#L1803C3-L1815C4

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
