### PR TITLE
lib: fix default AbortController.abort() message

### DIFF
--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -227,7 +227,7 @@ class AbortSignal extends EventTarget {
    * @returns {AbortSignal}
    */
   static abort(
-    reason = new DOMException('This operation was aborted', 'AbortError')) {
+    reason = new DOMException('This operation was aborted.', 'AbortError')) {
     return new AbortSignal(kDontThrowSymbol, { aborted: true, reason });
   }
 
@@ -464,7 +464,7 @@ class AbortController {
   /**
    * @param {any} [reason]
    */
-  abort(reason = new DOMException('This operation was aborted', 'AbortError')) {
+  abort(reason = new DOMException('This operation was aborted.', 'AbortError')) {
     abortSignal(this.#signal ??= new AbortSignal(kDontThrowSymbol), reason);
   }
 

--- a/test/fixtures/test-runner/output/abort.snapshot
+++ b/test/fixtures/test-runner/output/abort.snapshot
@@ -51,7 +51,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -73,7 +73,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -95,7 +95,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):7'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -133,7 +133,7 @@ not ok 2 - promise abort signal
   type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
-  error: 'This operation was aborted'
+  error: 'This operation was aborted.'
   code: 20
   name: 'AbortError'
   stack: |-
@@ -200,7 +200,7 @@ not ok 2 - promise abort signal
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -222,7 +222,7 @@ not ok 2 - promise abort signal
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -244,7 +244,7 @@ not ok 2 - promise abort signal
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort.js:(LINE):5'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -282,7 +282,7 @@ not ok 4 - callback abort signal
   type: 'test'
   location: '/test/fixtures/test-runner/output/abort.js:(LINE):1'
   failureType: 'testAborted'
-  error: 'This operation was aborted'
+  error: 'This operation was aborted.'
   code: 20
   name: 'AbortError'
   stack: |-

--- a/test/fixtures/test-runner/output/abort_hooks.snapshot
+++ b/test/fixtures/test-runner/output/abort_hooks.snapshot
@@ -35,7 +35,7 @@ not ok 1 - 1 before describe
   type: 'suite'
   location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):1'
   failureType: 'hookFailed'
-  error: 'This operation was aborted'
+  error: 'This operation was aborted.'
   code: 20
   name: 'AbortError'
   stack: |-
@@ -70,7 +70,7 @@ not ok 2 - 2 after describe
   type: 'suite'
   location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):1'
   failureType: 'hookFailed'
-  error: 'This operation was aborted'
+  error: 'This operation was aborted.'
   code: 20
   name: 'AbortError'
   stack: |-
@@ -93,7 +93,7 @@ not ok 2 - 2 after describe
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -115,7 +115,7 @@ not ok 2 - 2 after describe
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -148,7 +148,7 @@ not ok 3 - 3 beforeEach describe
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -170,7 +170,7 @@ not ok 3 - 3 beforeEach describe
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_hooks.js:(LINE):3'
       failureType: 'hookFailed'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-

--- a/test/fixtures/test-runner/output/abort_suite.snapshot
+++ b/test/fixtures/test-runner/output/abort_suite.snapshot
@@ -51,7 +51,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -73,7 +73,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -95,7 +95,7 @@ TAP version 13
       type: 'test'
       location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):3'
       failureType: 'testAborted'
-      error: 'This operation was aborted'
+      error: 'This operation was aborted.'
       code: 20
       name: 'AbortError'
       stack: |-
@@ -133,7 +133,7 @@ not ok 2 - describe abort signal
   type: 'suite'
   location: '/test/fixtures/test-runner/output/abort_suite.js:(LINE):1'
   failureType: 'testAborted'
-  error: 'This operation was aborted'
+  error: 'This operation was aborted.'
   code: 20
   name: 'AbortError'
   stack: |-

--- a/test/parallel/test-child-process-exec-abortcontroller-promisified.js
+++ b/test/parallel/test-child-process-exec-abortcontroller-promisified.js
@@ -21,7 +21,7 @@ const waitCommand = common.isWindows ?
   const promise = execPromisifed(waitCommand, { signal });
   assert.rejects(promise, {
     name: 'AbortError',
-    cause: new DOMException('This operation was aborted', 'AbortError'),
+    cause: new DOMException('This operation was aborted.', 'AbortError'),
   }).then(common.mustCall());
   ac.abort();
 }


### PR DESCRIPTION
did not previously match spec
https://dom.spec.whatwg.org/#dom-abortsignal-abort
https://webidl.spec.whatwg.org/#aborterror
