### PR TITLE
build: downgrade armv7 support to experimental

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/4-report-a-flaky-test.yml
@@ -28,7 +28,6 @@ body:
         - AIX
         - FreeBSD
         - Linux ARM64
-        - Linux ARMv7
         - Linux PPC64LE
         - Linux s390x
         - Linux x64

--- a/.github/workflows/label-flaky-test-issue.yml
+++ b/.github/workflows/label-flaky-test-issue.yml
@@ -26,7 +26,6 @@ jobs:
           platform2label["AIX"]="aix";
           platform2label["FreeBSD"]="freebsd";
           platform2label["Linux ARM64"]="linux";
-          platform2label["Linux ARMv7"]="arm";
           platform2label["Linux PPC64LE"]="ppc";
           platform2label["Linux s390x"]="s390";
           platform2label["Linux x64"]="linux";

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -110,7 +110,7 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | x64              | kernel >= 3.10, musl >= 1.1.19    | Experimental | e.g. Alpine 3.8                      |
 | GNU/Linux        | x86              | kernel >= 3.10, glibc >= 2.17     | Experimental | Downgraded as of Node.js 10          |
 | GNU/Linux        | arm64            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1       | e.g. Ubuntu 20.04, Debian 10, RHEL 8 |
-| GNU/Linux        | armv7            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 1       | e.g. Ubuntu 22.04, Debian 12         |
+| GNU/Linux        | armv7            | kernel >= 4.18[^1], glibc >= 2.28 | Experimental | Downgraded as of Node.js 24          |
 | GNU/Linux        | armv6            | kernel >= 4.14, glibc >= 2.24     | Experimental | Downgraded as of Node.js 12          |
 | GNU/Linux        | ppc64le >=power8 | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2       | e.g. Ubuntu 20.04, RHEL 8            |
 | GNU/Linux        | s390x            | kernel >= 4.18[^1], glibc >= 2.28 | Tier 2       | e.g. RHEL 8                          |
@@ -162,18 +162,17 @@ Depending on the host platform, the selection of toolchains may vary.
 
 Binaries at <https://nodejs.org/download/release/> are produced on:
 
-| Binary package          | Platform and Toolchain                                                                                        |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
-| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                                                                       |
-| darwin-x64              | macOS 13, Xcode 16 with -mmacosx-version-min=13.5                                                             |
-| darwin-arm64 (and .pkg) | macOS 13 (arm64), Xcode 16 with -mmacosx-version-min=13.5                                                     |
-| linux-arm64             | RHEL 8 with gcc-toolset-12[^6]                                                                                |
-| linux-armv7l            | Cross-compiled on RHEL 9 x64 with a [custom GCC toolchain](https://github.com/rvagg/rpi-newer-crosstools)[^7] |
-| linux-ppc64le           | RHEL 8 with gcc-toolset-12[^6]                                                                                |
-| linux-s390x             | RHEL 8 with gcc-toolset-12[^6]                                                                                |
-| linux-x64               | RHEL 8 with gcc-toolset-12[^6]                                                                                |
-| win-arm64               | Windows Server 2022 (x64) with Visual Studio 2022                                                             |
-| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022                                                             |
+| Binary package          | Platform and Toolchain                                    |
+| ----------------------- | --------------------------------------------------------- |
+| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                   |
+| darwin-x64              | macOS 13, Xcode 16 with -mmacosx-version-min=13.5         |
+| darwin-arm64 (and .pkg) | macOS 13 (arm64), Xcode 16 with -mmacosx-version-min=13.5 |
+| linux-arm64             | RHEL 8 with gcc-toolset-12[^6]                            |
+| linux-ppc64le           | RHEL 8 with gcc-toolset-12[^6]                            |
+| linux-s390x             | RHEL 8 with gcc-toolset-12[^6]                            |
+| linux-x64               | RHEL 8 with gcc-toolset-12[^6]                            |
+| win-arm64               | Windows Server 2022 (x64) with Visual Studio 2022         |
+| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022         |
 
 <!--lint disable final-definition-->
 
@@ -184,11 +183,6 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
     and libstdc++ >= 6.0.25 (`GLIBCXX_3.4.25`). These are available on
     distributions natively supporting GCC 8.1 or higher, such as Debian 10,
     RHEL 8 and Ubuntu 20.04.
-
-[^7]: Binaries produced on these systems are compatible with glibc >= 2.28
-    and libstdc++ >= 6.0.30 (`GLIBCXX_3.4.30`). These are available on
-    distributions natively supporting GCC 12.1 or higher, such as Debian 12,
-    Ubuntu 22.04.
 
 <!--lint enable final-definition-->
 


### PR DESCRIPTION
There are a bunch of issues on that platform with recent V8 versions and we don't have the capacity to fix them.

/cc @nodejs/tsc @nodejs/build @nodejs/platform-arm
