### PR TITLE
doc: allow the $schema property in node.config.json

### DIFF
--- a/doc/node-config-schema.json
+++ b/doc/node-config-schema.json
@@ -2,6 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "nodeOptions": {
       "additionalProperties": false,
       "properties": {

--- a/lib/internal/options.js
+++ b/lib/internal/options.js
@@ -45,6 +45,10 @@ function generateConfigJsonSchema() {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     additionalProperties: false,
     properties: {
+      $schema: {
+        __proto__: null,
+        type: 'string',
+      },
       nodeOptions: {
         __proto__: null,
         additionalProperties: false,


### PR DESCRIPTION
The documentation states people can use the `$schema` property, but the JSON schema forbids this. This change allows it.
