### PR TITLE
fs: use `getLazy` for lazy loading

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -159,7 +159,7 @@ const lazyCpFn = getLazy(() => {
 });
 const lazyCpSyncFn = getLazy(() => {
   const { cpSyncFn } = require('internal/fs/cp/cp-sync');
-  return cpSyncFn
+  return cpSyncFn;
 });
 const lazyPromises = getLazy(() => {
   const { exports: promises } = require('internal/fs/promises');
@@ -182,7 +182,7 @@ const lazyKResistStopPropagation = getLazy(() => {
   return kResistStopPropagation;
 });
 const lazyGlob = getLazy(() => {
-  const { Glob } = require('internal/fs/glob')
+  const { Glob } = require('internal/fs/glob');
   return Glob;
 });
 const lazyReadFileContext = getLazy(() => {
@@ -192,6 +192,8 @@ const lazyReadFileContext = getLazy(() => {
 
 // These have to be separate because of how graceful-fs happens to do it's
 // monkeypatching.
+let ReadStream;
+let WriteStream;
 let FileReadStream;
 let FileWriteStream;
 
@@ -3312,7 +3314,7 @@ module.exports = fs = {
   Stats,
 
   get ReadStream() {
-    const ReadStream = lazyReadStream();
+    ReadStream ??= lazyReadStream();
     return ReadStream;
   },
 
@@ -3321,7 +3323,7 @@ module.exports = fs = {
   },
 
   get WriteStream() {
-    const WriteStream = lazyWriteStream();
+    WriteStream ??= lazyWriteStream();
     return WriteStream;
   },
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -153,14 +153,42 @@ let truncateWarn = true;
 let fs;
 
 // Lazy loaded
-let cpFn;
-let cpSyncFn;
-let promises = null;
-let ReadStream;
-let WriteStream;
-let rimraf;
-let kResistStopPropagation;
-let ReadFileContext;
+const lazyCpFn = getLazy(() => {
+  const { cpFn } = require('internal/fs/cp/cp');
+  return require('util').callbackify(cpFn);
+});
+const lazyCpSyncFn = getLazy(() => {
+  const { cpSyncFn } = require('internal/fs/cp/cp-sync');
+  return cpSyncFn
+});
+const lazyPromises = getLazy(() => {
+  const { exports: promises } = require('internal/fs/promises');
+  return promises;
+});
+const lazyReadStream = getLazy(() => {
+  const { ReadStream } = require('internal/fs/streams');
+  return ReadStream;
+});
+const lazyWriteStream = getLazy(() => {
+  const { WriteStream } = require('internal/fs/streams');
+  return WriteStream;
+});
+const lazyRimraf = getLazy(() => {
+  const { rimraf } = require('internal/fs/rimraf');
+  return rimraf;
+});
+const lazyKResistStopPropagation = getLazy(() => {
+  const { kResistStopPropagation } = require('internal/event_target');
+  return kResistStopPropagation;
+});
+const lazyGlob = getLazy(() => {
+  const { Glob } = require('internal/fs/glob')
+  return Glob;
+});
+const lazyReadFileContext = getLazy(() => {
+  const ReadFileContext = require('internal/fs/read/context');
+  return ReadFileContext;
+});
 
 // These have to be separate because of how graceful-fs happens to do it's
 // monkeypatching.
@@ -363,7 +391,7 @@ function readFile(path, options, callback) {
   callback ||= options;
   validateFunction(callback, 'cb');
   options = getOptions(options, { flag: 'r' });
-  ReadFileContext ??= require('internal/fs/read/context');
+  const ReadFileContext = lazyReadFileContext();
   const context = new ReadFileContext(callback, options.encoding);
   context.isUserFd = isFd(path); // File descriptor ownership
 
@@ -1113,19 +1141,6 @@ function ftruncateSync(fd, len = 0) {
   binding.ftruncate(fd, len < 0 ? 0 : len);
 }
 
-function lazyLoadCp() {
-  if (cpFn === undefined) {
-    ({ cpFn } = require('internal/fs/cp/cp'));
-    cpFn = require('util').callbackify(cpFn);
-    ({ cpSyncFn } = require('internal/fs/cp/cp-sync'));
-  }
-}
-
-function lazyLoadRimraf() {
-  if (rimraf === undefined)
-    ({ rimraf } = require('internal/fs/rimraf'));
-}
-
 /**
  * Asynchronously removes a directory.
  * @param {string | Buffer | URL} path
@@ -1163,7 +1178,7 @@ function rmdir(path, options, callback) {
           return callback(err);
         }
 
-        lazyLoadRimraf();
+        const rimraf = lazyRimraf();
         rimraf(path, options, callback);
       });
   } else {
@@ -1224,7 +1239,7 @@ function rm(path, options, callback) {
     if (err) {
       return callback(err);
     }
-    lazyLoadRimraf();
+    const rimraf = lazyRimraf();
     return rimraf(path, options, callback);
   });
 }
@@ -2560,7 +2575,7 @@ function watch(filename, options, listener) {
       process.nextTick(() => watcher.close());
     } else {
       const listener = () => watcher.close();
-      kResistStopPropagation ??= require('internal/event_target').kResistStopPropagation;
+      const kResistStopPropagation = lazyKResistStopPropagation();
       options.signal.addEventListener('abort', listener, { __proto__: null, [kResistStopPropagation]: true });
       watcher.once('close', () => {
         options.signal.removeEventListener('abort', listener);
@@ -3107,7 +3122,7 @@ function cp(src, dest, options, callback) {
   options = validateCpOptions(options);
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
-  lazyLoadCp();
+  const cpFn = lazyCpFn();
   cpFn(src, dest, options, callback);
 }
 
@@ -3123,16 +3138,8 @@ function cpSync(src, dest, options) {
   options = validateCpOptions(options);
   src = getValidatedPath(src, 'src');
   dest = getValidatedPath(dest, 'dest');
-  lazyLoadCp();
+  const cpSyncFn = lazyCpSyncFn();
   cpSyncFn(src, dest, options);
-}
-
-function lazyLoadStreams() {
-  if (!ReadStream) {
-    ({ ReadStream, WriteStream } = require('internal/fs/streams'));
-    FileReadStream = ReadStream;
-    FileWriteStream = WriteStream;
-  }
 }
 
 /**
@@ -3155,7 +3162,7 @@ function lazyLoadStreams() {
  * @returns {ReadStream}
  */
 function createReadStream(path, options) {
-  lazyLoadStreams();
+  const ReadStream = lazyReadStream();
   return new ReadStream(path, options);
 }
 
@@ -3178,11 +3185,10 @@ function createReadStream(path, options) {
  * @returns {WriteStream}
  */
 function createWriteStream(path, options) {
-  lazyLoadStreams();
+  const WriteStream = lazyWriteStream();
   return new WriteStream(path, options);
 }
 
-const lazyGlob = getLazy(() => require('internal/fs/glob').Glob);
 
 function glob(pattern, options, callback) {
   emitExperimentalWarning('glob');
@@ -3306,7 +3312,7 @@ module.exports = fs = {
   Stats,
 
   get ReadStream() {
-    lazyLoadStreams();
+    const ReadStream = lazyReadStream();
     return ReadStream;
   },
 
@@ -3315,7 +3321,7 @@ module.exports = fs = {
   },
 
   get WriteStream() {
-    lazyLoadStreams();
+    const WriteStream = lazyWriteStream();
     return WriteStream;
   },
 
@@ -3326,7 +3332,7 @@ module.exports = fs = {
   // Legacy names... these have to be separate because of how graceful-fs
   // (and possibly other) modules monkey patch the values.
   get FileReadStream() {
-    lazyLoadStreams();
+    FileReadStream ??= lazyReadStream();
     return FileReadStream;
   },
 
@@ -3335,7 +3341,7 @@ module.exports = fs = {
   },
 
   get FileWriteStream() {
-    lazyLoadStreams();
+    FileWriteStream ??= lazyWriteStream();
     return FileWriteStream;
   },
 
@@ -3365,7 +3371,7 @@ ObjectDefineProperties(fs, {
     configurable: true,
     enumerable: true,
     get() {
-      promises ??= require('internal/fs/promises').exports;
+      const promises = lazyPromises();
       return promises;
     },
   },

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -766,7 +766,7 @@ function getLazy(initializer) {
   let value;
   let initialized = false;
   return function() {
-    if (initialized === false) {
+    if (!initialized) {
       value = initializer();
       initialized = true;
     }


### PR DESCRIPTION
I think we can centralize the usage of lazy loading with the getLazy util in the codebase

Also before, we lazy loaded multiple modules even when we needed only one, so I believe splitting them further should be a little faster

It's cleaner and more consistent to use this everywhere