### PR TITLE
src, permission: make ERR_ACCESS_DENIED more descriptive

### DIFF
--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -15,18 +15,19 @@ class Environment;
 namespace permission {
 
 #define FILESYSTEM_PERMISSIONS(V)                                              \
-  V(FileSystem, "fs", PermissionsRoot)                                         \
-  V(FileSystemRead, "fs.read", FileSystem)                                     \
-  V(FileSystemWrite, "fs.write", FileSystem)
+  V(FileSystem, "fs", PermissionsRoot, "")                                     \
+  V(FileSystemRead, "fs.read", FileSystem, "--allow-fs-read")                  \
+  V(FileSystemWrite, "fs.write", FileSystem, "--allow-fs-write")
 
-#define CHILD_PROCESS_PERMISSIONS(V) V(ChildProcess, "child", PermissionsRoot)
+#define CHILD_PROCESS_PERMISSIONS(V)                                           \
+  V(ChildProcess, "child", PermissionsRoot, "--allow-child-process")
 
-#define WASI_PERMISSIONS(V) V(WASI, "wasi", PermissionsRoot)
+#define WASI_PERMISSIONS(V) V(WASI, "wasi", PermissionsRoot, "--allow-wasi")
 
 #define WORKER_THREADS_PERMISSIONS(V)                                          \
-  V(WorkerThreads, "worker", PermissionsRoot)
+  V(WorkerThreads, "worker", PermissionsRoot, "--allow-worker")
 
-#define INSPECTOR_PERMISSIONS(V) V(Inspector, "inspector", PermissionsRoot)
+#define INSPECTOR_PERMISSIONS(V) V(Inspector, "inspector", PermissionsRoot, "")
 
 #define PERMISSIONS(V)                                                         \
   FILESYSTEM_PERMISSIONS(V)                                                    \
@@ -35,7 +36,7 @@ namespace permission {
   WORKER_THREADS_PERMISSIONS(V)                                                \
   INSPECTOR_PERMISSIONS(V)
 
-#define V(name, _, __) k##name,
+#define V(name, _, __, ___) k##name,
 enum class PermissionScope {
   kPermissionsRoot = -1,
   PERMISSIONS(V) kPermissionsCount

--- a/test/fixtures/permission/fs-read.js
+++ b/test/fixtures/permission/fs-read.js
@@ -14,6 +14,16 @@ const blockedFolder = process.env.BLOCKEDFOLDER;
 const allowedFolder = process.env.ALLOWEDFOLDER;
 const regularFile = __filename;
 
+// Guarantee the error message suggest the --allow-fs-read
+{
+  fs.readFile(blockedFile, common.expectsError({
+    message: 'Access to this API has been restricted. Use --allow-fs-read to manage permissions.',
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemRead',
+    resource: path.toNamespacedPath(blockedFile),
+  }));
+}
+
 // fs.readFile
 {
   fs.readFile(blockedFile, common.expectsError({

--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -25,6 +25,15 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
   assert.ok(!process.permission.has('fs.write', blockedFile));
 }
 
+// Guarantee the error message suggest the --allow-fs-write
+{
+  fs.writeFile(blockedFile, 'example', common.expectsError({
+    message: 'Access to this API has been restricted. Use --allow-fs-write to manage permissions.',
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
+}
+
 // fs.writeFile
 {
   assert.throws(() => {

--- a/test/parallel/test-permission-child-process-cli.js
+++ b/test/parallel/test-permission-child-process-cli.js
@@ -26,6 +26,7 @@ if (process.argv[2] === 'child') {
   assert.throws(() => {
     childProcess.spawn(process.execPath, ['--version']);
   }, common.expectsError({
+    message: 'Access to this API has been restricted. Use --allow-child-process to manage permissions.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
   }));

--- a/test/parallel/test-permission-inspector.js
+++ b/test/parallel/test-permission-inspector.js
@@ -22,6 +22,7 @@ if (!common.hasCrypto)
     const session = new Session();
     session.connect();
   }, common.expectsError({
+    message: 'Access to this API has been restricted. ',
     code: 'ERR_ACCESS_DENIED',
     permission: 'Inspector',
   }));

--- a/test/parallel/test-permission-wasi.js
+++ b/test/parallel/test-permission-wasi.js
@@ -13,6 +13,7 @@ const { WASI } = require('wasi');
       preopens: { '/': '/' },
     });
   }, common.expectsError({
+    message: 'Access to this API has been restricted. Use --allow-wasi to manage permission.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'WASI',
   }));

--- a/test/parallel/test-permission-wasi.js
+++ b/test/parallel/test-permission-wasi.js
@@ -13,7 +13,7 @@ const { WASI } = require('wasi');
       preopens: { '/': '/' },
     });
   }, common.expectsError({
-    message: 'Access to this API has been restricted. Use --allow-wasi to manage permission.',
+    message: 'Access to this API has been restricted. Use --allow-wasi to manage permissions.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'WASI',
   }));

--- a/test/parallel/test-permission-worker-threads-cli.js
+++ b/test/parallel/test-permission-worker-threads-cli.js
@@ -22,6 +22,7 @@ if (isMainThread) {
   assert.throws(() => {
     new Worker(__filename);
   }, common.expectsError({
+    message: 'Access to this API has been restricted. Use --allow-worker to manage permission.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'WorkerThreads',
   }));

--- a/test/parallel/test-permission-worker-threads-cli.js
+++ b/test/parallel/test-permission-worker-threads-cli.js
@@ -22,7 +22,7 @@ if (isMainThread) {
   assert.throws(() => {
     new Worker(__filename);
   }, common.expectsError({
-    message: 'Access to this API has been restricted. Use --allow-worker to manage permission.',
+    message: 'Access to this API has been restricted. Use --allow-worker to manage permissions.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'WorkerThreads',
   }));


### PR DESCRIPTION
This commit also adds a suggestion flag (if exists) when ERR_ACCESS_DENIED is thrown, so users don't need to jump into the documentation to see how to manage that permission error.