### PR TITLE
docs: add bjohansebas as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,8 @@ maintaining the Node.js project.
   **Chemi Atlow** <<chemi@atlow.co.il>> (he/him)
 * [Ayase-252](https://github.com/Ayase-252) -
   **Qingyu Deng** <<i@ayase-lab.com>>
+* [bjohansebas](https://github.com/bjohansebas) -
+  **Sebastian Beltran** <<bjohansebas@gmail.com>>
 * [bmuenzenmeyer](https://github.com/bmuenzenmeyer) -
   **Brian Muenzenmeyer** <<brian.muenzenmeyer@gmail.com>> (he/him)
 * [CanadaHonk](https://github.com/CanadaHonk) -


### PR DESCRIPTION
I would like to apply for the role of a triager in this project.

My motivation for being added as a triager is to be more connected with the Node.js community, helping to resolve people's issues with Node.js, and also to continue learning more about Node.js core to be more involved in future changes.

I hearby declare that I have read and understood the Code of Conduct of the project and will adhere to that.