### PR TITLE
http2: give name to promisified `connect()`

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3369,7 +3369,7 @@ function connect(authority, options, listener) {
 // Support util.promisify
 ObjectDefineProperty(connect, promisify.custom, {
   __proto__: null,
-  value: (authority, options) => {
+  value: function connect(authority, options) { // eslint-disable-line func-name-matching
     return new Promise((resolve, reject) => {
       const server = connect(authority, options, () => {
         server.removeListener('error', reject);

--- a/test/parallel/test-util-promisify-custom-names.mjs
+++ b/test/parallel/test-util-promisify-custom-names.mjs
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import readline from 'node:readline';
 import stream from 'node:stream';
 import timers from 'node:timers';
+import http2 from 'node:http2';
 
 
 assert.strictEqual(
@@ -37,4 +38,9 @@ assert.strictEqual(
 assert.strictEqual(
   promisify(timers.setTimeout).name,
   'setTimeout'
+);
+
+assert.strictEqual(
+  promisify(http2.connect).name,
+  'connect'
 );


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/57899 for the eslint exception.