### PR TITLE
assert,util: fix constructor lookup in deep equal comparison

### DIFF
--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -10,6 +10,7 @@ const notCircular = {};
 notCircular.circular = {};
 
 const primValues = {
+  'null_prototype': { __proto__: null },
   'string': 'abcdef',
   'number': 1_000,
   'boolean': true,
@@ -24,6 +25,7 @@ const primValues = {
 };
 
 const primValues2 = {
+  'null_prototype': { __proto__: null },
   'object': { property: 'abcdef' },
   'array': [1, 2, 3],
   'set_object': new Set([[1]]),
@@ -35,6 +37,7 @@ const primValues2 = {
 };
 
 const primValuesUnequal = {
+  'null_prototype': { __proto__: { __proto__: null } },
   'string': 'abcdez',
   'number': 1_001,
   'boolean': false,

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -1,14 +1,32 @@
 'use strict';
 
 const {
+  Array,
+  ArrayBuffer,
   ArrayIsArray,
   ArrayPrototypeFilter,
   ArrayPrototypePush,
+  BigInt,
+  BigInt64Array,
   BigIntPrototypeValueOf,
+  BigUint64Array,
+  Boolean,
   BooleanPrototypeValueOf,
+  DataView,
+  Date,
   DatePrototypeGetTime,
   Error,
+  Float16Array,
+  Float32Array,
+  Float64Array,
+  Function,
+  Int16Array,
+  Int32Array,
+  Int8Array,
+  Map,
+  Number,
   NumberPrototypeValueOf,
+  Object,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertySymbols: getOwnSymbols,
   ObjectGetPrototypeOf,
@@ -17,18 +35,65 @@ const {
   ObjectPrototypeHasOwnProperty: hasOwn,
   ObjectPrototypePropertyIsEnumerable: hasEnumerable,
   ObjectPrototypeToString,
+  Promise,
+  RegExp,
   SafeSet,
+  Set,
+  String,
   StringPrototypeValueOf,
+  Symbol,
   SymbolPrototypeValueOf,
   TypedArrayPrototypeGetByteLength: getByteLength,
   TypedArrayPrototypeGetSymbolToStringTag,
+  Uint16Array,
+  Uint32Array,
   Uint8Array,
+  Uint8ClampedArray,
+  WeakMap,
+  WeakSet,
 } = primordials;
 
 const { compare } = internalBinding('buffer');
 const assert = require('internal/assert');
 const { isURL } = require('internal/url');
 const { isError } = require('internal/util');
+const { Buffer } = require('buffer');
+
+const wellKnownConstructors = new SafeSet();
+wellKnownConstructors.add(Array);
+wellKnownConstructors.add(ArrayBuffer);
+wellKnownConstructors.add(BigInt);
+wellKnownConstructors.add(BigInt64Array);
+wellKnownConstructors.add(BigUint64Array);
+wellKnownConstructors.add(Boolean);
+wellKnownConstructors.add(Buffer);
+wellKnownConstructors.add(DataView);
+wellKnownConstructors.add(Date);
+wellKnownConstructors.add(Error);
+if (Float16Array) { // TODO(BridgeAR): Remove when regularly supported
+  wellKnownConstructors.add(Float16Array);
+}
+wellKnownConstructors.add(Float32Array);
+wellKnownConstructors.add(Float64Array);
+wellKnownConstructors.add(Function);
+wellKnownConstructors.add(Int16Array);
+wellKnownConstructors.add(Int32Array);
+wellKnownConstructors.add(Int8Array);
+wellKnownConstructors.add(Map);
+wellKnownConstructors.add(Number);
+wellKnownConstructors.add(Object);
+wellKnownConstructors.add(Promise);
+wellKnownConstructors.add(RegExp);
+wellKnownConstructors.add(Set);
+wellKnownConstructors.add(String);
+wellKnownConstructors.add(Symbol);
+wellKnownConstructors.add(Uint16Array);
+wellKnownConstructors.add(Uint32Array);
+wellKnownConstructors.add(Uint8Array);
+wellKnownConstructors.add(Uint8ClampedArray);
+wellKnownConstructors.add(WeakMap);
+wellKnownConstructors.add(WeakSet);
+
 const types = require('internal/util/types');
 const {
   isAnyArrayBuffer,
@@ -198,11 +263,15 @@ function innerDeepEqual(val1, val2, mode, memos) {
 }
 
 function objectComparisonStart(val1, val2, mode, memos) {
-  if (mode === kStrict &&
-      (val1.constructor !== val2.constructor ||
-        (val1.constructor === undefined &&
-          ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2)))) {
-    return false;
+  if (mode === kStrict) {
+    if (wellKnownConstructors.has(val1.constructor) ||
+        (val1.constructor !== undefined && !hasOwn(val1, 'constructor'))) {
+      if (val1.constructor !== val2.constructor) {
+        return false;
+      }
+    } else if (ObjectGetPrototypeOf(val1) !== ObjectGetPrototypeOf(val2)) {
+      return false;
+    }
   }
 
   const val1Tag = ObjectPrototypeToString(val1);

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -16,7 +16,6 @@ const {
   Date,
   DatePrototypeGetTime,
   Error,
-  Float16Array,
   Float32Array,
   Float64Array,
   Function,
@@ -51,6 +50,7 @@ const {
   Uint8ClampedArray,
   WeakMap,
   WeakSet,
+  globalThis: { Float16Array },
 } = primordials;
 
 const { compare } = internalBinding('buffer');
@@ -59,40 +59,41 @@ const { isURL } = require('internal/url');
 const { isError } = require('internal/util');
 const { Buffer } = require('buffer');
 
-const wellKnownConstructors = new SafeSet();
-wellKnownConstructors.add(Array);
-wellKnownConstructors.add(ArrayBuffer);
-wellKnownConstructors.add(BigInt);
-wellKnownConstructors.add(BigInt64Array);
-wellKnownConstructors.add(BigUint64Array);
-wellKnownConstructors.add(Boolean);
-wellKnownConstructors.add(Buffer);
-wellKnownConstructors.add(DataView);
-wellKnownConstructors.add(Date);
-wellKnownConstructors.add(Error);
+const wellKnownConstructors = new SafeSet()
+  .add(Array)
+  .add(ArrayBuffer)
+  .add(BigInt)
+  .add(BigInt64Array)
+  .add(BigUint64Array)
+  .add(Boolean)
+  .add(Buffer)
+  .add(DataView)
+  .add(Date)
+  .add(Error)
+  .add(Float32Array)
+  .add(Float64Array)
+  .add(Function)
+  .add(Int16Array)
+  .add(Int32Array)
+  .add(Int8Array)
+  .add(Map)
+  .add(Number)
+  .add(Object)
+  .add(Promise)
+  .add(RegExp)
+  .add(Set)
+  .add(String)
+  .add(Symbol)
+  .add(Uint16Array)
+  .add(Uint32Array)
+  .add(Uint8Array)
+  .add(Uint8ClampedArray)
+  .add(WeakMap)
+  .add(WeakSet);
+
 if (Float16Array) { // TODO(BridgeAR): Remove when regularly supported
   wellKnownConstructors.add(Float16Array);
 }
-wellKnownConstructors.add(Float32Array);
-wellKnownConstructors.add(Float64Array);
-wellKnownConstructors.add(Function);
-wellKnownConstructors.add(Int16Array);
-wellKnownConstructors.add(Int32Array);
-wellKnownConstructors.add(Int8Array);
-wellKnownConstructors.add(Map);
-wellKnownConstructors.add(Number);
-wellKnownConstructors.add(Object);
-wellKnownConstructors.add(Promise);
-wellKnownConstructors.add(RegExp);
-wellKnownConstructors.add(Set);
-wellKnownConstructors.add(String);
-wellKnownConstructors.add(Symbol);
-wellKnownConstructors.add(Uint16Array);
-wellKnownConstructors.add(Uint32Array);
-wellKnownConstructors.add(Uint8Array);
-wellKnownConstructors.add(Uint8ClampedArray);
-wellKnownConstructors.add(WeakMap);
-wellKnownConstructors.add(WeakSet);
 
 const types = require('internal/util/types');
 const {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -625,24 +625,24 @@ function isInstanceof(object, proto) {
 }
 
 // Special-case for some builtin prototypes in case their `constructor` property has been tampered.
-const wellKnownPrototypes = new SafeMap();
-wellKnownPrototypes.set(ArrayPrototype, { name: 'Array', constructor: Array });
-wellKnownPrototypes.set(ArrayBufferPrototype, { name: 'ArrayBuffer', constructor: ArrayBuffer });
-wellKnownPrototypes.set(FunctionPrototype, { name: 'Function', constructor: Function });
-wellKnownPrototypes.set(MapPrototype, { name: 'Map', constructor: Map });
-wellKnownPrototypes.set(SetPrototype, { name: 'Set', constructor: Set });
-wellKnownPrototypes.set(ObjectPrototype, { name: 'Object', constructor: Object });
-wellKnownPrototypes.set(TypedArrayPrototype, { name: 'TypedArray', constructor: TypedArray });
-wellKnownPrototypes.set(RegExpPrototype, { name: 'RegExp', constructor: RegExp });
-wellKnownPrototypes.set(DatePrototype, { name: 'Date', constructor: Date });
-wellKnownPrototypes.set(DataViewPrototype, { name: 'DataView', constructor: DataView });
-wellKnownPrototypes.set(ErrorPrototype, { name: 'Error', constructor: Error });
-wellKnownPrototypes.set(BooleanPrototype, { name: 'Boolean', constructor: Boolean });
-wellKnownPrototypes.set(NumberPrototype, { name: 'Number', constructor: Number });
-wellKnownPrototypes.set(StringPrototype, { name: 'String', constructor: String });
-wellKnownPrototypes.set(PromisePrototype, { name: 'Promise', constructor: Promise });
-wellKnownPrototypes.set(WeakMapPrototype, { name: 'WeakMap', constructor: WeakMap });
-wellKnownPrototypes.set(WeakSetPrototype, { name: 'WeakSet', constructor: WeakSet });
+const wellKnownPrototypes = new SafeMap()
+  .set(ArrayPrototype, { name: 'Array', constructor: Array })
+  .set(ArrayBufferPrototype, { name: 'ArrayBuffer', constructor: ArrayBuffer })
+  .set(FunctionPrototype, { name: 'Function', constructor: Function })
+  .set(MapPrototype, { name: 'Map', constructor: Map })
+  .set(SetPrototype, { name: 'Set', constructor: Set })
+  .set(ObjectPrototype, { name: 'Object', constructor: Object })
+  .set(TypedArrayPrototype, { name: 'TypedArray', constructor: TypedArray })
+  .set(RegExpPrototype, { name: 'RegExp', constructor: RegExp })
+  .set(DatePrototype, { name: 'Date', constructor: Date })
+  .set(DataViewPrototype, { name: 'DataView', constructor: DataView })
+  .set(ErrorPrototype, { name: 'Error', constructor: Error })
+  .set(BooleanPrototype, { name: 'Boolean', constructor: Boolean })
+  .set(NumberPrototype, { name: 'Number', constructor: Number })
+  .set(StringPrototype, { name: 'String', constructor: String })
+  .set(PromisePrototype, { name: 'Promise', constructor: Promise })
+  .set(WeakMapPrototype, { name: 'WeakMap', constructor: WeakMap })
+  .set(WeakSetPrototype, { name: 'WeakSet', constructor: WeakSet });
 
 function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   let firstProto;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -20,10 +20,18 @@ const {
   ArrayPrototypeSplice,
   ArrayPrototypeUnshift,
   BigIntPrototypeValueOf,
+  Boolean,
+  BooleanPrototype,
   BooleanPrototypeValueOf,
+  DataView,
+  DataViewPrototype,
+  Date,
+  DatePrototype,
   DatePrototypeGetTime,
   DatePrototypeToISOString,
   DatePrototypeToString,
+  Error,
+  ErrorPrototype,
   ErrorPrototypeToString,
   Function,
   FunctionPrototype,
@@ -47,6 +55,7 @@ const {
   NumberIsNaN,
   NumberParseFloat,
   NumberParseInt,
+  NumberPrototype,
   NumberPrototypeToString,
   NumberPrototypeValueOf,
   Object,
@@ -63,9 +72,12 @@ const {
   ObjectPrototypePropertyIsEnumerable,
   ObjectSeal,
   ObjectSetPrototypeOf,
+  Promise,
+  PromisePrototype,
   ReflectApply,
   ReflectOwnKeys,
   RegExp,
+  RegExpPrototype,
   RegExpPrototypeExec,
   RegExpPrototypeSymbolReplace,
   RegExpPrototypeSymbolSplit,
@@ -78,6 +90,7 @@ const {
   SetPrototypeGetSize,
   SetPrototypeValues,
   String,
+  StringPrototype,
   StringPrototypeCharCodeAt,
   StringPrototypeCodePointAt,
   StringPrototypeEndsWith,
@@ -106,6 +119,10 @@ const {
   TypedArrayPrototypeGetLength,
   TypedArrayPrototypeGetSymbolToStringTag,
   Uint8Array,
+  WeakMap,
+  WeakMapPrototype,
+  WeakSet,
+  WeakSetPrototype,
   globalThis,
   uncurryThis,
 } = primordials;
@@ -613,16 +630,26 @@ wellKnownPrototypes.set(ArrayPrototype, { name: 'Array', constructor: Array });
 wellKnownPrototypes.set(ArrayBufferPrototype, { name: 'ArrayBuffer', constructor: ArrayBuffer });
 wellKnownPrototypes.set(FunctionPrototype, { name: 'Function', constructor: Function });
 wellKnownPrototypes.set(MapPrototype, { name: 'Map', constructor: Map });
-wellKnownPrototypes.set(ObjectPrototype, { name: 'Object', constructor: Object });
 wellKnownPrototypes.set(SetPrototype, { name: 'Set', constructor: Set });
+wellKnownPrototypes.set(ObjectPrototype, { name: 'Object', constructor: Object });
 wellKnownPrototypes.set(TypedArrayPrototype, { name: 'TypedArray', constructor: TypedArray });
+wellKnownPrototypes.set(RegExpPrototype, { name: 'RegExp', constructor: RegExp });
+wellKnownPrototypes.set(DatePrototype, { name: 'Date', constructor: Date });
+wellKnownPrototypes.set(DataViewPrototype, { name: 'DataView', constructor: DataView });
+wellKnownPrototypes.set(ErrorPrototype, { name: 'Error', constructor: Error });
+wellKnownPrototypes.set(BooleanPrototype, { name: 'Boolean', constructor: Boolean });
+wellKnownPrototypes.set(NumberPrototype, { name: 'Number', constructor: Number });
+wellKnownPrototypes.set(StringPrototype, { name: 'String', constructor: String });
+wellKnownPrototypes.set(PromisePrototype, { name: 'Promise', constructor: Promise });
+wellKnownPrototypes.set(WeakMapPrototype, { name: 'WeakMap', constructor: WeakMap });
+wellKnownPrototypes.set(WeakSetPrototype, { name: 'WeakSet', constructor: WeakSet });
 
 function getConstructorName(obj, ctx, recurseTimes, protoProps) {
   let firstProto;
   const tmp = obj;
   while (obj || isUndetectableObject(obj)) {
     const wellKnownPrototypeNameAndConstructor = wellKnownPrototypes.get(obj);
-    if (wellKnownPrototypeNameAndConstructor != null) {
+    if (wellKnownPrototypeNameAndConstructor !== undefined) {
       const { name, constructor } = wellKnownPrototypeNameAndConstructor;
       if (FunctionPrototypeSymbolHasInstance(constructor, tmp)) {
         if (protoProps !== undefined && firstProto !== obj) {


### PR DESCRIPTION
The latest performance deep equal optimization did not take into account that
an object may have a property called constructor. This is addressed
in this PR by adding a new fast path and using fallbacks.

On top of that, this adds a few performance optimizations for the constructor
name in util.inspect().