### PR TITLE
test: add test for file descriptor 0 in fs streams

### DIFF
--- a/test/parallel/test-fs-file-descriptor-0.js
+++ b/test/parallel/test-fs-file-descriptor-0.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+// Test to ensure file descriptor 0 (stdin) is handled properly
+const stream = fs.createReadStream(null, { fd: 0 });
+
+stream.on('close', () => {
+  assert.ok(true, 'File descriptor 0 closed successfully');
+  console.log('Test passed: File descriptor 0 closed successfully');
+});
+
+stream.close();


### PR DESCRIPTION
### Testing
- A test case `test-fs-file-descriptor-0.js` was added to verify that file descriptor `0` is properly closed.
- The test ensures the `'close'` event is triggered correctly for the stream.