### PR TITLE
readline: add stricter validation for functions called after closed

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -536,6 +536,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   pause() {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (this.paused) return;
     this.input.pause();
     this.paused = true;
@@ -548,6 +551,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   resume() {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (!this.paused) return;
     this.input.resume();
     this.paused = false;
@@ -568,6 +574,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void}
    */
   write(d, key) {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (this.paused) this.resume();
     if (this.terminal) {
       this[kTtyWrite](d, key);

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1202,6 +1202,44 @@ for (let i = 0; i < 12; i++) {
     fi.emit('data', 'Node.js\n');
   }
 
+  // Call write after close
+  {
+    const [rli, fi] = getInterface({ terminal });
+    rli.question('What\'s your name?', common.mustCall((name) => {
+      assert.strictEqual(name, 'Node.js');
+      rli.close();
+      assert.throws(() => {
+        rli.write('I said Node.js');
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+    }));
+    fi.emit('data', 'Node.js\n');
+  }
+
+  // Call pause/resume after close
+  {
+    const [rli, fi] = getInterface({ terminal });
+    rli.question('What\'s your name?', common.mustCall((name) => {
+      assert.strictEqual(name, 'Node.js');
+      rli.close();
+      assert.throws(() => {
+        rli.pause();
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+      assert.throws(() => {
+        rli.resume();
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+    }));
+    fi.emit('data', 'Node.js\n');
+  }
+
   // Can create a new readline Interface with a null output argument
   {
     const [rli, fi] = getInterface({ output: null, terminal });

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1224,6 +1224,9 @@ for (let i = 0; i < 12; i++) {
     rli.question('What\'s your name?', common.mustCall((name) => {
       assert.strictEqual(name, 'Node.js');
       rli.close();
+      // No 'resume' nor 'pause' event should be emitted after close
+      rli.on('resume', common.mustNotCall());
+      rli.on('pause', common.mustNotCall());
       assert.throws(() => {
         rli.pause();
       }, {

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -204,9 +204,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     fi.emit('data', character);
   }
   fi.emit('data', '\n');
-  setTimeout(() => {
-    rli.close();
-  }, common.platformTimeout(100));
+  fi.end();
 }
 
 // \t when there is no completer function should behave like an ordinary

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -204,7 +204,9 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     fi.emit('data', character);
   }
   fi.emit('data', '\n');
-  rli.close();
+  setTimeout(() => {
+    rli.close();
+  });
 }
 
 // \t when there is no completer function should behave like an ordinary

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -206,7 +206,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
   fi.emit('data', '\n');
   setTimeout(() => {
     rli.close();
-  });
+  }, common.platformTimeout(100));
 }
 
 // \t when there is no completer function should behave like an ordinary

--- a/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/parallel/test-readline-promises-tab-complete.js
@@ -80,9 +80,7 @@ if (process.env.TERM === 'dumb') {
           output = '';
         });
       }
-      setTimeout(() => {
-        rli.close();
-      }, common.platformTimeout(100));
+      fi.end();
     });
   });
 });
@@ -116,7 +114,5 @@ if (process.env.TERM === 'dumb') {
     assert.match(output, /^Tab completion error: Error: message/);
     output = '';
   });
-  setTimeout(() => {
-    rli.close();
-  }, common.platformTimeout(100));
+  fi.end();
 }

--- a/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/parallel/test-readline-promises-tab-complete.js
@@ -80,7 +80,9 @@ if (process.env.TERM === 'dumb') {
           output = '';
         });
       }
-      rli.close();
+      setTimeout(() => {
+        rli.close();
+      });
     });
   });
 });
@@ -114,5 +116,7 @@ if (process.env.TERM === 'dumb') {
     assert.match(output, /^Tab completion error: Error: message/);
     output = '';
   });
-  rli.close();
+  setTimeout(() => {
+    rli.close();
+  });
 }

--- a/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/parallel/test-readline-promises-tab-complete.js
@@ -82,7 +82,7 @@ if (process.env.TERM === 'dumb') {
       }
       setTimeout(() => {
         rli.close();
-      });
+      }, common.platformTimeout(100));
     });
   });
 });
@@ -118,5 +118,5 @@ if (process.env.TERM === 'dumb') {
   });
   setTimeout(() => {
     rli.close();
-  });
+  }, common.platformTimeout(100));
 }

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -24,4 +24,6 @@ child.on('exit', common.mustCall(() => {
 
 child.stdin.write('await import(\'./message.mjs\');\n');
 child.stdin.write('.exit');
-child.stdin.end();
+setTimeout(() => {
+  child.stdin.end();
+}, 100);

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -26,4 +26,4 @@ child.stdin.write('await import(\'./message.mjs\');\n');
 child.stdin.write('.exit');
 setTimeout(() => {
   child.stdin.end();
-}, 100);
+}, common.platformTimeout(100));

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -26,4 +26,4 @@ child.stdin.write('await import(\'./message.mjs\');\n');
 child.stdin.write('.exit');
 setTimeout(() => {
   child.stdin.end();
-}, common.platformTimeout(100));
+}, common.platformTimeout(300));

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -8,22 +8,24 @@ const args = ['--interactive'];
 const opts = { cwd: fixtures.path('es-modules') };
 const child = cp.spawn(process.execPath, args, opts);
 
-let output = '';
+const outputs = [];
 child.stdout.setEncoding('utf8');
 child.stdout.on('data', (data) => {
-  output += data;
+  outputs.push(data);
+  if (outputs.length === 3) {
+    // All the expected outputs have been received
+    // so we can close the child process's stdin
+    child.stdin.end();
+  }
 });
 
 child.on('exit', common.mustCall(() => {
-  const results = output.replace(/^> /mg, '').split('\n').slice(2);
-  assert.deepStrictEqual(
+  const results = outputs[2].split('\n')[0];
+  assert.strictEqual(
     results,
-    ['[Module: null prototype] { message: \'A message\' }', '']
+    '[Module: null prototype] { message: \'A message\' }'
   );
 }));
 
 child.stdin.write('await import(\'./message.mjs\');\n');
 child.stdin.write('.exit');
-setTimeout(() => {
-  child.stdin.end();
-}, common.platformTimeout(300));

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -1,7 +1,12 @@
 'use strict';
 const common = require('../common');
-
+const ArrayStream = require('../common/arraystream');
 const repl = require('repl');
-const r = repl.start({ terminal: false });
-r.setupHistory('/nonexistent/file', common.mustSucceed());
-process.stdin.unref?.();
+
+const stream = new ArrayStream();
+
+const replServer = repl.start({ terminal: false, input: stream, output: stream });
+
+replServer.setupHistory('/nonexistent/file', common.mustSucceed(() => {
+  replServer.close();
+}));

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -3,6 +3,5 @@ const common = require('../common');
 
 const repl = require('repl');
 const r = repl.start({ terminal: false });
-r.setupHistory('/nonexistent/file', common.mustSucceed(() => {
-  process.stdin.unref?.();
-}));
+r.setupHistory('/nonexistent/file', common.mustSucceed());
+process.stdin.unref?.();

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -4,5 +4,5 @@ const common = require('../common');
 const repl = require('repl');
 const r = repl.start({ terminal: false });
 r.setupHistory('/nonexistent/file', common.mustSucceed(() => {
-    process.stdin.unref?.();
+  process.stdin.unref?.();
 }));

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -3,5 +3,6 @@ const common = require('../common');
 
 const repl = require('repl');
 const r = repl.start({ terminal: false });
-r.setupHistory('/nonexistent/file', common.mustSucceed());
-process.stdin.unref?.();
+r.setupHistory('/nonexistent/file', common.mustSucceed(() => {
+    process.stdin.unref?.();
+}));

--- a/test/parallel/test-repl-uncaught-exception-async.js
+++ b/test/parallel/test-repl-uncaught-exception-async.js
@@ -34,9 +34,9 @@ r.write(
   '  throw new RangeError("abc");\n' +
   '}, 1);console.log()\n'
 );
-r.close();
 
 setTimeout(() => {
+  r.close();
   const len = process.listenerCount('uncaughtException');
   process.removeAllListeners('uncaughtException');
   assert.strictEqual(len, 0);


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/57678

This PR makes it so that calling `pause()`, `resume()` or `write()` on a closed readline interface results in `ERR_USE_AFTER_CLOSE` errors being thrown (following the same behavior as `question()`)

> [!note]
> I'm slightly concerned regarding the tests I needed to update, as those might indicate that the stricted
> readline checks might have some potential unwanted implications, if the changes here were to land it might be
> safer to add them as a semver major I think :thinking: 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
