### PR TITLE
doc: update example of using `await` in REPL

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -258,8 +258,7 @@ undefined
 ```
 
 One known limitation of using the `await` keyword in the REPL is that
-it will invalidate the lexical scoping of the `const` and `let`
-keywords.
+it will invalidate the lexical scoping of the `const` keywords.
 
 For example:
 
@@ -268,10 +267,11 @@ For example:
 undefined
 > m
 123
-> const m = await Promise.resolve(234)
-undefined
-> m
+> m = await Promise.resolve(234)
 234
+// redeclaring the constant does error
+> const m = await Promise.resolve(345)
+Uncaught SyntaxError: Identifier 'm' has already been declared
 ```
 
 [`--no-experimental-repl-await`][] shall disable top-level await in REPL.

--- a/test/parallel/test-repl-top-level-await.js
+++ b/test/parallel/test-repl-top-level-await.js
@@ -173,6 +173,12 @@ async function ordinaryTests() {
       '3',
       'undefined',
     ]],
+    // Testing documented behavior of `const`s (see: https://github.com/nodejs/node/issues/45918)
+    ['const k = await Promise.resolve(123)'],
+    ['k', '123'],
+    ['k = await Promise.resolve(234)', '234'],
+    ['k', '234'],
+    ['const k = await Promise.resolve(345)', "Uncaught SyntaxError: Identifier 'k' has already been declared"],
     // Regression test for https://github.com/nodejs/node/issues/43777.
     ['await Promise.resolve(123), Promise.resolve(456)', 'Promise {', { line: 0 }],
     ['await Promise.resolve(123), await Promise.resolve(456)', '456'],


### PR DESCRIPTION
> [!Note]
> I'm just trying to do a bit of caretaking here and trying to resolve this stalled PR: https://github.com/nodejs/node/pull/45939
> credit to the original author @deokjinkim :slightly_smiling_face: 

Clarify that the lexical scope of `const` is
invalidated when using top-level `await` in REPL.

As part of this change also add tests for the
documented behavior

Fixes: https://github.com/nodejs/node/issues/45918


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
