### PR TITLE
test_runner: ensure proper teardown when tests run without isolation

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -797,6 +797,7 @@ function run(options = kEmptyObject) {
         finishBootstrap();
         root.processPendingSubtests();
       };
+      teardown = () => root.harness.teardown();
     }
   }
 

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -629,6 +629,41 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
       assert.strictEqual(diagnostics.includes(entry), true);
     }
   });
+
+  it('should report immediately without waiting for beforeExit event when isolation is none', (t) => {
+    t.plan(1, { wait: 5_000 });
+    const events = [];
+    const expectedEvents = [
+      'test:enqueue',
+      'test:dequeue',
+      'test:complete',
+      'test:start',
+      'test:pass',
+      'test:plan',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:diagnostic',
+      'test:summary',
+    ];
+
+    const stream = run({
+      isolation: 'none',
+      files: [fixtures.path('test-runner', 'default-behavior', 'index.test.js')],
+    });
+
+    stream.on('data', (event) => {
+      events.push(event);
+    });
+
+    stream.on('end', () => {
+      t.assert.deepStrictEqual(events.map(({ type }) => type), expectedEvents);
+    });
+  });
 });
 
 describe('forceExit', () => {


### PR DESCRIPTION
This should address #57234.

Adding the teardown in case of `isolation: none` addresses this specific issue, and I see no potential negative effects in having it.

@cjihrig, was there a reason why we avoided it in the first place?

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
