### PR TITLE
util: add internal `assignFunctionName()` function

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -47,6 +47,7 @@ const {
 } = primordials;
 
 const {
+  assignFunctionName,
   convertToValidSignal,
   getSystemErrorName,
   kEmptyObject,
@@ -236,7 +237,7 @@ function exec(command, options, callback) {
 }
 
 const customPromiseExecFunction = (orig) => {
-  return (...args) => {
+  return assignFunctionName(orig.name, function(...args) {
     const { promise, resolve, reject } = PromiseWithResolvers();
 
     promise.child = orig(...args, (err, stdout, stderr) => {
@@ -250,7 +251,7 @@ const customPromiseExecFunction = (orig) => {
     });
 
     return promise;
-  };
+  });
 };
 
 ObjectDefineProperty(exec, promisify.custom, {

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -26,6 +26,7 @@ const {
 } = primordials;
 
 const {
+  assignFunctionName,
   assertCrypto,
   customInspectSymbol: kInspect,
   kEmptyObject,
@@ -3405,7 +3406,7 @@ function connect(authority, options, listener) {
 // Support util.promisify
 ObjectDefineProperty(connect, promisify.custom, {
   __proto__: null,
-  value: (authority, options) => {
+  value: assignFunctionName('connect', function(authority, options) {
     return new Promise((resolve, reject) => {
       const server = connect(authority, options, () => {
         server.removeListener('error', reject);
@@ -3414,7 +3415,7 @@ ObjectDefineProperty(connect, promisify.custom, {
 
       server.once('error', reject);
     });
-  },
+  }),
 });
 
 function createSecureServer(options, handler) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -38,6 +38,7 @@ const {
   StringPrototypeToUpperCase,
   Symbol,
   SymbolFor,
+  SymbolPrototypeGetDescription,
   SymbolReplace,
   SymbolSplit,
 } = primordials;
@@ -850,10 +851,37 @@ const encodingsMap = { __proto__: null };
 for (let i = 0; i < encodings.length; ++i)
   encodingsMap[encodings[i]] = i;
 
+/**
+ * Reassigns the .name property of a function.
+ * Should be used when function can't be initially defined with desired name
+ * or when desired name should include `#`, `[`, `]`, etc.
+ * @param {string | symbol} name
+ * @param {Function} fn
+ * @param {object} [descriptor]
+ * @returns {Function} the same function, renamed
+ */
+function assignFunctionName(name, fn, descriptor = kEmptyObject) {
+  if (typeof name !== 'string') {
+    const symbolDescription = SymbolPrototypeGetDescription(name);
+    assert(symbolDescription !== undefined, 'Attempted to name function after descriptionless Symbol');
+    name = `[${symbolDescription}]`;
+  }
+  return ObjectDefineProperty(fn, 'name', {
+    __proto__: null,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+    ...ObjectGetOwnPropertyDescriptor(fn, 'name'),
+    ...descriptor,
+    value: name,
+  });
+}
+
 module.exports = {
   getLazy,
   assertCrypto,
   assertTypeScript,
+  assignFunctionName,
   cachedResult,
   convertToValidSignal,
   createClassWrapper,

--- a/test/parallel/test-util-promisify-custom-names.mjs
+++ b/test/parallel/test-util-promisify-custom-names.mjs
@@ -1,4 +1,4 @@
-import '../common/index.mjs';
+import { hasCrypto } from '../common/index.mjs';
 import assert from 'node:assert';
 import { promisify } from 'node:util';
 
@@ -48,3 +48,11 @@ assert.strictEqual(
   promisify(child_process.execFile).name,
   'execFile'
 );
+
+if (hasCrypto) {
+  const http2 = await import('node:http2');
+  assert.strictEqual(
+    promisify(http2.connect).name,
+    'connect'
+  );
+}

--- a/test/parallel/test-util-promisify-custom-names.mjs
+++ b/test/parallel/test-util-promisify-custom-names.mjs
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 import readline from 'node:readline';
 import stream from 'node:stream';
 import timers from 'node:timers';
+import child_process from 'node:child_process';
 
 
 assert.strictEqual(
@@ -37,4 +38,13 @@ assert.strictEqual(
 assert.strictEqual(
   promisify(timers.setTimeout).name,
   'setTimeout'
+);
+
+assert.strictEqual(
+  promisify(child_process.exec).name,
+  'exec'
+);
+assert.strictEqual(
+  promisify(child_process.execFile).name,
+  'execFile'
 );


### PR DESCRIPTION
Extracted from: https://github.com/nodejs/node/pull/57901

We have a lot of functions exposed to userspace or mentioned in stack traces that are anonymous or have something inherited like `value` as name; because it's not convenient to define it with name, or because the correct name is already taken by another variable, or because the name comes from a `Symbol`, or because of false positives from linter.

This helper function will simplify giving such functions a correct name.