### PR TITLE
assert,util: improve array comparison

### DIFF
--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -29,6 +29,7 @@ function myersDiff(actual, expected, checkCommaDisparity = false) {
   const actualLength = actual.length;
   const expectedLength = expected.length;
   const max = actualLength + expectedLength;
+  // TODO(BridgeAR): Cap the input in case the values go beyond the limit of 2^31 - 1.
   const v = new Int32Array(2 * max + 1);
   const trace = [];
 

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -8,7 +8,6 @@ const {
   BooleanPrototypeValueOf,
   DatePrototypeGetTime,
   Error,
-  NumberIsNaN,
   NumberPrototypeValueOf,
   ObjectGetOwnPropertySymbols: getOwnSymbols,
   ObjectGetPrototypeOf,
@@ -185,7 +184,9 @@ function innerDeepEqual(val1, val2, mode, memos) {
   // Check more closely if val1 and val2 are equal.
   if (mode !== kLoose) {
     if (typeof val1 === 'number') {
-      return NumberIsNaN(val1) && NumberIsNaN(val2);
+      // Check for NaN
+      // eslint-disable-next-line no-self-compare
+      return val1 !== val1 && val2 !== val2;
     }
     if (typeof val2 !== 'object' ||
         typeof val1 !== 'object' ||
@@ -197,8 +198,9 @@ function innerDeepEqual(val1, val2, mode, memos) {
   } else {
     if (val1 === null || typeof val1 !== 'object') {
       return (val2 === null || typeof val2 !== 'object') &&
-             // eslint-disable-next-line eqeqeq
-             (val1 == val2 || (NumberIsNaN(val1) && NumberIsNaN(val2)));
+             // Check for NaN
+             // eslint-disable-next-line eqeqeq, no-self-compare
+             (val1 == val2 || (val1 !== val1 && val2 !== val2));
     }
     if (val2 === null || typeof val2 !== 'object') {
       return false;
@@ -498,7 +500,9 @@ function findLooseMatchingPrimitives(prim) {
       // a regular number and not NaN.
       // Fall through
     case 'number':
-      if (NumberIsNaN(prim)) {
+      // Check for NaN
+      // eslint-disable-next-line no-self-compare
+      if (prim !== prim) {
         return false;
       }
   }

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -196,11 +196,9 @@ function innerDeepEqual(val1, val2, mode, memos) {
     }
   } else {
     if (val1 === null || typeof val1 !== 'object') {
-      if (val2 === null || typeof val2 !== 'object') {
-        // eslint-disable-next-line eqeqeq
-        return val1 == val2 || (NumberIsNaN(val1) && NumberIsNaN(val2));
-      }
-      return false;
+      return (val2 === null || typeof val2 !== 'object') &&
+             // eslint-disable-next-line eqeqeq
+             (val1 == val2 || (NumberIsNaN(val1) && NumberIsNaN(val2)));
     }
     if (val2 === null || typeof val2 !== 'object') {
       return false;
@@ -384,9 +382,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
       }
     } else if (keys2.length !== ObjectKeys(val1).length) {
       return false;
-    }
-
-    if (mode === kStrict) {
+    } else if (mode === kStrict) {
       const symbolKeysA = getOwnSymbols(val1);
       if (symbolKeysA.length !== 0) {
         let count = 0;
@@ -758,9 +754,9 @@ function sparseArrayEquiv(a, b, mode, memos, i) {
   if (keysA.length !== keysB.length) {
     return false;
   }
-  for (; i < keysA.length; i++) {
-    const key = keysA[i];
-    if (!hasOwn(b, key) || !innerDeepEqual(a[key], b[key], mode, memos)) {
+  for (; i < keysB.length; i++) {
+    const key = keysB[i];
+    if ((a[key] === undefined && !hasOwn(a, key)) || !innerDeepEqual(a[key], b[key], mode, memos)) {
       return false;
     }
   }
@@ -782,16 +778,13 @@ function objEquiv(a, b, mode, keys2, memos, iterationType) {
       return partialArrayEquiv(a, b, mode, memos);
     }
     for (let i = 0; i < a.length; i++) {
-      if (!innerDeepEqual(a[i], b[i], mode, memos)) {
+      if (b[i] === undefined) {
+        if (!hasOwn(b, i))
+          return sparseArrayEquiv(a, b, mode, memos, i);
+        if (a[i] !== undefined || !hasOwn(a, i))
+          return false;
+      } else if (a[i] === undefined || !innerDeepEqual(a[i], b[i], mode, memos)) {
         return false;
-      }
-      const isSparseA = a[i] === undefined && !hasOwn(a, i);
-      const isSparseB = b[i] === undefined && !hasOwn(b, i);
-      if (isSparseA !== isSparseB) {
-        return false;
-      }
-      if (isSparseA) {
-        return sparseArrayEquiv(a, b, mode, memos, i);
       }
     }
   } else if (iterationType === kIsSet) {


### PR DESCRIPTION
Sparse arrays and arrays containing undefined are now compared faster using assert.deepStrictEqual() or util.isDeepStrictEqual().

Update: I added another commit that also improves the comparison performance for unequal numbers.

Local benchmark (more configurations and higher iterations to show that even regular arrays improve by ~1%. This should not matter for regular runs, so I kept the benchmark simpler in here):

```
                                                                                                                         confidence improvement accuracy (*)   (**)  (***)
assert/deepequal-simple-array-and-set.js method='deepEqual_Array' containsUndefined=0 strict=1 len=10000 n=4000                 ***      1.39 %       ±0.67% ±0.90% ±1.17%
assert/deepequal-simple-array-and-set.js method='deepEqual_Array' containsUndefined=1 strict=1 len=10000 n=4000                 ***     24.22 %       ±0.92% ±1.23% ±1.60%
assert/deepequal-simple-array-and-set.js method='deepEqual_Set' containsUndefined=0 strict=1 len=10000 n=4000                            1.41 %       ±1.71% ±2.28% ±2.98%
assert/deepequal-simple-array-and-set.js method='deepEqual_Set' containsUndefined=1 strict=1 len=10000 n=4000                            1.56 %       ±1.57% ±2.08% ±2.71%
assert/deepequal-simple-array-and-set.js method='deepEqual_sparseArray' containsUndefined=0 strict=1 len=10000 n=4000           ***     28.45 %       ±0.80% ±1.06% ±1.38%
assert/deepequal-simple-array-and-set.js method='deepEqual_sparseArray' containsUndefined=1 strict=1 len=10000 n=4000           ***     28.36 %       ±0.85% ±1.14% ±1.48%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Array' containsUndefined=0 strict=1 len=10000 n=4000                *      1.70 %       ±1.53% ±2.05% ±2.70%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Array' containsUndefined=1 strict=1 len=10000 n=4000              ***     23.54 %       ±0.95% ±1.26% ±1.64%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Set' containsUndefined=0 strict=1 len=10000 n=4000                        -1.20 %       ±1.35% ±1.80% ±2.36%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Set' containsUndefined=1 strict=1 len=10000 n=4000                         0.33 %       ±1.81% ±2.41% ±3.14%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_sparseArray' containsUndefined=0 strict=1 len=10000 n=4000        ***     28.05 %       ±0.86% ±1.15% ±1.49%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_sparseArray' containsUndefined=1 strict=1 len=10000 n=4000        ***     28.11 %       ±0.98% ±1.31% ±1.70%
```