### PR TITLE
fix: Use of a weak cryptographic key

### DIFF
--- a/benchmark/crypto/keygen.js
+++ b/benchmark/crypto/keygen.js
@@ -43,8 +43,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i) {
       generateKeyPairSync('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       });
     }
     bench.end(n);
@@ -60,8 +60,8 @@ const methods = {
     bench.start();
     for (let i = 0; i < n; ++i)
       generateKeyPair('dsa', {
-        modulusLength: 1024,
-        divisorLength: 160,
+        modulusLength: 2048,
+        divisorLength: 256,
       }, done);
   },
 };


### PR DESCRIPTION
https://github.com/nodejs/node/blob/72aa2ea8416e7790ac0ae586584b7a2f10f3f8f3/benchmark/crypto/keygen.js#L45-L48

Modern encryption relies on it being computationally infeasible to break the cipher and decode a message without the key. As computational power increases, the ability to break ciphers grows and keys need to become larger.


### References
[RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem))
[AES](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
[NodeJS](https://nodejs.org/api/crypto.html)
[Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf)
[Key size](https://en.wikipedia.org/wiki/Key_size)
[CWE-326](https://cwe.mitre.org/data/definitions/326.html)