### PR TITLE
watch: clarify completion/failure watch mode messages

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -79,10 +79,11 @@ function start() {
   }
   child.once('exit', (code) => {
     exited = true;
+    const waitingForChanges = 'Waiting for file changes before restarting...';
     if (code === 0) {
-      process.stdout.write(`${blue}Completed running ${kCommandStr}${white}\n`);
+      process.stdout.write(`${blue}Completed running ${kCommandStr}. ${waitingForChanges}${white}\n`);
     } else {
-      process.stdout.write(`${red}Failed running ${kCommandStr}${white}\n`);
+      process.stdout.write(`${red}Failed running ${kCommandStr}. ${waitingForChanges}${white}\n`);
     }
   });
   return child;

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -171,10 +171,10 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -185,10 +185,10 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -209,7 +209,7 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
       assert.deepStrictEqual(stdout, [
         `Restarting ${inspect(jsFile)}`,
         'ENV: value2',
-        `Completed running ${inspect(jsFile)}`,
+        `Completed running ${inspect(jsFile)}. Waiting for file changes before restarting...`,
       ]);
     } finally {
       await done();
@@ -235,7 +235,7 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
         `Restarting ${inspect(jsFile)}`,
         'ENV: value1',
         'ENV2: newValue',
-        `Completed running ${inspect(jsFile)}`,
+        `Completed running ${inspect(jsFile)}. Waiting for file changes before restarting...`,
       ]);
     } finally {
       await done();
@@ -261,7 +261,7 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
         `Restarting ${inspect(jsFile)}`,
         'ENV: value1',
         'ENV2: newValue',
-        `Completed running ${inspect(jsFile)}`,
+        `Completed running ${inspect(jsFile)}. Waiting for file changes before restarting...`,
       ]);
     } finally {
       await done();
@@ -279,9 +279,9 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
 
     assert.match(stderr, /Error: fails\r?\n/);
     assert.deepStrictEqual(stdout, [
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -298,10 +298,10 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
     assert.strictEqual(stderr, '');
   });
@@ -324,9 +324,9 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
 
     assert.match(stderr, /Error: Cannot find module/g);
     assert.deepStrictEqual(stdout, [
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -348,9 +348,9 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
 
     assert.match(stderr, /Error: Cannot find module/g);
     assert.deepStrictEqual(stdout, [
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
-      `Failed running ${inspect(file)}`,
+      `Failed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -380,10 +380,10 @@ console.log(dependency);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       '{}',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       '{}',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -398,10 +398,10 @@ console.log(dependency);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       '{}',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       '{}',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -412,13 +412,13 @@ console.log(dependency);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -435,10 +435,10 @@ console.log(values.random);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       random,
-      `Completed running ${inspect(`${file} --random ${random}`)}`,
+      `Completed running ${inspect(`${file} --random ${random}`)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(`${file} --random ${random}`)}`,
       random,
-      `Completed running ${inspect(`${file} --random ${random}`)}`,
+      `Completed running ${inspect(`${file} --random ${random}`)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -452,10 +452,10 @@ console.log(values.random);
     assert.notStrictEqual(pid, importPid);
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -472,10 +472,10 @@ console.log(values.random);
 
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -521,10 +521,10 @@ console.log(values.random);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -536,10 +536,10 @@ console.log(values.random);
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -567,11 +567,11 @@ console.log(values.random);
     assert.deepStrictEqual(stdout, [
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -599,11 +599,11 @@ console.log(values.random);
     assert.deepStrictEqual(stdout, [
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -631,11 +631,11 @@ console.log(values.random);
     assert.deepStrictEqual(stdout, [
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -663,11 +663,11 @@ console.log(values.random);
     assert.deepStrictEqual(stdout, [
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -679,10 +679,10 @@ console.log(values.random);
     assert.match(stderr, /listening on ws:\/\//);
     assert.deepStrictEqual(stdout, [
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -704,11 +704,11 @@ console.log(values.random);
     assert.deepStrictEqual(stdout, [
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'hello',
       'running',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
@@ -788,7 +788,7 @@ process.on('message', (message) => {
       `Restarting ${inspect(file)}`,
       'running',
       'Received: second message',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 });


### PR DESCRIPTION
clarify the messages that `node --watch` presents to the user when the process terminates (either successfully or because of some error) by clearly conveying that node is waiting for new file changes before restarting the process

___

I am not sure if it fixes it but it might partially help with https://github.com/nodejs/node/issues/57657

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
