### PR TITLE
src: refactor WriteUCS2 and remove flags argument

### DIFF
--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -99,8 +99,7 @@ class StringBytes {
   static size_t WriteUCS2(v8::Isolate* isolate,
                           char* buf,
                           size_t buflen,
-                          v8::Local<v8::String> str,
-                          int flags);
+                          v8::Local<v8::String> str);
 };
 
 }  // namespace node


### PR DESCRIPTION
This change refactors `StringBytes::WriteUCS2()` in multiple ways.

The `flags` argument being passed to `WriteUCS2()` is not useful: the only really relevant flag is `NO_NULL_TERMINATION` since V8 ignores `REPLACE_INVALID_UTF8`, `HINT_MANY_WRITES_EXPECTED`, and `PRESERVE_ONE_BYTE_NULL` for UTF-16 strings. However, `WriteUCS2()` might not null-terminate the result correctly regardless of whether `NO_NULL_TERMINATION` is set because it makes multiple calls to `String::Write()` internally. For these reasons, this patch removes the `flags` argument entirely and always assumes `NO_NULL_TERMINATION`.

Next, this patch replaces the calls to the deprecated function `String::Write()` with calls to the new function `String::WriteV2()`, which always succeeds and always writes a predictable number of characters, removing the need to deal with a return value here.

Lastly, this patch simplifies the implementation of `WriteUCS2()` and computes the exact number of characters `nchars` from the beginning, removing the need to later check again if the number of characters is zero.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
