### PR TITLE
module: handle instantiated async module jobs in require(esm)

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -386,7 +386,7 @@ class ModuleLoader {
         throw new ERR_REQUIRE_ASYNC_MODULE(filename, parentFilename);
       }
       const status = job.module.getStatus();
-      debug('Module status', filename, status);
+      debug('Module status', job, status);
       if (status === kEvaluated) {
         return { wrap: job.module, namespace: job.module.getNamespaceSync(filename, parentFilename) };
       } else if (status === kInstantiated) {

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -22,7 +22,14 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
 
-const { ModuleWrap, kInstantiated, kEvaluationPhase } = internalBinding('module_wrap');
+const {
+  ModuleWrap,
+  kErrored,
+  kEvaluated,
+  kEvaluationPhase,
+  kInstantiated,
+  kUninstantiated,
+} = internalBinding('module_wrap');
 const {
   privateSymbols: {
     entry_point_module_private_symbol,
@@ -277,17 +284,34 @@ class ModuleJob extends ModuleJobBase {
   runSync(parent) {
     assert(this.phase === kEvaluationPhase);
     assert(this.module instanceof ModuleWrap);
-    if (this.instantiated !== undefined) {
-      return { __proto__: null, module: this.module };
-    }
+    let status = this.module.getStatus();
 
-    this.module.instantiate();
-    this.instantiated = PromiseResolve();
-    setHasStartedUserESMExecution();
-    const filename = urlToFilename(this.url);
-    const parentFilename = urlToFilename(parent?.filename);
-    const namespace = this.module.evaluateSync(filename, parentFilename);
-    return { __proto__: null, module: this.module, namespace };
+    debug('ModuleJob.runSync', this.module);
+    // FIXME(joyeecheung): this cannot fully handle < kInstantiated. Make the linking
+    // fully synchronous instead.
+    if (status === kUninstantiated) {
+      this.module.async = this.module.instantiateSync();
+      status = this.module.getStatus();
+    }
+    if (status === kInstantiated || status === kErrored) {
+      const filename = urlToFilename(this.url);
+      const parentFilename = urlToFilename(parent?.filename);
+      this.module.async ??= this.module.isGraphAsync();
+
+      if (this.module.async && !getOptionValue('--experimental-print-required-tla')) {
+        throw new ERR_REQUIRE_ASYNC_MODULE(filename, parentFilename);
+      }
+      if (status === kInstantiated) {
+        setHasStartedUserESMExecution();
+        const namespace = this.module.evaluateSync(filename, parentFilename);
+        return { __proto__: null, module: this.module, namespace };
+      }
+      throw this.module.getError();
+
+    } else if (status === kEvaluated) {
+      return { __proto__: null, module: this.module, namespace: this.module.getNamespaceSync() };
+    }
+    assert.fail(`Unexpected module status ${status}.`);
   }
 
   async run(isEntryPoint = false) {

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -52,6 +52,7 @@ void NODE_EXTERN_PRIVATE FWrite(FILE* file, const std::string& str);
   V(NGTCP2_DEBUG)                                                              \
   V(SEA)                                                                       \
   V(WASI)                                                                      \
+  V(MODULE)                                                                    \
   V(MKSNAPSHOT)                                                                \
   V(SNAPSHOT_SERDES)                                                           \
   V(PERMISSION_MODEL)                                                          \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -860,6 +860,16 @@ void ModuleWrap::GetStatus(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(module->GetStatus());
 }
 
+void ModuleWrap::IsGraphAsync(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  ModuleWrap* obj;
+  ASSIGN_OR_RETURN_UNWRAP(&obj, args.This());
+
+  Local<Module> module = obj->module_.Get(isolate);
+
+  args.GetReturnValue().Set(module->IsGraphAsync());
+}
+
 void ModuleWrap::GetError(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   ModuleWrap* obj;
@@ -1282,6 +1292,7 @@ void ModuleWrap::CreatePerIsolateProperties(IsolateData* isolate_data,
       isolate, tpl, "createCachedData", CreateCachedData);
   SetProtoMethodNoSideEffect(isolate, tpl, "getNamespace", GetNamespace);
   SetProtoMethodNoSideEffect(isolate, tpl, "getStatus", GetStatus);
+  SetProtoMethodNoSideEffect(isolate, tpl, "isGraphAsync", IsGraphAsync);
   SetProtoMethodNoSideEffect(isolate, tpl, "getError", GetError);
   SetConstructorFunction(isolate, target, "ModuleWrap", tpl);
   isolate_data->set_module_wrap_constructor_template(tpl);
@@ -1343,6 +1354,7 @@ void ModuleWrap::RegisterExternalReferences(
   registry->Register(GetNamespace);
   registry->Register(GetStatus);
   registry->Register(GetError);
+  registry->Register(IsGraphAsync);
 
   registry->Register(CreateRequiredModuleFacade);
 

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -121,6 +121,7 @@ class ModuleWrap : public BaseObject {
   static void Instantiate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Evaluate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetNamespace(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void IsGraphAsync(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetStatus(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void GetError(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/test/es-module/test-require-module-instantiated.mjs
+++ b/test/es-module/test-require-module-instantiated.mjs
@@ -1,0 +1,4 @@
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { b, c } from '../fixtures/es-modules/require-module-instantiated/a.mjs';
+assert.strictEqual(b, c);

--- a/test/fixtures/es-modules/require-module-instantiated/a.mjs
+++ b/test/fixtures/es-modules/require-module-instantiated/a.mjs
@@ -1,0 +1,2 @@
+export { default as b } from './b.cjs';
+export { default as c } from './c.mjs';

--- a/test/fixtures/es-modules/require-module-instantiated/b.cjs
+++ b/test/fixtures/es-modules/require-module-instantiated/b.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./c.mjs');

--- a/test/fixtures/es-modules/require-module-instantiated/c.mjs
+++ b/test/fixtures/es-modules/require-module-instantiated/c.mjs
@@ -1,0 +1,3 @@
+const foo = 1;
+export default foo;
+export { foo as 'module.exports' };


### PR DESCRIPTION
When require(esm) encounters a cached module job that is instantiated but not yet evaluated, run the evaluation. This catches an edge case previously missed in https://github.com/nodejs/node/pull/57187.

Fixes: https://github.com/nodejs/node/issues/58061

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
