### PR TITLE
crypto: add optional callback to crypto.diffieHellman

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3533,22 +3533,31 @@ the corresponding digest algorithm. This does not work for all signature
 algorithms, such as `'ecdsa-with-SHA256'`, so it is best to always use digest
 algorithm names.
 
-### `crypto.diffieHellman(options)`
+### `crypto.diffieHellman(options[, callback])`
 
 <!-- YAML
 added:
  - v13.9.0
  - v12.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57274
+    description: Optional callback argument added.
 -->
 
 * `options`: {Object}
   * `privateKey`: {KeyObject}
   * `publicKey`: {KeyObject}
-* Returns: {Buffer}
+* `callback` {Function}
+  * `err` {Error}
+  * `secret` {Buffer}
+* Returns: {Buffer} if the `callback` function is not provided.
 
 Computes the Diffie-Hellman secret based on a `privateKey` and a `publicKey`.
 Both keys must have the same `asymmetricKeyType`, which must be one of `'dh'`
 (for Diffie-Hellman), `'ec'`, `'x448'`, or `'x25519'` (for ECDH).
+
+If the `callback` function is provided this function uses libuv's threadpool.
 
 ### `crypto.fips`
 

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayBufferPrototypeSlice,
+  FunctionPrototypeCall,
   MathCeil,
   ObjectDefineProperty,
   SafeSet,
@@ -11,13 +12,14 @@ const {
 const { Buffer } = require('buffer');
 
 const {
+  DHBitsJob,
   DiffieHellman: _DiffieHellman,
   DiffieHellmanGroup: _DiffieHellmanGroup,
   ECDH: _ECDH,
   ECDHBitsJob,
   ECDHConvertKey: _ECDHConvertKey,
-  statelessDH,
   kCryptoJobAsync,
+  kCryptoJobSync,
 } = internalBinding('crypto');
 
 const {
@@ -32,6 +34,7 @@ const {
 } = require('internal/errors');
 
 const {
+  validateFunction,
   validateInt32,
   validateObject,
   validateString,
@@ -268,8 +271,11 @@ function getFormat(format) {
 
 const dhEnabledKeyTypes = new SafeSet(['dh', 'ec', 'x448', 'x25519']);
 
-function diffieHellman(options) {
+function diffieHellman(options, callback) {
   validateObject(options, 'options');
+
+  if (callback !== undefined)
+    validateFunction(callback, 'callback');
 
   const { privateKey, publicKey } = options;
   if (!(privateKey instanceof KeyObject))
@@ -293,7 +299,24 @@ function diffieHellman(options) {
                                           `${privateType} and ${publicType}`);
   }
 
-  return statelessDH(privateKey[kHandle], publicKey[kHandle]);
+  const job = new DHBitsJob(
+    callback ? kCryptoJobAsync : kCryptoJobSync,
+    publicKey[kHandle],
+    privateKey[kHandle]);
+
+  if (!callback) {
+    const { 0: err, 1: secret } = job.run();
+    if (err !== undefined)
+      throw err;
+
+    return Buffer.from(secret);
+  }
+
+  job.ondone = (error, secret) => {
+    if (error) return FunctionPrototypeCall(callback, job, error);
+    FunctionPrototypeCall(callback, job, null, Buffer.from(secret));
+  };
+  job.run();
 }
 
 let masks;

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -483,49 +483,11 @@ WebCryptoKeyExportStatus DHKeyExportTraits::DoExport(
   }
 }
 
-namespace {
-ByteSource StatelessDiffieHellmanThreadsafe(const EVPKeyPointer& our_key,
-                                            const EVPKeyPointer& their_key) {
-  auto dp = DHPointer::stateless(our_key, their_key);
-  if (!dp) return {};
-  DCHECK(!dp.isSecure());
-
-  return ByteSource::Allocated(dp.release());
-}
-
-void Stateless(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  CHECK(args[0]->IsObject() && args[1]->IsObject());
-  KeyObjectHandle* our_key_object;
-  ASSIGN_OR_RETURN_UNWRAP(&our_key_object, args[0].As<Object>());
-  CHECK_EQ(our_key_object->Data().GetKeyType(), kKeyTypePrivate);
-  KeyObjectHandle* their_key_object;
-  ASSIGN_OR_RETURN_UNWRAP(&their_key_object, args[1].As<Object>());
-  CHECK_NE(their_key_object->Data().GetKeyType(), kKeyTypeSecret);
-
-  const auto& our_key = our_key_object->Data().GetAsymmetricKey();
-  const auto& their_key = their_key_object->Data().GetAsymmetricKey();
-
-  Local<Value> out;
-  if (!StatelessDiffieHellmanThreadsafe(our_key, their_key)
-          .ToBuffer(env)
-              .ToLocal(&out)) return;
-
-  if (Buffer::Length(out) == 0)
-    return ThrowCryptoError(env, ERR_get_error(), "diffieHellman failed");
-
-  args.GetReturnValue().Set(out);
-}
-}  // namespace
-
 Maybe<void> DHBitsTraits::AdditionalConfig(
     CryptoJobMode mode,
     const FunctionCallbackInfo<Value>& args,
     unsigned int offset,
     DHBitsConfig* params) {
-  Environment* env = Environment::GetCurrent(args);
-
   CHECK(args[offset]->IsObject());  // public key
   CHECK(args[offset + 1]->IsObject());  // private key
 
@@ -535,11 +497,8 @@ Maybe<void> DHBitsTraits::AdditionalConfig(
   ASSIGN_OR_RETURN_UNWRAP(&public_key, args[offset], Nothing<void>());
   ASSIGN_OR_RETURN_UNWRAP(&private_key, args[offset + 1], Nothing<void>());
 
-  if (private_key->Data().GetKeyType() != kKeyTypePrivate ||
-      public_key->Data().GetKeyType() != kKeyTypePublic) {
-    THROW_ERR_CRYPTO_INVALID_KEYTYPE(env);
-    return Nothing<void>();
-  }
+  CHECK(private_key->Data().GetKeyType() == kKeyTypePrivate);
+  CHECK(public_key->Data().GetKeyType() != kKeyTypeSecret);
 
   params->public_key = public_key->Data().addRef();
   params->private_key = private_key->Data().addRef();
@@ -557,8 +516,20 @@ bool DHBitsTraits::DeriveBits(
     Environment* env,
     const DHBitsConfig& params,
     ByteSource* out) {
-  *out = StatelessDiffieHellmanThreadsafe(params.private_key.GetAsymmetricKey(),
-                                          params.public_key.GetAsymmetricKey());
+  auto dp = DHPointer::stateless(params.private_key.GetAsymmetricKey(),
+                                 params.public_key.GetAsymmetricKey());
+  if (!dp) {
+    bool can_throw =
+        per_process::v8_initialized && Isolate::TryGetCurrent() != nullptr;
+    if (can_throw) {
+      unsigned long err = ERR_get_error();  // NOLINT(runtime/int)
+      if (err) ThrowCryptoError(env, err, "diffieHellman failed");
+    }
+    return false;
+  }
+
+  *out = ByteSource::Allocated(dp.release());
+  CHECK(!out->empty());
   return true;
 }
 
@@ -611,7 +582,6 @@ void DiffieHellman::Initialize(Environment* env, Local<Object> target) {
   make(FIXED_ONE_BYTE_STRING(env->isolate(), "DiffieHellmanGroup"),
        DiffieHellmanGroup);
 
-  SetMethodNoSideEffect(context, target, "statelessDH", Stateless);
   DHKeyPairGenJob::Initialize(env, target);
   DHKeyExportJob::Initialize(env, target);
   DHBitsJob::Initialize(env, target);
@@ -632,7 +602,6 @@ void DiffieHellman::RegisterExternalReferences(
   registry->Register(SetPrivateKey);
 
   registry->Register(Check);
-  registry->Register(Stateless);
 
   DHKeyPairGenJob::RegisterExternalReferences(registry);
   DHKeyExportJob::RegisterExternalReferences(registry);


### PR DESCRIPTION
This adds optional callback for the stateless `crypto.diffieHellman` method to allow for the key derivation to happen in libuv's threadpool.

In the asynchronous case, the OpenSSL code/library/reason error decoration is missing (because it relies on retrieving details from OpenSSL's error queue, which does not work across threads), this is something we will have to refactor in a semver-major with a broader callback methods error handling reimagining (as I've discussed privately with @tniessen), this is likely a larger endeavor now that ncrypto is in the mix.

cc @jasnell 