### PR TITLE
Add possible-flaky test-perf-hooks entry to solaris/SmartOS/illumos

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -31,8 +31,10 @@ test-single-executable-application-empty: PASS, FLAKY
 # https://github.com/nodejs/node/issues/43465
 test-http-server-request-timeouts-mixed: PASS, FLAKY
 
-[$system==solaris] # Also applies to SmartOS
+[$system==solaris] # Also applies to SmartOS/illumos
 test-worker-prof: PASS, FLAKY
+# https://github.com/nodejs/node/issues/57000
+test-perf-hooks: PASS, FLAKY
 
 [$system==freebsd]
 


### PR DESCRIPTION
Per #57000 , the SmartOS/illumos failure seems due to jitter in one of the three terms of the test assertion.  Until we determine if it's an underpowered VM, disparate sources of high-res-time, or some other factor, I'd like to put a "flaky" entry for `test-perf-hooks`.