### PR TITLE
test: add missing newlines to repl .exit writes

### DIFF
--- a/test/parallel/test-repl-function-definition-edge-case.js
+++ b/test/parallel/test-repl-function-definition-edge-case.js
@@ -1,6 +1,6 @@
 // Reference: https://github.com/nodejs/node/pull/7624
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
 const repl = require('repl');
 const stream = require('stream');
@@ -9,7 +9,8 @@ const r = initRepl();
 
 r.input.emit('data', 'function a() { return 42; } (1)\n');
 r.input.emit('data', 'a\n');
-r.input.emit('data', '.exit');
+r.input.emit('data', '.exit\n');
+r.once('exit', common.mustCall());
 
 const expected = '1\n[Function: a]\n';
 const got = r.output.accumulator.join('');

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -23,5 +23,4 @@ child.on('exit', common.mustCall(() => {
 }));
 
 child.stdin.write('await import(\'./message.mjs\');\n');
-child.stdin.write('.exit');
-child.stdin.end();
+child.stdin.write('.exit\n');

--- a/test/parallel/test-repl-options.js
+++ b/test/parallel/test-repl-options.js
@@ -136,6 +136,5 @@ r4.close();
   child.stdin.write(
     'assert.ok(util.inspect(repl.repl, {depth: -1}).includes("REPLServer"));\n'
   );
-  child.stdin.write('.exit');
-  child.stdin.end();
+  child.stdin.write('.exit\n');
 }

--- a/test/parallel/test-repl-require-context.js
+++ b/test/parallel/test-repl-require-context.js
@@ -20,5 +20,4 @@ child.on('exit', common.mustCall(() => {
 child.stdin.write('const isObject = (obj) => obj.constructor === Object;\n');
 child.stdin.write('isObject({});\n');
 child.stdin.write(`require(${JSON.stringify(fixture)}).isObject({});\n`);
-child.stdin.write('.exit');
-child.stdin.end();
+child.stdin.write('.exit\n');

--- a/test/parallel/test-repl-require-self-referential.js
+++ b/test/parallel/test-repl-require-self-referential.js
@@ -23,5 +23,4 @@ child.on('exit', common.mustCall(() => {
 }));
 
 child.stdin.write('require("self_ref");\n');
-child.stdin.write('.exit');
-child.stdin.end();
+child.stdin.write('.exit\n');


### PR DESCRIPTION
I noticed that some repl tests write `".exit"` in the repl, without a newline character (`\n`), as far as I can tell such write operations don't have any effect (removing those lines don't cause any test failures (AFAICT)).

I'm adding the missing newline characters so that the exit command is actually executed.

As part of this I'm also removing some `end` calls applied to the repl streams that are no longer necessary.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
