### PR TITLE
lib: allow Immediate to be coerced to primitive

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -200,6 +200,16 @@ Timeout.prototype[SymbolToPrimitive] = function() {
   return id;
 };
 
+Immediate.prototype[SymbolToPrimitive] = function() {
+  const id = this[async_id_symbol];
+  if (!this[kHasPrimitive]) {
+    this[kHasPrimitive] = true;
+    knownTimersById[id] = this;
+  }
+
+  return id;
+};
+
 /**
  * Schedules the immediate execution of `callback`
  * after I/O events' callbacks.
@@ -227,25 +237,34 @@ ObjectDefineProperty(setImmediate, customPromisify, {
  * @returns {void}
  */
 function clearImmediate(immediate) {
-  if (!immediate?._onImmediate || immediate._destroyed)
+  let instance = immediate;
+
+  if (typeof immediate === 'number' || typeof immediate == 'string') {
+    instance = knownTimersById[immediate];
+    if (immediate === undefined) {
+      return;
+    }
+  }
+
+  if (!instance?._onImmediate || instance._destroyed)
     return;
 
   immediateInfo[kCount]--;
-  immediate._destroyed = true;
+  instance._destroyed = true;
 
-  if (immediate[kRefed] && --immediateInfo[kRefCount] === 0) {
+  if (instance[kRefed] && --immediateInfo[kRefCount] === 0) {
     // We need to use the binding as the receiver for fast API calls.
     binding.toggleImmediateRef(false);
   }
-  immediate[kRefed] = null;
+  instance[kRefed] = null;
 
-  if (destroyHooksExist() && immediate[async_id_symbol] !== undefined) {
-    emitDestroy(immediate[async_id_symbol]);
+  if (destroyHooksExist() && instance[async_id_symbol] !== undefined) {
+    emitDestroy(instance[async_id_symbol]);
   }
 
-  immediate._onImmediate = null;
+  instance._onImmediate = null;
 
-  immediateQueue.remove(immediate);
+  immediateQueue.remove(instance);
 }
 
 Immediate.prototype[SymbolDispose] = function() {

--- a/test/parallel/test-timers-immediate-as-number.js
+++ b/test/parallel/test-timers-immediate-as-number.js
@@ -1,0 +1,46 @@
+'use strict';
+const common = require('../common');
+const { test } = require('node:test');
+
+test('setImmediate return value is coerced to a number', (t) => {
+  const immediateId = +setImmediate(common.mustNotCall());
+  clearImmediate(immediateId);
+
+  t.assert.strictEqual(typeof immediateId, 'number');
+  t.assert.ok(!Number.isNaN(immediateId), 'setImmediate return value is NaN');
+});
+
+test('setImmediate return value is coerced to a string', (t) => {
+  const immediateId = '' + setImmediate(common.mustNotCall());
+  clearImmediate(immediateId);
+
+  t.assert.strictEqual(typeof immediateId, 'string');
+  t.assert.match(immediateId, /^\d+$/, 'setImmediate return value is not non-negative integer');
+});
+
+test('clearImmediate with a non-used immediate id', () => {
+  // No-op when the immediate id is not used
+  const immediateId = setImmediate(common.mustCall());
+
+  clearImmediate(immediateId + 1);
+  clearImmediate(`${immediateId + 1}`);
+
+  // Obviusly invalid ids
+  clearImmediate(Number.MAX_SAFE_INTEGER);
+  clearImmediate('random-string');
+});
+
+test('clearImmediate with a numeric immediate id coerced to a string', () => {
+  const immediateId = +setImmediate(common.mustNotCall());
+  clearImmediate(immediateId.toString());
+});
+
+test('clearImmediate with a string immediate id coerced to a number', () => {
+  const immediateId = '' + setImmediate(common.mustNotCall());
+  clearImmediate(Number(immediateId));
+});
+
+test('two coerced immediate ids are equal if taken from the same immediate', (t) => {
+  const immediate = setImmediate(common.mustCall());
+  t.assert.equal('' + immediate, +immediate);
+});


### PR DESCRIPTION
Fixes #56776

Inspired by what is done for `Timeout`, this PR allows the `Immediate`, returned by the `setImmediate` function, to be coerced to a `number`.