### PR TITLE
Update `--require` docs

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2193,7 +2193,7 @@ changes:
       - v23.0.0
       - v22.12.0
       - v20.19.0
-    pr-url: https://github.com/nodejs/node/issues/52697
+    pr-url: https://github.com/nodejs/node/pull/51977
     description: This option also supports ECMAScript module.
 -->
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2188,6 +2188,13 @@ native stack and other runtime environment data.
 
 <!-- YAML
 added: v1.6.0
+changes:
+  - version:
+      - v23.0.0
+      - v22.12.0
+      - v20.19.0
+    pr-url: https://github.com/nodejs/node/issues/52697
+    description: This option also supports ECMAScript module.
 -->
 
 Preload the specified module at startup.
@@ -2195,8 +2202,8 @@ Preload the specified module at startup.
 Follows `require()`'s module resolution
 rules. `module` may be either a path to a file, or a node module name.
 
-Only CommonJS modules are supported.
-Use [`--import`][] to preload an [ECMAScript module][].
+Both CommonJS module and [ECMAScript module][] are supported.
+Use [`--import`][] to preload only [ECMAScript module][].
 Modules preloaded with `--require` will run before modules preloaded with `--import`.
 
 Modules are preloaded into the main thread as well as any worker threads,

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2202,8 +2202,6 @@ Preload the specified module at startup.
 Follows `require()`'s module resolution
 rules. `module` may be either a path to a file, or a node module name.
 
-Both CommonJS module and [ECMAScript module][] are supported.
-Use [`--import`][] to preload only [ECMAScript module][].
 Modules preloaded with `--require` will run before modules preloaded with `--import`.
 
 Modules are preloaded into the main thread as well as any worker threads,


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
With `require(esm)` being unflagged, `node --require module` now also supports ES modules.