### PR TITLE
win: fix SIGQUIT on ClangCL

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -67,7 +67,8 @@
 #endif
 
 #ifdef _WIN32
-# define SIGKILL 9
+#define SIGQUIT 3
+#define SIGKILL 9
 #endif
 
 #include "v8.h"  // NOLINT(build/include_order)

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -42,9 +42,7 @@ assert.strictEqual(cat.killed, true);
 
 // Test different types of kill signals on Windows.
 if (common.isWindows) {
-  // SIGQUIT is not supported on Windows 2022, Visual Studio 2022 ClangCL-produced node.exe.
-  // TODO(StefanStojanovic): Investigate this and re-enable it when the issue is fixed.
-  for (const sendSignal of ['SIGTERM', 'SIGKILL', /* 'SIGQUIT', */'SIGINT']) {
+  for (const sendSignal of ['SIGTERM', 'SIGKILL', 'SIGQUIT', 'SIGINT']) {
     const process = spawn('cmd');
     process.on('exit', (code, signal) => {
       assert.strictEqual(code, null);


### PR DESCRIPTION
This PR fixes the cause of the failure when killing the process with `SIGQUIT` on Windows on a ClangCL-produced binary. Since it is fixed now, the test is reenabled.