### PR TITLE
lib: remove obsolete Cipher export

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -303,7 +303,7 @@ console.log(cert.verifySpkac(Buffer.from(spkac)));
 // Prints: true or false
 ```
 
-## Class: `Cipher`
+## Class: `Cipheriv`
 
 <!-- YAML
 added: v0.1.94
@@ -311,7 +311,7 @@ added: v0.1.94
 
 * Extends: {stream.Transform}
 
-Instances of the `Cipher` class are used to encrypt data. The class can be
+Instances of the `Cipheriv` class are used to encrypt data. The class can be
 used in one of two ways:
 
 * As a [stream][] that is both readable and writable, where plain unencrypted
@@ -320,10 +320,10 @@ used in one of two ways:
   the encrypted data.
 
 The [`crypto.createCipheriv()`][] method is
-used to create `Cipher` instances. `Cipher` objects are not to be created
+used to create `Cipheriv` instances. `Cipheriv` objects are not to be created
 directly using the `new` keyword.
 
-Example: Using `Cipher` objects as streams:
+Example: Using `Cipheriv` objects as streams:
 
 ```mjs
 const {
@@ -391,7 +391,7 @@ scrypt(password, 'salt', 24, (err, key) => {
 });
 ```
 
-Example: Using `Cipher` and piped streams:
+Example: Using `Cipheriv` and piped streams:
 
 ```mjs
 import {
@@ -538,7 +538,7 @@ added: v0.1.94
   If `outputEncoding` is specified, a string is
   returned. If an `outputEncoding` is not provided, a [`Buffer`][] is returned.
 
-Once the `cipher.final()` method has been called, the `Cipher` object can no
+Once the `cipher.final()` method has been called, the `Cipheriv` object can no
 longer be used to encrypt data. Attempts to call `cipher.final()` more than
 once will result in an error being thrown.
 
@@ -570,7 +570,7 @@ added: v1.0.0
 * `options` {Object} [`stream.transform` options][]
   * `plaintextLength` {number}
   * `encoding` {string} The string encoding to use when `buffer` is a string.
-* Returns: {Cipher} The same `Cipher` instance for method chaining.
+* Returns: {Cipher} The same `Cipheriv` instance for method chaining.
 
 When using an authenticated encryption mode (`GCM`, `CCM`, `OCB`, and
 `chacha20-poly1305` are
@@ -590,9 +590,9 @@ added: v0.7.1
 -->
 
 * `autoPadding` {boolean} **Default:** `true`
-* Returns: {Cipher} The same `Cipher` instance for method chaining.
+* Returns: {Cipher} The same `Cipheriv` instance for method chaining.
 
-When using block encryption algorithms, the `Cipher` class will automatically
+When using block encryption algorithms, the `Cipheriv` class will automatically
 add padding to the input data to the appropriate block size. To disable the
 default padding call `cipher.setAutoPadding(false)`.
 
@@ -635,7 +635,7 @@ The `cipher.update()` method can be called multiple times with new data until
 [`cipher.final()`][] is called. Calling `cipher.update()` after
 [`cipher.final()`][] will result in an error being thrown.
 
-## Class: `Decipher`
+## Class: `Decipheriv`
 
 <!-- YAML
 added: v0.1.94
@@ -643,7 +643,7 @@ added: v0.1.94
 
 * Extends: {stream.Transform}
 
-Instances of the `Decipher` class are used to decrypt data. The class can be
+Instances of the `Decipheriv` class are used to decrypt data. The class can be
 used in one of two ways:
 
 * As a [stream][] that is both readable and writable, where plain encrypted
@@ -652,10 +652,10 @@ used in one of two ways:
   produce the unencrypted data.
 
 The [`crypto.createDecipheriv()`][] method is
-used to create `Decipher` instances. `Decipher` objects are not to be created
+used to create `Decipheriv` instances. `Decipheriv` objects are not to be created
 directly using the `new` keyword.
 
-Example: Using `Decipher` objects as streams:
+Example: Using `Decipheriv` objects as streams:
 
 ```mjs
 import { Buffer } from 'node:buffer';
@@ -731,7 +731,7 @@ decipher.write(encrypted, 'hex');
 decipher.end();
 ```
 
-Example: Using `Decipher` and piped streams:
+Example: Using `Decipheriv` and piped streams:
 
 ```mjs
 import {
@@ -848,7 +848,7 @@ added: v0.1.94
   If `outputEncoding` is specified, a string is
   returned. If an `outputEncoding` is not provided, a [`Buffer`][] is returned.
 
-Once the `decipher.final()` method has been called, the `Decipher` object can
+Once the `decipher.final()` method has been called, the `Decipheriv` object can
 no longer be used to decrypt data. Attempts to call `decipher.final()` more
 than once will result in an error being thrown.
 
@@ -3038,7 +3038,7 @@ changes:
 * `options` {Object} [`stream.transform` options][]
 * Returns: {Cipher}
 
-Creates and returns a `Cipher` object, with the given `algorithm`, `key` and
+Creates and returns a `Cipheriv` object, with the given `algorithm`, `key` and
 initialization vector (`iv`).
 
 The `options` argument controls stream behavior and is optional except when a
@@ -3108,7 +3108,7 @@ changes:
 * `options` {Object} [`stream.transform` options][]
 * Returns: {Decipher}
 
-Creates and returns a `Decipher` object that uses the given `algorithm`, `key`
+Creates and returns a `Decipheriv` object that uses the given `algorithm`, `key`
 and initialization vector (`iv`).
 
 The `options` argument controls stream behavior and is optional except when a

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2276,7 +2276,7 @@ initialization vectors.
 It is recommended to derive a key using
 [`crypto.pbkdf2()`][] or [`crypto.scrypt()`][] with random salts and to use
 [`crypto.createCipheriv()`][] and [`crypto.createDecipheriv()`][] to obtain the
-[`Cipher`][] and [`Decipher`][] objects respectively.
+[`Cipheriv`][] and [`Decipheriv`][] objects respectively.
 
 ### DEP0107: `tls.convertNPNProtocols()`
 
@@ -3854,8 +3854,8 @@ deprecated, as their values are guaranteed to be identical to that of `process.f
 [`Buffer.from(array)`]: buffer.md#static-method-bufferfromarray
 [`Buffer.from(buffer)`]: buffer.md#static-method-bufferfrombuffer
 [`Buffer.isBuffer()`]: buffer.md#static-method-bufferisbufferobj
-[`Cipher`]: crypto.md#class-cipher
-[`Decipher`]: crypto.md#class-decipher
+[`Cipheriv`]: crypto.md#class-cipheriv
+[`Decipheriv`]: crypto.md#class-decipheriv
 [`REPLServer.clearBufferedCommand()`]: repl.md#replserverclearbufferedcommand
 [`ReadStream.open()`]: fs.md#class-fsreadstream
 [`Server.getConnections()`]: net.md#servergetconnectionscallback

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -88,9 +88,7 @@ const {
   diffieHellman,
 } = require('internal/crypto/diffiehellman');
 const {
-  Cipher,
   Cipheriv,
-  Decipher,
   Decipheriv,
   privateDecrypt,
   privateEncrypt,
@@ -224,9 +222,7 @@ module.exports = {
 
   // Classes
   Certificate,
-  Cipher,
   Cipheriv,
-  Decipher,
   Decipheriv,
   DiffieHellman,
   DiffieHellmanGroup,

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -138,20 +138,12 @@ function createCipherWithIV(cipher, key, options, decipher, iv) {
 // the Cipher class is defined using the legacy function syntax rather than
 // ES6 classes.
 
-function Cipher(cipher, password, options) {
-  if (!(this instanceof Cipher))
-    return new Cipher(cipher, password, options);
-}
-
-ObjectSetPrototypeOf(Cipher.prototype, LazyTransform.prototype);
-ObjectSetPrototypeOf(Cipher, LazyTransform);
-
-Cipher.prototype._transform = function _transform(chunk, encoding, callback) {
+function _transform(chunk, encoding, callback) {
   this.push(this[kHandle].update(chunk, encoding));
   callback();
 };
 
-Cipher.prototype._flush = function _flush(callback) {
+function _flush(callback) {
   try {
     this.push(this[kHandle].final());
   } catch (e) {
@@ -161,7 +153,7 @@ Cipher.prototype._flush = function _flush(callback) {
   callback();
 };
 
-Cipher.prototype.update = function update(data, inputEncoding, outputEncoding) {
+function update(data, inputEncoding, outputEncoding) {
   if (typeof data === 'string') {
     validateEncoding(data, inputEncoding);
   } else if (!isArrayBufferView(data)) {
@@ -179,8 +171,7 @@ Cipher.prototype.update = function update(data, inputEncoding, outputEncoding) {
   return ret;
 };
 
-
-Cipher.prototype.final = function final(outputEncoding) {
+function final(outputEncoding) {
   const ret = this[kHandle].final();
 
   if (outputEncoding && outputEncoding !== 'buffer') {
@@ -191,20 +182,18 @@ Cipher.prototype.final = function final(outputEncoding) {
   return ret;
 };
 
-
-Cipher.prototype.setAutoPadding = function setAutoPadding(ap) {
+function setAutoPadding(ap) {
   if (!this[kHandle].setAutoPadding(!!ap))
     throw new ERR_CRYPTO_INVALID_STATE('setAutoPadding');
   return this;
 };
 
-Cipher.prototype.getAuthTag = function getAuthTag() {
+function getAuthTag() {
   const ret = this[kHandle].getAuthTag();
   if (ret === undefined)
     throw new ERR_CRYPTO_INVALID_STATE('getAuthTag');
   return ret;
 };
-
 
 function setAuthTag(tagbuf, encoding) {
   tagbuf = getArrayBufferOrView(tagbuf, 'buffer', encoding);
@@ -213,7 +202,7 @@ function setAuthTag(tagbuf, encoding) {
   return this;
 }
 
-Cipher.prototype.setAAD = function setAAD(aadbuf, options) {
+function setAAD(aadbuf, options) {
   const encoding = getStringOption(options, 'encoding');
   const plaintextLength = getUIntOption(options, 'plaintextLength');
   aadbuf = getArrayBufferOrView(aadbuf, 'aadbuf', encoding);
@@ -235,42 +224,27 @@ function Cipheriv(cipher, key, iv, options) {
 }
 
 function addCipherPrototypeFunctions(constructor) {
-  constructor.prototype._transform = Cipher.prototype._transform;
-  constructor.prototype._flush = Cipher.prototype._flush;
-  constructor.prototype.update = Cipher.prototype.update;
-  constructor.prototype.final = Cipher.prototype.final;
-  constructor.prototype.setAutoPadding = Cipher.prototype.setAutoPadding;
+  constructor.prototype._transform = _transform;
+  constructor.prototype._flush = _flush;
+  constructor.prototype.update = update;
+  constructor.prototype.final = final;
+  constructor.prototype.setAutoPadding = setAutoPadding;
   if (constructor === Cipheriv) {
-    constructor.prototype.getAuthTag = Cipher.prototype.getAuthTag;
+    constructor.prototype.getAuthTag = getAuthTag;
   } else {
     constructor.prototype.setAuthTag = setAuthTag;
   }
-  constructor.prototype.setAAD = Cipher.prototype.setAAD;
+  constructor.prototype.setAAD = setAAD;
 }
 
 ObjectSetPrototypeOf(Cipheriv.prototype, LazyTransform.prototype);
 ObjectSetPrototypeOf(Cipheriv, LazyTransform);
 addCipherPrototypeFunctions(Cipheriv);
 
-// The Decipher class is part of the legacy Node.js crypto API. It exposes
-// a stream-based encryption/decryption model. For backwards compatibility
-// the Decipher class is defined using the legacy function syntax rather than
-// ES6 classes.
-
-function Decipher(cipher, password, options) {
-  if (!(this instanceof Decipher))
-    return new Decipher(cipher, password, options);
-}
-
-ObjectSetPrototypeOf(Decipher.prototype, LazyTransform.prototype);
-ObjectSetPrototypeOf(Decipher, LazyTransform);
-addCipherPrototypeFunctions(Decipher);
-
 // The Decipheriv class is part of the legacy Node.js crypto API. It exposes
 // a stream-based encryption/decryption model. For backwards compatibility
 // the Decipheriv class is defined using the legacy function syntax rather than
 // ES6 classes.
-
 function Decipheriv(cipher, key, iv, options) {
   if (!(this instanceof Decipheriv))
     return new Decipheriv(cipher, key, iv, options);

--- a/tools/doc/type-parser.mjs
+++ b/tools/doc/type-parser.mjs
@@ -75,8 +75,8 @@ const customTypesMap = {
 
   'cluster.Worker': 'cluster.html#class-worker',
 
-  'Cipher': 'crypto.html#class-cipher',
-  'Decipher': 'crypto.html#class-decipher',
+  'Cipheriv': 'crypto.html#class-cipheriv',
+  'Decipheriv': 'crypto.html#class-decipheriv',
   'DiffieHellman': 'crypto.html#class-diffiehellman',
   'DiffieHellmanGroup': 'crypto.html#class-diffiehellmangroup',
   'ECDH': 'crypto.html#class-ecdh',


### PR DESCRIPTION
`Cipher` and `Decipher` were removed from the public API a while ago but we were still defining them and exporting both on `require('crypto')` as `undefined`. What's worse is that the documentation was showing `Cipher` and `Decipher` and not mentioning `Cipheriv` or `Decipheriv` at all (which are the actual exports). Silly us.

This *should not* technically be semver-major thankfully since the values were `undefined` already and wouldn't have worked for anything. That said, if someone is using ESM, `import { Cipher, Decipher } from 'node:crypto'` would have worked before but wouldn't work now... so maybe that means it still technically needs to be semver-major? Really not sure so asking for some input. @nodejs/tsc @nodejs/security 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
