### PR TITLE
doc: increase z-index of header element

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -820,7 +820,7 @@ kbd {
 .header {
   position: sticky;
   top: -1px;
-  z-index: 2;
+  z-index: 10;
   padding-top: 1rem;
   background-color: var(--color-fill-app);
 }

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -821,7 +821,7 @@ kbd {
 .header {
   position: sticky;
   top: -1px;
-  z-index: 1;
+  z-index: 2;
   padding-top: 1rem;
   background-color: var(--color-fill-app);
 }

--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -220,7 +220,6 @@ li.picker-header.expanded > .picker,
 :root:not(.has-js) li.picker-header:focus-within > .picker,
 :root:not(.has-js) li.picker-header:hover > .picker {
   display: block;
-  z-index: 1;
 }
 
 li.picker-header a span {


### PR DESCRIPTION
increase the z-index of the header element to make sure that opened pickers from it (such as the node verion picker) are on top of other content

___

This is addressing a minor issue I just noticed when reading the docs, the header pickers can be covered by api stability banners, for example go to  https://nodejs.org/docs/latest/api/repl.html open the nodejs versions picker and while the picker is open scroll down till the REPL section and you should see the following:

![Screenshot of the issue in nodejs.org/docs](https://github.com/user-attachments/assets/8fbfef4d-7c5d-49ba-b78b-d9434b2f1707)

with my change the picker remains on top:

![Screenshot of the issue solved in localhost:8000](https://github.com/user-attachments/assets/55661f35-13be-4e4c-9a4b-9ede13e3d94e)



<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
