### PR TITLE
assert: improve partialDeepStrictEqual

### DIFF
--- a/benchmark/assert/deepequal-buffer.js
+++ b/benchmark/assert/deepequal-buffer.js
@@ -7,7 +7,7 @@ const bench = common.createBenchmark(main, {
   len: [1e2, 1e3],
   strict: [0, 1],
   arrayBuffer: [0, 1],
-  method: ['deepEqual', 'notDeepEqual', 'unequal_length'],
+  method: ['deepEqual', 'notDeepEqual', 'unequal_length', 'partial'],
 }, {
   combinationFilter: (p) => {
     return p.strict === 1 || p.method === 'deepEqual';
@@ -18,9 +18,14 @@ function main({ len, n, method, strict, arrayBuffer }) {
   let actual = Buffer.alloc(len);
   let expected = Buffer.alloc(len + Number(method === 'unequal_length'));
 
-
   if (method === 'unequal_length') {
     method = 'notDeepEqual';
+  }
+
+  if (method === 'partial') {
+    method = 'partialDeepStrictEqual';
+  } else if (strict) {
+    method = method.replace('eep', 'eepStrict');
   }
 
   for (let i = 0; i < len; i++) {
@@ -31,10 +36,6 @@ function main({ len, n, method, strict, arrayBuffer }) {
   if (method.includes('not')) {
     const position = Math.floor(len / 2);
     expected[position] = expected[position] + 1;
-  }
-
-  if (strict) {
-    method = method.replace('eep', 'eepStrict');
   }
 
   const fn = assert[method];

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -243,7 +243,7 @@ function innerDeepEqual(val1, val2, mode, memos) {
         TypedArrayPrototypeGetSymbolToStringTag(val2)) {
       return false;
     }
-    if (mode === kPartial) {
+    if (mode === kPartial && val1.byteLength !== val2.byteLength) {
       if (!isPartialArrayBufferView(val1, val2)) {
         return false;
       }
@@ -280,7 +280,7 @@ function innerDeepEqual(val1, val2, mode, memos) {
     if (!isAnyArrayBuffer(val2)) {
       return false;
     }
-    if (mode !== kPartial) {
+    if (mode !== kPartial || val1.byteLength === val2.byteLength) {
       if (!areEqualArrayBuffers(val1, val2)) {
         return false;
       }
@@ -546,17 +546,17 @@ function partialObjectSetEquiv(a, b, mode, set, memo) {
 }
 
 function setObjectEquiv(a, b, mode, set, memo) {
-  if (mode === kPartial) {
-    return partialObjectSetEquiv(a, b, mode, set, memo);
-  }
   // Fast path for objects only
-  if (mode === kStrict && set.size === a.size) {
+  if (mode !== kLoose && set.size === a.size) {
     for (const val of a) {
       if (!setHasEqualElement(set, val, mode, memo)) {
         return false;
       }
     }
     return true;
+  }
+  if (mode === kPartial) {
+    return partialObjectSetEquiv(a, b, mode, set, memo);
   }
 
   for (const val of a) {
@@ -639,17 +639,17 @@ function partialObjectMapEquiv(a, b, mode, set, memo) {
 }
 
 function mapObjectEquivalence(a, b, mode, set, memo) {
-  if (mode === kPartial) {
-    return partialObjectMapEquiv(a, b, mode, set, memo);
-  }
   // Fast path for objects only
-  if (mode === kStrict && set.size === a.size) {
+  if (mode !== kLoose && set.size === a.size) {
     for (const { 0: key1, 1: item1 } of a) {
       if (!mapHasEqualEntry(set, b, key1, item1, mode, memo)) {
         return false;
       }
     }
     return true;
+  }
+  if (mode === kPartial) {
+    return partialObjectMapEquiv(a, b, mode, set, memo);
   }
   for (const { 0: key1, 1: item1 } of a) {
     if (typeof key1 === 'object' && key1 !== null) {

--- a/test/parallel/test-assert-partial-deep-equal.js
+++ b/test/parallel/test-assert-partial-deep-equal.js
@@ -281,6 +281,11 @@ describe('Object Comparison Tests', () => {
           ]),
         },
         {
+          description: 'throws for Maps with mixed unequal entries',
+          actual: new Map([[{ a: 2 }, 1], [1, 1], [{ b: 1 }, 1], [[], 1], [2, 1], [{ a: 1 }, 1]]),
+          expected: new Map([[{ a: 1 }, 1], [[], 1], [2, 1], [{ a: 1 }, 1]]),
+        },
+        {
           description: 'throws for sets with different object values',
           actual: new Set([
             { a: 1 },
@@ -493,6 +498,11 @@ describe('Object Comparison Tests', () => {
           description: 'throws when comparing Float32Array([+0.0]) with Float32Array([-0.0])',
           actual: new Float32Array([+0.0]),
           expected: new Float32Array([-0.0]),
+        },
+        {
+          description: 'throws when comparing two Uint8Array objects with non-matching entries',
+          actual: { typedArray: new Uint8Array([1, 2, 3, 4, 5]) },
+          expected: { typedArray: new Uint8Array([1, 333, 2, 4]) },
         },
         {
           description: 'throws when comparing two different urls',
@@ -713,7 +723,7 @@ describe('Object Comparison Tests', () => {
       {
         description: 'compares two Uint8Array objects',
         actual: { typedArray: new Uint8Array([1, 2, 3, 4, 5]) },
-        expected: { typedArray: new Uint8Array([1, 2, 3]) },
+        expected: { typedArray: new Uint8Array([1, 2, 3, 5]) },
       },
       {
         description: 'compares two Int16Array objects',


### PR DESCRIPTION
This implements fast paths for typed arrays, array buffers and sets
and maps that contain only objects as keys.