### PR TITLE
src: use Maybe<void> in ProcessEmitWarningSync

### DIFF
--- a/src/node_process.h
+++ b/src/node_process.h
@@ -37,7 +37,7 @@ inline v8::Maybe<bool> ProcessEmitWarning(Environment* env,
                                           const char* fmt,
                                           Args&&... args);
 
-v8::Maybe<bool> ProcessEmitWarningSync(Environment* env,
+v8::Maybe<void> ProcessEmitWarningSync(Environment* env,
                                        std::string_view message);
 v8::Maybe<bool> ProcessEmitExperimentalWarning(Environment* env,
                                                const std::string& warning);

--- a/src/node_process_events.cc
+++ b/src/node_process_events.cc
@@ -10,6 +10,7 @@ using v8::Function;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Just;
+using v8::JustVoid;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
@@ -19,7 +20,7 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-Maybe<bool> ProcessEmitWarningSync(Environment* env, std::string_view message) {
+Maybe<void> ProcessEmitWarningSync(Environment* env, std::string_view message) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
   Local<String> message_string;
@@ -28,7 +29,7 @@ Maybe<bool> ProcessEmitWarningSync(Environment* env, std::string_view message) {
                            NewStringType::kNormal,
                            static_cast<int>(message.size()))
            .ToLocal(&message_string)) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
 
   Local<Value> argv[] = {message_string};
@@ -39,9 +40,9 @@ Maybe<bool> ProcessEmitWarningSync(Environment* env, std::string_view message) {
   if (emit_function.As<Function>()
           ->Call(context, v8::Undefined(isolate), arraysize(argv), argv)
           .IsEmpty()) {
-    return Nothing<bool>();
+    return Nothing<void>();
   }
-  return Just(true);
+  return JustVoid();
 }
 
 MaybeLocal<Value> ProcessEmit(Environment* env,


### PR DESCRIPTION
This patch uses `Maybe<void>` in the function where only the success result seems needed.