### PR TITLE
[v20.x] tools: update sccache version to v0.10.0

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -96,7 +96,7 @@ jobs:
           echo "TAR_DIR=$RUNNER_TEMP/`basename tarballs/*.tar.gz .tar.gz`" >> $GITHUB_ENV
       - name: Copy directories needed for testing
         run: |
-          cp -r tools/eslint $TAR_DIR/tools
+          cp -r tools/node_modules $TAR_DIR/tools
           cp -r tools/eslint-rules $TAR_DIR/tools
       - name: Build
         run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.8.1
+          version: v0.10.0
       - name: Environment Information
         run: npx envinfo
       # The `npm ci` for this step fails a lot as part of the Test step. Run it


### PR DESCRIPTION
The update in https://github.com/nodejs/node/commit/29c032403cb6ae1229cab29cb641cd9aa2c508b8 was overwritten by https://github.com/nodejs/node/commit/d45517ccbf0b215946d208296a9396e146fb549d.

Also this line breaks the test https://github.com/nodejs/node/commit/29c032403cb6ae1229cab29cb641cd9aa2c508b8#diff-9e078b64804cbda5c87567835a5da2f1314788813ec5c5e9809a2f96519b9b01R99
not sure why it worked during the release 🤔 

@nodejs/releasers 