### PR TITLE
http2: add session tracking and graceful server close

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -251,6 +251,7 @@ const kServer = Symbol('server');
 const kState = Symbol('state');
 const kType = Symbol('type');
 const kWriteGeneric = Symbol('write-generic');
+const kSessions = Symbol('sessions');
 
 const {
   kBitfield,
@@ -1125,9 +1126,13 @@ function emitClose(self, error) {
 function cleanupSession(session) {
   const socket = session[kSocket];
   const handle = session[kHandle];
+  const server = session[kServer];
   session[kProxySocket] = undefined;
   session[kSocket] = undefined;
   session[kHandle] = undefined;
+  if (server) {
+    server[kSessions].delete(session);
+  }
   session[kNativeFields] = trackAssignmentsTypedArray(
     new Uint8Array(kSessionUint8FieldCount));
   if (handle)
@@ -1644,6 +1649,9 @@ class ServerHttp2Session extends Http2Session {
   constructor(options, socket, server) {
     super(NGHTTP2_SESSION_SERVER, options, socket);
     this[kServer] = server;
+    if (server) {
+      server[kSessions].add(this);
+    }
     // This is a bit inaccurate because it does not reflect changes to
     // number of listeners made after the session was created. This should
     // not be an issue in practice. Additionally, the 'priority' event on
@@ -3168,11 +3176,25 @@ function onErrorSecureServerSession(err, socket) {
     socket.destroy(err);
 }
 
+/**
+ * This function closes all active sessions gracefully.
+ * @param {*} server the underlying server whose sessions to be closed
+ */
+function closeAllSessions(server) {
+  const sessions = server[kSessions];
+  if (sessions.size > 0) {
+    sessions.forEach((session) => {
+      session.close();
+    });
+  }
+}
+
 class Http2SecureServer extends TLSServer {
   constructor(options, requestListener) {
     options = initializeTLSOptions(options);
     super(options, connectionListener);
     this[kOptions] = options;
+    this[kSessions] = new SafeSet();
     this.timeout = 0;
     this.on('newListener', setupCompat);
     if (options.allowHTTP1 === true) {
@@ -3202,10 +3224,11 @@ class Http2SecureServer extends TLSServer {
   }
 
   close() {
+    ReflectApply(TLSServer.prototype.close, this, arguments);
     if (this[kOptions].allowHTTP1 === true) {
       httpServerPreClose(this);
     }
-    ReflectApply(TLSServer.prototype.close, this, arguments);
+    closeAllSessions(this);
   }
 
   closeIdleConnections() {
@@ -3220,6 +3243,7 @@ class Http2Server extends NETServer {
     options = initializeOptions(options);
     super(options, connectionListener);
     this[kOptions] = options;
+    this[kSessions] = new SafeSet();
     this.timeout = 0;
     this.on('newListener', setupCompat);
     if (typeof requestListener === 'function')
@@ -3239,6 +3263,11 @@ class Http2Server extends NETServer {
     assertIsObject(settings, 'settings');
     validateSettings(settings);
     this[kOptions].settings = { ...this[kOptions].settings, ...settings };
+  }
+
+  close() {
+    ReflectApply(NETServer.prototype.close, this, arguments);
+    closeAllSessions(this);
   }
 
   async [SymbolAsyncDispose]() {

--- a/test/parallel/test-http2-capture-rejection.js
+++ b/test/parallel/test-http2-capture-rejection.js
@@ -108,8 +108,6 @@ events.captureRejections = true;
   server.on('stream', common.mustCall(async (stream) => {
     const { port } = server.address();
 
-    server.close();
-
     stream.pushStream({
       ':scheme': 'http',
       ':path': '/foobar',
@@ -127,6 +125,8 @@ events.captureRejections = true;
     stream.respond({
       ':status': 200
     });
+
+    server.close();
   }));
 
   server.listen(0, common.mustCall(() => {

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property-set.js
@@ -24,7 +24,6 @@ server.listen(0, common.mustCall(function() {
       response.statusMessage = 'test';
       response.statusMessage = 'test'; // only warn once
       assert.strictEqual(response.statusMessage, ''); // no change
-      server.close();
     }));
     response.end();
   }));
@@ -43,6 +42,9 @@ server.listen(0, common.mustCall(function() {
     }, 1));
     request.on('end', common.mustCall(function() {
       client.close();
+    }));
+    request.on('close', common.mustCall(function() {
+      server.close();
     }));
     request.end();
     request.resume();

--- a/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
+++ b/test/parallel/test-http2-compat-serverresponse-statusmessage-property.js
@@ -23,7 +23,6 @@ server.listen(0, common.mustCall(function() {
     response.on('finish', common.mustCall(function() {
       assert.strictEqual(response.statusMessage, '');
       assert.strictEqual(response.statusMessage, ''); // only warn once
-      server.close();
     }));
     response.end();
   }));
@@ -42,6 +41,9 @@ server.listen(0, common.mustCall(function() {
     }, 1));
     request.on('end', common.mustCall(function() {
       client.close();
+    }));
+    request.on('close', common.mustCall(function() {
+      server.close();
     }));
     request.end();
     request.resume();

--- a/test/parallel/test-http2-graceful-close.js
+++ b/test/parallel/test-http2-graceful-close.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// This test verifies that the server waits for active connections/sessions
+// to complete and all data to be sent before fully closing
+
+// Keep track of the test flow with these flags
+const states = {
+  serverListening: false,
+  responseStarted: false,
+  dataFullySent: false,
+  streamClosed: false,
+  serverClosed: false
+};
+
+// Create a server that will send a large response in chunks
+const server = http2.createServer();
+
+// Track server events
+server.on('stream', common.mustCall((stream, headers) => {
+  assert.strictEqual(states.serverListening, true);
+
+  // Setup the response
+  stream.respond({
+    'content-type': 'text/plain',
+    ':status': 200
+  });
+
+  // Initiate the server close before client data is sent, this will
+  // test if the server properly waits for the stream to finish
+  server.close(common.mustCall(() => {
+    // Stream should be closed before server close callback
+    // Should be called only after the stream has closed
+    assert.strictEqual(states.streamClosed, true);
+    states.serverClosed = true;
+  }));
+
+  // Mark response as started
+  states.responseStarted = true;
+
+  // Create a large response (1MB) to ensure it takes some time to send
+  const chunk = Buffer.alloc(64 * 1024, 'x');
+
+  // Send 16 chunks (1MB total) to simulate a large response
+  for (let i = 0; i < 16; i++) {
+    stream.write(chunk);
+  }
+
+
+  // Stream end should happen after data is written
+  stream.end();
+  states.dataFullySent = true;
+
+  // When stream closes, we can verify order of events
+  stream.on('close', common.mustCall(() => {
+    // Data should be fully sent before stream closes
+    assert.strictEqual(states.dataFullySent, true);
+    states.streamClosed = true;
+  }));
+}));
+
+// Start the server
+server.listen(0, common.mustCall(() => {
+  states.serverListening = true;
+
+  // Create client and request
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+  const req = client.request({ ':path': '/' });
+
+  // Track received data
+  let receivedData = 0;
+  req.on('data', (chunk) => {
+    receivedData += chunk.length;
+  });
+
+  // When the request completes
+  req.on('end', common.mustCall(() => {
+    // All data should be sent before request ends
+    assert.strictEqual(states.dataFullySent, true);
+  }));
+
+  // When request closes
+  req.on('close', common.mustCall(() => {
+    // Check final state
+    assert.strictEqual(states.streamClosed, true);
+    // Should receive all data
+    assert.strictEqual(receivedData, 64 * 1024 * 16);
+
+    // Wait for the server close confirmation
+    process.on('exit', () => {
+      // Server should be fully closed
+      assert.strictEqual(states.serverClosed, true);
+    });
+  }));
+
+  // Start the request
+  req.end();
+}));

--- a/test/parallel/test-http2-server-close-idle-connection.js
+++ b/test/parallel/test-http2-server-close-idle-connection.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// This test verifies that the server closes idle connections
+
+// Track test state with flags
+const states = {
+  serverListening: false,
+  initialRequestCompleted: false,
+  connectionBecameIdle: false,
+  serverClosedIdleConnection: false
+};
+
+const server = http2.createServer();
+
+// Track server events
+server.on('stream', common.mustCall((stream, headers) => {
+  assert.strictEqual(states.serverListening, true);
+
+  // Respond to the request with a small payload
+  stream.respond({
+    'content-type': 'text/plain',
+    ':status': 200
+  });
+  stream.end('hello');
+
+  // After the request is done, the connection should become idle
+  stream.on('close', () => {
+    states.initialRequestCompleted = true;
+    // Mark connection as idle after the request completes
+    states.connectionBecameIdle = true;
+  });
+}));
+
+// Track session closure events
+server.on('session', common.mustCall((session) => {
+  session.on('stream', common.mustCall((stream) => {
+    stream.on('close', common.mustCall(() => {
+      // This should only happen after the connection became idle
+      assert.strictEqual(states.connectionBecameIdle, true);
+      states.serverClosedIdleConnection = true;
+
+      // Test is successful, close the server
+      server.close(common.mustCall(() => {
+        console.log('server closed');
+      }));
+    }));
+  }));
+  session.on('close', common.mustCall(() => {
+    console.log('session closed');
+  }));
+}));
+
+// Start the server
+server.listen(0, common.mustCall(() => {
+  states.serverListening = true;
+
+  // Create client and initial request
+  const client = http2.connect(`http://localhost:${server.address().port}`);
+
+  // Track client session events
+  client.on('close', common.mustCall(() => {
+    // Verify server closed the connection after it became idle
+    assert.strictEqual(states.serverClosedIdleConnection, true);
+  }));
+
+  // Make an initial request
+  const req = client.request({ ':path': '/' });
+
+  req.on('response', common.mustCall());
+
+  // Process the response data
+  req.setEncoding('utf8');
+  let data = '';
+  req.on('data', (chunk) => {
+    data += chunk;
+  });
+
+  // When initial request ends
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(data, 'hello');
+
+    // Don't explicitly close the client - keep it idle
+    // Wait for the server to close the idle connection
+  }));
+
+  client.on('close', common.mustCall());
+
+  req.end();
+}));
+
+// Final verification on exit
+process.on('exit', () => {
+  assert.strictEqual(states.serverClosedIdleConnection, true);
+});


### PR DESCRIPTION
This change adds proper tracking of HTTP / 2 server sessions to ensure they are gracefully closed when the server is shut down.It implements:

- A new kSessions symbol for tracking active sessions
- Adding/removing sessions from a SafeSet in the server
- A closeAllSessions helper function to close active sessions
- Updates to Http2Server and Http2SecureServer close methods

Breaking Change: any client trying to create new requests on existing connections will not be able to do so once server close is initiated

Refs: https://datatracker.ietf.org/doc/html/rfc7540\#section-9.1
Refs: https://nodejs.org/api/http.html\#serverclosecallback

More Details:

### Purpose

This PR implements proper tracking and graceful shutdown of HTTP/2 sessions when a server is closed. It addresses the gap between the documented behavior of server.close() and its actual implementation for HTTP/2 servers. Also if server have fired close, we should allow it to close as early as possible to free up system resources quickly. This change ensure that once server wants to close, goaway frame will be sent to every open session(connection) so that client get to know that server started shutdown process and client should not send any new request on existing connection.

### Current Issues

- Currently, HTTP/2 servers are at the mercy of clients to close connections.
- There is no mechanism to notify clients that the server wants to shut down.
- Misbehaving/Non-compliant clients can keep connections open indefinitely, preventing proper server shutdown.
- Clients can continue to initiate new requests on existing connections even when the server is trying to close.
- Start of server shutdown can starve indefinitely, leading to processes that cannot terminate cleanly and causing resource leaks.

### Implementation Details

- Added a kSessions symbol and SafeSet to track active HTTP/2 sessions.
- Implemented session registration when sessions are created.
- Created a closeAllSessions helper function to initiate graceful shutdown of all tracked sessions
- Updated Http2Server and Http2SecureServer close methods to use this functionality

### Behavior Clarification

According to the Node.js documentation for `server.close()`:
> server.close stops the server from accepting new connections and closes all connections connected to this server which are not sending a request or waiting for a response.

This PR ensures that HTTP/2 servers follow this behavior by:
***Closing existing HTTP/2 sessions gracefully, which means:***
- When session.close() is called, a GOAWAY frame is sent to notify clients that the server wants to close the session
- No new streams (requests) can be initiated on existing connections
- Existing streams can continue writing/reading data until completion
- In-flight requests will be allowed to complete
- Sessions will be terminated after all active streams complete

This implementation aligns with the HTTP/2 protocol specification for connection management as described in RFC 7540 Section 9.1.

### API Impact

This is technically a breaking change, as clients attempting to create new requests on existing HTTP/2 connections will be unable to do so once server.close() is called. However, this behavior now correctly matches the documented behavior for HTTP servers.

### Testing

This PR includes tests to verify that HTTP/2 sessions are properly tracked and gracefully shut down when the server is closed.

Modified test files: 

- ***test-http2-compat-serverresponse-statusmessage-property-set.js:*** After server close behavior is updated, this test started to fail. The failure happened because the request from client is under pendingAck state so the session is not yet initiated, as server close is fired during this time and hence client didn't received response which leads to test failure. Now the test is updated to fire server close once the request is complete. As this unit test, test that client should receive http2 status message response, so it is good to close the server only after the request/response cycle is completed. This [line](https://github.com/nodejs/node/blob/669b6927e498a0cfcc1e57afc53d8c5e53ba190f/lib/internal/http2/core.js#L1203) tells that pending stream will be cancelled once session close is emitted.
- ***test-http2-compat-serverresponse-statusmessage-property.js:*** Same as above.
- ***test-http2-capture-rejection.js:*** Server close should be fired after server have sent push promise frame.

This replaces #57586 