### PR TITLE
doc: clarify Corepack removal in v25+

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -12,7 +12,7 @@ added:
 
 > Stability: 1 - Experimental
 
-Corepack is no longer be distributed with Node.js 25+.
-Please refer to [Corepack repository][] for documentation.
+Corepack is no longer distributed with Node.js 25+.
+Please refer to the [Corepack repository][] for documentation.
 
 [Corepack repository]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -12,10 +12,7 @@ added:
 
 > Stability: 1 - Experimental
 
-Documentation for this tool can be found on the [Corepack repository][].
-
-Despite Corepack being distributed with default installs of Node.js, the package
-managers managed by Corepack are not part of the Node.js distribution, and
-Corepack itself will no longer be distributed with Node.js 25+.
+Corepack is no longer be distributed with Node.js.
+Please refer to [Corepack repository][] for documentation.
 
 [Corepack repository]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -10,7 +10,7 @@ added:
   - v14.19.0
 -->
 
-> Stability: 1 - Experimental
+> Stability: 0 - Deprecated
 
 Corepack is no longer distributed with Node.js 25+.
 Please refer to the [Corepack repository][] for documentation.

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -12,7 +12,7 @@ added:
 
 > Stability: 1 - Experimental
 
-Corepack is no longer be distributed with Node.js.
+Corepack is no longer be distributed with Node.js 25+.
 Please refer to [Corepack repository][] for documentation.
 
 [Corepack repository]: https://github.com/nodejs/corepack


### PR DESCRIPTION
Alternative to https://github.com/nodejs/node/pull/57663

This preserves the existing documentation page for corepack which has backlinks from all over the internet.
It can be removed close to April 2028, after corepack is completely removed from all Node.js versions.

Refs:
* https://github.com/nodejs/node/pull/57663#issuecomment-2766906437
* https://github.com/nodejs/node/pull/57663#issuecomment-2788722443