### PR TITLE
src: disable abseil deadlock detection

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -834,6 +834,7 @@
         'deps/googletest/googletest.gyp:gtest_prod',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
+        'tools/v8_gypfiles/abseil.gyp:abseil',
         'node_js2c#host',
       ],
 
@@ -1159,6 +1160,7 @@
         'deps/googletest/googletest.gyp:gtest_main',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
+        'tools/v8_gypfiles/abseil.gyp:abseil',
       ],
 
       'includes': [

--- a/src/node.cc
+++ b/src/node.cc
@@ -119,6 +119,8 @@
 #include <unistd.h>        // STDIN_FILENO, STDERR_FILENO
 #endif
 
+#include "absl/synchronization/mutex.h"
+
 // ========== global C++ headers ==========
 
 #include <cerrno>
@@ -1211,6 +1213,11 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
 
   if (!(flags & ProcessInitializationFlags::kNoInitializeV8)) {
     V8::Initialize();
+
+    // Disable absl deadlock detection in V8 as it reports false-positive cases.
+    // TODO(legendecas): Replace this global disablement with case suppressions.
+    // https://github.com/nodejs/node-v8/issues/301
+    absl::SetMutexDeadlockDetectionMode(absl::OnDeadlockCycle::kIgnore);
   }
 
   if (!(flags & ProcessInitializationFlags::kNoInitializeCppgc)) {

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -1,4 +1,5 @@
 #include "node_test_fixture.h"
+#include "absl/synchronization/mutex.h"
 #include "cppgc/platform.h"
 
 ArrayBufferUniquePtr NodeZeroIsolateTestFixture::allocator{nullptr, nullptr};
@@ -31,6 +32,11 @@ void NodeTestEnvironment::SetUp() {
   v8::V8::SetFlagsFromString("--no-freeze-flags-after-init");
 
   v8::V8::Initialize();
+
+  // Disable absl deadlock detection in V8 as it reports false-positive cases.
+  // TODO(legendecas): Replace this global disablement with case suppressions.
+  // https://github.com/nodejs/node-v8/issues/301
+  absl::SetMutexDeadlockDetectionMode(absl::OnDeadlockCycle::kIgnore);
 }
 
 void NodeTestEnvironment::TearDown() {

--- a/tools/v8_gypfiles/abseil.gyp
+++ b/tools/v8_gypfiles/abseil.gyp
@@ -277,6 +277,8 @@
         '<(ABSEIL_ROOT)/absl/synchronization/internal/waiter.h',
         '<(ABSEIL_ROOT)/absl/synchronization/internal/waiter_base.h',
         '<(ABSEIL_ROOT)/absl/synchronization/internal/waiter_base.cc',
+        '<(ABSEIL_ROOT)/absl/synchronization/internal/win32_waiter.h',
+        '<(ABSEIL_ROOT)/absl/synchronization/internal/win32_waiter.cc',
         '<(ABSEIL_ROOT)/absl/synchronization/mutex.h',
         '<(ABSEIL_ROOT)/absl/synchronization/mutex.cc',
         '<(ABSEIL_ROOT)/absl/time/civil_time.h',


### PR DESCRIPTION
Abseil deadlock detection is reporting false positives in tests in V8.
Abseil mutexes are not used in node core, so disable it for now.

Refs: https://github.com/nodejs/node-v8/issues/301