### PR TITLE
doc: explicitly state that corepack will be removed in v25+

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -16,6 +16,6 @@ Documentation for this tool can be found on the [Corepack repository][].
 
 Despite Corepack being distributed with default installs of Node.js, the package
 managers managed by Corepack are not part of the Node.js distribution, and
-Corepack itself will no longer be distributed with future versions of Node.js.
+Corepack itself will no longer be distributed with Node.js v25+.
 
 [Corepack repository]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -16,6 +16,6 @@ Documentation for this tool can be found on the [Corepack repository][].
 
 Despite Corepack being distributed with default installs of Node.js, the package
 managers managed by Corepack are not part of the Node.js distribution, and
-Corepack itself will no longer be distributed with Node.js v25+.
+Corepack itself will no longer be distributed with Node.js 25+.
 
 [Corepack repository]: https://github.com/nodejs/corepack


### PR DESCRIPTION
The generic "future versions of" Node.js is causing a confusion among corepack users.
Example https://github.com/nodejs/corepack/issues/688#issuecomment-2778719004

This PR explicitly changes it to v25+ as agreed in TSC vote in https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616