### PR TITLE
dns: remove redundant code using common variable

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -46,6 +46,8 @@ const {
   getDefaultResultOrder,
   setDefaultResultOrder,
   errorCodes: dnsErrorCodes,
+  validDnsOrders,
+  validFamilies,
 } = require('internal/dns/utils');
 const {
   Resolver,
@@ -138,7 +140,6 @@ function onlookupall(err, addresses) {
 
 // Easy DNS A/AAAA look up
 // lookup(hostname, [options,] callback)
-const validFamilies = [0, 4, 6];
 function lookup(hostname, options, callback) {
   let hints = 0;
   let family = 0;
@@ -192,7 +193,7 @@ function lookup(hostname, options, callback) {
       dnsOrder = options.verbatim ? 'verbatim' : 'ipv4first';
     }
     if (options?.order != null) {
-      validateOneOf(options.order, 'options.order', ['ipv4first', 'ipv6first', 'verbatim']);
+      validateOneOf(options.order, 'options.order', validDnsOrders);
       dnsOrder = options.order;
     }
   }

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -16,6 +16,8 @@ const {
   getDefaultResultOrder,
   setDefaultResultOrder,
   setDefaultResolver,
+  validDnsOrders,
+  validFamilies,
 } = require('internal/dns/utils');
 
 const {
@@ -179,7 +181,6 @@ function createLookupPromise(family, hostname, all, hints, dnsOrder) {
   });
 }
 
-const validFamilies = [0, 4, 6];
 /**
  * Get the IP address for a given hostname.
  * @param {string} hostname - The hostname to resolve (ex. 'nodejs.org').
@@ -227,7 +228,7 @@ function lookup(hostname, options) {
       dnsOrder = options.verbatim ? 'verbatim' : 'ipv4first';
     }
     if (options?.order != null) {
-      validateOneOf(options.order, 'options.order', ['ipv4first', 'ipv6first', 'verbatim']);
+      validateOneOf(options.order, 'options.order', validDnsOrders);
       dnsOrder = options.order;
     }
   }

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -201,6 +201,8 @@ class ResolverBase {
 
 let defaultResolver;
 let dnsOrder;
+const validDnsOrders = ['verbatim', 'ipv4first', 'ipv6first'];
+const validFamilies = [0, 4, 6];
 
 function initializeDns() {
   const orderFromCLI = getOptionValue('--dns-result-order');
@@ -208,7 +210,7 @@ function initializeDns() {
     dnsOrder ??= 'verbatim';
   } else {
     // Allow the deserialized application to override order from CLI.
-    validateOneOf(orderFromCLI, '--dns-result-order', ['verbatim', 'ipv4first', 'ipv6first']);
+    validateOneOf(orderFromCLI, '--dns-result-order', validDnsOrders);
     dnsOrder = orderFromCLI;
   }
 
@@ -281,7 +283,7 @@ function emitInvalidHostnameWarning(hostname) {
 }
 
 function setDefaultResultOrder(value) {
-  validateOneOf(value, 'dnsOrder', ['verbatim', 'ipv4first', 'ipv6first']);
+  validateOneOf(value, 'dnsOrder', validDnsOrders);
   dnsOrder = value;
 }
 
@@ -356,4 +358,6 @@ module.exports = {
   errorCodes,
   createResolverClass,
   initializeDns,
+  validDnsOrders,
+  validFamilies,
 };


### PR DESCRIPTION
`validFamilies` variable is defined 2 times, so remove redundant code by defining `validFamilies` in util. Plus, apply the same approach to `validDnsOrders` because it's also used multiple times.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
