### PR TITLE
src: do not pass `nullptr` to `std::string` ctor

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -254,7 +254,7 @@ class Win32SymbolDebuggingContext final : public NativeSymbolDebuggingContext {
       USE(GetLastError());
 #endif  // DEBUG
     }
-    return nullptr;
+    return {};
   }
 
   SymbolInfo LookupSymbol(void* address) override {


### PR DESCRIPTION
Fixes this error that I hit when working on a Chromium bump today in Electron:

> 2025-03-07T01:05:01.8637705Z ../../third_party/electron_node/src/debug_utils.cc(257,12): error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull]
> 2025-03-07T01:05:01.8638267Z   257 |     return nullptr;
> 2025-03-07T01:05:01.8638481Z       |            ^~~~~~~
> 2025-03-07T01:05:01.8638700Z 1 error generated.

This code has been around for awhile in Node.js, so the new build failure is probably an Electron issue, e.g. CI config.

Even so, upstreaming a fix feels worthwhile since building a `std::string` from `nullptr`is undefined behavior in [C++20](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2166r1.html#introduction-and-motivation) and is prohibited as of [C++23](https://en.cppreference.com/w/cpp/string/basic_string/basic_string).

This PR just replaces the `return nullptr;` with a `return {};` in a function that returns a `std::string`.

CC @codebytere 