### PR TITLE
http2: fix a error in the check for frame->hd.type (related to CVE-2025-23085)

### DIFF
--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -1206,7 +1206,7 @@ int Http2Session::OnFrameNotSent(nghttp2_session* handle,
     // closed but the Http2Session will still be up causing a memory leak.
     // Therefore, if the GOAWAY frame couldn't be send due to
     // ERR_SESSION_CLOSING we should force close from our side.
-    if (frame->hd.type != 0x03) {
+    if (frame->hd.type != NGHTTP2_GOAWAY) {
       return 0;
     }
   }

--- a/test/parallel/test-http2-premature-close.js
+++ b/test/parallel/test-http2-premature-close.js
@@ -29,9 +29,9 @@ async function requestAndClose(server) {
     // Send a valid HEADERS frame
     const headersFrame = Buffer.concat([
       Buffer.from([
-        0x00, 0x00, 0x0e, // Length: 12 bytes
+        0x00, 0x00, 0x0e, // Length: 14 bytes
         0x01, // Type: HEADERS
-        0x04, // Flags: END_HEADERS + END_STREAM
+        0x04, // Flags: END_HEADERS
         (streamId >> 24) & 0xFF, // Stream ID: high byte
         (streamId >> 16) & 0xFF,
         (streamId >> 8) & 0xFF,
@@ -41,7 +41,7 @@ async function requestAndClose(server) {
         0x82, // Indexed Header Field Representation (Predefined ":method: GET")
         0x84, // Indexed Header Field Representation (Predefined ":path: /")
         0x86, // Indexed Header Field Representation (Predefined ":scheme: http")
-        0x41, 0x09, // Custom ":authority: localhost"
+        0x41, 0x09, // ":authority: localhost" Length: 9 bytes
         0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74,
       ]),
     ]);

--- a/test/parallel/test-http2-premature-close.js
+++ b/test/parallel/test-http2-premature-close.js
@@ -29,9 +29,9 @@ async function requestAndClose(server) {
     // Send a valid HEADERS frame
     const headersFrame = Buffer.concat([
       Buffer.from([
-        0x00, 0x00, 0x0c, // Length: 12 bytes
+        0x00, 0x00, 0x0e, // Length: 12 bytes
         0x01, // Type: HEADERS
-        0x05, // Flags: END_HEADERS + END_STREAM
+        0x04, // Flags: END_HEADERS + END_STREAM
         (streamId >> 24) & 0xFF, // Stream ID: high byte
         (streamId >> 16) & 0xFF,
         (streamId >> 8) & 0xFF,
@@ -41,7 +41,7 @@ async function requestAndClose(server) {
         0x82, // Indexed Header Field Representation (Predefined ":method: GET")
         0x84, // Indexed Header Field Representation (Predefined ":path: /")
         0x86, // Indexed Header Field Representation (Predefined ":scheme: http")
-        0x44, 0x0a, // Custom ":authority: localhost"
+        0x41, 0x09, // Custom ":authority: localhost"
         0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74,
       ]),
     ]);


### PR DESCRIPTION
http2: fix a typo in the check for frame->hd.type in 1b693fa

According to the description above, this should be checking 
whether frame->hd.type is NGHTTP2_GOAWAY,
 and the value of NGHTTP2_GOAWAY is 0x07. However, 
it is written as 0x03 here, which I think  it is a typo.

Refs: https://github.com/nodejs/node/commit/1b693fa03a0d36bc1dc9ec8d95060e3e5ceeee7b

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
