### PR TITLE
#57169 fix/streamResetBurst-and-streamResetRate-options-are-missing-in-the-documentation-of-http2.CreateSecureServer

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3057,7 +3057,7 @@ changes:
     remote peer upon connection.
   * `streamResetBurst` {number} and `streamResetRate` {number} Sets the rate
     limit for the incoming stream reset (RST\_STREAM frame). Both settings must
-    be set to have any effect, and default to 1000 and 33 respectively.  
+    be set to have any effect, and default to 1000 and 33 respectively.
   * `remoteCustomSettings` {Array} The array of integer values determines the
     settings types, which are included in the `customSettings`-property of the
     received remoteSettings. Please see the `customSettings`-property of the

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3055,6 +3055,9 @@ changes:
     **Default:** `100`.
   * `settings` {HTTP/2 Settings Object} The initial settings to send to the
     remote peer upon connection.
+  * `streamResetBurst` {number} and `streamResetRate` {number} Sets the rate
+    limit for the incoming stream reset (RST\_STREAM frame). Both settings must
+    be set to have any effect, and default to 1000 and 33 respectively.  
   * `remoteCustomSettings` {Array} The array of integer values determines the
     settings types, which are included in the `customSettings`-property of the
     received remoteSettings. Please see the `customSettings`-property of the


### PR DESCRIPTION

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Title: Documentation Update: Include streamResetBurst and streamResetRate Options in http2.CreateSecureServer

Description:

This PR addresses the issue where the streamResetBurst and streamResetRate options were missing in the documentation for http2.CreateSecureServer.

Changes:

Added documentation for the streamResetBurst and streamResetRate options in the http2.CreateSecureServer section.


If you need any adjustments or further additions, feel free to let me know!

