### PR TITLE
win,test: disable test case failing with ClangCL

### DIFF
--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -42,7 +42,9 @@ assert.strictEqual(cat.killed, true);
 
 // Test different types of kill signals on Windows.
 if (common.isWindows) {
-  for (const sendSignal of ['SIGTERM', 'SIGKILL', 'SIGQUIT', 'SIGINT']) {
+  // SIGQUIT is not supported on Windows 2022, Visual Studio 2022 ClangCL-produced node.exe.
+  // TODO(StefanStojanovic): Investigate this and re-enable it when the issue is fixed.
+  for (const sendSignal of ['SIGTERM', 'SIGKILL', /* 'SIGQUIT', */'SIGINT']) {
     const process = spawn('cmd');
     process.on('exit', (code, signal) => {
       assert.strictEqual(code, null);


### PR DESCRIPTION
This PR disables a `SIGQUIT` test case on Windows for `test-child-process-kill.js`. As it can be seen from the [CI results](https://ci.nodejs.org/job/mefi-node-test-binary-windows-js-suites/), this is the only blocker for enabling tests for ClangCL binaries on all CI runs. IMHO, this is a worthy trade-off.

In addition, this is a temporary thing as I plan to investigate it further and re-enable it ASAP. This problem does not exist when compiling Node.js on the latest Windows 10. Our CI compilation machines use Windows 2022 (Windows 11 basically), so the issue is Windows version specific, and I didn't experience it a few months ago.

I am currently reinstalling my Windows 11 machine (talk about bad timing...), so I should be able to investigate it there later this week.

I'll also request fast tracking, as the change is trivial.

After investigating, I will decide on how to approach it, there is the Node.js part and the libuv part here. Ideally, the fix will be on the Node.js side if feasible. This can be easily done by treating `SIGQUIT` as `SIGKILL`, but I'd like to keep possibility of using it on Windows if possible, as that is a possibility now.