### PR TITLE
test: more common.mustNotCall in net

### DIFF
--- a/test/parallel/test-net-eaddrinuse.js
+++ b/test/parallel/test-net-eaddrinuse.js
@@ -24,10 +24,8 @@ const common = require('../common');
 const assert = require('assert');
 const net = require('net');
 
-const server1 = net.createServer(function(socket) {
-});
-const server2 = net.createServer(function(socket) {
-});
+const server1 = net.createServer(common.mustNotCall());
+const server2 = net.createServer(common.mustNotCall());
 server1.listen(0, common.mustCall(function() {
   server2.on('error', function(error) {
     assert.strictEqual(error.message.includes('EADDRINUSE'), true);

--- a/test/parallel/test-net-listen-close-server.js
+++ b/test/parallel/test-net-listen-close-server.js
@@ -23,8 +23,7 @@
 const common = require('../common');
 const net = require('net');
 
-const server = net.createServer(function(socket) {
-});
+const server = net.createServer(common.mustNotCall());
 server.listen(0, common.mustNotCall());
 server.on('error', common.mustNotCall());
 server.close();

--- a/test/parallel/test-net-listen-error.js
+++ b/test/parallel/test-net-listen-error.js
@@ -23,7 +23,6 @@
 const common = require('../common');
 const net = require('net');
 
-const server = net.createServer(function(socket) {
-});
+const server = net.createServer(common.mustNotCall());
 server.listen(1, '1.1.1.1', common.mustNotCall()); // EACCES or EADDRNOTAVAIL
 server.on('error', common.mustCall());

--- a/test/parallel/test-tls-close-error.js
+++ b/test/parallel/test-tls-close-error.js
@@ -11,8 +11,7 @@ const fixtures = require('../common/fixtures');
 const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem')
-}, function(c) {
-}).listen(0, common.mustCall(function() {
+}, common.mustNotCall()).listen(0, common.mustCall(function() {
   const c = tls.connect(this.address().port, common.mustNotCall());
 
   c.on('error', common.mustCall());

--- a/test/parallel/test-tls-handshake-error.js
+++ b/test/parallel/test-tls-handshake-error.js
@@ -14,8 +14,7 @@ const server = tls.createServer({
   key: fixtures.readKey('agent1-key.pem'),
   cert: fixtures.readKey('agent1-cert.pem'),
   rejectUnauthorized: true
-}, function(c) {
-}).listen(0, common.mustCall(function() {
+}, common.mustNotCall()).listen(0, common.mustCall(function() {
   assert.throws(() => {
     tls.connect({
       port: this.address().port,


### PR DESCRIPTION
common.mustCall and common.mustNotCall are always better than empty callbacks when ensuring correctness