### PR TITLE
doc: explicit mention arbitrary code execution as a vuln

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -107,8 +107,7 @@ causing an unrecoverable crash, or any other unexpected side effects that can
 lead to a loss of confidentiality, integrity, or availability.
 
 For example, if trusted input (like secure application code) is correct,
-then untrusted input must not lead to arbitrary JavaScript code execution or
-escape the sandbox.
+then untrusted input must not lead to arbitrary JavaScript code execution.
 
 **Node.js trusts everything else**. Examples include:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,6 +106,10 @@ a security vulnerability. Examples of unwanted actions are polluting globals,
 causing an unrecoverable crash, or any other unexpected side effects that can
 lead to a loss of confidentiality, integrity, or availability.
 
+For example, if trusted input (like secure application code) is correct,
+then untrusted input must not lead to arbitrary JavaScript code execution or
+escape the sandbox.
+
 **Node.js trusts everything else**. Examples include:
 
 * The developers and infrastructure that runs it.


### PR DESCRIPTION
This request came from Github Open Source Secure and it's always welcome to clarify the policy
