### PR TITLE
deps: V8: cherry-pick c172ffc5bf54

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -6356,12 +6356,13 @@ void Heap::AddRetainedMaps(DirectHandle<NativeContext> context,
                            GlobalHandleVector<Map> maps) {
   Handle<WeakArrayList> array(Cast<WeakArrayList>(context->retained_maps()),
                               isolate());
-  if (array->IsFull()) {
+  int new_maps_size = static_cast<int>(maps.size()) * kRetainMapEntrySize;
+  if (array->length() + new_maps_size > array->capacity()) {
     CompactRetainedMaps(*array);
   }
   int cur_length = array->length();
-  array = WeakArrayList::EnsureSpace(
-      isolate(), array, cur_length + static_cast<int>(maps.size()) * 2);
+  array =
+      WeakArrayList::EnsureSpace(isolate(), array, cur_length + new_maps_size);
   if (*array != context->retained_maps()) {
     context->set_retained_maps(*array);
   }
@@ -6379,7 +6380,7 @@ void Heap::AddRetainedMaps(DirectHandle<NativeContext> context,
       raw_array->Set(cur_length, MakeWeak(*map));
       raw_array->Set(cur_length + 1,
                      Smi::FromInt(v8_flags.retain_maps_for_n_gc));
-      cur_length += 2;
+      cur_length += kRetainMapEntrySize;
       raw_array->set_length(cur_length);
 
       map->set_is_in_retained_map_list(true);
@@ -6391,7 +6392,7 @@ void Heap::CompactRetainedMaps(Tagged<WeakArrayList> retained_maps) {
   int length = retained_maps->length();
   int new_length = 0;
   // This loop compacts the array by removing cleared weak cells.
-  for (int i = 0; i < length; i += 2) {
+  for (int i = 0; i < length; i += kRetainMapEntrySize) {
     Tagged<MaybeObject> maybe_object = retained_maps->Get(i);
     if (maybe_object.IsCleared()) {
       continue;
@@ -6405,7 +6406,7 @@ void Heap::CompactRetainedMaps(Tagged<WeakArrayList> retained_maps) {
       retained_maps->Set(new_length, maybe_object);
       retained_maps->Set(new_length + 1, age);
     }
-    new_length += 2;
+    new_length += kRetainMapEntrySize;
   }
   Tagged<HeapObject> undefined = ReadOnlyRoots(this).undefined_value();
   for (int i = new_length; i < length; i++) {

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1812,6 +1812,8 @@ class Heap final {
   void AddToRingBuffer(const char* string);
   void GetFromRingBuffer(char* buffer);
 
+  static constexpr int kRetainMapEntrySize = 2;
+
   void CompactRetainedMaps(Tagged<WeakArrayList> retained_maps);
 
   void CollectGarbageOnMemoryPressure();


### PR DESCRIPTION
fix: #57412

This upstream V8 commit fixes the issue where the size of RetainedMaps continuously increases, leading to higher memory usage.

This issue has been occurring since AddRetainedMap was changed to AddRetainedMaps in the commit [d8c97e48573ef9679751be0c7a308e08d0101c47](https://github.com/nodejs/node/commit/d8c97e48573ef9679751be0c7a308e08d0101c47).

As a result, the Main branch, v23.x.x, and v22.x.x should need this.

Original commit message:

    Compact retained maps array more often

    When we add maps to the retained maps array, we compacted the array if
    it's full. But, since we are now adding maps in a batch, it's unlikely
    to meet the condition. Thus, update the condition to check whether new
    size exceeds the capacity.

    Bug: 398528460
    Change-Id: I89caa47b69532c6397596edfe5caf7c7d24768cc
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6330019
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Commit-Queue: Choongwoo Han <choongwoo.han@microsoft.com>
    Cr-Commit-Position: refs/heads/main@{#99163}

Refs: https://github.com/v8/v8/commit/c172ffc5bf54e704558103973e1d5cb7aec491cb

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
