### PR TITLE
src: fix node_config_file.h compilation error in GN build

### DIFF
--- a/src/node_config_file.h
+++ b/src/node_config_file.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <variant>
+#include "node_internals.h"
 #include "simdjson.h"
 #include "util-inl.h"
 


### PR DESCRIPTION
Fix the same compilation error of https://github.com/nodejs/node/pull/57173, without breaking building after https://github.com/nodejs/node/pull/57170.