### PR TITLE
doc: fix pseudo code in modules.md

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -415,7 +415,7 @@ NODE_MODULES_PATHS(START)
 4. while I >= 0,
    a. if PARTS[I] = "node_modules", GOTO d.
    b. DIR = path join(PARTS[0 .. I] + "node_modules")
-   c. DIRS = DIR + DIRS
+   c. DIRS = DIRS + DIR
    d. let I = I - 1
 5. return DIRS + GLOBAL_FOLDERS
 


### PR DESCRIPTION
The pseudo code involved in the change adds the `node_modules` directories closer and closer to the root directory to `DIRS`. The correct way should be to add it to the end, which is consistent with the actual behavior of Node.

This problem was introduced in f77fe645 of PR #38837.

@Ayase-252 applied a change suggested by @guybedford, although they discovered that the change is wrong in a later conversation, the change was still merged.[^1]

[^1]: https://github.com/nodejs/node/pull/38837#discussion_r641990919