### PR TITLE
src: initialize privateSymbols for per_context

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -769,9 +769,7 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
 
 Local<Object> InitializePrivateSymbols(Local<Context> context,
                                        IsolateData* isolate_data) {
-  if (isolate_data == nullptr) {
-    return Local<Object>();
-  }
+  CHECK(isolate_data);
   Isolate* isolate = context->GetIsolate();
   EscapableHandleScope scope(isolate);
   Context::Scope context_scope(context);

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -615,12 +615,11 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context,
   if (existing_value->IsObject())
     return handle_scope.Escape(existing_value.As<Object>());
 
-  Local<String> primordials_string =
-      FIXED_ONE_BYTE_STRING(isolate, "primordials");
+  // To initialize the per-context binding exports, a non-nullptr isolate_data
+  // is needed
+  CHECK(isolate_data);
   Local<Object> exports = Object::New(isolate);
   if (context->Global()->SetPrivate(context, key, exports).IsNothing() ||
-      (isolate_data == nullptr &&
-       exports->Has(context, primordials_string).FromJust()) ||
       InitializePrimordials(context, isolate_data).IsNothing()) {
     return MaybeLocal<Object>();
   }

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include "env_properties.h"
 #include "node.h"
 #include "node_builtins.h"
 #include "node_context_data.h"
@@ -599,7 +600,8 @@ std::unique_ptr<MultiIsolatePlatform> MultiIsolatePlatform::Create(
                                         page_allocator);
 }
 
-MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
+MaybeLocal<Object> GetPerContextExports(Local<Context> context,
+                                        IsolateData* isolate_data) {
   Isolate* isolate = context->GetIsolate();
   EscapableHandleScope handle_scope(isolate);
 
@@ -613,10 +615,15 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
   if (existing_value->IsObject())
     return handle_scope.Escape(existing_value.As<Object>());
 
+  Local<String> primordials_string =
+      FIXED_ONE_BYTE_STRING(isolate, "primordials");
   Local<Object> exports = Object::New(isolate);
   if (context->Global()->SetPrivate(context, key, exports).IsNothing() ||
-      InitializePrimordials(context).IsNothing())
+      (isolate_data == nullptr &&
+       exports->Has(context, primordials_string).FromJust()) ||
+      InitializePrimordials(context, isolate_data).IsNothing()) {
     return MaybeLocal<Object>();
+  }
   return handle_scope.Escape(exports);
 }
 
@@ -761,7 +768,34 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
   return JustVoid();
 }
 
-Maybe<void> InitializePrimordials(Local<Context> context) {
+Local<Object> InitializePrivateSymbols(Local<Context> context,
+                                       IsolateData* isolate_data) {
+  if (isolate_data == nullptr) {
+    return Local<Object>();
+  }
+  Isolate* isolate = context->GetIsolate();
+  EscapableHandleScope scope(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> private_symbols = ObjectTemplate::New(isolate);
+  Local<Object> private_symbols_object;
+#define V(PropertyName, _)                                                     \
+  private_symbols->Set(isolate, #PropertyName, isolate_data->PropertyName());
+
+  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
+#undef V
+
+  if (!private_symbols->NewInstance(context).ToLocal(&private_symbols_object) ||
+      private_symbols_object->SetPrototypeV2(context, Null(isolate))
+          .IsNothing()) {
+    return Local<Object>();
+  }
+
+  return scope.Escape(private_symbols_object);
+}
+
+Maybe<void> InitializePrimordials(Local<Context> context,
+                                  IsolateData* isolate_data) {
   // Run per-context JS files.
   Isolate* isolate = context->GetIsolate();
   Context::Scope context_scope(context);
@@ -783,6 +817,9 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
     return Nothing<void>();
   }
 
+  Local<Object> private_symbols =
+      InitializePrivateSymbols(context, isolate_data);
+
   static const char* context_files[] = {"internal/per_context/primordials",
                                         "internal/per_context/domexception",
                                         "internal/per_context/messageport",
@@ -798,7 +835,12 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
   builtin_loader.SetEagerCompile();
 
   for (const char** module = context_files; *module != nullptr; module++) {
-    Local<Value> arguments[] = {exports, primordials};
+    Local<Value> arguments[3];
+    arguments[0] = exports;
+    arguments[1] = primordials;
+    arguments[2] = private_symbols.IsEmpty() ? Local<Value>(Undefined(isolate))
+                                             : Local<Value>(private_symbols);
+
     if (builtin_loader
             .CompileAndCall(
                 context, *module, arraysize(arguments), arguments, nullptr)

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -405,6 +405,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompile(Local<Context> context,
     parameters = {
         FIXED_ONE_BYTE_STRING(isolate, "exports"),
         FIXED_ONE_BYTE_STRING(isolate, "primordials"),
+        FIXED_ONE_BYTE_STRING(isolate, "privateSymbols"),
     };
   } else if (strncmp(id, "internal/main/", strlen("internal/main/")) == 0 ||
              strncmp(id,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -115,8 +115,8 @@ v8::Maybe<void> InitializeBaseContextForSnapshot(
 v8::Maybe<void> InitializeContextRuntime(v8::Local<v8::Context> context);
 v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context,
                                       IsolateData* isolate_data);
-v8::Local<v8::Object> InitializePrivateSymbols(v8::Local<v8::Context> context,
-                                               IsolateData* isolate_data);
+v8::MaybeLocal<v8::Object> InitializePrivateSymbols(
+    v8::Local<v8::Context> context, IsolateData* isolate_data);
 
 class NodeArrayBufferAllocator : public ArrayBufferAllocator {
  public:

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -113,7 +113,10 @@ std::string GetHumanReadableProcessName();
 v8::Maybe<void> InitializeBaseContextForSnapshot(
     v8::Local<v8::Context> context);
 v8::Maybe<void> InitializeContextRuntime(v8::Local<v8::Context> context);
-v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context);
+v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context,
+                                      IsolateData* isolate_data);
+v8::Local<v8::Object> InitializePrivateSymbols(v8::Local<v8::Context> context,
+                                               IsolateData* isolate_data);
 
 class NodeArrayBufferAllocator : public ArrayBufferAllocator {
  public:
@@ -340,7 +343,8 @@ v8::Isolate* NewIsolate(v8::Isolate::CreateParams* params,
 // was provided by the embedder.
 v8::MaybeLocal<v8::Value> StartExecution(Environment* env,
                                          StartExecutionCallback cb = nullptr);
-v8::MaybeLocal<v8::Object> GetPerContextExports(v8::Local<v8::Context> context);
+v8::MaybeLocal<v8::Object> GetPerContextExports(
+    v8::Local<v8::Context> context, IsolateData* isolate_data = nullptr);
 void MarkBootstrapComplete(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 class InitializationResultImpl final : public InitializationResult {

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -251,14 +251,16 @@ void Message::AdoptSharedValueConveyor(SharedValueConveyor&& conveyor) {
 
 namespace {
 
-MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context) {
+MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context,
+                                            IsolateData* isolate_data) {
   Isolate* isolate = context->GetIsolate();
   Local<Object> per_context_bindings;
   Local<Value> emit_message_val;
-  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
-      !per_context_bindings->Get(context,
-                                FIXED_ONE_BYTE_STRING(isolate, "emitMessage"))
-          .ToLocal(&emit_message_val)) {
+  if (!GetPerContextExports(context, isolate_data)
+           .ToLocal(&per_context_bindings) ||
+      !per_context_bindings
+           ->Get(context, FIXED_ONE_BYTE_STRING(isolate, "emitMessage"))
+           .ToLocal(&emit_message_val)) {
     return MaybeLocal<Function>();
   }
   CHECK(emit_message_val->IsFunction());
@@ -682,7 +684,8 @@ MessagePort::MessagePort(Environment* env,
   }
 
   Local<Function> emit_message_fn;
-  if (!GetEmitMessageFunction(context).ToLocal(&emit_message_fn))
+  if (!GetEmitMessageFunction(context, env->isolate_data())
+           .ToLocal(&emit_message_fn))
     return;
   emit_message_fn_.Reset(env->isolate(), emit_message_fn);
 

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -45,7 +45,7 @@ void Realm::CreateProperties() {
 
   // Store primordials setup by the per-context script in the environment.
   Local<Object> per_context_bindings =
-      GetPerContextExports(ctx).ToLocalChecked();
+      GetPerContextExports(ctx, env_->isolate_data()).ToLocalChecked();
   Local<Value> primordials =
       per_context_bindings->Get(ctx, env_->primordials_string())
           .ToLocalChecked();


### PR DESCRIPTION
In some cases, `per_context` files need to access privateSymbols. This commit lets `GetPerContextExports` to be able to pass down `IsolateData` to `InitializePrimordials`, so it can compile `per_context` files with `privateSymbols` from `IsolateData`.

With this change we can access `privateSymbols` in `per_context/domexception.js` like
```
const { transfer_mode_private_symbol } = privateSymbols;
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
