### PR TITLE
meta: remove ovflowd as collaborator

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,8 +403,6 @@ For information about the governance of the Node.js project, see
   **Moshe Atlow** <<moshe@atlow.co.il>> (he/him)
 * [MrJithil](https://github.com/MrJithil) -
   **Jithil P Ponnan** <<jithil@outlook.com>> (he/him)
-* [ovflowd](https://github.com/ovflowd) -
-  **Claudio Wunder** <<cwunder@gnome.org>> (he/they)
 * [panva](https://github.com/panva) -
   **Filip Skokan** <<panva.ip@gmail.com>> (he/him)
 * [pimterry](https://github.com/pimterry) -

--- a/README.md
+++ b/README.md
@@ -627,6 +627,8 @@ For information about the governance of the Node.js project, see
   **Alexis Campailla** <<orangemocha@nodejs.org>>
 * [othiym23](https://github.com/othiym23) -
   **Forrest L Norvell** <<ogd@aoaioxxysz.net>> (they/them/themself)
+* [ovflowd](https://github.com/ovflowd) -
+  **Claudio Wunder** <<cwunder@gnome.org>> (he/they)
 * [oyyd](https://github.com/oyyd) -
   **Ouyang Yadong** <<oyydoibh@gmail.com>> (he/him)
 * [petkaantonov](https://github.com/petkaantonov) -


### PR DESCRIPTION
I don't feel comfortable being a collaborator. While I am not actively involved in the day-to-day work within nodejs/node, I believe my contributions are still critical to it. However, I do not feel at ease participating in conversations within nodejs/collaborators. Given the internal discussions, I genuinely prefer to refrain from engaging in conversations related to collaborations; otherwise, I feel like I'm compromising my values and being hypocritical.

I will continue to do critical work, but I don’t think I should be a core collaborator as I don't belong in the "core collaborators" team.

Thank you.