### PR TITLE
buffer: move SlowBuffer to EOL

### DIFF
--- a/benchmark/buffers/buffer-iterate.js
+++ b/benchmark/buffers/buffer-iterate.js
@@ -1,5 +1,5 @@
 'use strict';
-const SlowBuffer = require('buffer').SlowBuffer;
+const { Buffer } = require('buffer');
 const common = require('../common.js');
 const assert = require('assert');
 
@@ -19,7 +19,7 @@ const methods = {
 function main({ size, type, method, n }) {
   const buffer = type === 'fast' ?
     Buffer.alloc(size) :
-    SlowBuffer(size).fill(0);
+    Buffer.allocUnsafeSlow(size).fill(0);
 
   const fn = methods[method];
 

--- a/benchmark/buffers/buffer-read-with-byteLength.js
+++ b/benchmark/buffers/buffer-read-with-byteLength.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common.js');
+const { Buffer } = require('buffer');
 
 const types = [
   'IntBE',
@@ -18,7 +19,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, buf, type, byteLength }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
-    require('buffer').SlowBuffer(8);
+    Buffer.allocUnsafeSlow(8);
   const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0);

--- a/benchmark/buffers/buffer-read.js
+++ b/benchmark/buffers/buffer-read.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common.js');
+const { Buffer } = require('buffer');
 
 const types = [
   'BigUInt64LE',
@@ -27,7 +28,7 @@ const bench = common.createBenchmark(main, {
 function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
-    require('buffer').SlowBuffer(8);
+    Buffer.allocUnsafeSlow(8);
   const fn = `read${type}`;
 
   buff.writeDoubleLE(0, 0);

--- a/benchmark/buffers/buffer-slice.js
+++ b/benchmark/buffers/buffer-slice.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-const SlowBuffer = require('buffer').SlowBuffer;
+const { Buffer } = require('buffer');
 
 const bench = common.createBenchmark(main, {
   type: ['fast', 'slow', 'subarray'],
@@ -8,7 +8,7 @@ const bench = common.createBenchmark(main, {
 });
 
 const buf = Buffer.allocUnsafe(1024);
-const slowBuf = new SlowBuffer(1024);
+const slowBuf = Buffer.allocUnsafeSlow(1024);
 
 function main({ n, type }) {
   const b = type === 'slow' ? slowBuf : buf;

--- a/benchmark/buffers/buffer-write.js
+++ b/benchmark/buffers/buffer-write.js
@@ -1,6 +1,6 @@
 'use strict';
 const common = require('../common.js');
-
+const { Buffer } = require('buffer');
 const types = [
   'BigUInt64LE',
   'BigUInt64BE',
@@ -73,7 +73,7 @@ const byteLength = {
 function main({ n, buf, type }) {
   const buff = buf === 'fast' ?
     Buffer.alloc(8) :
-    require('buffer').SlowBuffer(8);
+    Buffer.allocUnsafeSlow(8);
   const fn = `write${type}`;
 
   if (!/\d/.test(fn))

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -5340,28 +5340,6 @@ console.log(newBuf.toString('ascii'));
 Because the Euro (`€`) sign is not representable in US-ASCII, it is replaced
 with `?` in the transcoded `Buffer`.
 
-### Class: `SlowBuffer`
-
-<!-- YAML
-deprecated: v6.0.0
--->
-
-> Stability: 0 - Deprecated: Use [`Buffer.allocUnsafeSlow()`][] instead.
-
-See [`Buffer.allocUnsafeSlow()`][]. This was never a class in the sense that
-the constructor always returned a `Buffer` instance, rather than a `SlowBuffer`
-instance.
-
-#### `new SlowBuffer(size)`
-
-<!-- YAML
-deprecated: v6.0.0
--->
-
-* `size` {integer} The desired length of the new `SlowBuffer`.
-
-See [`Buffer.allocUnsafeSlow()`][].
-
 ### Buffer constants
 
 <!-- YAML
@@ -5494,11 +5472,11 @@ added: v5.10.0
 
 Node.js can be started using the `--zero-fill-buffers` command-line option to
 cause all newly-allocated `Buffer` instances to be zero-filled upon creation by
-default. Without the option, buffers created with [`Buffer.allocUnsafe()`][],
-[`Buffer.allocUnsafeSlow()`][], and `new SlowBuffer(size)` are not zero-filled.
-Use of this flag can have a measurable negative impact on performance. Use the
-`--zero-fill-buffers` option only when necessary to enforce that newly allocated
-`Buffer` instances cannot contain old data that is potentially sensitive.
+default. Without the option, buffers created with [`Buffer.allocUnsafe()`][] and
+[`Buffer.allocUnsafeSlow()`][] are not zero-filled. Use of this flag can have a
+measurable negative impact on performance. Use the `--zero-fill-buffers` option
+only when necessary to enforce that newly allocated `Buffer` instances cannot
+contain old data that is potentially sensitive.
 
 ```console
 $ node --zero-fill-buffers

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3111,8 +3111,7 @@ node --watch --watch-preserve-output test.js
 added: v6.0.0
 -->
 
-Automatically zero-fills all newly allocated [`Buffer`][] and [`SlowBuffer`][]
-instances.
+Automatically zero-fills all newly allocated [`Buffer`][] instances.
 
 ## Environment variables
 
@@ -3887,7 +3886,6 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`]: errors.md#err_unsupported_typescript_syntax
 [`NODE_OPTIONS`]: #node_optionsoptions
 [`NO_COLOR`]: https://no-color.org
-[`SlowBuffer`]: buffer.md#class-slowbuffer
 [`Web Storage`]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
 [`WebSocket`]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
 [`YoungGenerationSizeFromSemiSpaceSize`]: https://chromium.googlesource.com/v8/v8.git/+/refs/tags/10.3.129/src/heap/heap.cc#328

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -696,7 +696,7 @@ Type: End-of-Life
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/58008
     description: End-of-Life.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/55175

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -696,6 +696,9 @@ Type: End-of-Life
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/55175
     description: Runtime deprecation.
   - version: v6.12.0
@@ -706,9 +709,9 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The [`SlowBuffer`][] class is deprecated. Please use
+The `SlowBuffer` class has been removed. Please use
 [`Buffer.allocUnsafeSlow(size)`][] instead.
 
 ### DEP0031: `ecdh.setPublicKey()`
@@ -3921,7 +3924,6 @@ upon `require('node:module').builtinModules`.
 [`ReadStream.open()`]: fs.md#class-fsreadstream
 [`Server.getConnections()`]: net.md#servergetconnectionscallback
 [`Server.listen({fd: <number>})`]: net.md#serverlistenhandle-backlog-callback
-[`SlowBuffer`]: buffer.md#class-slowbuffer
 [`String.prototype.toWellFormed`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed
 [`WriteStream.open()`]: fs.md#class-fswritestream
 [`assert.CallTracker`]: assert.md#class-assertcalltracker

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -572,7 +572,7 @@ the code inside the `main` function if it's more than just declaration.
 ```js
 'use strict';
 const common = require('../common.js');
-const { SlowBuffer } = require('node:buffer');
+const { Buffer } = require('node:buffer');
 
 const configs = {
   // Number of operations, specified here so they show up in the report.
@@ -603,10 +603,11 @@ function main(conf) {
   bench.start();
 
   // Do operations here
-  const BufferConstructor = conf.type === 'fast' ? Buffer : SlowBuffer;
 
   for (let i = 0; i < conf.n; i++) {
-    new BufferConstructor(conf.size);
+    conf.type === 'fast' ?
+      Buffer.allocUnsafe(conf.size) :
+      Buffer.allocUnsafeSlow(conf.size);
   }
 
   // End the timer, pass in the number of operations

--- a/doc/node.1
+++ b/doc/node.1
@@ -619,7 +619,7 @@ If set to 0 then V8 will choose an appropriate size of the thread pool based on 
 If the value provided is larger than V8's maximum, then the largest value will be chosen.
 .
 .It Fl -zero-fill-buffers
-Automatically zero-fills all newly allocated Buffer and SlowBuffer instances.
+Automatically zero-fills all newly allocated Buffer instances.
 .
 .It Fl c , Fl -check
 Check the script's syntax without executing it.

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -52,7 +52,6 @@ const {
   TypedArrayPrototypeSet,
   TypedArrayPrototypeSlice,
   Uint8Array,
-  Uint8ArrayPrototype,
 } = primordials;
 
 const {
@@ -89,7 +88,6 @@ const {
   kIsEncodingSymbol,
   defineLazyProperties,
   encodingsMap,
-  deprecate,
 } = require('internal/util');
 const {
   isAnyArrayBuffer,
@@ -411,24 +409,14 @@ Buffer.allocUnsafe = function allocUnsafe(size) {
 };
 
 /**
- * Equivalent to SlowBuffer(num), by default creates a non-zero-filled
- * Buffer instance that is not allocated off the pre-initialized pool.
- * If `--zero-fill-buffers` is set, will zero-fill the buffer.
+ * By default creates a non-zero-filled Buffer instance that is not allocated
+ * off the pre-initialized pool. If `--zero-fill-buffers` is set, will zero-fill
+ * the buffer.
  */
 Buffer.allocUnsafeSlow = function allocUnsafeSlow(size) {
   validateNumber(size, 'size', 0, kMaxLength);
   return createUnsafeBuffer(size);
 };
-
-// If --zero-fill-buffers command line argument is set, a zero-filled
-// buffer is returned.
-function SlowBuffer(size) {
-  validateNumber(size, 'size', 0, kMaxLength);
-  return createUnsafeBuffer(size);
-}
-
-ObjectSetPrototypeOf(SlowBuffer.prototype, Uint8ArrayPrototype);
-ObjectSetPrototypeOf(SlowBuffer, Uint8Array);
 
 function allocate(size) {
   if (size <= 0) {
@@ -1331,10 +1319,6 @@ function isAscii(input) {
 
 module.exports = {
   Buffer,
-  SlowBuffer: deprecate(
-    SlowBuffer,
-    'SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()',
-    'DEP0030'),
   transcode,
   isUtf8,
   isAscii,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1052,8 +1052,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             &PerProcessOptions::v8_thread_pool_size,
             kAllowedInEnvvar);
   AddOption("--zero-fill-buffers",
-            "automatically zero-fill all newly allocated Buffer and "
-            "SlowBuffer instances",
+            "automatically zero-fill all newly allocated Buffer instances",
             &PerProcessOptions::zero_fill_all_buffers,
             kAllowedInEnvvar);
   AddOption("--debug-arraybuffer-allocations",

--- a/test/parallel/test-buffer-alloc.js
+++ b/test/parallel/test-buffer-alloc.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const vm = require('vm');
 
 const {
-  SlowBuffer,
+  Buffer,
   kMaxLength,
 } = require('buffer');
 
@@ -1104,9 +1104,6 @@ assert.throws(() => Buffer.from(null), {
 // Test prototype getters don't throw
 assert.strictEqual(Buffer.prototype.parent, undefined);
 assert.strictEqual(Buffer.prototype.offset, undefined);
-assert.strictEqual(SlowBuffer.prototype.parent, undefined);
-assert.strictEqual(SlowBuffer.prototype.offset, undefined);
-
 
 {
   // Test that large negative Buffer length inputs don't affect the pool offset.
@@ -1139,7 +1136,7 @@ assert.throws(() => {
   a.copy(b, 0, 0x100000000, 0x100000001);
 }, outOfRangeError);
 
-// Unpooled buffer (replaces SlowBuffer)
+// Unpooled buffer
 {
   const ubuf = Buffer.allocUnsafeSlow(10);
   assert(ubuf);

--- a/test/parallel/test-buffer-bytelength.js
+++ b/test/parallel/test-buffer-bytelength.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const SlowBuffer = require('buffer').SlowBuffer;
+const { Buffer } = require('buffer');
 const vm = require('vm');
 
 [
@@ -24,7 +24,6 @@ const vm = require('vm');
 });
 
 assert(ArrayBuffer.isView(new Buffer(10)));
-assert(ArrayBuffer.isView(new SlowBuffer(10)));
 assert(ArrayBuffer.isView(Buffer.alloc(10)));
 assert(ArrayBuffer.isView(Buffer.allocUnsafe(10)));
 assert(ArrayBuffer.isView(Buffer.allocUnsafeSlow(10)));

--- a/test/parallel/test-buffer-failed-alloc-typed-arrays.js
+++ b/test/parallel/test-buffer-failed-alloc-typed-arrays.js
@@ -2,7 +2,7 @@
 
 require('../common');
 const assert = require('assert');
-const SlowBuffer = require('buffer').SlowBuffer;
+const { Buffer } = require('buffer');
 
 // Test failed or zero-sized Buffer allocations not affecting typed arrays.
 // This test exists because of a regression that occurred. Because Buffer
@@ -15,7 +15,6 @@ const zeroArray = new Uint32Array(10).fill(0);
 const sizes = [1e20, 0, 0.1, -1, 'a', undefined, null, NaN];
 const allocators = [
   Buffer,
-  SlowBuffer,
   Buffer.alloc,
   Buffer.allocUnsafe,
   Buffer.allocUnsafeSlow,

--- a/test/parallel/test-buffer-inspect.js
+++ b/test/parallel/test-buffer-inspect.js
@@ -30,7 +30,7 @@ buffer.INSPECT_MAX_BYTES = 2;
 let b = Buffer.allocUnsafe(4);
 b.fill('1234');
 
-let s = buffer.SlowBuffer(4);
+let s = Buffer.allocUnsafeSlow(4);
 s.fill('1234');
 
 let expected = '<Buffer 31 32 ... 2 more bytes>';
@@ -41,7 +41,7 @@ assert.strictEqual(util.inspect(s), expected);
 b = Buffer.allocUnsafe(2);
 b.fill('12');
 
-s = buffer.SlowBuffer(2);
+s = Buffer.allocUnsafeSlow(2);
 s.fill('12');
 
 expected = '<Buffer 31 32>';

--- a/test/parallel/test-buffer-no-negative-allocation.js
+++ b/test/parallel/test-buffer-no-negative-allocation.js
@@ -2,7 +2,6 @@
 
 require('../common');
 const assert = require('assert');
-const { SlowBuffer } = require('buffer');
 
 const msg = {
   code: 'ERR_OUT_OF_RANGE',
@@ -30,8 +29,3 @@ assert.throws(() => Buffer.allocUnsafeSlow(-Buffer.poolSize), msg);
 assert.throws(() => Buffer.allocUnsafeSlow(-100), msg);
 assert.throws(() => Buffer.allocUnsafeSlow(-1), msg);
 assert.throws(() => Buffer.allocUnsafeSlow(NaN), msg);
-
-assert.throws(() => SlowBuffer(-Buffer.poolSize), msg);
-assert.throws(() => SlowBuffer(-100), msg);
-assert.throws(() => SlowBuffer(-1), msg);
-assert.throws(() => SlowBuffer(NaN), msg);

--- a/test/parallel/test-buffer-over-max-length.js
+++ b/test/parallel/test-buffer-over-max-length.js
@@ -4,7 +4,6 @@ require('../common');
 const assert = require('assert');
 
 const buffer = require('buffer');
-const SlowBuffer = buffer.SlowBuffer;
 
 const kMaxLength = buffer.kMaxLength;
 const bufferMaxSizeMsg = {
@@ -13,7 +12,6 @@ const bufferMaxSizeMsg = {
 };
 
 assert.throws(() => Buffer(kMaxLength + 1), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.alloc(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafe(kMaxLength + 1), bufferMaxSizeMsg);
 assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-slow.js
+++ b/test/parallel/test-buffer-slow.js
@@ -1,20 +1,13 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
-const buffer = require('buffer');
-const SlowBuffer = buffer.SlowBuffer;
+const { Buffer, kMaxLength } = require('buffer');
 
 const ones = [1, 1, 1, 1];
 
-common.expectWarning(
-  'DeprecationWarning',
-  'SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()',
-  'DEP0030'
-);
-
 // Should create a Buffer
-let sb = SlowBuffer(4);
+let sb = Buffer.allocUnsafeSlow(4);
 assert(sb instanceof Buffer);
 assert.strictEqual(sb.length, 4);
 sb.fill(1);
@@ -26,7 +19,7 @@ for (const [key, value] of sb.entries()) {
 assert.strictEqual(sb.buffer.byteLength, 4);
 
 // Should work without new
-sb = SlowBuffer(4);
+sb = Buffer.allocUnsafeSlow(4);
 assert(sb instanceof Buffer);
 assert.strictEqual(sb.length, 4);
 sb.fill(1);
@@ -35,7 +28,7 @@ for (const [key, value] of sb.entries()) {
 }
 
 // Should work with edge cases
-assert.strictEqual(SlowBuffer(0).length, 0);
+assert.strictEqual(Buffer.allocUnsafeSlow(0).length, 0);
 
 // Should throw with invalid length type
 const bufferInvalidTypeMsg = {
@@ -43,17 +36,17 @@ const bufferInvalidTypeMsg = {
   name: 'TypeError',
   message: /^The "size" argument must be of type number/,
 };
-assert.throws(() => SlowBuffer(), bufferInvalidTypeMsg);
-assert.throws(() => SlowBuffer({}), bufferInvalidTypeMsg);
-assert.throws(() => SlowBuffer('6'), bufferInvalidTypeMsg);
-assert.throws(() => SlowBuffer(true), bufferInvalidTypeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(), bufferInvalidTypeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow({}), bufferInvalidTypeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow('6'), bufferInvalidTypeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(true), bufferInvalidTypeMsg);
 
 // Should throw with invalid length value
 const bufferMaxSizeMsg = {
   code: 'ERR_OUT_OF_RANGE',
   name: 'RangeError',
 };
-assert.throws(() => SlowBuffer(NaN), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer(Infinity), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer(-1), bufferMaxSizeMsg);
-assert.throws(() => SlowBuffer(buffer.kMaxLength + 1), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(NaN), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(Infinity), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(-1), bufferMaxSizeMsg);
+assert.throws(() => Buffer.allocUnsafeSlow(kMaxLength + 1), bufferMaxSizeMsg);

--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -7,7 +7,7 @@ require('../common');
 
 const assert = require('assert');
 const {
-  SlowBuffer,
+  Buffer,
   constants: {
     MAX_STRING_LENGTH,
   },
@@ -19,7 +19,7 @@ const message = {
   name: 'Error',
 };
 assert.throws(() => Buffer(len).toString('utf8'), message);
-assert.throws(() => SlowBuffer(len).toString('utf8'), message);
+assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);
 assert.throws(() => Buffer.alloc(len).toString('utf8'), message);
 assert.throws(() => Buffer.allocUnsafe(len).toString('utf8'), message);
 assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);

--- a/test/parallel/test-buffer-zero-fill-cli.js
+++ b/test/parallel/test-buffer-zero-fill-cli.js
@@ -1,11 +1,11 @@
 'use strict';
 // Flags: --zero-fill-buffers
 
-// when using --zero-fill-buffers, every Buffer and SlowBuffer
+// when using --zero-fill-buffers, every Buffer
 // instance must be zero filled upon creation
 
 require('../common');
-const SlowBuffer = require('buffer').SlowBuffer;
+const { Buffer } = require('buffer');
 const assert = require('assert');
 
 function isZeroFilled(buf) {
@@ -22,9 +22,8 @@ for (let i = 0; i < 50; i++) {
   const bufs = [
     Buffer.alloc(20),
     Buffer.allocUnsafe(20),
-    SlowBuffer(20),
+    Buffer.allocUnsafeSlow(20),
     Buffer(20),
-    new SlowBuffer(20),
   ];
   for (const buf of bufs) {
     assert(isZeroFilled(buf));

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -86,5 +86,5 @@ assert.deepStrictEqual(
 
 // Test that it doesn't crash
 {
-  buffer.transcode(new buffer.SlowBuffer(1), 'utf16le', 'ucs2');
+  buffer.transcode(new buffer.Buffer.allocUnsafeSlow(1), 'utf16le', 'ucs2');
 }

--- a/test/pummel/test-buffer-large-size-slowbuffer.js
+++ b/test/pummel/test-buffer-large-size-slowbuffer.js
@@ -5,18 +5,18 @@ const common = require('../common');
 common.skipIf32Bits();
 
 const assert = require('node:assert');
-const {
-  SlowBuffer,
-} = require('node:buffer');
+const { Buffer } = require('node:buffer');
 
 const size = 2 ** 31;
 
-// Test SlowBuffer with size larger than integer range
+// Test slow Buffer with size larger than integer range
 try {
-  assert.throws(() => SlowBuffer(size).toString('utf8'), { code: 'ERR_STRING_TOO_LONG' });
+  assert.throws(() => Buffer.allocUnsafeSlow(size).toString('utf8'), {
+    code: 'ERR_STRING_TOO_LONG',
+  });
 } catch (e) {
   if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
     throw e;
   }
-  common.skip('insufficient space for SlowBuffer');
+  common.skip('insufficient space for slow Buffer allocation');
 }


### PR DESCRIPTION
`SlowBuffer` has been deprecated for many years now. Let's remove it.
