### PR TITLE
process: disable building execve on IBM i

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3379,7 +3379,7 @@ any exit or close events and without running any cleanup handler.
 
 This function will never return, unless an error occurred.
 
-This function is not available on Windows.
+This function is not available on Windows or IBM i.
 
 ## `process.report`
 

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -286,7 +286,7 @@ function wrapProcessMethods(binding) {
 
     if (!isMainThread) {
       throw new ERR_WORKER_UNSUPPORTED_OPERATION('Calling process.execve');
-    } else if (process.platform === 'win32') {
+    } else if (process.platform === 'win32' || process.platform === 'os400') {
       throw new ERR_FEATURE_UNAVAILABLE_ON_PLATFORM('process.execve');
     }
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -497,7 +497,7 @@ static void ReallyExit(const FunctionCallbackInfo<Value>& args) {
   env->Exit(code);
 }
 
-#ifdef __POSIX__
+#if defined __POSIX__ && !defined(__PASE__)
 inline int persist_standard_stream(int fd) {
   int flags = fcntl(fd, F_GETFD, 0);
 
@@ -779,7 +779,7 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "dlopen", binding::DLOpen);
   SetMethod(isolate, target, "reallyExit", ReallyExit);
 
-#ifdef __POSIX__
+#if defined __POSIX__ && !defined(__PASE__)
   SetMethod(isolate, target, "execve", Execve);
 #endif
   SetMethodNoSideEffect(isolate, target, "uptime", Uptime);
@@ -826,7 +826,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(binding::DLOpen);
   registry->Register(ReallyExit);
 
-#ifdef __POSIX__
+#if defined __POSIX__ && !defined(__PASE__)
   registry->Register(Execve);
 #endif
   registry->Register(Uptime);

--- a/test/parallel/test-process-execve-abort.js
+++ b/test/parallel/test-process-execve-abort.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const { skip, isWindows } = require('../common');
+const { skip, isWindows, isIBMi } = require('../common');
 const { ok } = require('assert');
 const { spawnSync } = require('child_process');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'child') {

--- a/test/parallel/test-process-execve-on-exit.js
+++ b/test/parallel/test-process-execve-on-exit.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { mustNotCall, skip, isWindows } = require('../common');
+const { mustNotCall, skip, isWindows, isIBMi } = require('../common');
 const { strictEqual } = require('assert');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'replaced') {

--- a/test/parallel/test-process-execve-permission-fail.js
+++ b/test/parallel/test-process-execve-permission-fail.js
@@ -2,14 +2,14 @@
 
 'use strict';
 
-const { mustCall, skip, isWindows } = require('../common');
+const { mustCall, skip, isWindows, isIBMi } = require('../common');
 const { fail, throws } = require('assert');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'replaced') {

--- a/test/parallel/test-process-execve-permission-granted.js
+++ b/test/parallel/test-process-execve-permission-granted.js
@@ -2,14 +2,14 @@
 
 'use strict';
 
-const { skip, isWindows } = require('../common');
+const { skip, isWindows, isIBMi } = require('../common');
 const { deepStrictEqual } = require('assert');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'replaced') {

--- a/test/parallel/test-process-execve-socket.js
+++ b/test/parallel/test-process-execve-socket.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const { mustCall, mustNotCall, skip, isWindows } = require('../common');
+const { mustCall, mustNotCall, skip, isWindows, isIBMi } = require('../common');
 const { fail, ok } = require('assert');
 const { createServer } = require('net');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'replaced') {

--- a/test/parallel/test-process-execve-validation.js
+++ b/test/parallel/test-process-execve-validation.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { skip, isWindows } = require('../common');
+const { skip, isWindows, isIBMi } = require('../common');
 const { throws } = require('assert');
 const { isMainThread } = require('worker_threads');
 
@@ -8,7 +8,7 @@ if (!isMainThread) {
   skip('process.execve is not available in Workers');
 }
 
-if (!isWindows) {
+if (!isWindows && !isIBMi) {
   // Invalid path name
   {
     throws(() => {

--- a/test/parallel/test-process-execve-worker-threads.js
+++ b/test/parallel/test-process-execve-worker-threads.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { isWindows, mustCall, skip } = require('../common');
+const { isWindows, isIBMi, mustCall, skip } = require('../common');
 const { throws } = require('assert');
 const { isMainThread, Worker } = require('worker_threads');
 
-if (isWindows) {
-  skip('process.execve is not available in Windows');
+if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (isMainThread) {

--- a/test/parallel/test-process-execve.js
+++ b/test/parallel/test-process-execve.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { isWindows, skip } = require('../common');
+const { isWindows, isIBMi, skip } = require('../common');
 const { deepStrictEqual, fail, strictEqual } = require('assert');
 const { isMainThread } = require('worker_threads');
 
 if (!isMainThread) {
   skip('process.execve is not available in Workers');
-} else if (isWindows) {
-  skip('process.execve is not available in Windows');
+} else if (isWindows || isIBMi) {
+  skip('process.execve is not available in Windows or IBM i');
 }
 
 if (process.argv[2] === 'replaced') {


### PR DESCRIPTION
The `execve` syscall does exist on IBM i but
it has caveats that make it not usable in Node.js context.

These changes disable building with `execve` like Windows does.

Fixes https://github.com/nodejs/node/issues/57882

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
