### PR TITLE
src: ensure primordials are initialized exactly once

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -758,7 +758,7 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
   if (InitializeBaseContextForSnapshot(context).IsNothing()) {
     return Nothing<void>();
   }
-  return InitializePrimordials(context);
+  return JustVoid();
 }
 
 Maybe<void> InitializePrimordials(Local<Context> context) {
@@ -767,13 +767,18 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
   Context::Scope context_scope(context);
   Local<Object> exports;
 
+  if (!GetPerContextExports(context).ToLocal(&exports)) {
+    return Nothing<void>();
+  }
   Local<String> primordials_string =
       FIXED_ONE_BYTE_STRING(isolate, "primordials");
+  // Ensure that `InitializePrimordials` is called exactly once on a given
+  // context.
+  CHECK(!exports->Has(context, primordials_string).FromJust());
 
-  // Create primordials first and make it available to per-context scripts.
   Local<Object> primordials = Object::New(isolate);
+  // Create primordials and make it available to per-context scripts.
   if (primordials->SetPrototypeV2(context, Null(isolate)).IsNothing() ||
-      !GetPerContextExports(context).ToLocal(&exports) ||
       exports->Set(context, primordials_string, primordials).IsNothing()) {
     return Nothing<void>();
   }


### PR DESCRIPTION
Right now `InitializePrimordials` is invoked twice on a context created via `node::NewContext`: 
1. `InitializeMainContextForSnapshot` invokes `InitializePrimordials`.
2. `InitializePrimordials` invokes `GetPerContextExports` unconditionally.
    1. `GetPerContextExports` invokes `InitializePrimordials` when `node:per_context_binding_exports` private was not set.
        1. `InitializePrimordials` invokes `GetPerContextExports` and initialize primordials for the first time.
    2. Initialize primordials for the second time.

`GetPerContextExports` will be invoked during `node_mksnapshot` by [initializing the principal realm](https://github.com/nodejs/node/blob/38390e5f28043146391d61d9b899b47aa72f53f9/src/node_realm.cc#L48) so it is safe to remove invocation of `InitializePrimordials` in `InitializeMainContextForSnapshot`.

This patch ensures that `InitializePrimordials` is only invoked in `GetPerContextExports` and checks that primordials on the private per-context exports object are not initialized before.