### PR TITLE
tls: use crypto.hash() for faster sha1 creation

### DIFF
--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -1472,9 +1472,7 @@ Server.prototype.setSecureContext = function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = crypto.createHash('sha1')
-      .update(process.argv.join(' '))
-      .digest('hex')
+    this.sessionIdContext = crypto.hash('sha1', process.argv.join(' '), 'hex')
       .slice(0, 32);
   }
 
@@ -1570,9 +1568,7 @@ Server.prototype.setOptions = deprecate(function(options) {
   if (options.sessionIdContext) {
     this.sessionIdContext = options.sessionIdContext;
   } else {
-    this.sessionIdContext = crypto.createHash('sha1')
-      .update(process.argv.join(' '))
-      .digest('hex')
+    this.sessionIdContext = crypto.hash('sha1', process.argv.join(' '), 'hex')
       .slice(0, 32);
   }
   if (options.pskCallback) this[kPskCallback] = options.pskCallback;


### PR DESCRIPTION
We should use the new crypto.hash() method for faster sha1 creation.

cc @joyeecheung for creating the crypto.hash() method.