### PR TITLE
docs: fix `AsyncLocalStorage` example response changes after node v18

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -75,8 +75,8 @@ http.get('http://localhost:8080');
 http.get('http://localhost:8080');
 // Prints:
 //   0: start
-//   1: start
-//   0: finish
+//   0: start
+//   1: finish
 //   1: finish
 ```
 
@@ -107,8 +107,8 @@ http.get('http://localhost:8080');
 http.get('http://localhost:8080');
 // Prints:
 //   0: start
-//   1: start
-//   0: finish
+//   0: start
+//   1: finish
 //   1: finish
 ```
 


### PR DESCRIPTION
I can confirm that the change in behavior started with **Node.js 20.x**.

### ✅ Node.js v18.20.4 – Works as expected:
```
0: start  
1: start  
0: finish  
1: finish
```

### ❗ Node.js v20.17.0 and v22.11.0 – Changed behavior:
```
0: start  
0: finish  
1: start  
1: finish
```

According to the official [[Node.js changelog](https://nodejs.org/en/blog/release/v20.0.0#notable-changes)](https://nodejs.org/en/blog/release/v20.0.0#notable-changes), this difference is due to **bug fixes and improvements in async context handling** introduced in v20:

> "Several subtle bugs and inconsistencies in edge cases (e.g., using `AsyncResource`, event emitters, timers) have been fixed in v20.  
> Node.js now handles `setTimeout`, `setImmediate`, and event emitters more predictably in relation to the async context."

So if your code depends on `AsyncLocalStorage` or similar context-tracking features, be aware that behavior may differ between Node 18 and 20+ due to these changes.

