### PR TITLE
src: add ExecutionAsyncId getter for any Context

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -196,6 +196,12 @@ async_id AsyncHooksGetExecutionAsyncId(Isolate* isolate) {
   return env->execution_async_id();
 }
 
+async_id AsyncHooksGetExecutionAsyncId(Local<Context> context) {
+  Environment* env = Environment::GetCurrent(context);
+  if (env == nullptr) return -1;
+  return env->execution_async_id();
+}
+
 async_id AsyncHooksGetTriggerAsyncId(Isolate* isolate) {
   Environment* env = Environment::GetCurrent(isolate);
   if (env == nullptr) return -1;

--- a/src/node.h
+++ b/src/node.h
@@ -1407,7 +1407,8 @@ NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 /* Returns the id of the specified execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
- NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Local<v8::Context> context);
+NODE_EXTERN async_id
+AsyncHooksGetExecutionAsyncId(v8::Local<v8::Context> context);
 
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_id AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);

--- a/src/node.h
+++ b/src/node.h
@@ -1404,6 +1404,11 @@ NODE_EXTERN void RequestInterrupt(Environment* env,
  * I/O from native code. */
 NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 
+/* Returns the id of the specified execution context. If the return value is
+ * zero then no execution has been set. This will happen if the user handles
+ * I/O from native code. */
+ NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Local<v8::Context> context);
+
 /* Return same value as async_hooks.triggerAsyncId(); */
 NODE_EXTERN async_id AsyncHooksGetTriggerAsyncId(v8::Isolate* isolate);
 

--- a/src/node.h
+++ b/src/node.h
@@ -1404,7 +1404,7 @@ NODE_EXTERN void RequestInterrupt(Environment* env,
  * I/O from native code. */
 NODE_EXTERN async_id AsyncHooksGetExecutionAsyncId(v8::Isolate* isolate);
 
-/* Returns the id of the specified execution context. If the return value is
+/* Returns the id of the current execution context. If the return value is
  * zero then no execution has been set. This will happen if the user handles
  * I/O from native code. */
 NODE_EXTERN async_id

--- a/test/addons/async-hooks-id/binding.cc
+++ b/test/addons/async-hooks-id/binding.cc
@@ -12,6 +12,12 @@ void GetExecutionAsyncId(const FunctionCallbackInfo<Value>& args) {
     node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()));
 }
 
+void GetExecutionAsyncIdWithContext(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(
+    node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()->GetCurrentContext()));
+}
+
+
 void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(
     node::AsyncHooksGetTriggerAsyncId(args.GetIsolate()));
@@ -19,6 +25,7 @@ void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "getExecutionAsyncId", GetExecutionAsyncId);
+  NODE_SET_METHOD(exports, "getExecutionAsyncIdWithContext", GetExecutionAsyncIdWithContext);
   NODE_SET_METHOD(exports, "getTriggerAsyncId", GetTriggerAsyncId);
 }
 

--- a/test/addons/async-hooks-id/binding.cc
+++ b/test/addons/async-hooks-id/binding.cc
@@ -13,10 +13,9 @@ void GetExecutionAsyncId(const FunctionCallbackInfo<Value>& args) {
 }
 
 void GetExecutionAsyncIdWithContext(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(
-    node::AsyncHooksGetExecutionAsyncId(args.GetIsolate()->GetCurrentContext()));
+  args.GetReturnValue().Set(node::AsyncHooksGetExecutionAsyncId(
+      args.GetIsolate()->GetCurrentContext()));
 }
-
 
 void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(
@@ -25,7 +24,9 @@ void GetTriggerAsyncId(const FunctionCallbackInfo<Value>& args) {
 
 void Initialize(Local<Object> exports) {
   NODE_SET_METHOD(exports, "getExecutionAsyncId", GetExecutionAsyncId);
-  NODE_SET_METHOD(exports, "getExecutionAsyncIdWithContext", GetExecutionAsyncIdWithContext);
+  NODE_SET_METHOD(exports,
+                  "getExecutionAsyncIdWithContext",
+                  GetExecutionAsyncIdWithContext);
   NODE_SET_METHOD(exports, "getTriggerAsyncId", GetTriggerAsyncId);
 }
 

--- a/test/addons/async-hooks-id/test.js
+++ b/test/addons/async-hooks-id/test.js
@@ -10,6 +10,10 @@ assert.strictEqual(
   async_hooks.executionAsyncId(),
 );
 assert.strictEqual(
+  binding.getExecutionAsyncIdWithContext(),
+  async_hooks.executionAsyncId(),
+);
+assert.strictEqual(
   binding.getTriggerAsyncId(),
   async_hooks.triggerAsyncId(),
 );
@@ -17,6 +21,10 @@ assert.strictEqual(
 process.nextTick(common.mustCall(() => {
   assert.strictEqual(
     binding.getExecutionAsyncId(),
+    async_hooks.executionAsyncId(),
+  );
+  assert.strictEqual(
+    binding.getExecutionAsyncIdWithContext(),
     async_hooks.executionAsyncId(),
   );
   assert.strictEqual(


### PR DESCRIPTION
Adds a variant of `node::AsyncHooksGetExecutionAsyncId` that takes a `v8::Local<v8::Context>` and returns the async ID belonging to the `node::Environment` (if any) of that Context. 

This is not dissimilar to how e.g. `node::Environment::GetCurrent` method also exists with overloads for both `v8::Isolate*` and `v8::Local<v8::Context>`.

In certain situations it would be useful to pass a Context object different from `v8::Isolate::GetCurrentContext`, e.g. the one returned by `v8::Isolate::GetEnteredOrMicrotaskContext` would be useful in recording the async ID in a V8 GC prologue callback when current context is not set.