### PR TITLE
doc: process.execve is only unavailable for Windows

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3370,7 +3370,7 @@ any exit or close events and without running any cleanup handler.
 
 This function will never return, unless an error occurred.
 
-This function is only available on POSIX platforms (i.e. not Windows or Android).
+This function is not available on Windows.
 
 ## `process.report`
 


### PR DESCRIPTION
execve() call is available on Android as well. When process.execve was first added, it seems like no one checked if that is actually available on Android as well and works out of the box as `__POSIX__` is defined on Android. process.execve call seems to behave just as fine as on Linux environment in my testing, so just make the docs specify it.
