### PR TITLE
os: rename functions wrapped via `hideStackFrames()`

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -25,6 +25,7 @@ const {
   ArrayPrototypePush,
   Float64Array,
   ObjectDefineProperties,
+  ObjectDefineProperty,
   StringPrototypeSlice,
   SymbolToPrimitive,
 } = primordials;
@@ -59,14 +60,21 @@ const {
   setPriority: _setPriority,
 } = internalBinding('os');
 
-function getCheckedFunction(fn) {
-  return hideStackFrames(function checkError() {
+function getCheckedFunction(fn, name) {
+  const wrappedFn = hideStackFrames(function checkError() {
     const ctx = {};
     const ret = fn(ctx);
     if (ret === undefined) {
       throw new ERR_SYSTEM_ERROR.HideStackFramesError(ctx);
     }
     return ret;
+  });
+  return ObjectDefineProperty(wrappedFn, 'name', {
+    __proto__: null,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+    value: name,
   });
 }
 
@@ -77,10 +85,10 @@ const {
   3: machine,
 } = _getOSInformation();
 
-const getHomeDirectory = getCheckedFunction(_getHomeDirectory);
-const getHostname = getCheckedFunction(_getHostname);
-const getInterfaceAddresses = getCheckedFunction(_getInterfaceAddresses);
-const getUptime = getCheckedFunction(_getUptime);
+const getHomeDirectory = getCheckedFunction(_getHomeDirectory, 'getHomeDirectory');
+const getHostname = getCheckedFunction(_getHostname, 'getHostname');
+const getInterfaceAddresses = getCheckedFunction(_getInterfaceAddresses, 'getInterfaceAddresses');
+const getUptime = getCheckedFunction(_getUptime, 'getUptime');
 
 /**
  * @returns {string}

--- a/lib/os.js
+++ b/lib/os.js
@@ -25,7 +25,6 @@ const {
   ArrayPrototypePush,
   Float64Array,
   ObjectDefineProperties,
-  ObjectDefineProperty,
   StringPrototypeSlice,
   SymbolToPrimitive,
 } = primordials;
@@ -40,7 +39,10 @@ const {
   },
   hideStackFrames,
 } = require('internal/errors');
-const { getCIDR } = require('internal/util');
+const {
+  assignFunctionName,
+  getCIDR,
+} = require('internal/util');
 const { validateInt32 } = require('internal/validators');
 
 const {
@@ -61,21 +63,14 @@ const {
 } = internalBinding('os');
 
 function getCheckedFunction(fn, name) {
-  const wrappedFn = hideStackFrames(function checkError() {
+  return assignFunctionName(name, hideStackFrames(function checkError() {
     const ctx = {};
     const ret = fn(ctx);
     if (ret === undefined) {
       throw new ERR_SYSTEM_ERROR.HideStackFramesError(ctx);
     }
     return ret;
-  });
-  return ObjectDefineProperty(wrappedFn, 'name', {
-    __proto__: null,
-    writable: false,
-    enumerable: false,
-    configurable: true,
-    value: name,
-  });
+  }));
 }
 
 const {


### PR DESCRIPTION
The internal `hideStackFrames()` returns wrapper function with `.name === 'wrappedFn'` (and `.length === 0` which aligns with desired value), and these wrappers are exported directly to userspace. Let's give them more meaningful names.