### PR TITLE
test: buffer.indexOf: add more number cases

### DIFF
--- a/test/parallel/test-buffer-indexof.js
+++ b/test/parallel/test-buffer-indexof.js
@@ -71,6 +71,11 @@ assert.strictEqual(b.indexOf('f', 5), 5);
 assert.strictEqual(b.indexOf('f', -1), 5);
 assert.strictEqual(b.indexOf('f', 6), -1);
 
+assert.strictEqual(b.indexOf(100, 2), 3);
+assert.strictEqual(b.indexOf(102, 5), 5);
+assert.strictEqual(b.indexOf(102, -1), 5);
+assert.strictEqual(b.indexOf(102, 6), -1);
+
 assert.strictEqual(b.indexOf(Buffer.from('d'), 2), 3);
 assert.strictEqual(b.indexOf(Buffer.from('f'), 5), 5);
 assert.strictEqual(b.indexOf(Buffer.from('f'), -1), 5);


### PR DESCRIPTION
add some more cases that assert the success result is relative to the start of the Buffer and not the byteOffset parameter
existing number cases only checked 0 and -1 returns

discovered by https://github.com/oven-sh/bun/issues/17555
