### PR TITLE
doc: deprecate passing `args` to `spawn` and `execFile`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3885,9 +3885,9 @@ When an `args` array is passed to [`child_process.execFile`][] or [`child_proces
 [`assert`]: assert.md
 [`asyncResource.runInAsyncScope()`]: async_context.md#asyncresourceruninasyncscopefn-thisarg-args
 [`buffer.subarray`]: buffer.md#bufsubarraystart-end
-[`child_process`]: child_process.md
 [`child_process.execFile`]: child_process.md#child_processexecfilefile-args-options-callback
 [`child_process.spawn`]: child_process.md#child_processspawncommand-args-options
+[`child_process`]: child_process.md
 [`clearInterval()`]: timers.md#clearintervaltimeout
 [`clearTimeout()`]: timers.md#cleartimeouttimeout
 [`console.error()`]: console.md#consoleerrordata-args

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3849,7 +3849,7 @@ deprecated, as their values are guaranteed to be identical to that of `process.f
 changes:
   - version:
     - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/57199
+    pr-url: https://github.com/nodejs/node/pull/57389
     description: Documentation-only deprecation.
 -->
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3886,6 +3886,8 @@ When an `args` array is passed to [`child_process.execFile`][] or [`child_proces
 [`asyncResource.runInAsyncScope()`]: async_context.md#asyncresourceruninasyncscopefn-thisarg-args
 [`buffer.subarray`]: buffer.md#bufsubarraystart-end
 [`child_process`]: child_process.md
+[`child_process.execFile`]: child_process.md#child_processexecfilefile-args-options-callback
+[`child_process.spawn`]: child_process.md#child_processspawncommand-args-options
 [`clearInterval()`]: timers.md#clearintervaltimeout
 [`clearTimeout()`]: timers.md#cleartimeouttimeout
 [`console.error()`]: console.md#consoleerrordata-args

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3843,6 +3843,21 @@ Type: Documentation-only
 `process.features.tls_alpn`, `process.features.tls_ocsp`, and `process.features.tls_sni` are
 deprecated, as their values are guaranteed to be identical to that of `process.features.tls`.
 
+### DEP0190: Passing `args` to `node:child_process` `execFile`/`spawn` with `shell` option `true`
+
+<!-- YAML
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57199
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+When an `args` array is passed to [`child_process.execFile`][] or [`child_process.spawn`][] with the option
+`{ shell: true }`, the values are not escaped, only space-separated, which can lead to shell injection.
+
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/57199
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
