### PR TITLE
stream: fix `sizeAlgorithm` validation in WritableStream

### DIFF
--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -1181,7 +1181,9 @@ function writableStreamDefaultControllerGetChunkSize(controller, chunk) {
     sizeAlgorithm,
   } = controller[kState];
   if (sizeAlgorithm === undefined) {
-    assert(stream[kState].state === 'errored' || stream[kState].state === 'erroring');
+    assert(stream[kState].state === 'closed' ||
+           stream[kState].state === 'errored' ||
+           stream[kState].state === 'erroring');
     return 1;
   }
 

--- a/test/parallel/test-whatwg-writablestream-close.js
+++ b/test/parallel/test-whatwg-writablestream-close.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../common');
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+// https://github.com/nodejs/node/issues/57272
+
+test('should throw error when writing after close', async (t) => {
+  const writable = new WritableStream({
+    write(chunk) {
+      console.log(chunk);
+    },
+  });
+
+  const writer = writable.getWriter();
+
+  await writer.write('Hello');
+  await writer.close();
+
+  await assert.rejects(
+    async () => {
+      await writer.write('World');
+    },
+    {
+      name: 'TypeError',
+    }
+  );
+});


### PR DESCRIPTION
`sizeAlgorithm` seems to be set to `undefined` when the stream is closed as well. This patch adds the unchecked `closed` state to the assertion.

https://streams.spec.whatwg.org/#writable-stream-default-controller-process-close

> WritableStreamDefaultControllerProcessClose(controller) performs the following steps:
> 
>> 6. Perform ! WritableStreamDefaultControllerClearAlgorithms(controller).  <- Set `strategySizeAlgorithm` to undefined.
>> 7.1 Perform ! WritableStreamFinishInFlightClose(stream). <- Set stream.[[state]] to "closed".

Fixes: https://github.com/nodejs/node/issues/57272
Refs: https://github.com/nodejs/node/pull/56067

