### PR TITLE
process: improve error message for process.cwd() when directory is de…

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1116,6 +1116,14 @@ added:
 
 An attempt to invoke an unsupported crypto operation was made.
 
+<a id="ERR_CWD_DELETED"></a>
+
+### `ERR_CWD_DELETED`
+
+The current working directory has been deleted while the process was still inside it.
+
+To resolve this, use `process.chdir()` to switch to a valid directory.
+
 <a id="ERR_DEBUGGER_ERROR"></a>
 
 ### `ERR_DEBUGGER_ERROR`

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -37,6 +37,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
 
 #define ERRORS_WITH_CODE(V)                                                    \
   V(ERR_ACCESS_DENIED, Error)                                                  \
+  V(ERR_CWD_DELETED, Error)                                                    \
   V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE, Error)                                   \
   V(ERR_BUFFER_OUT_OF_BOUNDS, RangeError)                                      \
   V(ERR_BUFFER_TOO_LARGE, Error)                                               \
@@ -170,6 +171,10 @@ ERRORS_WITH_CODE(V)
 
 #define PREDEFINED_ERROR_MESSAGES(V)                                           \
   V(ERR_ACCESS_DENIED, "Access to this API has been restricted")               \
+  V(ERR_CWD_DELETED,                                                           \
+    "Current working directory does not exist. "                               \
+    "It may have been deleted while the process was still "                    \
+    "inside it. Use process.chdir() to change to a valid directory.")          \
   V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE,                                          \
     "Buffer is not available for the current Context")                         \
   V(ERR_CLOSED_MESSAGE_PORT, "Cannot send data on closed MessagePort")         \

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -159,6 +159,10 @@ static void Cwd(const FunctionCallbackInfo<Value>& args) {
   char buf[PATH_MAX_BYTES];
   size_t cwd_len = sizeof(buf);
   int err = uv_cwd(buf, &cwd_len);
+  if (err == UV_ENOENT) {
+    THROW_ERR_CWD_DELETED(env);
+    return;
+  }
   if (err) {
     return env->ThrowUVException(err, "uv_cwd");
   }

--- a/test/parallel/test-process-cwd-deleted.js
+++ b/test/parallel/test-process-cwd-deleted.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// This test verifies that an appropriate error is thrown when the current
+// working directory is deleted and process.cwd() is called.
+//
+// We do this by spawning a forked process and deleting the tmp cwd
+// while it is starting up.
+
+const common = require('../common');
+
+const { fork } = require('node:child_process');
+const { rmSync } = require('node:fs');
+const { strictEqual, ok } = require('node:assert');
+const { Buffer } = require('node:buffer');
+
+if (process.argv[2] === 'child') {
+  return;
+}
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+const tmpDir = tmpdir.path;
+
+const proc = fork(__filename, ['child'], {
+  cwd: tmpDir,
+  silent: true,
+});
+proc.on('spawn', common.mustCall(() => rmSync(tmpDir, { recursive: true })));
+
+proc.on('exit', common.mustCall((code) => {
+  strictEqual(code, 1);
+  proc.stderr.toArray().then(common.mustCall((chunks) => {
+    const buf = Buffer.concat(chunks);
+    ok(/Current working directory does not exist/.test(buf.toString()));
+  }));
+}));


### PR DESCRIPTION
…leted

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR improves the error message thrown by `process.cwd()` when the current working directory is deleted. Instead of throwing a new error, it enhances the original error message, making it clearer that the directory was deleted while the process was still inside it.  

#### **Changes Made:**  
- Modified `wrappedCwd()` to enhance the existing error message for `ENOENT: uv_cwd` instead of creating a new `Error` instance.  
- Ensured the error message explicitly states the reason and how to resolve it (using `process.chdir()` to switch directories).  

#### **Before (Old Behavior):**  
When the working directory was deleted, `process.cwd()` threw a generic error with little context:  
```sh
Error: ENOENT: no such file or directory, uv_cwd
```

#### **After (New Behavior):**  
Now, the error provides a more meaningful message:  
```sh
Error: Current working directory does not exist - this can happen if the directory was deleted while the process was still inside it. Original error: ENOENT: no such file or directory, uv_cwd
```

#### **Relevant Issue:**  
_(If this PR fixes an issue, add the issue number here)_  
Example: Fixes #XXXX  

#### **PR-URL:**  
https://github.com/nodejs/node/pull/57053

#### **Reviewer Notes:**  
-added to docs 
- added test js file
- Please review and let me know if further refinements are needed!  

