### PR TITLE
src: refine ncrypto more

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -2742,6 +2742,50 @@ const Cipher Cipher::FromCtx(const CipherCtxPointer& ctx) {
   return Cipher(EVP_CIPHER_CTX_cipher(ctx.get()));
 }
 
+const Cipher Cipher::EMPTY = Cipher();
+const Cipher Cipher::AES_128_CBC = Cipher::FromNid(NID_aes_128_cbc);
+const Cipher Cipher::AES_192_CBC = Cipher::FromNid(NID_aes_192_cbc);
+const Cipher Cipher::AES_256_CBC = Cipher::FromNid(NID_aes_256_cbc);
+const Cipher Cipher::AES_128_CTR = Cipher::FromNid(NID_aes_128_ctr);
+const Cipher Cipher::AES_192_CTR = Cipher::FromNid(NID_aes_192_ctr);
+const Cipher Cipher::AES_256_CTR = Cipher::FromNid(NID_aes_256_ctr);
+const Cipher Cipher::AES_128_GCM = Cipher::FromNid(NID_aes_128_gcm);
+const Cipher Cipher::AES_192_GCM = Cipher::FromNid(NID_aes_192_gcm);
+const Cipher Cipher::AES_256_GCM = Cipher::FromNid(NID_aes_256_gcm);
+const Cipher Cipher::AES_128_KW = Cipher::FromNid(NID_id_aes128_wrap);
+const Cipher Cipher::AES_192_KW = Cipher::FromNid(NID_id_aes192_wrap);
+const Cipher Cipher::AES_256_KW = Cipher::FromNid(NID_id_aes256_wrap);
+
+bool Cipher::isGcmMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_GCM_MODE;
+}
+
+bool Cipher::isWrapMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_WRAP_MODE;
+}
+
+bool Cipher::isCtrMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_CTR_MODE;
+}
+
+bool Cipher::isCcmMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_CCM_MODE;
+}
+
+bool Cipher::isOcbMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_OCB_MODE;
+}
+
+bool Cipher::isStreamMode() const {
+  if (!cipher_) return false;
+  return getMode() == EVP_CIPH_STREAM_CIPHER;
+}
+
 int Cipher::getMode() const {
   if (!cipher_) return 0;
   return EVP_CIPHER_mode(cipher_);
@@ -2851,9 +2895,9 @@ EVP_CIPHER_CTX* CipherCtxPointer::release() {
   return ctx_.release();
 }
 
-void CipherCtxPointer::setFlags(int flags) {
+void CipherCtxPointer::setAllowWrap() {
   if (!ctx_) return;
-  EVP_CIPHER_CTX_set_flags(ctx_.get(), flags);
+  EVP_CIPHER_CTX_set_flags(ctx_.get(), EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
 }
 
 bool CipherCtxPointer::setKeyLength(size_t length) {

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -274,11 +274,37 @@ class Cipher final {
   std::string_view getModeLabel() const;
   std::string_view getName() const;
 
+  bool isGcmMode() const;
+  bool isWrapMode() const;
+  bool isCtrMode() const;
+  bool isCcmMode() const;
+  bool isOcbMode() const;
+  bool isStreamMode() const;
+
   bool isSupportedAuthenticatedMode() const;
 
   static const Cipher FromName(std::string_view name);
   static const Cipher FromNid(int nid);
   static const Cipher FromCtx(const CipherCtxPointer& ctx);
+
+  // Utilities to get various ciphers by type. If the underlying
+  // implementation does not support the requested cipher, then
+  // the result will be an empty Cipher object whose bool operator
+  // will return false.
+
+  static const Cipher EMPTY;
+  static const Cipher AES_128_CBC;
+  static const Cipher AES_192_CBC;
+  static const Cipher AES_256_CBC;
+  static const Cipher AES_128_CTR;
+  static const Cipher AES_192_CTR;
+  static const Cipher AES_256_CTR;
+  static const Cipher AES_128_GCM;
+  static const Cipher AES_192_GCM;
+  static const Cipher AES_256_GCM;
+  static const Cipher AES_128_KW;
+  static const Cipher AES_192_KW;
+  static const Cipher AES_256_KW;
 
   struct CipherParams {
     int padding;
@@ -596,7 +622,8 @@ class CipherCtxPointer final {
   void reset(EVP_CIPHER_CTX* ctx = nullptr);
   EVP_CIPHER_CTX* release();
 
-  void setFlags(int flags);
+  void setAllowWrap();
+
   bool setKeyLength(size_t length);
   bool setIvLength(size_t length);
   bool setAeadTag(const Buffer<const char>& tag);

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -287,6 +287,12 @@ class Cipher final {
   static const Cipher FromNid(int nid);
   static const Cipher FromCtx(const CipherCtxPointer& ctx);
 
+  using CipherNameCallback = std::function<void(std::string_view name)>;
+
+  // Iterates the known ciphers if the underlying implementation
+  // is able to do so.
+  static void ForEach(CipherNameCallback callback);
+
   // Utilities to get various ciphers by type. If the underlying
   // implementation does not support the requested cipher, then
   // the result will be an empty Cipher object whose bool operator

--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -484,7 +484,7 @@ Maybe<void> AESCipherTraits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  if (params->cipher.isWrapMode()) {
+  if (!params->cipher.isWrapMode()) {
     if (!ValidateIV(env, mode, args[offset + 1], params)) {
       return Nothing<void>();
     }

--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -47,11 +47,11 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
                                  ByteSource* out) {
   CHECK_EQ(key_data.GetKeyType(), kKeyTypeSecret);
 
-  const int mode = params.cipher.getMode();
-
   auto ctx = CipherCtxPointer::New();
-  if (mode == EVP_CIPH_WRAP_MODE) {
-    ctx.setFlags(EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+  CHECK(ctx);
+
+  if (params.cipher.isWrapMode()) {
+    ctx.setAllowWrap();
   }
 
   const bool encrypt = cipher_mode == kWebCryptoCipherEncrypt;
@@ -61,7 +61,7 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
     return WebCryptoCipherStatus::FAILED;
   }
 
-  if (mode == EVP_CIPH_GCM_MODE && !ctx.setIvLength(params.iv.size())) {
+  if (params.cipher.isGcmMode() && !ctx.setIvLength(params.iv.size())) {
     return WebCryptoCipherStatus::FAILED;
   }
 
@@ -76,7 +76,7 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
 
   size_t tag_len = 0;
 
-  if (mode == EVP_CIPH_GCM_MODE) {
+  if (params.cipher.isGcmMode()) {
     switch (cipher_mode) {
       case kWebCryptoCipherDecrypt: {
         // If in decrypt mode, the auth tag must be set in the params.tag.
@@ -112,7 +112,7 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
       .data = params.additional_data.data<unsigned char>(),
       .len = params.additional_data.size(),
   };
-  if (mode == EVP_CIPH_GCM_MODE && params.additional_data.size() &&
+  if (params.cipher.isGcmMode() && params.additional_data.size() &&
       !ctx.update(buffer, nullptr, &out_len)) {
     return WebCryptoCipherStatus::FAILED;
   }
@@ -149,7 +149,7 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
 
   // If using AES_GCM, grab the generated auth tag and append
   // it to the end of the ciphertext.
-  if (cipher_mode == kWebCryptoCipherEncrypt && mode == EVP_CIPH_GCM_MODE) {
+  if (encrypt && params.cipher.isGcmMode()) {
     if (!ctx.getAeadTag(tag_len, ptr + total)) {
       return WebCryptoCipherStatus::FAILED;
     }
@@ -467,10 +467,9 @@ Maybe<void> AESCipherTraits::AdditionalConfig(
   params->variant =
       static_cast<AESKeyVariant>(args[offset].As<Uint32>()->Value());
 
-  int cipher_nid;
 #define V(name, _, nid)                                                        \
   case AESKeyVariant::name: {                                                  \
-    cipher_nid = nid;                                                          \
+    params->cipher = nid;                                                      \
     break;                                                                     \
   }
   switch (params->variant) {
@@ -480,22 +479,20 @@ Maybe<void> AESCipherTraits::AdditionalConfig(
   }
 #undef V
 
-  params->cipher = Cipher::FromNid(cipher_nid);
   if (!params->cipher) {
     THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
     return Nothing<void>();
   }
 
-  int cipher_op_mode = params->cipher.getMode();
-  if (cipher_op_mode != EVP_CIPH_WRAP_MODE) {
+  if (params->cipher.isWrapMode()) {
     if (!ValidateIV(env, mode, args[offset + 1], params)) {
       return Nothing<void>();
     }
-    if (cipher_op_mode == EVP_CIPH_CTR_MODE) {
+    if (params->cipher.isCtrMode()) {
       if (!ValidateCounter(env, args[offset + 2], params)) {
         return Nothing<void>();
       }
-    } else if (cipher_op_mode == EVP_CIPH_GCM_MODE) {
+    } else if (params->cipher.isGcmMode()) {
       if (!ValidateAuthTag(env, mode, cipher_mode, args[offset + 2], params) ||
           !ValidateAdditionalData(env, mode, args[offset + 3], params)) {
         return Nothing<void>();

--- a/src/crypto/crypto_aes.h
+++ b/src/crypto/crypto_aes.h
@@ -13,18 +13,18 @@ namespace node::crypto {
 constexpr unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
 
 #define VARIANTS(V)                                                            \
-  V(CTR_128, AES_CTR_Cipher, NID_aes_128_ctr)                                  \
-  V(CTR_192, AES_CTR_Cipher, NID_aes_192_ctr)                                  \
-  V(CTR_256, AES_CTR_Cipher, NID_aes_256_ctr)                                  \
-  V(CBC_128, AES_Cipher, NID_aes_128_cbc)                                      \
-  V(CBC_192, AES_Cipher, NID_aes_192_cbc)                                      \
-  V(CBC_256, AES_Cipher, NID_aes_256_cbc)                                      \
-  V(GCM_128, AES_Cipher, NID_aes_128_gcm)                                      \
-  V(GCM_192, AES_Cipher, NID_aes_192_gcm)                                      \
-  V(GCM_256, AES_Cipher, NID_aes_256_gcm)                                      \
-  V(KW_128, AES_Cipher, NID_id_aes128_wrap)                                    \
-  V(KW_192, AES_Cipher, NID_id_aes192_wrap)                                    \
-  V(KW_256, AES_Cipher, NID_id_aes256_wrap)
+  V(CTR_128, AES_CTR_Cipher, ncrypto::Cipher::AES_128_CTR)                     \
+  V(CTR_192, AES_CTR_Cipher, ncrypto::Cipher::AES_192_CTR)                     \
+  V(CTR_256, AES_CTR_Cipher, ncrypto::Cipher::AES_256_CTR)                     \
+  V(CBC_128, AES_Cipher, ncrypto::Cipher::AES_128_CBC)                         \
+  V(CBC_192, AES_Cipher, ncrypto::Cipher::AES_192_CBC)                         \
+  V(CBC_256, AES_Cipher, ncrypto::Cipher::AES_256_CBC)                         \
+  V(GCM_128, AES_Cipher, ncrypto::Cipher::AES_128_GCM)                         \
+  V(GCM_192, AES_Cipher, ncrypto::Cipher::AES_192_GCM)                         \
+  V(GCM_256, AES_Cipher, ncrypto::Cipher::AES_256_GCM)                         \
+  V(KW_128, AES_Cipher, ncrypto::Cipher::AES_128_KW)                           \
+  V(KW_192, AES_Cipher, ncrypto::Cipher::AES_192_KW)                           \
+  V(KW_256, AES_Cipher, ncrypto::Cipher::AES_256_KW)
 
 enum class AESKeyVariant {
 #define V(name, _, __) name,

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -9,6 +9,7 @@
 
 namespace node {
 
+using ncrypto::Digest;
 using v8::FunctionCallbackInfo;
 using v8::JustVoid;
 using v8::Maybe;
@@ -54,8 +55,8 @@ Maybe<void> HKDFTraits::AdditionalConfig(
   CHECK(args[offset + 4]->IsUint32());  // Length
 
   Utf8Value hash(env->isolate(), args[offset]);
-  params->digest = ncrypto::getDigestByName(hash.ToStringView());
-  if (params->digest == nullptr) [[unlikely]] {
+  params->digest = Digest::FromName(hash.ToStringView());
+  if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *hash);
     return Nothing<void>();
   }

--- a/src/crypto/crypto_hkdf.h
+++ b/src/crypto/crypto_hkdf.h
@@ -14,7 +14,7 @@ namespace crypto {
 struct HKDFConfig final : public MemoryRetainer {
   CryptoJobMode mode;
   size_t length;
-  const EVP_MD* digest;
+  ncrypto::Digest digest;
   KeyObjectData key;
   ByteSource salt;
   ByteSource info;

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -13,6 +13,7 @@
 
 namespace node {
 
+using ncrypto::Digest;
 using ncrypto::HMACCtxPointer;
 using v8::Boolean;
 using v8::FunctionCallbackInfo;
@@ -70,8 +71,8 @@ void Hmac::New(const FunctionCallbackInfo<Value>& args) {
 void Hmac::HmacInit(const char* hash_type, const char* key, int key_len) {
   HandleScope scope(env()->isolate());
 
-  const EVP_MD* md = ncrypto::getDigestByName(hash_type);
-  if (md == nullptr) [[unlikely]] {
+  Digest md = Digest::FromName(hash_type);
+  if (!md) [[unlikely]] {
     return THROW_ERR_CRYPTO_INVALID_DIGEST(
         env(), "Invalid digest: %s", hash_type);
   }
@@ -130,7 +131,7 @@ void Hmac::HmacDigest(const FunctionCallbackInfo<Value>& args) {
     encoding = ParseEncoding(env->isolate(), args[0], BUFFER);
   }
 
-  unsigned char md_value[EVP_MAX_MD_SIZE];
+  unsigned char md_value[Digest::MAX_SIZE];
   ncrypto::Buffer<void> buf{
       .data = md_value,
       .len = sizeof(md_value),
@@ -199,8 +200,8 @@ Maybe<void> HmacTraits::AdditionalConfig(
   CHECK(args[offset + 2]->IsObject());  // Key
 
   Utf8Value digest(env->isolate(), args[offset + 1]);
-  params->digest = ncrypto::getDigestByName(digest.ToStringView());
-  if (params->digest == nullptr) [[unlikely]] {
+  params->digest = Digest::FromName(digest.ToStringView());
+  if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
     return Nothing<void>();
   }

--- a/src/crypto/crypto_hmac.h
+++ b/src/crypto/crypto_hmac.h
@@ -45,7 +45,7 @@ struct HmacConfig final : public MemoryRetainer {
   KeyObjectData key;
   ByteSource data;
   ByteSource signature;
-  const EVP_MD* digest;
+  ncrypto::Digest digest;
 
   HmacConfig() = default;
 

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -9,6 +9,7 @@
 
 namespace node {
 
+using ncrypto::Digest;
 using v8::FunctionCallbackInfo;
 using v8::Int32;
 using v8::JustVoid;
@@ -100,8 +101,8 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
   }
 
   Utf8Value name(args.GetIsolate(), args[offset + 4]);
-  params->digest = ncrypto::getDigestByName(name.ToStringView());
-  if (params->digest == nullptr) [[unlikely]] {
+  params->digest = Digest::FromName(name.ToStringView());
+  if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *name);
     return Nothing<void>();
   }

--- a/src/crypto/crypto_pbkdf2.h
+++ b/src/crypto/crypto_pbkdf2.h
@@ -30,7 +30,7 @@ struct PBKDF2Config final : public MemoryRetainer {
   ByteSource salt;
   int32_t iterations;
   int32_t length;
-  const EVP_MD* digest = nullptr;
+  ncrypto::Digest digest;
 
   PBKDF2Config() = default;
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -16,6 +16,7 @@ namespace node {
 
 using ncrypto::BignumPointer;
 using ncrypto::DataPointer;
+using ncrypto::Digest;
 using ncrypto::EVPKeyCtxPointer;
 using ncrypto::EVPKeyPointer;
 using ncrypto::RSAPointer;
@@ -55,8 +56,7 @@ EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
   }
 
   if (params->params.variant == kKeyVariantRSA_PSS) {
-    if (params->params.md != nullptr &&
-        !ctx.setRsaPssKeygenMd(params->params.md)) {
+    if (params->params.md && !ctx.setRsaPssKeygenMd(params->params.md)) {
       return {};
     }
 
@@ -64,18 +64,18 @@ EVPKeyCtxPointer RsaKeyGenTraits::Setup(RsaKeyPairGenConfig* params) {
     // OpenSSL 1.1.1 behaves as recommended by RFC 8017 and defaults the MGF1
     // hash algorithm to the RSA-PSS hashAlgorithm. Remove this code if the
     // behavior of OpenSSL 3 changes.
-    const EVP_MD* mgf1_md = params->params.mgf1_md;
-    if (mgf1_md == nullptr && params->params.md != nullptr) {
+    auto& mgf1_md = params->params.mgf1_md;
+    if (!mgf1_md && params->params.md) {
       mgf1_md = params->params.md;
     }
 
-    if (mgf1_md != nullptr && !ctx.setRsaPssKeygenMgf1Md(mgf1_md)) {
+    if (mgf1_md && !ctx.setRsaPssKeygenMgf1Md(mgf1_md)) {
       return {};
     }
 
     int saltlen = params->params.saltlen;
-    if (saltlen < 0 && params->params.md != nullptr) {
-      saltlen = EVP_MD_size(params->params.md);
+    if (saltlen < 0 && params->params.md) {
+      saltlen = params->params.md.size();
     }
 
     if (saltlen >= 0 && !ctx.setRsaPssSaltlen(saltlen)) {
@@ -141,8 +141,8 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
     if (!args[*offset]->IsUndefined()) {
       CHECK(args[*offset]->IsString());
       Utf8Value digest(env->isolate(), args[*offset]);
-      params->params.md = ncrypto::getDigestByName(digest.ToStringView());
-      if (params->params.md == nullptr) {
+      params->params.md = Digest::FromName(digest.ToStringView());
+      if (!params->params.md) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
         return Nothing<void>();
       }
@@ -151,8 +151,8 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
     if (!args[*offset + 1]->IsUndefined()) {
       CHECK(args[*offset + 1]->IsString());
       Utf8Value digest(env->isolate(), args[*offset + 1]);
-      params->params.mgf1_md = ncrypto::getDigestByName(digest.ToStringView());
-      if (params->params.mgf1_md == nullptr) {
+      params->params.mgf1_md = Digest::FromName(digest.ToStringView());
+      if (!params->params.mgf1_md) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(
             env, "Invalid MGF1 digest: %s", *digest);
         return Nothing<void>();
@@ -276,9 +276,8 @@ Maybe<void> RSACipherTraits::AdditionalConfig(
     case kKeyVariantRSA_OAEP: {
       CHECK(args[offset + 1]->IsString());  // digest
       Utf8Value digest(env->isolate(), args[offset + 1]);
-
-      params->digest = ncrypto::getDigestByName(digest.ToStringView());
-      if (params->digest == nullptr) {
+      params->digest = Digest::FromName(digest.ToStringView());
+      if (!params->digest) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
         return Nothing<void>();
       }

--- a/src/crypto/crypto_rsa.h
+++ b/src/crypto/crypto_rsa.h
@@ -26,8 +26,8 @@ struct RsaKeyPairParams final : public MemoryRetainer {
 
   // The following options are used for RSA-PSS. If any of them are set, a
   // RSASSA-PSS-params sequence will be added to the key.
-  const EVP_MD* md = nullptr;
-  const EVP_MD* mgf1_md = nullptr;
+  ncrypto::Digest md = nullptr;
+  ncrypto::Digest mgf1_md = nullptr;
   int saltlen = -1;
 
   SET_NO_MEMORY_INFO()
@@ -80,7 +80,7 @@ struct RSACipherConfig final : public MemoryRetainer {
   CryptoJobMode mode = kCryptoJobAsync;
   ByteSource label;
   int padding = 0;
-  const EVP_MD* digest = nullptr;
+  ncrypto::Digest digest;
 
   RSACipherConfig() = default;
 

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -15,6 +15,7 @@ namespace node {
 using ncrypto::BignumPointer;
 using ncrypto::ClearErrorOnReturn;
 using ncrypto::DataPointer;
+using ncrypto::Digest;
 using ncrypto::ECDSASigPointer;
 using ncrypto::EVPKeyCtxPointer;
 using ncrypto::EVPKeyPointer;
@@ -233,8 +234,8 @@ bool UseP1363Encoding(const EVPKeyPointer& key, const DSASigEnc dsa_encoding) {
 
 SignBase::Error SignBase::Init(std::string_view digest) {
   CHECK_NULL(mdctx_);
-  auto md = ncrypto::getDigestByName(digest);
-  if (md == nullptr) [[unlikely]]
+  auto md = Digest::FromName(digest);
+  if (!md) [[unlikely]]
     return Error::UnknownDigest;
 
   mdctx_ = EVPMDCtxPointer::New();
@@ -587,8 +588,8 @@ Maybe<void> SignTraits::AdditionalConfig(
 
   if (args[offset + 6]->IsString()) {
     Utf8Value digest(env->isolate(), args[offset + 6]);
-    params->digest = ncrypto::getDigestByName(digest.ToStringView());
-    if (params->digest == nullptr) [[unlikely]] {
+    params->digest = Digest::FromName(digest.ToStringView());
+    if (!params->digest) [[unlikely]] {
       THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
       return Nothing<void>();
     }

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -107,7 +107,7 @@ struct SignConfiguration final : public MemoryRetainer {
   KeyObjectData key;
   ByteSource data;
   ByteSource signature;
-  const EVP_MD* digest = nullptr;
+  ncrypto::Digest digest;
   int flags = SignConfiguration::kHasNone;
   int padding = 0;
   int salt_length = 0;


### PR DESCRIPTION
An eventual goal for ncrypto is to completely abstract away
details of working directly with openssl in order to make it
easier to work with multiple different openssl/boringssl versions.
As part of that we want to move away from direct reliance on
specific openssl APIs in the runtime and instead go through
the ncrypto abstractions. Not only does this help other
runtimes trying to be compatible with Node.js, but it helps
Node.js also by reducing the complexity of the crypto code
in Node.js itself.