### PR TITLE
test: increase change_in_bytes for napi_adjust_external_memory test

### DIFF
--- a/test/js-native-api/test_general/test_general.c
+++ b/test/js-native-api/test_general/test_general.c
@@ -215,7 +215,8 @@ static napi_value testAdjustExternalMemory(napi_env env, napi_callback_info info
   napi_value result;
   int64_t adjustedValue;
 
-  NODE_API_CALL(env, napi_adjust_external_memory(env, 1, &adjustedValue));
+  // Some JavaScript engines may ignore small increments passed to napi_adjust_external_memory
+  NODE_API_CALL(env, napi_adjust_external_memory(env, 10000, &adjustedValue));
   NODE_API_CALL(env, napi_create_double(env, (double)adjustedValue, &result));
 
   return result;


### PR DESCRIPTION
JavaScriptCore ignores small deltas in its interface for reporting external memory:

https://github.com/WebKit/WebKit/blob/8bbba2aa777cf326e24a4e5c63b1f51bd52315ff/Source/JavaScriptCore/heap/HeapInlines.h#L213-L229

More broadly, it seem reasonable for any other JS engine to do the same. Passing a large change ensures that the change is actually applied and the new adjusted value will be greater than zero (otherwise, the test relies on some external memory previously being reported as allocated). In turn, this makes the test more applicable to non-V8 implementations of Node-API.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
