### PR TITLE
[v18.x backport] build: update gcovr to 7.2 and codecov config

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr
-        run: pip install gcovr==4.2
+        run: pip install gcovr==7.2
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage --without-intl"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
@@ -59,7 +59,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml --root=$(cd ../ && pwd)
+        run: gcovr --object-directory=out -v --filter src --xml -o ./coverage/coverage-cxx.xml --root=./ --gcov-executable="llvm-cov-18 gcov"
       # Clean temporary output from gcov and c8, so that it's not uploaded:
       - name: Clean tmp
         run: rm -rf coverage/tmp && rm -rf out

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr
-        run: pip install gcovr==4.2
+        run: pip install gcovr==7.2
       - name: Build
         run: make build-ci -j2 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
@@ -59,7 +59,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
       - name: Report C++
-        run: cd out && gcovr --gcov-exclude='.*\b(deps|usr|out|obj|cctest|embedding)\b' -v -r Release/obj.target --xml -o ../coverage/coverage-cxx.xml --root=$(cd ../ && pwd)
+        run: gcovr --object-directory=out -v --filter src --xml -o ./coverage/coverage-cxx.xml --root=./ --gcov-executable="llvm-cov-18 gcov"
       # Clean temporary output from gcov and c8, so that it's not uploaded:
       - name: Clean tmp
         run: rm -rf coverage/tmp && rm -rf out

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ coverage: coverage-test ## Run the tests and generate a coverage report.
 .PHONY: coverage-build
 coverage-build: all
 	-$(MAKE) coverage-build-js
-	if [ ! -d gcovr ]; then $(PYTHON) -m pip install -t gcovr gcovr==4.2; fi
+	if [ ! -d gcovr ]; then $(PYTHON) -m pip install -t gcovr gcovr==7.2; fi
 	$(MAKE)
 
 .PHONY: coverage-build-js
@@ -266,9 +266,10 @@ coverage-test: coverage-build
 	-NODE_V8_COVERAGE=coverage/tmp \
 		TEST_CI_ARGS="$(TEST_CI_ARGS) --type=coverage" $(MAKE) $(COVTESTS)
 	$(MAKE) coverage-report-js
-	-(cd out && PYTHONPATH=../gcovr $(PYTHON) -m gcovr \
-		--gcov-exclude='.*\b(deps|usr|out|cctest|embedding)\b' -v \
-		-r ../src/ --object-directory Release/obj.target \
+	-(PYTHONPATH=./gcovr $(PYTHON) -m gcovr \
+		--object-directory=out \
+		--filter src -v \
+		--root ./ \
 		--html --html-details -o ../coverage/cxxcoverage.html \
 		--gcov-executable="$(GCOV)")
 	@printf "Javascript coverage %%: "

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,15 @@
-# TODO(bcoe): re-enable coverage report comments, once we can figure out
-# how to make them more accurate for the Node.js project,
-# See: https://github.com/nodejs/node/issues/35759
-comment: false
-#  # Only show diff and files changed:
-#  layout: "diff, files"
-#  # Don't post if no changes in coverage:
-#  require_changes: true
+comment:
+  # Only show diff and files changed:
+  layout: diff, files
+  # Don't post if no changes in coverage:
+  require_changes: true
 
 codecov:
-  branch: main
   notify:
     # Wait for all coverage builds:
+    # - coverage-linux.yml
+    # - coverage-windows.yml [manually disabled see #50489]
+    # - coverage-linux-without-intl.yml
     after_n_builds: 2
 
 coverage:


### PR DESCRIPTION
PR-URL: https://github.com/nodejs/node/pull/54019
Reviewed-By: Yagiz Nizipli <yagiz@nizipli.com>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Michaël Zasso <targos@protonmail.com>

---

Opening to see if backporting this fixes the coverage workflows for `v18.x-staging`.