### PR TITLE
doc: fix deprecation type for `DEP0148`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3064,11 +3064,11 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Using a trailing `"/"` to define subpath folder mappings in the
-[subpath exports][] or [subpath imports][] fields is deprecated. Use
-[subpath patterns][] instead.
+[subpath exports][] or [subpath imports][] fields is no longer supported.
+Use [subpath patterns][] instead.
 
 ### DEP0149: `http.IncomingMessage#connection`
 


### PR DESCRIPTION
[DEP0148](https://nodejs.org/api/deprecations.html#DEP0148) is EOL since v17.0.0 but description says `Runtime`. Let's fix this.

Refs: https://github.com/nodejs/node/pull/40121