### PR TITLE
src: improve error handling in tcp_wrap.cc

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1627,10 +1627,15 @@ static void MessageChannel(const FunctionCallbackInfo<Value>& args) {
 
   MessagePort::Entangle(port1, port2);
 
-  args.This()->Set(context, env->port1_string(), port1->object())
-      .Check();
-  args.This()->Set(context, env->port2_string(), port2->object())
-      .Check();
+  if (args.This()
+          ->Set(context, env->port1_string(), port1->object())
+          .IsNothing() ||
+      args.This()
+          ->Set(context, env->port2_string(), port2->object())
+          .IsNothing()) {
+    port1->Close();
+    port2->Close();
+  }
 }
 
 static void BroadcastChannel(const FunctionCallbackInfo<Value>& args) {

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -390,8 +390,9 @@ MaybeLocal<Object> AddressToJS(Environment* env,
 
   int port;
 
-  if (info.IsEmpty())
+  if (info.IsEmpty()) {
     info = Object::New(env->isolate());
+  }
 
   switch (addr->sa_family) {
   case AF_INET6:
@@ -413,32 +414,45 @@ MaybeLocal<Object> AddressToJS(Environment* env,
       }
     }
     port = ntohs(a6->sin6_port);
-    info->Set(env->context(),
-              env->address_string(),
-              OneByteString(env->isolate(), ip)).Check();
-    info->Set(env->context(), env->family_string(), env->ipv6_string()).Check();
-    info->Set(env->context(),
-              env->port_string(),
-              Integer::New(env->isolate(), port)).Check();
+    if (info->Set(env->context(),
+                  env->address_string(),
+                  OneByteString(env->isolate(), ip))
+            .IsNothing() ||
+        info->Set(env->context(), env->family_string(), env->ipv6_string())
+            .IsNothing() ||
+        info->Set(env->context(),
+                  env->port_string(),
+                  Integer::New(env->isolate(), port))
+            .IsNothing()) {
+      return {};
+    }
     break;
 
   case AF_INET:
     a4 = reinterpret_cast<const sockaddr_in*>(addr);
     uv_inet_ntop(AF_INET, &a4->sin_addr, ip, sizeof ip);
     port = ntohs(a4->sin_port);
-    info->Set(env->context(),
-              env->address_string(),
-              OneByteString(env->isolate(), ip)).Check();
-    info->Set(env->context(), env->family_string(), env->ipv4_string()).Check();
-    info->Set(env->context(),
-              env->port_string(),
-              Integer::New(env->isolate(), port)).Check();
+    if (info->Set(env->context(),
+                  env->address_string(),
+                  OneByteString(env->isolate(), ip))
+            .IsNothing() ||
+        info->Set(env->context(), env->family_string(), env->ipv4_string())
+            .IsNothing() ||
+        info->Set(env->context(),
+                  env->port_string(),
+                  Integer::New(env->isolate(), port))
+            .IsNothing()) {
+      return {};
+    }
     break;
 
   default:
-    info->Set(env->context(),
-              env->address_string(),
-              String::Empty(env->isolate())).Check();
+    if (info->Set(env->context(),
+                  env->address_string(),
+                  String::Empty(env->isolate()))
+            .IsNothing()) {
+      return {};
+    }
   }
 
   return scope.Escape(info);

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -100,8 +100,12 @@ void TTYWrap::GetWindowSize(const FunctionCallbackInfo<Value>& args) {
 
   if (err == 0) {
     Local<Array> a = args[0].As<Array>();
-    a->Set(env->context(), 0, Integer::New(env->isolate(), width)).Check();
-    a->Set(env->context(), 1, Integer::New(env->isolate(), height)).Check();
+    if (a->Set(env->context(), 0, Integer::New(env->isolate(), width))
+            .IsNothing() ||
+        a->Set(env->context(), 1, Integer::New(env->isolate(), height))
+            .IsNothing()) {
+      return;
+    }
   }
 
   args.GetReturnValue().Set(err);


### PR DESCRIPTION
More error handling improvements.

In case folks are curious why I've been working on these across multiple PRs.. Consider this example:

```js
Object.defineProperty(Object.prototype, 'port1', {
  set() { throw new Error('boom'); }
});

new MessageChannel();
```

Before this PR: crashes the process
With this PR: throws the catchable error