### PR TITLE
doc: update maintaining-openssl.md for openssl

### DIFF
--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -35,7 +35,7 @@ jobs:
           author: Node.js GitHub Bot <github-bot@iojs.org>
           body: This is an automated update of OpenSSL to ${{ env.NEW_VERSION }}.
           branch: actions/tools-update-openssl  # Custom branch *just* for this Action.
-          commit-message: 'deps: upgrade openssl sources to quictls/openssl-${{ env.NEW_VERSION }}'
+          commit-message: 'deps: upgrade openssl sources to openssl-${{ env.NEW_VERSION }}'
           labels: dependencies, openssl
           title: 'deps: update OpenSSL to ${{ env.NEW_VERSION }}'
           path: deps/openssl

--- a/doc/contributing/maintaining/maintaining-openssl.md
+++ b/doc/contributing/maintaining/maintaining-openssl.md
@@ -4,28 +4,6 @@ OpenSSL is automatically updated by the [update-openssl-action][].
 There is also a script in `tools/dep_updaters` that can be used to update it.
 This document describes how to manually update `deps/openssl/`.
 
-If you need to provide updates across all active release lines you will
-currently need to generate four PRs as follows:
-
-* a PR for `main` which is generated following the instructions
-  below for OpenSSL 3.x.x.
-* a PR for 18.x following the instructions in the v18.x-staging version
-  of this guide.
-* a PR for 16.x following the instructions in the v16.x-staging version
-  of this guide.
-
-## Use of the quictls/openssl fork
-
-Node.js currently uses the quictls/openssl fork, which closely tracks
-the main openssl/openssl releases with the addition of APIs to support
-the QUIC protocol.
-
-Details on the fork, as well as the latest sources, can be found at
-<https://github.com/quictls/openssl>.
-
-Branches are used per OpenSSL version (for instance,
-<https://github.com/quictls/openssl/tree/OpenSSL_1_1_1j+quic>).
-
 ## Requirements
 
 * Linux environment.
@@ -52,35 +30,33 @@ NASM version 2.11.08
 
 ## 1. Obtain and extract new OpenSSL sources
 
-Get a new source from <https://github.com/quictls/openssl/tree/openssl-3.0.5+quic>
+Get a new source from <https://github.com/openssl/openssl/tree/openssl-3.0.16>
 and copy all files into `deps/openssl/openssl`. Then add all files and commit
 them. (The link above, and the branch, will change with each new OpenSSL
 release).
 
-### OpenSSL 3.x.x
-
 ```bash
-git clone https://github.com/quictls/openssl
+git clone https://github.com/openssl/openssl
 cd openssl
 cd ../node/deps/openssl
 rm -rf openssl
 cp -R ../../../openssl openssl
-rm -rf openssl/.git* openssl/.travis*
+rm -rf openssl/.git*
 git add --all openssl
 git commit openssl
 ```
 
 ```text
-deps: upgrade openssl sources to quictls/openssl-3.0.5+quic
+deps: upgrade openssl sources to openssl-3.0.16
 
 This updates all sources in deps/openssl/openssl by:
-    $ git clone git@github.com:quictls/openssl.git
+    $ git clone git@github.com:openssl/openssl.git
     $ cd openssl
-    $ git checkout openssl-3.0.5+quic
+    $ git checkout openssl-3.0.16
     $ cd ../node/deps/openssl
     $ rm -rf openssl
     $ cp -R ../../../openssl openssl
-    $ rm -rf openssl/.git* openssl/.travis*
+    $ rm -rf openssl/.git*
     $ git add --all openssl
     $ git commit openssl
 ```
@@ -99,7 +75,8 @@ make -C deps/openssl/config clean
 make -C deps/openssl/config
 ```
 
-**Note**: If the 32-bit Windows is failing to compile run this workflow instead:
+Fix up 32-bit Windows assembler directives. This will allow the commits to be
+cherry-picked to older release lines that still provide binaries on 32-bit Windows.
 
 ```bash
 make -C deps/openssl/config clean
@@ -140,10 +117,8 @@ git commit
 The commit message can be written as (with the openssl version set
 to the relevant value):
 
-### OpenSSL 3.x.x
-
 ```text
-deps: update archs files for quictls/openssl-3.0.5+quic
+deps: update archs files for openssl-3.0.16
 
 After an OpenSSL source update, all the config files need to be
 regenerated and committed by:


### PR DESCRIPTION
Update the instructions for maintaining OpenSSL in the Node.js source tree to reflect switching back from the quictls fork of OpenSSL back to official OpenSSL.

Refs: https://github.com/nodejs/node/pull/57335#issuecomment-2708306368
Refs: https://github.com/nodejs/node/pull/57301
Refs: https://github.com/nodejs/node/pull/57142

---

AFAICT we've been cherry-picking the OpenSSL commits from `main` to `v23.x-staging`, `v22.x-staging`, `v20.x-staging` and `v18.x-staging` instead of opening release line specific pull requests. This is much easier with the update tooling, but does mean the step for updating the 32-bit Windows assembler directives needs to happen (the automation does this) even though we don't build/test on 32-bit Windows from Node.js 23 onwards.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
