### PR TITLE
doc: list DOMException as a potential error raised by Node.js

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -4,22 +4,27 @@
 
 <!--type=misc-->
 
-Applications running in Node.js will generally experience four categories of
-errors:
+Applications running in Node.js will generally experience the following
+categories of errors:
 
 * Standard JavaScript errors such as {EvalError}, {SyntaxError}, {RangeError},
   {ReferenceError}, {TypeError}, and {URIError}.
+* Standard `DOMException`s.
 * System errors triggered by underlying operating system constraints such
   as attempting to open a file that does not exist or attempting to send data
   over a closed socket.
-* User-specified errors triggered by application code.
 * `AssertionError`s are a special class of error that can be triggered when
   Node.js detects an exceptional logic violation that should never occur. These
   are raised typically by the `node:assert` module.
+* User-specified errors triggered by application code.
 
 All JavaScript and system errors raised by Node.js inherit from, or are
 instances of, the standard JavaScript {Error} class and are guaranteed
 to provide _at least_ the properties available on that class.
+
+The [`error.message`][] property of errors raised by Node.js may be changed in
+any versions. Use [`error.code`][] to identify an error instead. For a
+`DOMException`, use [`domException.name`][] to identify its type.
 
 ## Error propagation and interception
 
@@ -4303,7 +4308,10 @@ An error occurred trying to allocate memory. This should never happen.
 [`dgram.createSocket()`]: dgram.md#dgramcreatesocketoptions-callback
 [`dgram.disconnect()`]: dgram.md#socketdisconnect
 [`dgram.remoteAddress()`]: dgram.md#socketremoteaddress
+[`domException.name`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name
 [`errno`(3) man page]: https://man7.org/linux/man-pages/man3/errno.3.html
+[`error.code`]: #errorcode
+[`error.message`]: #errormessage
 [`fs.Dir`]: fs.md#class-fsdir
 [`fs.cp()`]: fs.md#fscpsrc-dest-options-callback
 [`fs.readFileSync`]: fs.md#fsreadfilesyncpath-options


### PR DESCRIPTION
List `DOMException` as a potential error type raised by Node.js in `errors.md`, along with
standard JS error types.

This should also clarify that a change to DOMException message does not need semver-major.

Refs: https://github.com/nodejs/node/pull/57735