### PR TITLE
doc fix web.libera.chat link in pull-requests.md

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -53,7 +53,7 @@ help, questions, and discussions.
 development of Node.js core specifically.
 
 Node.js also has an unofficial IRC channel:
-[#Node.js](https://web.libera.chat/?channels=node.js).
+[#Node.js](https://web.libera.chat/#node.js).
 
 ## Setting up your local environment
 


### PR DESCRIPTION
The old link wasn't prefilling the channel name for me, and this is the format suggested in the docs: <https://libera.chat/guides/webchat#kiwiirc>

It works, too!