### PR TITLE
timers: remove unnecessary allocation of _onTimeout

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -208,9 +208,6 @@ class Timeout {
     this._idlePrev = this;
     this._idleNext = this;
     this._idleStart = null;
-    // This must be set to null first to avoid function tracking
-    // on the hidden class, revisit in V8 versions after 6.2
-    this._onTimeout = null;
     this._onTimeout = callback;
     this._timerArgs = args;
     this._repeat = isRepeat ? after : null;


### PR DESCRIPTION
This doesn't cause that problem anymore