### PR TITLE
assert: make comparisons file more performant

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -90,11 +90,7 @@ function areSimilarFloatArrays(a, b) {
 }
 
 function areSimilarTypedArrays(a, b) {
-  if (a.byteLength !== b.byteLength) {
-    return false;
-  }
-  return compare(new Uint8Array(a.buffer, a.byteOffset, a.byteLength),
-                 new Uint8Array(b.buffer, b.byteOffset, b.byteLength)) === 0;
+  return a.byteLength === b.byteLength && compare(a, b) === 0;
 }
 
 function areEqualArrayBuffers(buf1, buf2) {
@@ -321,12 +317,10 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
     aKeys = ObjectKeys(val1);
   }
 
-  // Cheap key test
-  if (aKeys.length > 0) {
-    for (const key of aKeys) {
-      if (!ObjectPrototypePropertyIsEnumerable(val2, key)) {
-        return false;
-      }
+  // Cheap key test: ensure every key in aKeys is enumerable on val2.
+  for (let i = 0; i < aKeys.length; i++) {
+    if (!ObjectPrototypePropertyIsEnumerable(val2, aKeys[i])) {
+      return false;
     }
   }
 
@@ -340,7 +334,8 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
       const symbolKeysA = ObjectGetOwnPropertySymbols(val1);
       if (symbolKeysA.length !== 0) {
         let count = 0;
-        for (const key of symbolKeysA) {
+        for (let i = 0; i < symbolKeysA.length; i++) {
+          const key = symbolKeysA[i];
           if (ObjectPrototypePropertyIsEnumerable(val1, key)) {
             if (!ObjectPrototypePropertyIsEnumerable(val2, key)) {
               return false;
@@ -389,8 +384,8 @@ function keyCheck(val1, val2, strict, memos, iterationType, aKeys) {
 
   if (memos.set === undefined) {
     if (memos.deep === false) {
-      if (memos.a === val1) {
-        if (memos.b === val2) return true;
+      if (memos.a === val1 && memos.b === val2) {
+        return true;
       }
       memos.c = val1;
       memos.d = val2;
@@ -550,6 +545,8 @@ function mapHasEqualEntry(set, map, key2, item2, strict, memo) {
 }
 
 function mapEquiv(a, b, strict, memo) {
+  if (a.size !== b.size) return false; // Early exit
+
   let set = null;
 
   for (const { 0: key, 1: item1 } of a) {
@@ -603,34 +600,47 @@ function mapEquiv(a, b, strict, memo) {
 
 function objEquiv(a, b, strict, keys, memos, iterationType) {
   // The pair must have equivalent values for every corresponding key.
-  if (keys.length > 0) {
-    for (const key of keys) {
-      if (!innerDeepEqual(a[key], b[key], strict, memos)) {
-        return false;
-      }
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (!innerDeepEqual(a[key], b[key], strict, memos)) {
+      return false;
     }
   }
 
   if (iterationType === kIsArray) {
-    for (let i = 0; i < a.length; i++) {
-      if (ObjectPrototypeHasOwnProperty(a, i)) {
+    // Fast path for dense arrays:
+    const alen = a.length;
+    let isDense = true;
+    for (let i = 0; i < alen; i++) {
+      // If any index is missing in a, mark as sparse.
+      if (!ObjectPrototypeHasOwnProperty(a, i)) {
+        isDense = false;
+        break;
+      }
+    }
+    if (isDense) {
+      for (let i = 0; i < alen; i++) {
+        // a[i] exists; so b must have it, too.
         if (!ObjectPrototypeHasOwnProperty(b, i) ||
             !innerDeepEqual(a[i], b[i], strict, memos)) {
           return false;
         }
-      } else if (ObjectPrototypeHasOwnProperty(b, i)) {
+      }
+    } else {
+      // Sparse array: compare only own keys.
+      const keysA = ObjectKeys(a);
+      const keysB = ObjectKeys(b);
+      const keysALen = keysA.length;
+
+      if (keysALen !== keysB.length) {
         return false;
-      } else {
-        // Array is sparse.
-        const keysA = ObjectKeys(a);
-        for (; i < keysA.length; i++) {
-          const key = keysA[i];
-          if (!ObjectPrototypeHasOwnProperty(b, key) ||
-              !innerDeepEqual(a[key], b[key], strict, memos)) {
-            return false;
-          }
+      }
+      for (let i = 0, len = keysALen; i < len; i++) {
+        const key = keysA[i];
+        if (!ObjectPrototypeHasOwnProperty(b, key) ||
+            !innerDeepEqual(a[key], b[key], strict, memos)) {
+          return false;
         }
-        return keysA.length === ObjectKeys(b).length;
       }
     }
   } else if (iterationType === kIsSet) {


### PR DESCRIPTION
As part of my ongoing review of the `assert` codebase, I started examining the `comparisons.js` file and optimizing some straightforward code that could be further refined for better performance.

Here are the benchmark results for the `assert/deepequal-simple-array-and-set.js` file:


```bash

OLD:

assert/deepequal-simple-array-and-set.js method="deepEqual_Array" strict=1 len=10000 n=500: 8,398.503339673252
assert/deepequal-simple-array-and-set.js method="notDeepEqual_Array" strict=1 len=10000 n=500: 8,365.394964343424
assert/deepequal-simple-array-and-set.js method="deepEqual_Set" strict=1 len=10000 n=500: 14,487.154442975576
assert/deepequal-simple-array-and-set.js method="notDeepEqual_Set" strict=1 len=10000 n=500: 14,514.332017493021

NEW: 

assert/deepequal-simple-array-and-set.js method="deepEqual_Array" strict=1 len=10000 n=500: 8,470.789541116153
assert/deepequal-simple-array-and-set.js method="notDeepEqual_Array" strict=1 len=10000 n=500: 8,443.200479573787
assert/deepequal-simple-array-and-set.js method="deepEqual_Set" strict=1 len=10000 n=500: 8,962.574475856993
assert/deepequal-simple-array-and-set.js method="notDeepEqual_Set" strict=1 len=10000 n=500: 10,943.39339352156
```

a performance improvement of 25-38% can be noticed in the sets tests