### PR TITLE
src: fix bugs and refactor NativeSymbolDebuggingContext::GetLoadedLibraries

### DIFF
--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -471,7 +471,7 @@ std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
   DWORD size_2 = 0;
   // First call to get the size of module array needed
   if (EnumProcessModules(process_handle, nullptr, 0, &size_1)) {
-    MallocedBuffer<HMODULE> modules(size_1/sizeof(HMODULE);
+    MallocedBuffer<HMODULE> modules(size_1 / sizeof(HMODULE));
 
     // Second call to populate the module array
     if (EnumProcessModules(process_handle, modules.data, size_1, &size_2)) {
@@ -480,15 +480,15 @@ std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
            i++) {
         WCHAR module_name[MAX_PATH];
         // Obtain and report the full pathname for each module
-        if (GetModuleFileNameW(modules.data[i],
-                               module_name,
-                               arraysize(module_name))) {
+        if (GetModuleFileNameW(
+                modules.data[i], module_name, arraysize(module_name))) {
           DWORD size = WideCharToMultiByte(
               CP_UTF8, 0, module_name, -1, nullptr, 0, nullptr, nullptr);
           char* str = new char[size];
           WideCharToMultiByte(
               CP_UTF8, 0, module_name, -1, str, size, nullptr, nullptr);
           list.emplace_back(str);
+          delete str;
         }
       }
     }

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -471,7 +471,7 @@ std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
   DWORD size_2 = 0;
   // First call to get the size of module array needed
   if (EnumProcessModules(process_handle, nullptr, 0, &size_1)) {
-    MallocedBuffer<HMODULE> modules(size_1);
+    MallocedBuffer<HMODULE> modules(size_1/sizeof(HMODULE);
 
     // Second call to populate the module array
     if (EnumProcessModules(process_handle, modules.data, size_1, &size_2)) {

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -482,7 +482,7 @@ std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
         // Obtain and report the full pathname for each module
         if (GetModuleFileNameW(modules.data[i],
                                module_name,
-                               arraysize(module_name) / sizeof(WCHAR))) {
+                               arraysize(module_name))) {
           DWORD size = WideCharToMultiByte(
               CP_UTF8, 0, module_name, -1, nullptr, 0, nullptr, nullptr);
           char* str = new char[size];

--- a/src/debug_utils.cc
+++ b/src/debug_utils.cc
@@ -480,10 +480,9 @@ std::vector<std::string> NativeSymbolDebuggingContext::GetLoadedLibraries() {
            i++) {
         WCHAR module_name[MAX_PATH];
         // Obtain and report the full pathname for each module
-        if (GetModuleFileNameExW(process_handle,
-                                 modules.data[i],
-                                 module_name,
-                                 arraysize(module_name) / sizeof(WCHAR))) {
+        if (GetModuleFileNameW(modules.data[i],
+                               module_name,
+                               arraysize(module_name) / sizeof(WCHAR))) {
           DWORD size = WideCharToMultiByte(
               CP_UTF8, 0, module_name, -1, nullptr, 0, nullptr, nullptr);
           char* str = new char[size];


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
### tldr: 
GetLoadedLibraries is used in process.report.GetReport to generate a list of loaded libraries. This PR fixes the following:
* Random failures when retrieving module file paths
* Retrieve only up to half the max file path length intended
* Allocating unused memory for module handles
* Memory leak from converting file path wchar* strings to utf8 std::strings

--

### Refactor:
1) **GetModuleFileNameExW can fail randomly**: Microsoft's Documentation recommends using GetModuleFileNameW over GetModuleFileNameExW when a process is trying to get a list of it's own dlls. GetModuleFileNameExW can fail unexpectedly for some calls.

<details>
<summary>Sources from Docs + Raymond Chen</summary>

* "To retrieve the name of a module in the current process, use the [GetModuleFileName](https://learn.microsoft.com/en-us/windows/desktop/api/libloaderapi/nf-libloaderapi-getmodulefilenamew) function" -- [WinApi Docs: Remarks](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulefilenameexw)

* Raymond Chen explains how GetModuleFileNameExW can fail randomly, in a way that GetModuleFileNameW avoids -- [Article](https://devblogs.microsoft.com/oldnewthing/20160310-00/?p=93141)
</details>

### Bug Fixes:
1)  **Unused Buffer Memory Allocated**: The constructor for `modules` allocates memory by multiplying the constructor arg `size_t n` by the `sizeof` it's type. In this case, `modules` would be allocated with `size_1 * sizeof(HMODULE)` bytes. But EnumProcessModules sets `size_1` to the number of *bytes* that need to be allocated for the `module` buffer. Using `size_1/sizeof(HMODULE)` gives the constructor what it's asking for i.e the number of HMODULES to allocate space for.
<details>
<summary>Exapnd to Step through MallocedBuffer constructor behavior</summary>

src/util.h MallocedBuffer
```c++
  explicit MallocedBuffer(size_t size) : data(Malloc<T>(size)), size(size) {}
```

src/util-inl.h UncheckedMalloc
```c++
template <typename T>
inline T* UncheckedMalloc(size_t n) {
  return UncheckedRealloc<T>(nullptr, n);
}
```

src/util-inl.h UncheckedRealloc
```c++
template <typename T>
T* UncheckedRealloc(T* pointer, size_t n) {
  size_t full_size = MultiplyWithOverflowCheck(sizeof(T), n); // <- Expects n to be number of T elements
/* other code not shown... */

  void* allocated = realloc(pointer, full_size);

/* other code not shown... */

  return static_cast<T*>(allocated);
}
```
src/util-inl.h MultiplyWithOverflowCheck
```c++
template <typename T>
inline T MultiplyWithOverflowCheck(T a, T b) {
  auto ret = a * b;
  if (a != 0)
    CHECK_EQ(b, ret / a);

  return ret;
}
```
</details>



2) **Unnecessary Module path truncation**: GetModuleFileName is called using `array_size(module_name) / sizeof(WCHAR)` for the `nSize` param. `nSize` is supposed to be the number of characters in the wchar array supplied. `module_name` is already a WCHAR array, so `nSize` should just be `array_size(module_name)`. The current code causes GetModuleFileName to truncate after reaching half the capacity of the buffer (i.e half of MAX_PATH)

3)  **Memory Leak**: When converting the file path written by GetModuleFileName from a wchar array to a char array with UTF8 encoding, a char array `str` is added to the heap using `new`. Next, it's added to `list`, a `std::vector<std::string>` using `emplace_back`. `emplace_back` will pass `str` intro the `std::string` constructor. This constructor is defined to copy values from a null terminated `char * array` into the `std::string`. I assume `str` was created on the heap so that it could be dynamically allocated based on the number of bytes returned by `WideCharToMultiByte`. Once it's added to `list`, the memory is no longer needed, but is never deleted from the heap.  