### PR TITLE
tools: revert to use @stylistic/eslint-plugin-js v3

### DIFF
--- a/tools/eslint/package-lock.json
+++ b/tools/eslint/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/eslint-parser": "^7.26.8",
         "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@babel/plugin-syntax-import-source": "^7.25.9",
-        "@stylistic/eslint-plugin-js": "^4.1.0",
+        "@stylistic/eslint-plugin-js": "^3.0.1",
         "eslint": "^9.21.0",
         "eslint-formatter-tap": "^8.40.0",
         "eslint-plugin-jsdoc": "^50.6.3",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.1.0.tgz",
-      "integrity": "sha512-YOe+dChNoR26JVVt+7BjyebsPIQF05OLNmHCXivq8lLZ4ZeVs4+wXaW+pREVboDiAaSRznauAdAU8f+iQouw6Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-3.1.0.tgz",
+      "integrity": "sha512-lQktsOiCr8S6StG29C5fzXYxLOD6ID1rp4j6TRS+E/qY1xd59Fm7dy5qm9UauJIEoSTlYx6yGsCHYh5UkgXPyg==",
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^4.2.0",
@@ -586,7 +586,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=9.0.0"
+        "eslint": ">=8.40.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -7,7 +7,7 @@
     "@babel/eslint-parser": "^7.26.8",
     "@babel/plugin-syntax-import-attributes": "^7.26.0",
     "@babel/plugin-syntax-import-source": "^7.25.9",
-    "@stylistic/eslint-plugin-js": "^4.1.0",
+    "@stylistic/eslint-plugin-js": "^3.0.1",
     "eslint": "^9.21.0",
     "eslint-formatter-tap": "^8.40.0",
     "eslint-plugin-jsdoc": "^50.6.3",


### PR DESCRIPTION
@stylistic/eslint-plugin-js v4 has been updated to ship ESM-only, which needs require(esm) support due to the monkey-patching we do in our eslint.config.mjs. The node-test-linter job in Jenkins still runs Node.js v20 which has not yet released unflagging of require(esm). Revert to use v3 for now until we upgrade the Node.js version used in the CI.

Refs: https://github.com/nodejs/node/pull/57261
For an example of broken CI, see https://ci.nodejs.org/job/node-test-linter/59234/console

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
