### PR TITLE
module: implement synchronous module evaluate hooks

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2256,6 +2256,12 @@ The V8 platform used by this instance of Node.js does not support creating
 Workers. This is caused by lack of embedder support for Workers. In particular,
 this error will not occur with standard builds of Node.js.
 
+<a id="ERR_MODULE_ALREADY_EVALUATED"></a>
+
+### `ERR_MODULE_ALREADY_EVALUATED`
+
+A module cannot be evaluated twice using the `evalaute` customization hook.
+
 <a id="ERR_MODULE_NOT_FOUND"></a>
 
 ### `ERR_MODULE_NOT_FOUND`

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -923,6 +923,61 @@ hook that returns without calling `next<hookName>()` _and_ without returning
 prevent unintentional breaks in the chain. Return `shortCircuit: true` from a
 hook to signal that the chain is intentionally ending at your hook.
 
+#### `evaluate(context, nextEvaluate)`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1.1 - Active Development
+
+* `context` {Object} An object that will be used along the evaluation of a module.
+  It contains the following immutable properties.
+  * `module` {Object} The `Module` instance of the module being evaluated.
+  * `format` {string} The format of the module, which may be one of the list of
+    acceptable values described in the [`load` hook][load hook].
+* `nextEvaluate` {Function} The subsequent `evaluate` hook in the chain, or the
+  Node.js default `evaluate` hook after the last user-supplied `evaluate` hook.
+  This hook does not take any arguments.
+* Returns: {Object}
+  * `returned` {any} When the module is being required and it is a CommonJS module,
+    this contains the value that the CommonJS module returns, if
+    it uses any top-level `return` statement.
+  * `shortCircuit` {undefined|boolean} A signal that this hook intends to
+    terminate the chain of `evaluate` hooks. **Default:** `false`
+
+The `evaluate` hook is run after the `resolve` and `load` hook,
+abstracting the final execution of the code in the module. It is only
+available to `module.registerHooks`. It is currently only run for the
+execution of the following modules:
+
+1. CommonJS modules, either being `require`d or `import`ed. In this
+   case, `context.module` equals to the `module` object in the CommonJS
+   module being evaluated, and `context.module.exports` is mutable.
+2. ECMAScript modules that are `require`d. This hook would only be run
+   for the evaluation of the module being directly `require`d, but
+   could not be run for each of its inner modules being `import`ed. In
+   this case, `context.module` is a `Module` wrapper around the
+   ECMAScript modules. Reassigning `context.module.exports` to
+   something else only affects the result of `require()` call, but
+   would not affect access within the ECMAScript module. Properties of
+   `context.module.exports` (exports of the ECMAScript module) are not
+   mutable.
+
+In future versions it may cover more module types, but the following
+are unlikely to be supported due to restrictions in the ECMAScript
+specifications:
+
+1. The ability to skip evaluation of an inner ECMAScript module being
+   `import`ed by ECMAScript modules.
+2. The ability to mutate the exports of a ECMAScript module.
+
+For the ability to customize execution and exports of all the
+ECMAScript modules in the graph, consider patching the source code of
+the ECMAScript modules using the [`load` hook][load hook] as an imperfect
+workaround.
+
 #### `initialize()`
 
 <!-- YAML

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1578,6 +1578,7 @@ E('ERR_MISSING_ARGS',
     return `${msg} must be specified`;
   }, TypeError);
 E('ERR_MISSING_OPTION', '%s is required', TypeError);
+E('ERR_MODULE_ALREADY_EVALUATED', 'Module cannot be evaluated twice', Error);
 E('ERR_MODULE_NOT_FOUND', function(path, base, exactUrl) {
   if (exactUrl) {
     lazyInternalUtil().setOwnProperty(this, 'url', `${exactUrl}`);

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -101,6 +101,7 @@ const kIsMainSymbol = Symbol('kIsMainSymbol');
 const kIsCachedByESMLoader = Symbol('kIsCachedByESMLoader');
 const kRequiredModuleSymbol = Symbol('kRequiredModuleSymbol');
 const kIsExecuting = Symbol('kIsExecuting');
+const kHasBeenEvaluated = Symbol('kHasBeenEvaluated');
 
 const kURL = Symbol('kURL');
 const kFormat = Symbol('kFormat');
@@ -122,6 +123,7 @@ module.exports = {
   kIsCachedByESMLoader,
   kRequiredModuleSymbol,
   kIsExecuting,
+  kHasBeenEvaluated,
 };
 
 const { BuiltinModule } = require('internal/bootstrap/realm');
@@ -169,6 +171,8 @@ const {
   registerHooks,
   resolveHooks,
   resolveWithHooks,
+  evaluateWithHooks,
+  evaluateHooks,
 } = require('internal/modules/customization_hooks');
 const { stripTypeScriptModuleTypes } = require('internal/modules/typescript');
 const packageJsonReader = require('internal/modules/package_json_reader');
@@ -184,6 +188,7 @@ const {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_MODULE_SPECIFIER,
+    ERR_MODULE_ALREADY_EVALUATED,
     ERR_REQUIRE_CYCLE_MODULE,
     ERR_REQUIRE_ESM,
     ERR_UNKNOWN_BUILTIN_MODULE,
@@ -1712,31 +1717,59 @@ Module.prototype._compile = function(content, filename, format) {
     }
   }
 
-  if (format === 'module') {
-    loadESMFromCJS(this, filename, format, content);
-    return;
+  function defaultEvaluate(context) {
+    const mod = context.module;
+    if (mod[kHasBeenEvaluated]) {
+      throw new ERR_MODULE_ALREADY_EVALUATED();
+    }
+    const filename = mod.filename;
+    if (context.format === 'module') {
+      // TODO(joyeecheung): consider putting content in the context and this doesn't
+      // need to be a closure.
+      loadESMFromCJS(mod, filename, format, content);
+      mod[kHasBeenEvaluated] = true;
+      // ESM do not have top-level returns.
+      return { __proto__: null, returned: undefined };
+    }
+
+    const dirname = path.dirname(filename);
+    const require = makeRequireFunction(mod, redirects);
+    const expts = mod.exports;
+    const thisValue = expts;
+    if (requireDepth === 0) { statCache = new SafeMap(); }
+    const args = [expts, require, mod, filename, dirname];
+
+    // TODO(joyeecheung): consider putting compiledWrapper in the context and this doesn't
+    // need to be a closure.
+    // This is whatever returned by the wrapped function, note that users might not assign it to exports
+    // in case they put a return statement directly in CJS.
+    let returned;
+    if (mod[kIsMainSymbol] && getOptionValue('--inspect-brk')) {
+      const { callAndPauseOnStart } = internalBinding('inspector');
+      returned = callAndPauseOnStart(compiledWrapper, thisValue, ...args);
+    } else {
+      returned = ReflectApply(compiledWrapper, thisValue, args);
+    }
+    mod[kHasBeenEvaluated] = true;
+
+    if (requireDepth === 0) { statCache = null; }
+    return { __proto__: null, returned };
   }
 
-  const dirname = path.dirname(filename);
-  const require = makeRequireFunction(this, redirects);
-  let result;
-  const exports = this.exports;
-  const thisValue = exports;
-  const module = this;
-  if (requireDepth === 0) { statCache = new SafeMap(); }
   setHasStartedUserCJSExecution();
   this[kIsExecuting] = true;
-  if (this[kIsMainSymbol] && getOptionValue('--inspect-brk')) {
-    const { callAndPauseOnStart } = internalBinding('inspector');
-    result = callAndPauseOnStart(compiledWrapper, thisValue, exports,
-                                 require, module, filename, dirname);
+  format ||= 'commonjs';  // At this point, it's considered CommonJS.
+  let returned;
+  if (evaluateHooks.length > 0) {
+    const result = evaluateWithHooks(this, format, defaultEvaluate);
+    returned = result?.returned;
   } else {
-    result = ReflectApply(compiledWrapper, thisValue,
-                          [exports, require, module, filename, dirname]);
+    // Avoid creating a full ModuleEvaluateContext for fully internal code.
+    const result = defaultEvaluate({ __proto__: null, format, module: this });
+    returned = result?.returned;
   }
   this[kIsExecuting] = false;
-  if (requireDepth === 0) { statCache = null; }
-  return result;
+  return returned;
 };
 
 /**
@@ -1907,6 +1940,7 @@ Module._extensions['.js'] = function(module, filename) {
 Module._extensions['.json'] = function(module, filename) {
   const { source: content } = loadSource(module, filename, 'json');
 
+  // TODO(joyeecheung): invoke evaluate hook with 'json' format.
   try {
     setOwnProperty(module, 'exports', JSONParse(stripBOM(content)));
   } catch (err) {
@@ -1922,6 +1956,7 @@ Module._extensions['.json'] = function(module, filename) {
  */
 Module._extensions['.node'] = function(module, filename) {
   // Be aware this doesn't use `content`
+  // TODO(joyeecheung): invoke evaluate hook with 'addon' format.
   return process.dlopen(module, path.toNamespacedPath(filename));
 };
 

--- a/lib/internal/modules/customization_hooks.js
+++ b/lib/internal/modules/customization_hooks.js
@@ -5,6 +5,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSplice,
   ObjectAssign,
+  ObjectDefineProperties,
   ObjectFreeze,
   StringPrototypeStartsWith,
   Symbol,
@@ -52,6 +53,12 @@ let debug = require('internal/util/debuglog').debuglog('module_hooks', (fn) => {
  *   nextLoad: NextLoad,
  * ) => ModuleLoadResult
  * } LoadHook
+ * @typedef {() => ModuleEvaluateResult} NextEvaluate
+ * @typedef {(
+ *   context: ModuleEvaluateContext,
+ *   nextEvaluate: NextEvaluate,
+ * ) => ModuleEvaluateResult
+ * } EvaluateHook
  */
 
 // Use arrays for better insertion and iteration performance, we don't care
@@ -61,6 +68,7 @@ let debug = require('internal/util/debuglog').debuglog('module_hooks', (fn) => {
 const resolveHooks = [];
 /** @type {LoadHook[]} */
 const loadHooks = [];
+const evaluateHooks = [];
 const hookId = Symbol('kModuleHooksIdKey');
 let nextHookId = 0;
 
@@ -69,17 +77,21 @@ class ModuleHooks {
    * @param {ResolveHook|undefined} resolve User-provided hook.
    * @param {LoadHook|undefined} load User-provided hook.
    */
-  constructor(resolve, load) {
+  constructor(resolve, load, evaluate) {
     this[hookId] = Symbol(`module-hook-${nextHookId++}`);
     // Always initialize all hooks, if it's unspecified it'll be an owned undefined.
     this.resolve = resolve;
     this.load = load;
+    this.evaluate = evaluate;
 
     if (resolve) {
       ArrayPrototypePush(resolveHooks, this);
     }
     if (load) {
       ArrayPrototypePush(loadHooks, this);
+    }
+    if (evaluate) {
+      ArrayPrototypePush(evaluateHooks, this);
     }
 
     ObjectFreeze(this);
@@ -101,23 +113,30 @@ class ModuleHooks {
     if (index !== -1) {
       ArrayPrototypeSplice(loadHooks, index, 1);
     }
+    index = ArrayPrototypeFindIndex(evaluateHooks, (hook) => hook[hookId] === id);
+    if (index !== -1) {
+      ArrayPrototypeSplice(evaluateHooks, index, 1);
+    }
   }
 };
 
 /**
  * TODO(joyeecheung): taken an optional description?
- * @param {{ resolve?: ResolveHook, load?: LoadHook }} hooks User-provided hooks
+ * @param {{ resolve?: ResolveHook, load?: LoadHook, evaluate?: EvaluateHook }} hooks User-provided hooks
  * @returns {ModuleHooks}
  */
 function registerHooks(hooks) {
-  const { resolve, load } = hooks;
+  const { resolve, load, evaluate } = hooks;
   if (resolve) {
     validateFunction(resolve, 'hooks.resolve');
   }
   if (load) {
     validateFunction(load, 'hooks.load');
   }
-  return new ModuleHooks(resolve, load);
+  if (evaluate) {
+    validateFunction(evaluate, 'hooks.evaluate');
+  }
+  return new ModuleHooks(resolve, load, evaluate);
 }
 
 /**
@@ -152,6 +171,22 @@ function convertURLToCJSFilename(url) {
     return fileURLToPath(url);
   }
   return url;
+}
+
+/**
+ * Wrapper used by buildHooks to build the chain.
+ * @param {ModuleHooks[]} hooks @see {buildHooks}
+ * @param {'load'|'resolve'} name @see {buildHooks}
+ * @param {Function} defaultStep @see {buildHooks}
+ * @param {Function} wrapHook A helper used to wrap the hooks.
+ */
+function chainHooks(hooks, name, defaultStep, wrapHook) {
+  const chain = [wrapHook(0, defaultStep)];
+  for (let i = 0; i < hooks.length; ++i) {
+    const wrappedHook = wrapHook(i + 1, hooks[i][name], chain[i]);
+    ArrayPrototypePush(chain, wrappedHook);
+  }
+  return chain[chain.length - 1];
 }
 
 /**
@@ -190,12 +225,45 @@ function buildHooks(hooks, name, defaultStep, validate, mergedContext) {
       return validate(arg0, mergedContext, hookResult);
     };
   }
-  const chain = [wrapHook(0, defaultStep)];
-  for (let i = 0; i < hooks.length; ++i) {
-    const wrappedHook = wrapHook(i + 1, hooks[i][name], chain[i]);
-    ArrayPrototypePush(chain, wrappedHook);
+  return chainHooks(hooks, name, defaultStep, wrapHook);
+}
+
+/**
+ * Similar to @see {buildHooks} but specifically for the evaluate hook, which does
+ * not do merging of the context (whose existing properties are immutable),
+ * and does not allow overriding of the context for safety.
+ * @param {ModuleHooks[]} hooks @see {buildHooks}
+ * @param {Function} defaultStep @see {buildHooks}
+ * @param {Function} validate @see {buildHooks}
+ * @param {ModuleEvaluateContext} context Context used by this evaluate chain.
+ * @returns {ModuleEvaluateResult}
+ */
+function buildEvaluateHooks(hooks, defaultStep, validate, context) {
+  let lastRunIndex = hooks.length;
+  /**
+   * Helper function to wrap around invocation of user hook or the default step
+   * in order to fill in missing arguments or check returned results.
+   * This does not merge the context, and does not allow overriding of the context.
+   * The context passed in have the important properties configured to be immutable.
+   * Users can add new properties to the context, at most.
+   * @param {number} index Index in the chain. Default step is 0, last added hook is 1,
+   *                       and so on.
+   * @param {Function} userHookOrDefault Either the user hook or the default step to invoke.
+   * @param {Function|undefined} next The next wrapped step. If this is the default step, it's undefined.
+   * @returns {Function} Wrapped hook or default step.
+   */
+  function wrapHook(index, userHookOrDefault, next) {
+    return function nextStep() {  // This does not accept user-provided context.
+      lastRunIndex = index;
+      const hookResult = userHookOrDefault(context, next);
+      if (lastRunIndex > 0 && lastRunIndex === index && !(hookResult?.shortCircuit)) {
+        throw new ERR_INVALID_RETURN_PROPERTY_VALUE('true', 'evaluate', 'shortCircuit',
+                                                    hookResult?.shortCircuit);
+      }
+      return validate(context, hookResult);
+    };
   }
-  return chain[chain.length - 1];
+  return chainHooks(hooks, 'evaluate', defaultStep, wrapHook);
 }
 
 /**
@@ -297,6 +365,21 @@ function validateLoad(url, context, result) {
   };
 }
 
+/**
+ * @typedef {object} ModuleEvaluateResult
+ * @property {any} returned Result returned by the evaluation of the module. If it's a CommonJS
+ *                          module, this can be an arbitrary return value from top-level returns.
+ */
+/**
+ * Evaluate hook does not need validation, as there is no mandatory return value.
+ * @param {ModuleEvaluateContext} context
+ * @param {ModuleEvaluateResult} result
+ * @returns {ModuleEvaluateResult}
+ */
+function validateEvaluate(context, result) {
+  return result;
+}
+
 class ModuleResolveContext {
   /**
    * Context for the resolve hook.
@@ -323,6 +406,29 @@ class ModuleLoadContext {
     this.format = format;
     this.importAttributes = importAttributes;
     this.conditions = conditions;
+  }
+};
+
+class ModuleEvaluateContext {
+  /**
+   * Context for the evaluate hook.
+   * @param {Module} mod module.
+   * @param {string} format module format.
+   */
+  constructor(mod, format) {
+    ObjectDefineProperties(this, {
+      '__proto__': null,
+      'module': {
+        __proto__: null,
+        get() { return mod; },
+        configurable: false,
+      },
+      'format': {
+        __proto__: null,
+        get() { return format; },
+        configurable: false,
+      },
+    });
   }
 };
 
@@ -391,9 +497,30 @@ function resolveWithHooks(specifier, parentURL, importAttributes, conditions, de
   return runner(specifier, context);
 }
 
+/**
+ * Evaluate a CJS module with hooks, through a hooks chain if it exists.
+ * @param {Module} mod
+ * @param {string} format
+ * @param {(context: ModuleEvaluateContext) => ModuleEvaluateResult} defaultEvaluate
+ * @returns {ModuleEvaluateResult}
+ */
+function evaluateWithHooks(mod, format, defaultEvaluate) {
+  debug('evaluateWithHooks', mod);
+  const context = new ModuleEvaluateContext(mod, format);
+  if (evaluateHooks.length === 0) {
+    return defaultEvaluate(context);
+  }
+
+  const runner = buildEvaluateHooks(evaluateHooks, defaultEvaluate, validateEvaluate, context);
+
+  return runner(context);
+}
+
 module.exports = {
   convertCJSFilenameToURL,
   convertURLToCJSFilename,
+  evaluateHooks,
+  evaluateWithHooks,
   loadHooks,
   loadWithHooks,
   registerHooks,

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -37,6 +37,7 @@ const { stripTypeScriptModuleTypes } = require('internal/modules/typescript');
 const {
   kIsCachedByESMLoader,
   Module: CJSModule,
+  kHasBeenEvaluated,
   wrapModuleLoad,
   kModuleSource,
   kModuleExport,
@@ -52,9 +53,11 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
 const { emitExperimentalWarning, kEmptyObject, setOwnProperty, isWindows } = require('internal/util');
 const {
   ERR_INVALID_RETURN_PROPERTY_VALUE,
+  ERR_MODULE_ALREADY_EVALUATED,
   ERR_UNKNOWN_BUILTIN_MODULE,
 } = require('internal/errors').codes;
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
+const { evaluateHooks, evaluateWithHooks } = require('internal/modules/customization_hooks');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
 
@@ -162,8 +165,26 @@ function loadCJSModule(module, source, url, filename, isMain) {
   });
   setOwnProperty(requireFn, 'main', process.mainModule);
 
-  ReflectApply(compiledWrapper, module.exports,
-               [module.exports, requireFn, module, filename, __dirname]);
+  // TODO(joyeecheung): use sync hooks to implement async hooks and then
+  // just replace loadCJSModule with wrapModuleLoad, then there is no need to
+  // re-invent the wheels here.
+  function defaultEvaluate(context) {
+    const mod = context.module;
+    if (mod[kHasBeenEvaluated]) {
+      throw new ERR_MODULE_ALREADY_EVALUATED();
+    }
+    // This is whatever returned by the wrapped function, note that users might not assign it to exports
+    // in case they put a return statement directly in CJS.
+    const returned = ReflectApply(compiledWrapper, module.exports,
+                                  [module.exports, requireFn, module, filename, __dirname]);
+    mod[kHasBeenEvaluated] = true;
+    return { __proto__: null, returned };
+  }
+  if (evaluateHooks.length > 0) {
+    evaluateWithHooks(module, 'commonjs', defaultEvaluate);
+  } else {
+    defaultEvaluate({ __proto__: null, format: 'commonjs', module });
+  }
   setOwnProperty(module, 'loaded', true);
 }
 
@@ -436,6 +457,7 @@ translators.set('json', function jsonStrategy(url, source) {
     if (module?.loaded) {
       const exports = module.exports;
       return new ModuleWrap(url, undefined, ['default'], function() {
+        // TODO(joyeecheung): invoke evaluate hook with 'json' format.
         this.setExport('default', exports);
       });
     }
@@ -450,6 +472,7 @@ translators.set('json', function jsonStrategy(url, source) {
     if (module?.loaded) {
       const exports = module.exports;
       return new ModuleWrap(url, undefined, ['default'], function() {
+        // TODO(joyeecheung): invoke evaluate hook with 'json' format.
         this.setExport('default', exports);
       });
     }
@@ -507,6 +530,7 @@ translators.set('wasm', async function(url, source) {
   const createDynamicModule = require(
     'internal/modules/esm/create_dynamic_module');
   return createDynamicModule(imports, exports, url, (reflect) => {
+    // TODO(joyeecheung): invoke evaluate hook with 'wasm' format.
     const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
     for (const expt of ObjectKeys(exports)) {
       reflect.exports[expt].set(exports[expt]);

--- a/test/fixtures/console/console.snapshot
+++ b/test/fixtures/console/console.snapshot
@@ -8,3 +8,4 @@ Trace: foo
     at *
     at *
     at *
+    at *

--- a/test/fixtures/errors/force_colors.snapshot
+++ b/test/fixtures/errors/force_colors.snapshot
@@ -12,5 +12,6 @@ Error: Should include grayed stack trace
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
+[90m    at *[39m
 
 Node.js *

--- a/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
+++ b/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
@@ -8,5 +8,6 @@
     at *
     at *
     at *
+    at *
 (Use `* --trace-warnings ...` to show where the warning was created)
 (node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
+++ b/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
@@ -12,7 +12,9 @@
     at *
     at *
     at *
+    at *
 (node:*) Error: This was rejected
+    at *
     at *
     at *
     at *

--- a/test/fixtures/module-hooks/import-prop-exports-cjs.mjs
+++ b/test/fixtures/module-hooks/import-prop-exports-cjs.mjs
@@ -1,0 +1,3 @@
+'use strict';
+
+export { prop, getProp } from './prop-exports.cjs';

--- a/test/fixtures/module-hooks/import-throws-cjs.mjs
+++ b/test/fixtures/module-hooks/import-throws-cjs.mjs
@@ -1,0 +1,1 @@
+export { prop } from './throws.cjs';

--- a/test/fixtures/module-hooks/load-with-require-in-the-middle.js
+++ b/test/fixtures/module-hooks/load-with-require-in-the-middle.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const path = require('path');
+const { Hook } = require('./require-in-the-middle');
+
+const hook = new Hook(['foo', 'bar'], function (exports, name, basedir) {
+  const version = require(path.join(basedir, 'package.json')).version;
+  exports._version = version;
+  return exports;
+});
+
+module.exports = {
+  load(id) {
+    return require(id);
+  },
+  hook,
+};
+

--- a/test/fixtures/module-hooks/prop-exports-this.cjs
+++ b/test/fixtures/module-hooks/prop-exports-this.cjs
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  prop: 'original',
+  getProp() {
+    return this.prop;
+  }
+}

--- a/test/fixtures/module-hooks/prop-exports.cjs
+++ b/test/fixtures/module-hooks/prop-exports.cjs
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.prop = 'original';
+exports.getProp = function() {
+  return exports.prop;
+};

--- a/test/fixtures/module-hooks/prop-exports.mjs
+++ b/test/fixtures/module-hooks/prop-exports.mjs
@@ -1,0 +1,6 @@
+let prop = 'original';
+function getProp() {
+  return prop;
+};
+const namespace = { prop, getProp }
+export { prop, getProp, namespace as default };

--- a/test/fixtures/module-hooks/require-in-the-middle.js
+++ b/test/fixtures/module-hooks/require-in-the-middle.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { registerHooks } = require('module');
+const { getStats } = require('./get-stats');
+
+// This is a basic mock of https://www.npmjs.com/package/require-in-the-middle
+// to test that the module.registerHooks() can be used to replace the
+// CJS loader monkey-patching approach.
+
+class Hook {
+  constructor(modules, callback) {
+    function evaluate(context, nextEvaluate) {
+      let evaluated = nextEvaluate(context);
+      const mod = context.module;
+      const filepath = mod.filename || '';
+      const stats = getStats(filepath);
+      if (stats.name && modules.includes(stats.name)) {
+        callback(mod.exports, stats.name, stats.basedir);
+      }
+      return evaluated;
+    }
+    this.hook = registerHooks({ evaluate });
+  }
+  unhook() {
+    this.hook.deregister();
+  }
+}
+
+module.exports = {
+  Hook
+};

--- a/test/fixtures/module-hooks/throws.cjs
+++ b/test/fixtures/module-hooks/throws.cjs
@@ -1,0 +1,2 @@
+exports.prop = 'original';
+throw new Error('test');

--- a/test/fixtures/module-hooks/throws.mjs
+++ b/test/fixtures/module-hooks/throws.mjs
@@ -1,0 +1,3 @@
+throw new Error('test');
+let prop = 'original';
+export { prop };

--- a/test/fixtures/top-level-return.js
+++ b/test/fixtures/top-level-return.js
@@ -1,0 +1,1 @@
+return 'top-level-return';

--- a/test/message/assert_throws_stack.out
+++ b/test/message/assert_throws_stack.out
@@ -17,6 +17,7 @@ AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
     at *
     at *
     at *
+    at *
     at * {
   generatedMessage: true,
   code: 'ERR_ASSERTION',

--- a/test/message/util-inspect-error-cause.out
+++ b/test/message/util-inspect-error-cause.out
@@ -7,10 +7,12 @@ Error: Number error cause
     at *
     at *
     at *
+    at *
     at * {
   [cause]: 42
 }
 Error: Object cause
+    at *
     at *
     at *
     at *
@@ -36,10 +38,12 @@ Error: undefined cause
     at *
     at *
     at *
+    at *
     at * {
   [cause]: undefined
 }
 Error: cause that throws
+    at *
     at *
     at *
     at *
@@ -57,12 +61,13 @@ RangeError: New Stack Frames
   [cause]: FoobarError: Individual message
       at *
   *[90m    at *[39m
-  *[90m    ... 6 lines matching cause stack trace ...*[39m
+  *[90m    ... 7 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     status: *[32m'Feeling good'*[39m,
     extraProperties: *[32m'Yes!'*[39m,
     [cause]: TypeError: Inner error
         at *
+    *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
@@ -76,17 +81,18 @@ RangeError: New Stack Frames
 Error: Stack causes
     at *
 *[90m    at *[39m
-*[90m    ... 6 lines matching cause stack trace ...*[39m
+*[90m    ... 7 lines matching cause stack trace ...*[39m
 *[90m    at *[39m {
   [cause]: FoobarError: Individual message
       at *
   *[90m    at *[39m
-  *[90m    ... 6 lines matching cause stack trace ...*[39m
+  *[90m    ... 7 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     status: *[32m'Feeling good'*[39m,
     extraProperties: *[32m'Yes!'*[39m,
     [cause]: TypeError: Inner error
         at *
+    *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
     *[90m    at *[39m
@@ -103,17 +109,18 @@ RangeError: New Stack Frames
   [cause]: Error: Stack causes
       at *
   *[90m    at *[39m
-  *[90m    ... 6 lines matching cause stack trace ...*[39m
+  *[90m    ... 7 lines matching cause stack trace ...*[39m
   *[90m    at *[39m {
     [cause]: FoobarError: Individual message
         at *
     *[90m    at *[39m
-    *[90m    ... 6 lines matching cause stack trace ...*[39m
+    *[90m    ... 7 lines matching cause stack trace ...*[39m
     *[90m    at *[39m {
       status: *[32m'Feeling good'*[39m,
       extraProperties: *[32m'Yes!'*[39m,
       [cause]: TypeError: Inner error
           at *
+      *[90m    at *[39m
       *[90m    at *[39m
       *[90m    at *[39m
       *[90m    at *[39m
@@ -131,11 +138,12 @@ RangeError: New Stack Frames
   [cause]: FoobarError: Individual message
       at *
       at *
-      ... 6 lines matching cause stack trace ...
+      ... 7 lines matching cause stack trace ...
       at * {
     status: 'Feeling good',
     extraProperties: 'Yes!',
     [cause]: TypeError: Inner error
+        at *
         at *
         at *
         at *
@@ -150,16 +158,17 @@ RangeError: New Stack Frames
 Error: Stack causes
     at *
     at *
-    ... 6 lines matching cause stack trace ...
+    ... 7 lines matching cause stack trace ...
     at * {
   [cause]: FoobarError: Individual message
       at *
       at *
-      ... 6 lines matching cause stack trace ...
+      ... 7 lines matching cause stack trace ...
       at *
     status: 'Feeling good',
     extraProperties: 'Yes!',
     [cause]: TypeError: Inner error
+        at *
         at *
         at *
         at *
@@ -177,16 +186,17 @@ RangeError: New Stack Frames
   [cause]: Error: Stack causes
       at *
       at *
-      ... 6 lines matching cause stack trace ...
+      ... 7 lines matching cause stack trace ...
       at * {
     [cause]: FoobarError: Individual message
         at *
         at *
-        ... 6 lines matching cause stack trace ...
+        ... 7 lines matching cause stack trace ...
         at * {
       status: 'Feeling good',
       extraProperties: 'Yes!',
       [cause]: TypeError: Inner error
+          at *
           at *
           at *
           at *

--- a/test/message/util_inspect_error.out
+++ b/test/message/util_inspect_error.out
@@ -10,11 +10,13 @@
        at *
        at *
        at *
+       at *
   nested:
    { err:
       Error: foo
       bar
           at *util_inspect_error*
+          at *
           at *
           at *
           at *
@@ -35,10 +37,12 @@
       at *
       at *
       at *
+      at *
   nested: {
     err: Error: foo
     bar
         at *util_inspect_error*
+        at *
         at *
         at *
         at *
@@ -52,6 +56,7 @@
 { Error: foo
 bar
     at *util_inspect_error*
+    at *
     at *
     at *
     at *

--- a/test/module-hooks/test-module-hooks-evaluate-again.js
+++ b/test/module-hooks/test-module-hooks-evaluate-again.js
@@ -1,0 +1,21 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+registerHooks({
+  evaluate(context, nextEvaluate) {
+    nextEvaluate(context);
+    // It should not be possible to call defaultEvaluate on the same module again.
+    return nextEvaluate(context);
+  },
+});
+
+// Check both require(cjs) and require(esm).
+assert.throws(() => {
+  require('../fixtures/module-hooks/node_modules/bar');
+}, { code: 'ERR_MODULE_ALREADY_EVALUATED' });
+assert.throws(() => {
+  require('../fixtures/module-hooks/node_modules/bar-esm');
+}, { code: 'ERR_MODULE_ALREADY_EVALUATED' });

--- a/test/module-hooks/test-module-hooks-evaluate-modified-context-cjs-module.js
+++ b/test/module-hooks/test-module-hooks-evaluate-modified-context-cjs-module.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// This tests that the context of the evaluate hooks cannot be modified or
+// overriden when being passed to the nextEvaluate hook.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook1 = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.strictEqual(context.format, 'commonjs');
+    // context.module is still bar, unaffected by hook 2.
+    assert.match(context.module.filename, /bar\.js/);
+
+    // Cannot change the module.
+    const originalModule = context.module;
+    assert.throws(() => {
+      context.module = module;
+    }, { name: 'TypeError' });
+    assert.strictEqual(context.module, originalModule);
+    return nextEvaluate();
+  }, 1),
+});
+
+const hook2 = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.strictEqual(context.format, 'commonjs');
+    assert.match(context.module.filename, /bar\.js/);
+
+    // Changing the module does nothing.
+    const originalModule = context.module;
+    assert.throws(() => {
+      context.module = module;
+    }, { name: 'TypeError' });
+    assert.strictEqual(context.module, originalModule);
+    // Does not take the module from the argument.
+    return nextEvaluate({ ...context, cjsModule: module });
+  }, 1),
+});
+
+assert.deepStrictEqual(require('../fixtures/module-hooks/node_modules/bar'), { '$key': 'bar' });
+
+hook2.deregister();
+hook1.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-modified-context-format.js
+++ b/test/module-hooks/test-module-hooks-evaluate-modified-context-format.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// This tests that the context of the evaluate hooks cannot be modified or
+// overriden when being passed to the nextEvaluate hook.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook1 = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    // context.format is still module, unaffected by hook 2.
+    assert.strictEqual(context.format, 'module');
+    assert.match(context.module.filename, /bar-esm\.js/);
+
+    // Cannot change the format.
+    const originalFormat = context.format;
+    assert.throws(() => {
+      context.format = 'commonjs';
+    }, { name: 'TypeError' });
+    assert.strictEqual(context.format, originalFormat);
+    return nextEvaluate();
+  }, 1),
+});
+
+const hook2 = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.strictEqual(context.format, 'module');
+    assert.match(context.module.filename, /bar-esm\.js/);
+
+    // Cannot change the format.
+    const originalFormat = context.format;
+    assert.throws(() => {
+      context.format = 'commonjs';
+    }, { name: 'TypeError' });
+    assert.strictEqual(context.format, originalFormat);
+    // Does not take the format from the argument.
+    return nextEvaluate({ ...context, format: 'commonjs' });
+  }, 1),
+});
+
+common.expectRequiredModule(
+  require('../fixtures/module-hooks/node_modules/bar-esm'),
+  { '$key': 'bar-esm' });
+
+hook2.deregister();
+hook1.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-mutate-exports-import-cjs-esm.mjs
+++ b/test/module-hooks/test-module-hooks-evaluate-mutate-exports-import-cjs-esm.mjs
@@ -1,0 +1,21 @@
+// This tests that the nextEvaluate() can affect internal access to
+// the exports object for CommonJS modules from import cjs from ESM.
+
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    nextEvaluate();
+    // Invoked only once for the imported CJS module. import(esm) does not
+    // trigger evaluate for now.
+    assert.match(context.module.filename, /prop-exports\.cjs/);
+    assert.strictEqual(context.module.exports.prop, 'original');
+    context.module.exports.prop = 'updated';
+  }, 1),
+});
+
+const { getProp } = await import('../fixtures/module-hooks/import-prop-exports-cjs.mjs');
+assert.strictEqual(getProp(), 'updated');
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-mutate-exports-import-cjs.js
+++ b/test/module-hooks/test-module-hooks-evaluate-mutate-exports-import-cjs.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// This tests that the nextEvaluate() can affect internal access to
+// the exports object for CommonJS modules from import cjs.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    nextEvaluate();
+    if (context.format === 'module') {  // Invoked for require(esm) call.
+      assert.match(context.module.filename, /import-prop-exports-cjs\.mjs/);
+      return;
+    }
+    // Invoked for the import cjs call.
+    assert.match(context.module.filename, /prop-exports\.cjs/);
+    assert.strictEqual(context.module.exports.prop, 'original');
+    context.module.exports.prop = 'updated';
+  }, 2),
+});
+
+const { getProp } = require('../fixtures/module-hooks/import-prop-exports-cjs.mjs');
+assert.strictEqual(getProp(), 'updated');
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-mutate-exports-require-esm.js
+++ b/test/module-hooks/test-module-hooks-evaluate-mutate-exports-require-esm.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// This tests that the nextEvaluate() cannot affect internal access to
+// the exports object for ESM.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    nextEvaluate();
+    assert.throws(() => {
+      context.module.exports.prop = 'changed';
+    }, { name: 'TypeError' });
+    assert.strictEqual(context.module.exports.prop, 'original');
+  }, 1),
+});
+
+const { getProp } = require('../fixtures/module-hooks/prop-exports.mjs');
+assert.strictEqual(getProp(), 'original');
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-mutate-exports.js
+++ b/test/module-hooks/test-module-hooks-evaluate-mutate-exports.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// This tests that the nextEvaluate() can affect internal access to
+// the exports object for CommonJS modules.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    nextEvaluate();
+    assert.strictEqual(context.module.exports.prop, 'original');
+    context.module.exports.prop = 'updated';
+  }, 1),
+});
+
+const { getProp } = require('../fixtures/module-hooks/prop-exports.cjs');
+assert.strictEqual(getProp(), 'updated');
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-non-object-exports.js
+++ b/test/module-hooks/test-module-hooks-evaluate-non-object-exports.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// This tests that the evaluate() can deal with non-object exports.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    // module.exports is evalauted to be replaced by a string.
+    assert.strictEqual(context.module.exports, 'perhaps I work');
+    context.module.exports = { changed: true };  // Change it into an object again.
+    return { };
+  }, 1),
+});
+
+assert.deepStrictEqual(require('../fixtures/baz.js'), { changed: true });
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-replace-exports-accessor.js
+++ b/test/module-hooks/test-module-hooks-evaluate-replace-exports-accessor.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// This tests that the evaluate() can replace entire exports of require(cjs)
+// which does affect the internal access in the module.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    const originalExports = context.module.exports;
+    assert(typeof originalExports.getProp, 'function');
+    assert.deepStrictEqual(originalExports, { prop: 'original', getProp: originalExports.getProp });
+    context.module.exports = {
+      ...originalExports,
+      set prop(val) { originalExports.prop = val; },
+      get prop() { return originalExports.prop; },
+    };
+    context.module.exports.prop = 'updated';
+  }, 1),
+});
+
+// If the internal access is done as a receiver access, it can still be updated.
+const result = require('../fixtures/module-hooks/prop-exports.cjs');
+assert.strictEqual(result.prop, 'updated');
+assert.strictEqual(result.getProp(), 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-replace-exports-import-cjs-esm.mjs
+++ b/test/module-hooks/test-module-hooks-evaluate-replace-exports-import-cjs-esm.mjs
@@ -1,0 +1,31 @@
+// This tests that the evaluate() can replace entire exports of import cjs from ESM
+// which does affect the internal access in the module.
+
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    // Invoked only once for the imported CJS module. import(esm) does not
+    // trigger evaluate for now.
+    assert.match(context.module.filename, /prop-exports\.cjs/);
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    const originalExports = context.module.exports;
+    assert(typeof originalExports.getProp, 'function');
+    assert.deepStrictEqual(originalExports, { prop: 'original', getProp: originalExports.getProp });
+    context.module.exports = {
+      ...originalExports,
+      set prop(val) { originalExports.prop = val; },
+      get prop() { return originalExports.prop; },
+    };
+    context.module.exports.prop = 'updated';
+  }, 1),
+});
+
+const result = await import('../fixtures/module-hooks/import-prop-exports-cjs.mjs');
+assert.strictEqual(result.prop, 'updated');
+assert.strictEqual(result.getProp(), 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-replace-exports-import-cjs.js
+++ b/test/module-hooks/test-module-hooks-evaluate-replace-exports-import-cjs.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// This tests that the evaluate() can replace entire exports of import cjs
+// which does affect the internal access in the module.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    if (context.format === 'module') {  // Invoked for require(esm) call.
+      assert.match(context.module.filename, /import-prop-exports-cjs\.mjs/);
+      nextEvaluate();
+      return;
+    }
+    assert.match(context.module.filename, /prop-exports\.cjs/);
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    const originalExports = context.module.exports;
+    assert(typeof originalExports.getProp, 'function');
+    assert.deepStrictEqual(originalExports, { prop: 'original', getProp: originalExports.getProp });
+    context.module.exports = {
+      ...originalExports,
+      set prop(val) { originalExports.prop = val; },
+      get prop() { return originalExports.prop; },
+    };
+    context.module.exports.prop = 'updated';
+  }, 2),
+});
+
+const result = require('../fixtures/module-hooks/import-prop-exports-cjs.mjs');
+assert.strictEqual(result.prop, 'updated');
+assert.strictEqual(result.getProp(), 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-replace-exports-require-esm.js
+++ b/test/module-hooks/test-module-hooks-evaluate-replace-exports-require-esm.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// This tests that the evaluate() can replace entire exports of require(esm)
+// which does not affect the internal access in the module.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    const originalExports = context.module.exports;
+    assert(typeof originalExports.getProp, 'function');
+    const expected = { prop: 'original', getProp: originalExports.getProp };
+    common.expectRequiredModule(originalExports, { ...expected, default: expected });
+    context.module.exports = { ...expected, prop: 'updated' };
+  }, 1),
+});
+
+const result = require('../fixtures/module-hooks/prop-exports.mjs');
+assert.strictEqual(result.prop, 'updated');
+assert.strictEqual(result.getProp(), 'original');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-replace-exports.js
+++ b/test/module-hooks/test-module-hooks-evaluate-replace-exports.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// This tests that the evaluate() can replace entire exports of require(cjs)
+// which does affect the internal access in the module.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    nextEvaluate();
+    const originalExports = context.module.exports;
+    assert(typeof originalExports.getProp, 'function');
+    assert.deepStrictEqual(originalExports, { prop: 'original', getProp: originalExports.getProp });
+    context.module.exports = { ...originalExports, prop: 'updated' };
+  }, 1),
+});
+
+// If the internal access is done as a receiver access, it can still be updated.
+const result = require('../fixtures/module-hooks/prop-exports-this.cjs');
+assert.strictEqual(result.prop, 'updated');
+assert.strictEqual(result.getProp(), 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-require-in-the-middle.js
+++ b/test/module-hooks/test-module-hooks-evaluate-require-in-the-middle.js
@@ -1,0 +1,17 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { load, hook } = require('../fixtures/module-hooks/load-with-require-in-the-middle');
+
+// This is a basic mock of https://www.npmjs.com/package/require-in-the-middle
+// to test that the module.registerHooks() can be used to replace the
+// CJS loader monkey-patching approach.
+
+const foo = load('foo');
+assert.deepStrictEqual(foo, { '$key': 'foo', '_version': '1.0.0' });
+
+hook.unhook();
+
+const bar = load('bar');
+assert.deepStrictEqual(bar, { '$key': 'bar' });

--- a/test/module-hooks/test-module-hooks-evaluate-short-circuit-forgot.js
+++ b/test/module-hooks/test-module-hooks-evaluate-short-circuit-forgot.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// This tests that forgetting shortCircuit: true in the return value of evaluate()
+// hook without calling nextEvalaute causes an error.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    context.module.exports = { skipped: true };
+  }, 1),
+});
+
+assert.throws(() => {
+  require('../fixtures/module-hooks/prop-exports.cjs');
+}, {
+  code: 'ERR_INVALID_RETURN_PROPERTY_VALUE',
+});
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-short-circuit-import-cjs-esm.mjs
+++ b/test/module-hooks/test-module-hooks-evaluate-short-circuit-import-cjs-esm.mjs
@@ -1,0 +1,21 @@
+// This tests that the evaluate() can skip default evaluation for import cjs from ESM.
+
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    // Only invoked for the import cjs call.
+    assert.deepStrictEqual(context.module.exports, {});
+    context.module.exports = { prop: 'updated' };
+    return {
+      shortCircuit: true,
+    };
+  }, 1),
+});
+
+const result = await import('../fixtures/module-hooks/import-throws-cjs.mjs');
+assert.strict(result.prop, 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-short-circuit-import-cjs.js
+++ b/test/module-hooks/test-module-hooks-evaluate-short-circuit-import-cjs.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// This tests that the evaluate() can skip default evaluation for import cjs.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    if (!context.module.filename.endsWith('throws.cjs')) {
+      return nextEvaluate();
+    }
+    assert.deepStrictEqual(context.module.exports, {});
+    context.module.exports = { prop: 'updated' };
+    return {
+      shortCircuit: true,
+    };
+  }, 2),
+});
+
+const result = require('../fixtures/module-hooks/import-throws-cjs.mjs');
+assert.strictEqual(result.prop, 'updated');
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-short-circuit-require-esm.js
+++ b/test/module-hooks/test-module-hooks-evaluate-short-circuit-require-esm.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// This tests that the evaluate() can skip default evaluation for require(esm).
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    context.module.exports = { prop: 'updated' };
+    return {
+      shortCircuit: true,
+    };
+  }, 1),
+});
+
+assert.deepStrictEqual(require('../fixtures/module-hooks/throws.mjs'), { prop: 'updated' });
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-short-circuit.js
+++ b/test/module-hooks/test-module-hooks-evaluate-short-circuit.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// This tests that the evaluate() can skip default evaluation.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.deepStrictEqual(context.module.exports, {});
+    context.module.exports = { prop: 'updated' };
+    return {
+      shortCircuit: true,
+    };
+  }, 1),
+});
+
+assert.deepStrictEqual(require('../fixtures/module-hooks/throws.cjs'), { prop: 'updated' });
+
+hook.deregister();

--- a/test/module-hooks/test-module-hooks-evaluate-top-level-return.js
+++ b/test/module-hooks/test-module-hooks-evaluate-top-level-return.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// This tests that the nextEvaluate() returns the top-level return value, if any.
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+const hook = registerHooks({
+  evaluate: common.mustCall(function(context, nextEvaluate) {
+    assert.strictEqual(context.format, 'commonjs');
+    assert.match(context.module.filename, /top-level-return\.js/);
+    const { returned } = nextEvaluate();
+    assert.strictEqual(returned, 'top-level-return');
+    // Top-level return does not affect module.exports.
+    assert.deepStrictEqual(context.module.exports, {});
+    return { returned };
+  }, 1),
+});
+
+// Top-level return does not affect module.exports.
+assert.deepStrictEqual(require('../fixtures/top-level-return'), {});
+
+hook.deregister();

--- a/test/pseudo-tty/console_colors.out
+++ b/test/pseudo-tty/console_colors.out
@@ -14,9 +14,11 @@ foobar
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
+[90m    at *[39m
 
 Error: Should not ever get here.
     at Object.<anonymous> [90m(*node_modules*[4m*node_modules*[24m*bar.js:*:*[90m)[39m
+[90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
@@ -34,12 +36,14 @@ Error: Should not ever get here.
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
+[90m    at *[39m
 
 Error
     at evalmachine.<anonymous>:*:*
 [90m    at Script.runInThisContext (node:vm:*:*)[39m
 [90m    at Object.runInThisContext (node:vm:*:*)[39m
     at Object.<anonymous> [90m(*[39m*console_colors.js:*:*[90m)[39m
+[90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m

--- a/test/pseudo-tty/test-fatal-error.out
+++ b/test/pseudo-tty/test-fatal-error.out
@@ -4,10 +4,11 @@ throw err;
 
 TypeError: foobar
     at Object.<anonymous> [90m(*test-fatal-error.js:*:*[90m)[39m
-[90m    at *(node:internal*loader:*:*)[39m
-[90m    at *(node:internal*loader:*:*)[39m
-[90m    at *(node:internal*loader:*:*)[39m
-[90m    at *(node:internal*loader:*:*)[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
+[90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m
 [90m    at *[39m


### PR DESCRIPTION
This patch adds an `evaluate` hook that can be used as a supported alternative to monkey-patching the CJS module loader, when the primary use case is to modify the exports of modules, with the goal of reducing dependency on CJS loader monkey-patching in the wild.

```js
// mod.js
exports.prop = 'original';

// hook.js
require('module').registerHooks({
  evaluate(context, nextEvaluate) {
    context.module.exports;  // Access the exports before evaluation.
    nextEvaluate();  // Invokes default evaluation. Can be skipped.
    context.module.exports.prop;  // 'original'
    context.module.exports.prop = 'updated'; // Update exports.
  },
});

require('./mod.js');  // { prop: 'updated' }
```

The `evaluate` hook is run after the `resolve` and `load` hook, abstracting the final execution of the code in the module. It is only available to `module.registerHooks`. It is currently only run for the execution of the following modules:

1. CommonJS modules, either being `require`d or `import`ed. In this case, `context.module` equals to the `module` object in the CommonJS module being evaluated, and `context.module.exports` is mutable.
2. ECMAScript modules that are `require`d. This hook would only be run for the evaluation of the module being directly `require`d, but could not be run for each of its inner modules being `import`ed. In this case, `context.module` is a `Module` wrapper around the ECMAScript modules. Reassigning `context.module.exports` to something else only affects the result of `require()` call, but would not affect access within the ECMAScript module. Properties of `context.module.exports` (exports of the ECMAScript module) are not mutable.

In future versions it may cover more module types, but the following are unlikely to be supported due to restrictions in the ECMAScript specifications:

1. The ability to skip evaluation of an inner ECMAScript module being `import`ed by ECMAScript modules.
2. The ability to mutate the exports of a ECMAScript module.

For the ability to customize execution and exports of all the ECMAScript modules in the graph, consider patching the source code of the ECMAScript modules using the `load` hook as an imperfect workaround.

Refs: https://github.com/nodejs/node/issues/56241

In the test I included a POC for building https://www.npmjs.com/package/require-in-the-middle on top of it instead of monkey-patching. Support for (non-mutable) ESM evaluation depends on https://issues.chromium.org/u/1/issues/384413088 - mutability of ESM exports is off the table for V8 without spec support, so it's a non-goal/out of scope for this hook, and this mostly focus on at least sunsetting CJS monkey-patching.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
