### PR TITLE
doc: mark commonjs as legacy

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -2,12 +2,12 @@
 
 <!--introduced_in=v0.10.0-->
 
-> Stability: 2 - Stable
+> Stability: 3 - Legacy: Use [ECMAScript modules][] instead.
 
 <!--name=module-->
 
-CommonJS modules are the original way to package JavaScript code for Node.js.
-Node.js also supports the [ECMAScript modules][] standard used by browsers
+CommonJS modules are the legacy way to package JavaScript code for Node.js.
+Node.js supports the [ECMAScript modules][] standard used by browsers
 and other JavaScript runtimes.
 
 In Node.js, each file is treated as a separate module. For


### PR DESCRIPTION
# Mark CommonJS as legacy

LEGACY !== DEPRECATED

Legacy means that there is a newer, standardized alternative.
This also means we mark ESM as first class citizen.
ESM is not a 1-1 replacement and there are still some use cases where commonjs performs better.
Uniting under a common module sistem will help improving the esm condition.
If we all use the same thing it will be easier to optimize it.

## In practice?

This means that in the future the default module system will become esm, the module detection tries esm first etc....
This also discourages users to use CommonJS in greenfield projects.
Commonjs will still be supported forever.

## Why now?

In one month v18 will be EOL meaning there will be full interoperability between esm and commonjs modules.
Package authors are shifting to ESM and there is enthusiasm in the ecosystem for this big change.
This has no practical effect other than making a statement to our users, it's not a paternalistic REWRITE YOU APPLICATION IN ESM!
By marking commonjs as legacy, we gently help the ecosystem to shift towards the standardization path.


@nodejs/tsc 