### PR TITLE
inspector: initial support for Network.loadNetworkResource

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1069,6 +1069,17 @@ passing a second `parentURL` argument for contextual resolution.
 
 Previously gated the entire `import.meta.resolve` feature.
 
+### `--experimental-inspector-network-resource`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1.1 - Active Development
+
+Enable experimental support for inspector network resources.
+
 ### `--experimental-loader=module`
 
 <!-- YAML

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -600,6 +600,43 @@ This feature is only available with the `--experimental-network-inspection` flag
 Broadcasts the `Network.loadingFailed` event to connected frontends. This event indicates that
 HTTP request has failed to load.
 
+### `inspector.NetworkResources.put`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+> Stability: 1.1 - Active Development
+
+This feature is only available with the `--experimental-inspector-network-resource` flag enabled.
+
+The inspector.NetworkResources.put method is used to provide a response for a loadNetworkResource
+request issued via the Chrome DevTools Protocol (CDP).
+This is typically triggered when a source map is specified by URL, and a DevTools frontend—such as
+Chrome—requests the resource to retrieve the source map.
+
+This method allows developers to predefine the resource content to be served in response to such CDP requests.
+
+```js
+const inspector = require('node:inspector');
+// By preemptively calling put to register the resource, a source map can be resolved when
+// a loadNetworkResource request is made from the frontend.
+async function setNetworkResources() {
+  const mapUrl = 'http://localhost:3000/dist/app.js.map';
+  const tsUrl = 'http://localhost:3000/src/app.ts';
+  const distAppJsMap = await fetch(mapUrl).then((res) => res.text());
+  const srcAppTs = await fetch(tsUrl).then((res) => res.text());
+  inspector.NetworkResources.put(mapUrl, distAppJsMap);
+  inspector.NetworkResources.put(tsUrl, srcAppTs);
+};
+setNetworkResources().then(() => {
+  require('./dist/app');
+});
+```
+
+For more details, see the official CDP documentation: [Network.loadNetworkResource](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-loadNetworkResource)
+
 ## Support of breakpoints
 
 The Chrome DevTools Protocol [`Debugger` domain][] allows an

--- a/doc/node.1
+++ b/doc/node.1
@@ -229,6 +229,9 @@ Enable experimental WebAssembly module support.
 .It Fl -experimental-quic
 Enable the experimental QUIC support.
 .
+.It Fl -experimental-inspector-network-resource
+Enable experimental support for inspector network resources.
+.
 .It Fl -force-context-aware
 Disable loading native addons that are not context-aware.
 .

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -36,6 +36,9 @@ const {
 } = require('internal/validators');
 const { isMainThread } = require('worker_threads');
 const { _debugEnd } = internalBinding('process_methods');
+const {
+  put,
+} = require('internal/inspector/network_resources');
 
 const {
   Connection,
@@ -218,6 +221,10 @@ const Network = {
   dataReceived: (params) => broadcastToFrontend('Network.dataReceived', params),
 };
 
+const NetworkResources = {
+  put,
+};
+
 module.exports = {
   open: inspectorOpen,
   close: _debugEnd,
@@ -226,4 +233,5 @@ module.exports = {
   console,
   Session,
   Network,
+  NetworkResources,
 };

--- a/lib/internal/inspector/network_resources.js
+++ b/lib/internal/inspector/network_resources.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { getOptionValue } = require('internal/options');
+const { validateString } = require('internal/validators');
+const { putNetworkResource } = internalBinding('inspector');
+
+/**
+ * Registers a resource for the inspector using the internal 'putNetworkResource' binding.
+ * @param {string} url - The URL of the resource.
+ * @param {string} data - The content of the resource to provide.
+ */
+function put(url, data) {
+  if (!getOptionValue('--experimental-inspector-network-resource')) {
+    process.emitWarning(
+      'The --experimental-inspector-network-resource option is not enabled. ' +
+        'Please enable it to use the putNetworkResource function');
+    return;
+  }
+  validateString(url, 'url');
+  validateString(data, 'data');
+
+  putNetworkResource(url, data);
+}
+
+module.exports = {
+  put,
+};

--- a/src/inspector/io_agent.cc
+++ b/src/inspector/io_agent.cc
@@ -14,8 +14,8 @@ void IoAgent::Wire(UberDispatcher* dispatcher) {
 }
 
 DispatchResponse IoAgent::read(const String& in_handle,
-                               Maybe<int> in_offset,
-                               Maybe<int> in_size,
+                               std::optional<int> in_offset,
+                               std::optional<int> in_size,
                                String* out_data,
                                bool* out_eof) {
   std::string url = in_handle;
@@ -24,15 +24,15 @@ DispatchResponse IoAgent::read(const String& in_handle,
 
   int offset = 0;
   bool offset_was_specified = false;
-  if (in_offset.isJust()) {
-    offset = in_offset.fromJust();
+  if (in_offset.has_value()) {
+    offset = *in_offset;
     offset_was_specified = true;
   } else if (offset_map_.find(url) != offset_map_.end()) {
     offset = offset_map_[url];
   }
   int size = 1 << 20;
-  if (in_size.isJust()) {
-    size = in_size.fromJust();
+  if (in_size.has_value()) {
+    size = *in_size;
   }
   if (static_cast<std::size_t>(offset) < txt_view.length()) {
     std::string_view out_view = txt_view.substr(offset, size);

--- a/src/inspector/io_agent.cc
+++ b/src/inspector/io_agent.cc
@@ -29,13 +29,13 @@ DispatchResponse IoAgent::read(const String& in_handle,
   }
   stream_id = std::stoull(in_handle_str);
 
-  std::string url = NetworkResourceManager::GetUrlForStreamId(stream_id);
+  std::string url = network_resource_manager_->GetUrlForStreamId(stream_id);
   if (url.empty()) {
     *out_data = "";
     *out_eof = true;
     return DispatchResponse::Success();
   }
-  std::string txt = NetworkResourceManager::Get(url);
+  std::string txt = network_resource_manager_->Get(url);
   std::string_view txt_view(txt);
 
   int offset = 0;
@@ -73,7 +73,7 @@ DispatchResponse IoAgent::close(const String& in_handle) {
   if (is_number) {
     stream_id = std::stoull(in_handle_str);
     // Use accessor to erase resource and mapping by stream id
-    NetworkResourceManager::EraseByStreamId(stream_id);
+    network_resource_manager_->EraseByStreamId(stream_id);
   }
   return DispatchResponse::Success();
 }

--- a/src/inspector/io_agent.cc
+++ b/src/inspector/io_agent.cc
@@ -1,0 +1,80 @@
+#include "io_agent.h"
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include "crdtp/dispatch.h"
+#include "inspector/network_resource_manager.h"
+
+namespace node::inspector::protocol {
+
+void IoAgent::Wire(UberDispatcher* dispatcher) {
+  frontend_ = std::make_shared<IO::Frontend>(dispatcher->channel());
+  IO::Dispatcher::wire(dispatcher, this);
+}
+
+DispatchResponse IoAgent::read(const String& in_handle,
+                               Maybe<int> in_offset,
+                               Maybe<int> in_size,
+                               String* out_data,
+                               bool* out_eof) {
+  std::string in_handle_str = in_handle;
+  uint64_t stream_id = 0;
+  bool is_number =
+      std::all_of(in_handle_str.begin(), in_handle_str.end(), ::isdigit);
+  if (!is_number) {
+    *out_data = "";
+    *out_eof = true;
+    return DispatchResponse::Success();
+  }
+  stream_id = std::stoull(in_handle_str);
+
+  std::string url = NetworkResourceManager::GetUrlForStreamId(stream_id);
+  if (url.empty()) {
+    *out_data = "";
+    *out_eof = true;
+    return DispatchResponse::Success();
+  }
+  std::string txt = NetworkResourceManager::Get(url);
+  std::string_view txt_view(txt);
+
+  int offset = 0;
+  bool offset_was_specified = false;
+  if (in_offset.isJust()) {
+    offset = in_offset.fromJust();
+    offset_was_specified = true;
+  } else if (offset_map_.find(stream_id) != offset_map_.end()) {
+    offset = offset_map_[stream_id];
+  }
+  int size = 1 << 20;
+  if (in_size.isJust()) {
+    size = in_size.fromJust();
+  }
+  if (static_cast<std::size_t>(offset) < txt_view.length()) {
+    std::string_view out_view = txt_view.substr(offset, size);
+    out_data->assign(out_view.data(), out_view.size());
+    *out_eof = false;
+    if (!offset_was_specified) {
+      offset_map_[stream_id] = offset + size;
+    }
+  } else {
+    *out_data = "";
+    *out_eof = true;
+  }
+
+  return DispatchResponse::Success();
+}
+
+DispatchResponse IoAgent::close(const String& in_handle) {
+  std::string in_handle_str = in_handle;
+  uint64_t stream_id = 0;
+  bool is_number =
+      std::all_of(in_handle_str.begin(), in_handle_str.end(), ::isdigit);
+  if (is_number) {
+    stream_id = std::stoull(in_handle_str);
+    // Use accessor to erase resource and mapping by stream id
+    NetworkResourceManager::EraseByStreamId(stream_id);
+  }
+  return DispatchResponse::Success();
+}
+}  // namespace node::inspector::protocol

--- a/src/inspector/io_agent.h
+++ b/src/inspector/io_agent.h
@@ -1,13 +1,17 @@
 #ifndef SRC_INSPECTOR_IO_AGENT_H_
 #define SRC_INSPECTOR_IO_AGENT_H_
 
+#include <memory>
+#include "inspector/network_resource_manager.h"
 #include "node/inspector/protocol/IO.h"
 
 namespace node::inspector::protocol {
 
 class IoAgent : public IO::Backend {
  public:
-  IoAgent() {}
+  explicit IoAgent(
+      std::shared_ptr<NetworkResourceManager> network_resource_manager)
+      : network_resource_manager_(std::move(network_resource_manager)) {}
   void Wire(UberDispatcher* dispatcher);
   DispatchResponse read(const String& in_handle,
                         Maybe<int> in_offset,
@@ -19,6 +23,7 @@ class IoAgent : public IO::Backend {
  private:
   std::shared_ptr<IO::Frontend> frontend_;
   std::unordered_map<int, int> offset_map_ = {};  // Maps stream_id to offset
+  std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 }  // namespace node::inspector::protocol
 #endif  // SRC_INSPECTOR_IO_AGENT_H_

--- a/src/inspector/io_agent.h
+++ b/src/inspector/io_agent.h
@@ -1,0 +1,24 @@
+#ifndef SRC_INSPECTOR_IO_AGENT_H_
+#define SRC_INSPECTOR_IO_AGENT_H_
+
+#include "node/inspector/protocol/IO.h"
+
+namespace node::inspector::protocol {
+
+class IoAgent : public IO::Backend {
+ public:
+  IoAgent() {}
+  void Wire(UberDispatcher* dispatcher);
+  DispatchResponse read(const String& in_handle,
+                        Maybe<int> in_offset,
+                        Maybe<int> in_size,
+                        String* out_data,
+                        bool* out_eof) override;
+  DispatchResponse close(const String& in_handle) override;
+
+ private:
+  std::shared_ptr<IO::Frontend> frontend_;
+  std::unordered_map<int, int> offset_map_ = {};  // Maps stream_id to offset
+};
+}  // namespace node::inspector::protocol
+#endif  // SRC_INSPECTOR_IO_AGENT_H_

--- a/src/inspector/io_agent.h
+++ b/src/inspector/io_agent.h
@@ -22,7 +22,8 @@ class IoAgent : public IO::Backend {
 
  private:
   std::shared_ptr<IO::Frontend> frontend_;
-  std::unordered_map<int, int> offset_map_ = {};  // Maps stream_id to offset
+  std::unordered_map<std::string, int> offset_map_ =
+      {};  // Maps stream_id to offset
   std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 }  // namespace node::inspector::protocol

--- a/src/inspector/io_agent.h
+++ b/src/inspector/io_agent.h
@@ -14,8 +14,8 @@ class IoAgent : public IO::Backend {
       : network_resource_manager_(std::move(network_resource_manager)) {}
   void Wire(UberDispatcher* dispatcher);
   DispatchResponse read(const String& in_handle,
-                        Maybe<int> in_offset,
-                        Maybe<int> in_size,
+                        std::optional<int> in_offset,
+                        std::optional<int> in_size,
                         String* out_data,
                         bool* out_eof) override;
   DispatchResponse close(const String& in_handle) override;

--- a/src/inspector/network_agent.cc
+++ b/src/inspector/network_agent.cc
@@ -358,10 +358,9 @@ protocol::DispatchResponse NetworkAgent::loadNetworkResource(
   std::string data = network_resource_manager_->Get(in_url);
   bool found = !data.empty();
   if (found) {
-    uint64_t stream_id = network_resource_manager_->GetStreamId(in_url);
     auto result = protocol::Network::LoadNetworkResourcePageResult::create()
                       .setSuccess(true)
-                      .setStream(std::to_string(stream_id))
+                      .setStream(in_url)
                       .build();
     *out_resource = std::move(result);
     return protocol::DispatchResponse::Success();

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -3,9 +3,11 @@
 
 #include "env.h"
 #include "io_agent.h"
+#include "network_resource_manager.h"
 #include "node/inspector/protocol/Network.h"
 
 #include <map>
+#include <memory>
 #include <unordered_map>
 
 namespace node {
@@ -40,9 +42,11 @@ struct RequestEntry {
 
 class NetworkAgent : public protocol::Network::Backend {
  public:
-  explicit NetworkAgent(NetworkInspector* inspector,
-                        v8_inspector::V8Inspector* v8_inspector,
-                        Environment* env);
+  explicit NetworkAgent(
+      NetworkInspector* inspector,
+      v8_inspector::V8Inspector* v8_inspector,
+      Environment* env,
+      std::shared_ptr<NetworkResourceManager> network_resource_manager);
 
   void Wire(protocol::UberDispatcher* dispatcher);
 
@@ -98,6 +102,7 @@ class NetworkAgent : public protocol::Network::Backend {
   std::unordered_map<protocol::String, EventNotifier> event_notifier_map_;
   std::map<protocol::String, RequestEntry> requests_;
   Environment* env_;
+  std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 
 }  // namespace inspector

--- a/src/inspector/network_agent.h
+++ b/src/inspector/network_agent.h
@@ -1,6 +1,8 @@
 #ifndef SRC_INSPECTOR_NETWORK_AGENT_H_
 #define SRC_INSPECTOR_NETWORK_AGENT_H_
 
+#include "env.h"
+#include "io_agent.h"
 #include "node/inspector/protocol/Network.h"
 
 #include <map>
@@ -39,7 +41,8 @@ struct RequestEntry {
 class NetworkAgent : public protocol::Network::Backend {
  public:
   explicit NetworkAgent(NetworkInspector* inspector,
-                        v8_inspector::V8Inspector* v8_inspector);
+                        v8_inspector::V8Inspector* v8_inspector,
+                        Environment* env);
 
   void Wire(protocol::UberDispatcher* dispatcher);
 
@@ -59,6 +62,11 @@ class NetworkAgent : public protocol::Network::Backend {
   protocol::DispatchResponse streamResourceContent(
       const protocol::String& in_requestId,
       protocol::Binary* out_bufferedData) override;
+
+  protocol::DispatchResponse loadNetworkResource(
+      const protocol::String& in_url,
+      std::unique_ptr<protocol::Network::LoadNetworkResourcePageResult>*
+          out_resource) override;
 
   void emitNotification(v8::Local<v8::Context> context,
                         const protocol::String& event,
@@ -89,6 +97,7 @@ class NetworkAgent : public protocol::Network::Backend {
                                                v8::Local<v8::Object>);
   std::unordered_map<protocol::String, EventNotifier> event_notifier_map_;
   std::map<protocol::String, RequestEntry> requests_;
+  Environment* env_;
 };
 
 }  // namespace inspector

--- a/src/inspector/network_inspector.cc
+++ b/src/inspector/network_inspector.cc
@@ -3,10 +3,15 @@
 namespace node {
 namespace inspector {
 
-NetworkInspector::NetworkInspector(Environment* env,
-                                   v8_inspector::V8Inspector* v8_inspector)
-    : enabled_(false), env_(env) {
-  network_agent_ = std::make_unique<NetworkAgent>(this, v8_inspector, env);
+NetworkInspector::NetworkInspector(
+    Environment* env,
+    v8_inspector::V8Inspector* v8_inspector,
+    std::shared_ptr<NetworkResourceManager> network_resource_manager)
+    : enabled_(false),
+      env_(env),
+      network_resource_manager_(std::move(network_resource_manager)) {
+  network_agent_ = std::make_unique<NetworkAgent>(
+      this, v8_inspector, env, network_resource_manager_);
 }
 NetworkInspector::~NetworkInspector() {
   network_agent_.reset();

--- a/src/inspector/network_inspector.cc
+++ b/src/inspector/network_inspector.cc
@@ -6,7 +6,7 @@ namespace inspector {
 NetworkInspector::NetworkInspector(Environment* env,
                                    v8_inspector::V8Inspector* v8_inspector)
     : enabled_(false), env_(env) {
-  network_agent_ = std::make_unique<NetworkAgent>(this, v8_inspector);
+  network_agent_ = std::make_unique<NetworkAgent>(this, v8_inspector, env);
 }
 NetworkInspector::~NetworkInspector() {
   network_agent_.reset();

--- a/src/inspector/network_inspector.h
+++ b/src/inspector/network_inspector.h
@@ -1,8 +1,10 @@
 #ifndef SRC_INSPECTOR_NETWORK_INSPECTOR_H_
 #define SRC_INSPECTOR_NETWORK_INSPECTOR_H_
 
+#include <memory>
 #include "env.h"
 #include "network_agent.h"
+#include "network_resource_manager.h"
 
 namespace node {
 class Environment;
@@ -11,8 +13,10 @@ namespace inspector {
 
 class NetworkInspector {
  public:
-  explicit NetworkInspector(Environment* env,
-                            v8_inspector::V8Inspector* v8_inspector);
+  explicit NetworkInspector(
+      Environment* env,
+      v8_inspector::V8Inspector* v8_inspector,
+      std::shared_ptr<NetworkResourceManager> network_resource_manager);
   ~NetworkInspector();
 
   void Wire(protocol::UberDispatcher* dispatcher);
@@ -32,6 +36,7 @@ class NetworkInspector {
   bool enabled_;
   Environment* env_;
   std::unique_ptr<NetworkAgent> network_agent_;
+  std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 
 }  // namespace inspector

--- a/src/inspector/network_resource_manager.cc
+++ b/src/inspector/network_resource_manager.cc
@@ -7,18 +7,15 @@
 namespace node {
 namespace inspector {
 
-std::unordered_map<std::string, std::string> NetworkResourceManager::resources_;
-std::unordered_map<std::string, uint64_t>
-    NetworkResourceManager::url_to_stream_id_;
-std::atomic<uint64_t> NetworkResourceManager::stream_id_counter_{1};
-
 void NetworkResourceManager::Put(const std::string& url,
                                  const std::string& data) {
+  Mutex::ScopedLock lock(mutex_);
   resources_[url] = data;
   url_to_stream_id_[url] = ++stream_id_counter_;
 }
 
 std::string NetworkResourceManager::Get(const std::string& url) {
+  Mutex::ScopedLock lock(mutex_);
   auto it = resources_.find(url);
   if (it != resources_.end()) return it->second;
   return {};
@@ -29,6 +26,7 @@ uint64_t NetworkResourceManager::NextStreamId() {
 }
 
 std::string NetworkResourceManager::GetUrlForStreamId(uint64_t stream_id) {
+  Mutex::ScopedLock lock(mutex_);
   for (const auto& pair : url_to_stream_id_) {
     if (pair.second == stream_id) {
       return pair.first;
@@ -38,6 +36,7 @@ std::string NetworkResourceManager::GetUrlForStreamId(uint64_t stream_id) {
 }
 
 void NetworkResourceManager::EraseByStreamId(uint64_t stream_id) {
+  Mutex::ScopedLock lock(mutex_);
   for (auto it = url_to_stream_id_.begin(); it != url_to_stream_id_.end();
        ++it) {
     if (it->second == stream_id) {
@@ -49,6 +48,7 @@ void NetworkResourceManager::EraseByStreamId(uint64_t stream_id) {
 }
 
 uint64_t NetworkResourceManager::GetStreamId(const std::string& url) {
+  Mutex::ScopedLock lock(mutex_);
   auto it = url_to_stream_id_.find(url);
   if (it != url_to_stream_id_.end()) return it->second;
   return 0;

--- a/src/inspector/network_resource_manager.cc
+++ b/src/inspector/network_resource_manager.cc
@@ -11,7 +11,6 @@ void NetworkResourceManager::Put(const std::string& url,
                                  const std::string& data) {
   Mutex::ScopedLock lock(mutex_);
   resources_[url] = data;
-  url_to_stream_id_[url] = ++stream_id_counter_;
 }
 
 std::string NetworkResourceManager::Get(const std::string& url) {
@@ -21,37 +20,9 @@ std::string NetworkResourceManager::Get(const std::string& url) {
   return {};
 }
 
-uint64_t NetworkResourceManager::NextStreamId() {
-  return ++stream_id_counter_;
-}
-
-std::string NetworkResourceManager::GetUrlForStreamId(uint64_t stream_id) {
+void NetworkResourceManager::Erase(const std::string& stream_id) {
   Mutex::ScopedLock lock(mutex_);
-  for (const auto& pair : url_to_stream_id_) {
-    if (pair.second == stream_id) {
-      return pair.first;
-    }
-  }
-  return std::string();
-}
-
-void NetworkResourceManager::EraseByStreamId(uint64_t stream_id) {
-  Mutex::ScopedLock lock(mutex_);
-  for (auto it = url_to_stream_id_.begin(); it != url_to_stream_id_.end();
-       ++it) {
-    if (it->second == stream_id) {
-      resources_.erase(it->first);
-      url_to_stream_id_.erase(it);
-      break;
-    }
-  }
-}
-
-uint64_t NetworkResourceManager::GetStreamId(const std::string& url) {
-  Mutex::ScopedLock lock(mutex_);
-  auto it = url_to_stream_id_.find(url);
-  if (it != url_to_stream_id_.end()) return it->second;
-  return 0;
+  resources_.erase(stream_id);
 }
 
 }  // namespace inspector

--- a/src/inspector/network_resource_manager.cc
+++ b/src/inspector/network_resource_manager.cc
@@ -1,0 +1,58 @@
+#include "inspector/network_resource_manager.h"
+#include <atomic>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace node {
+namespace inspector {
+
+std::unordered_map<std::string, std::string> NetworkResourceManager::resources_;
+std::unordered_map<std::string, uint64_t>
+    NetworkResourceManager::url_to_stream_id_;
+std::atomic<uint64_t> NetworkResourceManager::stream_id_counter_{1};
+
+void NetworkResourceManager::Put(const std::string& url,
+                                 const std::string& data) {
+  resources_[url] = data;
+  url_to_stream_id_[url] = ++stream_id_counter_;
+}
+
+std::string NetworkResourceManager::Get(const std::string& url) {
+  auto it = resources_.find(url);
+  if (it != resources_.end()) return it->second;
+  return {};
+}
+
+uint64_t NetworkResourceManager::NextStreamId() {
+  return ++stream_id_counter_;
+}
+
+std::string NetworkResourceManager::GetUrlForStreamId(uint64_t stream_id) {
+  for (const auto& pair : url_to_stream_id_) {
+    if (pair.second == stream_id) {
+      return pair.first;
+    }
+  }
+  return std::string();
+}
+
+void NetworkResourceManager::EraseByStreamId(uint64_t stream_id) {
+  for (auto it = url_to_stream_id_.begin(); it != url_to_stream_id_.end();
+       ++it) {
+    if (it->second == stream_id) {
+      resources_.erase(it->first);
+      url_to_stream_id_.erase(it);
+      break;
+    }
+  }
+}
+
+uint64_t NetworkResourceManager::GetStreamId(const std::string& url) {
+  auto it = url_to_stream_id_.find(url);
+  if (it != url_to_stream_id_.end()) return it->second;
+  return 0;
+}
+
+}  // namespace inspector
+}  // namespace node

--- a/src/inspector/network_resource_manager.h
+++ b/src/inspector/network_resource_manager.h
@@ -5,27 +5,29 @@
 #include <atomic>
 #include <string>
 #include <unordered_map>
+#include "node_mutex.h"
 
 namespace node {
 namespace inspector {
 
 class NetworkResourceManager {
  public:
-  static void Put(const std::string& url, const std::string& data);
-  static std::string Get(const std::string& url);
+  void Put(const std::string& url, const std::string& data);
+  std::string Get(const std::string& url);
 
   // Accessor to get URL for a given stream id
-  static std::string GetUrlForStreamId(uint64_t stream_id);
+  std::string GetUrlForStreamId(uint64_t stream_id);
   // Erase resource and mapping by stream id
-  static void EraseByStreamId(uint64_t stream_id);
+  void EraseByStreamId(uint64_t stream_id);
   // Returns the stream id for a given url, or 0 if not found
-  static uint64_t GetStreamId(const std::string& url);
+  uint64_t GetStreamId(const std::string& url);
 
  private:
-  static uint64_t NextStreamId();
-  static std::unordered_map<std::string, std::string> resources_;
-  static std::unordered_map<std::string, uint64_t> url_to_stream_id_;
-  static std::atomic<uint64_t> stream_id_counter_;
+  uint64_t NextStreamId();
+  std::unordered_map<std::string, std::string> resources_;
+  std::unordered_map<std::string, uint64_t> url_to_stream_id_;
+  std::atomic<uint64_t> stream_id_counter_{1};
+  Mutex mutex_;  // Protects access to resources_ and url_to_stream_id_
 };
 
 }  // namespace inspector

--- a/src/inspector/network_resource_manager.h
+++ b/src/inspector/network_resource_manager.h
@@ -15,19 +15,12 @@ class NetworkResourceManager {
   void Put(const std::string& url, const std::string& data);
   std::string Get(const std::string& url);
 
-  // Accessor to get URL for a given stream id
-  std::string GetUrlForStreamId(uint64_t stream_id);
   // Erase resource and mapping by stream id
-  void EraseByStreamId(uint64_t stream_id);
-  // Returns the stream id for a given url, or 0 if not found
-  uint64_t GetStreamId(const std::string& url);
+  void Erase(const std::string& stream_id);
 
  private:
-  uint64_t NextStreamId();
   std::unordered_map<std::string, std::string> resources_;
-  std::unordered_map<std::string, uint64_t> url_to_stream_id_;
-  std::atomic<uint64_t> stream_id_counter_{1};
-  Mutex mutex_;  // Protects access to resources_ and url_to_stream_id_
+  Mutex mutex_;  // Protects access to resources_
 };
 
 }  // namespace inspector

--- a/src/inspector/network_resource_manager.h
+++ b/src/inspector/network_resource_manager.h
@@ -1,0 +1,34 @@
+// network_resource_manager.h
+#ifndef SRC_INSPECTOR_NETWORK_RESOURCE_MANAGER_H_
+#define SRC_INSPECTOR_NETWORK_RESOURCE_MANAGER_H_
+
+#include <atomic>
+#include <string>
+#include <unordered_map>
+
+namespace node {
+namespace inspector {
+
+class NetworkResourceManager {
+ public:
+  static void Put(const std::string& url, const std::string& data);
+  static std::string Get(const std::string& url);
+
+  // Accessor to get URL for a given stream id
+  static std::string GetUrlForStreamId(uint64_t stream_id);
+  // Erase resource and mapping by stream id
+  static void EraseByStreamId(uint64_t stream_id);
+  // Returns the stream id for a given url, or 0 if not found
+  static uint64_t GetStreamId(const std::string& url);
+
+ private:
+  static uint64_t NextStreamId();
+  static std::unordered_map<std::string, std::string> resources_;
+  static std::unordered_map<std::string, uint64_t> url_to_stream_id_;
+  static std::atomic<uint64_t> stream_id_counter_;
+};
+
+}  // namespace inspector
+}  // namespace node
+
+#endif  // SRC_INSPECTOR_NETWORK_RESOURCE_MANAGER_H_

--- a/src/inspector/node_inspector.gypi
+++ b/src/inspector/node_inspector.gypi
@@ -36,6 +36,10 @@
       'src/inspector/target_agent.h',
       'src/inspector/worker_inspector.cc',
       'src/inspector/worker_inspector.h',
+      'src/inspector/io_agent.cc',
+      'src/inspector/io_agent.h',
+      'src/inspector/network_resource_manager.cc',
+      'src/inspector/network_resource_manager.h',
     ],
     'node_inspector_generated_sources': [
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Forward.h',
@@ -51,6 +55,8 @@
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Network.h',
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Target.cpp',
       '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/Target.h',
+      '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/IO.h',
+      '<(SHARED_INTERMEDIATE_DIR)/src/node/inspector/protocol/IO.cpp',
     ],
     'node_protocol_files': [
       '<(protocol_tool_path)/lib/Forward_h.template',

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -180,6 +180,11 @@ experimental domain Network
   # Request / response headers as keys / values of JSON object.
   type Headers extends object
 
+  type LoadNetworkResourcePageResult extends object
+    properties
+      boolean success
+      optional IO.StreamHandle stream
+
   # Disables network tracking, prevents network events from being sent to the client.
   command disable
 
@@ -215,6 +220,13 @@ experimental domain Network
     returns
       # Data that has been buffered until streaming is enabled.
       binary bufferedData
+  # Fetches the resource and returns the content.
+  command loadNetworkResource
+    parameters
+      # URL of the resource to get content for.
+      string url
+    returns
+      LoadNetworkResourcePageResult resource
 
   # Fired when page is about to send HTTP request.
   event requestWillBeSent
@@ -321,3 +333,24 @@ experimental domain Target
     parameters
       boolean autoAttach
       boolean waitForDebuggerOnStart
+domain IO
+  type StreamHandle extends string
+  # Read a chunk of the stream
+  command read
+    parameters
+      # Handle of the stream to read.
+      StreamHandle handle
+      # Seek to the specified offset before reading (if not specified, proceed with offset
+      # following the last read). Some types of streams may only support sequential reads.
+      optional integer offset
+      # Maximum number of bytes to read (left upon the agent discretion if not specified).
+      optional integer size
+    returns
+      # Data that were read.
+      string data
+      # Set if the end-of-file condition occurred while reading.
+      boolean eof
+  command close
+    parameters
+      # Handle of the stream to close.
+      StreamHandle handle

--- a/src/inspector/worker_inspector.cc
+++ b/src/inspector/worker_inspector.cc
@@ -60,12 +60,14 @@ ParentInspectorHandle::ParentInspectorHandle(
     const std::string& url,
     std::shared_ptr<MainThreadHandle> parent_thread,
     bool wait_for_connect,
-    const std::string& name)
+    const std::string& name,
+    std::shared_ptr<NetworkResourceManager> network_resource_manager)
     : id_(id),
       url_(url),
       parent_thread_(parent_thread),
       wait_(wait_for_connect),
-      name_(name) {}
+      name_(name),
+      network_resource_manager_(network_resource_manager) {}
 
 ParentInspectorHandle::~ParentInspectorHandle() {
   parent_thread_->Post(
@@ -101,10 +103,13 @@ void WorkerManager::WorkerStarted(uint64_t session_id,
 }
 
 std::unique_ptr<ParentInspectorHandle> WorkerManager::NewParentHandle(
-    uint64_t thread_id, const std::string& url, const std::string& name) {
+    uint64_t thread_id,
+    const std::string& url,
+    const std::string& name,
+    std::shared_ptr<NetworkResourceManager> network_resource_manager) {
   bool wait = !delegates_waiting_on_start_.empty();
   return std::make_unique<ParentInspectorHandle>(
-      thread_id, url, thread_, wait, name);
+      thread_id, url, thread_, wait, name, network_resource_manager);
 }
 
 void WorkerManager::RemoveAttachDelegate(int id) {

--- a/src/inspector/worker_inspector.h
+++ b/src/inspector/worker_inspector.h
@@ -1,6 +1,7 @@
 #ifndef SRC_INSPECTOR_WORKER_INSPECTOR_H_
 #define SRC_INSPECTOR_WORKER_INSPECTOR_H_
 
+#include "inspector/network_resource_manager.h"
 #if !HAVE_INSPECTOR
 #error("This header can only be used when inspector is enabled")
 #endif
@@ -54,16 +55,18 @@ struct WorkerInfo {
 
 class ParentInspectorHandle {
  public:
-  ParentInspectorHandle(uint64_t id,
-                        const std::string& url,
-                        std::shared_ptr<MainThreadHandle> parent_thread,
-                        bool wait_for_connect,
-                        const std::string& name);
+  ParentInspectorHandle(
+      uint64_t id,
+      const std::string& url,
+      std::shared_ptr<MainThreadHandle> parent_thread,
+      bool wait_for_connect,
+      const std::string& name,
+      std::shared_ptr<NetworkResourceManager> network_resource_manager);
   ~ParentInspectorHandle();
   std::unique_ptr<ParentInspectorHandle> NewParentInspectorHandle(
       uint64_t thread_id, const std::string& url, const std::string& name) {
     return std::make_unique<ParentInspectorHandle>(
-        thread_id, url, parent_thread_, wait_, name);
+        thread_id, url, parent_thread_, wait_, name, network_resource_manager_);
   }
   void WorkerStarted(std::shared_ptr<MainThreadHandle> worker_thread,
                      bool waiting);
@@ -74,6 +77,9 @@ class ParentInspectorHandle {
   std::unique_ptr<inspector::InspectorSession> Connect(
       std::unique_ptr<inspector::InspectorSessionDelegate> delegate,
       bool prevent_shutdown);
+  std::shared_ptr<NetworkResourceManager> GetNetworkResourceManager() {
+    return network_resource_manager_;
+  }
 
  private:
   uint64_t id_;
@@ -81,6 +87,7 @@ class ParentInspectorHandle {
   std::shared_ptr<MainThreadHandle> parent_thread_;
   bool wait_;
   std::string name_;
+  std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 
 class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
@@ -89,7 +96,10 @@ class WorkerManager : public std::enable_shared_from_this<WorkerManager> {
                          : thread_(thread) {}
 
   std::unique_ptr<ParentInspectorHandle> NewParentHandle(
-      uint64_t thread_id, const std::string& url, const std::string& name);
+      uint64_t thread_id,
+      const std::string& url,
+      const std::string& name,
+      std::shared_ptr<NetworkResourceManager> network_resource_manager);
   void WorkerStarted(uint64_t session_id, const WorkerInfo& info, bool waiting);
   void WorkerFinished(uint64_t session_id);
   std::unique_ptr<WorkerManagerEventHandle> SetAutoAttach(

--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -239,6 +239,10 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
     }
     runtime_agent_ = std::make_unique<protocol::RuntimeAgent>();
     runtime_agent_->Wire(node_dispatcher_.get());
+    if (env->options()->experimental_inspector_network_resource) {
+      io_agent_ = std::make_unique<protocol::IoAgent>();
+      io_agent_->Wire(node_dispatcher_.get());
+    }
     network_inspector_ =
         std::make_unique<NetworkInspector>(env, inspector.get());
     network_inspector_->Wire(node_dispatcher_.get());
@@ -406,6 +410,7 @@ class ChannelImpl final : public v8_inspector::V8Inspector::Channel,
   std::unique_ptr<protocol::WorkerAgent> worker_agent_;
   std::shared_ptr<protocol::TargetAgent> target_agent_;
   std::unique_ptr<NetworkInspector> network_inspector_;
+  std::shared_ptr<protocol::IoAgent> io_agent_;
   std::unique_ptr<InspectorSessionDelegate> delegate_;
   std::unique_ptr<v8_inspector::V8InspectorSession> session_;
   std::unique_ptr<UberDispatcher> node_dispatcher_;

--- a/src/inspector_agent.h
+++ b/src/inspector_agent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "inspector/network_resource_manager.h"
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #if !HAVE_INSPECTOR
@@ -127,6 +128,7 @@ class Agent {
   std::shared_ptr<WorkerManager> GetWorkerManager();
 
   inline Environment* env() const { return parent_env_; }
+  std::shared_ptr<NetworkResourceManager> GetNetworkResourceManager();
 
  private:
   void ToggleAsyncHook(v8::Isolate* isolate, v8::Local<v8::Function> fn);
@@ -153,6 +155,7 @@ class Agent {
   bool network_tracking_enabled_ = false;
   bool pending_enable_network_tracking = false;
   bool pending_disable_network_tracking = false;
+  std::shared_ptr<NetworkResourceManager> network_resource_manager_;
 };
 
 }  // namespace inspector

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -1,4 +1,5 @@
 #include "base_object-inl.h"
+#include "inspector/network_resource_manager.h"
 #include "inspector/protocol_helper.h"
 #include "inspector_agent.h"
 #include "inspector_io.h"
@@ -334,6 +335,18 @@ void Url(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(OneByteString(env->isolate(), url));
 }
 
+void PutNetworkResource(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  CHECK_GE(args.Length(), 2);
+  CHECK(args[0]->IsString());
+  CHECK(args[1]->IsString());
+
+  Utf8Value url(env->isolate(), args[0].As<String>());
+  Utf8Value data(env->isolate(), args[1].As<String>());
+
+  NetworkResourceManager::Put(*url, *data);
+}
+
 void Initialize(Local<Object> target, Local<Value> unused,
                 Local<Context> context, void* priv) {
   Environment* env = Environment::GetCurrent(context);
@@ -378,6 +391,7 @@ void Initialize(Local<Object> target, Local<Value> unused,
   SetMethodNoSideEffect(context, target, "isEnabled", IsEnabled);
   SetMethod(context, target, "emitProtocolEvent", EmitProtocolEvent);
   SetMethod(context, target, "setupNetworkTracking", SetupNetworkTracking);
+  SetMethod(context, target, "putNetworkResource", PutNetworkResource);
 
   Local<String> console_string = FIXED_ONE_BYTE_STRING(isolate, "console");
 
@@ -420,6 +434,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(JSBindingsConnection<MainThreadConnection>::New);
   registry->Register(JSBindingsConnection<MainThreadConnection>::Dispatch);
   registry->Register(JSBindingsConnection<MainThreadConnection>::Disconnect);
+  registry->Register(PutNetworkResource);
 }
 
 }  // namespace inspector

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -344,7 +344,7 @@ void PutNetworkResource(const v8::FunctionCallbackInfo<v8::Value>& args) {
   Utf8Value url(env->isolate(), args[0].As<String>());
   Utf8Value data(env->isolate(), args[1].As<String>());
 
-  NetworkResourceManager::Put(*url, *data);
+  env->inspector_agent()->GetNetworkResourceManager()->Put(*url, *data);
 }
 
 void Initialize(Local<Object> target, Local<Value> unused,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -711,6 +711,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
   AddOption("--experimental-worker-inspection",
             "experimental worker inspection support",
             &EnvironmentOptions::experimental_worker_inspection);
+  AddOption("--experimental-inspector-network-resource",
+            "experimental load network resources via the inspector",
+            &EnvironmentOptions::experimental_inspector_network_resource);
   AddOption(
       "--heap-prof",
       "Start the V8 heap profiler on start up, and write the heap profile "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -175,6 +175,7 @@ class EnvironmentOptions : public Options {
   bool cpu_prof = false;
   bool experimental_network_inspection = false;
   bool experimental_worker_inspection = false;
+  bool experimental_inspector_network_resource = false;
   std::string heap_prof_dir;
   std::string heap_prof_name;
   static const uint64_t kDefaultHeapProfInterval = 512 * 1024;

--- a/test/fixtures/inspector-network-resource/app.js.map
+++ b/test/fixtures/inspector-network-resource/app.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "app.js",
+  "sourceRoot": "",
+  "sources": [
+    "http://localhost:3000/app.ts"
+  ],
+  "names": [],
+  "mappings": ";AAAA,SAAS,GAAG,CAAC,CAAS,EAAE,CAAS;IAC/B,OAAO,CAAC,GAAG,CAAC,CAAC;AACf,CAAC;AAED,GAAG,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC"
+}

--- a/test/parallel/test-inspector-network-resource.js
+++ b/test/parallel/test-inspector-network-resource.js
@@ -1,0 +1,126 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const { NodeInstance } = require('../common/inspector-helper');
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const fs = require('fs');
+
+const resourceUrl = 'http://localhost:3000/app.js';
+const resourcePath = path.join(__dirname, '../fixtures/inspector-network-resource/app.js.map');
+
+const script = `
+  const { NetworkResources } = require('node:inspector');
+  const fs = require('fs');
+  NetworkResources.put('${resourceUrl}', fs.readFileSync('${resourcePath.replace(/\\/g, '\\').replace(/'/g, "\\'")}', 'utf8'));
+  console.log('Network resource loaded:', '${resourceUrl}');
+`;
+
+async function setupSessionAndPauseAtEvalLine4(script) {
+  const instance = new NodeInstance([
+    '--inspect-brk=0',
+    '--experimental-inspector-network-resource',
+  ], script);
+  const session = await instance.connectInspectorSession();
+  await session.send({ method: 'NodeRuntime.enable' });
+  await session.waitForNotification('NodeRuntime.waitingForDebugger');
+  await session.send({ method: 'Runtime.enable' });
+  await session.send({ method: 'Debugger.enable' });
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+  await session.waitForNotification((notification) => {
+    return (
+      notification.method === 'Debugger.scriptParsed' &&
+      notification.params.url.includes('[eval]')
+    );
+  });
+  // Set breakpoint at line 4 of [eval] script
+  await session.send({
+    method: 'Debugger.setBreakpointByUrl',
+    params: {
+      lineNumber: 4,
+      url: '[eval]'
+    }
+  });
+  await session.waitForNotification('Debugger.paused');
+  await session.send({ method: 'Debugger.resume' });
+  await session.waitForNotification('Debugger.paused');
+  return { instance, session };
+}
+
+test('should load and stream a static network resource using loadNetworkResource and IO.read', async () => {
+  const { session } = await setupSessionAndPauseAtEvalLine4(script);
+  const { resource } = await session.send({
+    method: 'Network.loadNetworkResource',
+    params: { url: resourceUrl },
+  });
+  assert(resource.success, 'Resource should be loaded successfully');
+  assert(resource.stream, 'Resource should have a stream handle');
+  let result = await session.send({ method: 'IO.read', params: { handle: resource.stream } });
+  let data = result.data;
+  let eof = result.eof;
+  let content = '';
+  while (!eof) {
+    content += data;
+    result = await session.send({ method: 'IO.read', params: { handle: resource.stream } });
+    data = result.data;
+    eof = result.eof;
+  }
+  content += data;
+  const expected = fs.readFileSync(resourcePath, 'utf8');
+  assert.strictEqual(content, expected);
+  await session.send({ method: 'IO.close', params: { handle: resource.stream } });
+  await session.send({ method: 'Debugger.resume' });
+  await session.waitForDisconnect();
+});
+
+test('should return success: false for missing resource', async () => {
+  const { session } = await setupSessionAndPauseAtEvalLine4(script);
+  const { resource } = await session.send({
+    method: 'Network.loadNetworkResource',
+    params: { url: 'http://localhost:3000/does-not-exist.js' },
+  });
+  assert.strictEqual(resource.success, false);
+  assert(!resource.stream, 'No stream should be returned for missing resource');
+  await session.send({ method: 'Debugger.resume' });
+  await session.waitForDisconnect();
+});
+
+test('should error or return empty for wrong stream id', async () => {
+  const { session } = await setupSessionAndPauseAtEvalLine4(script);
+  const { resource } = await session.send({
+    method: 'Network.loadNetworkResource',
+    params: { url: resourceUrl },
+  });
+  assert(resource.success);
+  const bogus = '999999';
+  const result = await session.send({ method: 'IO.read', params: { handle: bogus } });
+  assert(result.eof, 'Should be eof for bogus stream id');
+  assert.strictEqual(result.data, '');
+  await session.send({ method: 'IO.close', params: { handle: resource.stream } });
+  await session.send({ method: 'Debugger.resume' });
+  await session.waitForDisconnect();
+});
+
+test('should support IO.read with size and offset', async () => {
+  const { session } = await setupSessionAndPauseAtEvalLine4(script);
+  const { resource } = await session.send({
+    method: 'Network.loadNetworkResource',
+    params: { url: resourceUrl },
+  });
+  assert(resource.success);
+  assert(resource.stream);
+  const expected = fs.readFileSync(resourcePath, 'utf8');
+  let result = await session.send({ method: 'IO.read', params: { handle: resource.stream, size: 5 } });
+  assert.strictEqual(result.data, expected.slice(0, 5));
+  result = await session.send({ method: 'IO.read', params: { handle: resource.stream, offset: 5, size: 5 } });
+  assert.strictEqual(result.data, expected.slice(5, 10));
+  result = await session.send({ method: 'IO.read', params: { handle: resource.stream, offset: 10 } });
+  assert.strictEqual(result.data, expected.slice(10));
+  await session.send({ method: 'IO.close', params: { handle: resource.stream } });
+  await session.send({ method: 'Debugger.resume' });
+  await session.waitForDisconnect();
+});

--- a/test/parallel/test-inspector-network-resource.js
+++ b/test/parallel/test-inspector-network-resource.js
@@ -14,10 +14,11 @@ const resourceUrl = 'http://localhost:3000/app.js';
 const resourcePath = path.join(__dirname, '../fixtures/inspector-network-resource/app.js.map');
 
 const resourceText = fs.readFileSync(resourcePath, 'utf8');
+const embedPath = resourcePath.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 const script = `
   const { NetworkResources } = require('node:inspector');
   const fs = require('fs');
-  NetworkResources.put('${resourceUrl}', fs.readFileSync('${resourcePath.replace(/\\/g, '\\').replace(/'/g, "\\'")}', 'utf8'));
+  NetworkResources.put('${resourceUrl}', fs.readFileSync('${embedPath}', 'utf8'));
   console.log('Network resource loaded:', '${resourceUrl}');
   debugger;
 `;
@@ -117,7 +118,7 @@ test('should load resource put from another thread', async () => {
   const script = `
   const { NetworkResources } = require('node:inspector');
   const fs = require('fs');
-  NetworkResources.put('${resourceUrl}', fs.readFileSync('${resourcePath.replace(/\\/g, '\\').replace(/'/g, "\\'")}', 'utf8'));
+  NetworkResources.put('${resourceUrl}', fs.readFileSync('${embedPath}', 'utf8'));
   const { Worker } = require('worker_threads');
   const worker = new Worker(\`${workerScript}\`, {eval: true});
   `;

--- a/typings/internalBinding/inspector.d.ts
+++ b/typings/internalBinding/inspector.d.ts
@@ -33,4 +33,5 @@ export interface InspectorBinding {
   console: Console;
   Connection: InspectorConnectionConstructor;
   MainThreadConnection: InspectorConnectionConstructor;
+  putNetworkResource: (url: string, resource: string) => void;
 }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/57873


Adds initial support for Network.loadNetworkResource in the inspector.
https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-loadNetworkResource
### how to load network resource
~Resource fetching is done via a spawned child process to keep the inspector's event loop clean and isolated.
The JavaScript code for the fetch process is currently hardcoded, which may not be ideal, but I couldn't come up with a better approach at this point.~

When --experimental-inspector-network-resource is set, a dedicated worker for loadNetworkResource is launched.
This worker fetches the resource and returns the result to the frontend.
https://github.com/nodejs/node/pull/58077/files#diff-5d3d58cbcfda008f49966a11d73863e67b78a237aa386f1fbdc5c9124136c1eb

### check the behavior in chromium
To verify this change in Chromium, modify the section in the link as shown below and launch Chromium with the built DevTools frontend.

https://source.chromium.org/chromium/chromium/src/+/main:third_party/devtools-frontend/src/front_end/core/sdk/Target.ts;l=87-88

``` typescript
      case Type.NODE:
        this.#capabilitiesMask = Capability.JS | Capability.NETWORK | Capability.TARGET | Capability.IO;
```
``` sh
# open Chromium with built devtools-frontend
Chromium --custom-devtools-frontend=(file path)
```

### other infomation
If this change is considered acceptable, I will send a follow-up change request to expand the Node.js DevTools target with IO support.
If it is necessary to wait until Network.loadNetworkResource becomes stable in CRDP, please feel free to keep this PR pending.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
