### PR TITLE
lib: use SafeMap primordial for ActiveAsyncContextFrame

### DIFF
--- a/lib/internal/async_context_frame.js
+++ b/lib/internal/async_context_frame.js
@@ -2,6 +2,7 @@
 
 const {
   ObjectSetPrototypeOf,
+  SafeMap,
 } = primordials;
 
 const {
@@ -11,7 +12,7 @@ const {
 
 let enabled_;
 
-class ActiveAsyncContextFrame extends Map {
+class ActiveAsyncContextFrame extends SafeMap {
   static get enabled() {
     return true;
   }
@@ -50,7 +51,7 @@ function checkEnabled() {
   return enabled;
 }
 
-class InactiveAsyncContextFrame extends Map {
+class InactiveAsyncContextFrame extends SafeMap {
   static get enabled() {
     enabled_ ??= checkEnabled();
     return enabled_;


### PR DESCRIPTION
Not sure if this was intentional, but `(In)ActiveAsyncContextFrame` seems to extend `Map` without using primordials

Tracked down the change to ef6b9ffc8dfc7b2a395c864d2729a0ce1be9ef18

Cc @bengl