### PR TITLE
assert,util: improve deep object comparison performance

### DIFF
--- a/benchmark/assert/deepequal-map.js
+++ b/benchmark/assert/deepequal-map.js
@@ -31,7 +31,7 @@ function benchmark(method, n, values, values2) {
 }
 
 function main({ n, len, method, strict }) {
-  const array = Array(len).fill(1);
+  const array = Array.from({ length: len }, () => '');
 
   switch (method) {
     case 'deepEqual_primitiveOnly': {

--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -14,7 +14,6 @@ const primValues = {
   'number': 1_000,
   'boolean': true,
   'object': { property: 'abcdef' },
-  'object_other_property': { property: 'abcdef' },
   'array': [1, 2, 3],
   'set_object': new Set([[1]]),
   'set_simple': new Set([1, 2, 3]),

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -6,8 +6,9 @@ const { deepEqual, deepStrictEqual, notDeepEqual, notDeepStrictEqual } =
 
 const bench = common.createBenchmark(main, {
   n: [1e3],
-  len: [2, 5e2],
+  len: [2, 1e2],
   strict: [0, 1],
+  order: ['insert', 'random', 'reversed'],
   method: [
     'deepEqual_primitiveOnly',
     'deepEqual_objectOnly',
@@ -16,12 +17,30 @@ const bench = common.createBenchmark(main, {
     'notDeepEqual_objectOnly',
     'notDeepEqual_mixed',
   ],
+}, {
+  combinationFilter(p) {
+    return p.order !== 'random' || p.strict === 1 && p.method !== 'notDeepEqual_objectOnly';
+  },
 });
 
-function benchmark(method, n, values, values2) {
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+}
+
+function benchmark(method, n, values, values2, order) {
   const actual = new Set(values);
   // Prevent reference equal elements
-  const deepCopy = JSON.parse(JSON.stringify(values2 ? values2 : values));
+  let deepCopy = JSON.parse(JSON.stringify(values2));
+  if (order === 'reversed') {
+    deepCopy = deepCopy.reverse();
+  } else if (order === 'random') {
+    shuffleArray(deepCopy);
+  }
   const expected = new Set(deepCopy);
   bench.start();
   for (let i = 0; i < n; ++i) {
@@ -30,39 +49,39 @@ function benchmark(method, n, values, values2) {
   bench.end(n);
 }
 
-function main({ n, len, method, strict }) {
-  const array = Array(len).fill(1);
+function main({ n, len, method, strict, order }) {
+  const array = Array.from({ length: len }, () => '');
 
   switch (method) {
     case 'deepEqual_primitiveOnly': {
       const values = array.map((_, i) => `str_${i}`);
-      benchmark(strict ? deepStrictEqual : deepEqual, n, values);
+      benchmark(strict ? deepStrictEqual : deepEqual, n, values, values, order);
       break;
     }
     case 'deepEqual_objectOnly': {
       const values = array.map((_, i) => [`str_${i}`, null]);
-      benchmark(strict ? deepStrictEqual : deepEqual, n, values);
+      benchmark(strict ? deepStrictEqual : deepEqual, n, values, values, order);
       break;
     }
     case 'deepEqual_mixed': {
       const values = array.map((_, i) => {
         return i % 2 ? [`str_${i}`, null] : `str_${i}`;
       });
-      benchmark(strict ? deepStrictEqual : deepEqual, n, values);
+      benchmark(strict ? deepStrictEqual : deepEqual, n, values, values, order);
       break;
     }
     case 'notDeepEqual_primitiveOnly': {
       const values = array.map((_, i) => `str_${i}`);
       const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = 'w00t';
-      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
+      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2, order);
       break;
     }
     case 'notDeepEqual_objectOnly': {
       const values = array.map((_, i) => [`str_${i}`, null]);
       const values2 = values.slice(0);
       values2[Math.floor(len / 2)] = ['w00t'];
-      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
+      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2, order);
       break;
     }
     case 'notDeepEqual_mixed': {
@@ -71,7 +90,7 @@ function main({ n, len, method, strict }) {
       });
       const values2 = values.slice();
       values2[0] = 'w00t';
-      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2);
+      benchmark(strict ? notDeepStrictEqual : notDeepEqual, n, values, values2, order);
       break;
     }
     default:

--- a/benchmark/assert/deepequal-set.js
+++ b/benchmark/assert/deepequal-set.js
@@ -6,7 +6,7 @@ const { deepEqual, deepStrictEqual, notDeepEqual, notDeepStrictEqual } =
 
 const bench = common.createBenchmark(main, {
   n: [1e3],
-  len: [5e2],
+  len: [2, 5e2],
   strict: [0, 1],
   method: [
     'deepEqual_primitiveOnly',

--- a/benchmark/assert/partial-deep-equal.js
+++ b/benchmark/assert/partial-deep-equal.js
@@ -62,7 +62,7 @@ function createSets(length, extraProps, depth = 0) {
       number: i,
     },
     ['array', 'with', 'values'],
-    !depth ? new Set([1, 2, { nested: i }]) : new Set(),
+    !depth ? new Set([1, { nested: i }]) : new Set(),
     !depth ? createSets(2, extraProps, depth + 1) : null,
   ]));
 }

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -9,6 +9,7 @@ const {
   DatePrototypeGetTime,
   Error,
   NumberPrototypeValueOf,
+  ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertySymbols: getOwnSymbols,
   ObjectGetPrototypeOf,
   ObjectIs,
@@ -192,7 +193,10 @@ function innerDeepEqual(val1, val2, mode, memos) {
         typeof val1 !== 'object' ||
         val1 === null ||
         val2 === null ||
-        (mode === kStrict && ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2))) {
+        (mode === kStrict &&
+          (val1.constructor !== val2.constructor ||
+            (val1.constructor === undefined &&
+              ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2))))) {
       return false;
     }
   } else {
@@ -316,6 +320,10 @@ function innerDeepEqual(val1, val2, mode, memos) {
              isNativeError(val2) ||
              val2 instanceof Error) {
     return false;
+  } else if (isURL(val1)) {
+    if (!isURL(val2) || val1.href !== val2.href) {
+      return false;
+    }
   } else if (isKeyObject(val1)) {
     if (!isKeyObject(val2) || !val1.equals(val2)) {
       return false;
@@ -332,10 +340,6 @@ function innerDeepEqual(val1, val2, mode, memos) {
     }
   } else if (isWeakMap(val1) || isWeakSet(val1)) {
     return false;
-  } else if (isURL(val1)) {
-    if (!isURL(val2) || val1.href !== val2.href) {
-      return false;
-    }
   }
 
   return keyCheck(val1, val2, mode, memos, kNoIterator);
@@ -343,6 +347,21 @@ function innerDeepEqual(val1, val2, mode, memos) {
 
 function getEnumerables(val, keys) {
   return ArrayPrototypeFilter(keys, (key) => hasEnumerable(val, key));
+}
+
+function partialSymbolEquiv(val1, val2, keys2) {
+  const symbolKeys = getOwnSymbols(val2);
+  if (symbolKeys.length !== 0) {
+    for (const key of symbolKeys) {
+      if (hasEnumerable(val2, key)) {
+        if (!hasEnumerable(val1, key)) {
+          return false;
+        }
+        ArrayPrototypePush(keys2, key);
+      }
+    }
+  }
+  return true;
 }
 
 function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
@@ -358,31 +377,15 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
   if (keys2 === undefined) {
     keys2 = ObjectKeys(val2);
   }
-
-  // Cheap key test
-  if (keys2.length > 0) {
-    for (const key of keys2) {
-      if (!hasEnumerable(val1, key)) {
-        return false;
-      }
-    }
-  }
+  let keys1;
 
   if (!isArrayLikeObject) {
     // The pair must have the same number of owned properties.
     if (mode === kPartial) {
-      const symbolKeys = getOwnSymbols(val2);
-      if (symbolKeys.length !== 0) {
-        for (const key of symbolKeys) {
-          if (hasEnumerable(val2, key)) {
-            if (!hasEnumerable(val1, key)) {
-              return false;
-            }
-            ArrayPrototypePush(keys2, key);
-          }
-        }
+      if (!partialSymbolEquiv(val1, val2, keys2)) {
+        return false;
       }
-    } else if (keys2.length !== ObjectKeys(val1).length) {
+    } else if (keys2.length !== (keys1 = ObjectKeys(val1)).length) {
       return false;
     } else if (mode === kStrict) {
       const symbolKeysA = getOwnSymbols(val1);
@@ -431,7 +434,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
       d: undefined,
       deep: false,
     };
-    return objEquiv(val1, val2, mode, keys2, memos, iterationType);
+    return objEquiv(val1, val2, mode, keys1, keys2, memos, iterationType);
   }
 
   if (memos.set === undefined) {
@@ -445,7 +448,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
       memos.c = val1;
       memos.d = val2;
       memos.deep = true;
-      const result = objEquiv(val1, val2, mode, keys2, memos, iterationType);
+      const result = objEquiv(val1, val2, mode, keys1, keys2, memos, iterationType);
       memos.deep = false;
       return result;
     }
@@ -465,7 +468,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
     return originalSize === set.size;
   }
 
-  const areEq = objEquiv(val1, val2, mode, keys2, memos, iterationType);
+  const areEq = objEquiv(val1, val2, mode, keys1, keys2, memos, iterationType);
 
   set.delete(val1);
   set.delete(val2);
@@ -581,7 +584,8 @@ function setEquiv(a, b, mode, memo) {
   // This is a lazily initiated Set of entries which have to be compared
   // pairwise.
   let set = null;
-  for (const val of b) {
+  const iteratorB = b.values();
+  for (const val of iteratorB) {
     if (!a.has(val)) {
       if ((typeof val !== 'object' || val === null) &&
           (mode !== kLoose || !setMightHaveLoosePrim(a, b, val))) {
@@ -589,8 +593,25 @@ function setEquiv(a, b, mode, memo) {
       }
 
       if (set === null) {
-        if (a.size === 1) {
-          return innerDeepEqual(a.values().next().value, val, mode, memo);
+        if (a.size < 3) {
+          const iteratorA = a.values();
+          const firstA = iteratorA.next().value;
+          const first = innerDeepEqual(firstA, val, mode, memo);
+          if (first) {
+            if (b.size === 1) { // Partial mode && a.size === 1
+              return true;
+            }
+            const secondA = iteratorA.next().value;
+            return b.has(secondA) || innerDeepEqual(secondA, iteratorB.next().value, mode, memo);
+          }
+          if (a.size === 1) {
+            return false;
+          }
+          return innerDeepEqual(iteratorA.next().value, val, mode, memo) && (
+            b.size === 1 || // Partial mode
+            b.has(firstA) || // Primitive or reference equal
+            innerDeepEqual(firstA, iteratorB.next().value, mode, memo)
+          );
         }
         set = new SafeSet();
       }
@@ -770,11 +791,28 @@ function sparseArrayEquiv(a, b, mode, memos, i) {
   return true;
 }
 
-function objEquiv(a, b, mode, keys2, memos, iterationType) {
+function objEquiv(a, b, mode, keys1, keys2, memos, iterationType) {
   // The pair must have equivalent values for every corresponding key.
   if (keys2.length > 0) {
-    for (const key of keys2) {
-      if (!innerDeepEqual(a[key], b[key], mode, memos)) {
+    let i = 0;
+    // Ordered keys
+    if (keys1 !== undefined) {
+      for (; i < keys2.length; i++) {
+        const key = keys2[i];
+        if (keys1[i] !== key) {
+          break;
+        }
+        if (!innerDeepEqual(a[key], b[key], mode, memos)) {
+          return false;
+        }
+      }
+    }
+    // Unordered keys
+    for (; i < keys2.length; i++) {
+      const key = keys2[i];
+      const descriptor = ObjectGetOwnPropertyDescriptor(a, key);
+      if (!descriptor?.enumerable ||
+          !innerDeepEqual(descriptor.value !== undefined ? descriptor.value : a[key], b[key], mode, memos)) {
         return false;
       }
     }

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -418,6 +418,13 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
     return true;
   }
 
+  if (memos === null) {
+    return objEquiv(val1, val2, mode, keys1, keys2, memos, iterationType);
+  }
+  return handleCycles(val1, val2, mode, keys1, keys2, memos, iterationType);
+}
+
+function handleCycles(val1, val2, mode, keys1, keys2, memos, iterationType) {
   // Use memos to handle cycles.
   if (memos === undefined) {
     memos = {
@@ -470,18 +477,6 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
   return areEq;
 }
 
-function setHasEqualElement(set, val1, mode, memo, fn) {
-  for (const val2 of set) {
-    if (fn(val1, val2, mode, memo)) {
-      // Remove the matching element to make sure we do not check that again.
-      set.delete(val2);
-      return true;
-    }
-  }
-
-  return false;
-}
-
 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness#Loose_equality_using
 // Sadly it is not possible to detect corresponding values properly in case the
 // type is a string, number, bigint or boolean. The reason is that those values
@@ -530,55 +525,124 @@ function mapMightHaveLoosePrim(a, b, prim, item2, memo) {
   return !b.has(altValue) && innerDeepEqual(item1, item2, kLoose, memo);
 }
 
-function partialObjectSetEquiv(a, b, mode, set, memo) {
+function partialObjectSetEquiv(array, a, b, mode, memo) {
   let aPos = 0;
-  for (const val of a) {
+  let direction = 1;
+  let start = 0;
+  let end = array.length - 1;
+  for (const val1 of a) {
     aPos++;
-    if (!b.has(val) && setHasEqualElement(set, val, mode, memo, innerDeepEqual) && set.size === 0) {
-      return true;
+    if (!b.has(val1)) {
+      let innerStart = start;
+      if (direction === 1) {
+        if (innerDeepEqual(val1, array[start], mode, memo)) {
+          if (end === start) {
+            return true;
+          }
+          start += 1;
+          continue;
+        }
+        if (start === end) {
+          continue;
+        }
+        direction = -1;
+        innerStart += 1;
+      }
+      let matched = true;
+      if (!innerDeepEqual(val1, array[end], mode, memo)) {
+        direction = 1;
+        matched = arrayHasEqualElement(array, val1, mode, memo, innerDeepEqual, innerStart, end);
+      }
+      if (matched) {
+        if (end === start) {
+          return true;
+        }
+        end -= 1;
+      }
     }
-    if (a.size - aPos < set.size) {
+    if (a.size - aPos <= end - start) {
       return false;
     }
   }
-  /* c8 ignore next */
-  assert.fail('Unreachable code');
+  return false;
 }
 
-function setObjectEquiv(a, b, mode, set, memo) {
-  // Fast path for objects only
-  if (mode !== kLoose && set.size === a.size) {
-    for (const val of a) {
-      if (!setHasEqualElement(set, val, mode, memo, objectComparisonStart)) {
-        return false;
-      }
+function arrayHasEqualElement(array, val1, mode, memo, comparator, start, end) {
+  let matched = false;
+  for (let i = end - 1; i >= start; i--) {
+    if (comparator(val1, array[i], mode, memo)) {
+      // Remove the matching element to make sure we do not check that again.
+      array.splice(i, 1);
+      matched = true;
+      break;
     }
-    return true;
   }
-  if (mode === kPartial) {
-    return partialObjectSetEquiv(a, b, mode, set, memo);
-  }
+  return matched;
+}
 
-  const fn = mode === kStrict ? objectComparisonStart : innerDeepEqual;
-  for (const val of a) {
-    // Primitive values have already been handled above.
-    if (typeof val === 'object') {
-      if (!b.has(val) && !setHasEqualElement(set, val, mode, memo, fn)) {
+function setObjectEquiv(array, a, b, mode, memo) {
+  let direction = 1;
+  let start = 0;
+  let end = array.length - 1;
+  const comparator = mode !== kLoose ? objectComparisonStart : innerDeepEqual;
+  const extraChecks = mode === kLoose || array.length !== a.size;
+  for (const val1 of a) {
+    if (extraChecks) {
+      if (typeof val1 === 'object') {
+        if (b.has(val1)) {
+          continue;
+        }
+      } else if (mode !== kLoose || b.has(val1)) {
+        continue;
+      }
+    }
+
+    let innerStart = start;
+    if (direction === 1) {
+      if (comparator(val1, array[start], mode, memo)) {
+        start += 1;
+        continue;
+      }
+      if (start === end) {
         return false;
       }
-    } else if (mode === kLoose &&
-              !b.has(val) &&
-              !setHasEqualElement(set, val, mode, memo, innerDeepEqual)) {
-      return false;
+      direction = -1;
+      innerStart += 1;
     }
+    if (!comparator(val1, array[end], mode, memo)) {
+      direction = 1;
+      if (!arrayHasEqualElement(array, val1, mode, memo, comparator, innerStart, end)) {
+        return false;
+      }
+    }
+    end -= 1;
   }
-  return set.size === 0;
+  return true;
+}
+
+function compareSmallSets(a, b, val, iteratorB, mode, memo) {
+  const iteratorA = a.values();
+  const firstA = iteratorA.next().value;
+  const first = innerDeepEqual(firstA, val, mode, memo);
+  if (first) {
+    if (b.size === 1) { // Partial mode && a.size === 1 || b.size === 1
+      return true;
+    }
+    const secondA = iteratorA.next().value;
+    return b.has(secondA) || innerDeepEqual(secondA, iteratorB.next().value, mode, memo);
+  }
+  return a.size !== 1 && innerDeepEqual(iteratorA.next().value, val, mode, memo) && (
+    b.size === 1 || // Partial mode
+    b.has(firstA) || // Primitive or reference equal
+    innerDeepEqual(firstA, iteratorB.next().value, mode, memo)
+  );
 }
 
 function setEquiv(a, b, mode, memo) {
   // This is a lazily initiated Set of entries which have to be compared
   // pairwise.
-  let set = null;
+  let array;
+
   const iteratorB = b.values();
   for (const val of iteratorB) {
     if (!a.has(val)) {
@@ -587,120 +651,141 @@ function setEquiv(a, b, mode, memo) {
         return false;
       }
 
-      if (set === null) {
+      if (array === undefined) {
         if (a.size < 3) {
-          const iteratorA = a.values();
-          const firstA = iteratorA.next().value;
-          const first = innerDeepEqual(firstA, val, mode, memo);
-          if (first) {
-            if (b.size === 1) { // Partial mode && a.size === 1
-              return true;
-            }
-            const secondA = iteratorA.next().value;
-            return b.has(secondA) || innerDeepEqual(secondA, iteratorB.next().value, mode, memo);
-          }
-          if (a.size === 1) {
-            return false;
-          }
-          return innerDeepEqual(iteratorA.next().value, val, mode, memo) && (
-            b.size === 1 || // Partial mode
-            b.has(firstA) || // Primitive or reference equal
-            innerDeepEqual(firstA, iteratorB.next().value, mode, memo)
-          );
+          return compareSmallSets(a, b, val, iteratorB, mode, memo);
         }
-        set = new SafeSet();
+        array = [];
       }
       // If the specified value doesn't exist in the second set it's a object
       // (or in loose mode: a non-matching primitive). Find the
       // deep-(mode-)equal element in a set copy to reduce duplicate checks.
-      set.add(val);
+      array.push(val);
     }
   }
 
-  if (set !== null) {
-    return setObjectEquiv(a, b, mode, set, memo);
-  }
-
-  return true;
-}
-
-function mapHasEqualEntry(set, map, key1, item1, mode, memo, fn) {
-  // To be able to handle cases like:
-  //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
-  // ... we need to consider *all* matching keys, not just the first we find.
-  for (const key2 of set) {
-    if (fn(key1, key2, mode, memo) &&
-      innerDeepEqual(item1, map.get(key2), mode, memo)) {
-      set.delete(key2);
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function partialObjectMapEquiv(a, b, mode, set, memo) {
-  let aPos = 0;
-  for (const { 0: key1, 1: item1 } of a) {
-    aPos++;
-    if (typeof key1 === 'object' &&
-        key1 !== null &&
-        mapHasEqualEntry(set, b, key1, item1, mode, memo, objectComparisonStart) &&
-        set.size === 0) {
-      return true;
-    }
-    if (a.size - aPos < set.size) {
-      return false;
-    }
-  }
-  /* c8 ignore next */
-  assert.fail('Unreachable code');
-}
-
-function mapObjectEquivalence(a, b, mode, set, memo) {
-  // Fast path for objects only
-  if (mode !== kLoose && set.size === a.size) {
-    for (const { 0: key1, 1: item1 } of a) {
-      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo, objectComparisonStart)) {
-        return false;
-      }
-    }
+  if (array === undefined) {
     return true;
   }
   if (mode === kPartial) {
-    return partialObjectMapEquiv(a, b, mode, set, memo);
+    return partialObjectSetEquiv(array, a, b, mode, memo);
   }
-  const fn = mode === kStrict ? objectComparisonStart : innerDeepEqual;
+  return setObjectEquiv(array, a, b, mode, memo);
+}
+
+function partialObjectMapEquiv(array, a, b, mode, memo) {
+  let aPos = 0;
+  let direction = 1;
+  let start = 0;
+  let end = array.length - 1;
   for (const { 0: key1, 1: item1 } of a) {
+    aPos++;
     if (typeof key1 === 'object' && key1 !== null) {
-      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo, fn))
-        return false;
-    } else if (set.size === 0) {
-      return true;
-    } else if (mode === kLoose &&
-              (!b.has(key1) ||
-                !innerDeepEqual(item1, b.get(key1), mode, memo)) &&
-              !mapHasEqualEntry(set, b, key1, item1, mode, memo, innerDeepEqual)) {
+      let innerStart = start;
+      if (direction === 1) {
+        const key2 = array[start];
+        if (objectComparisonStart(key1, key2, mode, memo) && innerDeepEqual(item1, b.get(key2), mode, memo)) {
+          if (end === start) {
+            return true;
+          }
+          start += 1;
+          continue;
+        }
+        if (start === end) {
+          continue;
+        }
+        direction = -1;
+        innerStart += 1;
+      }
+      let matched = true;
+      const key2 = array[end];
+      if (!objectComparisonStart(key1, key2, mode, memo) || !innerDeepEqual(item1, b.get(key2), mode, memo)) {
+        direction = 1;
+        matched = arrayHasEqualMapElement(array, key1, item1, b, mode, memo, objectComparisonStart, innerStart, end);
+      }
+      if (matched) {
+        if (end === start) {
+          return true;
+        }
+        end -= 1;
+      }
+    }
+    if (a.size - aPos <= end - start) {
       return false;
     }
   }
-  return set.size === 0;
+  return false;
+}
+
+function arrayHasEqualMapElement(array, key1, item1, b, mode, memo, comparator, start, end) {
+  let matched = false;
+  for (let i = end - 1; i >= start; i--) {
+    const key2 = array[i];
+    if (comparator(key1, key2, mode, memo) &&
+        innerDeepEqual(item1, b.get(key2), mode, memo)) {
+      // Remove the matching element to make sure we do not check that again.
+      array.splice(i, 1);
+      matched = true;
+      break;
+    }
+  }
+  return matched;
+}
+
+function mapObjectEquiv(array, a, b, mode, memo) {
+  let direction = 1;
+  let start = 0;
+  let end = array.length - 1;
+  const comparator = mode !== kLoose ? objectComparisonStart : innerDeepEqual;
+  const extraChecks = mode === kLoose || array.length !== a.size;
+
+  for (const { 0: key1, 1: item1 } of a) {
+    if (extraChecks &&
+        (typeof key1 !== 'object' || key1 === null) &&
+        (mode !== kLoose ||
+          (b.has(key1) && innerDeepEqual(item1, b.get(key1), mode, memo)))) { // Mixed mode
+      continue;
+    }
+
+    let innerStart = start;
+    if (direction === 1) {
+      const key2 = array[start];
+      if (comparator(key1, key2, mode, memo) && innerDeepEqual(item1, b.get(key2), mode, memo)) {
+        start += 1;
+        continue;
+      }
+      if (start === end) {
+        return false;
+      }
+      direction = -1;
+      innerStart += 1;
+    }
+    const key2 = array[end];
+    if ((!comparator(key1, key2, mode, memo) || !innerDeepEqual(item1, b.get(key2), mode, memo))) {
+      direction = 1;
+      if (!arrayHasEqualMapElement(array, key1, item1, b, mode, memo, comparator, innerStart, end)) {
+        return false;
+      }
+    }
+    end -= 1;
+  }
+  return true;
 }
 
 function mapEquiv(a, b, mode, memo) {
-  let set = null;
+  let array;
 
   for (const { 0: key2, 1: item2 } of b) {
     if (typeof key2 === 'object' && key2 !== null) {
-      if (set === null) {
+      if (array === undefined) {
         if (a.size === 1) {
           const { 0: key1, 1: item1 } = a.entries().next().value;
           return innerDeepEqual(key1, key2, mode, memo) &&
-                 innerDeepEqual(item1, item2, mode, memo);
+                  innerDeepEqual(item1, item2, mode, memo);
         }
-        set = new SafeSet();
+        array = [];
       }
-      set.add(key2);
+      array.push(key2);
     } else {
       // By directly retrieving the value we prevent another b.has(key2) check in
       // almost all possible cases.
@@ -713,19 +798,23 @@ function mapEquiv(a, b, mode, memo) {
         // keys.
         if (!mapMightHaveLoosePrim(a, b, key2, item2, memo))
           return false;
-        if (set === null) {
-          set = new SafeSet();
+        if (array === undefined) {
+          array = [];
         }
-        set.add(key2);
+        array.push(key2);
       }
     }
   }
 
-  if (set !== null) {
-    return mapObjectEquivalence(a, b, mode, set, memo);
+  if (array === undefined) {
+    return true;
   }
 
-  return true;
+  if (mode === kPartial) {
+    return partialObjectMapEquiv(array, a, b, mode, memo);
+  }
+
+  return mapObjectEquiv(array, a, b, mode, memo);
 }
 
 function partialSparseArrayEquiv(a, b, mode, memos, startA, startB) {
@@ -841,14 +930,25 @@ function objEquiv(a, b, mode, keys1, keys2, memos, iterationType) {
   return true;
 }
 
+// Only handle cycles when they are detected.
+// eslint-disable-next-line func-style
+let detectCycles = function(val1, val2, mode) {
+  try {
+    return innerDeepEqual(val1, val2, mode, null);
+  } catch {
+    detectCycles = innerDeepEqual;
+    return innerDeepEqual(val1, val2, mode, undefined);
+  }
+};
+
 module.exports = {
   isDeepEqual(val1, val2) {
-    return innerDeepEqual(val1, val2, kLoose);
+    return detectCycles(val1, val2, kLoose);
   },
   isDeepStrictEqual(val1, val2) {
-    return innerDeepEqual(val1, val2, kStrict);
+    return detectCycles(val1, val2, kStrict);
   },
   isPartialStrictEqual(val1, val2) {
-    return innerDeepEqual(val1, val2, kPartial);
+    return detectCycles(val1, val2, kPartial);
   },
 };

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -536,13 +536,14 @@ function partialObjectSetEquiv(array, a, b, mode, memo) {
       let innerStart = start;
       if (direction === 1) {
         if (innerDeepEqual(val1, array[start], mode, memo)) {
-          if (end === start) {
+          if (start === end) {
             return true;
           }
           start += 1;
           continue;
         }
         if (start === end) {
+          // The last element of set b might match a later element in set a.
           continue;
         }
         direction = -1;
@@ -554,7 +555,7 @@ function partialObjectSetEquiv(array, a, b, mode, memo) {
         matched = arrayHasEqualElement(array, val1, mode, memo, innerDeepEqual, innerStart, end);
       }
       if (matched) {
-        if (end === start) {
+        if (start === end) {
           return true;
         }
         end -= 1;
@@ -685,13 +686,14 @@ function partialObjectMapEquiv(array, a, b, mode, memo) {
       if (direction === 1) {
         const key2 = array[start];
         if (objectComparisonStart(key1, key2, mode, memo) && innerDeepEqual(item1, b.get(key2), mode, memo)) {
-          if (end === start) {
+          if (start === end) {
             return true;
           }
           start += 1;
           continue;
         }
         if (start === end) {
+          // The last element of map b might match a later element in map a.
           continue;
         }
         direction = -1;
@@ -704,7 +706,7 @@ function partialObjectMapEquiv(array, a, b, mode, memo) {
         matched = arrayHasEqualMapElement(array, key1, item1, b, mode, memo, objectComparisonStart, innerStart, end);
       }
       if (matched) {
-        if (end === start) {
+        if (start === end) {
           return true;
         }
         end -= 1;
@@ -895,6 +897,9 @@ function objEquiv(a, b, mode, keys1, keys2, memos, iterationType) {
     // Unordered keys
     for (; i < keys2.length; i++) {
       const key = keys2[i];
+      // It is faster to get the whole descriptor and to check it's enumerable
+      // property in V8 13.0 compared to calling Object.propertyIsEnumerable()
+      // and accessing the property regularly.
       const descriptor = ObjectGetOwnPropertyDescriptor(a, key);
       if (!descriptor?.enumerable ||
           !innerDeepEqual(descriptor.value !== undefined ? descriptor.value : a[key], b[key], mode, memos)) {

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -164,18 +164,6 @@ function isEnumerableOrIdentical(val1, val2, prop, mode, memos, method) {
       innerDeepEqual(val1[prop], val2[prop], mode, memos);
 }
 
-// Notes: Type tags are historical [[Class]] properties that can be set by
-// FunctionTemplate::SetClassName() in C++ or Symbol.toStringTag in JS
-// and retrieved using Object.prototype.toString.call(obj) in JS
-// See https://tc39.github.io/ecma262/#sec-object.prototype.tostring
-// for a list of tags pre-defined in the spec.
-// There are some unspecified tags in the wild too (e.g. typed array tags).
-// Since tags can be altered, they only serve fast failures
-//
-// For strict comparison, objects should have
-// a) The same built-in type tag.
-// b) The same prototypes.
-
 function innerDeepEqual(val1, val2, mode, memos) {
   // All identical values are equivalent, as determined by ===.
   if (val1 === val2) {
@@ -192,11 +180,7 @@ function innerDeepEqual(val1, val2, mode, memos) {
     if (typeof val2 !== 'object' ||
         typeof val1 !== 'object' ||
         val1 === null ||
-        val2 === null ||
-        (mode === kStrict &&
-          (val1.constructor !== val2.constructor ||
-            (val1.constructor === undefined &&
-              ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2))))) {
+        val2 === null) {
       return false;
     }
   } else {
@@ -210,6 +194,17 @@ function innerDeepEqual(val1, val2, mode, memos) {
       return false;
     }
   }
+  return objectComparisonStart(val1, val2, mode, memos);
+}
+
+function objectComparisonStart(val1, val2, mode, memos) {
+  if (mode === kStrict &&
+      (val1.constructor !== val2.constructor ||
+        (val1.constructor === undefined &&
+          ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2)))) {
+    return false;
+  }
+
   const val1Tag = ObjectPrototypeToString(val1);
   const val2Tag = ObjectPrototypeToString(val2);
 
@@ -218,7 +213,6 @@ function innerDeepEqual(val1, val2, mode, memos) {
   }
 
   if (ArrayIsArray(val1)) {
-    // Check for sparse arrays and general fast path
     if (!ArrayIsArray(val2) ||
         (val1.length !== val2.length && (mode !== kPartial || val1.length < val2.length))) {
       return false;
@@ -476,9 +470,9 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
   return areEq;
 }
 
-function setHasEqualElement(set, val1, mode, memo) {
+function setHasEqualElement(set, val1, mode, memo, fn) {
   for (const val2 of set) {
-    if (innerDeepEqual(val1, val2, mode, memo)) {
+    if (fn(val1, val2, mode, memo)) {
       // Remove the matching element to make sure we do not check that again.
       set.delete(val2);
       return true;
@@ -540,7 +534,7 @@ function partialObjectSetEquiv(a, b, mode, set, memo) {
   let aPos = 0;
   for (const val of a) {
     aPos++;
-    if (!b.has(val) && setHasEqualElement(set, val, mode, memo) && set.size === 0) {
+    if (!b.has(val) && setHasEqualElement(set, val, mode, memo, innerDeepEqual) && set.size === 0) {
       return true;
     }
     if (a.size - aPos < set.size) {
@@ -555,7 +549,7 @@ function setObjectEquiv(a, b, mode, set, memo) {
   // Fast path for objects only
   if (mode !== kLoose && set.size === a.size) {
     for (const val of a) {
-      if (!setHasEqualElement(set, val, mode, memo)) {
+      if (!setHasEqualElement(set, val, mode, memo, objectComparisonStart)) {
         return false;
       }
     }
@@ -565,15 +559,16 @@ function setObjectEquiv(a, b, mode, set, memo) {
     return partialObjectSetEquiv(a, b, mode, set, memo);
   }
 
+  const fn = mode === kStrict ? objectComparisonStart : innerDeepEqual;
   for (const val of a) {
     // Primitive values have already been handled above.
     if (typeof val === 'object') {
-      if (!b.has(val) && !setHasEqualElement(set, val, mode, memo)) {
+      if (!b.has(val) && !setHasEqualElement(set, val, mode, memo, fn)) {
         return false;
       }
     } else if (mode === kLoose &&
               !b.has(val) &&
-              !setHasEqualElement(set, val, mode, memo)) {
+              !setHasEqualElement(set, val, mode, memo, innerDeepEqual)) {
       return false;
     }
   }
@@ -629,12 +624,12 @@ function setEquiv(a, b, mode, memo) {
   return true;
 }
 
-function mapHasEqualEntry(set, map, key1, item1, mode, memo) {
+function mapHasEqualEntry(set, map, key1, item1, mode, memo, fn) {
   // To be able to handle cases like:
   //   Map([[{}, 'a'], [{}, 'b']]) vs Map([[{}, 'b'], [{}, 'a']])
   // ... we need to consider *all* matching keys, not just the first we find.
   for (const key2 of set) {
-    if (innerDeepEqual(key1, key2, mode, memo) &&
+    if (fn(key1, key2, mode, memo) &&
       innerDeepEqual(item1, map.get(key2), mode, memo)) {
       set.delete(key2);
       return true;
@@ -650,7 +645,7 @@ function partialObjectMapEquiv(a, b, mode, set, memo) {
     aPos++;
     if (typeof key1 === 'object' &&
         key1 !== null &&
-        mapHasEqualEntry(set, b, key1, item1, mode, memo) &&
+        mapHasEqualEntry(set, b, key1, item1, mode, memo, objectComparisonStart) &&
         set.size === 0) {
       return true;
     }
@@ -666,7 +661,7 @@ function mapObjectEquivalence(a, b, mode, set, memo) {
   // Fast path for objects only
   if (mode !== kLoose && set.size === a.size) {
     for (const { 0: key1, 1: item1 } of a) {
-      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo)) {
+      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo, objectComparisonStart)) {
         return false;
       }
     }
@@ -675,16 +670,17 @@ function mapObjectEquivalence(a, b, mode, set, memo) {
   if (mode === kPartial) {
     return partialObjectMapEquiv(a, b, mode, set, memo);
   }
+  const fn = mode === kStrict ? objectComparisonStart : innerDeepEqual;
   for (const { 0: key1, 1: item1 } of a) {
     if (typeof key1 === 'object' && key1 !== null) {
-      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo))
+      if (!mapHasEqualEntry(set, b, key1, item1, mode, memo, fn))
         return false;
     } else if (set.size === 0) {
       return true;
     } else if (mode === kLoose &&
               (!b.has(key1) ||
                 !innerDeepEqual(item1, b.get(key1), mode, memo)) &&
-              !mapHasEqualEntry(set, b, key1, item1, mode, memo)) {
+              !mapHasEqualEntry(set, b, key1, item1, mode, memo, innerDeepEqual)) {
       return false;
     }
   }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -406,6 +406,18 @@ test('es6 Maps and Sets', () => {
     new Set([xarray, ['y']]),
     new Set([xarray, ['y']])
   );
+  assertDeepAndStrictEqual(
+    new Set([2, xarray, ['y'], 1]),
+    new Set([xarray, ['y'], 1, 2])
+  );
+  assertDeepAndStrictEqual(
+    new Set([{ a: 1 }, { a: 3 }, { a: 2 }, { a: 4 }]),
+    new Set([{ a: 2 }, { a: 1 }, { a: 4 }, { a: 3 }])
+  );
+  assertNotDeepOrStrict(
+    new Set([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }]),
+    new Set([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 5 }])
+  );
   assertOnlyDeepEqual(
     new Set([null, '', 1n, 5, 2n, false]),
     new Set([undefined, 0, 5n, true, '2', '-000'])


### PR DESCRIPTION
This improves the performance for almost all objects when comparing
them deeply significantly.

```
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=0 strict=0 len=100 n=20000                                        -0.64 %       ±0.69%  ±0.92%  ±1.20%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=0 strict=0 len=1000 n=20000                               ***     -1.27 %       ±0.60%  ±0.80%  ±1.04%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=0 strict=1 len=100 n=20000                                ***      3.67 %       ±0.56%  ±0.74%  ±0.97%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=0 strict=1 len=1000 n=20000                               ***      3.46 %       ±0.82%  ±1.09%  ±1.42%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=1 strict=0 len=100 n=20000                                        -0.54 %       ±0.93%  ±1.24%  ±1.62%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=1 strict=0 len=1000 n=20000                                       -0.61 %       ±0.92%  ±1.23%  ±1.61%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=1 strict=1 len=100 n=20000                                ***      5.76 %       ±1.12%  ±1.49%  ±1.94%
assert/deepequal-buffer.js method='deepEqual' arrayBuffer=1 strict=1 len=1000 n=20000                               ***      5.59 %       ±0.70%  ±0.93%  ±1.21%
assert/deepequal-buffer.js method='notDeepEqual' arrayBuffer=0 strict=1 len=100 n=20000                             ***      4.45 %       ±1.03%  ±1.38%  ±1.79%
assert/deepequal-buffer.js method='notDeepEqual' arrayBuffer=0 strict=1 len=1000 n=20000                            ***      5.28 %       ±1.12%  ±1.50%  ±1.97%
assert/deepequal-buffer.js method='notDeepEqual' arrayBuffer=1 strict=1 len=100 n=20000                             ***      6.42 %       ±1.30%  ±1.74%  ±2.26%
assert/deepequal-buffer.js method='notDeepEqual' arrayBuffer=1 strict=1 len=1000 n=20000                            ***      5.74 %       ±0.78%  ±1.04%  ±1.35%
assert/deepequal-buffer.js method='partial' arrayBuffer=0 strict=1 len=100 n=20000                                   **      1.13 %       ±0.67%  ±0.89%  ±1.15%
assert/deepequal-buffer.js method='partial' arrayBuffer=0 strict=1 len=1000 n=20000                                         -0.53 %       ±0.60%  ±0.80%  ±1.04%
assert/deepequal-buffer.js method='partial' arrayBuffer=1 strict=1 len=100 n=20000                                  ***     -2.42 %       ±0.76%  ±1.01%  ±1.31%
assert/deepequal-buffer.js method='partial' arrayBuffer=1 strict=1 len=1000 n=20000                                  **     -0.83 %       ±0.52%  ±0.70%  ±0.91%
assert/deepequal-buffer.js method='unequal_length' arrayBuffer=0 strict=1 len=100 n=20000                           ***      3.22 %       ±1.49%  ±1.98%  ±2.59%
assert/deepequal-buffer.js method='unequal_length' arrayBuffer=0 strict=1 len=1000 n=20000                          ***      2.15 %       ±0.93%  ±1.24%  ±1.61%
assert/deepequal-buffer.js method='unequal_length' arrayBuffer=1 strict=1 len=100 n=20000                           ***      2.98 %       ±0.97%  ±1.29%  ±1.68%
assert/deepequal-buffer.js method='unequal_length' arrayBuffer=1 strict=1 len=1000 n=20000                          ***      5.88 %       ±0.80%  ±1.06%  ±1.38%
assert/deepequal-map.js method='deepEqual_mixed' strict=0 len=500 n=2000                                            ***     43.30 %       ±1.28%  ±1.72%  ±2.27%
assert/deepequal-map.js method='deepEqual_mixed' strict=1 len=500 n=2000                                            ***     73.10 %       ±0.87%  ±1.16%  ±1.53%
assert/deepequal-map.js method='deepEqual_objectOnly' strict=0 len=500 n=2000                                       ***     77.15 %       ±0.63%  ±0.85%  ±1.11%
assert/deepequal-map.js method='deepEqual_objectOnly' strict=1 len=500 n=2000                                       ***    101.62 %       ±1.21%  ±1.63%  ±2.16%
assert/deepequal-map.js method='deepEqual_primitiveOnly' strict=0 len=500 n=2000                                    ***     15.62 %       ±1.29%  ±1.72%  ±2.24%
assert/deepequal-map.js method='deepEqual_primitiveOnly' strict=1 len=500 n=2000                                    ***     14.63 %       ±1.83%  ±2.44%  ±3.20%
assert/deepequal-map.js method='notDeepEqual_mixed' strict=0 len=500 n=2000                                         ***      4.34 %       ±2.33%  ±3.10%  ±4.05%
assert/deepequal-map.js method='notDeepEqual_mixed' strict=1 len=500 n=2000                                                  1.24 %       ±2.89%  ±3.86%  ±5.04%
assert/deepequal-map.js method='notDeepEqual_objectOnly' strict=0 len=500 n=2000                                    ***     43.55 %       ±0.47%  ±0.63%  ±0.82%
assert/deepequal-map.js method='notDeepEqual_objectOnly' strict=1 len=500 n=2000                                    ***     68.34 %       ±0.46%  ±0.61%  ±0.80%
assert/deepequal-map.js method='notDeepEqual_primitiveOnly' strict=0 len=500 n=2000                                 ***     13.75 %       ±2.22%  ±2.96%  ±3.85%
assert/deepequal-map.js method='notDeepEqual_primitiveOnly' strict=1 len=500 n=2000                                 ***     13.56 %       ±2.29%  ±3.06%  ±3.99%
assert/deepequal-object.js method='deepEqual' size=10000 n=50                                                       ***     77.16 %       ±0.94%  ±1.26%  ±1.66%
assert/deepequal-object.js method='deepStrictEqual' size=10000 n=50                                                 ***     59.75 %       ±0.85%  ±1.14%  ±1.49%
assert/deepequal-object.js method='notDeepEqual' size=10000 n=50                                                    ***     13.82 %       ±5.52%  ±7.43%  ±9.84%
assert/deepequal-object.js method='notDeepStrictEqual' size=10000 n=50                                              ***     15.59 %       ±2.85%  ±3.80%  ±4.94%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='array'                  ***      9.19 %       ±0.52%  ±0.69%  ±0.90%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='boolean'                ***      6.78 %       ±1.63%  ±2.16%  ±2.82%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='circular'               ***     30.83 %       ±1.73%  ±2.31%  ±3.02%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='date'                           -0.24 %       ±1.22%  ±1.63%  ±2.12%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='empty_object'           ***     -7.41 %       ±2.73%  ±3.64%  ±4.75%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='number'                  **      3.24 %       ±2.15%  ±2.86%  ±3.74%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='object'                 ***     43.14 %       ±1.32%  ±1.77%  ±2.33%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='regexp'                   *     -1.69 %       ±1.34%  ±1.79%  ±2.33%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='set_object'               *     -0.75 %       ±0.66%  ±0.87%  ±1.14%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='set_simple'                     -0.28 %       ±1.08%  ±1.45%  ±1.90%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=0 n=100000 primitive='string'                 ***      3.41 %       ±1.93%  ±2.57%  ±3.34%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='array'                  ***     27.25 %       ±0.94%  ±1.25%  ±1.63%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='boolean'                ***      7.07 %       ±2.00%  ±2.67%  ±3.48%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='circular'               ***     31.68 %       ±0.65%  ±0.87%  ±1.13%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='date'                   ***     13.20 %       ±0.72%  ±0.96%  ±1.25%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='empty_object'           ***     15.22 %       ±1.11%  ±1.48%  ±1.94%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='number'                   *      2.07 %       ±1.72%  ±2.28%  ±2.97%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='object'                 ***     39.89 %       ±1.32%  ±1.75%  ±2.28%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='regexp'                 ***     15.33 %       ±1.00%  ±1.34%  ±1.75%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='set_object'             ***     13.76 %       ±1.03%  ±1.38%  ±1.81%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='set_simple'             ***     11.82 %       ±0.97%  ±1.30%  ±1.71%
assert/deepequal-prims-and-objs-big-loop.js method='deepEqual' strict=1 n=100000 primitive='string'                 ***      4.80 %       ±1.61%  ±2.15%  ±2.79%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='array'               ***     24.14 %       ±0.59%  ±0.79%  ±1.03%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='boolean'             ***      3.88 %       ±1.45%  ±1.92%  ±2.51%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='circular'            ***     45.59 %       ±0.96%  ±1.28%  ±1.68%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='date'                ***     20.66 %       ±1.95%  ±2.60%  ±3.41%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='empty_object'        ***     36.60 %       ±1.89%  ±2.51%  ±3.27%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='number'                *     -2.15 %       ±1.65%  ±2.19%  ±2.85%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='object'              ***    -33.17 %       ±1.00%  ±1.33%  ±1.74%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='regexp'              ***     17.37 %       ±1.66%  ±2.22%  ±2.90%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='set_object'          ***     15.22 %       ±0.80%  ±1.07%  ±1.39%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='set_simple'          ***     12.18 %       ±0.89%  ±1.19%  ±1.56%
assert/deepequal-prims-and-objs-big-loop.js method='notDeepEqual' strict=1 n=100000 primitive='string'                       0.60 %       ±1.48%  ±1.97%  ±2.57%
assert/deepequal-set.js method='deepEqual_mixed' order='insert' strict=0 len=120 n=1000                             ***     28.43 %       ±0.71%  ±0.95%  ±1.23%
assert/deepequal-set.js method='deepEqual_mixed' order='insert' strict=0 len=2 n=1000                               ***     35.04 %       ±2.00%  ±2.66%  ±3.47%
assert/deepequal-set.js method='deepEqual_mixed' order='insert' strict=1 len=120 n=1000                             ***     45.14 %       ±1.41%  ±1.88%  ±2.46%
assert/deepequal-set.js method='deepEqual_mixed' order='insert' strict=1 len=2 n=1000                               ***     35.68 %       ±1.72%  ±2.29%  ±2.98%
assert/deepequal-set.js method='deepEqual_mixed' order='reversed' strict=0 len=120 n=1000                           ***   1507.82 %       ±6.76%  ±9.11% ±12.10%
assert/deepequal-set.js method='deepEqual_mixed' order='reversed' strict=0 len=2 n=1000                             ***     39.52 %       ±2.26%  ±3.01%  ±3.91%
assert/deepequal-set.js method='deepEqual_mixed' order='reversed' strict=1 len=120 n=1000                           ***   1904.21 %       ±6.66%  ±8.97% ±11.91%
assert/deepequal-set.js method='deepEqual_mixed' order='reversed' strict=1 len=2 n=1000                             ***     35.28 %       ±2.32%  ±3.09%  ±4.04%
assert/deepequal-set.js method='deepEqual_objectOnly' order='insert' strict=0 len=120 n=1000                        ***     44.43 %       ±1.60%  ±2.15%  ±2.84%
assert/deepequal-set.js method='deepEqual_objectOnly' order='insert' strict=0 len=2 n=1000                          ***     36.89 %       ±1.54%  ±2.05%  ±2.67%
assert/deepequal-set.js method='deepEqual_objectOnly' order='insert' strict=1 len=120 n=1000                        ***     70.90 %       ±0.76%  ±1.02%  ±1.33%
assert/deepequal-set.js method='deepEqual_objectOnly' order='insert' strict=1 len=2 n=1000                          ***     34.78 %       ±1.79%  ±2.38%  ±3.11%
assert/deepequal-set.js method='deepEqual_objectOnly' order='random' strict=1 len=120 n=1000                        ***     37.27 %       ±3.09%  ±4.11%  ±5.37%
assert/deepequal-set.js method='deepEqual_objectOnly' order='random' strict=1 len=2 n=1000                          ***     35.59 %       ±3.02%  ±4.03%  ±5.25%
assert/deepequal-set.js method='deepEqual_objectOnly' order='reversed' strict=0 len=120 n=1000                      ***   3983.35 %      ±13.63% ±18.37% ±24.38%
assert/deepequal-set.js method='deepEqual_objectOnly' order='reversed' strict=0 len=2 n=1000                        ***     30.14 %       ±1.19%  ±1.58%  ±2.06%
assert/deepequal-set.js method='deepEqual_objectOnly' order='reversed' strict=1 len=120 n=1000                      ***   5327.60 %      ±24.09% ±32.47% ±43.11%
assert/deepequal-set.js method='deepEqual_objectOnly' order='reversed' strict=1 len=2 n=1000                        ***     30.62 %       ±1.56%  ±2.08%  ±2.71%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='insert' strict=0 len=120 n=1000                       *     -1.47 %       ±1.10%  ±1.47%  ±1.93%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='insert' strict=0 len=2 n=1000                       ***      5.18 %       ±1.93%  ±2.57%  ±3.35%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='insert' strict=1 len=120 n=1000                             -0.39 %       ±1.43%  ±1.91%  ±2.49%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='insert' strict=1 len=2 n=1000                       ***      5.66 %       ±2.05%  ±2.75%  ±3.61%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='random' strict=1 len=120 n=1000                       *     -1.68 %       ±1.29%  ±1.72%  ±2.25%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='random' strict=1 len=2 n=1000                       ***      5.46 %       ±1.79%  ±2.39%  ±3.12%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='reversed' strict=0 len=120 n=1000                           -1.42 %       ±1.73%  ±2.31%  ±3.04%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='reversed' strict=0 len=2 n=1000                      **      3.26 %       ±2.04%  ±2.72%  ±3.55%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='reversed' strict=1 len=120 n=1000                            0.13 %       ±1.32%  ±1.76%  ±2.30%
assert/deepequal-set.js method='deepEqual_primitiveOnly' order='reversed' strict=1 len=2 n=1000                     ***      6.23 %       ±2.12%  ±2.83%  ±3.70%
assert/deepequal-set.js method='notDeepEqual_mixed' order='insert' strict=0 len=120 n=1000                          ***      5.15 %       ±1.54%  ±2.05%  ±2.66%
assert/deepequal-set.js method='notDeepEqual_mixed' order='insert' strict=0 len=2 n=1000                            ***      3.65 %       ±2.09%  ±2.78%  ±3.62%
assert/deepequal-set.js method='notDeepEqual_mixed' order='insert' strict=1 len=120 n=1000                           **      3.92 %       ±2.59%  ±3.46%  ±4.53%
assert/deepequal-set.js method='notDeepEqual_mixed' order='insert' strict=1 len=2 n=1000                            ***      6.55 %       ±1.58%  ±2.11%  ±2.74%
assert/deepequal-set.js method='notDeepEqual_mixed' order='random' strict=1 len=120 n=1000                                  17.74 %      ±18.15% ±24.16% ±31.45%
assert/deepequal-set.js method='notDeepEqual_mixed' order='random' strict=1 len=2 n=1000                                    -2.43 %       ±5.54%  ±7.44%  ±9.81%
assert/deepequal-set.js method='notDeepEqual_mixed' order='reversed' strict=0 len=120 n=1000                        ***      6.41 %       ±1.92%  ±2.56%  ±3.34%
assert/deepequal-set.js method='notDeepEqual_mixed' order='reversed' strict=0 len=2 n=1000                          ***    -11.30 %       ±1.24%  ±1.65%  ±2.15%
assert/deepequal-set.js method='notDeepEqual_mixed' order='reversed' strict=1 len=120 n=1000                        ***      4.16 %       ±2.15%  ±2.86%  ±3.73%
assert/deepequal-set.js method='notDeepEqual_mixed' order='reversed' strict=1 len=2 n=1000                          ***    -14.19 %       ±1.58%  ±2.11%  ±2.76%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='insert' strict=0 len=120 n=1000                     ***     26.18 %       ±0.91%  ±1.21%  ±1.58%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='insert' strict=0 len=2 n=1000                       ***     33.08 %       ±1.51%  ±2.00%  ±2.61%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='insert' strict=1 len=120 n=1000                     ***     48.18 %       ±0.80%  ±1.08%  ±1.42%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='insert' strict=1 len=2 n=1000                       ***     32.15 %       ±1.65%  ±2.20%  ±2.87%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='reversed' strict=0 len=120 n=1000                   ***   3157.41 %      ±22.60% ±30.46% ±40.44%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='reversed' strict=0 len=2 n=1000                     ***     62.08 %       ±1.99%  ±2.65%  ±3.46%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='reversed' strict=1 len=120 n=1000                   ***   4008.03 %      ±10.50% ±14.15% ±18.79%
assert/deepequal-set.js method='notDeepEqual_objectOnly' order='reversed' strict=1 len=2 n=1000                     ***     57.50 %       ±2.20%  ±2.95%  ±3.86%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='insert' strict=0 len=120 n=1000                           0.54 %       ±1.11%  ±1.48%  ±1.93%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='insert' strict=0 len=2 n=1000                     **      2.55 %       ±1.84%  ±2.45%  ±3.20%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='insert' strict=1 len=120 n=1000                    *     -2.46 %       ±2.00%  ±2.67%  ±3.49%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='insert' strict=1 len=2 n=1000                    ***      3.48 %       ±1.75%  ±2.33%  ±3.04%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='random' strict=1 len=120 n=1000                           6.57 %      ±18.39% ±24.47% ±31.85%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='random' strict=1 len=2 n=1000                    ***      6.19 %       ±1.98%  ±2.63%  ±3.43%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='reversed' strict=0 len=120 n=1000                ***     -9.69 %       ±1.66%  ±2.21%  ±2.88%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='reversed' strict=0 len=2 n=1000                  ***      4.27 %       ±1.58%  ±2.10%  ±2.73%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='reversed' strict=1 len=120 n=1000                ***     -7.19 %       ±2.05%  ±2.74%  ±3.58%
assert/deepequal-set.js method='notDeepEqual_primitiveOnly' order='reversed' strict=1 len=2 n=1000                  ***      7.20 %       ±2.10%  ±2.80%  ±3.65%
assert/deepequal-simple-array-and-set.js method='deepEqual_Array' strict=1 len=10000 n=1000                         ***     68.73 %       ±3.54%  ±4.77%  ±6.33%
assert/deepequal-simple-array-and-set.js method='deepEqual_Set' strict=1 len=10000 n=1000                                   -5.87 %       ±7.67% ±10.22% ±13.36%
assert/deepequal-simple-array-and-set.js method='deepEqual_sparseArray' strict=1 len=10000 n=1000                   ***     14.35 %       ±0.43%  ±0.58%  ±0.76%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Array' strict=1 len=10000 n=1000                      ***     69.65 %       ±3.73%  ±5.02%  ±6.66%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_Set' strict=1 len=10000 n=1000                                 0.46 %       ±1.21%  ±1.60%  ±2.09%
assert/deepequal-simple-array-and-set.js method='notDeepEqual_sparseArray' strict=1 len=10000 n=1000                ***     13.56 %       ±0.62%  ±0.84%  ±1.10%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=25000 type='Float32Array'                     ***     -6.23 %       ±1.50%  ±1.99%  ±2.59%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=25000 type='Int8Array'                                -0.42 %       ±0.59%  ±0.78%  ±1.02%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=25000 type='Uint32Array'                              -0.50 %       ±1.00%  ±1.33%  ±1.73%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=0 n=25000 type='Uint8Array'                               -0.63 %       ±0.98%  ±1.31%  ±1.70%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=25000 type='Float32Array'                     ***      4.13 %       ±0.79%  ±1.05%  ±1.38%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=25000 type='Int8Array'                        ***      4.36 %       ±0.91%  ±1.22%  ±1.58%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=25000 type='Uint32Array'                      ***      3.55 %       ±1.08%  ±1.44%  ±1.87%
assert/deepequal-typedarrays.js len=100 method='deepEqual' strict=1 n=25000 type='Uint8Array'                       ***      3.45 %       ±0.93%  ±1.24%  ±1.61%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=25000 type='Float32Array'                  ***     -2.72 %       ±1.28%  ±1.70%  ±2.21%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=25000 type='Int8Array'                       *     -1.20 %       ±1.14%  ±1.52%  ±1.98%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=25000 type='Uint32Array'                    **     -2.16 %       ±1.36%  ±1.81%  ±2.36%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=0 n=25000 type='Uint8Array'                     **     -1.73 %       ±1.27%  ±1.70%  ±2.22%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=25000 type='Float32Array'                  ***      3.22 %       ±0.98%  ±1.31%  ±1.71%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=25000 type='Int8Array'                     ***      3.30 %       ±1.27%  ±1.70%  ±2.21%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=25000 type='Uint32Array'                   ***      2.66 %       ±1.09%  ±1.45%  ±1.89%
assert/deepequal-typedarrays.js len=100 method='notDeepEqual' strict=1 n=25000 type='Uint8Array'                    ***      4.22 %       ±1.17%  ±1.56%  ±2.03%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=25000 type='Int8Array'                        **     -0.93 %       ±0.57%  ±0.76%  ±0.99%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=25000 type='Uint32Array'                       *     -0.91 %       ±0.82%  ±1.10%  ±1.43%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=0 n=25000 type='Uint8Array'                      ***     -1.30 %       ±0.72%  ±0.96%  ±1.24%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=25000 type='Float32Array'                    ***      2.03 %       ±0.66%  ±0.89%  ±1.17%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=25000 type='Int8Array'                       ***      3.20 %       ±0.90%  ±1.20%  ±1.57%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=25000 type='Uint32Array'                     ***      2.66 %       ±0.42%  ±0.56%  ±0.73%
assert/deepequal-typedarrays.js len=5000 method='deepEqual' strict=1 n=25000 type='Uint8Array'                      ***      4.24 %       ±1.25%  ±1.68%  ±2.22%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=25000 type='Int8Array'                    ***     -2.16 %       ±0.93%  ±1.24%  ±1.62%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=25000 type='Uint32Array'                  ***     -2.39 %       ±0.60%  ±0.80%  ±1.04%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=0 n=25000 type='Uint8Array'                   ***     -1.42 %       ±0.79%  ±1.06%  ±1.38%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=25000 type='Float32Array'                 ***      1.62 %       ±0.74%  ±0.99%  ±1.29%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=25000 type='Int8Array'                    ***      2.96 %       ±1.14%  ±1.52%  ±1.99%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=25000 type='Uint32Array'                    *      1.15 %       ±0.91%  ±1.22%  ±1.60%
assert/deepequal-typedarrays.js len=5000 method='notDeepEqual' strict=1 n=25000 type='Uint8Array'                   ***      3.06 %       ±1.05%  ±1.39%  ±1.81%
assert/partial-deep-equal.js datasetName='array' extraProps=0 size=500 n=125                                        ***     29.54 %       ±3.92%  ±5.21%  ±6.78%
assert/partial-deep-equal.js datasetName='array' extraProps=1 size=500 n=125                                        ***     31.72 %       ±5.40%  ±7.24%  ±9.54%
assert/partial-deep-equal.js datasetName='arrayBuffers' extraProps=0 size=500 n=125                                         -0.65 %       ±0.69%  ±0.92%  ±1.20%
assert/partial-deep-equal.js datasetName='arrayBuffers' extraProps=1 size=500 n=125                                         -0.27 %       ±0.72%  ±0.96%  ±1.26%
assert/partial-deep-equal.js datasetName='circularRefs' extraProps=0 size=500 n=125                                 ***     11.14 %       ±0.43%  ±0.57%  ±0.74%
assert/partial-deep-equal.js datasetName='circularRefs' extraProps=1 size=500 n=125                                 ***     11.71 %       ±0.97%  ±1.30%  ±1.71%
assert/partial-deep-equal.js datasetName='dataViewArrayBuffers' extraProps=0 size=500 n=125                                 -0.39 %       ±0.93%  ±1.24%  ±1.61%
assert/partial-deep-equal.js datasetName='dataViewArrayBuffers' extraProps=1 size=500 n=125                                  0.54 %       ±0.96%  ±1.29%  ±1.69%
assert/partial-deep-equal.js datasetName='maps' extraProps=0 size=500 n=125                                         ***     64.71 %       ±2.00%  ±2.69%  ±3.56%
assert/partial-deep-equal.js datasetName='maps' extraProps=1 size=500 n=125                                         ***     68.27 %       ±1.01%  ±1.35%  ±1.75%
assert/partial-deep-equal.js datasetName='objects' extraProps=0 size=500 n=125                                      ***     63.01 %       ±0.78%  ±1.05%  ±1.37%
assert/partial-deep-equal.js datasetName='objects' extraProps=1 size=500 n=125                                      ***     64.22 %       ±0.89%  ±1.19%  ±1.55%
assert/partial-deep-equal.js datasetName='sets' extraProps=0 size=500 n=125                                         ***     62.31 %       ±0.74%  ±0.98%  ±1.28%
assert/partial-deep-equal.js datasetName='sets' extraProps=1 size=500 n=125                                         ***     70.55 %       ±0.88%  ±1.17%  ±1.52%
assert/partial-deep-equal.js datasetName='setsWithObjects' extraProps=0 size=500 n=125                              ***     57.70 %       ±0.96%  ±1.28%  ±1.68%
assert/partial-deep-equal.js datasetName='setsWithObjects' extraProps=1 size=500 n=125                              ***     52.33 %       ±1.02%  ±1.37%  ±1.79%
assert/partial-deep-equal.js datasetName='typedArrays' extraProps=0 size=500 n=125                                  ***      3.51 %       ±1.26%  ±1.69%  ±2.22%
assert/partial-deep-equal.js datasetName='typedArrays' extraProps=1 size=500 n=125                                  ***      2.92 %       ±0.82%  ±1.10%  ±1.43%
```