### PR TITLE
worker: add worker.getHeapStatistics()

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1337,6 +1337,31 @@ If the Worker thread is no longer running, which may occur before the
 [`'exit'` event][] is emitted, the returned `Promise` is rejected
 immediately with an [`ERR_WORKER_NOT_RUNNING`][] error.
 
+### `worker.getHeapStatistics()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* returns: {object}
+  * `total_heap_size` {number}
+  * `total_heap_size_executable` {number}
+  * `total_physical_size` {number}
+  * `total_available_size` {number}
+  * `used_heap_size` {number}
+  * `heap_size_limit` {number}
+  * `malloced_memory` {number}
+  * `peak_malloced_memory` {number}
+  * `does_zap_garbage` {number}
+  * `number_of_native_contexts` {number}
+  * `number_of_detached_contexts` {number}
+  * `total_global_handles_size` {number}
+  * `used_global_handles_size` {number}
+  * `external_memory` {number}
+
+This method is identical to [`v8.getHeapStatistics()`][] but it allows the
+statistics to be observed from outside the actual thread.
+
 ### `worker.performance`
 
 <!-- YAML
@@ -1362,7 +1387,7 @@ added:
   `eventLoopUtilization()`.
 * `utilization2` {Object} The result of a previous call to
   `eventLoopUtilization()` prior to `utilization1`.
-* Returns: {Object}
+* returns: {object}
   * `idle` {number}
   * `active` {number}
   * `utilization` {number}
@@ -1631,6 +1656,7 @@ thread spawned will spawn another until the application crashes.
 [`require('node:worker_threads').workerData`]: #workerworkerdata
 [`trace_events`]: tracing.md
 [`v8.getHeapSnapshot()`]: v8.md#v8getheapsnapshotoptions
+[`v8.getHeapStatistics()`]: v8.md#v8getheapstatistics
 [`vm`]: vm.md
 [`worker.SHARE_ENV`]: #workershare_env
 [`worker.on('message')`]: #event-message_1

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1343,21 +1343,7 @@ immediately with an [`ERR_WORKER_NOT_RUNNING`][] error.
 added: REPLACEME
 -->
 
-* returns: {object}
-  * `total_heap_size` {number}
-  * `total_heap_size_executable` {number}
-  * `total_physical_size` {number}
-  * `total_available_size` {number}
-  * `used_heap_size` {number}
-  * `heap_size_limit` {number}
-  * `malloced_memory` {number}
-  * `peak_malloced_memory` {number}
-  * `does_zap_garbage` {number}
-  * `number_of_native_contexts` {number}
-  * `number_of_detached_contexts` {number}
-  * `total_global_handles_size` {number}
-  * `used_global_handles_size` {number}
-  * `external_memory` {number}
+* Returns: {Object}
 
 This method is identical to [`v8.getHeapStatistics()`][] but it allows the
 statistics to be observed from outside the actual thread.
@@ -1387,7 +1373,7 @@ added:
   `eventLoopUtilization()`.
 * `utilization2` {Object} The result of a previous call to
   `eventLoopUtilization()` prior to `utilization1`.
-* returns: {object}
+* returns: {Object}
   * `idle` {number}
   * `active` {number}
   * `utilization` {number}

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1343,10 +1343,11 @@ immediately with an [`ERR_WORKER_NOT_RUNNING`][] error.
 added: REPLACEME
 -->
 
-* Returns: {Object}
+* Returns: {Promise}
 
-This method is identical to [`v8.getHeapStatistics()`][] but it allows the
-statistics to be observed from outside the actual thread.
+This method returns a `Promise` that will resolve to an object identical to [`v8.getHeapStatistics()`][],
+or reject with an [`ERR_WORKER_NOT_RUNNING`][] error if the worker is no longer running.
+This methods allows the statistics to be observed from outside the actual thread.
 
 ### `worker.performance`
 

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1373,7 +1373,7 @@ added:
   `eventLoopUtilization()`.
 * `utilization2` {Object} The result of a previous call to
   `eventLoopUtilization()` prior to `utilization1`.
-* returns: {Object}
+* Returns: {Object}
   * `idle` {number}
   * `active` {number}
   * `utilization` {number}

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -459,6 +459,12 @@ class Worker extends EventEmitter {
       };
     });
   }
+
+  getHeapStatistics() {
+    if (this[kHandle] === null) return {};
+
+    return this[kHandle].getHeapStatistics();
+  }
 }
 
 /**

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -461,9 +461,14 @@ class Worker extends EventEmitter {
   }
 
   getHeapStatistics() {
-    if (this[kHandle] === null) return {};
+    const taker = this[kHandle]?.getHeapStatistics();
 
-    return this[kHandle].getHeapStatistics();
+    return new Promise((resolve, reject) => {
+      if (!taker) return reject(new ERR_WORKER_NOT_RUNNING());
+      taker.ondone = (handle) => {
+        resolve(handle);
+      };
+    });
   }
 }
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -79,7 +79,7 @@ namespace node {
   V(SIGINTWATCHDOG)                                                            \
   V(WORKER)                                                                    \
   V(WORKERHEAPSNAPSHOT)                                                        \
-  V(WORKERHEAPSTATISTICS)                                                        \
+  V(WORKERHEAPSTATISTICS)                                                      \
   V(WRITEWRAP)                                                                 \
   V(ZLIB)
 

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -79,6 +79,7 @@ namespace node {
   V(SIGINTWATCHDOG)                                                            \
   V(WORKER)                                                                    \
   V(WORKERHEAPSNAPSHOT)                                                        \
+  V(WORKERHEAPSTATISTICS)                                                        \
   V(WRITEWRAP)                                                                 \
   V(ZLIB)
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -464,7 +464,7 @@
   V(tty_constructor_template, v8::FunctionTemplate)                            \
   V(write_wrap_template, v8::ObjectTemplate)                                   \
   V(worker_heap_snapshot_taker_template, v8::ObjectTemplate)                   \
-  V(worker_heap_statistics_taker_template, v8::ObjectTemplate)                   \
+  V(worker_heap_statistics_taker_template, v8::ObjectTemplate)                 \
   V(x509_constructor_template, v8::FunctionTemplate)
 
 #define PER_REALM_STRONG_PERSISTENT_VALUES(V)                                  \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -464,6 +464,7 @@
   V(tty_constructor_template, v8::FunctionTemplate)                            \
   V(write_wrap_template, v8::ObjectTemplate)                                   \
   V(worker_heap_snapshot_taker_template, v8::ObjectTemplate)                   \
+  V(worker_heap_statistics_taker_template, v8::ObjectTemplate)                   \
   V(x509_constructor_template, v8::FunctionTemplate)
 
 #define PER_REALM_STRONG_PERSISTENT_VALUES(V)                                  \

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -816,64 +816,6 @@ void Worker::Unref(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-/*
-void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
-  Worker* w;
-  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
-
-  v8::HeapStatistics heap_stats;
-  w->isolate_->GetHeapStatistics(&heap_stats);
-
-  auto* isolate = args.GetIsolate();
-  Local<Context> currentContext = isolate->GetCurrentContext();
-
-  // Define an array of property names
-  Local<v8::Name> heap_stats_names[] = {
-      FIXED_ONE_BYTE_STRING(isolate, "total_heap_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "total_heap_size_executable"),
-      FIXED_ONE_BYTE_STRING(isolate, "total_physical_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "total_available_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "used_heap_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "heap_size_limit"),
-      FIXED_ONE_BYTE_STRING(isolate, "malloced_memory"),
-      FIXED_ONE_BYTE_STRING(isolate, "peak_malloced_memory"),
-      FIXED_ONE_BYTE_STRING(isolate, "does_zap_garbage"),
-      FIXED_ONE_BYTE_STRING(isolate, "number_of_native_contexts"),
-      FIXED_ONE_BYTE_STRING(isolate, "number_of_detached_contexts"),
-      FIXED_ONE_BYTE_STRING(isolate, "total_global_handles_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "used_global_handles_size"),
-      FIXED_ONE_BYTE_STRING(isolate, "external_memory")
-  };
-
-  // Define an array of property values
-  Local<Value> heap_stats_values[] = {
-      Number::New(isolate, heap_stats.total_heap_size()),
-      Number::New(isolate, heap_stats.total_heap_size_executable()),
-      Number::New(isolate, heap_stats.total_physical_size()),
-      Number::New(isolate, heap_stats.total_available_size()),
-      Number::New(isolate, heap_stats.used_heap_size()),
-      Number::New(isolate, heap_stats.heap_size_limit()),
-      Number::New(isolate, heap_stats.malloced_memory()),
-      Number::New(isolate, heap_stats.peak_malloced_memory()),
-      Boolean::New(isolate, heap_stats.does_zap_garbage()),
-      Number::New(isolate, heap_stats.number_of_native_contexts()),
-      Number::New(isolate, heap_stats.number_of_detached_contexts()),
-      Number::New(isolate, heap_stats.total_global_handles_size()),
-      Number::New(isolate, heap_stats.used_global_handles_size()),
-      Number::New(isolate, heap_stats.external_memory())
-  };
-
-  // Create the object with the property names and values
-  Local<Object> stats = Object::New(isolate,
-                                   Null(isolate),
-                                   heap_stats_names,
-                                   heap_stats_values,
-                                   arraysize(heap_stats_names));
-
-  args.GetReturnValue().Set(stats);
-}
-*/
-
 class WorkerHeapStatisticsTaker : public AsyncWrap {
  public:
   WorkerHeapStatisticsTaker(Environment* env, Local<Object> obj)

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -1142,6 +1142,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Worker::TakeHeapSnapshot);
   registry->Register(Worker::LoopIdleTime);
   registry->Register(Worker::LoopStartTime);
+  registry->Register(Worker::GetHeapStatistics);
 }
 
 }  // anonymous namespace

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -816,6 +816,7 @@ void Worker::Unref(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+/*
 void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
@@ -870,6 +871,118 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
                                    arraysize(heap_stats_names));
 
   args.GetReturnValue().Set(stats);
+}
+*/
+
+class WorkerHeapStatisticsTaker : public AsyncWrap {
+ public:
+  WorkerHeapStatisticsTaker(Environment* env, Local<Object> obj)
+    : AsyncWrap(env, obj, AsyncWrap::PROVIDER_WORKERHEAPSTATISTICS) {}
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(WorkerHeapStatisticsTaker)
+  SET_SELF_SIZE(WorkerHeapStatisticsTaker)
+};
+
+void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
+  Worker* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+
+  Debug(w, "Worker %llu getting heap statistics", w->thread_id_.id);
+
+  Environment* env = w->env();
+  AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(w);
+  Local<Object> wrap;
+  if (!env->worker_heap_statistics_taker_template()
+      ->NewInstance(env->context()).ToLocal(&wrap)) {
+    return;
+  }
+
+  // The created WorkerHeapStatisticsTaker is an object owned by main
+  // thread's Isolate, it can not be accessed by worker thread
+  std::unique_ptr<BaseObjectPtr<WorkerHeapStatisticsTaker>> taker =
+      std::make_unique<BaseObjectPtr<WorkerHeapStatisticsTaker>>(
+          MakeDetachedBaseObject<WorkerHeapStatisticsTaker>(env, wrap));
+
+  // Interrupt the worker thread and take a snapshot, then schedule a call
+  // on the parent thread that turns that snapshot into a readable stream.
+  bool scheduled = w->RequestInterrupt([taker = std::move(taker), env](
+                                           Environment* worker_env) mutable {
+
+    v8::HeapStatistics heap_stats;
+    worker_env->isolate()->GetHeapStatistics(&heap_stats);
+
+    // Here, the worker thread temporarily owns the WorkerHeapStatisticsTaker
+    // object.
+
+    env->SetImmediateThreadsafe(
+        [taker = std::move(taker),
+         heap_stats = std::move(heap_stats)](Environment* env) mutable {
+          Isolate* isolate = env->isolate();
+          HandleScope handle_scope(isolate);
+          Context::Scope context_scope(env->context());
+
+          AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(taker->get());
+
+          Local<v8::Name> heap_stats_names[] = {
+              FIXED_ONE_BYTE_STRING(isolate, "total_heap_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "total_heap_size_executable"),
+              FIXED_ONE_BYTE_STRING(isolate, "total_physical_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "total_available_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "used_heap_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "heap_size_limit"),
+              FIXED_ONE_BYTE_STRING(isolate, "malloced_memory"),
+              FIXED_ONE_BYTE_STRING(isolate, "peak_malloced_memory"),
+              FIXED_ONE_BYTE_STRING(isolate, "does_zap_garbage"),
+              FIXED_ONE_BYTE_STRING(isolate, "number_of_native_contexts"),
+              FIXED_ONE_BYTE_STRING(isolate, "number_of_detached_contexts"),
+              FIXED_ONE_BYTE_STRING(isolate, "total_global_handles_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "used_global_handles_size"),
+              FIXED_ONE_BYTE_STRING(isolate, "external_memory")
+          };
+
+          // Define an array of property values
+          Local<Value> heap_stats_values[] = {
+              Number::New(isolate, heap_stats.total_heap_size()),
+              Number::New(isolate, heap_stats.total_heap_size_executable()),
+              Number::New(isolate, heap_stats.total_physical_size()),
+              Number::New(isolate, heap_stats.total_available_size()),
+              Number::New(isolate, heap_stats.used_heap_size()),
+              Number::New(isolate, heap_stats.heap_size_limit()),
+              Number::New(isolate, heap_stats.malloced_memory()),
+              Number::New(isolate, heap_stats.peak_malloced_memory()),
+              Boolean::New(isolate, heap_stats.does_zap_garbage()),
+              Number::New(isolate, heap_stats.number_of_native_contexts()),
+              Number::New(isolate, heap_stats.number_of_detached_contexts()),
+              Number::New(isolate, heap_stats.total_global_handles_size()),
+              Number::New(isolate, heap_stats.used_global_handles_size()),
+              Number::New(isolate, heap_stats.external_memory())
+          };
+
+          // Create the object with the property names and values
+          Local<Object> stats = Object::New(isolate,
+                                           Null(isolate),
+                                           heap_stats_names,
+                                           heap_stats_values,
+                                           arraysize(heap_stats_names));
+
+
+          Local<Value> args[] = {stats};
+          taker->get()->MakeCallback(
+              env->ondone_string(), arraysize(args), args);
+          // implicitly delete `taker`
+        },
+        CallbackFlags::kUnrefed);
+
+    // Now, the lambda is delivered to the main thread, as a result, the
+    // WorkerHeapSnapshotTaker object is delivered to the main thread, too.
+  });
+
+  if (scheduled) {
+    args.GetReturnValue().Set(wrap);
+  } else {
+    args.GetReturnValue().Set(Local<Object>());
+  }
 }
 
 void Worker::GetResourceLimits(const FunctionCallbackInfo<Value>& args) {
@@ -1068,6 +1181,20 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
         FIXED_ONE_BYTE_STRING(isolate, "WorkerHeapSnapshotTaker");
     wst->SetClassName(wst_string);
     isolate_data->set_worker_heap_snapshot_taker_template(
+        wst->InstanceTemplate());
+  }
+
+  {
+    Local<FunctionTemplate> wst = NewFunctionTemplate(isolate, nullptr);
+
+    wst->InstanceTemplate()->SetInternalFieldCount(
+        WorkerHeapSnapshotTaker::kInternalFieldCount);
+    wst->Inherit(AsyncWrap::GetConstructorTemplate(isolate_data));
+
+    Local<String> wst_string =
+        FIXED_ONE_BYTE_STRING(isolate, "WorkerHeapStatisticsTaker");
+    wst->SetClassName(wst_string);
+    isolate_data->set_worker_heap_statistics_taker_template(
         wst->InstanceTemplate());
   }
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -877,7 +877,7 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 class WorkerHeapStatisticsTaker : public AsyncWrap {
  public:
   WorkerHeapStatisticsTaker(Environment* env, Local<Object> obj)
-    : AsyncWrap(env, obj, AsyncWrap::PROVIDER_WORKERHEAPSTATISTICS) {}
+      : AsyncWrap(env, obj, AsyncWrap::PROVIDER_WORKERHEAPSTATISTICS) {}
 
   SET_NO_MEMORY_INFO()
   SET_MEMORY_INFO_NAME(WorkerHeapStatisticsTaker)
@@ -894,7 +894,8 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(w);
   Local<Object> wrap;
   if (!env->worker_heap_statistics_taker_template()
-      ->NewInstance(env->context()).ToLocal(&wrap)) {
+           ->NewInstance(env->context())
+           .ToLocal(&wrap)) {
     return;
   }
 
@@ -906,8 +907,8 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 
   // Interrupt the worker thread and take a snapshot, then schedule a call
   // on the parent thread that turns that snapshot into a readable stream.
-  bool scheduled = w->RequestInterrupt([taker = std::move(taker), env](
-                                           Environment* worker_env) mutable {
+  bool scheduled = w->RequestInterrupt([taker = std::move(taker),
+                                        env](Environment* worker_env) mutable {
     v8::HeapStatistics heap_stats;
     worker_env->isolate()->GetHeapStatistics(&heap_stats);
 
@@ -937,8 +938,7 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
               FIXED_ONE_BYTE_STRING(isolate, "number_of_detached_contexts"),
               FIXED_ONE_BYTE_STRING(isolate, "total_global_handles_size"),
               FIXED_ONE_BYTE_STRING(isolate, "used_global_handles_size"),
-              FIXED_ONE_BYTE_STRING(isolate, "external_memory")
-          };
+              FIXED_ONE_BYTE_STRING(isolate, "external_memory")};
 
           // Define an array of property values
           Local<Value> heap_stats_values[] = {
@@ -955,16 +955,14 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
               Number::New(isolate, heap_stats.number_of_detached_contexts()),
               Number::New(isolate, heap_stats.total_global_handles_size()),
               Number::New(isolate, heap_stats.used_global_handles_size()),
-              Number::New(isolate, heap_stats.external_memory())
-          };
+              Number::New(isolate, heap_stats.external_memory())};
 
           // Create the object with the property names and values
           Local<Object> stats = Object::New(isolate,
-                                           Null(isolate),
-                                           heap_stats_names,
-                                           heap_stats_values,
-                                           arraysize(heap_stats_names));
-
+                                            Null(isolate),
+                                            heap_stats_names,
+                                            heap_stats_values,
+                                            arraysize(heap_stats_names));
 
           Local<Value> args[] = {stats};
           taker->get()->MakeCallback(

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -828,84 +828,38 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> stats = Object::New(isolate);
 
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "total_heap_size").ToLocalChecked(),
-            Number::New(isolate, heap_stats.total_heap_size()))
+  #define SET_HEAP_STAT_NUMBER(name)                                   \
+  stats->Set(currentContext,                                           \
+             String::NewFromUtf8(isolate, #name).ToLocalChecked(),     \
+             Number::New(isolate, heap_stats.name()))                  \
       .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "total_heap_size_executable")
-                .ToLocalChecked(),
-            Number::New(isolate, heap_stats.total_heap_size_executable()))
+
+  #define SET_HEAP_STAT_BOOLEAN(name)                                  \
+  stats->Set(currentContext,                                           \
+             String::NewFromUtf8(isolate, #name).ToLocalChecked(),     \
+             Boolean::New(isolate, heap_stats.name()))                 \
       .Check();
-  stats
-      ->Set(
-          currentContext,
-          String::NewFromUtf8(isolate, "total_physical_size").ToLocalChecked(),
-          Number::New(isolate, heap_stats.total_physical_size()))
-      .Check();
-  stats
-      ->Set(
-          currentContext,
-          String::NewFromUtf8(isolate, "total_available_size").ToLocalChecked(),
-          Number::New(isolate, heap_stats.total_available_size()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "used_heap_size").ToLocalChecked(),
-            Number::New(isolate, heap_stats.used_heap_size()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "heap_size_limit").ToLocalChecked(),
-            Number::New(isolate, heap_stats.heap_size_limit()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "malloced_memory").ToLocalChecked(),
-            Number::New(isolate, heap_stats.malloced_memory()))
-      .Check();
-  stats
-      ->Set(
-          currentContext,
-          String::NewFromUtf8(isolate, "peak_malloced_memory").ToLocalChecked(),
-          Number::New(isolate, heap_stats.peak_malloced_memory()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "does_zap_garbage").ToLocalChecked(),
-            Boolean::New(isolate, heap_stats.does_zap_garbage()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "number_of_native_contexts")
-                .ToLocalChecked(),
-            Number::New(isolate, heap_stats.number_of_native_contexts()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "number_of_detached_contexts")
-                .ToLocalChecked(),
-            Number::New(isolate, heap_stats.number_of_detached_contexts()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "total_global_handles_size")
-                .ToLocalChecked(),
-            Number::New(isolate, heap_stats.total_global_handles_size()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "used_global_handles_size")
-                .ToLocalChecked(),
-            Number::New(isolate, heap_stats.used_global_handles_size()))
-      .Check();
-  stats
-      ->Set(currentContext,
-            String::NewFromUtf8(isolate, "external_memory").ToLocalChecked(),
-            Number::New(isolate, heap_stats.external_memory()))
-      .Check();
+
+  // Numeric stats
+  SET_HEAP_STAT_NUMBER(total_heap_size)
+  SET_HEAP_STAT_NUMBER(total_heap_size_executable)
+  SET_HEAP_STAT_NUMBER(total_physical_size)
+  SET_HEAP_STAT_NUMBER(total_available_size)
+  SET_HEAP_STAT_NUMBER(used_heap_size)
+  SET_HEAP_STAT_NUMBER(heap_size_limit)
+  SET_HEAP_STAT_NUMBER(malloced_memory)
+  SET_HEAP_STAT_NUMBER(peak_malloced_memory)
+  SET_HEAP_STAT_NUMBER(number_of_native_contexts)
+  SET_HEAP_STAT_NUMBER(number_of_detached_contexts)
+  SET_HEAP_STAT_NUMBER(total_global_handles_size)
+  SET_HEAP_STAT_NUMBER(used_global_handles_size)
+  SET_HEAP_STAT_NUMBER(external_memory)
+
+  // Boolean stat
+  SET_HEAP_STAT_BOOLEAN(does_zap_garbage)
+
+  #undef SET_HEAP_STAT_NUMBER
+  #undef SET_HEAP_STAT_BOOLEAN
 
   args.GetReturnValue().Set(stats);
 }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -908,7 +908,6 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   // on the parent thread that turns that snapshot into a readable stream.
   bool scheduled = w->RequestInterrupt([taker = std::move(taker), env](
                                            Environment* worker_env) mutable {
-
     v8::HeapStatistics heap_stats;
     worker_env->isolate()->GetHeapStatistics(&heap_stats);
 

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -830,50 +830,50 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "total_heap_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_heap_size()));
+      Number::New(isolate, heap_stats.total_heap_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "total_heap_size_executable")
         .ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_heap_size_executable()));
+      Number::New(isolate, heap_stats.total_heap_size_executable())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "total_physical_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_physical_size()));
+      Number::New(isolate, heap_stats.total_physical_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "total_available_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_available_size()));
+      Number::New(isolate, heap_stats.total_available_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "used_heap_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.used_heap_size()));
+      Number::New(isolate, heap_stats.used_heap_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "heap_size_limit").ToLocalChecked(),
-      Number::New(isolate, heap_stats.heap_size_limit()));
+      Number::New(isolate, heap_stats.heap_size_limit())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "malloced_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.malloced_memory()));
+      Number::New(isolate, heap_stats.malloced_memory())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "peak_malloced_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.peak_malloced_memory()));
+      Number::New(isolate, heap_stats.peak_malloced_memory())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "does_zap_garbage").ToLocalChecked(),
-      Boolean::New(isolate, heap_stats.does_zap_garbage()));
+      Boolean::New(isolate, heap_stats.does_zap_garbage())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "number_of_native_contexts")
         .ToLocalChecked(),
-      Number::New(isolate, heap_stats.number_of_native_contexts()));
+      Number::New(isolate, heap_stats.number_of_native_contexts())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "number_of_detached_contexts")
         .ToLocalChecked(),
-      Number::New(isolate, heap_stats.number_of_detached_contexts()));
+      Number::New(isolate, heap_stats.number_of_detached_contexts())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "total_global_handles_size")
         .ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_global_handles_size()));
+      Number::New(isolate, heap_stats.total_global_handles_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "used_global_handles_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.used_global_handles_size()));
+      Number::New(isolate, heap_stats.used_global_handles_size())).Check();
   stats->Set(currentContext,
       String::NewFromUtf8(isolate, "external_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.external_memory()));
+      Number::New(isolate, heap_stats.external_memory())).Check();
 
   args.GetReturnValue().Set(stats);
 }
@@ -1059,7 +1059,6 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
     SetProtoMethod(isolate, w, "loopIdleTime", Worker::LoopIdleTime);
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
     SetProtoMethod(isolate, w, "getHeapStatistics", Worker::GetHeapStatistics);
-
 
     SetConstructorFunction(isolate, target, "Worker", w);
   }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -828,52 +828,84 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> stats = Object::New(isolate);
 
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "total_heap_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_heap_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "total_heap_size_executable")
-        .ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_heap_size_executable())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "total_physical_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_physical_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "total_available_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_available_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "used_heap_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.used_heap_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "heap_size_limit").ToLocalChecked(),
-      Number::New(isolate, heap_stats.heap_size_limit())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "malloced_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.malloced_memory())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "peak_malloced_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.peak_malloced_memory())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "does_zap_garbage").ToLocalChecked(),
-      Boolean::New(isolate, heap_stats.does_zap_garbage())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "number_of_native_contexts")
-        .ToLocalChecked(),
-      Number::New(isolate, heap_stats.number_of_native_contexts())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "number_of_detached_contexts")
-        .ToLocalChecked(),
-      Number::New(isolate, heap_stats.number_of_detached_contexts())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "total_global_handles_size")
-        .ToLocalChecked(),
-      Number::New(isolate, heap_stats.total_global_handles_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "used_global_handles_size").ToLocalChecked(),
-      Number::New(isolate, heap_stats.used_global_handles_size())).Check();
-  stats->Set(currentContext,
-      String::NewFromUtf8(isolate, "external_memory").ToLocalChecked(),
-      Number::New(isolate, heap_stats.external_memory())).Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "total_heap_size").ToLocalChecked(),
+            Number::New(isolate, heap_stats.total_heap_size()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "total_heap_size_executable")
+                .ToLocalChecked(),
+            Number::New(isolate, heap_stats.total_heap_size_executable()))
+      .Check();
+  stats
+      ->Set(
+          currentContext,
+          String::NewFromUtf8(isolate, "total_physical_size").ToLocalChecked(),
+          Number::New(isolate, heap_stats.total_physical_size()))
+      .Check();
+  stats
+      ->Set(
+          currentContext,
+          String::NewFromUtf8(isolate, "total_available_size").ToLocalChecked(),
+          Number::New(isolate, heap_stats.total_available_size()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "used_heap_size").ToLocalChecked(),
+            Number::New(isolate, heap_stats.used_heap_size()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "heap_size_limit").ToLocalChecked(),
+            Number::New(isolate, heap_stats.heap_size_limit()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "malloced_memory").ToLocalChecked(),
+            Number::New(isolate, heap_stats.malloced_memory()))
+      .Check();
+  stats
+      ->Set(
+          currentContext,
+          String::NewFromUtf8(isolate, "peak_malloced_memory").ToLocalChecked(),
+          Number::New(isolate, heap_stats.peak_malloced_memory()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "does_zap_garbage").ToLocalChecked(),
+            Boolean::New(isolate, heap_stats.does_zap_garbage()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "number_of_native_contexts")
+                .ToLocalChecked(),
+            Number::New(isolate, heap_stats.number_of_native_contexts()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "number_of_detached_contexts")
+                .ToLocalChecked(),
+            Number::New(isolate, heap_stats.number_of_detached_contexts()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "total_global_handles_size")
+                .ToLocalChecked(),
+            Number::New(isolate, heap_stats.total_global_handles_size()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "used_global_handles_size")
+                .ToLocalChecked(),
+            Number::New(isolate, heap_stats.used_global_handles_size()))
+      .Check();
+  stats
+      ->Set(currentContext,
+            String::NewFromUtf8(isolate, "external_memory").ToLocalChecked(),
+            Number::New(isolate, heap_stats.external_memory()))
+      .Check();
 
   args.GetReturnValue().Set(stats);
 }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -914,7 +914,7 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
         CallbackFlags::kUnrefed);
 
     // Now, the lambda is delivered to the main thread, as a result, the
-    // WorkerHeapSnapshotTaker object is delivered to the main thread, too.
+    // WorkerHeapStatisticsTaker object is delivered to the main thread, too.
   });
 
   if (scheduled) {

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -830,7 +830,6 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
-  Debug(w, "Worker %llu getting heap statistics", w->thread_id_.id);
 
   Environment* env = w->env();
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(w);

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -826,40 +826,48 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   auto* isolate = args.GetIsolate();
   Local<Context> currentContext = isolate->GetCurrentContext();
 
-  Local<Object> stats = Object::New(isolate);
+  // Define an array of property names
+  Local<v8::Name> heap_stats_names[] = {
+      FIXED_ONE_BYTE_STRING(isolate, "total_heap_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "total_heap_size_executable"),
+      FIXED_ONE_BYTE_STRING(isolate, "total_physical_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "total_available_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "used_heap_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "heap_size_limit"),
+      FIXED_ONE_BYTE_STRING(isolate, "malloced_memory"),
+      FIXED_ONE_BYTE_STRING(isolate, "peak_malloced_memory"),
+      FIXED_ONE_BYTE_STRING(isolate, "does_zap_garbage"),
+      FIXED_ONE_BYTE_STRING(isolate, "number_of_native_contexts"),
+      FIXED_ONE_BYTE_STRING(isolate, "number_of_detached_contexts"),
+      FIXED_ONE_BYTE_STRING(isolate, "total_global_handles_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "used_global_handles_size"),
+      FIXED_ONE_BYTE_STRING(isolate, "external_memory")
+  };
 
-  #define SET_HEAP_STAT_NUMBER(name)                                   \
-  stats->Set(currentContext,                                           \
-             String::NewFromUtf8(isolate, #name).ToLocalChecked(),     \
-             Number::New(isolate, heap_stats.name()))                  \
-      .Check();
+  // Define an array of property values
+  Local<Value> heap_stats_values[] = {
+      Number::New(isolate, heap_stats.total_heap_size()),
+      Number::New(isolate, heap_stats.total_heap_size_executable()),
+      Number::New(isolate, heap_stats.total_physical_size()),
+      Number::New(isolate, heap_stats.total_available_size()),
+      Number::New(isolate, heap_stats.used_heap_size()),
+      Number::New(isolate, heap_stats.heap_size_limit()),
+      Number::New(isolate, heap_stats.malloced_memory()),
+      Number::New(isolate, heap_stats.peak_malloced_memory()),
+      Boolean::New(isolate, heap_stats.does_zap_garbage()),
+      Number::New(isolate, heap_stats.number_of_native_contexts()),
+      Number::New(isolate, heap_stats.number_of_detached_contexts()),
+      Number::New(isolate, heap_stats.total_global_handles_size()),
+      Number::New(isolate, heap_stats.used_global_handles_size()),
+      Number::New(isolate, heap_stats.external_memory())
+  };
 
-  #define SET_HEAP_STAT_BOOLEAN(name)                                  \
-  stats->Set(currentContext,                                           \
-             String::NewFromUtf8(isolate, #name).ToLocalChecked(),     \
-             Boolean::New(isolate, heap_stats.name()))                 \
-      .Check();
-
-  // Numeric stats
-  SET_HEAP_STAT_NUMBER(total_heap_size)
-  SET_HEAP_STAT_NUMBER(total_heap_size_executable)
-  SET_HEAP_STAT_NUMBER(total_physical_size)
-  SET_HEAP_STAT_NUMBER(total_available_size)
-  SET_HEAP_STAT_NUMBER(used_heap_size)
-  SET_HEAP_STAT_NUMBER(heap_size_limit)
-  SET_HEAP_STAT_NUMBER(malloced_memory)
-  SET_HEAP_STAT_NUMBER(peak_malloced_memory)
-  SET_HEAP_STAT_NUMBER(number_of_native_contexts)
-  SET_HEAP_STAT_NUMBER(number_of_detached_contexts)
-  SET_HEAP_STAT_NUMBER(total_global_handles_size)
-  SET_HEAP_STAT_NUMBER(used_global_handles_size)
-  SET_HEAP_STAT_NUMBER(external_memory)
-
-  // Boolean stat
-  SET_HEAP_STAT_BOOLEAN(does_zap_garbage)
-
-  #undef SET_HEAP_STAT_NUMBER
-  #undef SET_HEAP_STAT_BOOLEAN
+  // Create the object with the property names and values
+  Local<Object> stats = Object::New(isolate,
+                                   Null(isolate),
+                                   heap_stats_names,
+                                   heap_stats_values,
+                                   arraysize(heap_stats_names));
 
   args.GetReturnValue().Set(stats);
 }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -816,6 +816,68 @@ void Worker::Unref(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
+  Worker* w;
+  ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
+
+  v8::HeapStatistics heap_stats;
+  w->isolate_->GetHeapStatistics(&heap_stats);
+
+  auto* isolate = args.GetIsolate();
+  Local<Context> currentContext = isolate->GetCurrentContext();
+
+  Local<Object> stats = Object::New(isolate);
+
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "total_heap_size").ToLocalChecked(),
+      Number::New(isolate, heap_stats.total_heap_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "total_heap_size_executable")
+        .ToLocalChecked(),
+      Number::New(isolate, heap_stats.total_heap_size_executable()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "total_physical_size").ToLocalChecked(),
+      Number::New(isolate, heap_stats.total_physical_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "total_available_size").ToLocalChecked(),
+      Number::New(isolate, heap_stats.total_available_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "used_heap_size").ToLocalChecked(),
+      Number::New(isolate, heap_stats.used_heap_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "heap_size_limit").ToLocalChecked(),
+      Number::New(isolate, heap_stats.heap_size_limit()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "malloced_memory").ToLocalChecked(),
+      Number::New(isolate, heap_stats.malloced_memory()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "peak_malloced_memory").ToLocalChecked(),
+      Number::New(isolate, heap_stats.peak_malloced_memory()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "does_zap_garbage").ToLocalChecked(),
+      Boolean::New(isolate, heap_stats.does_zap_garbage()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "number_of_native_contexts")
+        .ToLocalChecked(),
+      Number::New(isolate, heap_stats.number_of_native_contexts()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "number_of_detached_contexts")
+        .ToLocalChecked(),
+      Number::New(isolate, heap_stats.number_of_detached_contexts()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "total_global_handles_size")
+        .ToLocalChecked(),
+      Number::New(isolate, heap_stats.total_global_handles_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "used_global_handles_size").ToLocalChecked(),
+      Number::New(isolate, heap_stats.used_global_handles_size()));
+  stats->Set(currentContext,
+      String::NewFromUtf8(isolate, "external_memory").ToLocalChecked(),
+      Number::New(isolate, heap_stats.external_memory()));
+
+  args.GetReturnValue().Set(stats);
+}
+
 void Worker::GetResourceLimits(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
@@ -996,6 +1058,8 @@ void CreateWorkerPerIsolateProperties(IsolateData* isolate_data,
     SetProtoMethod(isolate, w, "takeHeapSnapshot", Worker::TakeHeapSnapshot);
     SetProtoMethod(isolate, w, "loopIdleTime", Worker::LoopIdleTime);
     SetProtoMethod(isolate, w, "loopStartTime", Worker::LoopStartTime);
+    SetProtoMethod(isolate, w, "getHeapStatistics", Worker::GetHeapStatistics);
+
 
     SetConstructorFunction(isolate, target, "Worker", w);
   }

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -830,7 +830,6 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   Worker* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
 
-
   Environment* env = w->env();
   AsyncHooks::DefaultTriggerAsyncIdScope trigger_id_scope(w);
   Local<Object> wrap;
@@ -900,8 +899,7 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
               Number::New(isolate, heap_stats->used_global_handles_size()),
               Number::New(isolate, heap_stats->external_memory())};
 
-          DCHECK_EQ(
-              arraysize(heap_stats_names), arraysize(heap_stats_values));
+          DCHECK_EQ(arraysize(heap_stats_names), arraysize(heap_stats_values));
 
           // Create the object with the property names and values
           Local<Object> stats = Object::New(isolate,

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -78,6 +78,8 @@ class Worker : public AsyncWrap {
   static void TakeHeapSnapshot(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopIdleTime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void LoopStartTime(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetHeapStatistics(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
   bool CreateEnvMessagePort(Environment* env);

--- a/test/parallel/test-worker-heap-statistics.js
+++ b/test/parallel/test-worker-heap-statistics.js
@@ -45,7 +45,6 @@ if (isMainThread) {
     for (const key of keys) {
       if (key === 'does_zap_garbage') {
         assert.strictEqual(typeof stats[key], 'boolean', `Expected ${key} to be a boolean`);
-        assert.strictEqual(stats[key], false);
         continue;
       }
       assert.strictEqual(typeof stats[key], 'number', `Expected ${key} to be a number`);

--- a/test/parallel/test-worker-heap-statistics.js
+++ b/test/parallel/test-worker-heap-statistics.js
@@ -23,8 +23,8 @@ if (isMainThread) {
   const worker = new Worker(fixtures.path('worker-name.js'), {
     name,
   });
-  worker.once('message', common.mustCall((message) => {
-    const stats = worker.getHeapStatistics();
+  worker.once('message', common.mustCall(async (message) => {
+    const stats = await worker.getHeapStatistics();
     const keys = [
       `total_heap_size`,
       `total_heap_size_executable`,
@@ -53,5 +53,12 @@ if (isMainThread) {
     }
 
     worker.postMessage('done');
+  }));
+
+  worker.once('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+    assert.rejects(worker.getHeapStatistics(), {
+      code: 'ERR_WORKER_NOT_RUNNING'
+    });
   }));
 }

--- a/test/parallel/test-worker-heap-statistics.js
+++ b/test/parallel/test-worker-heap-statistics.js
@@ -55,9 +55,9 @@ if (isMainThread) {
     worker.postMessage('done');
   }));
 
-  worker.once('exit', common.mustCall((code) => {
+  worker.once('exit', common.mustCall(async (code) => {
     assert.strictEqual(code, 0);
-    assert.rejects(worker.getHeapStatistics(), {
+    await assert.rejects(worker.getHeapStatistics(), {
       code: 'ERR_WORKER_NOT_RUNNING'
     });
   }));

--- a/test/parallel/test-worker-heap-statistics.js
+++ b/test/parallel/test-worker-heap-statistics.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+
+common.skipIfInspectorDisabled();
+
+const {
+  Worker,
+  isMainThread,
+} = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('This test only works on a main thread');
+}
+
+// Ensures that worker.getHeapStatistics() returns valid data
+
+const assert = require('assert');
+
+if (isMainThread) {
+  const name = 'Hello Thread';
+  const worker = new Worker(fixtures.path('worker-name.js'), {
+    name,
+  });
+  worker.once('message', common.mustCall((message) => {
+    const stats = worker.getHeapStatistics();
+    const keys = [
+      `total_heap_size`,
+      `total_heap_size_executable`,
+      `total_physical_size`,
+      `total_available_size`,
+      `used_heap_size`,
+      `heap_size_limit`,
+      `malloced_memory`,
+      `peak_malloced_memory`,
+      `does_zap_garbage`,
+      `number_of_native_contexts`,
+      `number_of_detached_contexts`,
+      `total_global_handles_size`,
+      `used_global_handles_size`,
+      `external_memory`,
+    ].sort();
+    assert.deepStrictEqual(keys, Object.keys(stats).sort());
+    for (const key of keys) {
+      if (key === 'does_zap_garbage') {
+        assert.strictEqual(typeof stats[key], 'boolean', `Expected ${key} to be a boolean`);
+        assert.strictEqual(stats[key], false);
+        continue;
+      }
+      assert.strictEqual(typeof stats[key], 'number', `Expected ${key} to be a number`);
+      assert.ok(stats[key] >= 0, `Expected ${key} to be >= 0`);
+    }
+
+    worker.postMessage('done');
+  }));
+}

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -61,6 +61,7 @@ const { getSystemErrorName } = require('util');
     delete providers.ELDHISTOGRAM;
     delete providers.SIGINTWATCHDOG;
     delete providers.WORKERHEAPSNAPSHOT;
+    delete providers.WORKERHEAPSTATISTICS;
     delete providers.BLOBREADER;
     delete providers.RANDOMPRIMEREQUEST;
     delete providers.CHECKPRIMEREQUEST;

--- a/typings/internalBinding/worker.d.ts
+++ b/typings/internalBinding/worker.d.ts
@@ -15,6 +15,7 @@ declare namespace InternalWorkerBinding {
     unref(): void;
     getResourceLimits(): Float64Array;
     takeHeapSnapshot(): object;
+    getHeapStatistics(): Promise<object>;
     loopIdleTime(): number;
     loopStartTime(): number;
   }


### PR DESCRIPTION
Adds `worker.getHeapStatistics()` so that the heap usage of the worker could be observer from the parent thread.