### PR TITLE
crypto: fix cross-realm `SharedArrayBuffer` validation

### DIFF
--- a/lib/internal/crypto/webidl.js
+++ b/lib/internal/crypto/webidl.js
@@ -25,9 +25,6 @@ const {
   String,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetSymbolToStringTag,
-  globalThis: {
-    SharedArrayBuffer,
-  },
 } = primordials;
 
 const {
@@ -47,7 +44,7 @@ const {
   validateMaxBufferLength,
   kNamedCurveAliases,
 } = require('internal/crypto/util');
-const { isArrayBuffer } = require('internal/util/types');
+const { isArrayBuffer, isSharedArrayBuffer } = require('internal/util/types');
 
 // https://tc39.es/ecma262/#sec-tonumber
 function toNumber(value, opts = kEmptyObject) {
@@ -194,13 +191,6 @@ converters.object = (V, opts) => {
 };
 
 const isNonSharedArrayBuffer = isArrayBuffer;
-
-function isSharedArrayBuffer(V) {
-  // SharedArrayBuffers can be disabled with --no-harmony-sharedarraybuffer.
-  if (SharedArrayBuffer !== undefined)
-    return ObjectPrototypeIsPrototypeOf(SharedArrayBuffer.prototype, V);
-  return false;
-}
 
 converters.Uint8Array = (V, opts = kEmptyObject) => {
   if (!ArrayBufferIsView(V) ||


### PR DESCRIPTION
https://github.com/nodejs/node/pull/57828 only fixed the code for `ArrayBuffer`, let's handle `SharedArrayBuffer` as well. This also refactors the test to include the nits that didn't make it in the original PR.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
