### PR TITLE
meta: allow penetration testing on live system with prior authorization

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,7 +72,9 @@ When reporting security vulnerabilities, reporters must adhere to the following 
 
 3. **Responsible Testing**: When testing potential vulnerabilities:
    * Use isolated, controlled environments.
-   * Do not test on production systems.
+   * Do not test on production systems without prior authorization. Contact
+     the Node.js Technical Steering Committee (tsc@iojs.org) for permission or open
+     a HackerOne report.
    * Do not attempt to access or modify other users' data.
    * Immediately stop testing if unauthorized access is gained accidentally.
 


### PR DESCRIPTION
While reviewing the entire incident report, I found that this text was too strict. We need researchers to keep hardening our CI. However, we should avoid the kind of fire drill we had in March, and do it in a controlled manner.