### PR TITLE
timers: simplify the compareTimersLists function

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -442,10 +442,7 @@ function getTimerDuration(msecs, name) {
 function compareTimersLists(a, b) {
   const expiryDiff = a.expiry - b.expiry;
   if (expiryDiff === 0) {
-    if (a.id < b.id)
-      return -1;
-    if (a.id > b.id)
-      return 1;
+    return a.id - b.id;
   }
   return expiryDiff;
 }


### PR DESCRIPTION
Simplifies the compare function by returning directly if `expiryDiff` is equal to 0

We don't need to compare twice here, or return 1 or -1 -- if the ids are equal, which only happens if the same object is passed, we can just return the result of the difference as `expiryDiff` is 0 too

Before:

```
util/priority-queue.js
util/priority-queue.js n=100000: 5,113,431.506786623
```

After:

```
util/priority-queue.js
util/priority-queue.js n=100000: 5,559,752.550981263
```