### PR TITLE
meta: remove collaborator self-nomination

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -194,10 +194,6 @@ nominee publicly accepts it. In the case
 of an objection, the TSC is responsible for working with the individuals
 involved and finding a resolution.
 
-Collaborators might overlook someone with valuable contributions. In that case,
-the contributor may open an issue or contact a collaborator to request a
-nomination.
-
 #### How to review a collaborator nomination
 
 A collaborator nomination can be reviewed in the same way one would review a PR


### PR DESCRIPTION
Anyone with sufficient involvement in Node.js (such that becoming a collaborator would benefit Node.js) is going to have plenty of people to ask. The self-nomination process has been entirely superfluous the entire time I've been involved in Node.js. Simplify things and get rid of it.

This is based on my comment at https://github.com/nodejs/node/pull/57503/files#r1997694900. If there isn't consensus on this, then that's OK and we can just close it. I don't feel so strongly that I want to have a long back-and-forth about it. But if there is consensus, let's take this opportunity to simplify our governance.

Since this is a change to the Governance doc, I think it's appropriate to @-mention the TSC. @nodejs/tsc 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
