### PR TITLE
src: annotate BaseObjects in the heap snapshots correctly

### DIFF
--- a/src/base_object-inl.h
+++ b/src/base_object-inl.h
@@ -125,11 +125,6 @@ bool BaseObject::IsWeakOrDetached() const {
   return pd->wants_weak_jsobj || pd->is_detached;
 }
 
-v8::EmbedderGraph::Node::Detachedness BaseObject::GetDetachedness() const {
-  return IsWeakOrDetached() ? v8::EmbedderGraph::Node::Detachedness::kDetached
-                            : v8::EmbedderGraph::Node::Detachedness::kUnknown;
-}
-
 template <int Field>
 void BaseObject::InternalFieldGet(
     const v8::FunctionCallbackInfo<v8::Value>& args) {

--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -161,10 +161,6 @@ Local<Object> BaseObject::WrappedObject() const {
   return object();
 }
 
-bool BaseObject::IsRootNode() const {
-  return !persistent_handle_.IsWeak();
-}
-
 bool BaseObject::IsNotIndicativeOfMemoryLeakAtExit() const {
   return IsWeakOrDetached();
 }

--- a/src/base_object.h
+++ b/src/base_object.h
@@ -105,8 +105,6 @@ class BaseObject : public MemoryRetainer {
   // to it anymore.
   inline bool IsWeakOrDetached() const;
 
-  inline v8::EmbedderGraph::Node::Detachedness GetDetachedness() const override;
-
   // Utility to create a FunctionTemplate with one internal field (used for
   // the `BaseObject*` pointer) and a constructor that initializes that field
   // to `nullptr`.
@@ -192,7 +190,6 @@ class BaseObject : public MemoryRetainer {
 
  private:
   v8::Local<v8::Object> WrappedObject() const override;
-  bool IsRootNode() const override;
   void DeleteMe();
 
   // persistent_handle_ needs to be at a fixed offset from the start of the

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -221,6 +221,7 @@ function validateSnapshotNodes(...args) {
  * A alternative heap snapshot validator that can be used to verify cppgc-managed nodes.
  * Modified from
  * https://chromium.googlesource.com/v8/v8/+/b00e995fb212737802810384ba2b868d0d92f7e5/test/unittests/heap/cppgc-js/unified-heap-snapshot-unittest.cc#134
+ * @param {object[]} nodes Snapshot nodes returned by createJSHeapSnapshot() or a subset filtered from it.
  * @param {string} rootName Name of the root node. Typically a class name used to filter all native nodes with
  *                          this name. For cppgc-managed objects, this is typically the name configured by
  *                          SET_CPPGC_NAME() prefixed with an additional "Node /" prefix e.g.
@@ -231,12 +232,12 @@ function validateSnapshotNodes(...args) {
  *   node_type?: string,
  *   edge_type?: string,
  * }]} retainingPath The retaining path specification to search from the root nodes.
+ * @param {boolean} allowEmpty Whether the function should fail if no matching nodes can be found.
  * @returns {[object]} All the leaf nodes matching the retaining path specification. If none can be found,
  *                     logs the nodes found in the last matching step of the path (if any), and throws an
  *                     assertion error.
  */
-function findByRetainingPath(rootName, retainingPath) {
-  const nodes = createJSHeapSnapshot();
+function findByRetainingPathFromNodes(nodes, rootName, retainingPath, allowEmpty = false) {
   let haystack = nodes.filter((n) => n.name === rootName && n.type !== 'string');
 
   for (let i = 0; i < retainingPath.length; ++i) {
@@ -269,6 +270,9 @@ function findByRetainingPath(rootName, retainingPath) {
     }
 
     if (newHaystack.length === 0) {
+      if (allowEmpty) {
+        return [];
+      }
       const format = (val) => util.inspect(val, { breakLength: 128, depth: 3 });
       console.error('#');
       console.error('# Retaining path to search for:');
@@ -282,6 +286,7 @@ function findByRetainingPath(rootName, retainingPath) {
       }
 
       assert.fail(`Could not find target edge ${format(expected)} in the heap snapshot.`);
+
     }
 
     haystack = newHaystack;
@@ -321,9 +326,19 @@ function getHeapSnapshotOptionTests() {
   };
 }
 
+/**
+ * Similar to @see {findByRetainingPathFromNodes} but creates the snapshot from scratch.
+ */
+function findByRetainingPath(...args) {
+  const nodes = createJSHeapSnapshot();
+  return findByRetainingPathFromNodes(nodes, ...args);
+}
+
 module.exports = {
   recordState,
   validateSnapshotNodes,
   findByRetainingPath,
+  findByRetainingPathFromNodes,
   getHeapSnapshotOptionTests,
+  createJSHeapSnapshot,
 };

--- a/test/pummel/test-heapdump-dns.js
+++ b/test/pummel/test-heapdump-dns.js
@@ -1,19 +1,31 @@
-// Flags: --expose-internals
 'use strict';
-require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
+// This tests heap snapshot integration of dns ChannelWrap.
 
-validateSnapshotNodes('Node / ChannelWrap', []);
+require('../common');
+const { findByRetainingPath } = require('../common/heap');
+const assert = require('assert');
+
+// Before dns is loaded, no ChannelWrap should be created.
+{
+  const nodes = findByRetainingPath('Node / ChannelWrap', []);
+  assert.strictEqual(nodes.length, 0);
+}
+
 const dns = require('dns');
-validateSnapshotNodes('Node / ChannelWrap', [{}]);
+
+// Right after dns is loaded, a ChannelWrap should be created for the default
+// resolver, but it has no task list.
+{
+  findByRetainingPath('Node / ChannelWrap', [
+    { node_name: 'ChannelWrap', edge_name: 'native_to_javascript' },
+  ]);
+}
+
 dns.resolve('localhost', () => {});
-validateSnapshotNodes('Node / ChannelWrap', [
-  {
-    children: [
-      { node_name: 'Node / NodeAresTask::List', edge_name: 'task_list' },
-      // `Node / ChannelWrap` (C++) -> `ChannelWrap` (JS)
-      { node_name: 'ChannelWrap', edge_name: 'native_to_javascript' },
-    ],
-    detachedness: 2,
-  },
-]);
+
+// After dns resolution, the ChannelWrap of the default resolver has the task list.
+{
+  findByRetainingPath('Node / ChannelWrap', [
+    { node_name: 'Node / NodeAresTask::List', edge_name: 'task_list' },
+  ]);
+}

--- a/test/pummel/test-heapdump-env.js
+++ b/test/pummel/test-heapdump-env.js
@@ -1,4 +1,3 @@
-// Flags: --expose-internals
 'use strict';
 
 // This tests that Environment is tracked in heap snapshots.
@@ -6,19 +5,24 @@
 // test-heapdump-*.js files.
 
 require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
+const { createJSHeapSnapshot, findByRetainingPathFromNodes } = require('../common/heap');
 
-validateSnapshotNodes('Node / Environment', [{
-  children: [
-    { node_name: 'Node / CleanupQueue', edge_name: 'cleanup_queue' },
-    { node_name: 'Node / IsolateData', edge_name: 'isolate_data' },
-    { node_name: 'Node / PrincipalRealm', edge_name: 'principal_realm' },
-  ],
-}]);
+const nodes = createJSHeapSnapshot();
 
-validateSnapshotNodes('Node / PrincipalRealm', [{
-  children: [
-    { node_name: 'process', edge_name: 'process_object' },
-    { node_name: 'Node / BaseObjectList', edge_name: 'base_object_list' },
-  ],
-}]);
+const envs = findByRetainingPathFromNodes(nodes, 'Node / Environment', []);
+findByRetainingPathFromNodes(envs, 'Node / Environment', [
+  { node_name: 'Node / CleanupQueue', edge_name: 'cleanup_queue' },
+]);
+findByRetainingPathFromNodes(envs, 'Node / Environment', [
+  { node_name: 'Node / IsolateData', edge_name: 'isolate_data' },
+]);
+
+const realms = findByRetainingPathFromNodes(envs, 'Node / Environment', [
+  { node_name: 'Node / PrincipalRealm', edge_name: 'principal_realm' },
+]);
+findByRetainingPathFromNodes(realms, 'Node / PrincipalRealm', [
+  { node_name: 'process', edge_name: 'process_object' },
+]);
+findByRetainingPathFromNodes(realms, 'Node / PrincipalRealm', [
+  { node_name: 'Node / BaseObjectList', edge_name: 'base_object_list' },
+]);

--- a/test/pummel/test-heapdump-fs-promise.js
+++ b/test/pummel/test-heapdump-fs-promise.js
@@ -1,16 +1,26 @@
-// Flags: --expose-internals
 'use strict';
-require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
-const fs = require('fs').promises;
 
-validateSnapshotNodes('Node / FSReqPromise', []);
+// This tests heap snapshot integration of fs promise.
+
+require('../common');
+const { findByRetainingPath, findByRetainingPathFromNodes } = require('../common/heap');
+const fs = require('fs').promises;
+const assert = require('assert');
+
+// Before fs promise is used, no FSReqPromise should be created.
+{
+  const nodes = findByRetainingPath('Node / FSReqPromise', []);
+  assert.strictEqual(nodes.length, 0);
+}
+
 fs.stat(__filename);
-validateSnapshotNodes('Node / FSReqPromise', [
-  {
-    children: [
-      { node_name: 'FSReqPromise', edge_name: 'native_to_javascript' },
-      { node_name: 'Node / AliasedFloat64Array', edge_name: 'stats_field_array' },
-    ],
-  },
-]);
+
+{
+  const nodes = findByRetainingPath('Node / FSReqPromise', []);
+  findByRetainingPathFromNodes(nodes, 'Node / FSReqPromise', [
+    { node_name: 'FSReqPromise', edge_name: 'native_to_javascript' },
+  ]);
+  findByRetainingPathFromNodes(nodes, 'Node / FSReqPromise', [
+    { node_name: 'Node / AliasedFloat64Array', edge_name: 'stats_field_array' },
+  ]);
+}

--- a/test/pummel/test-heapdump-http2.js
+++ b/test/pummel/test-heapdump-http2.js
@@ -1,15 +1,21 @@
-// Flags: --expose-internals
 'use strict';
+
+// This tests heap snapshot integration of http2.
+
 const common = require('../common');
-const { recordState } = require('../common/heap');
+const { createJSHeapSnapshot, findByRetainingPath, findByRetainingPathFromNodes } = require('../common/heap');
+const assert = require('assert');
+
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const http2 = require('http2');
 
+// Before http2 is used, no Http2Session or Http2Streamshould be created.
 {
-  const state = recordState();
-  state.validateSnapshotNodes('Node / Http2Session', []);
-  state.validateSnapshotNodes('Node / Http2Stream', []);
+  const sessions = findByRetainingPath('Node / Http2Session', []);
+  assert.strictEqual(sessions.length, 0);
+  const streams = findByRetainingPath('Node / Http2Stream', []);
+  assert.strictEqual(streams.length, 0);
 }
 
 const server = http2.createServer();
@@ -21,63 +27,45 @@ server.listen(0, () => {
   const req = client.request();
 
   req.on('response', common.mustCall(() => {
-    const state = recordState();
+    const nodes = createJSHeapSnapshot();
 
     // `Node / Http2Stream` (C++) -> Http2Stream (JS)
-    state.validateSnapshotNodes('Node / Http2Stream', [
-      {
-        children: [
-          // current_headers and/or queue could be empty
-          { node_name: 'Http2Stream', edge_name: 'native_to_javascript' },
-        ],
-      },
-    ], { loose: true });
+    findByRetainingPathFromNodes(nodes, 'Node / Http2Stream', [
+      // current_headers and/or queue could be empty
+      { node_name: 'Http2Stream', edge_name: 'native_to_javascript' },
+    ]);
 
     // `Node / FileHandle` (C++) -> FileHandle (JS)
-    state.validateSnapshotNodes('Node / FileHandle', [
-      {
-        children: [
-          { node_name: 'FileHandle', edge_name: 'native_to_javascript' },
-          // current_headers could be empty
-        ],
-      },
-    ], { loose: true });
-    state.validateSnapshotNodes('Node / TCPSocketWrap', [
-      {
-        children: [
-          { node_name: 'TCP', edge_name: 'native_to_javascript' },
-        ],
-      },
-    ], { loose: true });
-    state.validateSnapshotNodes('Node / TCPServerWrap', [
-      {
-        children: [
-          { node_name: 'TCP', edge_name: 'native_to_javascript' },
-        ],
-      },
-    ], { loose: true });
-    // `Node / StreamPipe` (C++) -> StreamPipe (JS)
-    state.validateSnapshotNodes('Node / StreamPipe', [
-      {
-        children: [
-          { node_name: 'StreamPipe', edge_name: 'native_to_javascript' },
-        ],
-      },
+    findByRetainingPathFromNodes(nodes, 'Node / FileHandle', [
+      { node_name: 'FileHandle', edge_name: 'native_to_javascript' },
+      // current_headers could be empty
     ]);
+    findByRetainingPathFromNodes(nodes, 'Node / TCPSocketWrap', [
+      { node_name: 'TCP', edge_name: 'native_to_javascript' },
+    ]);
+
+    findByRetainingPathFromNodes(nodes, 'Node / TCPServerWrap', [
+      { node_name: 'TCP', edge_name: 'native_to_javascript' },
+    ]);
+
+    // `Node / StreamPipe` (C++) -> StreamPipe (JS)
+    findByRetainingPathFromNodes(nodes, 'Node / StreamPipe', [
+      { node_name: 'StreamPipe', edge_name: 'native_to_javascript' },
+    ]);
+
     // `Node / Http2Session` (C++) -> Http2Session (JS)
-    state.validateSnapshotNodes('Node / Http2Session', [
-      {
-        children: [
-          { node_name: 'Http2Session', edge_name: 'native_to_javascript' },
-          { node_name: 'Node / nghttp2_memory', edge_name: 'nghttp2_memory' },
-          {
-            node_name: 'Node / streams', edge_name: 'streams',
-          },
-          // outstanding_pings, outgoing_buffers, outgoing_storage,
-          // pending_rst_streams could be empty
-        ],
-      },
-    ], { loose: true });
+    const sessions = findByRetainingPathFromNodes(nodes, 'Node / Http2Session', []);
+    findByRetainingPathFromNodes(sessions, 'Node / Http2Session', [
+      { node_name: 'Http2Session', edge_name: 'native_to_javascript' },
+    ]);
+    findByRetainingPathFromNodes(sessions, 'Node / Http2Session', [
+      { node_name: 'Node / nghttp2_memory', edge_name: 'nghttp2_memory' },
+    ]);
+    findByRetainingPathFromNodes(sessions, 'Node / Http2Session', [
+      { node_name: 'Node / streams', edge_name: 'streams' },
+    ]);
+    // outstanding_pings, outgoing_buffers, outgoing_storage,
+    // pending_rst_streams could be empty
   }));
 
   req.resume();

--- a/test/pummel/test-heapdump-inspector.js
+++ b/test/pummel/test-heapdump-inspector.js
@@ -1,44 +1,29 @@
-// Flags: --expose-internals
 'use strict';
-const common = require('../common');
+// This tests heap snapshot integration of inspector.
 
+const common = require('../common');
+const assert = require('assert');
 common.skipIfInspectorDisabled();
 
-const { validateSnapshotNodes } = require('../common/heap');
+const { findByRetainingPath, findByRetainingPathFromNodes } = require('../common/heap');
 const inspector = require('inspector');
 
-const snapshotNode = {
-  children: [
-    { node_name: 'Node / InspectorSession', edge_name: 'session' },
-  ],
-};
-
-// Starts with no JSBindingsConnection (or 1 if coverage enabled).
+// Starts with no JSBindingsConnection.
 {
-  const expected = [];
-  if (process.env.NODE_V8_COVERAGE) {
-    expected.push(snapshotNode);
-  }
-  validateSnapshotNodes('Node / JSBindingsConnection', expected);
+  const nodes = findByRetainingPath('Node / JSBindingsConnection', []);
+  assert.strictEqual(nodes.length, 0);
 }
 
-// JSBindingsConnection should be added.
+// JSBindingsConnection should be added once inspector session is created.
 {
   const session = new inspector.Session();
   session.connect();
-  const expected = [
-    {
-      children: [
-        { node_name: 'Node / InspectorSession', edge_name: 'session' },
-        { node_name: 'Connection', edge_name: 'native_to_javascript' },
-        (edge) => edge.name === 'callback' &&
-          (edge.to.type === undefined || // embedded graph
-           edge.to.type === 'closure'), // snapshot
-      ],
-    },
-  ];
-  if (process.env.NODE_V8_COVERAGE) {
-    expected.push(snapshotNode);
-  }
-  validateSnapshotNodes('Node / JSBindingsConnection', expected);
+
+  const nodes = findByRetainingPath('Node / JSBindingsConnection', []);
+  findByRetainingPathFromNodes(nodes, 'Node / JSBindingsConnection', [
+    { node_name: 'Node / InspectorSession', edge_name: 'session' },
+  ]);
+  findByRetainingPathFromNodes(nodes, 'Node / JSBindingsConnection', [
+    { node_name: 'Connection', edge_name: 'native_to_javascript' },
+  ]);
 }

--- a/test/pummel/test-heapdump-shadow-realm.js
+++ b/test/pummel/test-heapdump-shadow-realm.js
@@ -1,9 +1,16 @@
-// Flags: --experimental-shadow-realm --expose-internals
+// Flags: --experimental-shadow-realm
+// This tests heap snapshot integration of ShadowRealm
+
 'use strict';
 require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
+const { findByRetainingPath } = require('../common/heap');
+const assert = require('assert');
 
-validateSnapshotNodes('Node / ShadowRealm', []);
+// Before shadow realm is created, no ShadowRealm should be captured.
+{
+  const nodes = findByRetainingPath('Node / ShadowRealm', []);
+  assert.strictEqual(nodes.length, 0);
+}
 
 let realm;
 let counter = 0;
@@ -23,19 +30,9 @@ function createRealms() {
 }
 
 function validateHeap() {
-  validateSnapshotNodes('Node / Environment', [
-    {
-      children: [
-        { node_name: 'Node / shadow_realms', edge_name: 'shadow_realms' },
-      ],
-    },
-  ]);
-  validateSnapshotNodes('Node / shadow_realms', [
-    {
-      children: [
-        { node_name: 'Node / ShadowRealm' },
-      ],
-    },
+  findByRetainingPath('Node / Environment', [
+    { node_name: 'Node / shadow_realms', edge_name: 'shadow_realms' },
+    { node_name: 'Node / ShadowRealm' },
   ]);
 }
 

--- a/test/pummel/test-heapdump-tls.js
+++ b/test/pummel/test-heapdump-tls.js
@@ -1,15 +1,20 @@
-// Flags: --expose-internals
 'use strict';
+// This tests heap snapshot integration of tls sockets.
 const common = require('../common');
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
-const { validateSnapshotNodes } = require('../common/heap');
+const { findByRetainingPath, findByRetainingPathFromNodes } = require('../common/heap');
+const assert = require('assert');
 const net = require('net');
 const tls = require('tls');
 
-validateSnapshotNodes('Node / TLSWrap', []);
+// Before tls is used, no TLSWrap should be created.
+{
+  const nodes = findByRetainingPath('Node / TLSWrap', []);
+  assert.strictEqual(nodes.length, 0);
+}
 
 const server = net.createServer(common.mustCall((c) => {
   c.end();
@@ -21,15 +26,16 @@ const server = net.createServer(common.mustCall((c) => {
   }));
   c.write('hello');
 
-  validateSnapshotNodes('Node / TLSWrap', [
-    {
-      children: [
-        { node_name: 'Node / NodeBIO', edge_name: 'enc_out' },
-        { node_name: 'Node / NodeBIO', edge_name: 'enc_in' },
-        // `Node / TLSWrap` (C++) -> `TLSWrap` (JS)
-        { node_name: 'TLSWrap', edge_name: 'native_to_javascript' },
-        // pending_cleartext_input could be empty
-      ],
-    },
+  const nodes = findByRetainingPath('Node / TLSWrap', []);
+  findByRetainingPathFromNodes(nodes, 'Node / TLSWrap', [
+    { node_name: 'Node / NodeBIO', edge_name: 'enc_out' },
+  ]);
+  findByRetainingPathFromNodes(nodes, 'Node / TLSWrap', [
+    { node_name: 'Node / NodeBIO', edge_name: 'enc_in' },
+  ]);
+  findByRetainingPathFromNodes(nodes, 'Node / TLSWrap', [
+    // `Node / TLSWrap` (C++) -> `TLSWrap` (JS)
+    { node_name: 'TLSWrap', edge_name: 'native_to_javascript' },
+    // pending_cleartext_input could be empty
   ]);
 }));

--- a/test/pummel/test-heapdump-urlpattern.js
+++ b/test/pummel/test-heapdump-urlpattern.js
@@ -1,24 +1,23 @@
-// Flags: --expose-internals
 'use strict';
+// This tests heap snapshot integration of URLPattern.
 require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
+const { findByRetainingPath } = require('../common/heap');
 const { URLPattern } = require('node:url');
+const assert = require('assert');
 
-validateSnapshotNodes('Node / URLPattern', []);
+// Before url pattern is used, no URLPattern should be created.
+{
+  const nodes = findByRetainingPath('Node / URLPattern', []);
+  assert.strictEqual(nodes.length, 0);
+}
+
 const urlPattern = new URLPattern('https://example.com/:id');
-validateSnapshotNodes('Node / URLPattern', [
-  {
-    children: [
-      { node_name: 'Node / ada::url_pattern', edge_name: 'url_pattern' },
-    ],
-  },
-]);
-validateSnapshotNodes('Node / ada::url_pattern', [
-  {
-    children: [
-      { node_name: 'Node / ada::url_pattern_component', edge_name: 'protocol_component' },
-    ],
-  },
+
+// After url pattern is used, a URLPattern should be created.
+findByRetainingPath('Node / URLPattern', [
+  { node_name: 'Node / ada::url_pattern', edge_name: 'url_pattern' },
+  // ada::url_pattern references ada::url_pattern_component.
+  { node_name: 'Node / ada::url_pattern_component', edge_name: 'protocol_component' },
 ]);
 
 // Use `urlPattern`.

--- a/test/pummel/test-heapdump-worker.js
+++ b/test/pummel/test-heapdump-worker.js
@@ -1,16 +1,27 @@
-// Flags: --expose-internals
 'use strict';
-require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
-const { Worker } = require('worker_threads');
 
-validateSnapshotNodes('Node / Worker', []);
+// This tests heap snapshot integration of worker.
+
+require('../common');
+const { findByRetainingPath } = require('../common/heap');
+const { Worker } = require('worker_threads');
+const assert = require('assert');
+
+// Before worker is used, no MessagePort should be created.
+{
+  const nodes = findByRetainingPath('Node / Worker', []);
+  assert.strictEqual(nodes.length, 0);
+}
+
 const worker = new Worker('setInterval(() => {}, 100);', { eval: true });
-validateSnapshotNodes('Node / MessagePort', [
-  {
-    children: [
-      { node_name: 'Node / MessagePortData', edge_name: 'data' },
-    ],
-  },
-], { loose: true });
+// When a worker is alive, a Worker instance and its message port should be captured.
+{
+  findByRetainingPath('Node / Worker', [
+    { node_name: 'Worker', edge_name: 'native_to_javascript' },
+    { node_name: 'MessagePort', edge_name: 'messagePort' },
+    { node_name: 'Node / MessagePort', edge_name: 'javascript_to_native' },
+    { node_name: 'Node / MessagePortData', edge_name: 'data' },
+  ]);
+}
+
 worker.terminate();

--- a/test/pummel/test-heapdump-zlib.js
+++ b/test/pummel/test-heapdump-zlib.js
@@ -1,28 +1,35 @@
-// Flags: --expose-internals
 'use strict';
+// This tests heap snapshot integration of zlib stream.
+
 const common = require('../common');
-const { validateSnapshotNodes } = require('../common/heap');
+const assert = require('assert');
+const { findByRetainingPath, findByRetainingPathFromNodes } = require('../common/heap');
 const zlib = require('zlib');
 
-validateSnapshotNodes('Node / ZlibStream', []);
+// Before zlib stream is created, no ZlibStream should be created.
+{
+  const nodes = findByRetainingPath('Node / ZlibStream', []);
+  assert.strictEqual(nodes.length, 0);
+}
 
 const gzip = zlib.createGzip();
-validateSnapshotNodes('Node / ZlibStream', [
-  {
-    children: [
-      { node_name: 'Zlib', edge_name: 'native_to_javascript' },
-      // No entry for memory because zlib memory is initialized lazily.
-    ],
-  },
-]);
 
+// After zlib stream is created, a ZlibStream should be created.
+{
+  const streams = findByRetainingPath('Node / ZlibStream', []);
+  findByRetainingPathFromNodes(streams, 'Node / ZlibStream', [
+    { node_name: 'Zlib', edge_name: 'native_to_javascript' },
+  ]);
+  // No entry for memory because zlib memory is initialized lazily.
+  const withMemory = findByRetainingPathFromNodes(streams, 'Node / ZlibStream', [
+    { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' },
+  ], true);
+  assert.strictEqual(withMemory.length, 0);
+}
+
+// After zlib stream is written, zlib_memory should be created.
 gzip.write('hello world', common.mustCall(() => {
-  validateSnapshotNodes('Node / ZlibStream', [
-    {
-      children: [
-        { node_name: 'Zlib', edge_name: 'native_to_javascript' },
-        { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' },
-      ],
-    },
+  findByRetainingPath('Node / ZlibStream', [
+    { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' },
   ]);
 }));


### PR DESCRIPTION
### src: annotate BaseObjects in the heap snapshots correctly

This fixes two issues in the BaseObject views in the heap snapshots:

1. BaseObjects are not conceptually roots when the environment and
   the realms are also showing up in the heap snapshot. Rather, they
   should be considered being held alive by the BaseObjectList in
   the realms, which are in turn held alive by Environment. The
   actual root from the containment view should be the Environment
   instead.
2. The concept of DOM detaching does not really apply to Node.js
   wrappers, and it's confusing to connect that with the weakness
   or detachment (native weakness) of BaseObjects, especially if we
   consider the Environment to be the root instead. To avoid the
   confusion, just restore to the default detachedness for them.

### test: use findByRetainingPath in heapdump tests

This makes sure that the tests are run on actual heap snapshots
and prints out missing paths when it cannot be found, which
makes failures easier to debug, and removes the unnecessary
requirement for BaseObjects to be root - which would make
the heap snapshot containment view rather noisy and is not
conceptually correct, since they are actually held by the
BaseObjectList held by the realms.

Previously with this snippet

```js
const v8 = require('v8');
const { Worker } = require('worker_threads');
const worker = new Worker('setInterval(() => {}, 100);', { eval: true });
console.log(v8.writeHeapSnapshot());
worker.terminate();
```

The containment view looked like this:

<img width="735" alt="Screenshot 2025-03-11 at 20 24 44" src="https://github.com/user-attachments/assets/4c8e82ab-480f-4933-a815-65d945fc827e" />

the base objects are again listed in Environment -> principal_realm -> base_object_list, but with some of other objects (mostly BindingData objects) shown as detached, it's a bit confusing here because the "detached from DOM" concept does not really apply to Node.js. Node.js does not have a DOM tree, and the nodes here would be shown as detached even when they are not reachable by user JS.

<img width="713" alt="Screenshot 2025-03-11 at 20 29 17" src="https://github.com/user-attachments/assets/688be530-4537-4167-b9f9-c9ad9be8d75c" />


After this patch,  the containment view looks like this

<img width="735" alt="Screenshot 2025-03-11 at 20 24 59" src="https://github.com/user-attachments/assets/91bbd077-6946-4bf3-9870-df0ccadb39ab" />

The base objects are usually referenced Environment -> principal_realm -> base_object_list which is more conceptually correct, and we no longer show the confusing detached state:

<img width="731" alt="Screenshot 2025-03-11 at 20 26 04" src="https://github.com/user-attachments/assets/c658a3bb-4049-440e-a19c-0f5b947929e8" />

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
