### PR TITLE
build: fix update-wpt workflow

### DIFF
--- a/.github/workflows/update-wpt.yml
+++ b/.github/workflows/update-wpt.yml
@@ -70,7 +70,11 @@ jobs:
       - name: Open or update PR for the subsystem update
         uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
         with:
-          branch: actions/update-wpt-${{ matrix.subsystem }}
+          # The create-or-update-pull-request-action matches the branch name by prefix,
+          # which is why we need to add the -wpt suffix. If we dont do that, we risk matching wrong PRs,
+          # like for example "url" mistakenly matching and updating the "urlpattern" PR
+          # as seen in https://github.com/nodejs/node/pull/57368
+          branch: actions/update-${{ matrix.subsystem }}-wpt
           author: Node.js GitHub Bot <github-bot@iojs.org>
           title: 'test: update WPT for ${{ matrix.subsystem }} to ${{ env.short_version }}'
           commit-message: 'test: update WPT for ${{ matrix.subsystem }} to ${{ env.short_version }}'


### PR DESCRIPTION
There is a bug in `create-or-update` action [here](https://github.com/gr2m/create-or-update-pull-request-action/blob/master/index.js#L153) which is causing url subsystem updates to mistakenly update the wrong PR (as seen in https://github.com/nodejs/node/pull/57368). The match being performed in that API call is not an exact match, which causes inference in L158 to pick up the wrong PR.