### PR TITLE
src: force gc for flaky (deadlock) tests

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1166,6 +1166,10 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "force FIPS crypto (cannot be disabled)",
             &PerProcessOptions::force_fips_crypto,
             kAllowedInEnvvar);
+  AddOption("--force-gc-for-test",
+            "",
+            &PerProcessOptions::force_gc_for_test,
+            kAllowedInEnvvar);
   AddOption("--secure-heap",
             "total size of the OpenSSL secure heap",
             &PerProcessOptions::secure_heap,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -321,6 +321,7 @@ class PerProcessOptions : public Options {
   std::string snapshot_blob;
 
   std::vector<std::string> security_reverts;
+  bool force_gc_for_test = false;
   bool print_bash_completion = false;
   bool print_help = false;
   bool print_v8_help = false;

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -464,6 +464,11 @@ void NodePlatform::DrainTasks(Isolate* isolate) {
   if (!per_isolate) return;
 
   do {
+    if (per_process::cli_options->force_gc_for_test) {
+      isolate->RequestGarbageCollectionForTesting(
+          Isolate::GarbageCollectionType::kFullGarbageCollection);
+    }
+
     // Worker tasks aren't associated with an Isolate.
     worker_thread_task_runner_->BlockingDrain();
   } while (per_isolate->FlushForegroundTasksInternal());


### PR DESCRIPTION
This patch adds a new flag `force_gc_for_test` (internal use for test purpose only) to force GC for flaky tests that suffer from deadlock. Refs: https://github.com/nodejs/node/issues/54918 and https://github.com/nodejs/node/pull/56827#issuecomment-2654039651

The deadlock occurs when (_correct me if I am wrong_):
1. Main thread calls DrainTasks and executes worker tasks
2. Worker task needs memory allocation requiring GC
3. GC must run on main thread, but main thread is busy running the worker task

Notes:
1. v8 `RequestGarbageCollectionForTesting` will require `--expose-gc` flag to work which means for the flaky tests that suffer from deadlock we will need `// Flags: --expose-gc --force-gc-for-test` at the top of the test file.
2. This patch **_does not_** resolve the deadlock issue but rather an attempt to reduce the flaky tests without marking them as flaky.
3. Based on the findings, I will take time looking into how chromium handles it and see if we can properly fix it in node, but any help would be greatly appreciated 🙏
4.  Bad at naming, if this patch is acceptable, please suggest a good name for the option name.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
5. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
