### PR TITLE
tls: optimize convertProtocols by using Uint8 and removing reduce

### DIFF
--- a/lib/tls.js
+++ b/lib/tls.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const {
-  Array,
   ArrayIsArray,
   // eslint-disable-next-line no-restricted-syntax
   ArrayPrototypePush,
@@ -30,6 +29,7 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   StringFromCharCode,
+  Uint8Array,
 } = primordials;
 
 const {
@@ -174,19 +174,23 @@ exports.getCACertificates = getCACertificates;
 // Convert protocols array into valid OpenSSL protocols list
 // ("\x06spdy/2\x08http/1.1\x08http/1.0")
 function convertProtocols(protocols) {
-  const lens = new Array(protocols.length);
-  const buff = Buffer.allocUnsafe(protocols.reduce((p, c, i) => {
-    const len = Buffer.byteLength(c);
+  const lens = new Uint8Array(protocols.length);
+  let totalSize = 0;
+
+  for (let i = 0; i < protocols.length; i++) {
+    const len = Buffer.byteLength(protocols[i]);
     if (len > 255) {
       throw new ERR_OUT_OF_RANGE('The byte length of the protocol at index ' +
         `${i} exceeds the maximum length.`, '<= 255', len, true);
     }
     lens[i] = len;
-    return p + 1 + len;
-  }, 0));
+    totalSize += 1 + len;
+  }
+
+  const buff = Buffer.allocUnsafe(totalSize);
 
   let offset = 0;
-  for (let i = 0, c = protocols.length; i < c; i++) {
+  for (let i = 0; i < protocols.length; i++) {
     buff[offset++] = lens[i];
     buff.write(protocols[i], offset);
     offset += lens[i];


### PR DESCRIPTION
Before:

```sh
tls/convertprotocols.js
tls/convertprotocols.js n=1: 12,257.4555973671
tls/convertprotocols.js n=50000: 2,620,556.4730706117

gurgunday@Gurguns-MacBook-Air node % ./out/Release/node benchmark/run.js tls

tls/convertprotocols.js
tls/convertprotocols.js n=1: 11,718.658447980873
tls/convertprotocols.js n=50000: 2,531,944.659589409

gurgunday@Gurguns-MacBook-Air node % ./out/Release/node benchmark/run.js tls

tls/convertprotocols.js
tls/convertprotocols.js n=1: 12,409.56529292779
tls/convertprotocols.js n=50000: 2,641,926.539330387
```

After:

```sh
gurgunday@Gurguns-MacBook-Air node % ./out/Release/node benchmark/run.js tls

tls/convertprotocols.js
tls/convertprotocols.js n=1: 13,706.51607774336
tls/convertprotocols.js n=50000: 2,533,211.4149343553

gurgunday@Gurguns-MacBook-Air node % ./out/Release/node benchmark/run.js tls

tls/convertprotocols.js
tls/convertprotocols.js n=1: 13,179.571663920922
tls/convertprotocols.js n=50000: 2,795,065.7251320067

gurgunday@Gurguns-MacBook-Air node % ./out/Release/node benchmark/run.js tls

tls/convertprotocols.js
tls/convertprotocols.js n=1: 13,528.687582017668
tls/convertprotocols.js n=50000: 2,689,298.5120810554
```