### PR TITLE
test: improve error output of test-http2-client-promisify-connect-error

### DIFF
--- a/test/parallel/test-http2-client-promisify-connect-error.js
+++ b/test/parallel/test-http2-client-promisify-connect-error.js
@@ -12,13 +12,10 @@ const server = http2.createServer();
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
-  server.close(() => {
+  server.close(common.mustCall(() => {
     const connect = util.promisify(http2.connect);
-    connect(`http://localhost:${port}`)
-      .then(common.mustNotCall('Promise should not be resolved'))
-      .catch(common.mustCall((err) => {
-        assert(err instanceof Error);
-        assert.strictEqual(err.code, 'ECONNREFUSED');
-      }));
-  });
+    assert.rejects(connect(`http://localhost:${port}`), {
+      code: 'ECONNREFUSED'
+    }).then(common.mustCall());
+  }));
 }));


### PR DESCRIPTION
I'm getting a quite useless error output on Nix CI, showing there's a failed assertion but not showing the actual assertion error. Using `assert.rejects` should improve it greatly, and also makes the test code more readable.

For reference, the current output is:

```
not ok 1611 parallel/test-http2-client-promisify-connect-error
  ---
  duration_ms: 70.93100
  severity: fail
  exitcode: 1
  stack: |-
    node:internal/process/promises:394
        triggerUncaughtException(err, true /* fromPromise */);
        ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    
    + 'ERR_ASSERTION'
    - 'ECONNREFUSED'
    
        at /build/node-v22.14.0/test/parallel/test-http2-client-promisify-connect-error.js:21:16
        at /build/node-v22.14.0/test/common/index.js:435:15
        at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 'ERR_ASSERTION',
      expected: 'ECONNREFUSED',
      operator: 'strictEqual'
    }
    
    Node.js v22.14.0
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
