### PR TITLE
doc: mark type stripping as release candidate

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1154,7 +1154,7 @@ This feature requires `--allow-worker` if used with the [Permission Model][].
 added: v22.7.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 Enables the transformation of TypeScript-only syntax into JavaScript code.
 Implies `--enable-source-maps`.
@@ -1767,7 +1767,7 @@ changes:
     description: Type stripping is enabled by default.
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 Disable experimental type-stripping for TypeScript files.
 For more information, see the [TypeScript type-stripping][] documentation.

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -239,7 +239,7 @@ added:
   - v22.13.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 * `code` {string} The code to strip type annotations from.
 * `options` {Object}

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2052,7 +2052,7 @@ added:
  - v22.10.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 * {boolean|string}
 

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -12,7 +12,7 @@ changes:
 
 <!--introduced_in=v22.6.0-->
 
-> Stability: 1.1 - Active development
+> Stability: 1.2 - Release candidate
 
 ## Enabling
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/typescript/issues/24

The design of this feature is pretty much stable and we have just been working on bug fixing and aesthetic improvements like error messages.
There is 1 issue open right now, and not many issues opened in general so I feel pretty confident in marking this as release candidate

cc @nodejs/typescript 