### PR TITLE
src: fix crash when lazy getter is invoked in a vm context

### DIFF
--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -84,6 +84,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
   V(ERR_INVALID_ARG_TYPE, TypeError)                                           \
   V(ERR_INVALID_FILE_URL_HOST, TypeError)                                      \
   V(ERR_INVALID_FILE_URL_PATH, TypeError)                                      \
+  V(ERR_INVALID_INVOCATION, TypeError)                                         \
   V(ERR_INVALID_PACKAGE_CONFIG, Error)                                         \
   V(ERR_INVALID_OBJECT_DEFINE_PROPERTY, TypeError)                             \
   V(ERR_INVALID_MODULE, Error)                                                 \
@@ -201,6 +202,7 @@ ERRORS_WITH_CODE(V)
     "Context not associated with Node.js environment")                         \
   V(ERR_ILLEGAL_CONSTRUCTOR, "Illegal constructor")                            \
   V(ERR_INVALID_ADDRESS, "Invalid socket address")                             \
+  V(ERR_INVALID_INVOCATION, "Invalid invocation")                              \
   V(ERR_INVALID_MODULE, "No such module")                                      \
   V(ERR_INVALID_STATE, "Invalid state")                                        \
   V(ERR_INVALID_THIS, "Value of \"this\" is the wrong type")                   \

--- a/test/parallel/test-vm-util-lazy-properties.js
+++ b/test/parallel/test-vm-util-lazy-properties.js
@@ -1,0 +1,26 @@
+'use strict';
+require('../common');
+
+const vm = require('node:vm');
+const util = require('node:util');
+const assert = require('node:assert');
+
+// This verifies that invoking property getters defined with
+// `require('internal/util').defineLazyProperties` does not crash
+// the process.
+
+const ctx = vm.createContext();
+const getter = vm.runInContext(`
+  function getter(object, property) {
+    return object[property];
+  }
+  getter;
+`, ctx);
+
+// `util.parseArgs` is a lazy property.
+const parseArgs = getter(util, 'parseArgs');
+assert.strictEqual(parseArgs, util.parseArgs);
+
+// `globalThis.TextEncoder` is a lazy property.
+const TextEncoder = getter(globalThis, 'TextEncoder');
+assert.strictEqual(TextEncoder, globalThis.TextEncoder);


### PR DESCRIPTION
V8 should invoke native functions in their creation context,
preventing dynamic context by the caller. However, the lazy getter has
no JavaScript function representation and has no creation context. It
is not invoked in the original creation context. Fix the null realm by
retrieving the creation context via `this` argument.

Fixes https://github.com/nodejs/node/issues/57166