### PR TITLE
tools: explicitly set umask in macOS postinstall script

### DIFF
--- a/tools/macos-installer/pkgbuild/npm/scripts/postinstall
+++ b/tools/macos-installer/pkgbuild/npm/scripts/postinstall
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 cd /usr/local/bin || exit 1
+umask 022
 ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm
 ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx


### PR DESCRIPTION
ensure symbolic links are created with 755 instead of the possibly configured 'umask for user apps'

Refs: https://support.apple.com/en-us/101914
Fixes: #57548