### PR TITLE
src: add `--run-from` flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2305,7 +2305,7 @@ added: REPLACEME
 Run a `package.json` script from a specified path to a `package.json` file or
 path to the containing folder of a `package.json` file.
 
-The script is ran from the directory of the `package.json` file.
+The script is run from the directory of the `package.json` file.
 
 ```bash
 node --run-from=/app/package.json --run test

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2308,8 +2308,6 @@ Run a `package.json` script from a specified path to a containing folder of a
 The script is run from the directory of the `package.json` file.
 
 ```bash
-node --run-from=/app/package.json --run test
-# Or
 node --run-from=/app/ --run test
 ```
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2302,8 +2302,8 @@ added: REPLACEME
 
 > Stability 1.0 - Early development
 
-Run a `package.json` script from a specified path to a `package.json` file or
-path to the containing folder of a `package.json` file.
+Run a `package.json` script from a specified path to a containing folder of a
+`package.json` file.
 
 The script is run from the directory of the `package.json` file.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2294,6 +2294,25 @@ The following environment variables are set when running a script with `--run`:
 * `NODE_RUN_PACKAGE_JSON_PATH`: The path to the `package.json` that is being
   processed.
 
+### `--run-from=<path>`
+
+<!--
+added: REPLACEME
+-->
+
+> Stability 1.0 - Early development
+
+Run a `package.json` script from a specified path to a `package.json` file or
+path to the containing folder of a `package.json` file.
+
+The script is ran from the directory of the `package.json` file.
+
+```bash
+node --run-from=/app/package.json --run test
+# Or
+node --run-from=/app/ --run test
+```
+
 ### `--secure-heap-min=n`
 
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -431,6 +431,10 @@ Enables
 to be generated on un-caught exceptions. Useful when inspecting JavaScript
 stack in conjunction with native stack and other runtime environment data.
 .
+.It Fl -run-from Ar string
+Run a package.json script from a specified path to a package.json file or a path to the containing folder of a package.json file.
+.Ar string
+.
 .It Fl -secure-heap Ns = Ns Ar n
 Specify the size of the OpenSSL secure heap. Any value less than 2 disables
 the secure heap. The default is 0. The value must be a power of two.

--- a/doc/node.1
+++ b/doc/node.1
@@ -432,7 +432,7 @@ to be generated on un-caught exceptions. Useful when inspecting JavaScript
 stack in conjunction with native stack and other runtime environment data.
 .
 .It Fl -run-from Ar string
-Run a package.json script from a specified path to a package.json file or a path to the containing folder of a package.json file.
+Run a package.json script from a specified path to a folder containing a package.json file.
 .Ar string
 .
 .It Fl -secure-heap Ns = Ns Ar n

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1216,6 +1216,9 @@ PerProcessOptionsParser::PerProcessOptionsParser(
   AddOption("--run",
             "Run a script specified in package.json",
             &PerProcessOptions::run);
+  AddOption("--run-from",
+            "Run a package.json script from a specific directory",
+            &PerProcessOptions::run_from);
   AddOption(
       "--disable-wasm-trap-handler",
       "Disable trap-handler-based WebAssembly bound checks. V8 will insert "

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1217,7 +1217,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "Run a script specified in package.json",
             &PerProcessOptions::run);
   AddOption("--run-from",
-            "Run a package.json script from a specific directory",
+            "Run a package.json script from a specific path",
             &PerProcessOptions::run_from);
   AddOption(
       "--disable-wasm-trap-handler",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -327,6 +327,7 @@ class PerProcessOptions : public Options {
   bool print_version = false;
   std::string experimental_sea_config;
   std::string run;
+  std::string run_from;
 
 #ifdef NODE_HAVE_I18N_SUPPORT
   std::string icu_data_dir;

--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -261,10 +261,7 @@ void RunTask(const std::shared_ptr<InitializationResultImpl>& result,
   } else {
     cwd = std::filesystem::absolute(std::filesystem::path(run_from));
 
-    if (is_regular_file(cwd)) {
-      // Given a package.json
-      cwd = cwd.parent_path();
-    } else if (!is_directory(cwd)) {
+    if (!is_directory(cwd)) {
       // Given a directory that should have a package.json
       fprintf(stderr, "Error: %s is not a directory\n", cwd.c_str());
       result->exit_code_ = ExitCode::kGenericUserError;

--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -218,7 +218,6 @@ void ProcessRunner::Run() {
 
 std::optional<std::tuple<std::filesystem::path, std::string, std::string>>
 FindPackageJson(const std::filesystem::path& cwd) {
-  printf("FindPackageJson(%s)\n", cwd.c_str());
   auto package_json_path = cwd / "package.json";
   std::string raw_content;
   std::string path_env_var;

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -238,22 +238,6 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 0);
   });
 
-  it('runs script in a custom working directory using --run-from is given a package.json', async () => {
-    const packageJson = fixtures.path('run-script/package.json');
-    const workingDir = fixtures.path('run-script');
-
-    const child = await common.spawnPromisified(
-      process.execPath,
-      [ '--run-from', packageJson, '--run', `pwd${envSuffix}` ],
-
-      { env: fixtures.path('run-script/sub-directory') }
-    );
-
-    assert.strictEqual(child.stdout.trim(), workingDir);
-    assert.strictEqual(child.stderr, '');
-    assert.strictEqual(child.code, 0);
-  });
-
   it('--run-from should be no-op when used without --run', async () => {
     const packageJson = fixtures.path('run-script/package.json');
 

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -222,4 +222,49 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.stdout, '');
     assert.strictEqual(child.code, 1);
   });
+
+  it('runs script in a custom working directory using --run-from', async () => {
+    const workingDir = fixtures.path('run-script');
+
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run-from', workingDir, '--run', `pwd${envSuffix}` ],
+
+      { env: fixtures.path('run-script/sub-directory') }
+    );
+
+    assert.strictEqual(child.stdout.trim(), workingDir);
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
+  it('runs script in a custom working directory using --run-from is given a package.json', async () => {
+    const packageJson = fixtures.path('run-script/package.json');
+    const workingDir = fixtures.path('run-script');
+
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run-from', packageJson, '--run', `pwd${envSuffix}` ],
+
+      { env: fixtures.path('run-script/sub-directory') }
+    );
+
+    assert.strictEqual(child.stdout.trim(), workingDir);
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
+  it('--run-from should be no-op when used without --run', async () => {
+    const packageJson = fixtures.path('run-script/package.json');
+
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run-from', packageJson, '--print', 'process.cwd()' ],
+      { cwd: process.cwd() }
+    );
+
+    assert.strictEqual(child.stdout.trim(), process.cwd());
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
 });


### PR DESCRIPTION
Closes #57489

This differs from #57523 in that this changes the working directory that the script is executed from.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
