### PR TITLE
fix: ensure file descriptor 0 is properly closed in fs streams

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -115,7 +115,7 @@ const FileHandleOperations = (handle) => {
 };
 
 function close(stream, err, cb) {
-  if (!stream.fd) {
+  if (stream.fd == null) {
     cb(err);
   } else if (stream.flush) {
     stream[kFs].fsync(stream.fd, (flushErr) => {


### PR DESCRIPTION
This PR fixes an issue where file descriptor `0` (stdin) was not being closed properly in file streams. 
The condition `if (!stream.fd)` was incorrectly excluding `fd = 0` due to its falsy value.

### Why is this needed?
Without this fix, file descriptor `0` remains open, which can lead to resource leaks in certain scenarios.

### What does this PR do?
- Updates the condition to explicitly check for `null` or `undefined` using `if (stream.fd == null)`.
- Adds a new test case `test-fs-file-descriptor-0.js` to ensure this behavior is correct.

### Testing
- A test case `test-fs-file-descriptor-0.js` was added to verify that file descriptor `0` is properly closed.
- The test ensures the `'close'` event is triggered correctly for the stream.

Fixes #57905