### PR TITLE
build: use //third_party/simdutf by default in GN

### DIFF
--- a/node.gni
+++ b/node.gni
@@ -14,7 +14,7 @@ declare_args() {
   node_openssl_path = "$node_path/deps/openssl"
 
   # The location of simdutf - use the one from node's deps by default.
-  node_simdutf_path = "$node_path/deps/simdutf"
+  node_simdutf_path = "//third_party/simdutf"
 
   # The NODE_MODULE_VERSION defined in node_version.h.
   node_module_version = exec_script("$node_path/tools/getmoduleversion.py", [], "value")


### PR DESCRIPTION
Use `//third_party/simdutf` by default in the GN build instead of `deps/simdutf`. Similar to what's currently done for `//third_party/zlib` for the same reason.

Added in https://chromium-review.googlesource.com/c/v8/node-ci/+/6177642
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
