### PR TITLE
util: preserve `length` of deprecated functions

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -142,6 +142,7 @@ function pendingDeprecate(fn, msg, code) {
     emitDeprecationWarning();
     return ReflectApply(fn, this, args);
   }
+  ObjectDefineProperty(deprecated, 'length', ObjectGetOwnPropertyDescriptor(fn, 'length'));
   return deprecated;
 }
 
@@ -179,6 +180,8 @@ function deprecate(fn, msg, code, useEmitSync) {
     // constructor.
     deprecated.prototype = fn.prototype;
   }
+
+  ObjectDefineProperty(deprecated, 'length', ObjectGetOwnPropertyDescriptor(fn, 'length'));
 
   return deprecated;
 }

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -142,7 +142,12 @@ function pendingDeprecate(fn, msg, code) {
     emitDeprecationWarning();
     return ReflectApply(fn, this, args);
   }
-  ObjectDefineProperty(deprecated, 'length', ObjectGetOwnPropertyDescriptor(fn, 'length'));
+
+  ObjectDefineProperty(deprecated, 'length', {
+    __proto__: null,
+    ...ObjectGetOwnPropertyDescriptor(fn, 'length'),
+  });
+
   return deprecated;
 }
 
@@ -181,7 +186,10 @@ function deprecate(fn, msg, code, useEmitSync) {
     deprecated.prototype = fn.prototype;
   }
 
-  ObjectDefineProperty(deprecated, 'length', ObjectGetOwnPropertyDescriptor(fn, 'length'));
+  ObjectDefineProperty(deprecated, 'length', {
+    __proto__: null,
+    ...ObjectGetOwnPropertyDescriptor(fn, 'length'),
+  });
 
   return deprecated;
 }

--- a/test/parallel/test-util-deprecate.js
+++ b/test/parallel/test-util-deprecate.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 
 require('../common');
@@ -6,8 +7,26 @@ require('../common');
 
 const assert = require('assert');
 const util = require('util');
+const internalUtil = require('internal/util');
 
 const expectedWarnings = new Map();
+
+// Deprecated function length is preserved
+for (const fn of [
+  function() {},
+  function(a) {},
+  function(a, b, c) {},
+  function(...args) {},
+  function(a, b, c, ...args) {},
+  () => {},
+  (a) => {},
+  (a, b, c) => {},
+  (...args) => {},
+  (a, b, c, ...args) => {},
+]) {
+  assert.strictEqual(util.deprecate(fn).length, fn.length);
+  assert.strictEqual(internalUtil.pendingDeprecate(fn).length, fn.length);
+}
 
 // Emits deprecation only once if same function is called.
 {


### PR DESCRIPTION
More radical (and probably breaking some existing tests) solution would be wrapping original function in `Proxy` instead of separate `deprecated()` function.