### PR TITLE
src: use ranges library (C++20) to simplify code

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -395,16 +395,16 @@ void OptionsParser<Options>::Parse(
         // Implications for negated options are defined with "--no-".
         implied_name.insert(2, "no-");
       }
-      auto implications = implications_.equal_range(implied_name);
+      auto [f, l] = implications_.equal_range(implied_name);
       std::ranges::for_each(
-        implications | std::views::values, [&](const auto& value) {
-          if (value.type == kV8Option) {
-            v8_args->push_back(value.name);
-          } else {
-            *value.target_field->template Lookup<bool>(options) =
-                value.target_value;
-          }
-      });
+        std::ranges::subrange(f,l) | std::views::values, [&](const auto& value) {
+            if (value.type == kV8Option) {
+              v8_args->push_back(value.name);
+            } else {
+              *value.target_field->template Lookup<bool>(options) =
+                  value.target_value;
+            }
+          });
     }
 
     if (it == options_.end()) {

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -395,11 +395,13 @@ void OptionsParser<Options>::Parse(
         implied_name.insert(2, "no-");
       }
       auto implications = implications_.equal_range(implied_name);
-      std::ranges::for_each(implications | std::views::values, [&](const auto& value) {
+      std::ranges::for_each(
+        implications | std::views::values, [&](const auto& value) {
           if (value.type == kV8Option) {
-              v8_args->push_back(value.name);
+            v8_args->push_back(value.name);
           } else {
-              *value.target_field->template Lookup<bool>(options) = value.target_value;
+            *value.target_field->template Lookup<bool>(options) =
+                value.target_value;
           }
       });
     }

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <cstdlib>
+#include <ranges>
 #include "node_options.h"
 #include "util.h"
 
@@ -394,14 +395,13 @@ void OptionsParser<Options>::Parse(
         implied_name.insert(2, "no-");
       }
       auto implications = implications_.equal_range(implied_name);
-      for (auto imp = implications.first; imp != implications.second; ++imp) {
-        if (imp->second.type == kV8Option) {
-          v8_args->push_back(imp->second.name);
-        } else {
-          *imp->second.target_field->template Lookup<bool>(options) =
-              imp->second.target_value;
-        }
-      }
+      std::ranges::for_each(implications | std::views::values, [&](const auto& value) {
+          if (value.type == kV8Option) {
+              v8_args->push_back(value.name);
+          } else {
+              *value.target_field->template Lookup<bool>(options) = value.target_value;
+          }
+      });
     }
 
     if (it == options_.end()) {

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -396,16 +396,15 @@ void OptionsParser<Options>::Parse(
         implied_name.insert(2, "no-");
       }
       auto [f, l] = implications_.equal_range(implied_name);
-      std::ranges::for_each(
-        std::ranges::subrange(f, l) | std::views::values, 
-          [&](const auto& value) {
-            if (value.type == kV8Option) {
-              v8_args->push_back(value.name);
-            } else {
-              *value.target_field->template Lookup<bool>(options) =
-                  value.target_value;
-            }
-          });
+      std::ranges::for_each(std::ranges::subrange(f, l) | std::views::values,
+                            [&](const auto& value) {
+                              if (value.type == kV8Option) {
+                                v8_args->push_back(value.name);
+                              } else {
+                                *value.target_field->template Lookup<bool>(
+                                    options) = value.target_value;
+                              }
+                            });
     }
 
     if (it == options_.end()) {

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <algorithm>
 #include <cstdlib>
 #include <ranges>
 #include "node_options.h"

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -397,7 +397,8 @@ void OptionsParser<Options>::Parse(
       }
       auto [f, l] = implications_.equal_range(implied_name);
       std::ranges::for_each(
-        std::ranges::subrange(f,l) | std::views::values, [&](const auto& value) {
+        std::ranges::subrange(f, l) | std::views::values, 
+          [&](const auto& value) {
             if (value.type == kV8Option) {
               v8_args->push_back(value.name);
             } else {


### PR DESCRIPTION
This PR uses C++20 ranges to slightly simplify a piece of code. To be honest, the real motivation of this PR is to introduce ranges and test whether the platforms play nice with ranges. If so, then this could be generalized in the code base.