### PR TITLE
module: improve typescript error message format

### DIFF
--- a/deps/amaro/README.md
+++ b/deps/amaro/README.md
@@ -29,6 +29,7 @@ console.log(code); // "const foo         = 'bar';"
 
 It is possible to use Amaro as an external loader to execute TypeScript files.
 This allows the installed Amaro to override the Amaro version used by Node.js.
+In order to use Amaro as an external loader, type stripping needs to be enabled.
 
 ```bash
 node --experimental-strip-types --import="amaro/register" script.ts
@@ -51,7 +52,7 @@ node --experimental-transform-types --import="amaro/transform" script.ts
 
 ### TypeScript Version
 
-The supported TypeScript version is 5.5.4, except the stage 3 decorator proposal.
+The supported TypeScript version is 5.8.
 
 ## License (MIT)
 

--- a/deps/amaro/dist/errors.js
+++ b/deps/amaro/dist/errors.js
@@ -3,14 +3,19 @@ export function isSwcError(error) {
   return error.code !== void 0;
 }
 export function wrapAndReThrowSwcError(error) {
+  const errorHints = `${error.filename}:${error.startLine}${error.snippet}`;
   switch (error.code) {
     case "UnsupportedSyntax": {
       const unsupportedSyntaxError = new Error(error.message);
       unsupportedSyntaxError.name = "UnsupportedSyntaxError";
+      unsupportedSyntaxError.stack = `${errorHints}${unsupportedSyntaxError.stack}`;
       throw unsupportedSyntaxError;
     }
-    case "InvalidSyntax":
-      throw new SyntaxError(error.message);
+    case "InvalidSyntax": {
+      const syntaxError = new SyntaxError(error.message);
+      syntaxError.stack = `${errorHints}${syntaxError.stack}`;
+      throw syntaxError;
+    }
     default:
       throw new Error(error.message);
   }

--- a/deps/amaro/dist/package.json
+++ b/deps/amaro/dist/package.json
@@ -4,7 +4,7 @@
     "강동윤 <kdy1997.dev@gmail.com>"
   ],
   "description": "wasm module for swc",
-  "version": "1.11.5",
+  "version": "1.11.12",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/deps/amaro/package.json
+++ b/deps/amaro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "amaro",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Node.js TypeScript wrapper",
 	"license": "MIT",
 	"type": "commonjs",
@@ -24,8 +24,8 @@
 		"build": "node esbuild.config.mjs",
 		"build:wasm": "node tools/build-wasm.js",
 		"typecheck": "tsc --noEmit",
-		"test": "node --test --experimental-test-snapshots \"**/*.test.js\"",
-		"test:regenerate": "node --test --experimental-test-snapshots --test-update-snapshots \"**/*.test.js\""
+		"test": "node --test \"**/*.test.js\"",
+		"test:regenerate": "node --test --test-update-snapshots \"**/*.test.js\""
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.8.3",

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -63,10 +63,14 @@ function parseTypeScript(source, options) {
      * It allows us to distinguish between invalid syntax and unsupported syntax.
      */
     switch (error?.code) {
-      case 'UnsupportedSyntax':
-        throw new ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX(error.message);
-      case 'InvalidSyntax':
-        throw new ERR_INVALID_TYPESCRIPT_SYNTAX(error.message);
+      case 'UnsupportedSyntax': {
+        const unsupportedSyntaxError = new ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX(error.message);
+        throw decorateErrorWithSnippet(unsupportedSyntaxError, error); /* node-do-not-add-exception-line */
+      }
+      case 'InvalidSyntax': {
+        const invalidSyntaxError = new ERR_INVALID_TYPESCRIPT_SYNTAX(error.message);
+        throw decorateErrorWithSnippet(invalidSyntaxError, error); /* node-do-not-add-exception-line */
+      }
       default:
         // SWC may throw strings when something goes wrong.
         if (typeof error === 'string') { assert.fail(error); }
@@ -74,6 +78,18 @@ function parseTypeScript(source, options) {
         assert.fail(error.message);
     }
   }
+}
+
+/**
+ *
+ * @param {Error} error the error to decorate: ERR_INVALID_TYPESCRIPT_SYNTAX, ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX
+ * @param {object} amaroError the error object from amaro
+ * @returns {Error} the decorated error
+ */
+function decorateErrorWithSnippet(error, amaroError) {
+  const errorHints = `${amaroError.filename}:${amaroError.startLine}${amaroError.snippet}`;
+  error.stack = `${errorHints}${error.stack}`;
+  return error;
 }
 
 /**

--- a/lib/internal/process/execution.js
+++ b/lib/internal/process/execution.js
@@ -44,6 +44,8 @@ const { emitExperimentalWarning } = require('internal/util');
 // communication with JS.
 const { shouldAbortOnUncaughtToggle } = internalBinding('util');
 
+const kEvalTag = '[eval]';
+
 function tryGetCwd() {
   try {
     return process.cwd();
@@ -259,7 +261,7 @@ function evalTypeScript(name, source, breakFirstLine, print, shouldLoadESM = fal
     compiledScript = compileScript(name, source, baseUrl);
   } catch (originalError) {
     try {
-      sourceToRun = stripTypeScriptModuleTypes(source, name, false);
+      sourceToRun = stripTypeScriptModuleTypes(source, kEvalTag, false);
       // Retry the CJS/ESM syntax detection after stripping the types.
       if (shouldUseModuleEntryPoint(name, sourceToRun)) {
         return evalTypeScriptModuleEntryPoint(source, print);
@@ -322,7 +324,7 @@ function evalTypeScriptModuleEntryPoint(source, print) {
         moduleWrap = loader.createModuleWrap(source, url);
       } catch (originalError) {
         try {
-          const strippedSource = stripTypeScriptModuleTypes(source, url, false);
+          const strippedSource = stripTypeScriptModuleTypes(source, kEvalTag, false);
           // If the moduleWrap was successfully created, execute the module job.
           // outside the try-catch block to avoid catching runtime errors.
           moduleWrap = loader.createModuleWrap(strippedSource, url);
@@ -355,7 +357,7 @@ function evalTypeScriptModuleEntryPoint(source, print) {
  */
 function parseAndEvalModuleTypeScript(source, print) {
   // We know its a TypeScript module, we can safely emit the experimental warning.
-  const strippedSource = stripTypeScriptModuleTypes(source, getEvalModuleUrl());
+  const strippedSource = stripTypeScriptModuleTypes(source, kEvalTag);
   evalModuleEntryPoint(strippedSource, print);
 }
 
@@ -370,7 +372,7 @@ function parseAndEvalModuleTypeScript(source, print) {
  */
 function parseAndEvalCommonjsTypeScript(name, source, breakFirstLine, print, shouldLoadESM = false) {
   // We know its a TypeScript module, we can safely emit the experimental warning.
-  const strippedSource = stripTypeScriptModuleTypes(source, getEvalModuleUrl());
+  const strippedSource = stripTypeScriptModuleTypes(source, kEvalTag);
   evalScript(name, strippedSource, breakFirstLine, print, shouldLoadESM);
 }
 

--- a/src/amaro_version.h
+++ b/src/amaro_version.h
@@ -2,5 +2,5 @@
 // Refer to tools/dep_updaters/update-amaro.sh
 #ifndef SRC_AMARO_VERSION_H_
 #define SRC_AMARO_VERSION_H_
-#define AMARO_VERSION "0.4.1"
+#define AMARO_VERSION "0.5.0"
 #endif  // SRC_AMARO_VERSION_H_

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -262,3 +262,23 @@ test('should not allow declare module keyword', async () => {
   match(result.stderr, /ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX/);
   strictEqual(result.code, 1);
 });
+
+// TODO (marco-ippolito) Remove the extra padding from the error message
+// The padding comes from swc it will be removed in a future amaro release
+test('the error message should not contain extra padding', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--input-type=module-typescript',
+    '--eval',
+    'declare module F { export type x = number }']);
+  strictEqual(result.stdout, '');
+  // Windows uses \r\n as line endings
+  const lines = result.stderr.replace(/\r\n/g, '\n').split('\n');
+  // The extra padding at the end should not be present
+  strictEqual(lines[0], '[eval]:1   ');
+  // The extra padding at the beginning should not be present
+  strictEqual(lines[2], '     declare module F { export type x = number }');
+  strictEqual(lines[3], '             ^^^^^^^^');
+  strictEqual(lines[5], 'SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]:' +
+    ' `module` keyword is not supported. Use `namespace` instead.');
+  strictEqual(result.code, 1);
+});

--- a/test/fixtures/eval/eval_messages.snapshot
+++ b/test/fixtures/eval/eval_messages.snapshot
@@ -2,11 +2,7 @@
 [eval]:1
 with(this){__filename}
 ^^^^
-  x The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
-   ,----
- 1 | with(this){__filename}
-   : ^^^^
-   `----
+The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 SyntaxError: Strict mode code may not include a with statement
 

--- a/test/fixtures/eval/eval_typescript.snapshot
+++ b/test/fixtures/eval/eval_typescript.snapshot
@@ -1,11 +1,7 @@
 [eval]:1
 enum Foo{};
 ^^^^
-  x TypeScript enum is not supported in strip-only mode
-   ,----
- 1 | enum Foo{};
-   : ^^^^^^^^^^
-   `----
+TypeScript enum is not supported in strip-only mode
 
 SyntaxError: Unexpected reserved word
 
@@ -20,11 +16,7 @@ Node.js *
 [eval]:1
 const foo;
       ^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | const foo;
-   :       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Missing initializer in const declaration
 
@@ -35,11 +27,7 @@ false
 [eval]:1
 interface Foo{};const foo;
           ^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | interface Foo{};const foo;
-   :                       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Unexpected identifier 'Foo'
 
@@ -47,11 +35,7 @@ Node.js *
 [eval]:1
 function foo(){ await Promise.resolve(1)};
                 ^^^^^
-  x await isn't allowed in non-async function
-   ,----
- 1 | function foo(){ await Promise.resolve(1)};
-   :                       ^^^^^^^
-   `----
+await isn't allowed in non-async function
 
 SyntaxError: await is only valid in async functions and the top level bodies of modules
 

--- a/test/fixtures/eval/stdin_messages.snapshot
+++ b/test/fixtures/eval/stdin_messages.snapshot
@@ -2,11 +2,7 @@
 [stdin]:1
 with(this){__filename}
 ^^^^
-  x The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
-   ,----
- 1 | with(this){__filename}
-   : ^^^^
-   `----
+The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 SyntaxError: Strict mode code may not include a with statement
 

--- a/test/fixtures/eval/stdin_typescript.snapshot
+++ b/test/fixtures/eval/stdin_typescript.snapshot
@@ -1,11 +1,7 @@
 [stdin]:1
 enum Foo{};
 ^^^^
-  x TypeScript enum is not supported in strip-only mode
-   ,----
- 1 | enum Foo{};
-   : ^^^^^^^^^^
-   `----
+TypeScript enum is not supported in strip-only mode
 
 SyntaxError: Unexpected reserved word
 
@@ -13,11 +9,7 @@ Node.js *
 [stdin]:1
 enum Foo{};
 ^^^^
-  x TypeScript enum is not supported in strip-only mode
-   ,----
- 1 | enum Foo{};
-   : ^^^^^^^^^^
-   `----
+TypeScript enum is not supported in strip-only mode
 
 SyntaxError: Unexpected reserved word
 
@@ -39,11 +31,7 @@ Node.js *
 [stdin]:1
 const foo;
       ^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | const foo;
-   :       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Missing initializer in const declaration
 
@@ -51,11 +39,7 @@ Node.js *
 [stdin]:1
 const foo;
       ^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | const foo;
-   :       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Missing initializer in const declaration
 
@@ -69,11 +53,7 @@ false
 [stdin]:1
 interface Foo{};const foo;
           ^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | interface Foo{};const foo;
-   :                       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Unexpected identifier 'Foo'
 
@@ -81,11 +61,7 @@ Node.js *
 [stdin]:1
 interface Foo{};const foo;
 ^^^^^^^^^
-  x 'const' declarations must be initialized
-   ,----
- 1 | interface Foo{};const foo;
-   :                       ^^^
-   `----
+'const' declarations must be initialized
 
 SyntaxError: Unexpected strict mode reserved word
 
@@ -93,11 +69,7 @@ Node.js *
 [stdin]:1
 function foo(){ await Promise.resolve(1)};
                 ^^^^^
-  x await isn't allowed in non-async function
-   ,----
- 1 | function foo(){ await Promise.resolve(1)};
-   :                       ^^^^^^^
-   `----
+await isn't allowed in non-async function
 
 SyntaxError: await is only valid in async functions and the top level bodies of modules
 
@@ -105,11 +77,7 @@ Node.js *
 [stdin]:1
 function foo(){ await Promise.resolve(1)};
                 ^^^^^
-  x await isn't allowed in non-async function
-   ,----
- 1 | function foo(){ await Promise.resolve(1)};
-   :                       ^^^^^^^
-   `----
+await isn't allowed in non-async function
 
 SyntaxError: await is only valid in async functions and the top level bodies of modules
 


### PR DESCRIPTION
> Unfortunately the automation deleted my commit https://github.com/nodejs/node/pull/57598
TIL dont push on dep update automation or the next sunday it will be overwritten 😆 

Fixes: https://github.com/nodejs/node/issues/56830

This PR improves the error messages generated by the transpiler.

Node.js v23.9.0:
```
marcoippolito@marcos-MacBook-Pro node % node --input-type=commonjs-typescript -p "enum Foo"
node:internal/modules/typescript:69
        throw new ERR_INVALID_TYPESCRIPT_SYNTAX(error.message);
        ^

SyntaxError [ERR_INVALID_TYPESCRIPT_SYNTAX]:   x Expected '{', got '<eof>'
   ,----
 1 | enum Foo
   :      ^^^
   `----

    at parseTypeScript (node:internal/modules/typescript:69:15)
    at processTypeScriptCode (node:internal/modules/typescript:129:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:196:22)
    at parseAndEvalCommonjsTypeScript (node:internal/process/execution:369:26)
    at node:internal/main/eval_string:71:3 {
  code: 'ERR_INVALID_TYPESCRIPT_SYNTAX'
}
```

This PR:

```
marcoippolito@marcos-MacBook-Pro node % ./node --input-type=commonjs-typescript -p "enum Foo"
[eval]:1   
        
     enum Foo
          ^^^
        
SyntaxError [ERR_INVALID_TYPESCRIPT_SYNTAX]: Expected '{', got '<eof>'
    at parseTypeScript (node:internal/modules/typescript:71:36)
    at processTypeScriptCode (node:internal/modules/typescript:145:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:212:22)
    at parseAndEvalCommonjsTypeScript (node:internal/process/execution:375:26)
    at node:internal/main/eval_string:71:3 {
  code: 'ERR_INVALID_TYPESCRIPT_SYNTAX'
}
```

It removes the internal file path:
```
node:internal/modules/typescript:69
        throw new ERR_INVALID_TYPESCRIPT_SYNTAX(error.message);
```
Removes the padding boxing the message:
```
   ,----
 1 | enum Foo
   :      ^^^
   `----

```
In general it blends better with Node.js error style.
There is still an improvement to make that involves removing the whitespace around:
```
        
     enum Foo
          ^^^
  
```
    
This depends from SWC and its currently being fixed.