### PR TITLE
module: remove extra padding from ts errors

### DIFF
--- a/deps/amaro/dist/errors.js
+++ b/deps/amaro/dist/errors.js
@@ -3,7 +3,9 @@ export function isSwcError(error) {
   return error.code !== void 0;
 }
 export function wrapAndReThrowSwcError(error) {
-  const errorHints = `${error.filename}:${error.startLine}${error.snippet}`;
+  const errorHints = `${error.filename}:${error.startLine}
+${error.snippet}
+`;
   switch (error.code) {
     case "UnsupportedSyntax": {
       const unsupportedSyntaxError = new Error(error.message);

--- a/deps/amaro/dist/package.json
+++ b/deps/amaro/dist/package.json
@@ -4,7 +4,7 @@
     "강동윤 <kdy1997.dev@gmail.com>"
   ],
   "description": "wasm module for swc",
-  "version": "1.11.12",
+  "version": "1.11.15",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/deps/amaro/dist/strip-loader.js
+++ b/deps/amaro/dist/strip-loader.js
@@ -1,4 +1,5 @@
 "use strict";
+import { fileURLToPath } from "node:url";
 import { isSwcError, wrapAndReThrowSwcError } from "./errors.js";
 import { transformSync } from "./index.js";
 export async function load(url, context, nextLoad) {
@@ -10,7 +11,8 @@ export async function load(url, context, nextLoad) {
         format: "module"
       });
       const { code } = transformSync(source.toString(), {
-        mode: "strip-only"
+        mode: "strip-only",
+        filename: fileURLToPath(url)
       });
       return {
         format: format.replace("-typescript", ""),

--- a/deps/amaro/dist/transform-loader.js
+++ b/deps/amaro/dist/transform-loader.js
@@ -1,4 +1,5 @@
 "use strict";
+import { fileURLToPath } from "node:url";
 import { isSwcError, wrapAndReThrowSwcError } from "./errors.js";
 import { transformSync } from "./index.js";
 export async function load(url, context, nextLoad) {
@@ -12,7 +13,7 @@ export async function load(url, context, nextLoad) {
       const { code, map } = transformSync(source.toString(), {
         mode: "transform",
         sourceMap: true,
-        filename: url
+        filename: fileURLToPath(url)
       });
       let output = code;
       if (map) {

--- a/deps/amaro/package.json
+++ b/deps/amaro/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "amaro",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Node.js TypeScript wrapper",
 	"license": "MIT",
 	"type": "commonjs",

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -87,8 +87,8 @@ function parseTypeScript(source, options) {
  * @returns {Error} the decorated error
  */
 function decorateErrorWithSnippet(error, amaroError) {
-  const errorHints = `${amaroError.filename}:${amaroError.startLine}${amaroError.snippet}`;
-  error.stack = `${errorHints}${error.stack}`;
+  const errorHints = `${amaroError.filename}:${amaroError.startLine}\n${amaroError.snippet}`;
+  error.stack = `${errorHints}\n${error.stack}`;
   return error;
 }
 

--- a/src/amaro_version.h
+++ b/src/amaro_version.h
@@ -2,5 +2,5 @@
 // Refer to tools/dep_updaters/update-amaro.sh
 #ifndef SRC_AMARO_VERSION_H_
 #define SRC_AMARO_VERSION_H_
-#define AMARO_VERSION "0.5.0"
+#define AMARO_VERSION "0.5.1"
 #endif  // SRC_AMARO_VERSION_H_

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -273,12 +273,10 @@ test('the error message should not contain extra padding', async () => {
   strictEqual(result.stdout, '');
   // Windows uses \r\n as line endings
   const lines = result.stderr.replace(/\r\n/g, '\n').split('\n');
-  // The extra padding at the end should not be present
-  strictEqual(lines[0], '[eval]:1   ');
-  // The extra padding at the beginning should not be present
-  strictEqual(lines[2], '     declare module F { export type x = number }');
-  strictEqual(lines[3], '             ^^^^^^^^');
-  strictEqual(lines[5], 'SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]:' +
+  strictEqual(lines[0], '[eval]:1');
+  strictEqual(lines[1], 'declare module F { export type x = number }');
+  strictEqual(lines[2], '        ^^^^^^^^');
+  strictEqual(lines[4], 'SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]:' +
     ' `module` keyword is not supported. Use `namespace` instead.');
   strictEqual(result.code, 1);
 });


### PR DESCRIPTION
This PR finally removed the extra padding from errors and this is the final result:
```
[eval]:1
declare module F { export type x = number }
        ^^^^^^^^

SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: `module` keyword is not supported. Use `namespace` instead.
    at parseTypeScript (node:internal/modules/typescript:67:40)
    at processTypeScriptCode (node:internal/modules/typescript:145:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:212:22)
    at parseAndEvalModuleTypeScript (node:internal/process/execution:360:26)
    at node:internal/main/eval_string:39:3 {
  code: 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'
}
```
