### PR TITLE
test: reduce flakiness in test-heapdump-http2

### DIFF
--- a/test/pummel/test-heapdump-http2.js
+++ b/test/pummel/test-heapdump-http2.js
@@ -48,10 +48,9 @@ server.listen(0, () => {
       { node_name: 'TCP', edge_name: 'native_to_javascript' },
     ]);
 
-    // `Node / StreamPipe` (C++) -> StreamPipe (JS)
-    validateByRetainingPathFromNodes(nodes, 'Node / StreamPipe', [
-      { node_name: 'StreamPipe', edge_name: 'native_to_javascript' },
-    ]);
+    // We don't necessarily have Node / StreamPipe here because by the time the
+    // response event is emitted, the file may have already been fully piped here
+    // and the stream pipe may have been destroyed.
 
     // `Node / Http2Session` (C++) -> Http2Session (JS)
     const sessions = validateByRetainingPathFromNodes(nodes, 'Node / Http2Session', []);


### PR DESCRIPTION
By the time the response event is emitted on the client's side, the file may have already been fully piped and the stream pipe may have been destroyed, so the test should not look for the stream pipe in the snapshot.

This doesn't seem to reproduce in the CI (the CI is seeing a timeout caused by the deadlock instead) but locally when I was trying to reproduce the deadlock with with `tools/test.py -J --repeat=1000 pummel/test-heapdump-http2` using a shared library build on macOS, this failure comes up first instead of the deadlock because the uv_try_write done for writing the file finishes too fast & synchronously - maybe because it's already cached under repeated runs - destroying the stream pipe already before the snapshot is taken.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
