### PR TITLE
Improve util getCallSites

### DIFF
--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -257,7 +257,7 @@ static void GetCallSites(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsNumber());
   const uint32_t frames = args[0].As<Uint32>()->Value();
-  DCHECK(frames >= 1 && frames <= 200);
+  CHECK(frames >= 1 && frames <= 200);
 
   // +1 for disregarding node:util
   Local<StackTrace> stack = StackTrace::CurrentStackTrace(isolate, frames + 1);

--- a/test/fixtures/typescript/ts/test-get-callsites-explicit.ts
+++ b/test/fixtures/typescript/ts/test-get-callsites-explicit.ts
@@ -7,4 +7,4 @@ interface CallSite {
 
 const callSite = getCallSites({ sourceMap: false })[0];
 
-console.log('mapCallSite: ', callSite);
+console.log('mapCallSites: ', callSite);

--- a/test/fixtures/typescript/ts/test-get-callsites.ts
+++ b/test/fixtures/typescript/ts/test-get-callsites.ts
@@ -7,4 +7,4 @@ interface CallSite {
 
 const callSite = getCallSites()[0];
 
-console.log('getCallSite: ', callSite);
+console.log('getCallSites: ', callSite);

--- a/test/parallel/test-util-getcallsites.js
+++ b/test/parallel/test-util-getcallsites.js
@@ -131,7 +131,7 @@ const assert = require('node:assert');
   const { status, stderr, stdout } = spawnSync(process.execPath, [
     '--no-warnings',
     '--experimental-transform-types',
-    fixtures.path('typescript/ts/test-get-callsite.ts'),
+    fixtures.path('typescript/ts/test-get-callsites.ts'),
   ]);
 
   const output = stdout.toString();
@@ -139,7 +139,7 @@ const assert = require('node:assert');
   assert.match(output, /lineNumber: 8/);
   assert.match(output, /column: 18/);
   assert.match(output, /columnNumber: 18/);
-  assert.match(output, /test-get-callsite\.ts/);
+  assert.match(output, /test-get-callsites\.ts/);
   assert.strictEqual(status, 0);
 }
 
@@ -148,7 +148,7 @@ const assert = require('node:assert');
     '--no-warnings',
     '--experimental-transform-types',
     '--no-enable-source-maps',
-    fixtures.path('typescript/ts/test-get-callsite.ts'),
+    fixtures.path('typescript/ts/test-get-callsites.ts'),
   ]);
 
   const output = stdout.toString();
@@ -157,7 +157,7 @@ const assert = require('node:assert');
   assert.match(output, /lineNumber: 2/);
   assert.match(output, /column: 18/);
   assert.match(output, /columnNumber: 18/);
-  assert.match(output, /test-get-callsite\.ts/);
+  assert.match(output, /test-get-callsites\.ts/);
   assert.strictEqual(status, 0);
 }
 
@@ -166,7 +166,7 @@ const assert = require('node:assert');
   const { status, stderr, stdout } = spawnSync(process.execPath, [
     '--no-warnings',
     '--experimental-transform-types',
-    fixtures.path('typescript/ts/test-get-callsite-explicit.ts'),
+    fixtures.path('typescript/ts/test-get-callsites-explicit.ts'),
   ]);
 
   const output = stdout.toString();
@@ -174,7 +174,7 @@ const assert = require('node:assert');
   assert.match(output, /lineNumber: 2/);
   assert.match(output, /column: 18/);
   assert.match(output, /columnNumber: 18/);
-  assert.match(output, /test-get-callsite-explicit\.ts/);
+  assert.match(output, /test-get-callsites-explicit\.ts/);
   assert.strictEqual(status, 0);
 }
 


### PR DESCRIPTION
This patch has two commits:
1. Renamed `test/fixtures/typescript/ts/test-get-callsite.ts` and `test/fixtures/typescript/ts/test-get-callsite-explicit.ts` to `test/fixtures/typescript/ts/test-get-callsites.ts` and `test/fixtures/typescript/ts/test-get-callsites-explicit.ts` respectively, and update relevant occurrence, since the function `getCallSite` was renamed to `getCallSites`.
2. Changed `DCHECK` TO `CHECK` to make the validation more robust.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
3. Update documentation if relevant.
4. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
