### PR TITLE
src: update std::vector<v8::Local<T>> to use v8::LocalVector<T>

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -17,6 +17,7 @@ using v8::FunctionCallbackInfo;
 using v8::IntegrityLevel;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::MaybeLocal;
 using v8::Name;
 using v8::None;
@@ -258,7 +259,7 @@ void BuiltinLoader::AddExternalizedBuiltin(const char* id,
 MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
     Local<Context> context,
     const char* id,
-    std::vector<Local<String>>* parameters,
+    LocalVector<String>* parameters,
     Realm* optional_realm) {
   Isolate* isolate = context->GetIsolate();
   EscapableHandleScope scope(isolate);
@@ -382,8 +383,8 @@ void BuiltinLoader::SaveCodeCache(const char* id, Local<Function> fun) {
 MaybeLocal<Function> BuiltinLoader::LookupAndCompile(Local<Context> context,
                                                      const char* id,
                                                      Realm* optional_realm) {
-  std::vector<Local<String>> parameters;
   Isolate* isolate = context->GetIsolate();
+  LocalVector<String> parameters(isolate);
   // Detects parameters of the scripts based on module ids.
   // internal/bootstrap/realm: process, getLinkedBinding,
   //                           getInternalBinding, primordials
@@ -497,7 +498,7 @@ MaybeLocal<Value> BuiltinLoader::CompileAndCall(Local<Context> context,
 MaybeLocal<Function> BuiltinLoader::LookupAndCompile(
     Local<Context> context,
     const char* id,
-    std::vector<Local<String>>* parameters,
+    LocalVector<String>* parameters,
     Realm* optional_realm) {
   return LookupAndCompileInternal(context, id, parameters, optional_realm);
 }

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -101,7 +101,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   v8::MaybeLocal<v8::Function> LookupAndCompile(
       v8::Local<v8::Context> context,
       const char* id,
-      std::vector<v8::Local<v8::String>>* parameters,
+      v8::LocalVector<v8::String>* parameters,
       Realm* optional_realm);
 
   v8::MaybeLocal<v8::Value> CompileAndCall(v8::Local<v8::Context> context,
@@ -159,7 +159,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
   v8::MaybeLocal<v8::Function> LookupAndCompileInternal(
       v8::Local<v8::Context> context,
       const char* id,
-      std::vector<v8::Local<v8::String>>* parameters,
+      v8::LocalVector<v8::String>* parameters,
       Realm* optional_realm);
   void SaveCodeCache(const char* id, v8::Local<v8::Function> fn);
 


### PR DESCRIPTION
According to V8's public API documentation, local handles (i.e., objects of type v8::Local<T>) "should never be allocated on the heap". This replaces the usage of heap-allocated data structures containing instances of `v8::Local`, specifically the `std::vector<v8::Local<v8::String>>` with recently introduced `v8::LocalVector<T>`.

This is first of the series of commits to replace all `std::vector<v8::Local<T>>` to use `v8::LocalVector<T>`.

