### PR TITLE
src: fix EnvironmentOptions.async_context_frame default value

### DIFF
--- a/src/node_options.h
+++ b/src/node_options.h
@@ -146,7 +146,7 @@ class EnvironmentOptions : public Options {
   bool allow_worker_threads = false;
   bool experimental_repl_await = true;
   bool experimental_vm_modules = false;
-  bool async_context_frame = false;
+  bool async_context_frame = true;
   bool expose_internals = false;
   bool force_node_api_uncaught_exceptions_policy = false;
   bool frozen_intrinsics = false;
@@ -408,6 +408,10 @@ class OptionsParser {
   // These methods add a single option to the parser. Optionally, it can be
   // specified whether the option should be allowed from environment variable
   // sources (i.e. NODE_OPTIONS).
+
+  // default_is_true is only a hint in printing help text, it does not
+  // affect the default value of the option. Set the default value in the
+  // Options struct instead.
   void AddOption(const char* name,
                  const char* help_text,
                  bool Options::*field,

--- a/test/parallel/test-internal-async-context-frame-disable.js
+++ b/test/parallel/test-internal-async-context-frame-disable.js
@@ -1,0 +1,9 @@
+// Flags: --expose-internals --no-async-context-frame
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const AsyncContextFrame = require('internal/async_context_frame');
+
+// Test that AsyncContextFrame can be disabled.
+assert(!AsyncContextFrame.enabled);

--- a/test/parallel/test-internal-async-context-frame-enabled.js
+++ b/test/parallel/test-internal-async-context-frame-enabled.js
@@ -1,0 +1,9 @@
+// Flags: --expose-internals
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const AsyncContextFrame = require('internal/async_context_frame');
+
+// Test that AsyncContextFrame is enabled by default.
+assert(AsyncContextFrame.enabled);


### PR DESCRIPTION
`default_is_true` in bool OptionsParser is a hint for help text. The
default value for an option is still required to be set in the option
struct.