### PR TITLE
module: clarify esm error message in `require` calls

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -78,7 +78,7 @@ const explainCommonJSGlobalLikeNotDefinedError = (e, url) => {
     e.message += ' in ES module scope';
 
     if (StringPrototypeStartsWith(e.message, 'require ')) {
-      e.message += ', you can use import instead';
+      e.message += ', use a static or dynamic import instead.';
     }
 
     const packageConfig =

--- a/test/es-module/test-esm-undefined-cjs-global-like-variables.js
+++ b/test/es-module/test-esm-undefined-cjs-global-like-variables.js
@@ -6,7 +6,7 @@ const { pathToFileURL } = require('url');
 
 assert.rejects(
   import('data:text/javascript,require;'),
-  /require is not defined in ES module scope, you can use import instead$/
+  /require is not defined in ES module scope, use a static or dynamic import instead\.$/
 ).then(common.mustCall());
 assert.rejects(
   import('data:text/javascript,exports={};'),

--- a/test/es-module/test-typescript-eval.mjs
+++ b/test/es-module/test-typescript-eval.mjs
@@ -86,7 +86,7 @@ test('expect fail eval TypeScript CommonJS syntax with input-type module-typescr
     console.log(util.styleText('red', text));`]);
 
   strictEqual(result.stdout, '');
-  match(result.stderr, /require is not defined in ES module scope, you can use import instead/);
+  match(result.stderr, /require is not defined in ES module scope, use a static or dynamic import instead\./);
   strictEqual(result.code, 1);
 });
 

--- a/test/es-module/test-typescript-module.mjs
+++ b/test/es-module/test-typescript-module.mjs
@@ -11,7 +11,7 @@ test('expect failure of a .mts file with CommonJS syntax', async () => {
   ]);
 
   strictEqual(result.stdout, '');
-  match(result.stderr, /require is not defined in ES module scope, you can use import instead/);
+  match(result.stderr, /require is not defined in ES module scope, use a static or dynamic import instead\./);
   strictEqual(result.code, 1);
 });
 

--- a/test/parallel/test-worker-eval-typescript.js
+++ b/test/parallel/test-worker-eval-typescript.js
@@ -63,5 +63,5 @@ test('Worker eval commonjs typescript with --input-type=module-typescript', asyn
                                                                disableTypeScriptWarningFlag] });
   const [err] = await once(w, 'error');
   assert.strictEqual(err.name, 'ReferenceError');
-  assert.match(err.message, /require is not defined in ES module scope, you can use import instead/);
+  assert.match(err.message, /require is not defined in ES module scope, use a static or dynamic import instead\./);
 });


### PR DESCRIPTION
The current  error message that is thrown when an ES module calls `require` simply suggests to "use import instead" this is slightly ambiguous since in JavaScript there are two types of imports: static and dynamic. This change simply clarifies the error message by clearly suggesting to use either a static or dynamic import

If someone is interested in a before-after screenshot:
![screenshot of the error message before and after the changes](https://github.com/user-attachments/assets/9a82e46a-d4c2-43b2-8c0b-7f476ff90ce1)

Fixes https://github.com/nodejs/node/issues/40544

> [!Note]
> This PR replaces the stalled https://github.com/nodejs/node/pull/53152, that PR provided more help to the user than mine does, I however softly disagree with that approach as I think we can assume a certain level of understanding by developers of how modules work, and if they don't it should be simple enough for them to refer to the docs.
> So I am simply clarifying that both static and dynamic imports can be used here (I assume everyone knows what those are, if not, googling/mdning it should be pretty trivial) rather than throwing errors with long elaborate explanatory messages 
> If someone disagree and thinks that we should indeed provide more details to users I'm happy to try to get closer to the solution in #53152

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
