### PR TITLE
test: skip test-buffer-tostring-rangeerror when low on memory

### DIFF
--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -1,9 +1,14 @@
 'use strict';
-require('../common');
+
+const common = require('../common');
 
 // This test ensures that Node.js throws an Error when trying to convert a
 // large buffer into a string.
 // Regression test for https://github.com/nodejs/node/issues/649.
+
+if (!common.enoughTestMem) {
+  common.skip('skipped due to memory requirements');
+}
 
 const assert = require('assert');
 const {


### PR DESCRIPTION
This has shown up as RangeError: Array buffer allocation failed and it should be totally fine to skip this test in case the memory is low.

https://ci.nodejs.org/job/node-test-binary-windows-js-suites/33969/RUN_SUBSET=2,nodes=win2019-COMPILED_BY-vs2019/console

```
13:36:31 not ok 105 parallel/test-buffer-tostring-rangeerror
13:36:31   ---
13:36:31   duration_ms: 263.03700
13:36:31   severity: fail
13:36:31   exitcode: 1
13:36:31   stack: |-
13:36:31     node:assert:377
13:36:31           throw err;
13:36:31           ^
13:36:31     
13:36:31     AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
13:36:31     + actual - expected
13:36:31     
13:36:31       Comparison {
13:36:31     +   name: 'RangeError'
13:36:31     -   code: 'ERR_STRING_TOO_LONG',
13:36:31     -   name: 'Error'
13:36:31       }
13:36:31         at Object.<anonymous> (C:\workspace\node-test-binary-windows-js-suites\node\test\parallel\test-buffer-tostring-rangeerror.js:21:8)
13:36:31         at Module._compile (node:internal/modules/cjs/loader:1529:14)
13:36:31         at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
13:36:31         at Module.load (node:internal/modules/cjs/loader:1275:32)
13:36:31         at Module._load (node:internal/modules/cjs/loader:1096:12)
13:36:31         at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
13:36:31         at node:internal/main/run_main_module:28:49 {
13:36:31       generatedMessage: true,
13:36:31       code: 'ERR_ASSERTION',
13:36:31       actual: RangeError: Array buffer allocation failed
13:36:31           at new ArrayBuffer (<anonymous>)
13:36:31           at new Uint8Array (<anonymous>)
13:36:31           at new FastBuffer (node:internal/buffer:961:5)
13:36:31           at Function.alloc (node:buffer:397:10)
13:36:31           at Buffer (node:buffer:275:19)
13:36:31           at C:\workspace\node-test-binary-windows-js-suites\node\test\parallel\test-buffer-tostring-rangeerror.js:21:21
13:36:31           at getActual (node:assert:498:5)
13:36:31           at Function.throws (node:assert:644:24)
13:36:31           at Object.<anonymous> (C:\workspace\node-test-binary-windows-js-suites\node\test\parallel\test-buffer-tostring-rangeerror.js:21:8)
13:36:31           at Module._compile (node:internal/modules/cjs/loader:1529:14),
13:36:31       expected: { code: 'ERR_STRING_TOO_LONG', name: 'Error' },
13:36:31       operator: 'throws'
13:36:31     }
13:36:31     
13:36:31     Node.js v20.19.2-pre
13:36:31   ...
```