### PR TITLE
test: simplify test-http2-client-promisify-connect-error

### DIFF
--- a/test/parallel/test-http2-client-promisify-connect-error.js
+++ b/test/parallel/test-http2-client-promisify-connect-error.js
@@ -8,14 +8,15 @@ const assert = require('assert');
 const http2 = require('http2');
 const util = require('util');
 
-const server = http2.createServer();
+const connect = util.promisify(http2.connect);
 
-server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
-  server.close(common.mustCall(() => {
-    const connect = util.promisify(http2.connect);
-    assert.rejects(connect(`http://localhost:${port}`), {
-      code: 'ECONNREFUSED'
-    }).then(common.mustCall());
-  }));
-}));
+const error = new Error('Unable to resolve hostname');
+
+function lookup(hostname, options, callback) {
+  callback(error);
+}
+
+assert.rejects(
+  connect('http://hostname', { lookup }),
+  error,
+).then(common.mustCall());


### PR DESCRIPTION
There is no need to try to create a TCP connection that fails due to a
missing listening server. Also, the port used for the connection might
be used by another process when the connection is made.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
