### PR TITLE
doc: reserve module version 136 for Electron 37

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 136,"runtime": "electron", "variant": "electron",             "versions": "37" },
     { "modules": 135,"runtime": "electron", "variant": "electron",             "versions": "36" },
     { "modules": 134,"runtime": "node",     "variant": "v8_13.0",              "versions": "24.0.0-pre" },
     { "modules": 133,"runtime": "electron", "variant": "electron",             "versions": "35" },


### PR DESCRIPTION
This PR reserves NMV 136 for Electron 37 as part of our regular [release preparation work](https://github.com/orgs/electron/projects/112/views/3?pane=issue&itemId=100704744). Thanks! 🙇