### PR TITLE
sqlite: add DatabaseSync.prototype.isOpen

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -198,6 +198,14 @@ added:
 This method is used to create SQLite user-defined functions. This method is a
 wrapper around [`sqlite3_create_function_v2()`][].
 
+### `database.isOpen`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean} Whether the database is currently open or not.
+
 ### `database.open()`
 
 <!-- YAML

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -757,6 +757,12 @@ void DatabaseSync::Open(const FunctionCallbackInfo<Value>& args) {
   db->Open();
 }
 
+void DatabaseSync::IsOpenGetter(const FunctionCallbackInfo<Value>& args) {
+  DatabaseSync* db;
+  ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
+  args.GetReturnValue().Set(db->IsOpen());
+}
+
 void DatabaseSync::Close(const FunctionCallbackInfo<Value>& args) {
   DatabaseSync* db;
   ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
@@ -2169,6 +2175,10 @@ static void Initialize(Local<Object> target,
                  DatabaseSync::EnableLoadExtension);
   SetProtoMethod(
       isolate, db_tmpl, "loadExtension", DatabaseSync::LoadExtension);
+  SetSideEffectFreeGetter(isolate,
+                          db_tmpl,
+                          FIXED_ONE_BYTE_STRING(isolate, "isOpen"),
+                          DatabaseSync::IsOpenGetter);
   SetConstructorFunction(context, target, "DatabaseSync", db_tmpl);
   SetConstructorFunction(context,
                          target,

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -55,6 +55,7 @@ class DatabaseSync : public BaseObject {
   void MemoryInfo(MemoryTracker* tracker) const override;
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void IsOpenGetter(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Close(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Prepare(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Exec(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -172,8 +172,10 @@ suite('DatabaseSync.prototype.open()', () => {
     const db = new DatabaseSync(dbPath, { open: false });
     t.after(() => { db.close(); });
 
+    t.assert.strictEqual(db.isOpen, false);
     t.assert.strictEqual(existsSync(dbPath), false);
     t.assert.strictEqual(db.open(), undefined);
+    t.assert.strictEqual(db.isOpen, true);
     t.assert.strictEqual(existsSync(dbPath), true);
   });
 
@@ -181,13 +183,16 @@ suite('DatabaseSync.prototype.open()', () => {
     const db = new DatabaseSync(nextDb(), { open: false });
     t.after(() => { db.close(); });
 
+    t.assert.strictEqual(db.isOpen, false);
     db.open();
+    t.assert.strictEqual(db.isOpen, true);
     t.assert.throws(() => {
       db.open();
     }, {
       code: 'ERR_INVALID_STATE',
       message: /database is already open/,
     });
+    t.assert.strictEqual(db.isOpen, true);
   });
 });
 
@@ -195,18 +200,22 @@ suite('DatabaseSync.prototype.close()', () => {
   test('closes an open database connection', (t) => {
     const db = new DatabaseSync(nextDb());
 
+    t.assert.strictEqual(db.isOpen, true);
     t.assert.strictEqual(db.close(), undefined);
+    t.assert.strictEqual(db.isOpen, false);
   });
 
   test('throws if database is not open', (t) => {
     const db = new DatabaseSync(nextDb(), { open: false });
 
+    t.assert.strictEqual(db.isOpen, false);
     t.assert.throws(() => {
       db.close();
     }, {
       code: 'ERR_INVALID_STATE',
       message: /database is not open/,
     });
+    t.assert.strictEqual(db.isOpen, false);
   });
 });
 


### PR DESCRIPTION
This commit adds a getter to indicate whether or not the database is currently open.

Fixes: https://github.com/nodejs/node/issues/57521

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
