### PR TITLE
doc: add missing v0.11.15 changelog entry

### DIFF
--- a/doc/changelogs/CHANGELOG_ARCHIVE.md
+++ b/doc/changelogs/CHANGELOG_ARCHIVE.md
@@ -14,6 +14,8 @@
 </tr>
 <tr>
 <td valign="top">
+<a href="#0.11.16">0.11.16</a><br/>
+<a href="#0.11.15">0.11.15</a><br/>
 <a href="#0.11.14">0.11.14</a><br/>
 <a href="#0.11.13">0.11.13</a><br/>
 <a href="#0.11.12">0.11.12</a><br/>
@@ -177,6 +179,90 @@
   * [0.12.x](CHANGELOG_V012.md)
   * [0.10.x](CHANGELOG_V010.md)
   * [io.js](CHANGELOG_IOJS.md)
+
+<a id="0.11.16"></a>
+
+## 2015.01.29, Version 0.11.16 (Unstable)
+
+* openssl: Upgrade to 1.0.1l
+* npm: Upgrade to 2.3.0
+* url: revert support of `path` for url.format" (Julien Gilli)
+* assert: use `util.inspect()` to create error messages (cjihrig)
+* net: throw on invalid socket timeouts (cjihrig)
+* url: fix parsing of ssh urls (Evan Lucas)
+
+<a id="0.11.15"></a>
+
+## 2015.01.20, Version 0.11.15 (Unstable)
+
+* v8: Upgrade to 3.28.73
+* uv: Upgrade to 1.0.2
+* npm: Upgrade to v2.1.6
+* uv: float patch to revert tty breakage (Trevor Norris)
+* v8: re-implement debugger-agent (Fedor Indutny)
+* v8: apply floating irhydra patch (Fedor Indutny)
+* v8: fix postmortem-metadata generator (Refael Ackermann)
+* debugger: fix unhandled error in setBreakpoint (Miroslav Bajtoš)
+* async-wrap: add event hooks (Trevor Norris)
+* async-wrap: expose async-wrap as binding (Trevor Norris)
+* buffer, doc: misc. fix and cleanup (Trevor Norris)
+* buffer: add generic functions for (u)int ops (Yazhong Liu)
+* buffer: fix and cleanup fill() (Trevor Norris)
+* buffer: mv floating point read/write checks to JS (Trevor Norris)
+* build, i18n: improve Intl build, add "--with-intl" (Steven R. Loomis)
+* build: add small-icu support for binary packages (Julien Gilli)
+* build: do not generate support for libuv's probes (Julien Gilli)
+* build: i18n: add icu config options (Steven R. Loomis)
+* build: i18n: support little-endian machines (Steven Loomis)
+* build: vcbuild fix "The input line is too long." (Alexis Campailla)
+* child\_process: improve `spawn()` argument handling (cjihrig)
+* cluster: avoid race enabling debugger in worker (Timothy J Fontaine)
+* cluster: `cluster.disconnect()` should check status (Sam Roberts)
+* cluster: do not signal children in debug mode (Fedor Indutny)
+* cluster: don't assert if worker has no handles (Sam Roberts)
+* core: fix usage of `uv_cwd` (Saúl Ibarra Corretgé)
+* core: replace `uv_fs_readdir` with `uv_fs_scandir` (Saúl Ibarra Corretgé)
+* crypto: `createDiffieHellman` throw for bad args (Trevor Norris)
+* crypto: lower RSS usage for TLSCallbacks (Fedor Indutny)
+* crypto: store thread id as pointer-sized (Alexis Campailla)
+* dns: propagate domain for c-ares methods (Chris Dickinson)
+* fs: fix symlink error message (Vladimir Kurchatkin)
+* http: Improve `_addHeaderLines` method (Jackson Tian)
+* http: cleanup `setHeader()` (Trevor Norris)
+* http: rename `flush` to `flushHeaders` (Timothy J Fontaine)
+* lib,src: fix `spawnSync` ignoring its 'env' option (Juanjo)
+* modules: adding load linked modules feature (Thorsten Lorenz)
+* net: Make `server.connections` un-enumerable (Patrick Mooney)
+* net: add `pauseOnConnect` option to `createServer()` (cjihrig)
+* net: make `connect()` input validation synchronous (cjihrig)
+* node: avoid automatic microtask runs (Vladimir Kurchatkin)
+* node: fix throws before timer module is loaded (Trevor Norris)
+* openssl: fix keypress requirement in apps on win32 (Fedor Indutny)
+* path: added `parse()` and `format()` functions (Rory Bradford)
+* path: allow calling platform specific methods (Timothy J Fontaine)
+* path: don't lower-cases drive letters (Bert Belder)
+* path: refactor `normalizeArray()` (Nathan Woltman)
+* process: pid can be a string in process.kill() (Sam Roberts)
+* readline: fix performance issue when large line (Jicheng Li)
+* readline: should not require an output stream. (Julien Gilli)
+* smalloc: check if obj has external data (Vladimir Kurchatkin)
+* smalloc: don't allow to dispose typed arrays (Vladimir Kurchatkin)
+* smalloc: fix bad assert for zero length data (Trevor Norris)
+* smalloc: fix copyOnto optimization (Vladimir Kurchatkin)
+* src: all wrap's now use actual FunctionTemplate (Trevor Norris)
+* src: fix VC++ warning C4244 (Rasmus Christian Pedersen)
+* src: remove Async Listener (Trevor Norris)
+* stream: switch `_writableState.buffer` to queue (Chris Dickinson)
+* streams: make setDefaultEncoding() throw (Brian White)
+* streams: set default encoding for writable streams (Johnny Ray)
+* tls: remove `tls.createSecurePair` code deprecation (Jackson Tian)
+* tls\_wrap: ignore `ZERO_RETURN` after `close_notify` (Fedor Indutny)
+* url: change hostname regex to negate invalid chars (Jonathan Johnson)
+* url: fixed encoding for slash switching emulation. (Evan Rutledge Borden)
+* url: improve parsing speed (CGavrila)
+* url: make query() consistent (Gabriel Wicke)
+* url: support `path` for `url.format` (Yazhong Liu)
+* util: add es6 Symbol support for `util.inspect` (gyson)
 
 <a id="0.11.14"></a>
 

--- a/doc/changelogs/CHANGELOG_V012.md
+++ b/doc/changelogs/CHANGELOG_V012.md
@@ -282,6 +282,8 @@ Security Update
 
 ## 2015.11.25, Version 0.12.8 (LTS), @rvagg
 
+### Commits
+
 * \[[`d9399569bd`](https://github.com/nodejs/node/commit/d9399569bd)] - build: backport tools/release.sh (Rod Vagg) <https://github.com/nodejs/node/pull/3642>
 * \[[`78c5b4c8bd`](https://github.com/nodejs/node/commit/78c5b4c8bd)] - build: backport config for new CI infrastructure (Rod Vagg) <https://github.com/nodejs/node/pull/3642>
 * \[[`83441616a5`](https://github.com/nodejs/node/commit/83441616a5)] - build: fix --without-ssl compile time error (Ben Noordhuis) <https://github.com/nodejs/node/pull/3825>
@@ -312,6 +314,10 @@ Security Update
 * \[[`eda2560cdc`](https://github.com/nodejs/node/commit/eda2560cdc)] - doc: additional refinement to readable event (James M Snell) <https://github.com/nodejs/node-v0.x-archive/pull/25591>
 * \[[`881d9bea01`](https://github.com/nodejs/node/commit/881d9bea01)] - doc: readable event clarification (James M Snell) <https://github.com/nodejs/node-v0.x-archive/pull/25591>
 * \[[`b6378f0c75`](https://github.com/nodejs/node/commit/b6378f0c75)] - doc: stream.unshift does not reset reading state (James M Snell) <https://github.com/nodejs/node-v0.x-archive/pull/25591>
+
+<a id="0.12.7"></a>
+
+## 2015-07-09, Version 0.12.7 (Stable)
 
 ### Commits
 


### PR DESCRIPTION
https://github.com/nodejs/node/pull/57343#issuecomment-2781525987 made me notice that we don't have a changelog entry for v0.11.15, despite being a real release, with some actual changes as outlined in https://github.com/nodejs/node/releases/tag/v0.11.15.
My understanding is this is due to having been released after the io.js fork (according to Wikipedia, the fork happened on December 2024, and v0.11.15 was released by Joyent on January 2015), which I think is why we're missing the changelog entry.

https://github.com/nodejs/node/blob/000ef895d714f269c109185b869411ffebc31391/doc/CHANGELOG.ARCHIVE.md?plain=1#L1428

Since then, io.js and Node.js have merged, so I think it's time to add the missing changelog entry; if there are v0.11.14 users out there, consider updating to ~v0.11.15~ v0.11.16, it looks like a nice release, better 10 years late than never :)

Refs: https://github.com/nodejs/node/releases/tag/v0.11.15
Refs: https://github.com/nodejs/node/releases/tag/v0.11.16
Refs: https://github.com/nodejs/node/releases/tag/v0.12.7


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
