### PR TITLE
build: define python when generating `out/Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ out/Makefile: config.gypi common.gypi node.gyp \
 	tools/v8_gypfiles/toolchain.gypi \
 	tools/v8_gypfiles/features.gypi \
 	tools/v8_gypfiles/inspector.gypi tools/v8_gypfiles/v8.gyp
-	$(PYTHON) tools/gyp_node.py -f make
+	$(PYTHON) tools/gyp_node.py -f make -Dpython=$(PYTHON)
 
 # node_version.h is listed because the N-API version is taken from there
 # and included in config.gypi


### PR DESCRIPTION
Ref: #48462

Equal to https://github.com/nodejs/node/blob/d74c4987351252f39c18305dd53dbf047639017f/configure.py#L2363-L2372

When `out/Makefile` is generated during `./configure`, `-Dpython=` is passed to GYP, however, when it's generated from the Makefile, it is not passed. This can lead to an undefined variable python on some systems.