### PR TITLE
util: add `types.isFloat16Array()`

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -3102,6 +3102,23 @@ types.isExternal(new String('foo')); // returns false
 For further information on `napi_create_external`, refer to
 [`napi_create_external()`][].
 
+### `util.types.isFloat16Array(value)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `value` {any}
+* Returns: {boolean}
+
+Returns `true` if the value is a built-in {Float16Array} instance.
+
+```js
+util.types.isFloat16Array(new ArrayBuffer());  // Returns false
+util.types.isFloat16Array(new Float16Array());  // Returns true
+util.types.isFloat16Array(new Float32Array());  // Returns false
+```
+
 ### `util.types.isFloat32Array(value)`
 
 <!-- YAML

--- a/lib/internal/util/types.js
+++ b/lib/internal/util/types.js
@@ -38,6 +38,10 @@ function isInt32Array(value) {
   return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Int32Array';
 }
 
+function isFloat16Array(value) {
+  return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float16Array';
+}
+
 function isFloat32Array(value) {
   return TypedArrayPrototypeGetSymbolToStringTag(value) === 'Float32Array';
 }
@@ -65,6 +69,7 @@ module.exports = {
   isInt8Array,
   isInt16Array,
   isInt32Array,
+  isFloat16Array,
   isFloat32Array,
   isFloat64Array,
   isBigInt64Array,

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,4 +1,5 @@
-// Flags: --experimental-vm-modules --expose-internals --allow-natives-syntax
+// Flags: --experimental-vm-modules --expose-internals --allow-natives-syntax --js-float16array
+// TODO(LiviaMedeiros): once `Float16Array` is unflagged in v8, remove `--js-float16array` above
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -38,6 +39,7 @@ for (const [ value, _method ] of [
   [ new Int8Array() ],
   [ new Int16Array() ],
   [ new Int32Array() ],
+  [ new Float16Array() ],
   [ new Float32Array() ],
   [ new Float64Array() ],
   [ new BigInt64Array() ],
@@ -102,6 +104,9 @@ for (const [ value, _method ] of [
   assert(!types.isInt32Array({ [Symbol.toStringTag]: 'Int32Array' }));
   assert(types.isInt32Array(vm.runInNewContext('new Int32Array')));
 
+  assert(!types.isFloat16Array({ [Symbol.toStringTag]: 'Float16Array' }));
+  assert(types.isFloat16Array(vm.runInNewContext('new Float16Array')));
+
   assert(!types.isFloat32Array({ [Symbol.toStringTag]: 'Float32Array' }));
   assert(types.isFloat32Array(vm.runInNewContext('new Float32Array')));
 
@@ -127,6 +132,7 @@ for (const [ value, _method ] of [
   const int8Array = new Int8Array(arrayBuffer);
   const int16Array = new Int16Array(arrayBuffer);
   const int32Array = new Int32Array(arrayBuffer);
+  const float16Array = new Float16Array(arrayBuffer);
   const float32Array = new Float32Array(arrayBuffer);
   const float64Array = new Float64Array(arrayBuffer);
   const bigInt64Array = new BigInt64Array(arrayBuffer);
@@ -141,6 +147,7 @@ for (const [ value, _method ] of [
   const fakeInt8Array = { __proto__: Int8Array.prototype };
   const fakeInt16Array = { __proto__: Int16Array.prototype };
   const fakeInt32Array = { __proto__: Int32Array.prototype };
+  const fakeFloat16Array = { __proto__: Float16Array.prototype };
   const fakeFloat32Array = { __proto__: Float32Array.prototype };
   const fakeFloat64Array = { __proto__: Float64Array.prototype };
   const fakeBigInt64Array = { __proto__: BigInt64Array.prototype };
@@ -164,6 +171,10 @@ for (const [ value, _method ] of [
     Object.setPrototypeOf(new Int16Array(arrayBuffer), Int16Array.prototype);
   const stealthyInt32Array =
     Object.setPrototypeOf(new Int32Array(arrayBuffer), Int32Array.prototype);
+  const stealthyFloat16Array =
+    Object.setPrototypeOf(
+      new Float16Array(arrayBuffer), Float16Array.prototype
+    );
   const stealthyFloat32Array =
     Object.setPrototypeOf(
       new Float32Array(arrayBuffer), Float32Array.prototype
@@ -191,6 +202,7 @@ for (const [ value, _method ] of [
     int8Array, fakeInt8Array, stealthyInt8Array,
     int16Array, fakeInt16Array, stealthyInt16Array,
     int32Array, fakeInt32Array, stealthyInt32Array,
+    float16Array, fakeFloat16Array, stealthyFloat16Array,
     float32Array, fakeFloat32Array, stealthyFloat32Array,
     float64Array, fakeFloat64Array, stealthyFloat64Array,
     bigInt64Array, fakeBigInt64Array, stealthyBigInt64Array,
@@ -208,6 +220,7 @@ for (const [ value, _method ] of [
       int8Array, stealthyInt8Array,
       int16Array, stealthyInt16Array,
       int32Array, stealthyInt32Array,
+      float16Array, stealthyFloat16Array,
       float32Array, stealthyFloat32Array,
       float64Array, stealthyFloat64Array,
       bigInt64Array, stealthyBigInt64Array,
@@ -222,6 +235,7 @@ for (const [ value, _method ] of [
       int8Array, stealthyInt8Array,
       int16Array, stealthyInt16Array,
       int32Array, stealthyInt32Array,
+      float16Array, stealthyFloat16Array,
       float32Array, stealthyFloat32Array,
       float64Array, stealthyFloat64Array,
       bigInt64Array, stealthyBigInt64Array,
@@ -247,6 +261,9 @@ for (const [ value, _method ] of [
     ],
     isInt32Array: [
       int32Array, stealthyInt32Array,
+    ],
+    isFloat16Array: [
+      float16Array, stealthyFloat16Array,
     ],
     isFloat32Array: [
       float32Array, stealthyFloat32Array,


### PR DESCRIPTION
[`Float16Array`](https://github.com/tc39/proposal-float16array) is expected to become a thing in upcoming major release, and it's already available with `--js-float16array` runtime v8 flag.