### PR TITLE
buffer: improve byteLength performance

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -17,6 +17,11 @@ using CFunctionCallbackWithMultipleValueAndOptions =
              v8::Local<v8::Value>,
              v8::Local<v8::Value>,
              v8::FastApiCallbackOptions&);
+using CFunctionA =
+    uint32_t (*)(v8::Local<v8::Value> receiver,
+                 v8::Local<v8::Value> sourceValue,
+                 // NOLINTNEXTLINE(runtime/references) This is V8 api.
+                 v8::FastApiCallbackOptions& options);
 using CFunctionCallbackWithOneByteString =
     uint32_t (*)(v8::Local<v8::Value>, const v8::FastOneByteString&);
 
@@ -98,6 +103,7 @@ class ExternalReferenceRegistry {
   ExternalReferenceRegistry();
 
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
+  V(CFunctionA)                                                                \
   V(CFunctionCallback)                                                         \
   V(CFunctionCallbackWithalueAndOptions)                                       \
   V(CFunctionCallbackWithMultipleValueAndOptions)                              \


### PR DESCRIPTION
This improves the performance for non one-byte strings.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1705/