### PR TITLE
build,win: disable node pch with ccache

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -69,12 +69,16 @@
         'NODE_PLATFORM="win32"',
         '_UNICODE=1',
       ],
-      'msvs_precompiled_header': 'tools/msvs/pch/node_pch.h',
-      'msvs_precompiled_source': 'tools/msvs/pch/node_pch.cc',
-      'sources': [
-        '<(_msvs_precompiled_header)',
-        '<(_msvs_precompiled_source)',
-      ],
+      'conditions': [
+          ['clang != 1 or use_ccache_win != 1', {
+            'msvs_precompiled_header': 'tools/msvs/pch/node_pch.h',
+            'msvs_precompiled_source': 'tools/msvs/pch/node_pch.cc',
+            'sources': [
+              '<(_msvs_precompiled_header)',
+              '<(_msvs_precompiled_source)',
+            ],
+          }]
+      ]
     }, { # POSIX
       'defines': [ '__POSIX__' ],
     }],


### PR DESCRIPTION
This is a continuation of the [previously landed PR](https://github.com/nodejs/node/pull/56847) disabling V8 pch when using ClangCL and ccache. The issue here is similar, only not visible in each build (as some V8 files are generated during the build phase).

I've disabled the ClangCL compilation in the CI until this lands as it can block valid PRs from landing. For more details check any failed build [here](https://ci.nodejs.org/job/node-compile-windows/nodes=win-vs2022_clang/). What you'll find there is that either embedtest.pch or libnode.pch is causing issue, and this change will resolve that.

cc @joyeecheung @nodejs/platform-windows 

P.S. I'd also like to use fast-tracking here so that I can reenable the ClangCL compilation in the CI ASAP.