### PR TITLE
src: remove `void*` -> `char*` -> `void*` casts

### DIFF
--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -781,9 +781,7 @@ CipherBase::UpdateResult CipherBase::Update(
   } else if (static_cast<size_t>(buf_len) != (*out)->ByteLength()) {
     std::unique_ptr<BackingStore> old_out = std::move(*out);
     *out = ArrayBuffer::NewBackingStore(env()->isolate(), buf_len);
-    memcpy(static_cast<char*>((*out)->Data()),
-           static_cast<char*>(old_out->Data()),
-           buf_len);
+    memcpy((*out)->Data(), old_out->Data(), buf_len);
   }
 
   // When in CCM mode, EVP_CipherUpdate will fail if the authentication tag is
@@ -879,9 +877,7 @@ bool CipherBase::Final(std::unique_ptr<BackingStore>* out) {
     } else if (static_cast<size_t>(out_len) != (*out)->ByteLength()) {
       std::unique_ptr<BackingStore> old_out = std::move(*out);
       *out = ArrayBuffer::NewBackingStore(env()->isolate(), out_len);
-      memcpy(static_cast<char*>((*out)->Data()),
-             static_cast<char*>(old_out->Data()),
-             out_len);
+      memcpy((*out)->Data(), old_out->Data(), out_len);
     }
 
     if (ok && kind_ == kCipher && IsAuthenticatedMode()) {
@@ -957,9 +953,7 @@ bool PublicKeyCipher::Cipher(
     *out = ArrayBuffer::NewBackingStore(env->isolate(), 0);
   } else {
     *out = ArrayBuffer::NewBackingStore(env->isolate(), buf.size());
-    memcpy(static_cast<char*>((*out)->Data()),
-           static_cast<char*>(buf.get()),
-           buf.size());
+    memcpy((*out)->Data(), buf.get(), buf.size());
   }
 
   return true;

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -101,9 +101,7 @@ std::unique_ptr<BackingStore> Node_SignFinal(Environment* env,
     if (sig_buf.len < sig->ByteLength()) {
       auto new_sig = ArrayBuffer::NewBackingStore(env->isolate(), sig_buf.len);
       if (sig_buf.len > 0) [[likely]] {
-        memcpy(static_cast<char*>(new_sig->Data()),
-               static_cast<char*>(sig->Data()),
-               sig_buf.len);
+        memcpy(new_sig->Data(), sig->Data(), sig_buf.len);
       }
       sig = std::move(new_sig);
     }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -329,9 +329,7 @@ MaybeLocal<Object> New(Isolate* isolate,
       if (actual < length) {
         std::unique_ptr<BackingStore> old_store = std::move(store);
         store = ArrayBuffer::NewBackingStore(isolate, actual);
-        memcpy(static_cast<char*>(store->Data()),
-               static_cast<char*>(old_store->Data()),
-               actual);
+        memcpy(store->Data(), old_store->Data(), actual);
       }
       Local<ArrayBuffer> buf = ArrayBuffer::New(isolate, std::move(store));
       Local<Object> obj;

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -2079,9 +2079,7 @@ void Http2Session::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
     // Shrink to the actual amount of used data.
     std::unique_ptr<BackingStore> old_bs = std::move(bs);
     bs = ArrayBuffer::NewBackingStore(env()->isolate(), nread);
-    memcpy(static_cast<char*>(bs->Data()),
-           static_cast<char*>(old_bs->Data()),
-           nread);
+    memcpy(bs->Data(), old_bs->Data(), nread);
   } else {
     // This is a very unlikely case, and should only happen if the ReadStart()
     // call in OnStreamAfterWrite() immediately provides data. If that does

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -401,7 +401,7 @@ int StreamBase::WriteString(const FunctionCallbackInfo<Value>& args) {
     // Copy partial data
     bs = ArrayBuffer::NewBackingStore(
         isolate, buf.len, BackingStoreInitializationMode::kUninitialized);
-    memcpy(static_cast<char*>(bs->Data()), buf.base, buf.len);
+    memcpy(bs->Data(), buf.base, buf.len);
     data_size = buf.len;
   } else {
     // Write it
@@ -709,9 +709,7 @@ void EmitToJSStreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf_) {
   if (static_cast<size_t>(nread) != bs->ByteLength()) {
     std::unique_ptr<BackingStore> old_bs = std::move(bs);
     bs = ArrayBuffer::NewBackingStore(isolate, nread);
-    memcpy(static_cast<char*>(bs->Data()),
-           static_cast<char*>(old_bs->Data()),
-           nread);
+    memcpy(bs->Data(), old_bs->Data(), nread);
   }
 
   stream->CallJSOnreadMethod(nread, ArrayBuffer::New(isolate, std::move(bs)));

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -760,9 +760,7 @@ void UDPWrap::OnRecv(ssize_t nread,
     CHECK_LE(static_cast<size_t>(nread), bs->ByteLength());
     std::unique_ptr<BackingStore> old_bs = std::move(bs);
     bs = ArrayBuffer::NewBackingStore(isolate, nread);
-    memcpy(static_cast<char*>(bs->Data()),
-           static_cast<char*>(old_bs->Data()),
-           nread);
+    memcpy(bs->Data(), old_bs->Data(), nread);
   }
 
   Local<Object> address;


### PR DESCRIPTION
When passing the return value of `BackingStore::Data()` as the first or second argument to `memcpy()`, it is unnecessary to cast the returned pointer to `char*`.

Refs: https://github.com/nodejs/node/pull/52292

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
