### PR TITLE
fs: improve `cpSync` dest overriding performance

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -81,15 +81,12 @@ function getStats(src, dest, opts) {
 
 function onFile(srcStat, destStat, src, dest, opts) {
   if (!destStat) return copyFile(srcStat, src, dest, opts);
-  return mayCopyFile(srcStat, src, dest, opts);
-}
 
-// TODO(@anonrig): Move this function to C++.
-function mayCopyFile(srcStat, src, dest, opts) {
   if (opts.force) {
-    unlinkSync(dest);
-    return copyFile(srcStat, src, dest, opts);
-  } else if (opts.errorOnExist) {
+    return fsBinding.cpSyncOverrideFile(src, dest, opts.mode, opts.preserveTimestamps);
+  }
+
+  if (opts.errorOnExist) {
     throw new ERR_FS_CP_EEXIST({
       message: `${dest} already exists`,
       path: dest,

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -775,6 +775,13 @@ inline void Environment::ThrowError(
   isolate()->ThrowException(fun(OneByteString(isolate(), errmsg), {}));
 }
 
+inline void Environment::ThrowStdErrException(std::error_code error_code,
+                                              const char* syscall,
+                                              const char* path) {
+  ThrowErrnoException(
+      error_code.value(), syscall, error_code.message().c_str(), path);
+}
+
 inline void Environment::ThrowErrnoException(int errorno,
                                              const char* syscall,
                                              const char* message,

--- a/src/env.h
+++ b/src/env.h
@@ -830,6 +830,9 @@ class Environment final : public MemoryRetainer {
   inline void ThrowError(const char* errmsg);
   inline void ThrowTypeError(const char* errmsg);
   inline void ThrowRangeError(const char* errmsg);
+  inline void ThrowStdErrException(std::error_code error_code,
+                                   const char* syscall,
+                                   const char* path = nullptr);
   inline void ThrowErrnoException(int errorno,
                                   const char* syscall = nullptr,
                                   const char* message = nullptr,

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3381,11 +3381,9 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
 
   std::filesystem::remove(*dest, error);
   if (error) {
-    auto dest_path = BufferValueToPath(dest);
-    auto dest_path_str = PathToString(dest_path);
     std::string message = "operation not permitted, unlink";
     return env->ThrowErrnoException(
-        EPERM, "unlink", message.c_str(), dest_path.c_str());
+        EPERM, "unlink", message.c_str(), dest.out());
   }
 
   if (mode == 0) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -37,7 +37,6 @@
 
 #include "tracing/trace_event.h"
 
-#include <utime.h>
 #include "req_wrap-inl.h"
 #include "stream_base-inl.h"
 #include "string_bytes.h"
@@ -3394,6 +3393,8 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
     }
   } else {
     uv_fs_t req;
+    auto cleanup =
+        OnScopeLeave([&mkstemp_req]() { uv_fs_req_cleanup(&req); });
     int result = uv_fs_copyfile(nullptr, &req, *src, *dest, mode, nullptr);
     if (is_uv_error(result)) {
       return env->ThrowUVException(result, "copyfile", nullptr, *src, *dest);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3394,7 +3394,7 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
   } else {
     uv_fs_t req;
     auto cleanup =
-        OnScopeLeave([&mkstemp_req]() { uv_fs_req_cleanup(&req); });
+        OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
     int result = uv_fs_copyfile(nullptr, &req, *src, *dest, mode, nullptr);
     if (is_uv_error(result)) {
       return env->ThrowUVException(result, "copyfile", nullptr, *src, *dest);
@@ -3403,6 +3403,8 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
 
   if (preserve_timestamps) {
     uv_fs_t req;
+    auto cleanup =
+      OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
     int result = uv_fs_stat(nullptr, &req, *src, nullptr);
     if (is_uv_error(result)) {
       return env->ThrowUVException(result, "stat", nullptr, *src);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3385,7 +3385,7 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
     auto dest_path_str = PathToString(dest_path);
     std::string message = "operation not permitted, unlink";
     return env->ThrowErrnoException(
-      EPERM, "unlink", message.c_str(), dest_path.c_str());
+        EPERM, "unlink", message.c_str(), dest_path.c_str());
   }
 
   if (mode == 0) {
@@ -3397,8 +3397,7 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
     }
   } else {
     uv_fs_t req;
-    auto cleanup =
-        OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
+    auto cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
     int result = uv_fs_copyfile(nullptr, &req, *src, *dest, mode, nullptr);
     if (is_uv_error(result)) {
       return env->ThrowUVException(result, "copyfile", nullptr, *src, *dest);
@@ -3407,8 +3406,7 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
 
   if (preserve_timestamps) {
     uv_fs_t req;
-    auto cleanup =
-      OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
+    auto cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
     int result = uv_fs_stat(nullptr, &req, *src, nullptr);
     if (is_uv_error(result)) {
       return env->ThrowUVException(result, "stat", nullptr, *src);

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3381,7 +3381,11 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
 
   std::filesystem::remove(*dest, error);
   if (error) {
-    return env->ThrowError(error.message().c_str());
+    auto dest_path = BufferValueToPath(dest);
+    auto dest_path_str = PathToString(dest_path);
+    std::string message = "operation not permitted, unlink";
+    return env->ThrowErrnoException(
+      EPERM, "unlink", message.c_str(), dest_path.c_str());
   }
 
   if (mode == 0) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3391,7 +3391,7 @@ static void CpSyncOverrideFile(const FunctionCallbackInfo<Value>& args) {
   if (mode == 0) {
     // if no mode is specified use the faster std::filesystem API
     std::filesystem::copy_file(
-        *src, *dest, std::filesystem::copy_options::skip_existing, error);
+        *src, *dest, std::filesystem::copy_options::none, error);
     if (error) {
       return env->ThrowError(error.message().c_str());
     }

--- a/typings/internalBinding/fs.d.ts
+++ b/typings/internalBinding/fs.d.ts
@@ -77,6 +77,7 @@ declare namespace InternalFSBinding {
   function copyFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, usePromises: typeof kUsePromises): Promise<void>;
 
   function cpSyncCheckPaths(src: StringOrBuffer, dest: StringOrBuffer, dereference: boolean, recursive: boolean): void;
+  function cpSyncOverrideFile(src: StringOrBuffer, dest: StringOrBuffer, mode: number, preserveTimestamps: boolean): void;
 
   function fchmod(fd: number, mode: number, req: FSReqCallback): void;
   function fchmod(fd: number, mode: number): void;
@@ -260,6 +261,7 @@ export interface FsBinding {
   close: typeof InternalFSBinding.close;
   copyFile: typeof InternalFSBinding.copyFile;
   cpSyncCheckPaths: typeof InternalFSBinding.cpSyncCheckPaths;
+  cpSyncOverrideFile: typeof InternalFSBinding.cpSyncOverrideFile;
   fchmod: typeof InternalFSBinding.fchmod;
   fchown: typeof InternalFSBinding.fchown;
   fdatasync: typeof InternalFSBinding.fdatasync;


### PR DESCRIPTION
move the logic in `cpSync` that overrides existing dest files from JavaScript to C++ increasing its performance

___

This is the type of perf improvement that this change makes:
![Screenshot at 2025-05-13 01-47-25](https://github.com/user-attachments/assets/31b0fbc9-096c-4218-a972-db946225ebd6)




<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
