### PR TITLE
doc: clarify future Corepack removal in v25+

### DIFF
--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -12,10 +12,8 @@ added:
 
 > Stability: 1 - Experimental
 
-Documentation for this tool can be found on the [Corepack repository][].
+**Corepack will no longer be distributed with Node.js 25+.**
+Users currently depending on the `corepack` from Node.js should switch
+to using the userland-provided [corepack][] module instead.
 
-Despite Corepack being distributed with default installs of Node.js, the package
-managers managed by Corepack are not part of the Node.js distribution, and
-Corepack itself will no longer be distributed with Node.js 25+.
-
-[Corepack repository]: https://github.com/nodejs/corepack
+[corepack]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -15,6 +15,6 @@ added:
 **Corepack will no longer be distributed starting with Node.js v25.**
 
 Users currently depending on the bundled `corepack` module from Node.js
-should switch to using the userland-provided [corepack][] module instead.
+can switch to using the userland-provided [corepack][] module.
 
 [corepack]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -12,7 +12,7 @@ added:
 
 > Stability: 1 - Experimental
 
-**Corepack will no longer be distributed with Node.js 25+.**
+**Corepack will no longer be distributed starting with Node.js v25.**
 
 Users currently depending on the bundled `corepack` module from Node.js
 should switch to using the userland-provided [corepack][] module instead.

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -14,7 +14,7 @@ added:
 
 **Corepack will no longer be distributed starting with Node.js v25.**
 
-Users currently depending on the bundled `corepack` module from Node.js
+Users currently depending on the bundled `corepack` executable from Node.js
 can switch to using the userland-provided [corepack][] module.
 
 [corepack]: https://github.com/nodejs/corepack

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -13,6 +13,7 @@ added:
 > Stability: 1 - Experimental
 
 **Corepack will no longer be distributed with Node.js 25+.**
+
 Users currently depending on the bundled `corepack` module from Node.js
 should switch to using the userland-provided [corepack][] module instead.
 

--- a/doc/api/corepack.md
+++ b/doc/api/corepack.md
@@ -13,7 +13,7 @@ added:
 > Stability: 1 - Experimental
 
 **Corepack will no longer be distributed with Node.js 25+.**
-Users currently depending on the `corepack` from Node.js should switch
-to using the userland-provided [corepack][] module instead.
+Users currently depending on the bundled `corepack` module from Node.js
+should switch to using the userland-provided [corepack][] module instead.
 
 [corepack]: https://github.com/nodejs/corepack


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/node/pull/57747

This highlights the removal, and gives a call to action for existing users.
This is similar to the documentation for punycode https://nodejs.org/api/punycode.html