### PR TITLE
doc: remove cryptoStream API reference

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -940,7 +940,7 @@ changes:
 
 Type: End-of-Life
 
-The [`tls.CryptoStream`][] class was removed. Please use
+The `tls.CryptoStream` class was removed. Please use
 [`tls.TLSSocket`][] instead.
 
 ### DEP0043: `tls.SecurePair`
@@ -3985,7 +3985,6 @@ When an `args` array is passed to [`child_process.execFile`][] or [`child_proces
 [`timeout.ref()`]: timers.md#timeoutref
 [`timeout.refresh()`]: timers.md#timeoutrefresh
 [`timeout.unref()`]: timers.md#timeoutunref
-[`tls.CryptoStream`]: tls.md#class-tlscryptostream
 [`tls.SecureContext`]: tls.md#tlscreatesecurecontextoptions
 [`tls.TLSSocket`]: tls.md#class-tlstlssocket
 [`tls.checkServerIdentity()`]: tls.md#tlscheckserveridentityhostname-cert

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -553,29 +553,6 @@ appends a hint suggesting that if the root CA is installed locally,
 try running with the `--use-system-ca` flag to direct developers towards a
 secure solution, to prevent unsafe workarounds.
 
-## Class: `tls.CryptoStream`
-
-<!-- YAML
-added: v0.3.4
-deprecated: v0.11.3
--->
-
-> Stability: 0 - Deprecated: Use [`tls.TLSSocket`][] instead.
-
-The `tls.CryptoStream` class represents a stream of encrypted data. This class
-is deprecated and should no longer be used.
-
-### `cryptoStream.bytesWritten`
-
-<!-- YAML
-added: v0.3.4
-deprecated: v0.11.3
--->
-
-The `cryptoStream.bytesWritten` property returns the total number of bytes
-written to the underlying socket _including_ the bytes required for the
-implementation of the TLS protocol.
-
 ## Class: `tls.Server`
 
 <!-- YAML


### PR DESCRIPTION
This was removed in https://github.com/nodejs/node/pull/22033