### PR TITLE
build: use FILE_OFFSET_BITS=64 even on 32-bit arch

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -276,6 +276,9 @@
     # Defines these mostly for node-gyp to pickup.
     'defines': [
       '_GLIBCXX_USE_CXX11_ABI=1',
+      # This help forks when building Node.js on a 32-bit arch as
+      # libuv is always compiled with _FILE_OFFSET_BITS=64
+      '_FILE_OFFSET_BITS=64'
     ],
 
     # Forcibly disable -Werror.  We support a wide range of compilers, it's


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/57934