### PR TITLE
async_hooks: add use() method to AsyncLocalStorage

### DIFF
--- a/doc/api/async_context.md
+++ b/doc/api/async_context.md
@@ -347,6 +347,43 @@ try {
 }
 ```
 
+### `asyncLocalStorage.use(store)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `store` {any}
+* Returns: {Disposable} A disposable object.
+
+Transitions into the given context, and transitions back into the previous
+context when the returned disposable object is disposed. The store is
+accessible to any asynchronous operations created before disposal.
+
+Example:
+
+```js
+const store1 = { id: 1 };
+const store2 = { id: 2 };
+
+function inner() {
+  // Once `using` syntax is supported, you can use that here, and omit the
+  // dispose call at the end of this function.
+  const disposable = asyncLocalStorage.use(store);
+  asyncLocalStorage.getStore(); // Returns store2
+  setTimeout(() => {
+    asyncLocalStorage.getStore(); // Returns store2
+  }, 200);
+  disposable[Symbol.dispose]();
+}
+
+asyncLocalStorage.run(store1, () => {
+  asyncLocalStorage.getStore(); // Returns store1
+  inner();
+  asyncLocalStorage.getStore(); // Returns store1
+});
+```
+
 ### `asyncLocalStorage.exit(callback[, ...args])`
 
 <!-- YAML

--- a/lib/internal/async_local_storage/async_context_frame.js
+++ b/lib/internal/async_local_storage/async_context_frame.js
@@ -2,6 +2,7 @@
 
 const {
   ReflectApply,
+  SymbolDispose,
 } = primordials;
 
 const {
@@ -10,6 +11,19 @@ const {
 
 const AsyncContextFrame = require('internal/async_context_frame');
 const { AsyncResource } = require('async_hooks');
+
+class DisposableStore {
+  #oldFrame = undefined;
+
+  constructor(store, storage) {
+    this.#oldFrame = AsyncContextFrame.current();
+    storage.enterWith(store);
+  }
+
+  [SymbolDispose]() {
+    AsyncContextFrame.set(this.#oldFrame);
+  }
+}
 
 class AsyncLocalStorage {
   #defaultValue = undefined;
@@ -60,6 +74,10 @@ class AsyncLocalStorage {
     } finally {
       AsyncContextFrame.set(prior);
     }
+  }
+
+  use(data) {
+    return new DisposableStore(data, this);
   }
 
   exit(fn, ...args) {

--- a/lib/internal/async_local_storage/async_hooks.js
+++ b/lib/internal/async_local_storage/async_hooks.js
@@ -7,6 +7,7 @@ const {
   ObjectIs,
   ReflectApply,
   Symbol,
+  SymbolDispose,
 } = primordials;
 
 const {
@@ -29,6 +30,31 @@ const storageHook = createHook({
     }
   },
 });
+
+class DisposableStore {
+  #oldStore = undefined;
+  #resource = undefined;
+  #kResourceStore = undefined;
+
+  constructor(store, storage) {
+    this.#oldStore = storage.getStore();
+
+    if (ObjectIs(store, this.#oldStore)) {
+      return;
+    }
+
+    this.#kResourceStore = storage.kResourceStore;
+    this.#resource = executionAsyncResource();
+    this.#resource[this.#kResourceStore] = store;
+  }
+
+  [SymbolDispose]() {
+    if (this.#resource === undefined) {
+      return;
+    }
+    this.#resource[this.#kResourceStore] = this.#oldStore;
+  }
+}
 
 class AsyncLocalStorage {
   #defaultValue = undefined;
@@ -118,6 +144,11 @@ class AsyncLocalStorage {
     } finally {
       resource[this.kResourceStore] = oldStore;
     }
+  }
+
+  use(store) {
+    this._enable();
+    return new DisposableStore(store, this);
   }
 
   exit(callback, ...args) {

--- a/test/parallel/test-async-local-storage-use.js
+++ b/test/parallel/test-async-local-storage-use.js
@@ -1,0 +1,25 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const storage = new AsyncLocalStorage();
+
+const store1 = {};
+const store2 = {};
+const store3 = {};
+
+function inner() {
+  // TODO(bengl): Once `using` is supported use that here and don't call
+  // dispose manually later.
+  const disposable = storage.use(store2);
+  assert.strictEqual(storage.getStore(), store2);
+  storage.enterWith(store3);
+  disposable[Symbol.dispose]();
+}
+
+storage.enterWith(store1);
+assert.strictEqual(storage.getStore(), store1);
+inner();
+assert.strictEqual(storage.getStore(), store1);


### PR DESCRIPTION
This provides a way to use the `using` syntax (when available) to manage AsyncLocalStorage contexts, as an alternative to `run()`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
