### PR TITLE
timers: remove unused parameter from insertGuarded

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -362,12 +362,12 @@ function unrefActive(item) {
 //
 // Appends a timer onto the end of an existing timers list, or creates a new
 // list if one does not already exist for the specified timeout duration.
-function insertGuarded(item, refed, start) {
+function insertGuarded(item, refed) {
   const msecs = item._idleTimeout;
   if (msecs < 0 || msecs === undefined)
     return;
 
-  insert(item, msecs, start);
+  insert(item, msecs);
 
   const isDestroyed = item._destroyed;
   if (isDestroyed || !item[async_id_symbol]) {


### PR DESCRIPTION
`insert` has a third optional parameter and sometimes it's called with 2 arguments instead of 3

This is not the case for `insertGuarded`, its third parameter is never used and the function is not exported, so it's safe to remove