### PR TITLE
doc: add new companion status to governance document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,7 @@
 
 <!-- TOC -->
 
+* [Companions](#companions)
 * [Triagers](#triagers)
 * [Collaborators](#collaborators)
   * [Collaborator activities](#collaborator-activities)
@@ -15,6 +16,17 @@
 * [Consensus seeking process](#consensus-seeking-process)
 
 <!-- /TOC -->
+
+## Companions
+
+Companions are people recognized for their significant contributions to Node.js.
+Contributions can take many forms and is not limited to code committed to the
+[nodejs/node][] repository. Typically, a contributor becomes a Companion before
+becoming a Triager or Collaborator.
+
+See:
+
+* [List of companions](./README.md#companions)
 
 ## Triagers
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ that discourage, exhaust, or otherwise negatively affect other participants.
   * [TSC (Technical Steering Committee)](#tsc-technical-steering-committee)
   * [Collaborators](#collaborators)
   * [Triagers](#triagers)
+  * [Companions](#companions)
   * [Release keys](#release-keys)
 * [License](#license)
 
@@ -766,6 +767,10 @@ maintaining the Node.js project.
 
 Triagers follow the [Triage Guide](./doc/contributing/issues.md#triaging-a-bug-report) when
 responding to new issues.
+
+### Companions
+
+Companions are people recognized for their significant contributions to Node.js.
 
 ### Release keys
 


### PR DESCRIPTION
In the recent Node.js discussions around nominations, we also discussed the need to show that someone contributed to the project in a significant way before we are able to nominate someone to become a collaborator.

This governance change should address that need.

The documentation is intentionally kept brief for now. AFAIC we are able to extend this at a later point.