### PR TITLE
net: replace brand checks with identity checks

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -381,7 +381,7 @@ function Socket(options) {
       'is not supported',
     );
   }
-  if (typeof options?.keepAliveInitialDelay !== 'undefined') {
+  if (options?.keepAliveInitialDelay !== undefined) {
     validateNumber(
       options?.keepAliveInitialDelay, 'options.keepAliveInitialDelay',
     );
@@ -1319,7 +1319,7 @@ function lookupAndConnect(self, options) {
     validateNumber(localPort, 'options.localPort');
   }
 
-  if (typeof port !== 'undefined') {
+  if (port !== undefined) {
     if (typeof port !== 'number' && typeof port !== 'string') {
       throw new ERR_INVALID_ARG_TYPE('options.port',
                                      ['number', 'string'], port);
@@ -1776,7 +1776,7 @@ function Server(options, connectionListener) {
   } else {
     throw new ERR_INVALID_ARG_TYPE('options', 'Object', options);
   }
-  if (typeof options.keepAliveInitialDelay !== 'undefined') {
+  if (options.keepAliveInitialDelay !== undefined) {
     validateNumber(
       options.keepAliveInitialDelay, 'options.keepAliveInitialDelay',
     );
@@ -1785,7 +1785,7 @@ function Server(options, connectionListener) {
       options.keepAliveInitialDelay = 0;
     }
   }
-  if (typeof options.highWaterMark !== 'undefined') {
+  if (options.highWaterMark !== undefined) {
     validateNumber(
       options.highWaterMark, 'options.highWaterMark',
     );
@@ -2076,7 +2076,7 @@ Server.prototype.listen = function(...args) {
   // or (options[, cb]) where options.port is explicitly set as undefined or
   // null, bind to an arbitrary unused port
   if (args.length === 0 || typeof args[0] === 'function' ||
-      (typeof options.port === 'undefined' && 'port' in options) ||
+      (options.port === undefined && 'port' in options) ||
       options.port === null) {
     options.port = 0;
   }


### PR DESCRIPTION
An identity check is always faster than a brand check. 