### PR TITLE
doc: clarify --watch and --watch-path usage with --run

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3056,6 +3056,10 @@ Use `--watch-path` to specify what paths to watch.
 This flag cannot be combined with
 `--check`, `--eval`, `--interactive`, or the REPL.
 
+Note: The `--watch` flag requires a file path as an argument. It does not support
+being used with `--run` or inline script input. If no file is provided, Node.js will
+exit with status code 9.
+
 ```bash
 node --watch index.js
 ```
@@ -3082,6 +3086,9 @@ combination with `--watch`.
 
 This flag cannot be combined with
 `--check`, `--eval`, `--interactive`, `--test`, or the REPL.
+
+Note: Using `--watch-path` implicitly enables `--watch`, which requires a file path
+and is incompatible with `--run`, as `--run` takes precedence and ignores watch mode.
 
 ```bash
 node --watch-path=./src --watch-path=./tests index.js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3056,9 +3056,9 @@ Use `--watch-path` to specify what paths to watch.
 This flag cannot be combined with
 `--check`, `--eval`, `--interactive`, or the REPL.
 
-Note: The `--watch` flag requires a file path as an argument. It does not support
-being used with `--run` or inline script input. If no file is provided, Node.js will
-exit with status code `9`.
+Note: The `--watch` flag requires a file path as an argument and is incompatible
+with `--run` or inline script input, as `--run` takes precedence and ignores watch
+mode. If no file is provided, Node.js will exit with status code `9`.
 
 ```bash
 node --watch index.js

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3058,7 +3058,7 @@ This flag cannot be combined with
 
 Note: The `--watch` flag requires a file path as an argument. It does not support
 being used with `--run` or inline script input. If no file is provided, Node.js will
-exit with status code 9.
+exit with status code `9`.
 
 ```bash
 node --watch index.js


### PR DESCRIPTION
This PR adds a note under the `--watch` and `--watch-path` CLI options in `cli.md` to clarify that these flags require a file path and cannot be used with `--run`.

Fixes confusion where users might assume `--watch-path` or `--watch` work with `--run`, which currently results in a runtime error.

Helps address issue discussion [here](https://github.com/nodejs/node/issues/58113)
