### PR TITLE
test: swap assert.strictEqual() parameters

### DIFF
--- a/test/parallel/test-buffer-bigint64.js
+++ b/test/parallel/test-buffer-bigint64.js
@@ -9,23 +9,23 @@ const buf = Buffer.allocUnsafe(8);
   let val = 123456789n;
   buf[`writeBigInt64${endianness}`](val, 0);
   let rtn = buf[`readBigInt64${endianness}`](0);
-  assert.strictEqual(val, rtn);
+  assert.strictEqual(rtn, val);
 
   // Should allow INT64_MAX to be written and read
   val = 0x7fffffffffffffffn;
   buf[`writeBigInt64${endianness}`](val, 0);
   rtn = buf[`readBigInt64${endianness}`](0);
-  assert.strictEqual(val, rtn);
+  assert.strictEqual(rtn, val);
 
   // Should read and write a negative signed 64-bit integer
   val = -123456789n;
   buf[`writeBigInt64${endianness}`](val, 0);
-  assert.strictEqual(val, buf[`readBigInt64${endianness}`](0));
+  assert.strictEqual(buf[`readBigInt64${endianness}`](0), val);
 
   // Should read and write an unsigned 64-bit integer
   val = 123456789n;
   buf[`writeBigUInt64${endianness}`](val, 0);
-  assert.strictEqual(val, buf[`readBigUInt64${endianness}`](0));
+  assert.strictEqual(buf[`readBigUInt64${endianness}`](0), val);
 
   // Should throw a RangeError upon INT64_MAX+1 being written
   assert.throws(function() {


### PR DESCRIPTION
The `actual` and the `expected` parameters are respectively the first and the second.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
