### PR TITLE
src: remove deleted tls file

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -122,10 +122,9 @@ BuiltinLoader::BuiltinCategories BuiltinLoader::GetBuiltinCategories() const {
 
 #if !HAVE_OPENSSL
         "crypto", "crypto/promises", "https", "http2", "tls", "_tls_common",
-        "_tls_wrap", "internal/tls/secure-pair",
-        "internal/tls/parse-cert-string", "internal/tls/secure-context",
-        "internal/http2/core", "internal/http2/compat",
-        "internal/streams/lazy_transform",
+        "_tls_wrap", "internal/tls/parse-cert-string",
+        "internal/tls/secure-context", "internal/http2/core",
+        "internal/http2/compat", "internal/streams/lazy_transform",
 #endif           // !HAVE_OPENSSL
 #if !NODE_OPENSSL_HAS_QUIC
         "internal/quic/quic", "internal/quic/symbols", "internal/quic/stats",


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/57361

cc @JonasBa

Fixes the following:

```
node on git:main ❯ ninja -C out/Release                       10:13AM
ninja: Entering directory `out/Release'
ninja: error: '../../lib/internal/tls/secure-pair.js', needed by 'gen/node_javascript.cc', missing and no known rule to make it
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
