### PR TITLE
build: allow using alternate `inspector_protocol` path

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -16,6 +16,9 @@ declare_args() {
   # The location of simdutf - use the one from node's deps by default.
   node_simdutf_path = "$node_path/deps/simdutf"
 
+  # The location of inspector_protocol - use the one from node's deps by default.
+  node_inspector_protocol_path = "$node_path/deps/inspector_protocol"
+
   # The NODE_MODULE_VERSION defined in node_version.h.
   node_module_version = exec_script("$node_path/tools/getmoduleversion.py", [], "value")
 

--- a/src/inspector/unofficial.gni
+++ b/src/inspector/unofficial.gni
@@ -13,7 +13,7 @@ template("inspector_gn_build") {
   }
 
   node_gen_dir = get_label_info("../..", "target_gen_dir")
-  protocol_tool_path = "../../deps/inspector_protocol"
+  protocol_tool_path = "$node_inspector_protocol_path"
 
   gypi_values = exec_script(
       "../../tools/gypi_to_gn.py",

--- a/unofficial.gni
+++ b/unofficial.gni
@@ -193,7 +193,7 @@ template("node_gn_build") {
     }
     if (node_enable_inspector) {
       deps += [
-        "src/inspector:crdtp",
+        "$node_inspector_protocol_path:crdtp",
         "src/inspector:node_protocol_generated_sources",
         "src/inspector:v8_inspector_compress_protocol_json",
       ]
@@ -382,6 +382,7 @@ template("node_gn_build") {
       include_dirs = [
         "$target_gen_dir/src",
         "$target_gen_dir/src/inspector",
+        "$node_inspector_protocol_path",
       ]
     } else {
       sources -= gypi_values.node_cctest_inspector_sources


### PR DESCRIPTION
Allow for embedder customization along the lines of similar dependency variables.

Electron needs this in order to prevent conflicts between different implementations in Node.js and Chromium.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
