### PR TITLE
test_runner: added restart log in test-runner/runner.js

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -469,6 +469,7 @@ function watchFiles(testFiles, opts) {
   opts.root.harness.watching = true;
 
   async function restartTestFile(file) {
+    process.stdout.write(`${new Date().toISOString()} Restarting ${file}\n`);
     const runningProcess = runningProcesses.get(file);
     if (runningProcess) {
       runningProcess.kill();


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/57206

Added restart log in test-runner/runner.js to log with timestamp and test-file
whenever the test file is restart testing in `--watch` mode.