### PR TITLE
fix: module.exports on CJS modules

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -188,9 +188,12 @@ function createCJSModuleWrap(url, source, isMain, format, loadCJS = loadCJSModul
   const { exportNames, module } = cjsPreparseModuleExports(filename, source, format);
   cjsCache.set(url, module);
 
-  const wrapperNames = [...exportNames, 'module.exports'];
+  const wrapperNames = [...exportNames];
   if (!exportNames.has('default')) {
     ArrayPrototypePush(wrapperNames, 'default');
+  }
+  if (!exportNames.has('module.exports')) {
+    ArrayPrototypePush(wrapperNames, 'module.exports');
   }
 
   if (isMain) {
@@ -212,7 +215,8 @@ function createCJSModuleWrap(url, source, isMain, format, loadCJS = loadCJSModul
       ({ exports } = module);
     }
     for (const exportName of exportNames) {
-      if (!ObjectPrototypeHasOwnProperty(exports, exportName) || exportName === 'default') {
+      if (exportName === 'default' || exportName === 'module.exports' ||
+          !ObjectPrototypeHasOwnProperty(exports, exportName)) {
         continue;
       }
       // We might trigger a getter -> dont fail.

--- a/test/fixtures/es-modules/exports-cases.js
+++ b/test/fixtures/es-modules/exports-cases.js
@@ -7,3 +7,4 @@ exports['\u{D83C}'] = 'no';
 exports['\u{D83C}\u{DF10}'] = 'yes';
 exports.package  = 10; // reserved word
 Object.defineProperty(exports, 'z', { value: 'yes' });
+exports['module.exports'] = 5;


### PR DESCRIPTION
Resolves #57295.

While the special `"module.exports"` name was defined for exporting from ESM modules for their representation in CommonJS, when writing a CommonJS with a `"module.exports"` export name will cause a V8 error.

The actual issue here is that we don't check if `module.exports` is already an export when defining the module wrap exports and as a result it is defined twice causing the failed V8 check.

To avoid unnecessary work, we also update the code path to instead of settin this export and then override it later, just not setting it at all. To avoid unnecessary `hasOwnProperty` checks, these checks are moved earlier in the sequence as well.

//cc @nodejs/loaders 