### PR TITLE
test: prevent extraneous HOSTNAME substitution in test-runner-output

### DIFF
--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -37,7 +37,7 @@ function replaceJunitDuration(str) {
   return str
     .replaceAll(/time="[0-9.]+"/g, 'time="*"')
     .replaceAll(/duration_ms [0-9.]+/g, 'duration_ms *')
-    .replaceAll(hostname(), 'HOSTNAME')
+    .replaceAll(`hostname="${hostname()}"`, 'hostname="HOSTNAME"')
     .replace(stackTraceBasePath, '$3');
 }
 


### PR DESCRIPTION
I have a box named "io". This got a good chuckle out of me.

```
=== release test-runner-output ===                                            
Path: parallel/test-runner-output
Test failure: 'test-runner/output/junit_reporter.js'
Location: test/parallel/test-runner-output.mjs:330:5
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected
... Skipped lines

+ '<?xml versHOSTNAMEn="1.0" encoding="utf-8"?>\n' +
- '<?xml version="1.0" encoding="utf-8"?>\n' +
    '<testsuites>\n' +
    '\t<testcase name="sync pass todo" time="*" classname="test">\n' +
    '\t\t<skipped type="todo" message="true"/>\n' +
    '\t</testcase>\n' +
    '\t<testcase name="sync pass todo with message" time="*" classname="test">\n' +
...
    '\t</testcase>\n' +
+   '\t<testcase name="async assertHOSTNAMEn fail" time="*" classname="test" failure="Expected values to be strictly equal:true !== false">\n' +
-   '\t<testcase name="async assertion fail" time="*" classname="test" failure="Expected values to be strictly equal:true !== false">\n' +
    '\t\t<failure type="testCodeFailure" message="Expected values to be strictly equal:true !== false">\n' +
    '[Error [ERR_TEST_FAILURE]: Expected values to be strictly equal:\n' +
    '\n' +
    'true !== false\n' +
    '] {\n' +
    "  code: 'ERR_TEST_FAILURE',\n" +
    "  failureType: 'testCodeFailure',\n" +
+   '  cause: AssertHOSTNAMEnError [ERR_ASSERTION]: Expected values to be strictly equal:\n' +
-   '  cause: AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:\n' +
    '  \n' +
    '  true !== false\n' +
    '  \n' +
    '      *\n' +
    '      *\n' +
...
    '\t</testcase>\n' +
+   '\t<testcase name="unhandled rejectHOSTNAMEn - passes but warns" time="*" classname="test"/>\n' +
+   '\t<testcase name="async unhandled rejectHOSTNAMEn - passes but warns" time="*" classname="test"/>\n' +
-   '\t<testcase name="unhandled rejection - passes but warns" time="*" classname="test"/>\n' +
-   '\t<testcase name="async unhandled rejection - passes but warns" time="*" classname="test"/>\n' +
    ...,
  operator: 'strictEqual'
}
```