### PR TITLE
util: fix formatting of objects with built-in Symbol.toPrimitive

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -436,7 +436,7 @@ corresponding argument. Supported specifiers are:
 
 * `%s`: `String` will be used to convert all values except `BigInt`, `Object`
   and `-0`. `BigInt` values will be represented with an `n` and Objects that
-  have no user defined `toString` function are inspected using `util.inspect()`
+  have neither a user defined `toString` function nor `Symbol.toPrimitive` function are inspected using `util.inspect()`
   with options `{ depth: 0, colors: false, compact: 3 }`.
 * `%d`: `Number` will be used to convert all values except `BigInt` and
   `Symbol`.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2160,19 +2160,18 @@ function hasBuiltInToString(value) {
     }
     value = proxyTarget;
   }
-
-  // Check if value has a custom Symbol.toPrimitive transformation.
-  if (typeof value[SymbolToPrimitive] === 'function') {
-    return false;
-  }
-
-  // Count objects that have no `toString` function as built-in.
-  if (typeof value.toString !== 'function') {
+  // Count objects that have neither a `toString` function nor a `Symbol.toPrimitive` function.
+  if (typeof value.toString !== 'function' && typeof value[SymbolToPrimitive] !== 'function') {
     return true;
   }
 
   // The object has a own `toString` property. Thus it's not not a built-in one.
   if (ObjectPrototypeHasOwnProperty(value, 'toString')) {
+    return false;
+  }
+
+  // The object has a own `Symbol.toPrimitive` property. Thus it's not not a built-in one.
+  if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
     return false;
   }
 

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2160,18 +2160,23 @@ function hasBuiltInToString(value) {
     }
     value = proxyTarget;
   }
+
+  let hasOwnToString = ObjectPrototypeHasOwnProperty;
+  let hasOwnToPrimitive = ObjectPrototypeHasOwnProperty;
+
   // Count objects without `toString` and `Symbol.toPrimitive` function as built-in.
-  if (typeof value.toString !== 'function' && typeof value[SymbolToPrimitive] !== 'function') {
-    return true;
-  }
-
-  // The object has a own `toString` property. Thus it's not not a built-in one.
-  if (ObjectPrototypeHasOwnProperty(value, 'toString')) {
+  if (typeof value.toString !== 'function') {
+    if (typeof value[SymbolToPrimitive] !== 'function') {
+      return true;
+    } else if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
+      return false;
+    }
+    hasOwnToString = returnFalse;
+  } else if (ObjectPrototypeHasOwnProperty(value, 'toString')) {
     return false;
-  }
-
-  // The object has a own `Symbol.toPrimitive` property. Thus it's not not a built-in one.
-  if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
+  } else if (typeof value[SymbolToPrimitive] !== 'function') {
+    hasOwnToPrimitive = returnFalse;
+  } else if (ObjectPrototypeHasOwnProperty(value, SymbolToPrimitive)) {
     return false;
   }
 
@@ -2180,14 +2185,18 @@ function hasBuiltInToString(value) {
   let pointer = value;
   do {
     pointer = ObjectGetPrototypeOf(pointer);
-  } while (!ObjectPrototypeHasOwnProperty(pointer, 'toString') &&
-    !ObjectPrototypeHasOwnProperty(pointer, SymbolToPrimitive));
+  } while (!hasOwnToString(pointer, 'toString') &&
+    !hasOwnToPrimitive(pointer, SymbolToPrimitive));
 
   // Check closer if the object is a built-in.
   const descriptor = ObjectGetOwnPropertyDescriptor(pointer, 'constructor');
   return descriptor !== undefined &&
     typeof descriptor.value === 'function' &&
     builtInObjects.has(descriptor.value.name);
+}
+
+function returnFalse() {
+  return false;
 }
 
 const firstErrorLine = (error) => StringPrototypeSplit(error.message, '\n', 1)[0];

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2160,7 +2160,7 @@ function hasBuiltInToString(value) {
     }
     value = proxyTarget;
   }
-  // Count objects that have neither a `toString` function nor a `Symbol.toPrimitive` function.
+  // Count objects without `toString` and `Symbol.toPrimitive` function as built-in.
   if (typeof value.toString !== 'function' && typeof value[SymbolToPrimitive] !== 'function') {
     return true;
   }
@@ -2175,12 +2175,13 @@ function hasBuiltInToString(value) {
     return false;
   }
 
-  // Find the object that has the `toString` property as own property in the
-  // prototype chain.
+  // Find the object that has the `toString` property or `Symbol.toPrimitive` property
+  // as own property in the prototype chain.
   let pointer = value;
   do {
     pointer = ObjectGetPrototypeOf(pointer);
-  } while (!ObjectPrototypeHasOwnProperty(pointer, 'toString'));
+  } while (!ObjectPrototypeHasOwnProperty(pointer, 'toString') &&
+    !ObjectPrototypeHasOwnProperty(pointer, SymbolToPrimitive));
 
   // Check closer if the object is a built-in.
   const descriptor = ObjectGetOwnPropertyDescriptor(pointer, 'constructor');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -294,6 +294,9 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
 {
   const date = new Date('2023-10-01T00:00:00Z');
   assert.strictEqual(util.format('%s', date), util.inspect(date));
+
+  const symbol = Symbol('foo');
+  assert.strictEqual(util.format('%s', symbol), util.inspect(symbol));
 }
 
 // JSON format specifier

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -290,6 +290,12 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   assert.strictEqual(util.format('%s', objectWithToPrimitive + ''), 'default context');
 }
 
+// built-in toPrimitive is the same behavior as inspect
+{
+  const date = new Date('2023-10-01T00:00:00Z');
+  assert.strictEqual(util.format('%s', date), util.inspect(date));
+}
+
 // JSON format specifier
 assert.strictEqual(util.format('%j'), '%j');
 assert.strictEqual(util.format('%j', 42), '42');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -299,6 +299,28 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   assert.strictEqual(util.format('%s', symbol), util.inspect(symbol));
 }
 
+{
+  function hasToStringButNoToPrimitive() {}
+
+  hasToStringButNoToPrimitive.prototype.toString = function() {
+    return 'hasToStringButNoToPrimitive';
+  };
+
+  const obj = new hasToStringButNoToPrimitive();
+  assert.strictEqual(util.format('%s', obj.toString()), 'hasToStringButNoToPrimitive');
+}
+
+{
+  function hasToPrimitiveButNoToString() {}
+
+  hasToPrimitiveButNoToString.prototype[Symbol.toPrimitive] = function() {
+    return 'hasToPrimitiveButNoToString';
+  };
+
+  const obj = new hasToPrimitiveButNoToString();
+  assert.strictEqual(util.format('%s', obj[Symbol.toPrimitive]()), 'hasToPrimitiveButNoToString');
+}
+
 // JSON format specifier
 assert.strictEqual(util.format('%j'), '%j');
 assert.strictEqual(util.format('%j', 42), '42');

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -306,7 +306,13 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
     return 'hasToStringButNoToPrimitive';
   };
 
-  const obj = new hasToStringButNoToPrimitive();
+  let obj = new hasToStringButNoToPrimitive();
+  assert.strictEqual(util.format('%s', obj.toString()), 'hasToStringButNoToPrimitive');
+
+  function inheritsFromHasToStringButNoToPrimitive() {}
+  Object.setPrototypeOf(inheritsFromHasToStringButNoToPrimitive.prototype,
+                        hasToStringButNoToPrimitive.prototype);
+  obj = new inheritsFromHasToStringButNoToPrimitive();
   assert.strictEqual(util.format('%s', obj.toString()), 'hasToStringButNoToPrimitive');
 }
 
@@ -317,8 +323,30 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
     return 'hasToPrimitiveButNoToString';
   };
 
-  const obj = new hasToPrimitiveButNoToString();
+  let obj = new hasToPrimitiveButNoToString();
   assert.strictEqual(util.format('%s', obj[Symbol.toPrimitive]()), 'hasToPrimitiveButNoToString');
+  function inheritsFromHasToPrimitiveButNoToString() {}
+  Object.setPrototypeOf(inheritsFromHasToPrimitiveButNoToString.prototype,
+                        hasToPrimitiveButNoToString.prototype);
+  obj = new inheritsFromHasToPrimitiveButNoToString();
+  assert.strictEqual(util.format('%s', obj[Symbol.toPrimitive]()), 'hasToPrimitiveButNoToString');
+}
+
+{
+  function hasBothToStringAndToPrimitive() {}
+  hasBothToStringAndToPrimitive.prototype.toString = function() {
+    return 'toString';
+  };
+  hasBothToStringAndToPrimitive.prototype[Symbol.toPrimitive] = function() {
+    return 'toPrimitive';
+  };
+  let obj = new hasBothToStringAndToPrimitive();
+  assert.strictEqual(util.format('%s', obj.toString()), 'toString');
+  function inheritsFromHasBothToStringAndToPrimitive() {}
+  Object.setPrototypeOf(inheritsFromHasBothToStringAndToPrimitive.prototype,
+                        hasBothToStringAndToPrimitive.prototype);
+  obj = new inheritsFromHasBothToStringAndToPrimitive();
+  assert.strictEqual(util.format('%s', obj.toString()), 'toString');
 }
 
 // JSON format specifier

--- a/test/parallel/test-util-format.js
+++ b/test/parallel/test-util-format.js
@@ -299,6 +299,7 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   assert.strictEqual(util.format('%s', symbol), util.inspect(symbol));
 }
 
+// Prototype chain handling for toString
 {
   function hasToStringButNoToPrimitive() {}
 
@@ -316,6 +317,7 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   assert.strictEqual(util.format('%s', obj.toString()), 'hasToStringButNoToPrimitive');
 }
 
+// Prototype chain handling for Symbol.toPrimitive
 {
   function hasToPrimitiveButNoToString() {}
 
@@ -332,6 +334,7 @@ assert.strictEqual(util.format('%s', -Infinity), '-Infinity');
   assert.strictEqual(util.format('%s', obj[Symbol.toPrimitive]()), 'hasToPrimitiveButNoToString');
 }
 
+// Prototype chain handling for both toString and Symbol.toPrimitive
 {
   function hasBothToStringAndToPrimitive() {}
   hasBothToStringAndToPrimitive.prototype.toString = function() {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/57818

Imo, built-in [Symbol.toPrimitive] can make use of inspect, just like built-in toString, because for built-in objects like Symbol and Date, their [Symbol.toPrimitive] and toString() return the same result.


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
