### PR TITLE
test: fix dangling promise in test_runner no isolation test setup

### DIFF
--- a/test/fixtures/test-runner/no-isolation/global-hooks.cjs
+++ b/test/fixtures/test-runner/no-isolation/global-hooks.cjs
@@ -1,0 +1,6 @@
+const test = require('node:test');
+
+test.before(() => console.log('before(): global'));
+test.beforeEach(() => console.log('beforeEach(): global'));
+test.after(() => console.log('after(): global'));
+test.afterEach(() => console.log('afterEach(): global'));

--- a/test/fixtures/test-runner/no-isolation/global-hooks.js
+++ b/test/fixtures/test-runner/no-isolation/global-hooks.js
@@ -1,6 +1,0 @@
-import('node:test').then((test) => {
-  test.before(() => console.log('before(): global'));
-  test.beforeEach(() => console.log('beforeEach(): global'));
-  test.after(() => console.log('after(): global'));
-  test.afterEach(() => console.log('afterEach(): global'));
-});

--- a/test/fixtures/test-runner/no-isolation/global-hooks.mjs
+++ b/test/fixtures/test-runner/no-isolation/global-hooks.mjs
@@ -1,0 +1,6 @@
+import test from 'node:test';
+
+test.before(() => console.log('before(): global'));
+test.beforeEach(() => console.log('beforeEach(): global'));
+test.after(() => console.log('after(): global'));
+test.afterEach(() => console.log('afterEach(): global'));

--- a/test/known_issues/test-runner-no-isolation-hooks.mjs
+++ b/test/known_issues/test-runner-no-isolation-hooks.mjs
@@ -45,22 +45,20 @@ const order = [
   'after two: <root>',
 ].join('\n');
 
-test('use --import (CJS) to define global hooks', async (t) => {
+/**
+ * TODO: The `--require` flag is processed in `loadPreloadModules` (process/pre_execution.js) BEFORE
+ * the root test is created by the test runner. This causes a global `before` hook to register (and
+ * run) but then the root test-case is created, causing the "subsequent" hooks to get lost. This
+ * behaviour (CJS route only) is different from the ESM route, where test runner explicitly handles
+ * `--import` in `root.runInAsyncScope` (test_runner/runner.js).
+ * @see https://github.com/nodejs/node/pull/57595#issuecomment-2770724492
+ * @see https://github.com/nodejs/node/issues/57728
+ * Moved from test/parallel/test-runner-no-isolation-hooks.mjs
+ */
+test('use --require to define global hooks', async (t) => {
   const { stdout } = await common.spawnPromisified(process.execPath, [
     ...testArguments,
-    '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.cjs'),
-    ...testFiles,
-  ]);
-
-  const testHookOutput = stdout.split('\n▶')[0];
-
-  t.assert.equal(testHookOutput, order);
-});
-
-test('use --import (ESM) to define global hooks', async (t) => {
-  const { stdout } = await common.spawnPromisified(process.execPath, [
-    ...testArguments,
-    '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.mjs'),
+    '--require', fixtures.path('test-runner', 'no-isolation', 'global-hooks.cjs'),
     ...testFiles,
   ]);
 

--- a/test/parallel/test-runner-no-isolation-hooks.mjs
+++ b/test/parallel/test-runner-no-isolation-hooks.mjs
@@ -43,24 +43,28 @@ const order = [
   'after(): global',
   'after one: <root>',
   'after two: <root>',
-];
+].join('\n');
 
 test('Using --require to define global hooks works', async (t) => {
-  const spawned = await common.spawnPromisified(process.execPath, [
+  const { stdout } = await common.spawnPromisified(process.execPath, [
     ...testArguments,
-    '--require', fixtures.path('test-runner', 'no-isolation', 'global-hooks.js'),
+    '--require', fixtures.path('test-runner', 'no-isolation', 'global-hooks.cjs'),
     ...testFiles,
   ]);
 
-  t.assert.ok(spawned.stdout.includes(order.join('\n')));
+  const testHookOutput = stdout.split('\n▶')[0];
+
+  t.assert.equal(testHookOutput, order);
 });
 
 test('Using --import to define global hooks works', async (t) => {
-  const spawned = await common.spawnPromisified(process.execPath, [
+  const { stdout } = await common.spawnPromisified(process.execPath, [
     ...testArguments,
-    '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.js'),
+    '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.mjs'),
     ...testFiles,
   ]);
 
-  t.assert.ok(spawned.stdout.includes(order.join('\n')));
+  const testHookOutput = stdout.split('\n▶')[0];
+
+  t.assert.equal(testHookOutput, order);
 });

--- a/test/parallel/test-runner-no-isolation-hooks.mjs
+++ b/test/parallel/test-runner-no-isolation-hooks.mjs
@@ -45,7 +45,7 @@ const order = [
   'after two: <root>',
 ].join('\n');
 
-test('Using --require to define global hooks works', async (t) => {
+test('use --require to define global hooks', async (t) => {
   const { stdout } = await common.spawnPromisified(process.execPath, [
     ...testArguments,
     '--require', fixtures.path('test-runner', 'no-isolation', 'global-hooks.cjs'),
@@ -57,7 +57,19 @@ test('Using --require to define global hooks works', async (t) => {
   t.assert.equal(testHookOutput, order);
 });
 
-test('Using --import to define global hooks works', async (t) => {
+test('use --import (CJS) to define global hooks', async (t) => {
+  const { stdout } = await common.spawnPromisified(process.execPath, [
+    ...testArguments,
+    '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.cjs'),
+    ...testFiles,
+  ]);
+
+  const testHookOutput = stdout.split('\n▶')[0];
+
+  t.assert.equal(testHookOutput, order);
+});
+
+test('use --import (ESM) to define global hooks', async (t) => {
   const { stdout } = await common.spawnPromisified(process.execPath, [
     ...testArguments,
     '--import', fixtures.fileURL('test-runner', 'no-isolation', 'global-hooks.mjs'),


### PR DESCRIPTION
The `--import`ed / `--require`d file contained an un-`await`ed dynamic import, so it's subsequent code was not guaranteed to finish before the entry-point starts. Strangely that should have caused this test to fail _some_ times, but it seems to be consistently fast enough so that the race condition doesn't occur.

I checked with the original author of the test, and this was not intended (it was only done that way in an attempt to simplify setup and recycle fixtures).

However, after speed improvements in https://github.com/nodejs/node/pull/57419, the race condition was exposed and does occur consistently (causing the global hooks to get registered out of their intended/expected sequence).