### PR TITLE
buffer: optimize read UInt16/24 functions with bitwise operators

### DIFF
--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -234,7 +234,7 @@ function readUInt24LE(buf, offset = 0) {
   if (first === undefined || last === undefined)
     boundsError(offset, buf.length - 3);
 
-  return first + buf[++offset] * 2 ** 8 + last * 2 ** 16;
+  return first | (buf[++offset] << 8) | (last << 16);
 }
 
 function readUInt16LE(offset = 0) {
@@ -244,7 +244,7 @@ function readUInt16LE(offset = 0) {
   if (first === undefined || last === undefined)
     boundsError(offset, this.length - 2);
 
-  return first + last * 2 ** 8;
+  return first | (last << 8);
 }
 
 function readUInt8(offset = 0) {
@@ -323,7 +323,7 @@ function readUInt24BE(buf, offset = 0) {
   if (first === undefined || last === undefined)
     boundsError(offset, buf.length - 3);
 
-  return first * 2 ** 16 + buf[++offset] * 2 ** 8 + last;
+  return (first << 16) | (buf[++offset] << 8) | last;
 }
 
 function readUInt16BE(offset = 0) {
@@ -333,7 +333,7 @@ function readUInt16BE(offset = 0) {
   if (first === undefined || last === undefined)
     boundsError(offset, this.length - 2);
 
-  return first * 2 ** 8 + last;
+  return (first << 8) | last;
 }
 
 function readIntLE(offset, byteLength) {


### PR DESCRIPTION
These are functions where it's completely safe to use bitwise operators

The maximum value here is 255, so up to `255 << 16` is fine