### PR TITLE
doc,test: fix docs/api copy

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -10,6 +10,8 @@ changes:
     description: Added `--experimental-transform-types` flag.
 -->
 
+<!--introduced_in=v23.6.0-->
+
 > Stability: 1.1 - Active development
 
 ## Enabling

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -10,7 +10,7 @@ changes:
     description: Added `--experimental-transform-types` flag.
 -->
 
-<!--introduced_in=v23.6.0-->
+<!--introduced_in=v22.6.0-->
 
 > Stability: 1.1 - Active development
 

--- a/tools/lint-md/lint-md.mjs
+++ b/tools/lint-md/lint-md.mjs
@@ -34,6 +34,14 @@ paths.forEach(async (path) => {
   const fileContents = file.toString();
   const result = await linter.process(file);
   const isDifferent = fileContents !== result.toString();
+
+  if (path.startsWith('doc/api/')) {
+    if (!fileContents.includes('introduced_in')) {
+      console.error(`${path} is missing an 'introduced_in' version. Please add one.`);
+      process.exitCode = 1;
+    }
+  }
+
   if (format) {
     if (isDifferent) {
       fs.writeFileSync(path, result.toString());


### PR DESCRIPTION

<img width="576" alt="image" src="https://github.com/user-attachments/assets/af0a5ad6-d4b8-4f26-8be8-fb9a6748b379" />

The Copy button doesn't work on page [docs/api/typescript](https://nodejs.org/docs/latest/api/typescript.html#full-typescript-support).

<img width="696" alt="image" src="https://github.com/user-attachments/assets/87dcdc7b-bce3-4116-a7a7-ab5bfb6964cf" />

`altDocs` function is throwing an null properties error because `introduced_in` is missing.

Probably all API documentation should have `<!--introduced_in=vVERSION-->`, So Added a test in `lint-md.mjs` as well.

<img src="https://github.com/user-attachments/assets/a45e8744-d7b5-4864-9db1-97e9249db4aa" width=500 />
