### PR TITLE
async_hooks: enable AsyncLocalStorage once constructed

### DIFF
--- a/lib/internal/async_local_storage/async_hooks.js
+++ b/lib/internal/async_local_storage/async_hooks.js
@@ -51,6 +51,8 @@ class AsyncLocalStorage {
     if (options.name !== undefined) {
       this.#name = `${options.name}`;
     }
+
+    this._enable();
   }
 
   /** @type {string} */

--- a/test/parallel/test-async-local-storage-enter-with.js
+++ b/test/parallel/test-async-local-storage-enter-with.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+// Verify that `enterWith()` does not leak the store to the parent context in a promise.
+
+const als = new AsyncLocalStorage();
+
+async function asyncFunctionAfterAwait() {
+  await 0;
+  als.enterWith('after await');
+}
+
+function promiseThen() {
+  return Promise.resolve()
+    .then(() => {
+      als.enterWith('inside then');
+    });
+}
+
+async function asyncFunctionBeforeAwait() {
+  als.enterWith('before await');
+  await 0;
+}
+
+async function main() {
+  await asyncFunctionAfterAwait();
+  await promiseThen();
+  assert.strictEqual(als.getStore(), undefined);
+
+  // This is a known limitation of the `enterWith` API.
+  await asyncFunctionBeforeAwait();
+  assert.strictEqual(als.getStore(), 'before await');
+}
+
+main().then(common.mustCall());


### PR DESCRIPTION
This fixes the leak behavior when using `enterWith` when no
`AsyncLocalStorage`s were enabled inside a promise. With this
change, the following code snippets will behave the same:

```js
import { AsyncLocalStorage } from 'node:async_hooks';

const als = new AsyncLocalStorage();

async function main () {
  await 1
  als.enterWith('internal');
}

await main()

console.log(als.getStore() ?? 'default');
```

```js
import { AsyncLocalStorage } from 'node:async_hooks';

const als = new AsyncLocalStorage();
als.enterWith(undefined); // Forcefully enable the AsyncLocalStorage.

async function main () {
  await 1
  als.enterWith('internal');
}

await main()

console.log(als.getStore() ?? 'default');
```

On the performance side, given that an `AsyncLocalStorage` is constructed, we should assume that it will be used and prefer correctness over lazy-initialization optimization.

Fixes: https://github.com/nodejs/node/issues/53037
Refs: https://github.com/nodejs/node/pull/58019

/cc @nodejs/diagnostics 