### PR TITLE
src: cleanup aliased_buffer.h

### DIFF
--- a/src/aliased_buffer.h
+++ b/src/aliased_buffer.h
@@ -22,19 +22,19 @@ typedef size_t AliasedBufferIndex;
  *
  * While this technique is computationally efficient, it is effectively a
  * write to JS program state w/out going through the standard
- * (monitored) API. Thus any VM capabilities to detect the modification are
+ * (monitored) API. Thus, any VM capabilities to detect the modification are
  * circumvented.
  *
  * The encapsulation herein provides a placeholder where such writes can be
  * observed. Any notification APIs will be left as a future exercise.
  */
 template <class NativeT, class V8T>
-class AliasedBufferBase : public MemoryRetainer {
+class AliasedBufferBase final : public MemoryRetainer {
  public:
-  static_assert(std::is_scalar<NativeT>::value);
+  static_assert(std::is_scalar_v<NativeT>);
 
   AliasedBufferBase(v8::Isolate* isolate,
-                    const size_t count,
+                    size_t count,
                     const AliasedBufferIndex* index = nullptr);
 
   /**
@@ -43,13 +43,13 @@ class AliasedBufferBase : public MemoryRetainer {
    * a native buffer, but will each read/write to different sections of the
    * native buffer.
    *
-   *  Note that byte_offset must by aligned by sizeof(NativeT).
+   *  Note that byte_offset must be aligned by sizeof(NativeT).
    */
   // TODO(refack): refactor into a non-owning `AliasedBufferBaseView`
   AliasedBufferBase(
       v8::Isolate* isolate,
-      const size_t byte_offset,
-      const size_t count,
+      size_t byte_offset,
+      size_t count,
       const AliasedBufferBase<uint8_t, v8::Uint8Array>& backing_buffer,
       const AliasedBufferIndex* index = nullptr);
 
@@ -58,7 +58,7 @@ class AliasedBufferBase : public MemoryRetainer {
   AliasedBufferIndex Serialize(v8::Local<v8::Context> context,
                                v8::SnapshotCreator* creator);
 
-  inline void Deserialize(v8::Local<v8::Context> context);
+  void Deserialize(v8::Local<v8::Context> context);
 
   AliasedBufferBase& operator=(AliasedBufferBase&& that) noexcept;
 
@@ -68,7 +68,7 @@ class AliasedBufferBase : public MemoryRetainer {
    */
   class Reference {
    public:
-    Reference(AliasedBufferBase<NativeT, V8T>* aliased_buffer, size_t index)
+    Reference(AliasedBufferBase* aliased_buffer, const size_t index)
         : aliased_buffer_(aliased_buffer), index_(index) {}
 
     Reference(const Reference& that)
@@ -76,12 +76,12 @@ class AliasedBufferBase : public MemoryRetainer {
           index_(that.index_) {
     }
 
-    inline Reference& operator=(const NativeT& val) {
+    Reference& operator=(const NativeT& val) {
       aliased_buffer_->SetValue(index_, val);
       return *this;
     }
 
-    inline Reference& operator=(const Reference& val) {
+    Reference& operator=(const Reference& val) {
       return *this = static_cast<NativeT>(val);
     }
 
@@ -89,24 +89,24 @@ class AliasedBufferBase : public MemoryRetainer {
       return aliased_buffer_->GetValue(index_);
     }
 
-    inline Reference& operator+=(const NativeT& val) {
+    Reference& operator+=(const NativeT& val) {
       const NativeT current = aliased_buffer_->GetValue(index_);
       aliased_buffer_->SetValue(index_, current + val);
       return *this;
     }
 
-    inline Reference& operator+=(const Reference& val) {
+    Reference& operator+=(const Reference& val) {
       return this->operator+=(static_cast<NativeT>(val));
     }
 
-    inline Reference& operator-=(const NativeT& val) {
+    Reference& operator-=(const NativeT& val) {
       const NativeT current = aliased_buffer_->GetValue(index_);
       aliased_buffer_->SetValue(index_, current - val);
       return *this;
     }
 
    private:
-    AliasedBufferBase<NativeT, V8T>* aliased_buffer_;
+    AliasedBufferBase* aliased_buffer_;
     size_t index_;
   };
 
@@ -123,7 +123,7 @@ class AliasedBufferBase : public MemoryRetainer {
    * array becomes unreachable. Usually this means the caller must maintain
    * a JS reference to the typed array from JS object.
    */
-  inline void MakeWeak();
+  void MakeWeak();
 
   /**
   *  Get the underlying v8::ArrayBuffer underlying the TypedArray and
@@ -135,22 +135,22 @@ class AliasedBufferBase : public MemoryRetainer {
    *  Get the underlying native buffer. Note that all reads/writes should occur
    *  through the GetValue/SetValue/operator[] methods
    */
-  inline const NativeT* GetNativeBuffer() const;
+  const NativeT* GetNativeBuffer() const;
 
   /**
    *  Synonym for GetBuffer()
    */
-  inline const NativeT* operator*() const;
+  const NativeT* operator*() const;
 
   /**
    *  Set position index to given value.
    */
-  inline void SetValue(const size_t index, NativeT value);
+  void SetValue(size_t index, NativeT value);
 
   /**
    *  Get value at position index
    */
-  inline const NativeT GetValue(const size_t index) const;
+  const NativeT GetValue(size_t index) const;
 
   /**
    *  Effectively, a synonym for GetValue/SetValue
@@ -166,13 +166,13 @@ class AliasedBufferBase : public MemoryRetainer {
   // an owning `AliasedBufferBase`.
   void reserve(size_t new_capacity);
 
-  inline size_t SelfSize() const override;
+  size_t SelfSize() const override;
 
-  inline const char* MemoryInfoName() const override;
-  inline void MemoryInfo(node::MemoryTracker* tracker) const override;
+  const char* MemoryInfoName() const override;
+  void MemoryInfo(MemoryTracker* tracker) const override;
 
  private:
-  inline bool is_valid() const;
+  bool is_valid() const;
   v8::Isolate* isolate_ = nullptr;
   size_t count_ = 0;
   size_t byte_offset_ = 0;


### PR DESCRIPTION
- Mark `AliasedBufferBase` as `final` as nothing derives from it.
- Simplify scalar check with `std::is_scalar_v`.
- Remove redundant `const`-qualifiers from function declaration parameters (see [[readability-avoid-const-params-in-decls]](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability/avoid-const-params-in-decls.html)).
- Add `const`-qualifiers to function definition parameters where appropriate.
- Remove redundant `inline` specifiers from functions that are templates or has template parents, and from functions that are entirely declared inside class definitions (see [[readability-redundant-inline-specifier]](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.html)).
- Remove redundant template arguments.
- Remove redundant qualified name.
- Fix typo and improve grammar.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
