### PR TITLE
net: emit an error when custom lookup resolves a non-string address

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -115,7 +115,7 @@ const {
   },
   genericNodeError,
 } = require('internal/errors');
-const { isUint8Array } = require('internal/util/types');
+const { isStringObject, isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
 const {
   guessHandleType,
@@ -1416,7 +1416,7 @@ function lookupAndConnect(self, options) {
         // calls net.Socket.connect() on it (that's us). There are no event
         // listeners registered yet so defer the error event to the next tick.
         process.nextTick(connectErrorNT, self, err);
-      } else if (!isIP(ip)) {
+      } else if ((typeof ip !== 'string' && !isStringObject(ip)) || !isIP(ip)) {
         err = new ERR_INVALID_IP_ADDRESS(ip);
         process.nextTick(connectErrorNT, self, err);
       } else if (addressType !== 4 && addressType !== 6) {

--- a/lib/net.js
+++ b/lib/net.js
@@ -115,7 +115,7 @@ const {
   },
   genericNodeError,
 } = require('internal/errors');
-const { isStringObject, isUint8Array } = require('internal/util/types');
+const { isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
 const {
   guessHandleType,
@@ -1416,7 +1416,7 @@ function lookupAndConnect(self, options) {
         // calls net.Socket.connect() on it (that's us). There are no event
         // listeners registered yet so defer the error event to the next tick.
         process.nextTick(connectErrorNT, self, err);
-      } else if ((typeof ip !== 'string' && !isStringObject(ip)) || !isIP(ip)) {
+      } else if ((typeof ip !== 'string') || !isIP(ip)) {
         err = new ERR_INVALID_IP_ADDRESS(ip);
         process.nextTick(connectErrorNT, self, err);
       } else if (addressType !== 4 && addressType !== 6) {

--- a/test/parallel/test-net-connect-custom-lookup-non-string-address.mjs
+++ b/test/parallel/test-net-connect-custom-lookup-non-string-address.mjs
@@ -1,0 +1,44 @@
+import * as common from '../common/index.mjs';
+import net from 'node:net';
+import { describe, it } from 'node:test';
+
+const brokenCustomLookup = (_hostname, options, callback) => {
+  // Incorrectly return an array of IPs instead of a string.
+  callback(null, ['127.0.0.1'], options.family);
+};
+
+describe('when family is ipv4', () => {
+  it('socket emits an error when lookup does not return a string', (t, done) => {
+    const options = {
+      host: 'example.com',
+      port: 80,
+      lookup: brokenCustomLookup,
+      family: 4
+    };
+
+    const socket = net.connect(options, common.mustNotCall());
+    socket.on('error', (err) => {
+      t.assert.strictEqual(err.code, 'ERR_INVALID_IP_ADDRESS');
+
+      done();
+    });
+  });
+});
+
+describe('when family is ipv6', () => {
+  it('socket emits an error when lookup does not return a string', (t, done) => {
+    const options = {
+      host: 'example.com',
+      port: 80,
+      lookup: brokenCustomLookup,
+      family: 6
+    };
+
+    const socket = net.connect(options, common.mustNotCall());
+    socket.on('error', (err) => {
+      t.assert.strictEqual(err.code, 'ERR_INVALID_IP_ADDRESS');
+
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fixes: #57112

This PR fixes the crash when the lookup function resolves to a non-string address. Instead, it will emit an ERR_INVALID_IP_ADDRESS error. 