### PR TITLE
Revert "assert,util: revert recursive breaking change"

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -556,6 +556,10 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57622
+    description: Recursion now stops when either side encounters a circular
+                 reference.
   - version:
       - v22.2.0
       - v20.15.0
@@ -632,7 +636,7 @@ are also recursively evaluated by the following rules.
 * [Object wrappers][] are compared both as objects and unwrapped values.
 * `Object` properties are compared unordered.
 * {Map} keys and {Set} items are compared unordered.
-* Recursion stops when both sides differ or both sides encounter a circular
+* Recursion stops when both sides differ or either side encounters a circular
   reference.
 * Implementation does not test the [`[[Prototype]]`][prototype-spec] of
   objects.
@@ -743,6 +747,10 @@ parameter is an instance of {Error} then it will be thrown instead of the
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57622
+    description: Recursion now stops when either side encounters a circular
+                 reference.
   - version:
     - v22.2.0
     - v20.15.0
@@ -802,7 +810,7 @@ are recursively evaluated also by the following rules.
 * [Object wrappers][] are compared both as objects and unwrapped values.
 * `Object` properties are compared unordered.
 * {Map} keys and {Set} items are compared unordered.
-* Recursion stops when both sides differ or both sides encounter a circular
+* Recursion stops when both sides differ or either side encounters a circular
   reference.
 * {WeakMap} and {WeakSet} instances are **not** compared structurally.
   They are only equal if they reference the same object. Any comparison between

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -439,7 +439,10 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
   if (memos.set === undefined) {
     if (memos.deep === false) {
       if (memos.a === val1) {
-        if (memos.b === val2) return true;
+        return memos.b === val2;
+      }
+      if (memos.b === val2) {
+        return false;
       }
       memos.c = val1;
       memos.d = val2;
@@ -460,8 +463,8 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
   const originalSize = set.size;
   set.add(val1);
   set.add(val2);
-  if (originalSize === set.size) {
-    return true;
+  if (originalSize !== set.size - 2) {
+    return originalSize === set.size;
   }
 
   const areEq = objEquiv(val1, val2, mode, keys2, memos, iterationType);

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -561,7 +561,7 @@ test('GH-14441. Circular structures should be consistent', () => {
     b.a = {};
     b.a.a = a;
 
-    assertDeepAndStrictEqual(a, b);
+    assertNotDeepOrStrict(a, b);
   }
 
   {
@@ -571,7 +571,7 @@ test('GH-14441. Circular structures should be consistent', () => {
     b.a = b;
     const c = {};
     c.a = a;
-    assertDeepAndStrictEqual(b, c);
+    assertNotDeepOrStrict(b, c);
   }
 
   {
@@ -581,7 +581,7 @@ test('GH-14441. Circular structures should be consistent', () => {
     b.add(b);
     const c = new Set();
     c.add(a);
-    assertDeepAndStrictEqual(b, c);
+    assertNotDeepOrStrict(b, c);
   }
 });
 


### PR DESCRIPTION
This reverts commit 575784b4cff6eb7fbb16e41cdd2b576563756a09.

This was an intentional commit at that time to make a bigger PR not breaking. This should in the real world never have a negative impact, since the algorithm somewhat works more correct with this change and it would very likely have resulted in a difference in user code, if this case really exists.