### PR TITLE
node-api: convert NewEnv to node_napi_env__::New

### DIFF
--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -9,6 +9,10 @@
 #include "util-inl.h"
 
 struct node_napi_env__ : public napi_env__ {
+  static napi_env New(v8::Local<v8::Context> context,
+                      const std::string& module_filename,
+                      int32_t module_api_version);
+
   node_napi_env__(v8::Local<v8::Context> context,
                   const std::string& module_filename,
                   int32_t module_api_version);


### PR DESCRIPTION
Convert local `v8impl::NewEnv` function to the `node_napi_env__::New` method.
The new method helps creating new Node-API environment by any code that includes the `node_api_internals.h` header file.
There are no changes to the function bodies except for moving them to the top of the file.
The `ThrowNodeApiVersionError` had to be moved because the node_napi_env__::New uses it.

This change is required for the new C-based Node.js embedding API - PR #54660.
Since the PR #54660 is too big, it was decided in a Node-API meeting to split it up into smaller PRs.
This is the first PR in the series.