### PR TITLE
build: commit some android build and test fixtures

### DIFF
--- a/android-patches/common.gypi.patch
+++ b/android-patches/common.gypi.patch
@@ -1,0 +1,18 @@
+diff --git a/common.gypi b/common.gypi
+index 5e39ad3f09..1e535f48a8 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -520,11 +520,11 @@
+           }],
+           ['_toolset=="host"', {
+             'conditions': [
+-              [ 'host_arch=="ia32"', {
++              [ 'host_arch=="ia32" or (target_arch=="ia32" or target_arch=="arm")', {
+                 'cflags': [ '-m32' ],
+                 'ldflags': [ '-m32' ],
+               }],
+-              [ 'host_arch=="x64"', {
++              [ 'host_arch=="x64" and (target_arch=="x64" or target_arch=="arm64")', {
+                 'cflags': [ '-m64' ],
+                 'ldflags': [ '-m64' ],
+               }],

--- a/android-patches/trap-handler.h.patch
+++ b/android-patches/trap-handler.h.patch
@@ -1,26 +1,50 @@
---- trap-handler.h	2022-08-11 09:01:23.384000000 +0800
-+++ fixed-trap-handler.h	2022-08-11 09:09:15.352000000 +0800
-@@ -17,23 +17,7 @@
+diff --git a/deps/v8/src/trap-handler/trap-handler.h b/deps/v8/src/trap-handler/trap-handler.h
+index 74967a00c1..d4f3b40269 100644
+--- a/deps/v8/src/trap-handler/trap-handler.h
++++ b/deps/v8/src/trap-handler/trap-handler.h
+@@ -17,45 +17,7 @@ namespace v8 {
  namespace internal {
  namespace trap_handler {
- 
+
 -// X64 on Linux, Windows, MacOS, FreeBSD.
 -#if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
 -    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN || \
 -     V8_OS_FREEBSD)
 -#define V8_TRAP_HANDLER_SUPPORTED true
--// Arm64 (non-simulator) on Mac.
--#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && V8_OS_DARWIN
+-// Arm64 (non-simulator) on Mac and Linux.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && \
+-    (V8_OS_DARWIN || (V8_OS_LINUX && !V8_OS_ANDROID))
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// Arm64 simulator on x64 on Linux, Mac, or Windows.
+-//
+-// The simulator case uses some inline assembly code, which cannot be
+-// compiled with MSVC, so don't enable the trap handler in that case.
+-// (MSVC #defines _MSC_VER, but so does Clang when targeting Windows, hence
+-// the check for __clang__.)
 -#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && \
--    (V8_OS_LINUX || V8_OS_DARWIN)
+-    (V8_OS_LINUX || V8_OS_DARWIN || V8_OS_WIN) && \
+-    (!defined(_MSC_VER) || defined(__clang__))
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Loong64 (non-simulator) on Linux.
+-#elif V8_TARGET_ARCH_LOONG64 && V8_HOST_ARCH_LOONG64 && V8_OS_LINUX
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Loong64 simulator on x64 on Linux
+-#elif V8_TARGET_ARCH_LOONG64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// RISCV64 (non-simulator) on Linux.
+-#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_RISCV64 && V8_OS_LINUX && \
+-    !V8_OS_ANDROID
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// RISCV64 simulator on x64 on Linux
+-#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
 -#define V8_TRAP_HANDLER_VIA_SIMULATOR
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// Everything else is unsupported.
 -#else
  #define V8_TRAP_HANDLER_SUPPORTED false
 -#endif
- 
- // Setup for shared library export.
- #if defined(BUILDING_V8_SHARED) && defined(V8_OS_WIN)
+
+ #if V8_OS_ANDROID && V8_TRAP_HANDLER_SUPPORTED
+ // It would require some careful security review before the trap handler

--- a/android-patches/v8.gyp.patch
+++ b/android-patches/v8.gyp.patch
@@ -1,0 +1,19 @@
+diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+index 1dd0b971d4..36b7c704dd 100644
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -1989,12 +1989,12 @@
+             ],
+           }, { # 'OS!="win"'
+             'conditions': [
+-              ['_toolset == "host" and host_arch == "x64" or _toolset == "target" and target_arch=="x64"', {
++              ['_toolset == "host" and host_arch == "x64" and (target_arch == "x64" or target_arch == "arm64") or (_toolset == "target" and target_arch == "x64")', {
+                 'sources': [
+                   '<(V8_ROOT)/src/heap/base/asm/x64/push_registers_asm.cc',
+                 ],
+               }],
+-              ['_toolset == "host" and host_arch == "ia32" or _toolset == "target" and target_arch=="ia32"', {
++              ['_toolset == "host" and host_arch == "x64" and (target_arch == "arm" or target_arch == "ia32") or (_toolset == "target" and target_arch == "ia32")', {
+                 'sources': [
+                   '<(V8_ROOT)/src/heap/base/asm/ia32/push_registers_asm.cc',
+                 ],

--- a/android_configure.py
+++ b/android_configure.py
@@ -5,9 +5,18 @@ import os
 # TODO: In next version, it will be a JSON file listing all the patches, and then it will iterate through to apply them.
 def patch_android():
     print("- Patches List -")
-    print("[1] [deps/v8/src/trap-handler/trap-handler.h] related to https://github.com/nodejs/node/issues/36287")
+    print("[1] [common.gypi] related to cross-compiling for 32-bit architectures on 64-bit host")
+    print("[2] [deps/v8/src/trap-handler/trap-handler.h] related to https://github.com/nodejs/node/issues/36287")
+    print("[3] [tools/v8_gypfiles/v8.gyp] build correct push_registers_asm.cc when cross-compiling for 32-bit on 64-bit host")
     if platform.system() == "Linux":
-        os.system('patch -f ./deps/v8/src/trap-handler/trap-handler.h < ./android-patches/trap-handler.h.patch')
+        patches = [
+            './android-patches/common.gypi.patch',
+            './android-patches/trap-handler.h.patch',
+            './android-patches/v8.gyp.patch',
+        ]
+        for patch in patches:
+            print(f"Applying patch: {patch}")
+            os.system('patch -p1 < ' + patch)
     print("\033[92mInfo: \033[0m" + "Tried to patch.")
 
 if platform.system() != "Linux" and platform.system() != "Darwin":

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -121,6 +121,7 @@ const isFreeBSD = process.platform === 'freebsd';
 const isOpenBSD = process.platform === 'openbsd';
 const isLinux = process.platform === 'linux';
 const isMacOS = process.platform === 'darwin';
+const isAndroid = process.platform === 'android';
 const isASan = process.config.variables.asan === 1;
 const isRiscv64 = process.arch === 'riscv64';
 const isDebug = process.features.debug;
@@ -891,6 +892,7 @@ const common = {
   isLinux,
   isOpenBSD,
   isMacOS,
+  isAndroid,
   isPi,
   isSunOS,
   isWindows,

--- a/test/parallel/test-cluster-bind-privileged-port.js
+++ b/test/parallel/test-cluster-bind-privileged-port.js
@@ -26,7 +26,7 @@ const cluster = require('cluster');
 const net = require('net');
 const { readFileSync } = require('fs');
 
-if (common.isLinux) {
+if (common.isLinux || common.isAndroid) {
   try {
     const unprivilegedPortStart = parseInt(readFileSync('/proc/sys/net/ipv4/ip_unprivileged_port_start'));
     if (unprivilegedPortStart <= 42) {

--- a/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
+++ b/test/parallel/test-cluster-shared-handle-bind-privileged-port.js
@@ -37,7 +37,7 @@ if (process.getuid() === 0)
 
 // Some systems won't have port 42 set as a privileged port, in that
 // case, skip the test.
-if (common.isLinux) {
+if (common.isLinux || common.isAndroid) {
   const { readFileSync } = require('fs');
 
   try {

--- a/test/parallel/test-dgram-bind-fd.js
+++ b/test/parallel/test-dgram-bind-fd.js
@@ -77,7 +77,7 @@ const BUFFER_SIZE = 4096;
         const sendBufferSize = socket.getSendBufferSize();
 
         // note: linux will double the buffer size
-        const expectedBufferSize = common.isLinux ?
+        const expectedBufferSize = (common.isLinux || common.isAndroid) ?
           BUFFER_SIZE * 2 : BUFFER_SIZE;
         assert.strictEqual(recvBufferSize, expectedBufferSize);
         assert.strictEqual(sendBufferSize, expectedBufferSize);

--- a/test/parallel/test-dgram-membership.js
+++ b/test/parallel/test-dgram-membership.js
@@ -106,11 +106,12 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 // addSourceSpecificMembership with invalid groupAddress should throw
 {
   const socket = setup();
+  const errCode = (common.isAndroid || common.isOpenBSD || common.isFreeBSD) ? 'ENOSYS' : 'EINVAL';
   assert.throws(() => {
     socket.addSourceSpecificMembership(multicastAddress, '0');
   }, {
-    code: 'EINVAL',
-    message: 'addSourceSpecificMembership EINVAL'
+    code: errCode,
+    message: `addSourceSpecificMembership ${errCode}`
   });
   socket.close();
 }
@@ -144,11 +145,12 @@ const setup = dgram.createSocket.bind(dgram, { type: 'udp4', reuseAddr: true });
 // dropSourceSpecificMembership with invalid UDP should throw
 {
   const socket = setup();
+  const errCode = (common.isAndroid || common.isOpenBSD || common.isFreeBSD) ? 'ENOSYS' : 'EINVAL';
   assert.throws(() => {
     socket.dropSourceSpecificMembership(multicastAddress, '0');
   }, {
-    code: 'EINVAL',
-    message: 'dropSourceSpecificMembership EINVAL'
+    code: errCode,
+    message: `dropSourceSpecificMembership ${errCode}`
   });
   socket.close();
 }

--- a/test/parallel/test-dgram-socket-buffer-size.js
+++ b/test/parallel/test-dgram-socket-buffer-size.js
@@ -114,7 +114,7 @@ function getExpectedError(type) {
     socket.setSendBufferSize(10000);
 
     // note: linux will double the buffer size
-    const expectedBufferSize = common.isLinux ? 20000 : 10000;
+    const expectedBufferSize = (common.isLinux || common.isAndroid) ? 20000 : 10000;
     assert.strictEqual(socket.getRecvBufferSize(), expectedBufferSize);
     assert.strictEqual(socket.getSendBufferSize(), expectedBufferSize);
     socket.close();

--- a/test/parallel/test-fs-readfile-eof.js
+++ b/test/parallel/test-fs-readfile-eof.js
@@ -2,19 +2,19 @@
 const common = require('../common');
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
+  common.skip(`No /dev/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs/promises');
 const childType = ['child-encoding', 'child-non-encoding'];
 
 if (process.argv[2] === childType[0]) {
-  fs.readFile('/proc/self/fd/0', 'utf8').then((data) => {
+  fs.readFile('/dev/fd/0', 'utf8').then((data) => {
     process.stdout.write(data);
   });
   return;
 } else if (process.argv[2] === childType[1]) {
-  fs.readFile('/proc/self/fd/0').then((data) => {
+  fs.readFile('/dev/fd/0').then((data) => {
     process.stdout.write(data);
   });
   return;

--- a/test/parallel/test-fs-readfile-eof.js
+++ b/test/parallel/test-fs-readfile-eof.js
@@ -2,19 +2,19 @@
 const common = require('../common');
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs/promises');
 const childType = ['child-encoding', 'child-non-encoding'];
 
 if (process.argv[2] === childType[0]) {
-  fs.readFile('/dev/stdin', 'utf8').then((data) => {
+  fs.readFile('/proc/self/fd/0', 'utf8').then((data) => {
     process.stdout.write(data);
   });
   return;
 } else if (process.argv[2] === childType[1]) {
-  fs.readFile('/dev/stdin').then((data) => {
+  fs.readFile('/proc/self/fd/0').then((data) => {
     process.stdout.write(data);
   });
   return;

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -4,13 +4,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
+  common.skip(`No /dev/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  fs.readFile('/proc/self/fd/0', function(er, data) {
+  fs.readFile('/dev/fd/0', function(er, data) {
     assert.ifError(er);
     process.stdout.write(data);
   });

--- a/test/parallel/test-fs-readfile-pipe-large.js
+++ b/test/parallel/test-fs-readfile-pipe-large.js
@@ -4,13 +4,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  fs.readFile('/dev/stdin', function(er, data) {
+  fs.readFile('/proc/self/fd/0', function(er, data) {
     assert.ifError(er);
     process.stdout.write(data);
   });

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -25,13 +25,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
+  common.skip(`No /dev/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  fs.readFile('/proc/self/fd/0', common.mustSucceed((data) => {
+  fs.readFile('/dev/fd/0', common.mustSucceed((data) => {
     process.stdout.write(data);
   }));
   return;

--- a/test/parallel/test-fs-readfile-pipe.js
+++ b/test/parallel/test-fs-readfile-pipe.js
@@ -25,13 +25,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  fs.readFile('/dev/stdin', common.mustSucceed((data) => {
+  fs.readFile('/proc/self/fd/0', common.mustSucceed((data) => {
     process.stdout.write(data);
   }));
   return;

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -4,13 +4,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
+  common.skip(`No /dev/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  process.stdout.write(fs.readFileSync('/proc/self/fd/0', 'utf8'));
+  process.stdout.write(fs.readFileSync('/dev/fd/0', 'utf8'));
   return;
 }
 

--- a/test/parallel/test-fs-readfilesync-pipe-large.js
+++ b/test/parallel/test-fs-readfilesync-pipe-large.js
@@ -4,13 +4,13 @@ const common = require('../common');
 // Simulate `cat readfile.js | node readfile.js`
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 const fs = require('fs');
 
 if (process.argv[2] === 'child') {
-  process.stdout.write(fs.readFileSync('/dev/stdin', 'utf8'));
+  process.stdout.write(fs.readFileSync('/proc/self/fd/0', 'utf8'));
   return;
 }
 

--- a/test/parallel/test-fs-realpath-pipe.js
+++ b/test/parallel/test-fs-realpath-pipe.js
@@ -3,14 +3,14 @@
 const common = require('../common');
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
+  common.skip(`No /dev/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 
 const { spawnSync } = require('child_process');
 
 for (const code of [
-  `require('fs').realpath('/proc/self/fd/0', (err, resolvedPath) => {
+  `require('fs').realpath('/dev/fd/0', (err, resolvedPath) => {
     if (err) {
       console.error(err);
       process.exit(1);
@@ -20,7 +20,7 @@ for (const code of [
     }
   });`,
   `try {
-    if (require('fs').realpathSync('/proc/self/fd/0')) {
+    if (require('fs').realpathSync('/dev/fd/0')) {
       process.exit(2);
     }
   } catch (e) {

--- a/test/parallel/test-fs-realpath-pipe.js
+++ b/test/parallel/test-fs-realpath-pipe.js
@@ -3,14 +3,14 @@
 const common = require('../common');
 
 if (common.isWindows || common.isAIX || common.isIBMi)
-  common.skip(`No /dev/stdin on ${process.platform}.`);
+  common.skip(`No /proc/self/fd/0 on ${process.platform}.`);
 
 const assert = require('assert');
 
 const { spawnSync } = require('child_process');
 
 for (const code of [
-  `require('fs').realpath('/dev/stdin', (err, resolvedPath) => {
+  `require('fs').realpath('/proc/self/fd/0', (err, resolvedPath) => {
     if (err) {
       console.error(err);
       process.exit(1);
@@ -20,7 +20,7 @@ for (const code of [
     }
   });`,
   `try {
-    if (require('fs').realpathSync('/dev/stdin')) {
+    if (require('fs').realpathSync('/proc/self/fd/0')) {
       process.exit(2);
     }
   } catch (e) {

--- a/test/parallel/test-process-constants-noatime.js
+++ b/test/parallel/test-process-constants-noatime.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const assert = require('assert');
 const constants = require('fs').constants;
 
-if (common.isLinux) {
+if (common.isLinux || common.isAndroid) {
   assert('O_NOATIME' in constants);
   assert.strictEqual(constants.O_NOATIME, 0x40000);
 } else {

--- a/test/sequential/test-fs-watch.js
+++ b/test/sequential/test-fs-watch.js
@@ -37,6 +37,7 @@ if (!isMainThread) {
 
 const expectFilePath = common.isWindows ||
                        common.isLinux ||
+                       common.isAndroid ||
                        common.isMacOS ||
                        common.isAIX;
 

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1322,7 +1322,7 @@
         # Platforms that don't have Compare-And-Swap (CAS) support need to link atomic library
         # to implement atomic memory access.
         # Clang needs it for some atomic operations (https://clang.llvm.org/docs/Toolchain.html#atomics-library).
-        ['(OS=="linux" and clang==1) or (v8_current_cpu in ["mips64", "mips64el", "arm", "riscv64", "loong64"])', {
+        ['((OS=="linux" or OS=="android") and clang==1) or (v8_current_cpu in ["mips64", "mips64el", "ppc", "arm", "riscv64", "loong64"])', {
           'link_settings': {
             'libraries': ['-latomic', ],
           },
@@ -1466,6 +1466,7 @@
             '<(V8_ROOT)/src/base/platform/platform-posix.h',
             '<(V8_ROOT)/src/base/platform/platform-posix-time.cc',
             '<(V8_ROOT)/src/base/platform/platform-posix-time.h',
+            '<(V8_ROOT)/src/base/platform/platform-linux.h',
           ],
           'link_settings': {
             'target_conditions': [


### PR DESCRIPTION
This commit contains some test fixes as well as build fixes for Android which I have been maintaining for Termux since a few years now. The full list of patches can be found at https://github.com/termux/termux-packages/tree/master/packages/nodejs and https://github.com/termux/termux-packages/tree/master/packages/nodejs-lts Not all the patches from the above sources are being committed over here as a some off them are specific to Termux. This does not fix the builds for Android completely, I was not able to successfully build Node locally according to the build instructions for Android, but I was able to build with the patches as in the above two URLs, in a separate environment. The build scripts used to build Node can be found in build.sh in the above directories linked.

Here's a summary of what's changed:

- Older Android versions doesn't have /dev/stdin, /dev/stdout, or /dev/stderr. Although this seems to have changed now, I can see that they exist on my new phone. Anyways these are specifically listed as not being the part of the POSIX standard. https://pubs.opengroup.org/onlinepubs/9799919799/ (See 2.1.1 Requirements, the last bullet point of 4th point specifically states that these three character special files are non- standard extension). The tests making use of /dev/stdin have been modified to use /proc/self/fd/0 which is guaranteed to exist on all POSIX platforms

- Some other tests where Linux kernel behavior is different from other platforms (buffer size tests) have been patched to treat Android as Linux since Android makes use of the Linux kernel under the hood.

- tools/v8_gypfiles/toolchain.gypi adds -m32 to host build flags when compiling for 32 bit target architecture. But in common.gypi adding -m64 conflicts with it which may cause compilation errors. Having both -m32 and -m64 may raise errors that are hard to debug. This patch probably needs to be improved but works good enough for Android builds. This probably hasn't been noticed yet because cross-compilations aren't that common for other platforms, Android has no other option but to cross compile. android-patches/common.gypi.patch does fix the builds for 32-bit architectures on 64-bit host, by not not adding -m64 to host build when cross compiling for 32-bit.

- android-patches/v8.gyp.patch fixes assembly errors during cross compilation for 32-bit on 64-bit host. This patch is needed for the same reason as for the above patch

- android-patches/trap-handler.h.patch has been updated so that it applies cleanly in the new source tree.

- libuv does not implement uv_udp_set_source_membership for Android, OpenBSD and FreeBSD. So for these platforms it returns ENOSYS instead of EINVAL in tests. Tests have been patched to reflect this

Additionally, I also tried building for FreeBSD in a VM, but the builds failed because I didn't apply the patches used by FreeBSD https://github.com/freebsd/freebsd-ports/tree/main/www/node23

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
