### PR TITLE
doc: mark devtools integration section as active development

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -490,6 +490,8 @@ An exception will be thrown if there is no active inspector.
 
 ## Integration with DevTools
 
+> Stability: 1.1 - Active development
+
 The `node:inspector` module provides an API for integrating with devtools that support Chrome DevTools Protocol.
 DevTools frontends connected to a running Node.js instance can capture protocol events emitted from the instance
 and display them accordingly to facilitate debugging.
@@ -517,8 +519,6 @@ added:
  - v20.18.0
 -->
 
-> Stability: 1 - Experimental
-
 * `params` {Object}
 
 This feature is only available with the `--experimental-network-inspection` flag enabled.
@@ -533,8 +533,6 @@ added:
  - v22.6.0
  - v20.18.0
 -->
-
-> Stability: 1 - Experimental
 
 * `params` {Object}
 
@@ -551,8 +549,6 @@ added:
  - v20.18.0
 -->
 
-> Stability: 1 - Experimental
-
 * `params` {Object}
 
 This feature is only available with the `--experimental-network-inspection` flag enabled.
@@ -567,8 +563,6 @@ added:
  - v22.7.0
  - v20.18.0
 -->
-
-> Stability: 1 - Experimental
 
 * `params` {Object}
 


### PR DESCRIPTION
This marks the whole devtools integration section as in active development.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
