### PR TITLE
doc: add back mention of visa fees to onboarding doc

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -261,7 +261,7 @@ needs to be pointed out separately during the onboarding.
 * The OpenJS Foundation hosts regular summits for active contributors to the
   Node.js project, where we have face-to-face discussions about our work on the
   project. The Foundation has travel funds to cover [participants' expenses][]
-  including accommodations, transportation and visa fees (even in case the visa
+  including accommodations, transportation, and visa fees (even in case the visa
   is denied) if needed. Check out the [summit](https://github.com/nodejs/summit)
   repository for details.
 * If you are interested in helping to fix coverity reports consider requesting

--- a/onboarding.md
+++ b/onboarding.md
@@ -261,8 +261,9 @@ needs to be pointed out separately during the onboarding.
 * The OpenJS Foundation hosts regular summits for active contributors to the
   Node.js project, where we have face-to-face discussions about our work on the
   project. The Foundation has travel funds to cover [participants' expenses][]
-  including accommodations and transportation if needed. Check out
-  the [summit](https://github.com/nodejs/summit) repository for details.
+  including accommodations, transportation and visa fees (even in case the visa
+  is denied) if needed. Check out the [summit](https://github.com/nodejs/summit)
+  repository for details.
 * If you are interested in helping to fix coverity reports consider requesting
   access to the projects coverity project as outlined in [static-analysis][].
 


### PR DESCRIPTION
Thanks to the incredible support from the community in https://github.com/openjs-foundation/cross-project-council/issues/1240 we were able to amend the OpenJS Foundation travel fund policy to now cover visa costs (even in case the visa is denied).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
