### PR TITLE
Add a `[[ErrorData]]` internal slot to DOMException

### DIFF
--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -3,6 +3,7 @@
 const {
   Error,
   ErrorPrototype,
+  FunctionPrototype,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
@@ -49,10 +50,15 @@ const disusedNamesSet = new SafeSet()
   .add('NoDataAllowedError')
   .add('ValidationError');
 
-class DOMException {
+// The DOMException class must not inherit from the Error class,
+// but its instance inherit from Error.prototype.
+// Make the runtime aware not to allocate `this` instance unnecessarily.
+class DOMException extends Error {
+  static {
+    ObjectSetPrototypeOf(DOMException, FunctionPrototype);
+  }
+
   constructor(message = '', options = 'Error') {
-    // The DOMException class must not inherit from the Error class,
-    // but its instance inherit from Error.prototype.
     // The stack property and [[ErrorData]] internal slot are given.
     const error = ReflectConstruct(Error, [], new.target);
 

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -51,6 +51,9 @@ const disusedNamesSet = new SafeSet()
 
 class DOMException {
   constructor(message = '', options = 'Error') {
+    // The DOMException class must not inherit from the Error class,
+    // but its instance inherit from Error.prototype.
+    // The stack property and [[ErrorData]] internal slot are given.
     const error = ReflectConstruct(Error, [], new.target);
 
     if (options && typeof options === 'object') {

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const {
-  ErrorCaptureStackTrace,
+  Error,
   ErrorPrototype,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  ReflectConstruct,
   SafeMap,
   SafeSet,
   SafeWeakMap,
@@ -50,17 +51,17 @@ const disusedNamesSet = new SafeSet()
 
 class DOMException {
   constructor(message = '', options = 'Error') {
-    ErrorCaptureStackTrace(this);
+    const error = ReflectConstruct(Error, [], new.target);
 
     if (options && typeof options === 'object') {
       const { name } = options;
-      internalsMap.set(this, {
+      internalsMap.set(error, {
         message: `${message}`,
         name: `${name}`,
       });
 
       if ('cause' in options) {
-        ObjectDefineProperty(this, 'cause', {
+        ObjectDefineProperty(error, 'cause', {
           __proto__: null,
           value: options.cause,
           configurable: true,
@@ -69,11 +70,13 @@ class DOMException {
         });
       }
     } else {
-      internalsMap.set(this, {
+      internalsMap.set(error, {
         message: `${message}`,
         name: `${options}`,
       });
     }
+
+    return error;
   }
 
   get name() {

--- a/test/parallel/test-util.js
+++ b/test/parallel/test-util.js
@@ -55,6 +55,7 @@ assert.strictEqual(util.toUSVString('string\ud801'), 'string\ufffd');
   assert.strictEqual(util.types.isNativeError(new Error()), true);
   assert.strictEqual(util.types.isNativeError(new TypeError()), true);
   assert.strictEqual(util.types.isNativeError(new SyntaxError()), true);
+  assert.strictEqual(util.types.isNativeError(new DOMException()), true);
   assert.strictEqual(util.types.isNativeError(new (context('Error'))()), true);
   assert.strictEqual(
     util.types.isNativeError(new (context('TypeError'))()),


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes #56497

`Error.isError`, implemented in V8 13.6 (#58070), must return `true` for `DOMException`.