### PR TITLE
doc: clarify examples section in REPL doc

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -911,30 +911,225 @@ possible to connect to a long-running Node.js process without restarting it.
 
 ### Examples
 
-* Running a "full-featured" (`terminal`) REPL over
-  a `net.Server` and `net.Socket` instance:
-  <https://gist.github.com/TooTallNate/2209310>.
+#### Full-featured "terminal" REPL over `net.Server` and `net.Socket`
 
-* Running a REPL instance over [`curl(1)`][]:
-  <https://gist.github.com/TooTallNate/2053342>.
+This is an example on how to run a "full-featured" (terminal) REPL using
+[`net.Server`][] and [`net.Socket`][]
 
-  **Note**: This example is intended purely for educational purposes to demonstrate how
-  Node.js REPLs can be started using different I/O streams.
-  It should **not** be used in production environments or any context where security
-  is a concern without additional protective measures.
-  If you need to implement REPLs in a real-world application, consider alternative
-  approaches that mitigate these risks, such as using secure input mechanisms and
-  avoiding open network interfaces.
+The following script starts an HTTP server on port `1337` that allows
+clients to establish socket connections to its REPL instance.
 
+```mjs
+// repl-server.js
+import repl from 'node:repl';
+import net from 'node:net';
+
+net
+  .createServer((socket) => {
+    const r = repl.start({
+      prompt: `socket ${socket.remoteAddress}:${socket.remotePort}> `,
+      input: socket,
+      output: socket,
+      terminal: true,
+      useGlobal: false,
+    });
+    r.on('exit', () => {
+      socket.end();
+    });
+    r.context.socket = socket;
+  })
+  .listen(1337);
+```
+
+```cjs
+// repl-server.js
+const repl = require('node:repl');
+const net = require('node:net');
+
+net
+  .createServer((socket) => {
+    const r = repl.start({
+      prompt: `socket ${socket.remoteAddress}:${socket.remotePort}> `,
+      input: socket,
+      output: socket,
+      terminal: true,
+      useGlobal: false,
+    });
+    r.on('exit', () => {
+      socket.end();
+    });
+    r.context.socket = socket;
+  })
+  .listen(1337);
+```
+
+While the following implements a client that can create a socket connection
+with the above defined server over port `1337`.
+
+```mjs
+// repl-client.js
+import net from 'node:net';
+import process from 'node:process';
+
+const sock = net.connect(1337);
+
+process.stdin.pipe(sock);
+sock.pipe(process.stdout);
+
+sock.on('connect', () => {
+  process.stdin.resume();
+  process.stdin.setRawMode(true);
+});
+
+sock.on('close', () => {
+  process.stdin.setRawMode(false);
+  process.stdin.pause();
+  sock.removeListener('close', done);
+});
+
+process.stdin.on('end', () => {
+  sock.destroy();
+  console.log();
+});
+
+process.stdin.on('data', (b) => {
+  if (b.length === 1 && b[0] === 4) {
+    process.stdin.emit('end');
+  }
+});
+```
+
+```cjs
+// repl-client.js
+const net = require('node:net');
+
+const sock = net.connect(1337);
+
+process.stdin.pipe(sock);
+sock.pipe(process.stdout);
+
+sock.on('connect', () => {
+  process.stdin.resume();
+  process.stdin.setRawMode(true);
+});
+
+sock.on('close', () => {
+  process.stdin.setRawMode(false);
+  process.stdin.pause();
+  sock.removeListener('close', done);
+});
+
+process.stdin.on('end', () => {
+  sock.destroy();
+  console.log();
+});
+
+process.stdin.on('data', (b) => {
+  if (b.length === 1 && b[0] === 4) {
+    process.stdin.emit('end');
+  }
+});
+```
+
+To run the example open two different terminals on your machine, start the server
+with `node repl-server.js` in one terminal and `node repl-client.js` on the other.
+
+Original code from: [gist.github.com/TooTallNate/2209310][full-featured REPL gist]
+
+#### REPL over `curl`
+
+This is an example on how to run a REPL instance over [`curl()`][]
+
+The following script starts an HTTP server on port `8000` that can accept
+a connection established via [`curl()`][].
+
+```mjs
+import http from 'node:http';
+import repl from 'node:repl';
+import { Buffer } from 'node:buffer';
+
+const buf0 = Buffer.from([0]);
+
+const server = http.createServer((req, res) => {
+  res.setHeader('content-type', 'multipart/octet-stream');
+
+  repl.start({
+    prompt: 'curl repl> ',
+    input: req,
+    output: res,
+    terminal: false,
+    useColors: true,
+    useGlobal: false,
+  });
+
+  // Hack to thread stdin and stdout
+  // simultaneously in curl's single thread
+  const iv = setInterval(() => {
+    res.write(buf0);
+  }, 100);
+
+  req.on('close', () => {
+    clearInterval(iv);
+  });
+});
+server.listen(8000);
+```
+
+```cjs
+const http = require('node:http');
+const repl = require('node:repl');
+const buf0 = Buffer.from([0]);
+
+const server = http.createServer((req, res) => {
+  res.setHeader('content-type', 'multipart/octet-stream');
+
+  repl.start({
+    prompt: 'curl repl> ',
+    input: req,
+    output: res,
+    terminal: false,
+    useColors: true,
+    useGlobal: false,
+  });
+
+  // Hack to thread stdin and stdout
+  // simultaneously in curl's single thread
+  const iv = setInterval(() => {
+    res.write(buf0);
+  }, 100);
+
+  req.on('close', () => {
+    clearInterval(iv);
+  });
+});
+server.listen(8000);
+```
+
+When the above script is running you can then use [`curl()`][] to connect to
+the server and connect to its REPL instance by running `curl -sSNT. localhost:8000`
+
+**Warning** This example is intended purely for educational purposes to demonstrate how
+Node.js REPLs can be started using different I/O streams.
+It should **not** be used in production environments or any context where security
+is a concern without additional protective measures.
+If you need to implement REPLs in a real-world application, consider alternative
+approaches that mitigate these risks, such as using secure input mechanisms and
+avoiding open network interfaces.
+
+Original code from: [gist.github.com/TooTallNate/2053342][REPL over curl gist]
+
+[REPL over curl gist]: https://gist.github.com/TooTallNate/2053342
 [TTY keybindings]: readline.md#tty-keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#event-uncaughtexception
 [`--no-experimental-repl-await`]: cli.md#--no-experimental-repl-await
 [`ERR_DOMAIN_CANNOT_SET_UNCAUGHT_EXCEPTION_CAPTURE`]: errors.md#err_domain_cannot_set_uncaught_exception_capture
 [`ERR_INVALID_REPL_INPUT`]: errors.md#err_invalid_repl_input
-[`curl(1)`]: https://curl.haxx.se/docs/manpage.html
+[`curl()`]: https://curl.haxx.se/docs/manpage.html
 [`domain`]: domain.md
 [`module.builtinModules`]: module.md#modulebuiltinmodules
+[`net.Server`]: net.md#class-netserver
+[`net.Socket`]: net.md#class-netsocket
 [`process.setUncaughtExceptionCaptureCallback()`]: process.md#processsetuncaughtexceptioncapturecallbackfn
 [`readline.InterfaceCompleter`]: readline.md#use-of-the-completer-function
 [`repl.ReplServer`]: #class-replserver
@@ -942,4 +1137,5 @@ possible to connect to a long-running Node.js process without restarting it.
 [`reverse-i-search`]: #reverse-i-search
 [`util.inspect()`]: util.md#utilinspectobject-options
 [custom evaluation functions]: #custom-evaluation-functions
+[full-featured REPL gist]: https://gist.github.com/TooTallNate/2209310
 [stream]: stream.md

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1034,7 +1034,7 @@ process.stdin.on('data', (b) => {
 To run the example open two different terminals on your machine, start the server
 with `node repl-server.js` in one terminal and `node repl-client.js` on the other.
 
-Original code from: [gist.github.com/TooTallNate/2209310][full-featured REPL gist]
+Original code from <https://gist.github.com/TooTallNate/2209310>.
 
 #### REPL over `curl`
 
@@ -1116,9 +1116,8 @@ If you need to implement REPLs in a real-world application, consider alternative
 approaches that mitigate these risks, such as using secure input mechanisms and
 avoiding open network interfaces.
 
-Original code from: [gist.github.com/TooTallNate/2053342][REPL over curl gist]
+Original code from <https://gist.github.com/TooTallNate/2053342>.
 
-[REPL over curl gist]: https://gist.github.com/TooTallNate/2053342
 [TTY keybindings]: readline.md#tty-keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#event-uncaughtexception
@@ -1137,5 +1136,4 @@ Original code from: [gist.github.com/TooTallNate/2053342][REPL over curl gist]
 [`reverse-i-search`]: #reverse-i-search
 [`util.inspect()`]: util.md#utilinspectobject-options
 [custom evaluation functions]: #custom-evaluation-functions
-[full-featured REPL gist]: https://gist.github.com/TooTallNate/2209310
 [stream]: stream.md

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -909,20 +909,22 @@ to connect to both Unix and TCP sockets.
 By starting a REPL from a Unix socket-based server instead of stdin, it is
 possible to connect to a long-running Node.js process without restarting it.
 
-For an example of running a "full-featured" (`terminal`) REPL over
-a `net.Server` and `net.Socket` instance, see:
-<https://gist.github.com/TooTallNate/2209310>.
+### Examples
 
-For an example of running a REPL instance over [`curl(1)`][], see:
-<https://gist.github.com/TooTallNate/2053342>.
+* running a "full-featured" (`terminal`) REPL over
+  a `net.Server` and `net.Socket` instance:
+  <https://gist.github.com/TooTallNate/2209310>.
 
-This example is intended purely for educational purposes to demonstrate how
-Node.js REPLs can be started using different I/O streams.
-It should **not** be used in production environments or any context where security
-is a concern without additional protective measures.
-If you need to implement REPLs in a real-world application, consider alternative
-approaches that mitigate these risks, such as using secure input mechanisms and
-avoiding open network interfaces.
+* running a REPL instance over [`curl(1)`][]:
+  <https://gist.github.com/TooTallNate/2053342>.
+
+  **Note**: This example is intended purely for educational purposes to demonstrate how
+  Node.js REPLs can be started using different I/O streams.
+  It should **not** be used in production environments or any context where security
+  is a concern without additional protective measures.
+  If you need to implement REPLs in a real-world application, consider alternative
+  approaches that mitigate these risks, such as using secure input mechanisms and
+  avoiding open network interfaces.
 
 [TTY keybindings]: readline.md#tty-keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -911,11 +911,11 @@ possible to connect to a long-running Node.js process without restarting it.
 
 ### Examples
 
-* running a "full-featured" (`terminal`) REPL over
+* Running a "full-featured" (`terminal`) REPL over
   a `net.Server` and `net.Socket` instance:
   <https://gist.github.com/TooTallNate/2209310>.
 
-* running a REPL instance over [`curl(1)`][]:
+* Running a REPL instance over [`curl(1)`][]:
   <https://gist.github.com/TooTallNate/2053342>.
 
   **Note**: This example is intended purely for educational purposes to demonstrate how

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1046,9 +1046,6 @@ a connection established via [`curl()`][].
 ```mjs
 import http from 'node:http';
 import repl from 'node:repl';
-import { Buffer } from 'node:buffer';
-
-const buf0 = Buffer.from([0]);
 
 const server = http.createServer((req, res) => {
   res.setHeader('content-type', 'multipart/octet-stream');
@@ -1061,24 +1058,14 @@ const server = http.createServer((req, res) => {
     useColors: true,
     useGlobal: false,
   });
-
-  // Hack to thread stdin and stdout
-  // simultaneously in curl's single thread
-  const iv = setInterval(() => {
-    res.write(buf0);
-  }, 100);
-
-  req.on('close', () => {
-    clearInterval(iv);
-  });
 });
+
 server.listen(8000);
 ```
 
 ```cjs
 const http = require('node:http');
 const repl = require('node:repl');
-const buf0 = Buffer.alloc(1);
 
 const server = http.createServer((req, res) => {
   res.setHeader('content-type', 'multipart/octet-stream');
@@ -1091,17 +1078,8 @@ const server = http.createServer((req, res) => {
     useColors: true,
     useGlobal: false,
   });
-
-  // Hack to thread stdin and stdout
-  // simultaneously in curl's single thread
-  const iv = setInterval(() => {
-    res.write(buf0);
-  }, 100);
-
-  req.on('close', () => {
-    clearInterval(iv);
-  });
 });
+
 server.listen(8000);
 ```
 

--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -1078,7 +1078,7 @@ server.listen(8000);
 ```cjs
 const http = require('node:http');
 const repl = require('node:repl');
-const buf0 = Buffer.from([0]);
+const buf0 = Buffer.alloc(1);
 
 const server = http.createServer((req, res) => {
   res.setHeader('content-type', 'multipart/octet-stream');
@@ -1106,7 +1106,7 @@ server.listen(8000);
 ```
 
 When the above script is running you can then use [`curl()`][] to connect to
-the server and connect to its REPL instance by running `curl -sSNT. localhost:8000`
+the server and connect to its REPL instance by running `curl --no-progress-meter -sSNT. localhost:8000`.
 
 **Warning** This example is intended purely for educational purposes to demonstrate how
 Node.js REPLs can be started using different I/O streams.


### PR DESCRIPTION
This is pretty minor, but I just figured a little bit of polishing wouldn't hurt :slightly_smiling_face: 

The current examples presented at the bottom of the REPL doc have three issues which I am trying to address here:
 - they look like they're part of the section above (on how to run multiple REPL instances in the same process) but they are not

     see the table of contents at the top of the REPL page:
    | before | after |
    |--------|--------|
    |  ![before-1](https://github.com/user-attachments/assets/53c66c4b-2138-4e48-9526-ca9ba1911a3d) (the examples are under the multiple REPL section) |   ![after-1](https://github.com/user-attachments/assets/7b7cff09-5780-4441-8484-12ee2a5e4c6c) (the examples are listed on their own) |  
    
- they link to old gists with code that uses outdates JS syntax (e.g `var`) and deprecated utilities (e.g. `new Buffer`)
 (so not something really ideal to present as an official example)

 - the alert informing readers not to use the second example in production environments can be wrongly interpreted as to refer to both examples 

    (this might be just me, but when I read the text there it really looked to me like the warning was referring to both examples and that `This example` was likely a typo and that `These examples` was supposed to be used)

    | before | after |
    |--------|--------|
    | ![before](https://github.com/user-attachments/assets/e95ea97b-c7f9-4481-87da-e08d2e0ad41a) | the warning is ananbiguously in the section specific for the example | 
    
  


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
