### PR TITLE
url: improve urlpattern regexp performance

### DIFF
--- a/src/node_url_pattern.cc
+++ b/src/node_url_pattern.cc
@@ -77,7 +77,7 @@ URLPatternRegexProvider::create_instance(std::string_view pattern,
                                          bool ignore_case) {
   auto isolate = Isolate::GetCurrent();
   auto env = Environment::GetCurrent(isolate);
-  int flags = RegExp::Flags::kUnicodeSets;
+  int flags = RegExp::Flags::kUnicodeSets | RegExp::Flags::kDotAll;
   if (ignore_case) {
     flags |= static_cast<int>(RegExp::Flags::kIgnoreCase);
   }


### PR DESCRIPTION
Thanks to @erikcorry's recommendation, we can speed up regexp performance of URLPattern

Benchmarks show no improvement, but I believe that is due to our lack of proper benchmark cases. (we don't have any benchmarks that use *)

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1658

```
confidence improvement accuracy (*)   (**)  (***)
url/urlpattern-parse.js n=100000 pattern='"[https://(sub.)?example(.com/)foo](https://(sub.)/?example(.com/)foo)"'                                                                  -0.34 %       ±0.57% ±0.76% ±1.01%
url/urlpattern-parse.js n=100000 pattern='{"hostname":"xn--caf-dma.com"}'                                                                *     -0.50 %       ±0.48% ±0.64% ±0.84%
url/urlpattern-parse.js n=100000 pattern='{"pathname":"/([[a-z]--a])"}'                                                                        -0.31 %       ±0.34% ±0.45% ±0.59%
url/urlpattern-parse.js n=100000 pattern='{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080/"}'                -0.07 %       ±0.34% ±0.46% ±0.59%
url/urlpattern-test.js n=100000 pattern='"[https://(sub.)?example(.com/)foo](https://(sub.)/?example(.com/)foo)"'                                                             *      0.72 %       ±0.63% ±0.84% ±1.10%
url/urlpattern-test.js n=100000 pattern='{"hostname":"xn--caf-dma.com"}'                                                                       -0.39 %       ±0.89% ±1.20% ±1.58%
url/urlpattern-test.js n=100000 pattern='{"pathname":"/([[a-z]--a])"}'                                                                   *      0.74 %       ±0.59% ±0.78% ±1.02%
url/urlpattern-test.js n=100000 pattern='{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080/"}'                  0.20 %       ±0.75% ±0.99% ±1.29%
```