### PR TITLE
doc: add history info for --use-system-ca

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2939,6 +2939,10 @@ The following values are valid for `mode`:
 
 <!-- YAML
 added: v23.8.0
+changes:
+  - version: v23.9.0
+    pr-url: https://github.com/nodejs/node/pull/57009
+    description: Added support on non-Windows and non-macOS.
 -->
 
 Node.js uses the trusted CA certificates present in the system store along with

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2937,6 +2937,10 @@ The following values are valid for `mode`:
 
 ### `--use-system-ca`
 
+<!-- YAML
+added: v23.8.0
+-->
+
 Node.js uses the trusted CA certificates present in the system store along with
 the `--use-bundled-ca` option and the `NODE_EXTRA_CA_CERTS` environment variable.
 On platforms other than Windows and macOS, this loads certificates from the directory


### PR DESCRIPTION
These are the PRs for --use-system-ca:
- initial implementation of the option with just macOS support https://github.com/nodejs/node/pull/56599 landed in v23.8.0.
- Windows support https://github.com/nodejs/node/pull/56833 landed in v23.8.0
- non-Windows and non-macOS support https://github.com/nodejs/node/pull/57009 landed in v23.9.0

This change documents the history info.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
