### PR TITLE
tools: do not use temp files when merging PRs

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -87,22 +87,18 @@ for pr in "$@"; do
     commit_body=$(git log -1 --pretty='format:%b')
     commit_head=$(grep 'Fetched commits as' output | cut -d. -f3 | xargs git rev-parse)
 
-    jq -n \
-      --arg title "${commit_title}" \
-      --arg body "${commit_body}" \
-      --arg head "${commit_head}" \
-      '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' > output.json
-    cat output.json
-    if ! gh api -X PUT "repos/${OWNER}/${REPOSITORY}/pulls/${pr}/merge" --input output.json > output; then
+    if ! commits="$(
+      jq -n \
+        --arg title "${commit_title}" \
+        --arg body "${commit_body}" \
+        --arg head "${commit_head}" \
+        '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' |\
+      gh api -X PUT "repos/${OWNER}/${REPOSITORY}/pulls/${pr}/merge" --input -\
+        --jq 'if .merged then .sha else halt_error end'
+    )"; then
       commit_queue_failed "$pr"
       continue
     fi
-    cat output
-    if ! commits="$(jq -r 'if .merged then .sha else error("not merged") end' < output)"; then
-      commit_queue_failed "$pr"
-      continue
-    fi
-    rm output.json
   fi
 
   rm output

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -88,7 +88,7 @@ for pr in "$@"; do
     commit_head=$(grep 'Fetched commits as' output | cut -d. -f3 | xargs git rev-parse)
 
     if ! commits="$(
-      jq -n \
+      jq -cn \
         --arg title "${commit_title}" \
         --arg body "${commit_body}" \
         --arg head "${commit_head}" \

--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -40,7 +40,7 @@ commit_title=$(git log -1 --pretty='format:%s')
 commit_body=$(git log -1 --pretty='format:%b')
 
 commitSHA="$(
-  jq -n \
+  jq -cn \
     --arg title "${commit_title}" \
     --arg body "${commit_body}" \
     --arg head "${commit_head}" \

--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -39,24 +39,14 @@ git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divi
 commit_title=$(git log -1 --pretty='format:%s')
 commit_body=$(git log -1 --pretty='format:%b')
 
-jq -n \
+commitSHA="$(
+  jq -n \
     --arg title "${commit_title}" \
     --arg body "${commit_body}" \
     --arg head "${commit_head}" \
-    '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' > output.json
-cat output.json
-if ! gh api -X PUT "repos/${OWNER}/${REPOSITORY}/pulls/${pr}/merge" --input output.json > output; then
-    cat output
-    echo "Failed to merge $pr"
-    rm output output.json
-    exit 1
-fi
-cat output
-if ! commits="$(jq -r 'if .merged then .sha else error("not merged") end' < output)"; then
-    echo "Failed to merge $pr"
-    rm output output.json
-    exit 1
-fi
-rm output.json output
+    '{merge_method:"squash",commit_title:$title,commit_message:$body,sha:$head}' |\
+  gh api -X PUT "repos/${OWNER}/${REPOSITORY}/pulls/${pr}/merge" --input -\
+    --jq 'if .merged then .sha else halt_error end'
+)"
 
-gh pr comment "$pr" --repo "$OWNER/$REPOSITORY" --body "Landed in $commits"
+gh pr comment "$pr" --repo "$OWNER/$REPOSITORY" --body "Landed in $commitSHA"


### PR DESCRIPTION
IIRC the script was written like this so it could work even without `set -xe` while maintaining a verbose enough output to allow debugging. However, with `set -e`, it's kind of an unnecessary step, and it's a bit annoying to have those temp files popping up when running the scripts.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
