### PR TITLE
tools: remove unused `osx-pkg-postinstall.sh`

### DIFF
--- a/tools/osx-pkg-postinstall.sh
+++ b/tools/osx-pkg-postinstall.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# TODO Can this be done inside the .pmdoc?
-# TODO Can we extract $PREFIX from the installer?
-cd /usr/local/bin || exit
-
-ln -sf ../lib/node_modules/npm/bin/npm-cli.js npm
-ln -sf ../lib/node_modules/npm/bin/npx-cli.js npx
-
-ln -sf ../lib/node_modules/corepack/dist/corepack.js corepack


### PR DESCRIPTION
According to https://github.com/nodejs/node/issues/4635#issuecomment-170956761, it's no longer in use, IIUC it was replaced with `tools/macos-installer/pkgbuild/npm/scripts/postinstall` in 03954f778ec491fe5a4f8e42996e3edbe35554d9 – you can see it removed `tools/osx-pkg.pmdoc/02npm.xml` which was the only mention of this script:

https://github.com/nodejs/node/blob/6975c490d11d4aa937c9df6835f4e75ac8c72cee/tools/osx-pkg.pmdoc/02npm.xml#L22

/cc @nodejs/build @nodejs/platform-macos 


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
