### PR TITLE
readline: fix unicode line separators being ignored

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -75,8 +75,15 @@ const { StringDecoder } = require('string_decoder');
 const kHistorySize = 30;
 const kMaxUndoRedoStackSize = 2048;
 const kMincrlfDelay = 100;
-// \r\n, \n, or \r followed by something other than \n
-const lineEnding = /\r?\n|\r(?!\n)/g;
+/**
+ * The end of a line is signaled by either one of the following:
+ *  - \r\n
+ *  - \n
+ *  - \r followed by something other than \n
+ *  - \u2028 (Unicode 'LINE SEPARATOR')
+ *  - \u2029 (Unicode 'PARAGRAPH SEPARATOR')
+ */
+const lineEnding = /\r?\n|\r(?!\n)|\u2028|\u2029/g;
 
 const kLineObjectStream = Symbol('line object stream');
 const kQuestionCancel = Symbol('kQuestionCancel');

--- a/test/parallel/test-readline-line-separators.js
+++ b/test/parallel/test-readline-line-separators.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+const readline = require('node:readline');
+const { Readable } = require('node:stream');
+
+const str = '123\n456\r789\u{2028}ABC\u{2029}DEF';
+
+const rli = new readline.Interface({
+  input: Readable.from(str),
+});
+
+const linesRead = [];
+rli.on('line', (line) => linesRead.push(line));
+
+rli.on('close', common.mustCall(() => {
+  const regexpLines = str.split(/^/m).map((line) => line.trim());
+  // Readline interprets different lines in the same way js regular expressions do
+  assert.deepStrictEqual(linesRead, regexpLines);
+}));

--- a/test/parallel/test-readline-line-separators.js
+++ b/test/parallel/test-readline-line-separators.js
@@ -14,7 +14,5 @@ const linesRead = [];
 rli.on('line', (line) => linesRead.push(line));
 
 rli.on('close', common.mustCall(() => {
-  const regexpLines = str.split(/^/m).map((line) => line.trim()).filter(Boolean);
-  // Readline interprets different lines in the same way js regular expressions do
-  assert.deepStrictEqual(linesRead, regexpLines);
+  assert.deepStrictEqual(linesRead, ['012', '345', '67', '89', 'ABC', 'DEF']);
 }));

--- a/test/parallel/test-readline-line-separators.js
+++ b/test/parallel/test-readline-line-separators.js
@@ -4,7 +4,7 @@ const assert = require('node:assert');
 const readline = require('node:readline');
 const { Readable } = require('node:stream');
 
-const str = '123\n456\r789\u{2028}ABC\u{2029}DEF';
+const str = '012\n345\r67\r\n89\u{2028}ABC\u{2029}DEF';
 
 const rli = new readline.Interface({
   input: Readable.from(str),
@@ -14,7 +14,7 @@ const linesRead = [];
 rli.on('line', (line) => linesRead.push(line));
 
 rli.on('close', common.mustCall(() => {
-  const regexpLines = str.split(/^/m).map((line) => line.trim());
+  const regexpLines = str.split(/^/m).map((line) => line.trim()).filter(Boolean);
   // Readline interprets different lines in the same way js regular expressions do
   assert.deepStrictEqual(linesRead, regexpLines);
 }));


### PR DESCRIPTION
Fixes #22448

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
