### PR TITLE
test_runner: emit test:watch:restarted event on watched file changes

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1114,6 +1114,9 @@ const customReporter = new Transform({
       case 'test:watch:drained':
         callback(null, 'test watch queue drained');
         break;
+      case 'test:watch:restarted':
+        callback(null, 'test watch restarted due to file change');
+        break;
       case 'test:start':
         callback(null, `test ${event.data.name} started`);
         break;
@@ -1159,6 +1162,9 @@ const customReporter = new Transform({
       case 'test:watch:drained':
         callback(null, 'test watch queue drained');
         break;
+      case 'test:watch:restarted':
+        callback(null, 'test watch restarted due to file change');
+        break;
       case 'test:start':
         callback(null, `test ${event.data.name} started`);
         break;
@@ -1203,6 +1209,9 @@ export default async function * customReporter(source) {
       case 'test:watch:drained':
         yield 'test watch queue drained\n';
         break;
+      case 'test:watch:restarted':
+        yield 'test watch restarted due to file change\n';
+        break;
       case 'test:start':
         yield `test ${event.data.name} started\n`;
         break;
@@ -1242,6 +1251,9 @@ module.exports = async function * customReporter(source) {
         break;
       case 'test:watch:drained':
         yield 'test watch queue drained\n';
+        break;
+      case 'test:watch:restarted':
+        yield 'test watch restarted due to file change\n';
         break;
       case 'test:start':
         yield `test ${event.data.name} started\n`;
@@ -3157,6 +3169,10 @@ generated for each test file in addition to a final cumulative summary.
 ### Event: `'test:watch:drained'`
 
 Emitted when no more tests are queued for execution in watch mode.
+
+### Event: `'test:watch:restarted'`
+
+Emitted when one or more tests are restarted due to a file change in watch mode.
 
 ## Class: `TestContext`
 

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -480,6 +480,7 @@ function watchFiles(testFiles, opts) {
       // Reset the topLevel counter
       opts.root.harness.counters.topLevel = 0;
     }
+
     await runningSubtests.get(file);
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
@@ -507,6 +508,8 @@ function watchFiles(testFiles, opts) {
     // Reset the root start time to recalculate the duration
     // of the run
     opts.root.clearExecutionTime();
+    opts.root.reporter[kEmitMessage]('test:watch:restarted');
+
     // Restart test files
     if (opts.isolation === 'none') {
       PromisePrototypeThen(restartTestFile(kIsolatedProcessName), undefined, (error) => {


### PR DESCRIPTION
The goal of this PR is to add a `test:watch:restarted` event to signal to the reporter that some tests have restarted while in watch mode.

This will enable a trivial fix for [nodejs/node#57206](https://github.com/nodejs/node/issues/57206), which I plan to address later.