### PR TITLE
crypto: revert dangerous uses of std::string_view

### DIFF
--- a/deps/ncrypto/engine.cc
+++ b/deps/ncrypto/engine.cc
@@ -44,15 +44,15 @@ ENGINE* EnginePointer::release() {
   return ret;
 }
 
-EnginePointer EnginePointer::getEngineByName(const std::string_view name,
+EnginePointer EnginePointer::getEngineByName(const char* name,
                                              CryptoErrorList* errors) {
   MarkPopErrorOnReturn mark_pop_error_on_return(errors);
-  EnginePointer engine(ENGINE_by_id(name.data()));
+  EnginePointer engine(ENGINE_by_id(name));
   if (!engine) {
     // Engine not found, try loading dynamically.
     engine = EnginePointer(ENGINE_by_id("dynamic"));
     if (engine) {
-      if (!ENGINE_ctrl_cmd_string(engine.get(), "SO_PATH", name.data(), 0) ||
+      if (!ENGINE_ctrl_cmd_string(engine.get(), "SO_PATH", name, 0) ||
           !ENGINE_ctrl_cmd_string(engine.get(), "LOAD", nullptr, 0)) {
         engine.reset();
       }
@@ -73,10 +73,10 @@ bool EnginePointer::init(bool finish_on_exit) {
   return ENGINE_init(engine) == 1;
 }
 
-EVPKeyPointer EnginePointer::loadPrivateKey(const std::string_view key_name) {
+EVPKeyPointer EnginePointer::loadPrivateKey(const char* key_name) {
   if (engine == nullptr) return EVPKeyPointer();
   return EVPKeyPointer(
-      ENGINE_load_private_key(engine, key_name.data(), nullptr, nullptr));
+      ENGINE_load_private_key(engine, key_name, nullptr, nullptr));
 }
 
 void EnginePointer::initEnginesOnce() {

--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -1325,7 +1325,7 @@ X509Pointer X509Pointer::PeerFrom(const SSLPointer& ssl) {
 // When adding or removing errors below, please also update the list in the API
 // documentation. See the "OpenSSL Error Codes" section of doc/api/errors.md
 // Also *please* update the respective section in doc/api/tls.md as well
-std::string_view X509Pointer::ErrorCode(int32_t err) {  // NOLINT(runtime/int)
+const char* X509Pointer::ErrorCode(int32_t err) {  // NOLINT(runtime/int)
 #define CASE(CODE)                                                             \
   case X509_V_ERR_##CODE:                                                      \
     return #CODE;
@@ -1363,7 +1363,7 @@ std::string_view X509Pointer::ErrorCode(int32_t err) {  // NOLINT(runtime/int)
   return "UNSPECIFIED";
 }
 
-std::optional<std::string_view> X509Pointer::ErrorReason(int32_t err) {
+std::optional<const char*> X509Pointer::ErrorReason(int32_t err) {
   if (err == X509_V_OK) return std::nullopt;
   return X509_verify_cert_error_string(err);
 }
@@ -1419,9 +1419,8 @@ BIOPointer BIOPointer::New(const void* data, size_t len) {
   return BIOPointer(BIO_new_mem_buf(data, len));
 }
 
-BIOPointer BIOPointer::NewFile(std::string_view filename,
-                               std::string_view mode) {
-  return BIOPointer(BIO_new_file(filename.data(), mode.data()));
+BIOPointer BIOPointer::NewFile(const char* filename, const char* mode) {
+  return BIOPointer(BIO_new_file(filename, mode));
 }
 
 BIOPointer BIOPointer::NewFp(FILE* fd, int close_flag) {
@@ -1703,17 +1702,17 @@ DataPointer DHPointer::stateless(const EVPKeyPointer& ourKey,
 // ============================================================================
 // KDF
 
-const EVP_MD* getDigestByName(const std::string_view name) {
+const EVP_MD* getDigestByName(const char* name) {
   // Historically, "dss1" and "DSS1" were DSA aliases for SHA-1
   // exposed through the public API.
-  if (name == "dss1" || name == "DSS1") [[unlikely]] {
+  if (strcmp(name, "dss1") == 0 || strcmp(name, "DSS1") == 0) [[unlikely]] {
     return EVP_sha1();
   }
-  return EVP_get_digestbyname(name.data());
+  return EVP_get_digestbyname(name);
 }
 
-const EVP_CIPHER* getCipherByName(const std::string_view name) {
-  return EVP_get_cipherbyname(name.data());
+const EVP_CIPHER* getCipherByName(const char* name) {
+  return EVP_get_cipherbyname(name);
 }
 
 bool checkHkdfLength(const Digest& md, size_t length) {
@@ -2560,8 +2559,7 @@ SSLPointer SSLPointer::New(const SSLCtxPointer& ctx) {
   return SSLPointer(SSL_new(ctx.get()));
 }
 
-void SSLPointer::getCiphers(
-    std::function<void(const std::string_view)> cb) const {
+void SSLPointer::getCiphers(std::function<void(const char*)> cb) const {
   if (!ssl_) return;
   STACK_OF(SSL_CIPHER)* ciphers = SSL_get_ciphers(get());
 
@@ -2626,7 +2624,7 @@ std::optional<uint32_t> SSLPointer::verifyPeerCertificate() const {
   return std::nullopt;
 }
 
-const std::string_view SSLPointer::getClientHelloAlpn() const {
+const char* SSLPointer::getClientHelloAlpn() const {
   if (ssl_ == nullptr) return {};
 #ifndef OPENSSL_IS_BORINGSSL
   const unsigned char* buf;
@@ -2651,7 +2649,7 @@ const std::string_view SSLPointer::getClientHelloAlpn() const {
 #endif
 }
 
-const std::string_view SSLPointer::getClientHelloServerName() const {
+const char* SSLPointer::getClientHelloServerName() const {
   if (ssl_ == nullptr) return {};
 #ifndef OPENSSL_IS_BORINGSSL
   const unsigned char* buf;
@@ -2794,10 +2792,10 @@ bool SSLCtxPointer::setGroups(const char* groups) {
   return SSL_CTX_set1_groups_list(get(), groups) == 1;
 }
 
-bool SSLCtxPointer::setCipherSuites(std::string_view ciphers) {
+bool SSLCtxPointer::setCipherSuites(const char* ciphers) {
 #ifndef OPENSSL_IS_BORINGSSL
   if (!ctx_) return false;
-  return SSL_CTX_set_ciphersuites(ctx_.get(), ciphers.data());
+  return SSL_CTX_set_ciphersuites(ctx_.get(), ciphers);
 #else
   // BoringSSL does not allow API config of TLS 1.3 cipher suites.
   // We treat this as a non-op.
@@ -2807,8 +2805,8 @@ bool SSLCtxPointer::setCipherSuites(std::string_view ciphers) {
 
 // ============================================================================
 
-const Cipher Cipher::FromName(std::string_view name) {
-  return Cipher(EVP_get_cipherbyname(name.data()));
+const Cipher Cipher::FromName(const char* name) {
+  return Cipher(EVP_get_cipherbyname(name));
 }
 
 const Cipher Cipher::FromNid(int nid) {
@@ -2922,7 +2920,7 @@ std::string_view Cipher::getModeLabel() const {
   return "{unknown}";
 }
 
-std::string_view Cipher::getName() const {
+const char* Cipher::getName() const {
   if (!cipher_) return {};
   // OBJ_nid2sn(EVP_CIPHER_nid(cipher)) is used here instead of
   // EVP_CIPHER_name(cipher) for compatibility with BoringSSL.
@@ -3839,7 +3837,7 @@ DataPointer Cipher::recover(const EVPKeyPointer& key,
 namespace {
 struct CipherCallbackContext {
   Cipher::CipherNameCallback cb;
-  void operator()(std::string_view name) { cb(name); }
+  void operator()(const char* name) { cb(name); }
 };
 
 #if OPENSSL_VERSION_MAJOR >= 3
@@ -3918,10 +3916,10 @@ int Ec::getCurve() const {
   return EC_GROUP_get_curve_name(getGroup());
 }
 
-int Ec::GetCurveIdFromName(std::string_view name) {
-  int nid = EC_curve_nist2nid(name.data());
+int Ec::GetCurveIdFromName(const char* name) {
+  int nid = EC_curve_nist2nid(name);
   if (nid == NID_undef) {
-    nid = OBJ_sn2nid(name.data());
+    nid = OBJ_sn2nid(name);
   }
   return nid;
 }
@@ -4294,7 +4292,7 @@ const Digest Digest::SHA256 = Digest(EVP_sha256());
 const Digest Digest::SHA384 = Digest(EVP_sha384());
 const Digest Digest::SHA512 = Digest(EVP_sha512());
 
-const Digest Digest::FromName(std::string_view name) {
+const Digest Digest::FromName(const char* name) {
   return ncrypto::getDigestByName(name);
 }
 

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -272,7 +272,7 @@ class Digest final {
   static const Digest SHA384;
   static const Digest SHA512;
 
-  static const Digest FromName(std::string_view name);
+  static const Digest FromName(const char* name);
 
  private:
   const EVP_MD* md_ = nullptr;
@@ -306,7 +306,7 @@ class Cipher final {
   int getKeyLength() const;
   int getBlockSize() const;
   std::string_view getModeLabel() const;
-  std::string_view getName() const;
+  const char* getName() const;
 
   bool isGcmMode() const;
   bool isWrapMode() const;
@@ -323,11 +323,11 @@ class Cipher final {
                  unsigned char* key,
                  unsigned char* iv) const;
 
-  static const Cipher FromName(std::string_view name);
+  static const Cipher FromName(const char* name);
   static const Cipher FromNid(int nid);
   static const Cipher FromCtx(const CipherCtxPointer& ctx);
 
-  using CipherNameCallback = std::function<void(std::string_view name)>;
+  using CipherNameCallback = std::function<void(const char* name)>;
 
   // Iterates the known ciphers if the underlying implementation
   // is able to do so.
@@ -469,9 +469,9 @@ class Ec final {
   inline operator bool() const { return ec_ != nullptr; }
   inline operator OSSL3_CONST EC_KEY*() const { return ec_; }
 
-  static int GetCurveIdFromName(std::string_view name);
+  static int GetCurveIdFromName(const char* name);
 
-  using GetCurveCallback = std::function<bool(std::string_view)>;
+  using GetCurveCallback = std::function<bool(const char*)>;
   static bool GetCurves(GetCurveCallback callback);
 
  private:
@@ -560,7 +560,7 @@ class BIOPointer final {
   static BIOPointer New(const BIO_METHOD* method);
   static BIOPointer New(const void* data, size_t len);
   static BIOPointer New(const BIGNUM* bn);
-  static BIOPointer NewFile(std::string_view filename, std::string_view mode);
+  static BIOPointer NewFile(const char* filename, const char* mode);
   static BIOPointer NewFp(FILE* fd, int flags);
 
   template <typename T>
@@ -933,9 +933,8 @@ class DHPointer final {
   static BignumPointer GetStandardGenerator();
 
   static BignumPointer FindGroup(
-      const std::string_view name,
-      FindGroupOption option = FindGroupOption::NONE);
-  static DHPointer FromGroup(const std::string_view name,
+      std::string_view name, FindGroupOption option = FindGroupOption::NONE);
+  static DHPointer FromGroup(std::string_view name,
                              FindGroupOption option = FindGroupOption::NONE);
 
   static DHPointer New(BignumPointer&& p, BignumPointer&& g);
@@ -1034,7 +1033,7 @@ class SSLCtxPointer final {
     SSL_CTX_set_tlsext_status_arg(get(), nullptr);
   }
 
-  bool setCipherSuites(std::string_view ciphers);
+  bool setCipherSuites(const char* ciphers);
 
   static SSLCtxPointer NewServer();
   static SSLCtxPointer NewClient();
@@ -1063,8 +1062,8 @@ class SSLPointer final {
   bool setSession(const SSLSessionPointer& session);
   bool setSniContext(const SSLCtxPointer& ctx) const;
 
-  const std::string_view getClientHelloAlpn() const;
-  const std::string_view getClientHelloServerName() const;
+  const char* getClientHelloAlpn() const;
+  const char* getClientHelloServerName() const;
 
   std::optional<const std::string_view> getServerName() const;
   X509View getCertificate() const;
@@ -1080,7 +1079,7 @@ class SSLPointer final {
 
   static std::optional<int> getSecurityLevel();
 
-  void getCiphers(std::function<void(const std::string_view)> cb) const;
+  void getCiphers(std::function<void(const char*)> cb) const;
 
   static SSLPointer New(const SSLCtxPointer& ctx);
   static std::optional<const std::string_view> GetServerName(const SSL* ssl);
@@ -1176,13 +1175,13 @@ class X509View final {
     INVALID_NAME,
     OPERATION_FAILED,
   };
-  CheckMatch checkHost(const std::string_view host,
+  CheckMatch checkHost(std::string_view host,
                        int flags,
                        DataPointer* peerName = nullptr) const;
-  CheckMatch checkEmail(const std::string_view email, int flags) const;
-  CheckMatch checkIp(const std::string_view ip, int flags) const;
+  CheckMatch checkEmail(std::string_view email, int flags) const;
+  CheckMatch checkIp(std::string_view ip, int flags) const;
 
-  using UsageCallback = std::function<void(std::string_view)>;
+  using UsageCallback = std::function<void(const char*)>;
   bool enumUsages(UsageCallback callback) const;
 
   template <typename T>
@@ -1219,8 +1218,8 @@ class X509Pointer final {
   X509View view() const;
   operator X509View() const { return view(); }
 
-  static std::string_view ErrorCode(int32_t err);
-  static std::optional<std::string_view> ErrorReason(int32_t err);
+  static const char* ErrorCode(int32_t err);
+  static std::optional<const char*> ErrorReason(int32_t err);
 
  private:
   DeleteFnPtr<X509, X509_free> cert_;
@@ -1436,7 +1435,7 @@ class EnginePointer final {
 
   bool setAsDefault(uint32_t flags, CryptoErrorList* errors = nullptr);
   bool init(bool finish_on_exit = false);
-  EVPKeyPointer loadPrivateKey(const std::string_view key_name);
+  EVPKeyPointer loadPrivateKey(const char* key_name);
 
   // Release ownership of the ENGINE* pointer.
   ENGINE* release();
@@ -1444,7 +1443,7 @@ class EnginePointer final {
   // Retrieve an OpenSSL Engine instance by name. If the name does not
   // identify a valid named engine, the returned EnginePointer will be
   // empty.
-  static EnginePointer getEngineByName(const std::string_view name,
+  static EnginePointer getEngineByName(const char* name,
                                        CryptoErrorList* errors = nullptr);
 
   // Call once when initializing OpenSSL at startup for the process.
@@ -1493,8 +1492,8 @@ Buffer<char> ExportChallenge(const char* input, size_t length);
 // ============================================================================
 // KDF
 
-const EVP_MD* getDigestByName(const std::string_view name);
-const EVP_CIPHER* getCipherByName(const std::string_view name);
+const EVP_MD* getDigestByName(const char* name);
+const EVP_CIPHER* getCipherByName(const char* name);
 
 // Verify that the specified HKDF output length is valid for the given digest.
 // The maximum length for HKDF output for a given digest is 255 times the

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -48,7 +48,7 @@ void GetCipherInfo(const FunctionCallbackInfo<Value>& args) {
   const auto cipher = ([&] {
     if (args[1]->IsString()) {
       Utf8Value name(env->isolate(), args[1]);
-      return Cipher::FromName(name.ToStringView());
+      return Cipher::FromName(*name);
     } else {
       int nid = args[1].As<Int32>()->Value();
       return Cipher::FromNid(nid);
@@ -117,7 +117,7 @@ void GetCipherInfo(const FunctionCallbackInfo<Value>& args) {
 
   if (info->Set(env->context(),
                 env->name_string(),
-                OneByteString(env->isolate(), name.data(), name.length()))
+                OneByteString(env->isolate(), name))
           .IsNothing()) {
     return;
   }
@@ -303,7 +303,7 @@ void CipherBase::New(const FunctionCallbackInfo<Value>& args) {
   new CipherBase(env, args.This(), args[0]->IsTrue() ? kCipher : kDecipher);
 }
 
-void CipherBase::CommonInit(std::string_view cipher_type,
+void CipherBase::CommonInit(const char* cipher_type,
                             const ncrypto::Cipher& cipher,
                             const unsigned char* key,
                             int key_len,
@@ -345,7 +345,7 @@ void CipherBase::CommonInit(std::string_view cipher_type,
   }
 }
 
-void CipherBase::InitIv(std::string_view cipher_type,
+void CipherBase::InitIv(const char* cipher_type,
                         const ByteSource& key_buf,
                         const ArrayBufferOrViewContents<unsigned char>& iv_buf,
                         unsigned int auth_tag_len) {
@@ -425,10 +425,10 @@ void CipherBase::InitIv(const FunctionCallbackInfo<Value>& args) {
     auth_tag_len = kNoAuthTagLength;
   }
 
-  cipher->InitIv(cipher_type.ToStringView(), key_buf, iv_buf, auth_tag_len);
+  cipher->InitIv(*cipher_type, key_buf, iv_buf, auth_tag_len);
 }
 
-bool CipherBase::InitAuthenticated(std::string_view cipher_type,
+bool CipherBase::InitAuthenticated(const char* cipher_type,
                                    int iv_len,
                                    unsigned int auth_tag_len) {
   CHECK(IsAuthenticatedMode());
@@ -939,7 +939,7 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
   Digest digest;
   if (args[offset + 2]->IsString()) {
     Utf8Value oaep_str(env->isolate(), args[offset + 2]);
-    digest = Digest::FromName(oaep_str.ToStringView());
+    digest = Digest::FromName(*oaep_str);
     if (!digest) return THROW_ERR_OSSL_EVP_INVALID_DIGEST(env);
   }
 

--- a/src/crypto/crypto_cipher.h
+++ b/src/crypto/crypto_cipher.h
@@ -43,18 +43,18 @@ class CipherBase : public BaseObject {
   };
   static const unsigned kNoAuthTagLength = static_cast<unsigned>(-1);
 
-  void CommonInit(std::string_view cipher_type,
+  void CommonInit(const char* cipher_type,
                   const ncrypto::Cipher& cipher,
                   const unsigned char* key,
                   int key_len,
                   const unsigned char* iv,
                   int iv_len,
                   unsigned int auth_tag_len);
-  void InitIv(std::string_view cipher_type,
+  void InitIv(const char* cipher_type,
               const ByteSource& key_buf,
               const ArrayBufferOrViewContents<unsigned char>& iv_buf,
               unsigned int auth_tag_len);
-  bool InitAuthenticated(std::string_view cipher_type,
+  bool InitAuthenticated(const char* cipher_type,
                          int iv_len,
                          unsigned int auth_tag_len);
   bool CheckCCMMessageLength(int message_len);

--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -1361,8 +1361,7 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
 
   CryptoErrorList errors;
   Utf8Value engine_id(env->isolate(), args[1]);
-  auto engine =
-      EnginePointer::getEngineByName(engine_id.ToStringView(), &errors);
+  auto engine = EnginePointer::getEngineByName(*engine_id, &errors);
   if (!engine) {
     Local<Value> exception;
     if (errors.empty()) {
@@ -1380,7 +1379,7 @@ void SecureContext::SetEngineKey(const FunctionCallbackInfo<Value>& args) {
   }
 
   Utf8Value key_name(env->isolate(), args[0]);
-  auto key = engine.loadPrivateKey(key_name.ToStringView());
+  auto key = engine.loadPrivateKey(*key_name);
 
   if (!key)
     return ThrowCryptoError(env, ERR_get_error(), "ENGINE_load_private_key");
@@ -1529,7 +1528,7 @@ void SecureContext::SetCipherSuites(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
   const Utf8Value ciphers(env->isolate(), args[0]);
-  if (!sc->ctx_.setCipherSuites(ciphers.ToStringView())) {
+  if (!sc->ctx_.setCipherSuites(*ciphers)) {
     return ThrowCryptoError(env, ERR_get_error(), "Failed to set ciphers");
   }
 }
@@ -1871,8 +1870,7 @@ void SecureContext::SetClientCertEngine(
 
   CryptoErrorList errors;
   const Utf8Value engine_id(env->isolate(), args[0]);
-  auto engine =
-      EnginePointer::getEngineByName(engine_id.ToStringView(), &errors);
+  auto engine = EnginePointer::getEngineByName(*engine_id, &errors);
   if (!engine) {
     Local<Value> exception;
     if (errors.empty()) {

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -540,7 +540,7 @@ Maybe<void> EcKeyGenTraits::AdditionalConfig(
   CHECK(args[*offset + 1]->IsInt32());  // param encoding
 
   Utf8Value curve_name(env->isolate(), args[*offset]);
-  params->params.curve_nid = Ec::GetCurveIdFromName(curve_name.ToStringView());
+  params->params.curve_nid = Ec::GetCurveIdFromName(*curve_name);
   if (params->params.curve_nid == NID_undef) {
     THROW_ERR_CRYPTO_INVALID_CURVE(env);
     return Nothing<void>();
@@ -827,7 +827,7 @@ KeyObjectData ImportJWKEcKey(Environment* env,
   CHECK(args[offset]->IsString());  // curve name
   Utf8Value curve(env->isolate(), args[offset].As<String>());
 
-  int nid = Ec::GetCurveIdFromName(curve.ToStringView());
+  int nid = Ec::GetCurveIdFromName(*curve);
   if (nid == NID_undef) {  // Unknown curve
     THROW_ERR_CRYPTO_INVALID_CURVE(env);
     return {};

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -203,7 +203,7 @@ const EVP_MD* GetDigestImplementation(Environment* env,
   return result.explicit_md ? result.explicit_md : result.implicit_md;
 #else
   Utf8Value utf8(env->isolate(), algorithm);
-  return ncrypto::getDigestByName(utf8.ToStringView());
+  return ncrypto::getDigestByName(*utf8);
 #endif
 }
 
@@ -448,7 +448,7 @@ Maybe<void> HashTraits::AdditionalConfig(
 
   CHECK(args[offset]->IsString());  // Hash algorithm
   Utf8Value digest(env->isolate(), args[offset]);
-  params->digest = ncrypto::getDigestByName(digest.ToStringView());
+  params->digest = ncrypto::getDigestByName(*digest);
   if (params->digest == nullptr) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
     return Nothing<void>();
@@ -518,7 +518,7 @@ void InternalVerifyIntegrity(const v8::FunctionCallbackInfo<v8::Value>& args) {
   CHECK(args[2]->IsArrayBufferView());
   ArrayBufferOrViewContents<unsigned char> expected(args[2]);
 
-  const EVP_MD* md_type = ncrypto::getDigestByName(algorithm.ToStringView());
+  const EVP_MD* md_type = ncrypto::getDigestByName(*algorithm);
   unsigned char digest[EVP_MAX_MD_SIZE];
   unsigned int digest_size;
   if (md_type == nullptr || EVP_Digest(content.data(),

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -55,7 +55,7 @@ Maybe<void> HKDFTraits::AdditionalConfig(
   CHECK(args[offset + 4]->IsUint32());  // Length
 
   Utf8Value hash(env->isolate(), args[offset]);
-  params->digest = Digest::FromName(hash.ToStringView());
+  params->digest = Digest::FromName(*hash);
   if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *hash);
     return Nothing<void>();

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -195,7 +195,7 @@ Maybe<void> HmacTraits::AdditionalConfig(
   CHECK(args[offset + 2]->IsObject());  // Key
 
   Utf8Value digest(env->isolate(), args[offset + 1]);
-  params->digest = Digest::FromName(digest.ToStringView());
+  params->digest = Digest::FromName(*digest);
   if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
     return Nothing<void>();

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -335,7 +335,7 @@ KeyObjectData::GetPrivateKeyEncodingFromJs(
     if (context != kKeyContextInput) {
       if (args[*offset]->IsString()) {
         Utf8Value cipher_name(env->isolate(), args[*offset]);
-        config.cipher = ncrypto::getCipherByName(cipher_name.ToStringView());
+        config.cipher = ncrypto::getCipherByName(*cipher_name);
         if (config.cipher == nullptr) {
           THROW_ERR_CRYPTO_UNKNOWN_CIPHER(env);
           return Nothing<EVPKeyPointer::PrivateKeyEncodingConfig>();

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -101,7 +101,7 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
   }
 
   Utf8Value name(args.GetIsolate(), args[offset + 4]);
-  params->digest = Digest::FromName(name.ToStringView());
+  params->digest = Digest::FromName(*name);
   if (!params->digest) [[unlikely]] {
     THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *name);
     return Nothing<void>();

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -141,7 +141,7 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
     if (!args[*offset]->IsUndefined()) {
       CHECK(args[*offset]->IsString());
       Utf8Value digest(env->isolate(), args[*offset]);
-      params->params.md = Digest::FromName(digest.ToStringView());
+      params->params.md = Digest::FromName(*digest);
       if (!params->params.md) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
         return Nothing<void>();
@@ -151,7 +151,7 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
     if (!args[*offset + 1]->IsUndefined()) {
       CHECK(args[*offset + 1]->IsString());
       Utf8Value digest(env->isolate(), args[*offset + 1]);
-      params->params.mgf1_md = Digest::FromName(digest.ToStringView());
+      params->params.mgf1_md = Digest::FromName(*digest);
       if (!params->params.mgf1_md) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(
             env, "Invalid MGF1 digest: %s", *digest);
@@ -277,7 +277,7 @@ Maybe<void> RSACipherTraits::AdditionalConfig(
     case kKeyVariantRSA_OAEP: {
       CHECK(args[offset + 1]->IsString());  // digest
       Utf8Value digest(env->isolate(), args[offset + 1]);
-      params->digest = Digest::FromName(digest.ToStringView());
+      params->digest = Digest::FromName(*digest);
       if (!params->digest) {
         THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
         return Nothing<void>();

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -232,7 +232,7 @@ bool UseP1363Encoding(const EVPKeyPointer& key, const DSASigEnc dsa_encoding) {
 }
 }  // namespace
 
-SignBase::Error SignBase::Init(std::string_view digest) {
+SignBase::Error SignBase::Init(const char* digest) {
   CHECK_NULL(mdctx_);
   auto md = Digest::FromName(digest);
   if (!md) [[unlikely]]
@@ -319,7 +319,7 @@ void Sign::SignInit(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&sign, args.This());
 
   const node::Utf8Value sign_type(env->isolate(), args[0]);
-  crypto::CheckThrow(env, sign->Init(sign_type.ToStringView()));
+  crypto::CheckThrow(env, sign->Init(*sign_type));
 }
 
 void Sign::SignUpdate(const FunctionCallbackInfo<Value>& args) {
@@ -429,7 +429,7 @@ void Verify::VerifyInit(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&verify, args.This());
 
   const node::Utf8Value verify_type(env->isolate(), args[0]);
-  crypto::CheckThrow(env, verify->Init(verify_type.ToStringView()));
+  crypto::CheckThrow(env, verify->Init(*verify_type));
 }
 
 void Verify::VerifyUpdate(const FunctionCallbackInfo<Value>& args) {
@@ -588,7 +588,7 @@ Maybe<void> SignTraits::AdditionalConfig(
 
   if (args[offset + 6]->IsString()) {
     Utf8Value digest(env->isolate(), args[offset + 6]);
-    params->digest = Digest::FromName(digest.ToStringView());
+    params->digest = Digest::FromName(*digest);
     if (!params->digest) [[unlikely]] {
       THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
       return Nothing<void>();

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -30,7 +30,7 @@ class SignBase : public BaseObject {
 
   SignBase(Environment* env, v8::Local<v8::Object> wrap);
 
-  Error Init(std::string_view digest);
+  Error Init(const char* digest);
   Error Update(const char* data, size_t len);
 
   // TODO(joyeecheung): track the memory used by OpenSSL types

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1868,7 +1868,7 @@ void TLSWrap::VerifyError(const FunctionCallbackInfo<Value>& args) {
                             .FromMaybe(Local<Object>());
 
   auto code = X509Pointer::ErrorCode(x509_verify_error);
-  if (Set(env, error, env->code_string(), code.data()))
+  if (Set(env, error, env->code_string(), code))
     args.GetReturnValue().Set(error);
 }
 

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -600,8 +600,7 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
   // If the engine name is not known, calling setAsDefault on the
   // empty engine pointer will be non-op that always returns false.
   args.GetReturnValue().Set(
-      EnginePointer::getEngineByName(engine_id.ToStringView())
-          .setAsDefault(flags));
+      EnginePointer::getEngineByName(*engine_id).setAsDefault(flags));
 }
 #endif  // !OPENSSL_NO_ENGINE
 


### PR DESCRIPTION
An `std::string_view v` is a `const char* v.data()` along with an `std::size_t v.size()` that guarantees that `v.size()` contiguous elements of type `char` can be accessed relative to the pointer `v.data()`.

One of the main reasons behind the existence of  `std::string_view` is the ability to operate on `char` sequences without requiring null termination, which otherwise often requires expensive copies of strings to be made. As a consequence, it is generally incorrect to assume that `v.data()` points to a null-terminated sequence of `char`, and the only way to obtain a null-terminated string from an `std::string_view` is to make a copy. It is not even possible to check if the sequence pointed to by `v.data()` is null-terminated because the null character would be at position `v.data() + v.size()`, which is outside of the range that `v` guarantees safe access to. (A default-constructed `std::string_view` even sets its own data pointer to a `nullptr`, which is fine because it only needs to guarantee safe access to zero elements, i.e., to no elements).

In `deps/ncrypto` and `src/crypto`, there are various APIs that consume `std::string_view v` arguments but then ignore `v.size()` and treat `v.data()` as a C-style string of type `const char*`. However, that is not what call sites would expect from functions that explicitly ask for `std::string_view` arguments, since it makes assumptions beyond the guarantees provided by `std::string_view` and leads to undefined behavior unless the given view either contains an embedded null character or the `char` at address `v.data() + v.size()` is a null character. This is not a reasonable assumption for `std::string_view` in general, and it also defeats the purpose of `std::string_view` for the most part since, when `v.size()` is being ignored, it is essentially just a `const char*`.

Constructing an `std::string_view` from a `const char*` is also not "free" but requires computing the length of the C-style string (unless the length can be computed at compile time, e.g., because the value is just a string literal). Repeated conversion between `const char*` as used by OpenSSL and `std::string_view` as used by ncrypto thus incurs the additional overhead of computing the length of the string whenever an `std::string_view` is constructed from a `const char*`. (This seems negligible compared to the safety argument though.)

Similarly, returning a `const char*` pointer to a C-style string as an `std::string_view` has two downsides: the function must compute the length of the string in order to construct the view, and the caller can no longer assume that the return value is null-terminated and thus cannot pass the returned view to functions that require their arguments to be null terminated. (And, for the reasons explained above, the caller also cannot check if the value is null-terminated without potentially invoking undefined behavior.)

C++20 unfortunately does not have a type similar to Rust's `CStr` or GSL `czstring`. Therefore, this commit changes many occurrences of `std::string_view` back to `const char*`, which is conventional for null-terminated C-style strings and does not require computing the length of strings.

There are _a lot_ of occurrences of `std::string_view` in ncrypto and for each one, we need to evaluate if it is safe and a good abstraction. I tried to do so, but I might have changed too few or too many, so please feel free to give feedback on individual occurrences.

cc @nodejs/cpp-reviewers

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
