### PR TITLE
crypto: handle missing OPENSSL_TLS_SECURITY_LEVEL

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -2744,8 +2744,9 @@ std::optional<int> SSLPointer::getSecurityLevel() {
 
   return SSL_get_security_level(ssl);
 #else
-  // for BoringSSL assume the same as the default
-  return OPENSSL_TLS_SECURITY_LEVEL;
+  // OPENSSL_TLS_SECURITY_LEVEL is not defined in BoringSSL
+  // so assume it is the default OPENSSL_TLS_SECURITY_LEVEL value.
+  return 1;
 #endif  // OPENSSL_IS_BORINGSSL
 }
 


### PR DESCRIPTION
`OPENSSL_TLS_SECURITY_LEVEL` isn't defined at all in BoringSSL and will cause compilation failures.

Ref https://github.com/nodejs/node/pull/57323
Ref https://github.com/nodejs/node/pull/56601

See [boringssl search results](https://source.chromium.org/search?q=OPENSSL_TLS_SECURITY_LEVEL&sq=package:chromium)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
