### PR TITLE
doc: add section stating that very stale PRs should be closed

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -455,7 +455,7 @@ requests should generally be closed unless they provide clear ongoing value
 or have a well defined path forward. When closing a pull request, always
 leave a polite comment explaining the reason and encouraging the contributor
 to restart the effort and submit a new pull request if the changes are still
-relevant or valuable.
+relevant and applicable.
 
 ### Approving a change
 

--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -446,6 +446,17 @@ credit for the work they started (either by preserving their name and email
 address) in the commit log, or by using an `Author:` meta-data tag in the
 commit.
 
+If a pull request has been inactive for more than six months, it is unlikely
+to be merged. The contributor may no longer be engaged, may have lost context
+on their changes, the Node.js codebase may have evolved to the point where
+resuming the effort is impractical, or all of the above.
+To keep the project well organized and more maintainable, such stale pull
+requests should generally be closed unless they provide clear ongoing value
+or have a well defined path forward. When closing a pull request, always
+leave a polite comment explaining the reason and encouraging the contributor
+to restart the effort and submit a new pull request if the changes are still
+relevant or valuable.
+
 ### Approving a change
 
 Any Node.js core collaborator (any GitHub user with commit rights in the

--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -447,7 +447,7 @@ address) in the commit log, or by using an `Author:` meta-data tag in the
 commit.
 
 If a pull request has been inactive for more than six months, add the `stalled` label
-to it. That should trigger an automation that adds a comment explaining the pull request
+to it. That will trigger an automation that adds a comment explaining the pull request
 may be close for inactivity, giving a heads-up to the contributor before actually
 closing it if it remains inactive.
 

--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -449,7 +449,7 @@ commit.
 If a pull request has been inactive for more than six months, add the `stalled` label
 to it. That should trigger an automation that adds a comment explaining the pull request
 may be close for inactivity, giving a heads-up to the contributor before actually
-close it if is still inactive.
+closing it if it remains inactive.
 
 ### Approving a change
 

--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -446,16 +446,10 @@ credit for the work they started (either by preserving their name and email
 address) in the commit log, or by using an `Author:` meta-data tag in the
 commit.
 
-If a pull request has been inactive for more than six months, it is unlikely
-to be merged. The contributor may no longer be engaged, may have lost context
-on their changes, the Node.js codebase may have evolved to the point where
-resuming the effort is impractical, or all of the above.
-To keep the project well organized and more maintainable, such stale pull
-requests should generally be closed unless they provide clear ongoing value
-or have a well defined path forward. When closing a pull request, always
-leave a polite comment explaining the reason and encouraging the contributor
-to restart the effort and submit a new pull request if the changes are still
-relevant and applicable.
+If a pull request has been inactive for more than six months, add the `stalled` label
+to it. That should trigger an automation that adds a comment explaining the pull request
+may be close for inactivity, giving a heads-up to the contributor before actually
+close it if is still inactive.
 
 ### Approving a change
 


### PR DESCRIPTION
I just wanted to open this PR to see if there could be some consensus on closing PRs that
have been state for a significant amount of time (I'm proposing 6 months here, this is very
arbitrary and can definitely be changed/generalized).

The fact is that the number of current PRs in the project, as I am opening this one is 492,
although that's not very problematic it feels rather messy to me (without providing any
noticeable value I think?), having a clear policy on when a PR is so stale that it should probably
be closed could be beneficial in trying to clean outdated and stale PRs without the risk to
generate too much controversy (since right now, as far as I can tell, abandoned PRs just stay
there indefinitely and there isn't a clear procedure on what to do with them). 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
