### PR TITLE
tools: expose v8 fast-calls header to native addons

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -267,6 +267,7 @@ def headers(options, action):
       'include/v8-exception.h',
       'include/v8-extension.h',
       'include/v8-external.h',
+      'include/v8-fast-api-calls.h',
       'include/v8-forward.h',
       'include/v8-function-callback.h',
       'include/v8-function.h',


### PR DESCRIPTION
Fixes #52923 

This wasn't exposed initially because the V8 team objected to it as it wasn't stable enough. 
If everything is stable now, it should be fine to do so now? 