### PR TITLE
test: test-buffer-write.js: test each write throw case individually

### DIFF
--- a/test/parallel/test-buffer-write.js
+++ b/test/parallel/test-buffer-write.js
@@ -116,7 +116,17 @@ assert.strictEqual(Buffer.alloc(4)
 assert.throws(() => {
   const buf = Buffer.alloc(1);
   assert.strictEqual(buf.asciiWrite('ww', 0, -1));
+}, common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+}));
+assert.throws(() => {
+  const buf = Buffer.alloc(1);
   assert.strictEqual(buf.latin1Write('ww', 0, -1));
+}, common.expectsError({
+  code: 'ERR_BUFFER_OUT_OF_BOUNDS',
+}));
+assert.throws(() => {
+  const buf = Buffer.alloc(1);
   assert.strictEqual(buf.utf8Write('ww', 0, -1));
 }, common.expectsError({
   code: 'ERR_BUFFER_OUT_OF_BOUNDS',


### PR DESCRIPTION
as written, if `buf.asciiWrite` threw then none of the others would have been checked