### PR TITLE
lib: make `new SafeSet(arr)` safe

### DIFF
--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -387,7 +387,8 @@ SafePromiseAllReturnVoid([]); // safe
 SafePromiseAllReturnArrayLike([]); // safe
 
 const array = [promise];
-const set = new SafeSet().add(promise);
+const set = new SafeSet(array);
+
 // When running one of these functions on a non-empty iterable, it will also:
 // 1. Lookup `then` property on `promise` (user-mutable if user-provided).
 // 2. Lookup `then` property on `%Promise.prototype%` (user-mutable).

--- a/lib/internal/main/mksnapshot.js
+++ b/lib/internal/main/mksnapshot.js
@@ -5,7 +5,6 @@ const {
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   ObjectSetPrototypeOf,
-  SafeArrayIterator,
   SafeSet,
 } = primordials;
 
@@ -36,7 +35,7 @@ const {
 const path = require('path');
 const { getOptionValue } = require('internal/options');
 
-const supportedModules = new SafeSet(new SafeArrayIterator([
+const supportedModules = new SafeSet([
   // '_http_agent',
   // '_http_client',
   // '_http_common',
@@ -100,7 +99,7 @@ const supportedModules = new SafeSet(new SafeArrayIterator([
   // 'vm',
   // 'worker_threads',
   'zlib',
-]));
+]);
 
 const warnedModules = new SafeSet();
 function supportedInUserSnapshot(id) {

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -8,7 +8,6 @@ const {
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ReflectApply,
-  SafeArrayIterator,
   SafeMap,
   SafeSet,
   StringPrototypeIncludes,
@@ -371,7 +370,7 @@ function cjsPreparseModuleExports(filename, source, format) {
     reexports = [];
   }
 
-  const exportNames = new SafeSet(new SafeArrayIterator(exports));
+  const exportNames = new SafeSet(exports);
 
   // Set first for cycles.
   module[kModuleExportNames] = exportNames;

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -43,10 +43,11 @@ const nameToCodeMap = new SafeMap();
 
 // These were removed from the error names table.
 // See https://github.com/heycam/webidl/pull/946.
-const disusedNamesSet = new SafeSet()
-  .add('DOMStringSizeError')
-  .add('NoDataAllowedError')
-  .add('ValidationError');
+const disusedNamesSet = new SafeSet([
+  'DOMStringSizeError',
+  'NoDataAllowedError',
+  'ValidationError',
+]);
 
 class DOMException {
   constructor(message = '', options = 'Error') {

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -268,6 +268,7 @@ primordials.IteratorPrototype = Reflect.getPrototypeOf(primordials.ArrayIterator
 
 const {
   Array: ArrayConstructor,
+  ArrayIsArray,
   ArrayPrototypeForEach,
   ArrayPrototypeMap,
   FinalizationRegistry,
@@ -296,6 +297,7 @@ const {
   RegExpPrototypeGetSource,
   RegExpPrototypeGetSticky,
   RegExpPrototypeGetUnicode,
+  SafeArrayIterator,
   Set,
   SymbolIterator,
   SymbolMatch,
@@ -419,7 +421,13 @@ primordials.SafeWeakMap = makeSafe(
 primordials.SafeSet = makeSafe(
   Set,
   class SafeSet extends Set {
-    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
+    constructor(i) {
+      super(
+        i && ArrayIsArray(i) ?
+          new SafeArrayIterator(i) :
+          i,
+      );
+    }
   },
 );
 primordials.SafeWeakSet = makeSafe(
@@ -476,7 +484,7 @@ primordials.AsyncIteratorPrototype =
       async function* () {}).prototype);
 
 const arrayToSafePromiseIterable = (promises, mapFn) =>
-  new primordials.SafeArrayIterator(
+  new SafeArrayIterator(
     ArrayPrototypeMap(
       promises,
       (promise, i) =>

--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -2,7 +2,6 @@
 
 const {
   ObjectDefineProperties,
-  SafeArrayIterator,
   SafeMap,
   SafeSet,
   Symbol,
@@ -41,14 +40,14 @@ const kDetail = Symbol('kDetail');
 
 const markTimings = new SafeMap();
 
-const nodeTimingReadOnlyAttributes = new SafeSet(new SafeArrayIterator([
+const nodeTimingReadOnlyAttributes = new SafeSet([
   'nodeStart',
   'v8Start',
   'environment',
   'loopStart',
   'loopExit',
   'bootstrapComplete',
-]));
+]);
 
 function getMark(name) {
   if (name === undefined) return;

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -86,9 +86,12 @@ const kDefaultTimeout = null;
 const noop = FunctionPrototype;
 const kShouldAbort = Symbol('kShouldAbort');
 const kHookNames = ObjectSeal(['before', 'after', 'beforeEach', 'afterEach']);
-const kUnwrapErrors = new SafeSet()
-  .add(kTestCodeFailure).add(kHookFailure)
-  .add('uncaughtException').add('unhandledRejection');
+const kUnwrapErrors = new SafeSet([
+  kTestCodeFailure,
+  kHookFailure,
+  'uncaughtException',
+  'unhandledRejection',
+]);
 let kResistStopPropagation;
 let assertObj;
 let findSourceMap;


### PR DESCRIPTION
This has the direct ergonomic benefit of being able to safely pass an array to `new SafeSet()`.

It has the unintended but desirable benefit of making a lot of existing post-startup calls to `new SafeSet` with an array more robust.

This helps with #57876, and whichever lands first, the other will want to rebase on top of it.