### PR TITLE
lib: make getCallSites sourceMap option truly optional

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -388,7 +388,9 @@ function getCallSites(frameCount = 10, options) {
       // If frameCount is an object, it is the options object
       options = frameCount;
       validateObject(options, 'options');
-      validateBoolean(options.sourceMap, 'options.sourceMap');
+      if (options.sourceMap !== undefined) {
+        validateBoolean(options.sourceMap, 'options.sourceMap');
+      }
       frameCount = 10;
     } else {
       // If options is not provided, set it to an empty object
@@ -397,7 +399,9 @@ function getCallSites(frameCount = 10, options) {
   } else {
     // If options is provided, validate it
     validateObject(options, 'options');
-    validateBoolean(options.sourceMap, 'options.sourceMap');
+    if (options.sourceMap !== undefined) {
+      validateBoolean(options.sourceMap, 'options.sourceMap');
+    }
   }
 
   // Using kDefaultMaxCallStackSizeToCapture as reference

--- a/test/parallel/test-util-getcallsites.js
+++ b/test/parallel/test-util-getcallsites.js
@@ -172,3 +172,17 @@ const assert = require('node:assert');
   assert.match(output, /test-get-callsite-explicit\.ts/);
   assert.strictEqual(status, 0);
 }
+
+{
+  // sourceMap must be a boolean
+  assert.throws(() => getCallSites({ sourceMap: 1 }), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+  assert.throws(() => getCallSites(1, { sourceMap: 1 }), {
+    code: 'ERR_INVALID_ARG_TYPE'
+  });
+
+  // Not specifying the sourceMap option should not fail.
+  getCallSites({});
+  getCallSites(1, {});
+}


### PR DESCRIPTION
When calling the `util.getCallSites(...)` API, if the `options` argument is omitted, then the `options.sourceMap` option is defaulted to false. However, if any empty `options` is passed, it would throw an error if `sourceMap` was not explicitly given. This relaxes that so that `sourceMap` can be left unspecified.

For instance, before this commit, `getCallSites({})` would throw an error.

Also, add more test coverage of this.


