### PR TITLE
esm: add support for dynamic source phase hook

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -717,13 +717,9 @@ into a new instance of `library.wasm`:
 ```js
 import source libraryModule from './library.wasm';
 
-const instance1 = await WebAssembly.instantiate(libraryModule, {
-  custom: import1,
-});
+const instance1 = await WebAssembly.instantiate(libraryModule, importObject1);
 
-const instance2 = await WebAssembly.instantiate(libraryModule, {
-  custom: import2,
-});
+const instance2 = await WebAssembly.instantiate(libraryModule, importObject2);
 ```
 
 In addition to the static source phase, there is also a dynamic variant of the
@@ -732,9 +728,7 @@ source phase via the `import.source` dynamic phase import syntax:
 ```js
 const dynamicLibrary = await import.source('./library.wasm');
 
-const instance = await WebAssembly.instantiate(dynamicLibrary, {
-  custom: importObj,
-});
+const instance = await WebAssembly.instantiate(dynamicLibrary, importObject);
 ```
 
 <i id="esm_experimental_top_level_await"></i>

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -729,13 +729,11 @@ const instance2 = await WebAssembly.instantiate(libraryModule, {
 In addition to the static source phase, there is also a dynamic variant of the
 source phase via the `import.source` dynamic phase import syntax:
 
-<!-- eslint-skip -->
-
 ```js
 const dynamicLibrary = await import.source('./library.wasm');
 
 const instance = await WebAssembly.instantiate(dynamicLibrary, {
-  custom: import
+  custom: importObj,
 });
 ```
 

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -726,6 +726,17 @@ const instance2 = await WebAssembly.instantiate(libraryModule, {
 });
 ```
 
+In addition to the static source phase, there is also a dynamic variant of the
+source phase via the `import.source` dynamic phase import syntax:
+
+```js
+const dynamicLibrary = await import.source('./library.wasm');
+
+const instance = await WebAssembly.instantiate(dynamicLibrary, {
+  custom: import
+});
+```
+
 <i id="esm_experimental_top_level_await"></i>
 
 ## Top-level `await`

--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -729,6 +729,8 @@ const instance2 = await WebAssembly.instantiate(libraryModule, {
 In addition to the static source phase, there is also a dynamic variant of the
 source phase via the `import.source` dynamic phase import syntax:
 
+<!-- eslint-skip -->
+
 ```js
 const dynamicLibrary = await import.source('./library.wasm');
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,6 +104,7 @@ export default [
       parser: babelEslintParser,
       parserOptions: {
         babelOptions: {
+          parserOpts: { createImportExpressions: true },
           plugins: [
             babelPluginProposalExplicitResourceManagement,
             babelPluginSyntaxImportAttributes,

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1065,10 +1065,8 @@ void ModuleWrap::SetImportModuleDynamicallyCallback(
   realm->set_host_import_module_dynamically_callback(import_callback);
 
   isolate->SetHostImportModuleDynamicallyCallback(ImportModuleDynamically);
-  // TODO(guybedford): Enable this once
-  //                   https://github.com/nodejs/node/pull/56842 lands.
-  // isolate->SetHostImportModuleWithPhaseDynamicallyCallback(
-  //     ImportModuleDynamicallyWithPhase);
+  isolate->SetHostImportModuleWithPhaseDynamicallyCallback(
+      ImportModuleDynamicallyWithPhase);
 }
 
 void ModuleWrap::HostInitializeImportMetaObjectCallback(

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -192,6 +192,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
         '  strictEqual(e instanceof SyntaxError, true);',
         '  strictEqual(e.message.includes("Source phase import object is not defined for module"), true);',
         `  strictEqual(e.message.includes(${JSON.stringify(fileUrl)}), true);`,
+        `  return true`,
         '});',
       ].join('\n'),
     ]);

--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -124,8 +124,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
     strictEqual(code, 0);
   });
 
-  // TODO: Enable this once https://github.com/nodejs/node/pull/56842 lands.
-  it.skip('should support dynamic source phase imports', async () => {
+  it('should support dynamic source phase imports', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-wasm-modules',
@@ -166,8 +165,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
     strictEqual(code, 0);
   });
 
-  // TODO: Enable this once https://github.com/nodejs/node/pull/56842 lands.
-  it.skip('should not execute dynamic source phase imports', async () => {
+  it('should not execute dynamic source phase imports', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-wasm-modules',
@@ -181,8 +179,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
     strictEqual(code, 0);
   });
 
-  // TODO: Enable this once https://github.com/nodejs/node/pull/56842 lands.
-  it.skip('should throw for dynamic source phase imports not defined', async () => {
+  it('should throw for dynamic source phase imports not defined', async () => {
     const fileUrl = fixtures.fileURL('es-modules/wasm-source-phase.js');
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
@@ -238,8 +235,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
     notStrictEqual(code, 0);
   });
 
-  // TODO: Enable this once https://github.com/nodejs/node/pull/56842 lands.
-  it.skip('should throw for vm source phase dynamic import', async () => {
+  it('should throw for vm source phase dynamic import', async () => {
     const { code, stderr, stdout } = await spawnPromisified(execPath, [
       '--no-warnings',
       '--experimental-wasm-modules',


### PR DESCRIPTION
This adds the support for the dynamic `import.source()` phase from the latest V8, and enabling the tests.

//cc @nodejs/loaders 