### PR TITLE
util: update isError with new Error.isError

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -7,6 +7,7 @@ const {
   ArrayPrototypeSort,
   Error,
   ErrorCaptureStackTrace,
+  ErrorIsError,
   FunctionPrototypeCall,
   NumberParseInt,
   ObjectDefineProperties,
@@ -66,7 +67,7 @@ const {
   },
   sleep: _sleep,
 } = internalBinding('util');
-const { isNativeError, isPromise } = internalBinding('types');
+const { isPromise } = internalBinding('types');
 const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
 const { encodings } = internalBinding('string_decoder');
@@ -96,7 +97,7 @@ function isError(e) {
   // An error could be an instance of Error while not being a native error
   // or could be from a different realm and not be instance of Error but still
   // be a native error.
-  return Error.isError ? Error.isError(e) : isNativeError(e) || e instanceof Error;
+  return ErrorIsError(e) || e instanceof Error;
 }
 
 // Keep a list of deprecation codes that have been warned on so we only warn on

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -96,7 +96,7 @@ function isError(e) {
   // An error could be an instance of Error while not being a native error
   // or could be from a different realm and not be instance of Error but still
   // be a native error.
-  return isNativeError(e) || e instanceof Error;
+  return Error.isError ? Error.isError(e) : isNativeError(e) || e instanceof Error;
 }
 
 // Keep a list of deprecation codes that have been warned on so we only warn on

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -16,6 +16,7 @@ const {
   Date,
   DatePrototypeGetTime,
   Error,
+  ErrorIsError,
   Float32Array,
   Float64Array,
   Function,
@@ -103,7 +104,6 @@ const {
   isMap,
   isRegExp,
   isSet,
-  isNativeError,
   isBoxedPrimitive,
   isNumberObject,
   isStringObject,
@@ -383,7 +383,7 @@ function objectComparisonStart(val1, val2, mode, memos) {
              isRegExp(val2) ||
              isAnyArrayBuffer(val2) ||
              isBoxedPrimitive(val2) ||
-             isNativeError(val2) ||
+             ErrorIsError(val2) ||
              val2 instanceof Error) {
     return false;
   } else if (isURL(val1)) {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -31,6 +31,7 @@ const {
   DatePrototypeToISOString,
   DatePrototypeToString,
   Error,
+  ErrorIsError,
   ErrorPrototype,
   ErrorPrototypeToString,
   Function,
@@ -165,7 +166,6 @@ const {
   isMap,
   isMapIterator,
   isModuleNamespaceObject,
-  isNativeError,
   isPromise,
   isSet,
   isSetIterator,
@@ -793,7 +793,7 @@ function getKeys(value, showHidden) {
     try {
       keys = ObjectKeys(value);
     } catch (err) {
-      assert(isNativeError(err) && err.name === 'ReferenceError' &&
+      assert(ErrorIsError(err) && err.name === 'ReferenceError' &&
              isModuleNamespaceObject(value));
       keys = ObjectGetOwnPropertyNames(value);
     }
@@ -1750,7 +1750,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i],
                                  kObjectType);
     } catch (err) {
-      assert(isNativeError(err) && err.name === 'ReferenceError');
+      assert(ErrorIsError(err) && err.name === 'ReferenceError');
       // Use the existing functionality. This makes sure the indentation and
       // line breaks are always correct. Otherwise it is very difficult to keep
       // this aligned, even though this is a hacky way of dealing with this.

--- a/test/parallel/test-internal-util-helpers.js
+++ b/test/parallel/test-internal-util-helpers.js
@@ -3,9 +3,11 @@
 
 require('../common');
 const assert = require('assert');
-const { types } = require('util');
 const { assignFunctionName, isError } = require('internal/util');
 const vm = require('vm');
+const {
+  ErrorIsError
+} = require('internal/test/binding').primordials;
 
 // Special cased errors. Test the internal function which is used in
 // `util.inspect()`, the `repl` and maybe more. This verifies that errors from
@@ -15,7 +17,7 @@ const vm = require('vm');
 // actual errors.
 {
   const fake = { [Symbol.toStringTag]: 'Error' };
-  assert(!types.isNativeError(fake));
+  assert(!ErrorIsError(fake));
   assert(!(fake instanceof Error));
   assert(!isError(fake));
 
@@ -24,14 +26,14 @@ const vm = require('vm');
     Object.getPrototypeOf(err),
     Object.getOwnPropertyDescriptors(err));
   Object.defineProperty(err, 'message', { value: err.message });
-  assert(types.isNativeError(err));
-  assert(!types.isNativeError(newErr));
+  assert(ErrorIsError(err));
+  assert(!ErrorIsError(newErr));
   assert(newErr instanceof Error);
   assert(isError(newErr));
 
   const context = vm.createContext({});
   const differentRealmErr = vm.runInContext('new Error()', context);
-  assert(types.isNativeError(differentRealmErr));
+  assert(ErrorIsError(differentRealmErr));
   assert(!(differentRealmErr instanceof Error));
   assert(isError(differentRealmErr));
 }

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -26,6 +26,9 @@ const assert = require('assert');
 const util = require('util');
 const errors = require('internal/errors');
 const context = require('vm').runInNewContext;
+const {
+  ErrorIsError
+} = require('internal/test/binding').primordials;
 
 // isArray
 assert.strictEqual(util.isArray([]), true);
@@ -52,30 +55,30 @@ assert.deepStrictEqual(util._extend({ a: 1, b: 2 }, { b: 3 }), { a: 1, b: 3 });
 assert.strictEqual(util.toUSVString('string\ud801'), 'string\ufffd');
 
 {
-  assert.strictEqual(util.types.isNativeError(new Error()), true);
-  assert.strictEqual(util.types.isNativeError(new TypeError()), true);
-  assert.strictEqual(util.types.isNativeError(new SyntaxError()), true);
-  assert.strictEqual(util.types.isNativeError(new (context('Error'))()), true);
+  assert.strictEqual(ErrorIsError(new Error()), true);
+  assert.strictEqual(ErrorIsError(new TypeError()), true);
+  assert.strictEqual(ErrorIsError(new SyntaxError()), true);
+  assert.strictEqual(ErrorIsError(new (context('Error'))()), true);
   assert.strictEqual(
-    util.types.isNativeError(new (context('TypeError'))()),
+    ErrorIsError(new (context('TypeError'))()),
     true
   );
   assert.strictEqual(
-    util.types.isNativeError(new (context('SyntaxError'))()),
+    ErrorIsError(new (context('SyntaxError'))()),
     true
   );
-  assert.strictEqual(util.types.isNativeError({}), false);
+  assert.strictEqual(ErrorIsError({}), false);
   assert.strictEqual(
-    util.types.isNativeError({ name: 'Error', message: '' }),
+    ErrorIsError({ name: 'Error', message: '' }),
     false
   );
-  assert.strictEqual(util.types.isNativeError([]), false);
+  assert.strictEqual(ErrorIsError([]), false);
   assert.strictEqual(
-    util.types.isNativeError({ __proto__: Error.prototype }),
+    ErrorIsError({ __proto__: Error.prototype }),
     false
   );
   assert.strictEqual(
-    util.types.isNativeError(new errors.codes.ERR_IPC_CHANNEL_CLOSED()),
+    ErrorIsError(new errors.codes.ERR_IPC_CHANNEL_CLOSED()),
     true
   );
 }


### PR DESCRIPTION
Refs [57961](https://github.com/nodejs/node/issues/57961)
Fixes: https://github.com/nodejs/node/issues/57961

This PR updates the `isError` function in `lib/internal/util.js` to use the native `Error.isError` method if it is available. 
