### PR TITLE
doc: clarify napi_get_value_string_* for bufsize 0

### DIFF
--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3688,7 +3688,8 @@ napi_status napi_get_value_string_latin1(napi_env env,
   passed in, the length of the string in bytes and excluding the null terminator
   is returned in `result`.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated.
+  insufficient, the returned string is truncated and null-terminated if possible,
+  i.e., it is null-terminated if `bufsize` is not zero.
 * `[out] result`: Number of bytes copied into the buffer, excluding the null
   terminator.
 
@@ -3719,7 +3720,8 @@ napi_status napi_get_value_string_utf8(napi_env env,
   in, the length of the string in bytes and excluding the null terminator is
   returned in `result`.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated.
+  insufficient, the returned string is truncated and null-terminated if possible,
+  i.e., it is null-terminated if `bufsize` is not zero.
 * `[out] result`: Number of bytes copied into the buffer, excluding the null
   terminator.
 
@@ -3749,7 +3751,8 @@ napi_status napi_get_value_string_utf16(napi_env env,
   passed in, the length of the string in 2-byte code units and excluding the
   null terminator is returned.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated.
+  insufficient, the returned string is truncated and null-terminated if possible,
+  i.e., it is null-terminated if `bufsize` is not zero.
 * `[out] result`: Number of 2-byte code units copied into the buffer, excluding
   the null terminator.
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -3688,8 +3688,9 @@ napi_status napi_get_value_string_latin1(napi_env env,
   passed in, the length of the string in bytes and excluding the null terminator
   is returned in `result`.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated if possible,
-  i.e., it is null-terminated if `bufsize` is not zero.
+  insufficient, the returned string is truncated and null-terminated.
+  If this value is zero, then the string is not returned and no changes are done
+  to the buffer.
 * `[out] result`: Number of bytes copied into the buffer, excluding the null
   terminator.
 
@@ -3720,8 +3721,9 @@ napi_status napi_get_value_string_utf8(napi_env env,
   in, the length of the string in bytes and excluding the null terminator is
   returned in `result`.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated if possible,
-  i.e., it is null-terminated if `bufsize` is not zero.
+  insufficient, the returned string is truncated and null-terminated.
+  If this value is zero, then the string is not returned and no changes are done
+  to the buffer.
 * `[out] result`: Number of bytes copied into the buffer, excluding the null
   terminator.
 
@@ -3751,8 +3753,9 @@ napi_status napi_get_value_string_utf16(napi_env env,
   passed in, the length of the string in 2-byte code units and excluding the
   null terminator is returned.
 * `[in] bufsize`: Size of the destination buffer. When this value is
-  insufficient, the returned string is truncated and null-terminated if possible,
-  i.e., it is null-terminated if `bufsize` is not zero.
+  insufficient, the returned string is truncated and null-terminated.
+  If this value is zero, then the string is not returned and no changes are done
+  to the buffer.
 * `[out] result`: Number of 2-byte code units copied into the buffer, excluding
   the null terminator.
 


### PR DESCRIPTION
This edge case is ambiguous and it is unclear from the existing documentation what happens in this case.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
