### PR TITLE
src: do not expose simdjson.h in node_config_file.h

### DIFF
--- a/src/node_config_file.h
+++ b/src/node_config_file.h
@@ -6,7 +6,6 @@
 #include <map>
 #include <string>
 #include <variant>
-#include "simdjson.h"
 #include "util-inl.h"
 
 namespace node {


### PR DESCRIPTION
It is not needed, and on Windows files including the header needs some other configs otherwise errors like this may happen:

```
../../node/deps/simdjson/simdjson.h(12949,7): error: implicitly declaring library function '_BitScanReverse64' with type 'unsigned char (unsigned long *, unsigned long long) noexcept' [-Werror,-Wimplicit-function-declaration]
 12949 |   if (_BitScanReverse64(&leading_zero, input_num))
       |       ^
../../node/deps/simdjson/simdjson.h(12949,7): note: include the header <intrin.h> or explicitly provide a declaration for '_BitScanReverse64'
1 error generated.
```