### PR TITLE
doc: improved `fetch` docs

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -531,6 +531,39 @@ changes:
 
 A browser-compatible implementation of the [`fetch()`][] function.
 
+```mjs
+const res = await fetch('https://nodejs.org/api/documentation.json');
+if (res.ok) {
+  const data = await res.json();
+  console.log(data);
+}
+```
+
+The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.1 client written from scratch for Node.js. You can figure out which version of `undici` is bundled in your Node.js process reading the `process.versions.undici` property.
+
+## Custom dispatcher
+
+You can use a custom dispatcher to dispatch requests passing it in fetch's options object.
+The dispatcher must be compatible with `undici`'s [`Dispatcher` class](https://undici.nodejs.org/#/docs/api/Dispatcher.md).
+
+```js
+fetch(url, { dispatcher: new MyAgent() });
+```
+
+It is possible to change the global dispatcher in Node.js using:
+
+```js
+globalThis[Symbol.for('undici.globalDispatcher.1')] = yourDispatcher;
+```
+
+## Related classes
+
+The following globals are available to use with `fetch`:
+- [`FormData`](https://nodejs.org/api/globals.html#class-formdata)
+- [`Headers`](https://nodejs.org/api/globals.html#class-headers)
+- [`Request`](https://nodejs.org/api/globals.html#request)
+- [`Response`](https://nodejs.org/api/globals.html#response).
+
 ## Class: `File`
 
 <!-- YAML

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -539,12 +539,15 @@ if (res.ok) {
 }
 ```
 
-The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.1 client written from scratch for Node.js. You can figure out which version of `undici` is bundled in your Node.js process reading the `process.versions.undici` property.
+The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.1 client
+written from scratch for Node.js. You can figure out which version of `undici` is bundled
+in your Node.js process reading the `process.versions.undici` property.
 
 ## Custom dispatcher
 
 You can use a custom dispatcher to dispatch requests passing it in fetch's options object.
-The dispatcher must be compatible with `undici`'s [`Dispatcher` class](https://undici.nodejs.org/#/docs/api/Dispatcher.md).
+The dispatcher must be compatible with `undici`'s
+[`Dispatcher` class](https://undici.nodejs.org/#/docs/api/Dispatcher.md).
 
 ```js
 fetch(url, { dispatcher: new MyAgent() });

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -553,10 +553,13 @@ The dispatcher must be compatible with `undici`'s
 fetch(url, { dispatcher: new MyAgent() });
 ```
 
-It is possible to change the global dispatcher in Node.js using:
+It is possible to change the global dispatcher in Node.js installing `undici` and using
+the `setGlobalDispatcher()` method. Calling this method will affect both `undici` and
+Node.js.
 
-```js
-globalThis[Symbol.for('undici.globalDispatcher.1')] = yourDispatcher;
+```mjs
+import { setGlobalDispatcher } from 'undici';
+setGlobalDispatcher(new MyAgent());
 ```
 
 ## Related classes

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -559,10 +559,11 @@ globalThis[Symbol.for('undici.globalDispatcher.1')] = yourDispatcher;
 ## Related classes
 
 The following globals are available to use with `fetch`:
-- [`FormData`](https://nodejs.org/api/globals.html#class-formdata)
-- [`Headers`](https://nodejs.org/api/globals.html#class-headers)
-- [`Request`](https://nodejs.org/api/globals.html#request)
-- [`Response`](https://nodejs.org/api/globals.html#response).
+
+* [`FormData`](https://nodejs.org/api/globals.html#class-formdata)
+* [`Headers`](https://nodejs.org/api/globals.html#class-headers)
+* [`Request`](https://nodejs.org/api/globals.html#request)
+* [`Response`](https://nodejs.org/api/globals.html#response).
 
 ## Class: `File`
 


### PR DESCRIPTION
Updated `fetch` documentation:
- added a fetch example
- explained its connection with `undici`
- explained how to get the current `undici` version
- explained how to use a custom dispatcher
- added link to related HTTP classes

Refs:
- https://undici.nodejs.org
- https://github.com/nodejs/undici/discussions/2167
- https://nodejs.org/en/blog/release/v18.0.0#fetch-experimental