### PR TITLE
src: improve error handling in cares_wrap

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -474,7 +474,7 @@ void Initialize(Local<Object> target,
   SetProtoMethod(isolate, channel_wrap, "queryA", Query<QueryAWrap>);
   // ...
   SetProtoMethod(isolate, channel_wrap, "querySoa", Query<QuerySoaWrap>);
-  SetProtoMethod(isolate, channel_wrap, "getHostByAddr", Query<GetHostByAddrWrap>);
+  SetProtoMethod(isolate, channel_wrap, "getHostByAddr", Query<QueryReverseWrap>);
 
   SetProtoMethodNoSideEffect(isolate, channel_wrap, "getServers", GetServers);
 

--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -406,119 +406,38 @@ class QueryWrap final : public AsyncWrap {
   QueryWrap<Traits>** callback_ptr_ = nullptr;
 };
 
-struct AnyTraits final {
-  static constexpr const char* name = "resolveAny";
-  static int Send(QueryWrap<AnyTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<AnyTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
+#define QUERY_TYPES(V)                                                         \
+  V(Reverse, reverse, getHostByAddr)                                           \
+  V(A, resolve4, queryA)                                                       \
+  V(Any, resolveAny, queryAny)                                                 \
+  V(Aaaa, resolve6, queryAaaa)                                                 \
+  V(Caa, resolveCaa, queryCaa)                                                 \
+  V(Cname, resolveCname, queryCname)                                           \
+  V(Mx, resolveMx, queryMx)                                                    \
+  V(Naptr, resolveNaptr, queryNaptr)                                           \
+  V(Ns, resolveNs, queryNs)                                                    \
+  V(Ptr, resolvePtr, queryPtr)                                                 \
+  V(Srv, resolveSrv, querySrv)                                                 \
+  V(Soa, resolveSoa, querySoa)                                                 \
+  V(Tlsa, resolveTlsa, queryTlsa)                                              \
+  V(Txt, resolveTxt, queryTxt)
 
-struct ATraits final {
-  static constexpr const char* name = "resolve4";
-  static int Send(QueryWrap<ATraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<ATraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
+// All query type handlers share the same basic structure, so we can simplify
+// the code a bit by using a macro to define that structure.
+#define TYPE_TRAITS(Name, label)                                               \
+  struct Name##Traits final {                                                  \
+    static constexpr const char* name = #label;                                \
+    static int Send(QueryWrap<Name##Traits>* wrap, const char* name);          \
+    static v8::Maybe<int> Parse(                                               \
+        QueryWrap<Name##Traits>* wrap,                                         \
+        const std::unique_ptr<ResponseData>& response);                        \
+  };                                                                           \
+  using Query##Name##Wrap = QueryWrap<Name##Traits>;
 
-struct AaaaTraits final {
-  static constexpr const char* name = "resolve6";
-  static int Send(QueryWrap<AaaaTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<AaaaTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct CaaTraits final {
-  static constexpr const char* name = "resolveCaa";
-  static int Send(QueryWrap<CaaTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<CaaTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct CnameTraits final {
-  static constexpr const char* name = "resolveCname";
-  static int Send(QueryWrap<CnameTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<CnameTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct MxTraits final {
-  static constexpr const char* name = "resolveMx";
-  static int Send(QueryWrap<MxTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<MxTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct NsTraits final {
-  static constexpr const char* name = "resolveNs";
-  static int Send(QueryWrap<NsTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<NsTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct TlsaTraits final {
-  static constexpr const char* name = "resolveTlsa";
-  static int Send(QueryWrap<TlsaTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<TlsaTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct TxtTraits final {
-  static constexpr const char* name = "resolveTxt";
-  static int Send(QueryWrap<TxtTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<TxtTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct SrvTraits final {
-  static constexpr const char* name = "resolveSrv";
-  static int Send(QueryWrap<SrvTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<SrvTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct PtrTraits final {
-  static constexpr const char* name = "resolvePtr";
-  static int Send(QueryWrap<PtrTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<PtrTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct NaptrTraits final {
-  static constexpr const char* name = "resolveNaptr";
-  static int Send(QueryWrap<NaptrTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<NaptrTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct SoaTraits final {
-  static constexpr const char* name = "resolveSoa";
-  static int Send(QueryWrap<SoaTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<SoaTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-struct ReverseTraits final {
-  static constexpr const char* name = "reverse";
-  static int Send(QueryWrap<ReverseTraits>* wrap, const char* name);
-  static v8::Maybe<int> Parse(QueryWrap<ReverseTraits>* wrap,
-                              const std::unique_ptr<ResponseData>& response);
-};
-
-using QueryAnyWrap = QueryWrap<AnyTraits>;
-using QueryAWrap = QueryWrap<ATraits>;
-using QueryAaaaWrap = QueryWrap<AaaaTraits>;
-using QueryCaaWrap = QueryWrap<CaaTraits>;
-using QueryCnameWrap = QueryWrap<CnameTraits>;
-using QueryMxWrap = QueryWrap<MxTraits>;
-using QueryNsWrap = QueryWrap<NsTraits>;
-using QueryTlsaWrap = QueryWrap<TlsaTraits>;
-using QueryTxtWrap = QueryWrap<TxtTraits>;
-using QuerySrvWrap = QueryWrap<SrvTraits>;
-using QueryPtrWrap = QueryWrap<PtrTraits>;
-using QueryNaptrWrap = QueryWrap<NaptrTraits>;
-using QuerySoaWrap = QueryWrap<SoaTraits>;
-using GetHostByAddrWrap = QueryWrap<ReverseTraits>;
-
+#define V(NAME, LABEL, _) TYPE_TRAITS(NAME, LABEL)
+QUERY_TYPES(V)
+#undef V
+#undef TYPE_TRAITS
 }  // namespace cares_wrap
 }  // namespace node
 


### PR DESCRIPTION
Improve error handling in cares_wrap by replacing `ToLocalChecked()` and `Check()` calls.
Reduce some code duplication using macros