### PR TITLE
doc: replace NOTEs that do not render properly

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -919,14 +919,10 @@ added: v23.10.0
 
 > Stability: 1.0 - Early development
 
-If present, Node.js will look for a
-configuration file at the specified path.
-Node.js will read the configuration file and apply the settings.
-The configuration file should be a JSON file
-with the following structure:
-
-> \[!NOTE]
-> Replace `vX.Y.Z` in the `$schema` with the version of Node.js you are using.
+If present, Node.js will look for a configuration file at the specified path.
+Node.js will read the configuration file and apply the settings. The
+configuration file should be a JSON file with the following structure. `vX.Y.Z`
+in the `$schema` must be replaced with the version of Node.js you are using.
 
 ```json
 {

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -91,9 +91,9 @@ but we recommend version 5.8 or newer with the following `tsconfig.json` setting
 }
 ```
 
-> \[!NOTE]
-> Use the `noEmit` option if you intend to only execute `*.ts` files, for example a build script.
-> You won't need this flag if you intend to distribute `*.js` files.
+Use the `noEmit` option if you intend to only execute `*.ts` files, for example
+a build script. You won't need this flag if you intend to distribute `*.js`
+files.
 
 ### Determining module system
 


### PR DESCRIPTION
This commit removes two NOTEs that render properly as Markdown, but not on the docs website.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
