### PR TITLE
test: add fast api tests for getLibuvNow()

### DIFF
--- a/src/timers.cc
+++ b/src/timers.cc
@@ -1,5 +1,7 @@
 #include "timers.h"
+
 #include "env-inl.h"
+#include "node_debug.h"
 #include "node_external_reference.h"
 #include "util-inl.h"
 #include "v8.h"
@@ -33,8 +35,8 @@ void BindingData::SlowGetLibuvNow(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(Number::New(args.GetIsolate(), now));
 }
 
-double BindingData::FastGetLibuvNow(Local<Object> unused,
-                                    Local<Object> receiver) {
+double BindingData::FastGetLibuvNow(Local<Value> receiver) {
+  TRACK_V8_FAST_API_CALL("timers.getLibuvNow");
   return GetLibuvNowImpl(FromJSObject<BindingData>(receiver));
 }
 

--- a/src/timers.h
+++ b/src/timers.h
@@ -26,8 +26,7 @@ class BindingData : public SnapshotableObject {
   static void SetupTimers(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void SlowGetLibuvNow(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static double FastGetLibuvNow(v8::Local<v8::Object> unused,
-                                v8::Local<v8::Object> receiver);
+  static double FastGetLibuvNow(v8::Local<v8::Value> receiver);
   static double GetLibuvNowImpl(BindingData* data);
 
   static void SlowScheduleTimer(

--- a/test/parallel/test-timers-now.js
+++ b/test/parallel/test-timers-now.js
@@ -1,11 +1,29 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
 'use strict';
-// Flags: --expose-internals
 
-require('../common');
-const assert = require('assert');
+const common = require('../common');
+const assert = require('node:assert');
 const { internalBinding } = require('internal/test/binding');
 const binding = internalBinding('timers');
 
 // Return value of getLibuvNow() should easily fit in a SMI after start-up.
 // We need to use the binding as the receiver for fast API calls.
 assert(binding.getLibuvNow() < 0x3ffffff);
+
+{
+  // Only javascript methods can be optimized through %OptimizeFunctionOnNextCall
+  // This is why we surround the C++ method we want to optimize with a JS function.
+  function getLibuvNow() {
+    return binding.getLibuvNow();
+  }
+
+  eval('%PrepareFunctionForOptimization(getLibuvNow)');
+  getLibuvNow();
+  eval('%OptimizeFunctionOnNextCall(getLibuvNow)');
+  assert(getLibuvNow() < 0x3ffffff);
+
+  if (common.isDebug) {
+    const { getV8FastApiCallCount } = internalBinding('debug');
+    assert.strictEqual(getV8FastApiCallCount('timers.getLibuvNow'), 1);
+  }
+}


### PR DESCRIPTION
Adds a test for the v8 fast api we use for getLibuvNow() method.