### PR TITLE
build: print 'Formatting Markdown...' for long task markdown formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1398,6 +1398,7 @@ lint-md: lint-js-doc | tools/.mdlintstamp ## Lint the markdown documents maintai
 run-format-md = tools/lint-md/lint-md.mjs --format $(LINT_MD_FILES)
 .PHONY: format-md
 format-md: tools/lint-md/node_modules/remark-parse/package.json ## Format the markdown documents maintained by us in the codebase.
+	$(info Formatting Markdown...)
 	@$(call available-node,$(run-format-md))
 
 


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/17cf2fb0-b9b4-4e70-bbce-580ea43526c9" width=400 />

Task `format-md` takes quite a long time (30 seconds). So, Added console output like the other tasks.