### PR TITLE
crypto: allow inspecting a crypto key prototype

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -762,7 +762,7 @@ class CryptoKey {
   get type() {
     if (!(this instanceof CryptoKey))
       throw new ERR_INVALID_THIS('CryptoKey');
-    return this[kKeyObject].type;
+    return this[kKeyObject]?.type;
   }
 
   get extractable() {

--- a/test/parallel/test-crypto-inspect.js
+++ b/test/parallel/test-crypto-inspect.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const { subtle } = require('crypto');
+const { strictEqual } = require('assert');
+const { inspect } = require('util');
+
+const promise = subtle.importKey('raw', Buffer.from([1, 2, 3]), {
+  name: 'HMAC', hash: 'SHA-256'
+}, true, ['sign', 'verify']);
+
+promise.then(common.mustCall((key) => {
+  const inspected = inspect(Object.getPrototypeOf(key));
+  strictEqual(
+    inspected,
+    'CryptoKey {\n' +
+    '  type: undefined,\n' +
+    '  extractable: undefined,\n' +
+    '  algorithm: undefined,\n' +
+    '  usages: undefined\n' +
+    '}'
+  );
+}));


### PR DESCRIPTION
This would fail so far due to accessing a undefined property.