### PR TITLE
deps: fix typos across multiple files

### DIFF
--- a/deps/icu-small/source/common/mlbe.cpp
+++ b/deps/icu-small/source/common/mlbe.cpp
@@ -180,7 +180,7 @@ int32_t MlBreakEngine::initIndexList(const UnicodeString &inString, int32_t *ind
     }
     int32_t index = 0;
     int32_t length = inString.countChar32();
-    // Set all (lenght+4) items inside indexLength to -1 presuming -1 is 4 bytes of 0xff.
+    // Set all (length+4) items inside indexLength to -1 presuming -1 is 4 bytes of 0xff.
     uprv_memset(indexList, 0xff, (length + 4) * sizeof(int32_t));
     if (length > 0) {
         indexList[2] = 0;

--- a/deps/icu-small/source/common/uresdata.h
+++ b/deps/icu-small/source/common/uresdata.h
@@ -399,7 +399,7 @@ typedef struct ResourceData {
     UBool useNativeStrcmp;
 } ResourceData;
 
-struct UResourceDataEntry;   // forward declared for ResoureDataValue below; actually defined in uresimp.h
+struct UResourceDataEntry;   // forward declared for ResourceDataValue below; actually defined in uresimp.h
 
 /*
  * Read a resource bundle from memory.

--- a/deps/ngtcp2/ngtcp2/lib/ngtcp2_log.h
+++ b/deps/ngtcp2/ngtcp2/lib/ngtcp2_log.h
@@ -46,7 +46,7 @@ typedef struct ngtcp2_log {
      told. */
   ngtcp2_tstamp last_ts;
   /* user_data is user-defined opaque data which is passed to
-     log_pritnf. */
+     log_printf. */
   void *user_data;
   /* scid is SCID encoded as NULL-terminated hex string. */
   uint8_t scid[NGTCP2_MAX_CIDLEN * 2 + 1];

--- a/deps/v8/src/codegen/code-stub-assembler.cc
+++ b/deps/v8/src/codegen/code-stub-assembler.cc
@@ -13194,7 +13194,7 @@ void CodeStubAssembler::EmitElementStore(
   // TODO(ishell): introduce TryToIntPtrOrSmi() and use BInt.
   TNode<IntPtrT> intptr_key = TryToIntptr(key, bailout);
 
-  // TODO(rmcilroy): TNodify the converted value once this funciton and
+  // TODO(rmcilroy): TNodify the converted value once this function and
   // StoreElement are templated based on the type elements_kind type.
   if (IsTypedArrayOrRabGsabTypedArrayElementsKind(elements_kind)) {
     TNode<JSTypedArray> typed_array = CAST(object);

--- a/deps/v8/src/codegen/compiler.cc
+++ b/deps/v8/src/codegen/compiler.cc
@@ -2912,7 +2912,7 @@ bool Compiler::Compile(Isolate* isolate, Handle<SharedFunctionInfo> shared_info,
   }
 
   if (script->produce_compile_hints()) {
-    // Log lazy funtion compilation.
+    // Log lazy function compilation.
     Handle<ArrayList> list;
     if (IsUndefined(script->compiled_lazy_function_positions())) {
       constexpr int kInitialLazyFunctionPositionListSize = 100;
@@ -4438,7 +4438,7 @@ void Compiler::PostInstantiation(Isolate* isolate,
       // Evict any deoptimized code on feedback vector. We need to do this after
       // creating the closure, since any heap allocations could trigger a GC and
       // deoptimized the code on the feedback vector. So check for any
-      // deoptimized code just before installing it on the funciton.
+      // deoptimized code just before installing it on the function.
       function->feedback_vector()->EvictOptimizedCodeMarkedForDeoptimization(
           isolate, *shared, "new function from shared function info");
       Tagged<Code> code = function->feedback_vector()->optimized_code(isolate);

--- a/deps/v8/src/execution/messages.h
+++ b/deps/v8/src/execution/messages.h
@@ -41,7 +41,7 @@ class V8_EXPORT_PRIVATE MessageLocation {
   MessageLocation(Handle<Script> script, int start_pos, int end_pos,
                   Handle<SharedFunctionInfo> shared);
   // Constructor for when source positions were not collected but which can be
-  // reconstructed from the SharedFuncitonInfo and bytecode offset.
+  // reconstructed from the SharedFunctionInfo and bytecode offset.
   MessageLocation(Handle<Script> script, Handle<SharedFunctionInfo> shared,
                   int bytecode_offset);
   MessageLocation();

--- a/deps/v8/src/objects/js-temporal-objects.cc
+++ b/deps/v8/src/objects/js-temporal-objects.cc
@@ -3727,7 +3727,7 @@ inline double IfEmptyReturnZero(double value) {
 Maybe<DurationRecord> ParseTemporalDurationString(Isolate* isolate,
                                                   Handle<String> iso_string) {
   TEMPORAL_ENTER_FUNC();
-  // In this funciton, we use 'double' as type for all mathematical values
+  // In this function, we use 'double' as type for all mathematical values
   // because in
   // https://tc39.es/proposal-temporal/#sec-properties-of-temporal-duration-instances
   // they are "A float64-representable integer representing the number" in the

--- a/deps/v8/test/cctest/test-swiss-name-dictionary-shared-tests.h
+++ b/deps/v8/test/cctest/test-swiss-name-dictionary-shared-tests.h
@@ -34,7 +34,7 @@ extern const char kCSATestFileName[];
 // Whenever creating an instance of this class in a file bar.cc, the template
 // parameter |kTestFileName| should be set to the name of the file that
 // *instantiates the class* (i.e., "bar.cc"). This ensures that the tests
-// defined below are then registred within the overall cctest machinery as if
+// defined below are then registered within the overall cctest machinery as if
 // they were directly written within bar.cc.
 template <typename TestRunner, char const* kTestFileName>
 struct SharedSwissTableTests {

--- a/deps/v8/test/mjsunit/compiler/regress-v8-5756.js
+++ b/deps/v8/test/mjsunit/compiler/regress-v8-5756.js
@@ -17,7 +17,7 @@ function k() {
                 // This causes two deopts, one eager at x = 1 and the
                 // other lazy at t[2] = z.
      t[2] = z; // since we are assigning to Uint8Array, ToNumber
-              // is called which calls this funciton again.
+              // is called which calls this function again.
   }
 }
 

--- a/deps/v8/test/webkit/stack-overflow-catch.js
+++ b/deps/v8/test/webkit/stack-overflow-catch.js
@@ -34,7 +34,7 @@ function test1()
 
     try {
         level = level + 1;
-        // Dummy code to make this funciton different from test2()
+        // Dummy code to make this function different from test2()
         dummy = level * level + 1;
         if (dummy == 0)
             debug('Should never get here!!!!');
@@ -53,7 +53,7 @@ function test2()
 {
     var myLevel = level;
 
-    // Dummy code to make this funciton different from test1()
+    // Dummy code to make this function different from test1()
     if (gotWrongCatch)
         debug('Should never get here!!!!');
 

--- a/deps/v8/tools/clusterfuzz/js_fuzzer/test/test_mutate_function_calls.js
+++ b/deps/v8/tools/clusterfuzz/js_fuzzer/test/test_mutate_function_calls.js
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 /**
- * @fileoverview Tests for mutating funciton calls.
+ * @fileoverview Tests for mutating function calls.
  */
 
 'use strict';


### PR DESCRIPTION
[deps] Fix typos across multiple files  

This PR fixes minor typos in various dependency-related files.  
These changes do not affect functionality and are limited to comments and documentation.  

- Fixed typos in `deps/icu-small`, `deps/ngtcp2`, and `deps/v8`.  
- No changes to executable code.  
- No impact on existing tests.  