### PR TITLE
doc: TypeScript docs should recommend `erasableSyntaxOnly`

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -76,7 +76,7 @@ generation, and by replacing inline types with whitespace, Node.js can run
 TypeScript code without the need for source maps.
 
 Type stripping is compatible with most versions of TypeScript
-but we recommend version 5.7 or newer with the following `tsconfig.json` settings:
+but we recommend version 5.8 or newer with the following `tsconfig.json` settings:
 
 ```json
 {
@@ -85,6 +85,7 @@ but we recommend version 5.7 or newer with the following `tsconfig.json` setting
      "module": "nodenext",
      "allowImportingTsExtensions": true,
      "rewriteRelativeImportExtensions": true,
+     "erasableSyntaxOnly": true,
      "verbatimModuleSyntax": true
   }
 }

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -83,7 +83,6 @@ but we recommend version 5.8 or newer with the following `tsconfig.json` setting
   "compilerOptions": {
      "target": "esnext",
      "module": "nodenext",
-     "allowImportingTsExtensions": true,
      "rewriteRelativeImportExtensions": true,
      "erasableSyntaxOnly": true,
      "verbatimModuleSyntax": true


### PR DESCRIPTION
TypeScript 5.8 is now released which adds a new tsconfig flag (`--erasableSyntaxOnly`) that aligns the TypeScript checker with Node's default behavior.

https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly

Two weeks ago this options was added to the recommended TSConfig for Node which resides in the `tsconfig/bases` project.

https://github.com/tsconfig/bases/blob/main/bases/node-ts.json

cc: @nodejs/typescript 