### PR TITLE
doc,build,win: update docs with clang

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -640,7 +640,10 @@ Refs:
   [Visual Studio 2022 (17.6 or newer)](https://visualstudio.microsoft.com/downloads/)
   or the "C++ build tools" workload from the
   [Build Tools](https://aka.ms/vs/17/release/vs_buildtools.exe),
-  with the default optional components
+  with the default optional components. Starting with Node.js v24, ClangCL is required to compile
+  on Windows. To enable it, two additional components are needed:
+  * C++ Clang Compiler for Windows (Microsoft.VisualStudio.Component.VC.Llvm.Clang)
+  * MSBuild support for LLVM toolset (Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset)
 * Basic Unix tools required for some tests,
   [Git for Windows](https://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.
@@ -663,13 +666,6 @@ Optional requirements for compiling for Windows on ARM (ARM64):
   * Visual C++ compilers and libraries for ARM64
   * Visual C++ ATL for ARM64
 * Windows 10 SDK 10.0.17763.0 or newer
-
-Optional requirements for compiling with ClangCL (search for `clang` in Visual Studio
-Installer's "individual component" tab):
-
-* Visual Studio individual components
-  * C++ Clang Compiler for Windows
-  * MSBuild support for LLVM toolset
 
 NOTE: Currently we only support compiling with Clang that comes from Visual Studio.
 

--- a/tools/bootstrap/windows_boxstarter
+++ b/tools/bootstrap/windows_boxstarter
@@ -18,7 +18,7 @@ choco install python3 -y
 
 # Installs VS 2022 Build Tools
 choco install visualstudio2022buildtools -y
-choco install visualstudio2022-workload-vctools -y --params="--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64"
+choco install visualstudio2022-workload-vctools -y --params="--add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.ATL.ARM64 --add Microsoft.NetCore.Component.SDK --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset"
 
 # NASM
 choco install nasm -y

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -237,6 +237,14 @@ if errorlevel 1 echo Could not find NASM, install it or build with openssl-no-as
 
 call :getnodeversion || exit /b 1
 
+@REM Forcing ClangCL usage for version 24 and above
+set NODE_MAJOR_VERSION=
+for /F "tokens=1 delims=." %%i in ("%NODE_VERSION%") do set "NODE_MAJOR_VERSION=%%i"
+if %NODE_MAJOR_VERSION% GEQ 24 (
+  echo Using ClangCL for version 24 and above is mandatory.
+  set clang_cl=1
+)
+
 if defined TAG set configure_flags=%configure_flags% --tag=%TAG%
 
 if not "%target%"=="Clean" goto skip-clean

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -241,7 +241,7 @@ call :getnodeversion || exit /b 1
 set NODE_MAJOR_VERSION=
 for /F "tokens=1 delims=." %%i in ("%NODE_VERSION%") do set "NODE_MAJOR_VERSION=%%i"
 if %NODE_MAJOR_VERSION% GEQ 24 (
-  echo Using ClangCL for version 24 and above is mandatory.
+  echo Using ClangCL because the Node.js version being compiled is >= 24.
   set clang_cl=1
 )
 


### PR DESCRIPTION
This PR changes the documentation to fit the new compiler on Windows - ClangCL. The main focus is the `BUILDING.md` file. All three `Windows Prerequisites` sections are updated to reflect the compiler change (WinGet configuration already supported it, so no changes there).

In addition, there are changes to `vcbuild.bat` to add the `clang-cl` flag for Node.js v24+ even if not provided. Since v24 will include https://github.com/nodejs/node/pull/57753 (or some other V8 update), compiling with MSVC will result in errors, so IMHO, there is not much use in allowing MSVC compilation at all, although I'm open to suggestions and different opinions on this.