### PR TITLE
src: add FromV8Value<T>() for integral and enum types

### DIFF
--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -780,7 +780,7 @@ void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
   Utf8Value name(env->isolate(), args[0]);
 
   ArrayBufferOrViewContents<unsigned char> key_data(args[1]);
-  KeyType type = static_cast<KeyType>(args[2].As<Int32>()->Value());
+  KeyType type = FromV8Value<KeyType>(args[2]);
 
   MarkPopErrorOnReturn mark_pop_error_on_return;
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2881,10 +2881,10 @@ static void Chown(const FunctionCallbackInfo<Value>& args) {
   ToNamespacedPath(env, &path);
 
   CHECK(IsSafeJsInt(args[1]));
-  const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
+  const uv_uid_t uid = FromV8Value<uv_uid_t>(args[1]);
 
   CHECK(IsSafeJsInt(args[2]));
-  const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Integer>()->Value());
+  const uv_gid_t gid = FromV8Value<uv_gid_t>(args[2]);
 
   if (argc > 3) {  // chown(path, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);
@@ -2956,10 +2956,10 @@ static void LChown(const FunctionCallbackInfo<Value>& args) {
   ToNamespacedPath(env, &path);
 
   CHECK(IsSafeJsInt(args[1]));
-  const uv_uid_t uid = static_cast<uv_uid_t>(args[1].As<Integer>()->Value());
+  const uv_uid_t uid = FromV8Value<uv_uid_t>(args[1]);
 
   CHECK(IsSafeJsInt(args[2]));
-  const uv_gid_t gid = static_cast<uv_gid_t>(args[2].As<Integer>()->Value());
+  const uv_gid_t gid = FromV8Value<uv_gid_t>(args[2]);
 
   if (argc > 3) {  // lchown(path, uid, gid, req)
     FSReqBase* req_wrap_async = GetReqWrap(args, 3);

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -61,8 +61,7 @@ static void GetOwnNonIndexProperties(
 
   Local<Array> properties;
 
-  PropertyFilter filter =
-    static_cast<PropertyFilter>(args[1].As<Uint32>()->Value());
+  PropertyFilter filter = FromV8Value<PropertyFilter>(args[1]);
 
   if (!object->GetPropertyNames(
         context, KeyCollectionMode::kOwnOnly,

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -40,7 +40,6 @@ using v8::HandleScope;
 using v8::HeapCodeStatistics;
 using v8::HeapSpaceStatistics;
 using v8::HeapStatistics;
-using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
@@ -492,8 +491,7 @@ static void GetCppHeapStatistics(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsInt32());
 
   cppgc::HeapStatistics stats = isolate->GetCppHeap()->CollectStatistics(
-      static_cast<cppgc::HeapStatistics::DetailLevel>(
-          args[0].As<Int32>()->Value()));
+      FromV8Value<cppgc::HeapStatistics::DetailLevel>(args[0]));
 
   Local<Object> result;
   if (!ConvertHeapStatsToJSObject(isolate, stats).ToLocal(&result)) {

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -53,7 +53,6 @@ using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
-using v8::Int32;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
@@ -687,8 +686,7 @@ class ZlibStream final : public CompressionStream<ZlibContext> {
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    node_zlib_mode mode =
-        static_cast<node_zlib_mode>(args[0].As<Int32>()->Value());
+    node_zlib_mode mode = FromV8Value<node_zlib_mode>(args[0]);
     new ZlibStream(env, args.This(), mode);
   }
 
@@ -793,8 +791,7 @@ class BrotliCompressionStream final :
   static void New(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
     CHECK(args[0]->IsInt32());
-    node_zlib_mode mode =
-        static_cast<node_zlib_mode>(args[0].As<Int32>()->Value());
+    node_zlib_mode mode = FromV8Value<node_zlib_mode>(args[0]);
     new BrotliCompressionStream(env, args.This(), mode);
   }
 

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -173,7 +173,7 @@ class ProcessWrap : public HandleWrap {
           return Nothing<void>();
         }
         CHECK(fd_value->IsNumber());
-        int fd = static_cast<int>(fd_value.As<Integer>()->Value());
+        int fd = FromV8Value<int>(fd_value);
         options->stdio[i].flags = UV_INHERIT_FD;
         options->stdio[i].data.fd = fd;
       }

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -354,7 +354,7 @@ void UDPWrap::Open(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(
       &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
   CHECK(args[0]->IsNumber());
-  int fd = static_cast<int>(args[0].As<Integer>()->Value());
+  int fd = FromV8Value<int>(args[0]);
   int err = uv_udp_open(&wrap->handle_, fd);
 
   args.GetReturnValue().Set(err);

--- a/src/util-inl.h
+++ b/src/util-inl.h
@@ -591,6 +591,38 @@ constexpr std::string_view FastStringKey::as_string_view() const {
   return name_;
 }
 
+// Converts a V8 numeric value to a corresponding C++ primitive or enum type.
+template <typename T,
+          typename = std::enable_if_t<std::numeric_limits<T>::is_specialized ||
+                                      std::is_enum_v<T>>>
+T FromV8Value(v8::Local<v8::Value> value) {
+  if constexpr (std::is_enum_v<T>) {
+    using Underlying = std::underlying_type_t<T>;
+    return static_cast<T>(FromV8Value<Underlying>(value));
+  } else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>) {
+    static_assert(
+        std::numeric_limits<T>::max() <= std::numeric_limits<uint32_t>::max() &&
+            std::numeric_limits<T>::min() >=
+                std::numeric_limits<uint32_t>::min(),
+        "Type is out of unsigned integer range");
+    CHECK(value->IsUint32());
+    return static_cast<T>(value.As<v8::Uint32>()->Value());
+  } else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>) {
+    static_assert(
+        std::numeric_limits<T>::max() <= std::numeric_limits<int32_t>::max() &&
+            std::numeric_limits<T>::min() >=
+                std::numeric_limits<int32_t>::min(),
+        "Type is out of signed integer range");
+    CHECK(value->IsInt32());
+    return static_cast<T>(value.As<v8::Int32>()->Value());
+  } else {
+    static_assert(std::is_floating_point_v<T>,
+                  "Type must be arithmetic or enum.");
+    CHECK(value->IsNumber());
+    return static_cast<T>(value.As<v8::Number>()->Value());
+  }
+}
+
 #ifdef _WIN32
 inline bool IsWindowsBatchFile(const char* filename) {
   std::string file_with_extension = filename;


### PR DESCRIPTION
From the following comment in the pull request: https://github.com/nodejs/node/pull/57146#discussion_r1963799600


Add a template utility method `FromV8Value<T>()` to replace the repetitive `static_cast<...>(value.As<>()‑>Value())` pattern. It also additionally adds compile‑time range checks for integers.

I've also replaced a bunch of `static_cast`s with the new `FromV8Value<T>()`
