### PR TITLE
doc: mark more long-time experimental APIs as stable

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5281,9 +5281,11 @@ An alias for [`buffer.constants.MAX_STRING_LENGTH`][].
 
 <!-- YAML
 added: v16.7.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `id` {string} A `'blob:nodedata:...` URL string returned by a prior call to
   `URL.createObjectURL()`.

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5283,7 +5283,7 @@ An alias for [`buffer.constants.MAX_STRING_LENGTH`][].
 added: v16.7.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -481,6 +481,9 @@ number of bytes read is zero.
 <!-- YAML
 added: v17.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version: v23.8.0
     pr-url: https://github.com/nodejs/node/pull/55461
     description: Removed option to create a 'bytes' stream. Streams are now always 'bytes' streams.
@@ -490,8 +493,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/46933
     description: Added option to create a 'bytes' stream.
 -->
-
-> Stability: 1 - Experimental
 
 * Returns: {ReadableStream}
 
@@ -1074,6 +1075,9 @@ behavior is similar to `cp dir1/ dir2/`.
 <!-- YAML
 added: v22.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v23.7.0
     - v22.14.0
@@ -1083,8 +1087,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/52837
     description: Add support for `withFileTypes` as an option.
 -->
-
-> Stability: 1 - Experimental
 
 * `pattern` {string|string\[]}
 * `options` {Object}
@@ -3132,6 +3134,9 @@ descriptor. See [`fs.utimes()`][].
 <!-- YAML
 added: v22.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v23.7.0
     - v22.14.0
@@ -3141,8 +3146,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/52837
     description: Add support for `withFileTypes` as an option.
 -->
-
-> Stability: 1 - Experimental
 
 * `pattern` {string|string\[]}
 
@@ -3583,9 +3586,11 @@ Functions based on `fs.open()` exhibit this behavior as well:
 
 <!-- YAML
 added: v19.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `path` {string|Buffer|URL}
 * `options` {Object}
@@ -5682,6 +5687,9 @@ Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 <!-- YAML
 added: v22.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v23.7.0
     - v22.14.0
@@ -5691,8 +5699,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/52837
     description: Add support for `withFileTypes` as an option.
 -->
-
-> Stability: 1 - Experimental
 
 * `pattern` {string|string\[]}
 * `options` {Object}
@@ -6837,9 +6843,11 @@ added:
   - v21.4.0
   - v20.12.0
   - v18.20.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * {string}
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -482,7 +482,7 @@ number of bytes read is zero.
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
   - version: v23.8.0
     pr-url: https://github.com/nodejs/node/pull/55461
@@ -1076,7 +1076,7 @@ behavior is similar to `cp dir1/ dir2/`.
 added: v22.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
   - version:
     - v23.7.0
@@ -3135,7 +3135,7 @@ descriptor. See [`fs.utimes()`][].
 added: v22.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
   - version:
     - v23.7.0
@@ -3588,7 +3588,7 @@ Functions based on `fs.open()` exhibit this behavior as well:
 added: v19.8.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -5688,7 +5688,7 @@ Synchronous version of [`fs.futimes()`][]. Returns `undefined`.
 added: v22.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
   - version:
     - v23.7.0
@@ -6845,7 +6845,7 @@ added:
   - v18.20.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -502,7 +502,7 @@ line prompts are included in the calculations.
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -500,9 +500,11 @@ line prompts are included in the calculations.
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 ### Class: `readlinePromises.Interface`
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -877,9 +877,11 @@ the stream has not been destroyed, errored, or ended.
 added:
   - v18.0.0
   - v16.17.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * {boolean}
 
@@ -1641,9 +1643,11 @@ the stream has not been destroyed or emitted `'error'` or `'end'`.
 
 <!-- YAML
 added: v16.8.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * {boolean}
 
@@ -1655,9 +1659,11 @@ Returns whether the stream was destroyed or errored before emitting `'end'`.
 added:
   - v16.7.0
   - v14.18.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * {boolean}
 
@@ -2003,9 +2009,11 @@ a promise that fulfills when the stream is finished.
 added:
   - v19.1.0
   - v18.13.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `stream` {Stream|Iterable|AsyncIterable|Function}
 * `options` {Object}
@@ -2038,9 +2046,11 @@ See [`stream.compose`][] for more information.
 
 <!-- YAML
 added: v16.3.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `options` {Object}
   * `destroyOnReturn` {boolean} When set to `false`, calling `return` on the
@@ -2095,14 +2105,15 @@ added:
   - v17.4.0
   - v16.14.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v20.7.0
     - v18.19.0
     pr-url: https://github.com/nodejs/node/pull/49249
     description: added `highWaterMark` in options.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to map over every chunk in the
   stream.
@@ -2150,14 +2161,15 @@ added:
   - v17.4.0
   - v16.14.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v20.7.0
     - v18.19.0
     pr-url: https://github.com/nodejs/node/pull/49249
     description: added `highWaterMark` in options.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to filter chunks from the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2208,9 +2220,11 @@ for await (const result of dnsResults) {
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2269,9 +2283,11 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `options` {Object}
   * `signal` {AbortSignal} allows cancelling the toArray operation if the
@@ -2309,9 +2325,11 @@ const dnsResults = await Readable.from([
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2360,9 +2378,11 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2412,9 +2432,11 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2463,9 +2485,11 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncGeneratorFunction|AsyncFunction} a function to map over
   every chunk in the stream.
@@ -2514,9 +2538,11 @@ for await (const result of concatResult) {
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `limit` {number} the number of chunks to drop from the readable.
 * `options` {Object}
@@ -2538,9 +2564,11 @@ await Readable.from([1, 2, 3, 4]).drop(2).toArray(); // [3, 4]
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `limit` {number} the number of chunks to take from the readable.
 * `options` {Object}
@@ -2562,9 +2590,11 @@ await Readable.from([1, 2, 3, 4]).take(2).toArray(); // [1, 2]
 added:
   - v17.5.0
   - v16.15.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a reducer function to call over every chunk
   in the stream.
@@ -3079,9 +3109,11 @@ Readable.from([
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `readableStream` {ReadableStream}
 * `options` {Object}
@@ -3095,9 +3127,11 @@ added: v17.0.0
 
 <!-- YAML
 added: v16.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `stream` {stream.Readable|ReadableStream}
 * Returns: `boolean`
@@ -3110,9 +3144,11 @@ Returns whether the stream has been read from or cancelled.
 added:
   - v17.3.0
   - v16.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `stream` {Readable|Writable|Duplex|WritableStream|ReadableStream}
 * Returns: {boolean}
@@ -3125,9 +3161,11 @@ Returns whether the stream has encountered an error.
 added:
   - v17.4.0
   - v16.14.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `stream` {Readable|Duplex|ReadableStream}
 * Returns: {boolean}
@@ -3139,13 +3177,14 @@ Returns whether the stream is readable.
 <!-- YAML
 added: v17.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
   - version:
     - v18.7.0
     pr-url: https://github.com/nodejs/node/pull/43515
     description: include strategy options on Readable.
 -->
-
-> Stability: 1 - Experimental
 
 * `streamReadable` {stream.Readable}
 * `options` {Object}
@@ -3164,9 +3203,11 @@ changes:
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `writableStream` {WritableStream}
 * `options` {Object}
@@ -3180,9 +3221,11 @@ added: v17.0.0
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `streamWritable` {stream.Writable}
 * Returns: {WritableStream}
@@ -3242,9 +3285,11 @@ Duplex.from([
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `pair` {Object}
   * `readable` {ReadableStream}
@@ -3323,9 +3368,11 @@ duplex.once('readable', () => console.log('readable', duplex.read()));
 
 <!-- YAML
 added: v17.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `streamDuplex` {stream.Duplex}
 * Returns: {Object}

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -879,7 +879,7 @@ added:
   - v16.17.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -1645,7 +1645,7 @@ the stream has not been destroyed or emitted `'error'` or `'end'`.
 added: v16.8.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -1661,7 +1661,7 @@ added:
   - v14.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -2011,7 +2011,7 @@ added:
   - v18.13.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -2048,7 +2048,7 @@ See [`stream.compose`][] for more information.
 added: v16.3.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -2105,15 +2105,14 @@ added:
   - v17.4.0
   - v16.14.0
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
   - version:
     - v20.7.0
     - v18.19.0
     pr-url: https://github.com/nodejs/node/pull/49249
     description: added `highWaterMark` in options.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to map over every chunk in the
   stream.
@@ -2161,15 +2160,14 @@ added:
   - v17.4.0
   - v16.14.0
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
   - version:
     - v20.7.0
     - v18.19.0
     pr-url: https://github.com/nodejs/node/pull/49249
     description: added `highWaterMark` in options.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to filter chunks from the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2220,11 +2218,9 @@ for await (const result of dnsResults) {
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2283,11 +2279,9 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `options` {Object}
   * `signal` {AbortSignal} allows cancelling the toArray operation if the
@@ -2325,11 +2319,9 @@ const dnsResults = await Readable.from([
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2379,10 +2371,9 @@ added:
   - v17.5.0
   - v16.17.0
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2432,11 +2423,9 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a function to call on each chunk of the stream.
   * `data` {any} a chunk of data from the stream.
@@ -2485,11 +2474,9 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncGeneratorFunction|AsyncFunction} a function to map over
   every chunk in the stream.
@@ -2538,11 +2525,9 @@ for await (const result of concatResult) {
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `limit` {number} the number of chunks to drop from the readable.
 * `options` {Object}
@@ -2565,10 +2550,9 @@ added:
   - v17.5.0
   - v16.15.0
 changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `limit` {number} the number of chunks to take from the readable.
 * `options` {Object}
@@ -2590,11 +2574,9 @@ await Readable.from([1, 2, 3, 4]).take(2).toArray(); // [1, 2]
 added:
   - v17.5.0
   - v16.15.0
-changes:
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
-    description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 * `fn` {Function|AsyncFunction} a reducer function to call over every chunk
   in the stream.
@@ -3111,7 +3093,7 @@ Readable.from([
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3129,7 +3111,7 @@ changes:
 added: v16.8.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3146,7 +3128,7 @@ added:
   - v16.14.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3163,7 +3145,7 @@ added:
   - v16.14.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3178,7 +3160,7 @@ Returns whether the stream is readable.
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
   - version:
     - v18.7.0
@@ -3205,7 +3187,7 @@ changes:
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3223,7 +3205,7 @@ changes:
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3287,7 +3269,7 @@ Duplex.from([
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 
@@ -3370,7 +3352,7 @@ duplex.once('readable', () => console.log('readable', duplex.read()));
 added: v17.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
 -->
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2370,7 +2370,6 @@ console.log('done'); // Stream has finished
 added:
   - v17.5.0
   - v16.17.0
-changes:
 -->
 
 > Stability: 1 - Experimental
@@ -2549,7 +2548,6 @@ await Readable.from([1, 2, 3, 4]).drop(2).toArray(); // [3, 4]
 added:
   - v17.5.0
   - v16.15.0
-changes:
 -->
 
 > Stability: 1 - Experimental

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -628,9 +628,11 @@ console.log(JSON.stringify(myURLs));
 
 <!-- YAML
 added: v16.7.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `blob` {Blob}
 * Returns: {string}
@@ -664,9 +666,11 @@ to other workers or the main thread.
 
 <!-- YAML
 added: v16.7.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `id` {string} A `'blob:nodedata:...` URL string returned by a prior call to
   `URL.createObjectURL()`.

--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -630,7 +630,7 @@ console.log(JSON.stringify(myURLs));
 added: v16.7.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -668,7 +668,7 @@ to other workers or the main thread.
 added: v16.7.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -582,7 +582,7 @@ added:
   - v16.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 
@@ -1120,7 +1120,7 @@ added:
   - v16.17.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -580,9 +580,11 @@ if (isMainThread) {
 added:
   - v18.10.0
   - v16.18.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `limit` {integer}
 
@@ -1116,9 +1118,11 @@ occur synchronously in the case of `Promise.resolve()` or `Promise.reject()`.
 added:
   - v18.6.0
   - v16.17.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 The `v8.startupSnapshot` interface can be used to add serialization and
 deserialization hooks for custom startup snapshots.

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -406,11 +406,9 @@ console.log(script.sourceMapURL);
 added:
  - v13.0.0
  - v12.16.0
-changes:
- - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
-   description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -743,11 +741,9 @@ value that is not `undefined`.
 
 <!-- YAML
 added: v9.6.0
-changes:
- - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
-   description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -899,11 +895,9 @@ const module2 = new vm.SourceTextModule('const a = 1;', { cachedData });
 added:
  - v13.0.0
  - v12.16.0
-changes:
- - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
-   description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -1215,11 +1209,9 @@ using [`vm.constants.DONT_CONTEXTIFY`][].
 
 <!-- YAML
 added: v13.10.0
-changes:
- - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
-   description: Marking the API stable.
 -->
+
+> Stability: 1 - Experimental
 
 Measure the memory known to V8 and used by all contexts known to the
 current V8 isolate, or the main context.

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -406,9 +406,11 @@ console.log(script.sourceMapURL);
 added:
  - v13.0.0
  - v12.16.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -741,9 +743,11 @@ value that is not `undefined`.
 
 <!-- YAML
 added: v9.6.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -895,9 +899,11 @@ const module2 = new vm.SourceTextModule('const a = 1;', { cachedData });
 added:
  - v13.0.0
  - v12.16.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 This feature is only available with the `--experimental-vm-modules` command
 flag enabled.
@@ -1209,9 +1215,11 @@ using [`vm.constants.DONT_CONTEXTIFY`][].
 
 <!-- YAML
 added: v13.10.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 Measure the memory known to V8 and used by all contexts known to the
 current V8 isolate, or the main context.

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -995,9 +995,11 @@ port2.postMessage(new URL('https://example.org'));
 added:
   - v18.1.0
   - v16.17.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/00000
+   description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * Returns: {boolean}
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -997,7 +997,7 @@ added:
   - v16.17.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/57513
    description: Marking the API stable.
 -->
 


### PR DESCRIPTION
I'm guessing 3-7 years is long enough to be experimental