### PR TITLE
module: fix incorrect formatting in require(esm) cycle error message

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -416,8 +416,8 @@ class ModuleLoader {
       if (parentFilename) {
         message += ` (from ${parentFilename})`;
       }
-      message += 'A cycle involving require(esm) is disallowed to maintain ';
-      message += 'invariants madated by the ECMAScript specification';
+      message += ' A cycle involving require(esm) is not allowed to maintain ';
+      message += 'invariants mandated by the ECMAScript specification. ';
       message += 'Try making at least part of the dependency in the graph lazily loaded.';
       throw new ERR_REQUIRE_CYCLE_MODULE(message);
 


### PR DESCRIPTION
This pull request includes minor wording and punctuation tweaks to fix the formatting of the require(esm) cycle error message. The message still seems a bit confusing to me, but these changes should at least be an improvement.

I am not sure whether tests should be implemented for this change, as the original error message didn't have tests either, but I can try my hand at implementing some if that would be preferred.

Fixes: https://github.com/nodejs/node/issues/57451