### PR TITLE
Fixing typo in URLPattern parameters

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -767,7 +767,7 @@ case-insensitive matching if set to true.
 
 The constructor can throw a `TypeError` to indicate parsing failure.
 
-#### `new URLPattern(objg[, baseURL][, options])`
+#### `new URLPattern(obj[, baseURL][, options])`
 
 * `obj` {Object} An input pattern
 * `baseURL` {string | undefined} A base URL string


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/57464