### PR TITLE
url: add flatpak+https url scheme

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -128,6 +128,8 @@ const slashedProtocol = new SafeSet([
   'ws:',
   'wss',
   'wss:',
+  'flatpak+https',
+  'flatpak+https:',
 ]);
 
 const updateActions = {


### PR DESCRIPTION
This new scheme gets used by linux systems to show flatpak packages in system native apps.

Before this routers such as the one from next.js, will not allow these scheme to have the correct number of slashes, as it wasn't an allowed `slashedProtocol` and thus using urls with this schema would fail.
