### PR TITLE
doc: classify Chrome DevTools Protocol as tier 2

### DIFF
--- a/doc/contributing/diagnostic-tooling-support-tiers.md
+++ b/doc/contributing/diagnostic-tooling-support-tiers.md
@@ -100,9 +100,9 @@ The tools are currently assigned to Tiers as follows:
 
 ## Tier 2
 
-| Tool Type | Tool/API Name | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
-| --------- | ------------- | ----------------------------- | ----------------------- | ----------- |
-|           |               |                               |                         |             |
+| Tool Type | Tool/API Name                | Regular Testing in Node.js CI | Integrated with Node.js | Target Tier |
+| --------- | ---------------------------- | ----------------------------- | ----------------------- | ----------- |
+| Debugger  | [Chrome DevTools Protocol][] | Yes                           | Yes                     | 1           |
 
 ## Tier 3
 
@@ -114,7 +114,7 @@ The tools are currently assigned to Tiers as follows:
 | Profiling | V8 --interpreted-frames-native-stack | Yes                           | Yes                     | 2           |
 | Profiling | [Linux perf][]                       | Yes                           | Partial                 | 2           |
 | Profiling | [node-clinic][]                      | No                            | No                      | 3           |
-| Debugger  | [Chrome Dev tools][]                 | No                            | No                      | 3           |
+| Debugger  | [Chrome DevTools Frontend][]         | No                            | No                      | 3           |
 
 ## Tier 4
 
@@ -129,15 +129,15 @@ The tools are currently assigned to Tiers as follows:
 | Memory    | V8 heap profiler                          | No                            | Yes                     | 1           |
 | Memory    | V8 sampling heap profiler                 | No                            | Yes                     | 1           |
 | AsyncFlow | [Async Hooks (API)][]                     | ?                             | Yes                     | 1           |
-| Debugger  | V8 Debug protocol (API)                   | No                            | Yes                     | 1           |
 | Debugger  | [Command line Debug Client][]             | ?                             | Yes                     | 1           |
 | Tracing   | [trace\_events (API)][trace_events (API)] | No                            | Yes                     | 1           |
 | Tracing   | trace\_gc                                 | No                            | Yes                     | 1           |
 
 [0x]: https://github.com/davidmarkclements/0x
 [Async Hooks (API)]: https://nodejs.org/api/async_hooks.html
-[Chrome Dev Tools]: https://developer.chrome.com/docs/devtools/
-[Command line Debug Client]: https://nodejs.org/api/inspector.html
+[Chrome DevTools Frontend]: https://developer.chrome.com/docs/devtools/
+[Chrome DevTools Protocol]: https://chromedevtools.github.io/devtools-protocol/
+[Command line Debug Client]: https://nodejs.org/api/debugger.html
 [Linux perf]: https://perf.wiki.kernel.org/index.php/Main_Page
 [diagnostic report]: https://nodejs.org/api/report.html
 [node-clinic]: https://github.com/clinicjs/node-clinic/


### PR DESCRIPTION
Chrome DevTools Protocol is the de-facto debugger protocol for
Node.js and is tested regularly in Node.js test suite / CI. It matches
the tier 2 classification but lacks proper documentation in Node.js for tier 1.

Classify the Chrome DevTools Protocol as tier 2 with a target of
tier 1 once we have proper documentation on stable protocols.

On the other hand, the Chrome DevTools Frontend is not shipped with
Node.js and not tested in Node.js CI. So keep it as tier 3.

The legacy V8 Debug Protocol is not supported.