### PR TITLE
test: mark test-file-write-stream4 as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -12,6 +12,10 @@ test-shadow-realm-gc-module: SKIP
 # https://github.com/nodejs/node/issues/51862
 test-fs-read-stream-concurrent-reads: PASS, FLAKY
 
+# https://github.com/nodejs/node/issues/56883
+# Potentially caused by https://github.com/nodejs/node/issues/54918
+test-file-write-stream4: PASS, FLAKY
+
 # Until V8 provides a better way to check for flag mismatch without
 # making the code cache/snapshot unreproducible, disable the test
 # for a preemptive check now. It should ideally fail more gracefully


### PR DESCRIPTION
The flake has been detected since 2021-10-30 and still has been affecting recent PRs significantly (failing 8 PRs out of the last 100 CI run up until 2025-04-18). The underlying cause is still under investigation but in the meantime it's better to mark it as a known flake to keep the CI functional.

This flake affects at least Windows, Linux and macOS, according to https://github.com/nodejs/reliability/blob/main/reports/2025-04-18.md and likely affects all platforms. So the status is applied to all platforms in this PR.

Refs: https://github.com/nodejs/reliability/issues/102
Refs: https://github.com/nodejs/reliability/blob/main/reports/2025-04-18.md
Refs: https://github.com/nodejs/node/issues/56883
Refs: https://github.com/nodejs/node/issues/54918

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
