### PR TITLE
lib: destroy waiting httpMessage on socket close

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -801,7 +801,7 @@ function socketOnClose(socket, state) {
   debug('server socket close');
   freeParser(socket.parser, null, socket);
   abortIncoming(state.incoming);
-  abortIncomingAndPendingMessages(state.outgoing);
+  abortPendingMessages(state.outgoing);
 }
 
 function abortIncoming(incoming) {
@@ -812,7 +812,7 @@ function abortIncoming(incoming) {
   // Abort socket._httpMessage ?
 }
 
-function abortIncomingAndPendingMessages(outgoing){
+function abortPendingMessages(outgoing){
   while (outgoing.length) {
     const res = outgoing.shift();
     emitCloseNT(res);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -996,7 +996,7 @@ function resOnFinish(req, res, socket, state, server) {
   }
 
   // Usually the first incoming element should be our request.  it may
-  // be that in the case abortIncomingAndPendingMessages() was called that the incoming
+  // be that in the case abortIncoming() was called that the incoming
   // array will be empty.
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -801,6 +801,7 @@ function socketOnClose(socket, state) {
   debug('server socket close');
   freeParser(socket.parser, null, socket);
   abortIncoming(state.incoming);
+  abortIncomingAndPendingMessages(state.outgoing);
 }
 
 function abortIncoming(incoming) {
@@ -809,6 +810,13 @@ function abortIncoming(incoming) {
     req.destroy(new ConnResetException('aborted'));
   }
   // Abort socket._httpMessage ?
+}
+
+function abortIncomingAndPendingMessages(outgoing){
+  while (outgoing.length) {
+    const res = outgoing.shift();
+    emitCloseNT(res);
+  }
 }
 
 function socketOnEnd(server, socket, parser, state) {
@@ -988,7 +996,7 @@ function resOnFinish(req, res, socket, state, server) {
   }
 
   // Usually the first incoming element should be our request.  it may
-  // be that in the case abortIncoming() was called that the incoming
+  // be that in the case abortIncomingAndPendingMessages() was called that the incoming
   // array will be empty.
   assert(state.incoming.length === 0 || state.incoming[0] === req);
 


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/57946

I am not sure if this fix is safe or correct in all cases — I have only tested it locally in a minimal setup.
It may have unintended side effects, so further validation is needed.