### PR TITLE
src: fix kill signal 0 on Windows

### DIFF
--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -385,7 +385,7 @@ class ProcessWrap : public HandleWrap {
     }
 #ifdef _WIN32
     if (signal != SIGKILL && signal != SIGTERM && signal != SIGINT &&
-        signal != SIGQUIT) {
+        signal != SIGQUIT && signal != 0) {
       signal = SIGKILL;
     }
 #endif

--- a/test/parallel/test-child-process-kill.js
+++ b/test/parallel/test-child-process-kill.js
@@ -60,3 +60,23 @@ if (common.isWindows) {
   });
   process.kill('SIGHUP');
 }
+
+// Test that the process is not killed when sending a 0 signal.
+// This is a no-op signal that is used to check if the process is alive.
+const code = `const interval = setInterval(() => {}, 1000);
+process.stdin.on('data', () => { clearInterval(interval); });
+process.stdout.write('x');`;
+
+const checkProcess = spawn(process.execPath, ['-e', code]);
+
+checkProcess.on('exit', (code, signal) => {
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+});
+
+checkProcess.stdout.on('data', common.mustCall((chunk) => {
+  assert.strictEqual(chunk.toString(), 'x');
+  checkProcess.kill(0);
+  checkProcess.stdin.write('x');
+  checkProcess.stdin.end();
+}));


### PR DESCRIPTION
The [previous changes to this file](https://github.com/nodejs/node/pull/55514) missed the special case of `process.kill(0)`, thus breaking it on Windows. This PR fixes that.

Refs: https://github.com/nodejs/node/pull/55514
Refs: https://github.com/nodejs/node/issues/42923
Fixes: https://github.com/nodejs/node/issues/57669