### PR TITLE
build: fix compatibility with V8's `depot_tools`

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -53,7 +53,7 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
   gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="is_component_build=false is_debug=false use_goma=false goma_dir=\"None\" use_custom_libcxx=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true $CC_WRAPPER"
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" "${JOBS_ARG}" d8 cctest inspector-test
 else
-  DEPOT_TOOLS_DIR="$(cd _depot_tools && pwd)"
+  DEPOT_TOOLS_DIR="$(cd depot_tools && pwd)"
   # shellcheck disable=SC2086
   PATH="$DEPOT_TOOLS_DIR":$PATH tools/dev/v8gen.py "$BUILD_ARCH_TYPE" $V8_BUILD_OPTIONS
   PATH="$DEPOT_TOOLS_DIR":$PATH ninja -C "out.gn/$BUILD_ARCH_TYPE/" "${JOBS_ARG}" d8 cctest inspector-test

--- a/tools/v8/node_common.py
+++ b/tools/v8/node_common.py
@@ -18,7 +18,7 @@ DEPOT_TOOLS_URL = \
 
 def EnsureDepotTools(v8_path, fetch_if_not_exist):
   def _Get(v8_path):
-    depot_tools = os.path.join(v8_path, "_depot_tools")
+    depot_tools = os.path.join(v8_path, "depot_tools")
     try:
       gclient_path = os.path.join(depot_tools, "gclient.py")
       if os.path.isfile(gclient_path):


### PR DESCRIPTION
Recent changes to `depot_tools`'s `ninja.py` proxy is causing infinite recursion in our V8 CI builds as we checkout `depot_tools` into a directory with a leading `_` (i.e. `_depot_tools`) and the proxy now checks for an exact match (i.e. `== "depot_tools"`) instead of `endswith("depot_tools")`.

Rename our checkout to `depot_tools` (without the leading `_`) so the `ninja.py` proxy can exclude it when reinvoking `ninja`.

Refs: https://chromium-review.googlesource.com/c/chromium/tools/depot_tools/+/6259139
Fixes: https://github.com/nodejs/build/issues/4027

---

cc @nodejs/v8-update @targos 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
