### PR TITLE
[v18.x] deps: update undici to v5.29.0 

### DIFF
--- a/deps/undici/src/lib/cookies/index.js
+++ b/deps/undici/src/lib/cookies/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { parseSetCookie } = require('./parse')
-const { stringify, getHeadersList } = require('./util')
+const { stringify } = require('./util')
 const { webidl } = require('../fetch/webidl')
 const { Headers } = require('../fetch/headers')
 
@@ -77,14 +77,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**

--- a/deps/undici/src/lib/cookies/util.js
+++ b/deps/undici/src/lib/cookies/util.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const assert = require('assert')
-const { kHeadersList } = require('../core/symbols')
-
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -263,29 +264,11 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  if (headers[kHeadersList]) {
-    return headers[kHeadersList]
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
-  stringify,
-  getHeadersList
+  validateCookieName,
+  validateCookiePath,
+  validateCookieValue,
+  toIMFDate,
+  stringify
 }

--- a/deps/undici/src/lib/fetch/headers.js
+++ b/deps/undici/src/lib/fetch/headers.js
@@ -10,6 +10,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = require('./util')
+const util = require('util')
 const { webidl } = require('./webidl')
 const assert = require('assert')
 
@@ -563,6 +564,9 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
+  },
+  [util.inspect.custom]: {
+    enumerable: false
   }
 })
 

--- a/deps/undici/src/package.json
+++ b/deps/undici/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undici",
-  "version": "5.28.5",
+  "version": "5.29.0",
   "description": "An HTTP/1.1 client, written from scratch for Node.js",
   "homepage": "https://undici.nodejs.org",
   "bugs": {

--- a/deps/undici/undici.js
+++ b/deps/undici/undici.js
@@ -2168,6 +2168,7 @@ var require_headers = __commonJS({
       isValidHeaderName,
       isValidHeaderValue
     } = require_util2();
+    var util = require("util");
     var { webidl } = require_webidl();
     var assert = require("assert");
     var kHeadersMap = Symbol("headers map");
@@ -2531,6 +2532,9 @@ var require_headers = __commonJS({
       [Symbol.toStringTag]: {
         value: "Headers",
         configurable: true
+      },
+      [util.inspect.custom]: {
+        enumerable: false
       }
     });
     webidl.converters.HeadersInit = function(V) {
@@ -10122,6 +10126,14 @@ var require_pool = __commonJS({
         this[kOptions] = { ...util.deepClone(options), connect, allowH2 };
         this[kOptions].interceptors = options.interceptors ? { ...options.interceptors } : void 0;
         this[kFactory] = factory;
+        this.on("connectionError", (origin2, targets, error) => {
+          for (const target of targets) {
+            const idx = this[kClients].indexOf(target);
+            if (idx !== -1) {
+              this[kClients].splice(idx, 1);
+            }
+          }
+        });
       }
       [kGetDispatcher]() {
         let dispatcher = this[kClients].find((dispatcher2) => !dispatcher2[kNeedDrain]);

--- a/src/undici_version.h
+++ b/src/undici_version.h
@@ -2,5 +2,5 @@
 // Refer to tools/update-undici.sh
 #ifndef SRC_UNDICI_VERSION_H_
 #define SRC_UNDICI_VERSION_H_
-#define UNDICI_VERSION "5.28.5"
+#define UNDICI_VERSION "5.29.0"
 #endif  // SRC_UNDICI_VERSION_H_


### PR DESCRIPTION
This updates Undici to v5.29.0 in Node v18.