### PR TITLE
http2: fix graceful session close

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1068,6 +1068,7 @@ function setupHandle(socket, type, options) {
   if (typeof options.selectPadding === 'function')
     this[kSelectPadding] = options.selectPadding;
   handle.consume(socket._handle);
+  handle.onstreamafterwrite = this[kMaybeDestroy].bind(this, null);
 
   this[kHandle] = handle;
   if (this[kNativeFields]) {
@@ -1609,11 +1610,13 @@ class Http2Session extends EventEmitter {
   // * session is closed and there are no more pending or open streams
   [kMaybeDestroy](error) {
     if (error == null) {
+      const handle = this[kHandle];
+      const hasPendingData = !!handle && handle.hasPendingData();
       const state = this[kState];
       // Do not destroy if we're not closed and there are pending/open streams
       if (!this.closed ||
           state.streams.size > 0 ||
-          state.pendingStreams.size > 0) {
+          state.pendingStreams.size > 0 || hasPendingData) {
         return;
       }
     }
@@ -3300,7 +3303,7 @@ function socketOnClose() {
     state.streams.forEach((stream) => stream.close(NGHTTP2_CANCEL));
     state.pendingStreams.forEach((stream) => stream.close(NGHTTP2_CANCEL));
     session.close();
-    session[kMaybeDestroy](err);
+    closeSession(session, NGHTTP2_NO_ERROR, err);
   }
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1068,7 +1068,7 @@ function setupHandle(socket, type, options) {
   if (typeof options.selectPadding === 'function')
     this[kSelectPadding] = options.selectPadding;
   handle.consume(socket._handle);
-  handle.onstreamafterwrite = this[kMaybeDestroy].bind(this, null);
+  handle.ongracefulclosecomplete = this[kMaybeDestroy].bind(this, null);
 
   this[kHandle] = handle;
   if (this[kNativeFields]) {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1590,6 +1590,10 @@ class Http2Session extends EventEmitter {
     if (typeof callback === 'function')
       this.once('close', callback);
     this.goaway();
+    const handle = this[kHandle];
+    if (handle) {
+      handle.setGracefulClose();
+    }
     this[kMaybeDestroy]();
   }
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -285,7 +285,7 @@
   V(onsignal_string, "onsignal")                                               \
   V(onunpipe_string, "onunpipe")                                               \
   V(onwrite_string, "onwrite")                                                 \
-  V(onstreamafterwrite_string, "onstreamafterwrite")                           \
+  V(ongracefulclosecomplete_string, "ongracefulclosecomplete")                 \
   V(openssl_error_stack, "opensslErrorStack")                                  \
   V(options_string, "options")                                                 \
   V(order_string, "order")                                                     \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -285,6 +285,7 @@
   V(onsignal_string, "onsignal")                                               \
   V(onunpipe_string, "onunpipe")                                               \
   V(onwrite_string, "onwrite")                                                 \
+  V(onstreamafterwrite_string, "onstreamafterwrite")                           \
   V(openssl_error_stack, "opensslErrorStack")                                  \
   V(options_string, "options")                                                 \
   V(order_string, "order")                                                     \

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -559,7 +559,8 @@ Http2Session::Http2Session(Http2State* http2_state,
     : AsyncWrap(http2_state->env(), wrap, AsyncWrap::PROVIDER_HTTP2SESSION),
       js_fields_(http2_state->env()->isolate()),
       session_type_(type),
-      http2_state_(http2_state) {
+      http2_state_(http2_state),
+      graceful_close_initiated_(false) {
   MakeWeak();
   statistics_.session_type = type;
   statistics_.start_time = uv_hrtime();
@@ -1759,8 +1760,7 @@ void Http2Session::HandleSettingsFrame(const nghttp2_frame* frame) {
 void Http2Session::OnStreamAfterWrite(WriteWrap* w, int status) {
   Debug(this, "write finished with status %d", status);
 
-  HandleScope scope(env()->isolate());
-  MakeCallback(env()->onstreamafterwrite_string(), 0, nullptr);
+  CheckAndNotifyJSAfterWrite();
   CHECK(is_write_in_progress());
   set_write_in_progress(false);
 
@@ -1983,8 +1983,7 @@ uint8_t Http2Session::SendPendingData() {
   if (!res.async) {
     set_write_in_progress(false);
     ClearOutgoing(res.err);
-    HandleScope scope(env()->isolate());
-    MakeCallback(env()->onstreamafterwrite_string(), 0, nullptr);
+    CheckAndNotifyJSAfterWrite();
   }
 
   MaybeStopReading();
@@ -3520,6 +3519,11 @@ void Initialize(Local<Object> target,
       "remoteSettings",
       Http2Session::RefreshSettings<nghttp2_session_get_remote_settings,
                                     false>);
+  SetProtoMethod(
+      isolate,
+      session,
+      "setGracefulClose",
+      Http2Session::SetGracefulClose);
   SetConstructorFunction(context, target, "Http2Session", session);
 
   Local<Object> constants = Object::New(isolate);
@@ -3573,6 +3577,39 @@ void Initialize(Local<Object> target,
 #ifdef NODE_DEBUG_NGHTTP2
   nghttp2_set_debug_vprintf_callback(NgHttp2Debug);
 #endif
+}
+
+void Http2Session::SetGracefulClose(const FunctionCallbackInfo<Value>& args) {
+  Http2Session* session;
+  ASSIGN_OR_RETURN_UNWRAP(&session, args.Holder());
+  CHECK_NOT_NULL(session);
+  // Set the graceful close flag
+  session->SetGracefulCloseInitiated(true);
+
+  Debug(session, "Setting graceful close initiated flag");
+}
+
+bool Http2Session::CheckAndNotifyJSAfterWrite() {
+  nghttp2_session* session = session_.get();
+
+  if (!IsGracefulCloseInitiated()) {
+    return false;
+  }
+
+  int want_write = nghttp2_session_want_write(session);
+  int want_read = nghttp2_session_want_read(session);
+  bool should_notify = (want_write == 0 && want_read == 0);
+
+  if (should_notify) {
+    Debug(this, "Notifying JS after write in graceful close mode");
+
+    // Make the callback to JavaScript
+    HandleScope scope(env()->isolate());
+    MakeCallback(env()->onstreamafterwrite_string(), 0, nullptr);
+    return true;
+  }
+
+  return false;
 }
 }  // namespace http2
 }  // namespace node

--- a/src/node_http2.cc
+++ b/src/node_http2.cc
@@ -3520,10 +3520,7 @@ void Initialize(Local<Object> target,
       Http2Session::RefreshSettings<nghttp2_session_get_remote_settings,
                                     false>);
   SetProtoMethod(
-      isolate,
-      session,
-      "setGracefulClose",
-      Http2Session::SetGracefulClose);
+      isolate, session, "setGracefulClose", Http2Session::SetGracefulClose);
   SetConstructorFunction(context, target, "Http2Session", session);
 
   Local<Object> constants = Object::New(isolate);

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -724,6 +724,7 @@ class Http2Session : public AsyncWrap,
   static void Ping(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void AltSvc(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Origin(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetGracefulClose(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   template <get_setting fn, bool local>
   static void RefreshSettings(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -786,6 +787,11 @@ class Http2Session : public AsyncWrap,
   };
 
   Statistics statistics_ = {};
+
+  bool IsGracefulCloseInitiated() const { return graceful_close_initiated_; }
+  void SetGracefulCloseInitiated(bool value) {
+    graceful_close_initiated_ = value;
+  }
 
  private:
   void EmitStatistics();
@@ -953,8 +959,13 @@ class Http2Session : public AsyncWrap,
   void CopyDataIntoOutgoing(const uint8_t* src, size_t src_length);
   void ClearOutgoing(int status);
 
+  bool CheckAndNotifyJSAfterWrite();
+
   friend class Http2Scope;
   friend class Http2StreamListener;
+
+  // Flag to indicate that JavaScript has initiated a graceful closure
+  bool graceful_close_initiated_ = false;
 };
 
 struct Http2SessionPerformanceEntryTraits {

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -712,6 +712,7 @@ class Http2Session : public AsyncWrap,
   static void Consume(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Receive(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Destroy(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void HasPendingData(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Settings(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Request(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetNextStreamID(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -735,6 +736,7 @@ class Http2Session : public AsyncWrap,
 
   BaseObjectPtr<Http2Ping> PopPing();
   bool AddPing(const uint8_t* data, v8::Local<v8::Function> callback);
+  bool HasPendingData() const;
 
   BaseObjectPtr<Http2Settings> PopSettings();
   bool AddSettings(v8::Local<v8::Function> callback);

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -961,7 +961,7 @@ class Http2Session : public AsyncWrap,
   void CopyDataIntoOutgoing(const uint8_t* src, size_t src_length);
   void ClearOutgoing(int status);
 
-  bool CheckAndNotifyJSAfterWrite();
+  void MaybeNotifyGracefulCloseComplete();
 
   friend class Http2Scope;
   friend class Http2StreamListener;

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -788,7 +788,9 @@ class Http2Session : public AsyncWrap,
 
   Statistics statistics_ = {};
 
-  bool IsGracefulCloseInitiated() const { return graceful_close_initiated_; }
+  bool IsGracefulCloseInitiated() const {
+    return graceful_close_initiated_;
+  }
   void SetGracefulCloseInitiated(bool value) {
     graceful_close_initiated_ = value;
   }

--- a/test/parallel/test-http2-session-graceful-close.js
+++ b/test/parallel/test-http2-session-graceful-close.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const h2 = require('http2');
+
+const server = h2.createServer();
+let response;
+
+server.on('session', common.mustCall(function(session) {
+  session.on('stream', common.mustCall(function (stream) {
+    response.end();
+    session.close();
+  }));
+  session.on('close', common.mustCall(function() {
+    server.close();
+  }));
+}));
+
+server.listen(0, common.mustCall(function() {
+  const port = server.address().port;
+  server.once('request', common.mustCall(function (request, resp) {
+    response = resp;
+  }));
+
+  const url = `http://localhost:${port}`;
+  const client = h2.connect(url, common.mustCall(function() {
+    const headers = {
+      ':path': '/',
+      ':method': 'GET',
+      ':scheme': 'http',
+      ':authority': `localhost:${port}`
+    };
+    const request = client.request(headers);
+    request.on('response', common.mustCall(function(headers) {
+      assert.strictEqual(headers[':status'], 200);
+    }, 1));
+    request.on('end', common.mustCall(function() {
+      client.close();
+    }));
+    request.end();
+    request.resume();
+  }));
+  client.on('goaway', common.mustCallAtLeast(1));
+}));

--- a/test/parallel/test-http2-session-graceful-close.js
+++ b/test/parallel/test-http2-session-graceful-close.js
@@ -10,10 +10,10 @@ const server = h2.createServer();
 let session;
 
 server.on('session', common.mustCall(function(s) {
-    session = s;
-    session.on('close', common.mustCall(function() {
-        server.close();
-    }));
+  session = s;
+  session.on('close', common.mustCall(function() {
+    server.close();
+  }));
 }));
 
 server.listen(0, common.mustCall(function() {
@@ -41,8 +41,8 @@ server.listen(0, common.mustCall(function() {
 }));
 
 server.once('request', common.mustCall(function(request, response) {
-    response.on('finish', common.mustCall(function() {
-        session.close();
-    }));
-    response.end();
+  response.on('finish', common.mustCall(function() {
+    session.close();
+  }));
+  response.end();
 }));

--- a/test/parallel/test-http2-session-graceful-close.js
+++ b/test/parallel/test-http2-session-graceful-close.js
@@ -7,23 +7,17 @@ const assert = require('assert');
 const h2 = require('http2');
 
 const server = h2.createServer();
-let response;
+let session;
 
-server.on('session', common.mustCall(function(session) {
-  session.on('stream', common.mustCall(function (stream) {
-    response.end();
-    session.close();
-  }));
-  session.on('close', common.mustCall(function() {
-    server.close();
-  }));
+server.on('session', common.mustCall(function(s) {
+    session = s;
+    session.on('close', common.mustCall(function() {
+        server.close();
+    }));
 }));
 
 server.listen(0, common.mustCall(function() {
   const port = server.address().port;
-  server.once('request', common.mustCall(function (request, resp) {
-    response = resp;
-  }));
 
   const url = `http://localhost:${port}`;
   const client = h2.connect(url, common.mustCall(function() {
@@ -44,4 +38,11 @@ server.listen(0, common.mustCall(function() {
     request.resume();
   }));
   client.on('goaway', common.mustCallAtLeast(1));
+}));
+
+server.once('request', common.mustCall(function(request, response) {
+    response.on('finish', common.mustCall(function() {
+        session.close();
+    }));
+    response.end();
 }));


### PR DESCRIPTION
Fix issue where session.close() prematurely destroys the session when response.end() was called with an empty payload while active http2 streams still existed. This change ensures that sessions are closed gracefully only after all http2 streams complete and clients properly receive the GOAWAY frame as per the HTTP/2 spec.

Refs: https://nodejs.org/api/http2.html\#http2sessionclosecallback
Fixes: #57809 

## Update:
Please refer detailed explanation below to know the intention behind updating `test/parallel/test-http2-client-rststream-before-connect.js` test.
https://github.com/nodejs/node/pull/57808#issuecomment-2799023031