### PR TITLE
crypto: fix misleading positional argument

### DIFF
--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -112,21 +112,21 @@ function getUIntOption(options, key) {
   return -1;
 }
 
-function createCipherBase(cipher, credential, options, decipher, iv) {
+function createCipherBase(cipher, credential, options, isEncrypt, iv) {
   const authTagLength = getUIntOption(options, 'authTagLength');
-  this[kHandle] = new CipherBase(decipher);
+  this[kHandle] = new CipherBase(isEncrypt);
   this[kHandle].initiv(cipher, credential, iv, authTagLength);
   this._decoder = null;
 
   ReflectApply(LazyTransform, this, [options]);
 }
 
-function createCipherWithIV(cipher, key, options, decipher, iv) {
+function createCipherWithIV(cipher, key, options, isEncrypt, iv) {
   validateString(cipher, 'cipher');
   const encoding = getStringOption(options, 'encoding');
   key = prepareSecretKey(key, encoding);
   iv = iv === null ? null : getArrayBufferOrView(iv, 'iv');
-  ReflectApply(createCipherBase, this, [cipher, key, options, decipher, iv]);
+  ReflectApply(createCipherBase, this, [cipher, key, options, isEncrypt, iv]);
 }
 
 // The Cipher class is part of the legacy Node.js crypto API. It exposes


### PR DESCRIPTION
The fourth positional argument of `createCipherBase` is `true` when called from within the `Cipheriv` constructor and `false`when called from within the `Decipheriv` constructor. This value is then passed to the `CipherBase::New()` method, which treats it as follows:

    args[0]->IsTrue() ? kCipher : kDecipher

However, the current name of said positional argument is `decipher` and thus indicates the exact opposite: when the argument is set to true, the instance is *not* a `Decipheriv` object. Therefore, this commit renames the argument to `isEncrypt`, which matches the actual semantics.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
