### PR TITLE
src: enforce assumptions in FIXED_ONE_BYTE_STRING

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -346,17 +346,19 @@ inline v8::Local<v8::String> OneByteString(v8::Isolate* isolate,
                                            std::string_view str);
 
 // Used to be a macro, hence the uppercase name.
-template <int N>
-inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(
-    v8::Isolate* isolate,
-    const char(&data)[N]) {
+template <std::size_t N>
+  requires(N > 0)
+inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(v8::Isolate* isolate,
+                                                   const char (&data)[N]) {
+  CHECK_EQ(data[N - 1], '\0');
   return OneByteString(isolate, data, N - 1);
 }
 
 template <std::size_t N>
+  requires(N > 0)
 inline v8::Local<v8::String> FIXED_ONE_BYTE_STRING(
-    v8::Isolate* isolate,
-    const std::array<char, N>& arr) {
+    v8::Isolate* isolate, const std::array<char, N>& arr) {
+  CHECK_EQ(arr[N - 1], '\0');
   return OneByteString(isolate, arr.data(), N - 1);
 }
 


### PR DESCRIPTION
These functions are both meant to be used with a null-terminated and thus non-empty sequence of `char`s. However, there is nothing stopping call sites from passing zero-length sequences, which would certainly not be null-terminated and also would cause an underflow in `N - 1`. Therefore, this commit

- changes the size `N` of the array from `int` to `std::size_t`,
- ensures that compilation will fail if `N = 0`, and
- adds a runtime assertion that fails if the `N`-th `char` is not `\0`.

Note that the runtime assertion should be eliminated by any optimizing compiler when given a string literal, which is how these functions are used for the most part (though not exclusively).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
