### PR TITLE
libnode: Added C FFI compatible function to act as an entrypoint for embedded consumers

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1557,3 +1557,7 @@ void Initialize() {}
 
 NODE_BINDING_CONTEXT_AWARE_INTERNAL(inspector, Initialize)
 #endif  // !HAVE_INSPECTOR
+
+extern "C" int node_start(int argc, char** argv) {
+  return node::Start(argc, argv); 
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

# Motivation

Hi all,

I have been working on embedding Nodejs in my Rust application to act as a plugin runtime however, while `libnode` exposes a C++ API, it does not work with consumers that only have access to C FFI calls (like Rust).

# Changes

- Added `node_start()` function in `node.cc` to proxy `node::Start()`
  - Enables C bindings to be written for Nodejs 

# Examples

[I created a repo](https://github.com/alshdavid/libnode) that patches nodejs to add this function, generate static binaries (under GitHub releases) and offers a Rust crate that provides bindings. So far, all I need is this one function added to `node.cc`.

Usage:

```rust
use libnode_rs;

pub fn main() -> std::io::Result<()> {
  // Register a napi module and inject it into the JavaScript runtime
  libnode_rs::napi_module_register("my_native_extension", |env, exports| exports);

  libnode_rs::eval_blocking(r"
    console.log('Hello World')
    console.log(process._linkedBinding('my_native_extension'))
  ")
}
```

CC: https://github.com/nodejs/node/issues/52289