### PR TITLE
test_runner: recalculate run duration on watch restart

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -502,7 +502,10 @@ function watchFiles(testFiles, opts) {
         return; // Avoid rerunning files when file deleted
       }
     }
-
+    // Reset the root start time to recalculate the duration
+    // of the run
+    opts.root.clearStartTime();
+    // Start the test file
     if (opts.isolation === 'none') {
       PromisePrototypeThen(restartTestFile(kIsolatedProcessName), undefined, (error) => {
         triggerUncaughtException(error, true /* fromPromise */);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -504,7 +504,7 @@ function watchFiles(testFiles, opts) {
     }
     // Reset the root start time to recalculate the duration
     // of the run
-    opts.root.clearStartTime();
+    opts.root.clearExecutionTime();
     // Start the test file
     if (opts.isolation === 'none') {
       PromisePrototypeThen(restartTestFile(kIsolatedProcessName), undefined, (error) => {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -505,7 +505,7 @@ function watchFiles(testFiles, opts) {
     // Reset the root start time to recalculate the duration
     // of the run
     opts.root.clearExecutionTime();
-    // Start the test file
+    // Restart test files
     if (opts.isolation === 'none') {
       PromisePrototypeThen(restartTestFile(kIsolatedProcessName), undefined, (error) => {
         triggerUncaughtException(error, true /* fromPromise */);

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1335,6 +1335,11 @@ class Test extends AsyncResource {
     this.parent.reportStarted();
     this.reporter.start(this.nesting, this.loc, this.name);
   }
+
+  clearStartTime() {
+    this.startTime = hrtime();
+    this.endTime = null;
+  }
 }
 
 class TestHook extends Test {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1336,7 +1336,7 @@ class Test extends AsyncResource {
     this.reporter.start(this.nesting, this.loc, this.name);
   }
 
-  clearStartTime() {
+  clearExecutionTime() {
     this.startTime = hrtime();
     this.endTime = null;
   }

--- a/test/parallel/test-runner-run-watch.mjs
+++ b/test/parallel/test-runner-run-watch.mjs
@@ -189,6 +189,8 @@ async function testWatch(
   action === 'rename2' && await testRename();
   action === 'delete' && await testDelete();
   action === 'create' && await testCreate();
+
+  return runs;
 }
 
 describe('test runner watch mode', () => {
@@ -240,6 +242,20 @@ describe('test runner watch mode', () => {
     async () => {
       await testWatch({ action: 'create', fileToCreate: 'new-test-file.test.js' });
     });
+  
+  // This test is flaky by its nature as it relies on the timing of 2 different runs
+  // considering the number of digits in the duration_ms is 9 
+  // the chances of having the same duration_ms are very low
+  // but not impossible
+  // In case of costant failures, consider increasing the number of tests
+  it('should recalculate the run duration on a watch restart', async () => {
+    const testRuns = await testWatch({ file: 'test.js', fileToUpdate: 'test.js' });
+    const durations = testRuns.map((run) => {
+      const runDuration = run.match(/# duration_ms\s([\d.]+)/);
+      return runDuration
+    });
+    assert.notDeepStrictEqual(durations[0][1] , durations[1][1]);
+  });
 
   describe('test runner watch mode with different cwd', () => {
     it(

--- a/test/parallel/test-runner-run-watch.mjs
+++ b/test/parallel/test-runner-run-watch.mjs
@@ -242,9 +242,9 @@ describe('test runner watch mode', () => {
     async () => {
       await testWatch({ action: 'create', fileToCreate: 'new-test-file.test.js' });
     });
-  
+
   // This test is flaky by its nature as it relies on the timing of 2 different runs
-  // considering the number of digits in the duration_ms is 9 
+  // considering the number of digits in the duration_ms is 9
   // the chances of having the same duration_ms are very low
   // but not impossible
   // In case of costant failures, consider increasing the number of tests
@@ -252,9 +252,9 @@ describe('test runner watch mode', () => {
     const testRuns = await testWatch({ file: 'test.js', fileToUpdate: 'test.js' });
     const durations = testRuns.map((run) => {
       const runDuration = run.match(/# duration_ms\s([\d.]+)/);
-      return runDuration
+      return runDuration;
     });
-    assert.notDeepStrictEqual(durations[0][1] , durations[1][1]);
+    assert.notDeepStrictEqual(durations[0][1], durations[1][1]);
   });
 
   describe('test runner watch mode with different cwd', () => {


### PR DESCRIPTION
Re-running a test using the `--watch` flag keeps the duration unchanged across the various reruns.  
I've drafted a trivial implementation.

The test I introduced is flaky by design; I need to consider a better approach even though the number of digits is high and the likelihood of getting the same number in two consecutive runs is really low.

<img width="772" alt="image" src="https://github.com/user-attachments/assets/fad512de-ed95-468c-9ac7-b0a937f41920" />
