### PR TITLE
repl: fix multiline history editing string order

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -467,9 +467,15 @@ class Interface extends InterfaceConstructor {
   }
 
   // Convert newlines to a consistent format for history storage
-  [kNormalizeHistoryLineEndings](line, from, to) {
+  [kNormalizeHistoryLineEndings](line, from, to, reverse = true) {
     // Multiline history entries are saved reversed
-    if (StringPrototypeIncludes(line, '\r')) {
+    // History is structured with the newest entries at the top
+    // and the oldest at the bottom. Multiline histories, however, only occupy
+    // one line in the history file. When loading multiline history with
+    // an old node binary, the history will be saved in the old format.
+    // This is why we need to reverse the multilines.
+    // Reversing the multilines is necessary when adding / editing and displaying them
+    if (reverse) {
       // First reverse the lines for proper order, then convert separators
       return ArrayPrototypeJoin(
         ArrayPrototypeReverse(StringPrototypeSplit(line, from)),
@@ -488,7 +494,7 @@ class Interface extends InterfaceConstructor {
 
     // If the trimmed line is empty then return the line
     if (StringPrototypeTrim(this.line).length === 0) return this.line;
-    const normalizedLine = this[kNormalizeHistoryLineEndings](this.line, '\n', '\r');
+    const normalizedLine = this[kNormalizeHistoryLineEndings](this.line, '\n', '\r', false);
 
     if (this.history.length === 0 || this.history[0] !== normalizedLine) {
       if (this[kLastCommandErrored] && this.historyIndex === 0) {


### PR DESCRIPTION
fixing an issue introduced in the last commit of https://github.com/nodejs/node/pull/57400:  
when editing a multiline history in REPL, the string gets reversed.

Added relevant automated tests