### PR TITLE
doc: clarify --cpu-prof-name allowed values

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -495,12 +495,18 @@ in the current working directory.
 If `--cpu-prof-name` is not specified, the generated profile is
 named `CPU.${yyyymmdd}.${hhmmss}.${pid}.${tid}.${seq}.cpuprofile`.
 
-If `--cpu-prof-name` is specified, the provided value will be used as-is; patterns such as `${hhmmss}` or `${pid}` are not supported.
-
 ```console
 $ node --cpu-prof index.js
 $ ls *.cpuprofile
 CPU.20190409.202950.15293.0.0.cpuprofile
+```
+
+If `--cpu-prof-name` is specified, the provided value will be used as-is; patterns such as `${hhmmss}` or `${pid}` are not supported.
+
+```console
+$ node --cpu-prof --cpu-prof-name 'CPU.${pid}.cpuprofile' index.js
+$ ls *.cpuprofile
+'CPU.${pid}.cpuprofile'
 ```
 
 ### `--cpu-prof-dir`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -501,7 +501,8 @@ $ ls *.cpuprofile
 CPU.20190409.202950.15293.0.0.cpuprofile
 ```
 
-If `--cpu-prof-name` is specified, the provided value will be used as-is; patterns such as `${hhmmss}` or `${pid}` are not supported.
+If `--cpu-prof-name` is specified, the provided value will be used as-is; patterns such as
+`${hhmmss}` or `${pid}` are not supported.
 
 ```console
 $ node --cpu-prof --cpu-prof-name 'CPU.${pid}.cpuprofile' index.js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -495,6 +495,8 @@ in the current working directory.
 If `--cpu-prof-name` is not specified, the generated profile is
 named `CPU.${yyyymmdd}.${hhmmss}.${pid}.${tid}.${seq}.cpuprofile`.
 
+If `--cpu-prof-name` is specified, the provided value will be used as-is; patterns such as `${hhmmss}` or `${pid}` are not supported.
+
 ```console
 $ node --cpu-prof index.js
 $ ls *.cpuprofile


### PR DESCRIPTION
Added clarification for the `--cpu-prof-name` cli parameter allowed values.

Refs: https://github.com/nodejs/node/issues/57418

