### PR TITLE
net: validate non-string host for `socket.connect`

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -1311,6 +1311,8 @@ function lookupAndConnect(self, options) {
   const host = options.host || 'localhost';
   let { port, autoSelectFamilyAttemptTimeout, autoSelectFamily } = options;
 
+  validateString(host, 'options.host');
+
   if (localAddress && !isIP(localAddress)) {
     throw new ERR_INVALID_IP_ADDRESS(localAddress);
   }

--- a/test/parallel/test-net-connect-options-invalid.js
+++ b/test/parallel/test-net-connect-options-invalid.js
@@ -25,3 +25,15 @@ const net = require('net');
     });
   });
 }
+
+{
+  assert.throws(() => {
+    net.createConnection({
+      host: ['192.168.0.1'],
+      port: 8080,
+    });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+  });
+}


### PR DESCRIPTION
This fixes another issue discovered while reviewing #57112.

Internally, `socket.connect` checks the host string, implicitly coercing an array to a string in the process. That leads to the error below.


```js
import net from 'node:net';

net.createConnection({
  host: ['192.168.0.1'],
  port: 8080,
});
```

```shell
#  node[2568546]: static void node::TCPWrap::Connect(const v8::FunctionCallbackInfo<v8::Value>&, std::function<int(const char*, T*)>) [with T = sockaddr_in] at ../src/tcp_wrap.cc:325
#  Assertion failed: args[1]->IsString()

----- Native stack trace -----

 1: 0x102d7b7 node::Assert(node::AssertionInfo const&) [node]
 2: 0x11aa8c2 void node::TCPWrap::Connect<sockaddr_in>(v8::FunctionCallbackInfo<v8::Value> const&, std::function<int (char const*, sockaddr_in*)>) [node]
 3: 0x11a9a73 node::TCPWrap::Connect(v8::FunctionCallbackInfo<v8::Value> const&) [node]
 4: 0x7f5b17e0f186

----- JavaScript stack trace -----

1: internalConnect (node:net:1096:26)
2: defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
3: node:net:1353:9
4: processTicksAndRejections (node:internal/process/task_queues:85:11)
```

Signed-off-by: Daeyeon Jeong <daeyeon.dev@gmail.com>