### PR TITLE
test: improve getCallSites

### DIFF
--- a/test/parallel/test-util-getcallsites.js
+++ b/test/parallel/test-util-getcallsites.js
@@ -48,6 +48,11 @@ const assert = require('node:assert');
     code: 'ERR_OUT_OF_RANGE'
   }));
   assert.throws(() => {
+    getCallSites(0.5);
+  }, common.expectsError({
+    code: 'ERR_OUT_OF_RANGE'
+  }));
+  assert.throws(() => {
     getCallSites(-1);
   }, common.expectsError({
     code: 'ERR_OUT_OF_RANGE'

--- a/test/parallel/test-util-getcallsites.js
+++ b/test/parallel/test-util-getcallsites.js
@@ -29,7 +29,7 @@ const assert = require('node:assert');
   );
 }
 
-// Guarantee dot-left numbers are ignored
+// Guarantee dot-right numbers are ignored
 {
   const callSites = getCallSites(3.6);
   assert.strictEqual(callSites.length, 3);


### PR DESCRIPTION
`dot-left` supposed to be `dot-right`

The frame count is between 1 and 200. Testing 0.5 will be testing decimal fraction truncation to 0 which is still invalid range.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
