### PR TITLE
repl: deprecate `repl.builtinModules`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3879,6 +3879,24 @@ Type: Runtime
 When an `args` array is passed to [`child_process.execFile`][] or [`child_process.spawn`][] with the option
 `{ shell: true }`, the values are not escaped, only space-separated, which can lead to shell injection.
 
+### DEP0191: `repl.builtinModules`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57508
+    description: Documentation-only deprecation
+                 with `--pending-deprecation` support.
+-->
+
+Type: Documentation-only (supports [`--pending-deprecation`][])
+
+The `node:repl` module exports a `builtinModules` property that contains an array
+of built-in modules. This was incomplete and matched the already deprecated
+`repl._builtinLibs` ([DEP0142][]) instead it's better to rely
+upon `require('node:module').builtinModules`.
+
+[DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -646,11 +646,14 @@ with REPL instances programmatically.
 
 <!-- YAML
 added: v14.5.0
+deprecated: REPLACEME
 -->
+
+> Stability: 0 - Deprecated. Use [`module.builtinModules`][] instead.
 
 * {string\[]}
 
-A list of the names of all Node.js modules, e.g., `'http'`.
+A list of the names of some Node.js modules, e.g., `'http'`.
 
 ## `repl.start([options])`
 
@@ -908,6 +911,7 @@ avoiding open network interfaces.
 [`ERR_INVALID_REPL_INPUT`]: errors.md#err_invalid_repl_input
 [`curl(1)`]: https://curl.haxx.se/docs/manpage.html
 [`domain`]: domain.md
+[`module.builtinModules`]: module.md#modulebuiltinmodules
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#processsetuncaughtexceptioncapturecallbackfn
 [`readline.InterfaceCompleter`]: readline.md#use-of-the-completer-function
 [`repl.ReplServer`]: #class-replserver

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1858,9 +1858,17 @@ module.exports = {
 
 ObjectDefineProperty(module.exports, 'builtinModules', {
   __proto__: null,
-  get: () => _builtinLibs,
-  set: (val) => _builtinLibs = val,
-  enumerable: true,
+  get: pendingDeprecation ? deprecate(
+    () => _builtinLibs,
+    'repl.builtinModules is deprecated. Check module.builtinModules instead',
+    'DEP0191',
+  ) : () => _builtinLibs,
+  set: pendingDeprecation ? deprecate(
+    (val) => _builtinLibs = val,
+    'repl.builtinModules is deprecated. Check module.builtinModules instead',
+    'DEP0191',
+  ) : (val) => _builtinLibs = val,
+  enumerable: false,
   configurable: true,
 });
 

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -29,12 +29,15 @@ const repl = require('repl');
 const cp = require('child_process');
 
 assert.strictEqual(repl.repl, undefined);
+
 repl._builtinLibs; // eslint-disable-line no-unused-expressions
+repl.builtinModules; // eslint-disable-line no-unused-expressions
 
 common.expectWarning({
   DeprecationWarning: {
     DEP0142:
       'repl._builtinLibs is deprecated. Check module.builtinModules instead',
+    DEP0191: 'repl.builtinModules is deprecated. Check module.builtinModules instead',
     DEP0141: 'repl.inputStream and repl.outputStream are deprecated. ' +
              'Use repl.input and repl.output instead',
   }


### PR DESCRIPTION
Fixes #57504 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
