### PR TITLE
src: improve TextEncoder encodeInto performance

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -137,13 +137,13 @@ void BindingData::FastEncodeInto(
   char* write_result = static_cast<char*>(buf->Data()) + dest_->ByteOffset();
   size_t dest_length = dest_->ByteLength();
 
-  int nchars;
-  int written = source_->WriteUtf8(
+  size_t nchars;
+  size_t written = source_->WriteUtf8V2(
       options.isolate,
       write_result,
       dest_length,
-      &nchars,
-      String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
+      String::WriteFlags::kReplaceInvalidUtf8,
+      &nchars);
 
   binding_data->encode_into_results_buffer_[0] = nchars;
   binding_data->encode_into_results_buffer_[1] = written;

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -2,10 +2,12 @@
 #include "ada.h"
 #include "env-inl.h"
 #include "node_buffer.h"
+#include "node_debug.h"
 #include "node_errors.h"
 #include "node_external_reference.h"
 #include "simdutf.h"
 #include "string_bytes.h"
+#include "v8-fast-api-calls.h"
 #include "v8.h"
 
 #include <cstdint>
@@ -16,7 +18,9 @@ namespace encoding_binding {
 using v8::ArrayBuffer;
 using v8::BackingStore;
 using v8::BackingStoreInitializationMode;
+using v8::CFunction;
 using v8::Context;
+using v8::FastApiCallbackOptions;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Isolate;
@@ -111,6 +115,42 @@ void BindingData::EncodeInto(const FunctionCallbackInfo<Value>& args) {
   binding_data->encode_into_results_buffer_[0] = nchars;
   binding_data->encode_into_results_buffer_[1] = written;
 }
+
+void BindingData::FastEncodeInto(
+    Local<Value> receiver,
+    Local<Value> source,
+    Local<Value> dest,
+    // NOLINTNEXTLINE(runtime/references) This is V8 api.
+    FastApiCallbackOptions& options) {
+  TRACK_V8_FAST_API_CALL("encoding_binding.encodeInto");
+  CHECK(source->IsString());
+  CHECK(dest->IsUint8Array());
+
+  HandleScope scope(options.isolate);
+  auto context = options.isolate->GetCurrentContext();
+  Realm* realm = Realm::GetCurrent(context);
+  BindingData* binding_data = realm->GetBindingData<BindingData>();
+
+  auto source_ = source.As<String>();
+  auto dest_ = dest.As<Uint8Array>();
+  Local<ArrayBuffer> buf = dest_->Buffer();
+  char* write_result = static_cast<char*>(buf->Data()) + dest_->ByteOffset();
+  size_t dest_length = dest_->ByteLength();
+
+  int nchars;
+  int written = source_->WriteUtf8(
+      options.isolate,
+      write_result,
+      dest_length,
+      &nchars,
+      String::NO_NULL_TERMINATION | String::REPLACE_INVALID_UTF8);
+
+  binding_data->encode_into_results_buffer_[0] = nchars;
+  binding_data->encode_into_results_buffer_[1] = written;
+}
+
+static CFunction fast_encode_into_ =
+    CFunction::Make(BindingData::FastEncodeInto);
 
 // Encode a single string to a UTF-8 Uint8Array (not Buffer).
 // Used in TextEncoder.prototype.encode.
@@ -217,7 +257,7 @@ void BindingData::ToUnicode(const FunctionCallbackInfo<Value>& args) {
 void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
                                              Local<ObjectTemplate> target) {
   Isolate* isolate = isolate_data->isolate();
-  SetMethod(isolate, target, "encodeInto", EncodeInto);
+  SetFastMethod(isolate, target, "encodeInto", EncodeInto, &fast_encode_into_);
   SetMethodNoSideEffect(isolate, target, "encodeUtf8String", EncodeUtf8String);
   SetMethodNoSideEffect(isolate, target, "decodeUTF8", DecodeUTF8);
   SetMethodNoSideEffect(isolate, target, "toASCII", ToASCII);
@@ -236,6 +276,8 @@ void BindingData::CreatePerContextProperties(Local<Object> target,
 void BindingData::RegisterTimerExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(EncodeInto);
+  registry->Register(FastEncodeInto);
+  registry->Register(fast_encode_into_.GetTypeInfo());
   registry->Register(EncodeUtf8String);
   registry->Register(DecodeUTF8);
   registry->Register(ToASCII);

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -29,6 +29,10 @@ class BindingData : public SnapshotableObject {
   SET_MEMORY_INFO_NAME(BindingData)
 
   static void EncodeInto(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void FastEncodeInto(v8::Local<v8::Value> receiver,
+                             v8::Local<v8::Value> source,
+                             v8::Local<v8::Value> dest,
+                             v8::FastApiCallbackOptions& options);
   static void EncodeUtf8String(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DecodeUTF8(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DecodeLatin1(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -92,6 +92,13 @@ using CFunctionBufferCopy = uint32_t (*)(v8::Local<v8::Value>,
                                          uint32_t,
                                          v8::FastApiCallbackOptions&);
 
+using CFunctionEncodeInto =
+    void (*)(v8::Local<v8::Value> receiver,
+             v8::Local<v8::Value> source,
+             v8::Local<v8::Value> dest,
+             // NOLINTNEXTLINE(runtime/references) This is V8 api.
+             v8::FastApiCallbackOptions& options);
+
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
 class ExternalReferenceRegistry {
@@ -121,6 +128,7 @@ class ExternalReferenceRegistry {
   V(CFunctionWithBool)                                                         \
   V(CFunctionBufferCopy)                                                       \
   V(CFunctionWriteString)                                                      \
+  V(CFunctionEncodeInto)                                                       \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \


### PR DESCRIPTION
Improves the performance of TextEncoder.encodeInto method

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1712/

It seems none of the benchmarks are triggering the fast path

```
                                                                               confidence improvement accuracy (*)   (**)  (***)
util/text-encoder.js op='encode' type='ascii' n=1000000 len=1024                              -0.77 %       ±1.08% ±1.44% ±1.87%
util/text-encoder.js op='encode' type='ascii' n=1000000 len=256                                0.70 %       ±0.97% ±1.29% ±1.67%
util/text-encoder.js op='encode' type='ascii' n=1000000 len=32                                -0.34 %       ±1.12% ±1.50% ±1.95%
util/text-encoder.js op='encode' type='ascii' n=1000000 len=8192                               0.08 %       ±0.09% ±0.12% ±0.15%
util/text-encoder.js op='encode' type='one-byte-string' n=1000000 len=1024                     0.36 %       ±0.61% ±0.81% ±1.05%
util/text-encoder.js op='encode' type='one-byte-string' n=1000000 len=256                      0.29 %       ±0.64% ±0.85% ±1.10%
util/text-encoder.js op='encode' type='one-byte-string' n=1000000 len=32                       0.48 %       ±0.95% ±1.27% ±1.65%
util/text-encoder.js op='encode' type='one-byte-string' n=1000000 len=8192                    -0.02 %       ±0.05% ±0.06% ±0.08%
util/text-encoder.js op='encode' type='two-byte-string' n=1000000 len=1024             **      0.26 %       ±0.15% ±0.20% ±0.26%
util/text-encoder.js op='encode' type='two-byte-string' n=1000000 len=256              **     -0.73 %       ±0.45% ±0.60% ±0.79%
util/text-encoder.js op='encode' type='two-byte-string' n=1000000 len=32                       0.02 %       ±0.84% ±1.11% ±1.45%
util/text-encoder.js op='encode' type='two-byte-string' n=1000000 len=8192            ***     -0.15 %       ±0.02% ±0.03% ±0.04%
util/text-encoder.js op='encodeInto' type='ascii' n=1000000 len=1024                  ***     -0.64 %       ±0.21% ±0.29% ±0.37%
util/text-encoder.js op='encodeInto' type='ascii' n=1000000 len=256                   ***     -2.94 %       ±0.56% ±0.75% ±0.99%
util/text-encoder.js op='encodeInto' type='ascii' n=1000000 len=32                    ***     -8.50 %       ±2.68% ±3.57% ±4.64%
util/text-encoder.js op='encodeInto' type='ascii' n=1000000 len=8192                  ***     -0.05 %       ±0.02% ±0.02% ±0.03%
util/text-encoder.js op='encodeInto' type='one-byte-string' n=1000000 len=1024        ***     -0.99 %       ±0.22% ±0.29% ±0.38%
util/text-encoder.js op='encodeInto' type='one-byte-string' n=1000000 len=256         ***     -1.47 %       ±0.81% ±1.08% ±1.41%
util/text-encoder.js op='encodeInto' type='one-byte-string' n=1000000 len=32            *     -2.82 %       ±2.60% ±3.46% ±4.50%
util/text-encoder.js op='encodeInto' type='one-byte-string' n=1000000 len=8192          *     -0.07 %       ±0.06% ±0.08% ±0.10%
util/text-encoder.js op='encodeInto' type='two-byte-string' n=1000000 len=1024        ***     -0.67 %       ±0.13% ±0.18% ±0.23%
util/text-encoder.js op='encodeInto' type='two-byte-string' n=1000000 len=256         ***     -1.69 %       ±0.42% ±0.56% ±0.73%
util/text-encoder.js op='encodeInto' type='two-byte-string' n=1000000 len=32           **     -2.70 %       ±1.93% ±2.57% ±3.35%
util/text-encoder.js op='encodeInto' type='two-byte-string' n=1000000 len=8192        ***      0.11 %       ±0.05% ±0.06% ±0.08%
```