### PR TITLE
test: update parallel/test-tls-dhe for OpenSSL 3.5

### DIFF
--- a/test/parallel/test-tls-dhe.js
+++ b/test/parallel/test-tls-dhe.js
@@ -85,7 +85,10 @@ function test(dhparam, keylen, expectedCipher) {
 
     execFile(opensslCli, args, common.mustSucceed((stdout) => {
       assert(keylen === null ||
-             stdout.includes(`Server Temp Key: DH, ${keylen} bits`));
+             // s_client < OpenSSL 3.5
+             stdout.includes(`Server Temp Key: DH, ${keylen} bits`) ||
+             // s_client >= OpenSSL 3.5
+             stdout.includes(`Peer Temp Key: DH, ${keylen} bits`));
       assert(stdout.includes(`Cipher    : ${expectedCipher}`));
       server.close();
     }));


### PR DESCRIPTION
The output of the `s_client` command invoked by the test has changed in the OpenSSL 3.5.0 version of `s_client`. Update the test so that it works with both the old and new output -- the `s_client` binary being run may not be at the exact same version of OpenSSL as used by Node.js so the updated test allows either output.

Refs: https://github.com/openssl/openssl/pull/26734
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
