### PR TITLE
child_process: disallow args in execFile/spawn when shell option is true

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -158,7 +158,7 @@ exec('my.bat', (err, stdout, stderr) => {
 });
 
 // Script with spaces in the filename:
-const bat = spawn('"my script.cmd"', ['a', 'b'], { shell: true });
+const bat = spawn('"my script.cmd" a b', { shell: true });
 // or:
 exec('"my script.cmd" a b', (err, stdout, stderr) => {
   // ...

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3859,13 +3859,16 @@ deprecated, as their values are guaranteed to be identical to that of `process.f
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57199
+    description: Runtime deprecation.
   - version:
     - REPLACEME
     pr-url: https://github.com/nodejs/node/pull/57389
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 When an `args` array is passed to [`child_process.execFile`][] or [`child_process.spawn`][] with the option
 `{ shell: true }`, the values are not escaped, only space-separated, which can lead to shell injection.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -535,6 +535,7 @@ function copyProcessEnvToEnv(env, name, optionEnv) {
   }
 }
 
+let emittedDEP0190Already = false;
 function normalizeSpawnArguments(file, args, options) {
   validateString(file, 'file');
   validateArgumentNullCheck(file, 'file');
@@ -611,12 +612,13 @@ function normalizeSpawnArguments(file, args, options) {
 
   if (options.shell) {
     validateArgumentNullCheck(options.shell, 'options.shell');
-    if (args.length > 0) {
+    if (args.length > 0 && !emittedDEP0190Already) {
       process.emitWarning(
         'Passing args to a child process with shell option true can lead to security ' +
         'vulnerabilities, as the arguments are not escaped, only concatenated.',
         'DeprecationWarning',
         'DEP0190');
+        emittedDEP0190Already = true;
     }
     const command = ArrayPrototypeJoin([file, ...args], ' ');
     // Set the shell, switches, and commands.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -618,7 +618,7 @@ function normalizeSpawnArguments(file, args, options) {
         'vulnerabilities, as the arguments are not escaped, only concatenated.',
         'DeprecationWarning',
         'DEP0190');
-        emittedDEP0190Already = true;
+      emittedDEP0190Already = true;
     }
     const command = ArrayPrototypeJoin([file, ...args], ' ');
     // Set the shell, switches, and commands.

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -611,6 +611,13 @@ function normalizeSpawnArguments(file, args, options) {
 
   if (options.shell) {
     validateArgumentNullCheck(options.shell, 'options.shell');
+    if (args.length > 0) {
+      process.emitWarning(
+        'Passing args to a child process with shell option true can lead to security ' +
+        'vulnerabilities, as the arguments are not escaped, only concatenated.',
+        'DeprecationWarning',
+        'DEP0190');
+    }
     const command = ArrayPrototypeJoin([file, ...args], ' ');
     // Set the shell, switches, and commands.
     if (process.platform === 'win32') {

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -47,8 +47,7 @@ const execOpts = { encoding: 'utf8', shell: true, env: { ...process.env, NODE: p
 {
   // Verify the shell option works properly
   execFile(
-    `"${common.isWindows ? execOpts.env.NODE : '$NODE'}"`,
-    [`"${common.isWindows ? execOpts.env.FIXTURE : '$FIXTURE'}"`, 0],
+    common.isWindows ? `"${execOpts.env.NODE}" "${execOpts.env.FIXTURE} 0` : `"$NODE" "$FIXTURE" 0`,
     execOpts,
     common.mustSucceed(),
   );
@@ -117,10 +116,14 @@ const execOpts = { encoding: 'utf8', shell: true, env: { ...process.env, NODE: p
     ...(common.isWindows ? [] : [{ encoding: 'utf8' }]),
     { shell: true, encoding: 'utf8' },
   ].forEach((options) => {
-    const execFileSyncStdout = execFileSync(file, args, options);
+    const command = options.shell ?
+      [[file, ...args].join(' ')] :
+      [file, args];
+
+    const execFileSyncStdout = execFileSync(...command, options);
     assert.strictEqual(execFileSyncStdout, `foo bar${os.EOL}`);
 
-    execFile(file, args, options, common.mustCall((_, stdout) => {
+    execFile(...command, options, common.mustCall((_, stdout) => {
       assert.strictEqual(stdout, execFileSyncStdout);
     }));
   });

--- a/test/parallel/test-child-process-spawn-shell.js
+++ b/test/parallel/test-child-process-spawn-shell.js
@@ -18,6 +18,12 @@ doesNotExist.on('exit', common.mustCall((code, signal) => {
 }));
 
 // Verify that passing arguments works
+common.expectWarning(
+  'DeprecationWarning',
+  'Passing args to a child process with shell option true can lead to security ' +
+  'vulnerabilities, as the arguments are not escaped, only concatenated.',
+  'DEP0190');
+
 const echo = cp.spawn('echo', ['foo'], {
   encoding: 'utf8',
   shell: true

--- a/test/parallel/test-child-process-spawnsync-shell.js
+++ b/test/parallel/test-child-process-spawnsync-shell.js
@@ -19,6 +19,12 @@ else
   assert.strictEqual(doesNotExist.status, 127);  // Exit code of /bin/sh
 
 // Verify that passing arguments works
+common.expectWarning(
+  'DeprecationWarning',
+  'Passing args to a child process with shell option true can lead to security ' +
+  'vulnerabilities, as the arguments are not escaped, only concatenated.',
+  'DEP0190');
+
 internalCp.spawnSync = common.mustCall(function(opts) {
   assert.strictEqual(opts.args[opts.args.length - 1].replace(/"/g, ''),
                      'echo foo');


### PR DESCRIPTION
This will make it throw an error when args are passed to execFile or
spawn when the shell option is true. The reason for this is that when it
accepts args, it gives the false impression that the args are escaped while
really they are just concatenated. This makes it easy to introduce bugs
and security vulnerabilities.

This will break any code that relies on passing args to execFile or
spawn with `{ shell: true }`.

Fixes: https://github.com/nodejs/node/issues/57143
