### PR TITLE
tools: enable linter on some fixtures file

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ import {
 } from './tools/eslint/eslint.config_utils.mjs';
 import nodeCore from './tools/eslint/eslint-plugin-node-core.js';
 
+const { globalIgnores } = await importEslintTool('eslint/config');
 const { default: js } = await importEslintTool('@eslint/js');
 const { default: babelEslintParser } = await importEslintTool('@babel/eslint-parser');
 const babelPluginSyntaxImportAttributes = resolveEslintTool('@babel/plugin-syntax-import-attributes');
@@ -39,19 +40,22 @@ Module._resolveFilename = (request, parent, isMain, options) => {
 
 export default [
   // #region ignores
-  {
-    ignores: [
-      '**/node_modules/**',
-      'benchmark/fixtures/**',
-      'benchmark/tmp/**',
-      'doc/changelogs/CHANGELOG_V1*.md',
-      '!doc/changelogs/CHANGELOG_V18.md',
-      'lib/punycode.js',
-      'test/.tmp.*/**',
-      'test/addons/??_*',
-      'test/fixtures/**',
-    ],
-  },
+  globalIgnores([
+    '**/node_modules/**',
+    'benchmark/fixtures/**',
+    'benchmark/tmp/**',
+    'doc/changelogs/CHANGELOG_V1*.md',
+    '!doc/changelogs/CHANGELOG_V18.md',
+    'lib/punycode.js',
+    'test/.tmp.*/**',
+    'test/addons/??_*',
+
+    // We want to lint only a few specific fixtures folders
+    'test/fixtures/*',
+    '!test/fixtures/console',
+    '!test/fixtures/v8',
+    '!test/fixtures/vm',
+  ]),
   // #endregion
   // #region general config
   js.configs.recommended,

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -139,7 +139,7 @@ export default [
   },
   {
     files: [
-      'test/{common,wpt}/**/*.{js,mjs,cjs}',
+      'test/{common,fixtures,wpt}/**/*.{js,mjs,cjs}',
       'test/eslint.config_partial.mjs',
     ],
     rules: {


### PR DESCRIPTION
Those files used to be linted, until b6738c1af040505bcb241b8740eb91e81c15eb44 moved them to the `fixtures/` dir, which is excluded from lint rules (for good reasons, we have there files that are purposefully testing e.g. edge-case syntax which would be forbidden in the other areas of the codebase). However, with the recent addition of `globalIgnores` (pending #57673), it's now possible for us to define more precise rules regarding which files are ignored.

(I've chosen to enable it only on subfolder where the files are already passing the linter, I'll open follow-up PRs to enable it in more areas, but the diff is too large for a single PR, see https://github.com/nodejs/node/compare/main...aduh95:node:lint-snapshot-files?expand=1)
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
