### PR TITLE
buffer: avoid creating unnecessary environment

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -721,11 +721,11 @@ void StringWrite(const FunctionCallbackInfo<Value>& args) {
 }
 
 void SlowByteLengthUtf8(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsString());
 
   // Fast case: avoid StringBytes on UTF8 string. Jump to v8.
-  args.GetReturnValue().Set(args[0].As<String>()->Utf8Length(env->isolate()));
+  args.GetReturnValue().Set(
+      args[0].As<String>()->Utf8Length(args.GetIsolate()));
 }
 
 uint32_t FastByteLengthUtf8(Local<Value> receiver,


### PR DESCRIPTION
We don't have to deference the args pointer to create an environment variable while having access to isolate using `args.GetIsolate()`