### PR TITLE
doc: add gurgunday as triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,8 @@ maintaining the Node.js project.
   **Feng Yu** <<F3n67u@outlook.com>> (he/him)
 * [gireeshpunathil](https://github.com/gireeshpunathil) -
   **Gireesh Punathil** <<gpunathi@in.ibm.com>> (he/him)
+* [gurgunday](https://github.com/gurgunday) -
+  **Gürgün Dayıoğlu** <<hey@gurgun.day>>
 * [iam-frankqiu](https://github.com/iam-frankqiu) -
   **Frank Qiu** <<iam.frankqiu@gmail.com>> (he/him)
 * [KevinEady](https://github.com/KevinEady) -


### PR DESCRIPTION
I would like to apply for the role of triager.

After Fastify, [I started regularly contributing to Node.js a few months ago](https://github.com/nodejs/node/pulls?q=is%3Apr+author%3Agurgunday), and I have no intention of slowing down! I love the Node.js project, its community structure, and pretty much everything else about it. I'd love to help as much as possible and be a part of this awesome project! Like I said, I already have a bunch of merged PRs and I've been occasionally commenting on other people's issues to help them for a while. I believe this is a natural next step for me.

I hereby declare that I have read and understood the Code of Conduct of the project and will adhere to that.