### PR TITLE
module: remove underscore modules from builtinModules and isBuiltin

### DIFF
--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -310,9 +310,20 @@ class BuiltinModule {
   }
 
   static isBuiltin(id) {
-    return BuiltinModule.canBeRequiredWithoutScheme(id) || (
-      typeof id === 'string' &&
-        StringPrototypeStartsWith(id, 'node:') &&
+    if (typeof id !== 'string') {
+      return false;
+    }
+
+    if (StringPrototypeStartsWith(id, '_')) {
+      return false;
+    }
+
+    if (BuiltinModule.canBeRequiredWithoutScheme(id)) {
+      return true;
+    }
+
+    return (
+      StringPrototypeStartsWith(id, 'node:') &&
         BuiltinModule.canBeRequiredByUsers(StringPrototypeSlice(id, 5))
     );
   }
@@ -321,10 +332,15 @@ class BuiltinModule {
     return ArrayFrom(schemelessBlockList);
   }
 
-  static getAllBuiltinModuleIds() {
+  static getAllPublicBuiltinModuleIds() {
     const allBuiltins = ArrayFrom(canBeRequiredByUsersWithoutSchemeList);
     ArrayPrototypePushApply(allBuiltins, ArrayFrom(schemelessBlockList, (x) => `node:${x}`));
-    return allBuiltins;
+    return ArrayPrototypeFilter(allBuiltins, (id) => {
+      // Modules starting with an underscore (e.g. `_http_agent`) can be
+      // required by users because of historical reasons, but they are not
+      // proper documented public modules, so they need to be filtered out
+      return id[0] !== '_';
+    });
   }
 
   // Used by user-land module loaders to compile and load builtins.

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -316,9 +316,8 @@ class BuiltinModule {
 
     // Modules starting with underscore (e.g. `_http_agent`) can be required
     // by users but those are discouraged and should not be exposed as proper
-    // public ones, so if `id` starts with `_` return `false` right away
-    if (StringPrototypeStartsWith(id, '_') ||
-      StringPrototypeStartsWith(id, 'node:_') {
+    // public ones, so if `id` starts with `_` (or `node:_`) return `false` right away
+    if (StringPrototypeStartsWith(id, '_') || StringPrototypeStartsWith(id, 'node:_')) {
       return false;
     }
 

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -317,7 +317,8 @@ class BuiltinModule {
     // Modules starting with underscore (e.g. `_http_agent`) can be required
     // by users but those are discouraged and should not be exposed as proper
     // public ones, so if `id` starts with `_` return `false` right away
-    if (StringPrototypeStartsWith(id, '_')) {
+    if (StringPrototypeStartsWith(id, '_') ||
+      StringPrototypeStartsWith(id, 'node:_') {
       return false;
     }
 

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -314,18 +314,27 @@ class BuiltinModule {
       return false;
     }
 
+    // Modules starting with underscore (e.g. `_http_agent`) can be required
+    // by users but those are discouraged and should not be exposed as proper
+    // public ones, so if `id` starts with `_` return `false` right away
     if (StringPrototypeStartsWith(id, '_')) {
       return false;
     }
 
+    // Check if `id` matches a builtin module without the `node:` prefix
     if (BuiltinModule.canBeRequiredWithoutScheme(id)) {
       return true;
     }
 
-    return (
+    // Check if `id` matches a builtin module with the `node:` prefix
+    if (
       StringPrototypeStartsWith(id, 'node:') &&
         BuiltinModule.canBeRequiredByUsers(StringPrototypeSlice(id, 5))
-    );
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   static getSchemeOnlyModuleNames() {

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -439,7 +439,7 @@ Module.isBuiltin = BuiltinModule.isBuiltin;
 function initializeCJS() {
   // This need to be done at runtime in case --expose-internals is set.
 
-  let modules = Module.builtinModules = BuiltinModule.getAllBuiltinModuleIds();
+  let modules = Module.builtinModules = BuiltinModule.getAllPublicBuiltinModuleIds();
   if (!getOptionValue('--experimental-quic')) {
     modules = modules.filter((i) => i !== 'node:quic');
   }

--- a/test/parallel/test-module-builtin.js
+++ b/test/parallel/test-module-builtin.js
@@ -12,3 +12,10 @@ assert.deepStrictEqual(
   builtinModules.filter((mod) => mod.startsWith('internal/')),
   []
 );
+
+// Does not include modules starting with an underscore
+// (these are exposed to users but not proper public documented modules)
+assert.deepStrictEqual(
+  builtinModules.filter((mod) => mod.startsWith('_')),
+  []
+);

--- a/test/parallel/test-module-isBuiltin.js
+++ b/test/parallel/test-module-isBuiltin.js
@@ -14,3 +14,21 @@ assert(!isBuiltin('internal/errors'));
 assert(!isBuiltin('test'));
 assert(!isBuiltin(''));
 assert(!isBuiltin(undefined));
+
+// Does not include modules starting with underscore
+// (these can be required for historical reasons but
+// are not proper documented public modules)
+assert(!isBuiltin('_http_agent'));
+assert(!isBuiltin('_http_client'));
+assert(!isBuiltin('_http_common'));
+assert(!isBuiltin('_http_incoming'));
+assert(!isBuiltin('_http_outgoing'));
+assert(!isBuiltin('_http_server'));
+assert(!isBuiltin('_stream_duplex'));
+assert(!isBuiltin('_stream_passthrough'));
+assert(!isBuiltin('_stream_readable'));
+assert(!isBuiltin('_stream_transform'));
+assert(!isBuiltin('_stream_wrap'));
+assert(!isBuiltin('_stream_writable'));
+assert(!isBuiltin('_tls_common'));
+assert(!isBuiltin('_tls_wrap'));

--- a/test/parallel/test-module-isBuiltin.js
+++ b/test/parallel/test-module-isBuiltin.js
@@ -15,20 +15,28 @@ assert(!isBuiltin('test'));
 assert(!isBuiltin(''));
 assert(!isBuiltin(undefined));
 
+const underscoreModules = [
+  '_http_agent',
+  '_http_client',
+  '_http_common',
+  '_http_incoming',
+  '_http_outgoing',
+  '_http_server',
+  '_stream_duplex',
+  '_stream_passthrough',
+  '_stream_readable',
+  '_stream_transform',
+  '_stream_wrap',
+  '_stream_writable',
+  '_tls_common',
+  '_tls_wrap',
+  'node:_http_agent',
+];
+
 // Does not include modules starting with underscore
 // (these can be required for historical reasons but
 // are not proper documented public modules)
-assert(!isBuiltin('_http_agent'));
-assert(!isBuiltin('_http_client'));
-assert(!isBuiltin('_http_common'));
-assert(!isBuiltin('_http_incoming'));
-assert(!isBuiltin('_http_outgoing'));
-assert(!isBuiltin('_http_server'));
-assert(!isBuiltin('_stream_duplex'));
-assert(!isBuiltin('_stream_passthrough'));
-assert(!isBuiltin('_stream_readable'));
-assert(!isBuiltin('_stream_transform'));
-assert(!isBuiltin('_stream_wrap'));
-assert(!isBuiltin('_stream_writable'));
-assert(!isBuiltin('_tls_common'));
-assert(!isBuiltin('_tls_wrap'));
+for (const module of underscoreModules) {
+  assert(!isBuiltin(module));
+  assert(!isBuiltin(`node:${module}`));
+}

--- a/test/parallel/test-module-isBuiltin.js
+++ b/test/parallel/test-module-isBuiltin.js
@@ -30,7 +30,6 @@ const underscoreModules = [
   '_stream_writable',
   '_tls_common',
   '_tls_wrap',
-  'node:_http_agent',
 ];
 
 // Does not include modules starting with underscore


### PR DESCRIPTION
these changes remove modules starting with underscore (e.g. `__http_agent`) from `Module#builtinModules` and `Module#isBuiltin` since they are not properly documented as public. They can't easily be removed since many libraries use them, but their usage should be discouraged and they should not be exposed by such utilities

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
