### PR TITLE
src: improve error message for invalid child stdio type in spawn_sync

### DIFF
--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -1055,7 +1055,10 @@ Maybe<int> SyncProcessRunner::ParseStdioOption(int child_fd,
     return Just(AddStdioInheritFD(child_fd, inherit_fd));
   }
 
-  UNREACHABLE("invalid child stdio type");
+  Utf8Value stdio_type(env()->isolate(), js_type);
+  fprintf(stderr, "invalid child stdio type: %s\n", stdio_type.out());
+
+  UNREACHABLE();
 }
 
 int SyncProcessRunner::AddStdioIgnore(uint32_t child_fd) {


### PR DESCRIPTION
This is pretty minor, but as I was looking into https://github.com/nodejs/node/issues/52776 (which I still am) and I noticed that the current error message that users see is not super helpful:
```
  #  Assertion failed: "Unreachable code reached" __VA_OPT__(": ") "invalid child stdio type"
```

What I'm doing in here is simply updating this so that instead what the user sees the following:
```
invalid child stdio type: wrap

  #  <node binary location>[192863]: v8::Maybe<int> node::SyncProcessRunner::ParseStdioOption(int, v8::Local<v8::Object>) at ../src/spawn_sync.cc:1061
  #  Assertion failed: "Unreachable code reached"
```
(where `wrap` is the problematic stdio type I get for #52776)

I'm not really good at C++ (I'm still learning), so if there is a better way of doing the above I would really love
some suggestions :slightly_smiling_face: 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
