### PR TITLE
[v22.x backport] deps: V8: backport e5dbbbadcbff

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/compiler/backend/code-generator.cc
+++ b/deps/v8/src/compiler/backend/code-generator.cc
@@ -408,7 +408,7 @@ void CodeGenerator::AssembleCode() {
     }
   }
 
-  // The LinuxPerfJitLogger logs code up until here, excluding the safepoint
+  // The PerfJitLogger logs code up until here, excluding the safepoint
   // table. Resolve the unwinding info now so it is aware of the same code
   // size as reported by perf.
   unwinding_info_writer_.Finish(masm()->pc_offset());

--- a/deps/v8/src/diagnostics/perf-jit.cc
+++ b/deps/v8/src/diagnostics/perf-jit.cc
@@ -30,8 +30,8 @@
 #include "src/common/assert-scope.h"
 #include "src/flags/flags.h"
 
-// Only compile the {LinuxPerfJitLogger} on Linux.
-#if V8_OS_LINUX
+// Only compile the {PerfJitLogger} on Linux & Darwin.
+#if V8_OS_LINUX || V8_OS_DARWIN
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -118,22 +118,22 @@ struct PerfJitCodeUnwindingInfo : PerfJitBase {
   // Followed by size_ - sizeof(PerfJitCodeUnwindingInfo) bytes of data.
 };
 
-const char LinuxPerfJitLogger::kFilenameFormatString[] = "%s/jit-%d.dump";
+const char PerfJitLogger::kFilenameFormatString[] = "%s/jit-%d.dump";
 
 // Extra padding for the PID in the filename
-const int LinuxPerfJitLogger::kFilenameBufferPadding = 16;
+const int PerfJitLogger::kFilenameBufferPadding = 16;
 
 static const char kStringTerminator[] = {'\0'};
 
 // The following static variables are protected by
 // GetFileMutex().
-int LinuxPerfJitLogger::process_id_ = 0;
-uint64_t LinuxPerfJitLogger::reference_count_ = 0;
-void* LinuxPerfJitLogger::marker_address_ = nullptr;
-uint64_t LinuxPerfJitLogger::code_index_ = 0;
-FILE* LinuxPerfJitLogger::perf_output_handle_ = nullptr;
+int PerfJitLogger::process_id_ = 0;
+uint64_t PerfJitLogger::reference_count_ = 0;
+void* PerfJitLogger::marker_address_ = nullptr;
+uint64_t PerfJitLogger::code_index_ = 0;
+FILE* PerfJitLogger::perf_output_handle_ = nullptr;
 
-void LinuxPerfJitLogger::OpenJitDumpFile() {
+void PerfJitLogger::OpenJitDumpFile() {
   // Open the perf JIT dump file.
   perf_output_handle_ = nullptr;
 
@@ -153,8 +153,17 @@ void LinuxPerfJitLogger::OpenJitDumpFile() {
   if (v8_flags.perf_prof_delete_file)
     CHECK_EQ(0, unlink(perf_dump_name.begin()));
 
+  // On Linux, call OpenMarkerFile so that perf knows about the file path via
+  // an MMAP record.
+  // On macOS, don't call OpenMarkerFile because samply has already detected
+  // the file path during the call to `open` above (it interposes `open` with
+  // a preloaded library), and because the mmap call can be slow.
+#if V8_OS_DARWIN
+  marker_address_ = nullptr;
+#else
   marker_address_ = OpenMarkerFile(fd);
   if (marker_address_ == nullptr) return;
+#endif
 
   perf_output_handle_ = fdopen(fd, "w+");
   if (perf_output_handle_ == nullptr) return;
@@ -162,13 +171,13 @@ void LinuxPerfJitLogger::OpenJitDumpFile() {
   setvbuf(perf_output_handle_, nullptr, _IOFBF, kLogBufferSize);
 }
 
-void LinuxPerfJitLogger::CloseJitDumpFile() {
+void PerfJitLogger::CloseJitDumpFile() {
   if (perf_output_handle_ == nullptr) return;
   base::Fclose(perf_output_handle_);
   perf_output_handle_ = nullptr;
 }
 
-void* LinuxPerfJitLogger::OpenMarkerFile(int fd) {
+void* PerfJitLogger::OpenMarkerFile(int fd) {
   long page_size = sysconf(_SC_PAGESIZE);  // NOLINT(runtime/int)
   if (page_size == -1) return nullptr;
 
@@ -180,15 +189,14 @@ void* LinuxPerfJitLogger::OpenMarkerFile(int fd) {
   return (marker_address == MAP_FAILED) ? nullptr : marker_address;
 }
 
-void LinuxPerfJitLogger::CloseMarkerFile(void* marker_address) {
+void PerfJitLogger::CloseMarkerFile(void* marker_address) {
   if (marker_address == nullptr) return;
   long page_size = sysconf(_SC_PAGESIZE);  // NOLINT(runtime/int)
   if (page_size == -1) return;
   munmap(marker_address, page_size);
 }
 
-LinuxPerfJitLogger::LinuxPerfJitLogger(Isolate* isolate)
-    : CodeEventLogger(isolate) {
+PerfJitLogger::PerfJitLogger(Isolate* isolate) : CodeEventLogger(isolate) {
   base::LockGuard<base::RecursiveMutex> guard_file(GetFileMutex().Pointer());
   process_id_ = base::OS::GetCurrentProcessId();
 
@@ -201,7 +209,7 @@ LinuxPerfJitLogger::LinuxPerfJitLogger(Isolate* isolate)
   }
 }
 
-LinuxPerfJitLogger::~LinuxPerfJitLogger() {
+PerfJitLogger::~PerfJitLogger() {
   base::LockGuard<base::RecursiveMutex> guard_file(GetFileMutex().Pointer());
 
   reference_count_--;
@@ -211,16 +219,11 @@ LinuxPerfJitLogger::~LinuxPerfJitLogger() {
   }
 }
 
-uint64_t LinuxPerfJitLogger::GetTimestamp() {
-  struct timespec ts;
-  int result = clock_gettime(CLOCK_MONOTONIC, &ts);
-  DCHECK_EQ(0, result);
-  USE(result);
-  static const uint64_t kNsecPerSec = 1000000000;
-  return (ts.tv_sec * kNsecPerSec) + ts.tv_nsec;
+uint64_t PerfJitLogger::GetTimestamp() {
+  return base::TimeTicks::Now().since_origin().InNanoseconds();
 }
 
-void LinuxPerfJitLogger::LogRecordedBuffer(
+void PerfJitLogger::LogRecordedBuffer(
     Tagged<AbstractCode> abstract_code,
     MaybeHandle<SharedFunctionInfo> maybe_sfi, const char* name, int length) {
   DisallowGarbageCollection no_gc;
@@ -263,8 +266,8 @@ void LinuxPerfJitLogger::LogRecordedBuffer(
 }
 
 #if V8_ENABLE_WEBASSEMBLY
-void LinuxPerfJitLogger::LogRecordedBuffer(const wasm::WasmCode* code,
-                                           const char* name, int length) {
+void PerfJitLogger::LogRecordedBuffer(const wasm::WasmCode* code,
+                                      const char* name, int length) {
   base::LockGuard<base::RecursiveMutex> guard_file(GetFileMutex().Pointer());
 
   if (perf_output_handle_ == nullptr) return;
@@ -276,10 +279,9 @@ void LinuxPerfJitLogger::LogRecordedBuffer(const wasm::WasmCode* code,
 }
 #endif  // V8_ENABLE_WEBASSEMBLY
 
-void LinuxPerfJitLogger::WriteJitCodeLoadEntry(const uint8_t* code_pointer,
-                                               uint32_t code_size,
-                                               const char* name,
-                                               int name_length) {
+void PerfJitLogger::WriteJitCodeLoadEntry(const uint8_t* code_pointer,
+                                          uint32_t code_size, const char* name,
+                                          int name_length) {
   PerfJitCodeLoad code_load;
   code_load.event_ = PerfJitCodeLoad::kLoad;
   code_load.size_ = sizeof(code_load) + name_length + 1 + code_size;
@@ -342,8 +344,8 @@ SourcePositionInfo GetSourcePositionInfo(Isolate* isolate, Tagged<Code> code,
 
 }  // namespace
 
-void LinuxPerfJitLogger::LogWriteDebugInfo(Tagged<Code> code,
-                                           Handle<SharedFunctionInfo> shared) {
+void PerfJitLogger::LogWriteDebugInfo(Tagged<Code> code,
+                                      Handle<SharedFunctionInfo> shared) {
   // Line ends of all scripts have been initialized prior to this.
   DisallowGarbageCollection no_gc;
   // The WasmToJS wrapper stubs have source position entries.
@@ -426,7 +428,7 @@ void LinuxPerfJitLogger::LogWriteDebugInfo(Tagged<Code> code,
 }
 
 #if V8_ENABLE_WEBASSEMBLY
-void LinuxPerfJitLogger::LogWriteDebugInfo(const wasm::WasmCode* code) {
+void PerfJitLogger::LogWriteDebugInfo(const wasm::WasmCode* code) {
   wasm::WasmModuleSourceMap* source_map =
       code->native_module()->GetWasmSourceMap();
   wasm::WireBytesRef code_ref =
@@ -494,7 +496,7 @@ void LinuxPerfJitLogger::LogWriteDebugInfo(const wasm::WasmCode* code) {
 }
 #endif  // V8_ENABLE_WEBASSEMBLY
 
-void LinuxPerfJitLogger::LogWriteUnwindingInfo(Tagged<Code> code) {
+void PerfJitLogger::LogWriteUnwindingInfo(Tagged<Code> code) {
   PerfJitCodeUnwindingInfo unwinding_info_header;
   unwinding_info_header.event_ = PerfJitCodeLoad::kUnwindingInfo;
   unwinding_info_header.time_stamp_ = GetTimestamp();
@@ -529,13 +531,13 @@ void LinuxPerfJitLogger::LogWriteUnwindingInfo(Tagged<Code> code) {
   LogWriteBytes(padding_bytes, static_cast<int>(padding_size));
 }
 
-void LinuxPerfJitLogger::LogWriteBytes(const char* bytes, int size) {
+void PerfJitLogger::LogWriteBytes(const char* bytes, int size) {
   size_t rv = fwrite(bytes, 1, size, perf_output_handle_);
   DCHECK(static_cast<size_t>(size) == rv);
   USE(rv);
 }
 
-void LinuxPerfJitLogger::LogWriteHeader() {
+void PerfJitLogger::LogWriteHeader() {
   DCHECK_NOT_NULL(perf_output_handle_);
   PerfJitHeader header;
 
@@ -556,4 +558,4 @@ void LinuxPerfJitLogger::LogWriteHeader() {
 }  // namespace internal
 }  // namespace v8
 
-#endif  // V8_OS_LINUX
+#endif  // V8_OS_LINUX || V8_OS_DARWIN

--- a/deps/v8/src/diagnostics/perf-jit.h
+++ b/deps/v8/src/diagnostics/perf-jit.h
@@ -30,8 +30,8 @@
 
 #include "include/v8config.h"
 
-// {LinuxPerfJitLogger} is only implemented on Linux.
-#if V8_OS_LINUX
+// {PerfJitLogger} is only implemented on Linux & Darwin.
+#if V8_OS_LINUX || V8_OS_DARWIN
 
 #include "src/logging/log.h"
 
@@ -39,10 +39,10 @@ namespace v8 {
 namespace internal {
 
 // Linux perf tool logging support.
-class LinuxPerfJitLogger : public CodeEventLogger {
+class PerfJitLogger : public CodeEventLogger {
  public:
-  explicit LinuxPerfJitLogger(Isolate* isolate);
-  ~LinuxPerfJitLogger() override;
+  explicit PerfJitLogger(Isolate* isolate);
+  ~PerfJitLogger() override;
 
   void CodeMoveEvent(Tagged<InstructionStream> from,
                      Tagged<InstructionStream> to) override {
@@ -142,6 +142,6 @@ class LinuxPerfJitLogger : public CodeEventLogger {
 }  // namespace internal
 }  // namespace v8
 
-#endif  // V8_OS_LINUX
+#endif  // V8_OS_LINUX || V8_OS_DARWIN
 
 #endif  // V8_DIAGNOSTICS_PERF_JIT_H_

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -2782,7 +2782,7 @@ DEFINE_IMPLICATION(prof, log_code)
 
 DEFINE_BOOL(ll_prof, false, "Enable low-level linux profiler.")
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_DARWIN
 #define DEFINE_PERF_PROF_BOOL(nam, cmt) DEFINE_BOOL(nam, false, cmt)
 #define DEFINE_PERF_PROF_IMPLICATION DEFINE_IMPLICATION
 #else
@@ -2799,7 +2799,7 @@ DEFINE_BOOL(ll_prof, false, "Enable low-level linux profiler.")
 #endif
 
 DEFINE_PERF_PROF_BOOL(perf_basic_prof,
-                      "Enable perf linux profiler (basic support).")
+                      "Enable basic support for perf profiler.")
 DEFINE_NEG_IMPLICATION(perf_basic_prof, compact_code_space)
 DEFINE_STRING(perf_basic_prof_path, DEFAULT_PERF_BASIC_PROF_PATH,
               "directory to write perf-<pid>.map symbol file to")
@@ -2808,8 +2808,8 @@ DEFINE_PERF_PROF_BOOL(
     "Only report function code ranges to perf (i.e. no stubs).")
 DEFINE_PERF_PROF_IMPLICATION(perf_basic_prof_only_functions, perf_basic_prof)
 
-DEFINE_PERF_PROF_BOOL(
-    perf_prof, "Enable perf linux profiler (experimental annotate support).")
+DEFINE_PERF_PROF_BOOL(perf_prof,
+                      "Enable experimental annotate support for perf profiler.")
 DEFINE_STRING(perf_prof_path, DEFAULT_PERF_PROF_PATH,
               "directory to write jit-<pid>.dump symbol file to")
 DEFINE_PERF_PROF_BOOL(

--- a/deps/v8/src/logging/log.h
+++ b/deps/v8/src/logging/log.h
@@ -63,8 +63,8 @@ class Isolate;
 class JitLogger;
 class LogFile;
 class LowLevelLogger;
-class LinuxPerfBasicLogger;
-class LinuxPerfJitLogger;
+class PerfBasicLogger;
+class PerfJitLogger;
 class Profiler;
 class SourcePosition;
 class Ticker;
@@ -357,9 +357,9 @@ class V8FileLogger : public LogEventListener {
 
   std::atomic<bool> is_logging_;
   std::unique_ptr<LogFile> log_file_;
-#if V8_OS_LINUX
-  std::unique_ptr<LinuxPerfBasicLogger> perf_basic_logger_;
-  std::unique_ptr<LinuxPerfJitLogger> perf_jit_logger_;
+#if V8_OS_LINUX || V8_OS_DARWIN
+  std::unique_ptr<PerfBasicLogger> perf_basic_logger_;
+  std::unique_ptr<PerfJitLogger> perf_jit_logger_;
 #endif
   std::unique_ptr<LowLevelLogger> ll_logger_;
   std::unique_ptr<JitLogger> jit_logger_;


### PR DESCRIPTION
Manual backport for v22.x of the changes in https://github.com/nodejs/node/pull/58010 which has been closed in favor of the V8 upgrade https://github.com/nodejs/node/pull/58070 which already contains this change.

Original commit message:

    Enable --perf-prof flag on MacOS

    MacOS actually can share the implementation of {PerfJitLogger} with
    Linux. From the issue 40112126, only Fuzzer tests on Windows ran
    into UNREACHABLE/FATAL because of the unimplemented {PerfJitLogger}.
    This CL enables the flag --perf-prof on MacOS.

    Bug: 403765219
    Change-Id: I97871fbcc0cb9890c51ca14fd7a6e65bd0e3c0d2
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6385655
    Reviewed-by: Clemens Backes <clemensb@chromium.org>
    Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
    Auto-Submit: 杨文明 <yangwenming@bytedance.com>
    Commit-Queue: Clemens Backes <clemensb@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#99885}

Refs: https://github.com/v8/v8/commit/e5dbbbadcbff64d4d6031e0288278aacd67eb904

cc @targos @tmm1

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
