### PR TITLE
doc: call out potentially unexpected results when mocking and testing synchronous callback-based APIs

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -652,6 +652,86 @@ test('spies on an object method', (t) => {
 });
 ```
 
+### Mocking callback-based APIs
+
+When mocking callback-based APIs (continuation-passing style), note that call
+tracking is updated _after_ the mocked function completes execution. This can
+lead to unexpected behavior when inspecting the mock's [`MockFunctionContext`][]
+object when asserting on how it was invoked. Using [`process.nextTick()`][] or
+[`util.promisify()`][] in your tests can help avoid this problem:
+
+```mjs
+import fs from 'node:fs';
+import { test } from 'node:test';
+import util from 'node:util';
+
+test('callback-style API mocking behavior', (t, done) => {
+  // Mock the fs.writeFile method
+  t.mock.method(fs, 'writeFile', (path, data, cb) => {
+    // Invoke callback synchronously
+    cb(null, 'success');
+  });
+
+  fs.writeFile('test.txt', 'hello', (err, result) => {
+    // This will show 0 because call tracking is updated after function completion
+    console.log('Immediate call count:', fs.writeFile.mock.callCount());
+
+    // Use process.nextTick to check after the event loop tick
+    process.nextTick(() => {
+      // This will correctly show 1
+      console.log('Call count after nextTick:', fs.writeFile.mock.callCount());
+
+      // Another approach is to use util.promisify
+      const writeFilePromise = util.promisify(fs.writeFile);
+
+      // With promises, the call count will be correctly updated
+      // after the promise is resolved
+      writeFilePromise('test.txt', 'world')
+        .then(() => {
+          console.log('Call count with promises:', fs.writeFile.mock.callCount());
+          done();
+        });
+    });
+  });
+});
+```
+
+```cjs
+const fs = require('node:fs')
+const { test } = require('node:test')
+const util = require('node:util')
+
+test('callback-style API mocking behavior', (t, done) => {
+  // Mock the fs.writeFile method
+  t.mock.method(fs, 'writeFile', (path, data, cb) => {
+    // Invoke callback synchronously
+    cb(null, 'success');
+  });
+
+  fs.writeFile('test.txt', 'hello', (err, result) => {
+    // This will show 0 because call tracking is updated after function completion
+    console.log('Immediate call count:', fs.writeFile.mock.callCount());
+
+    // Use process.nextTick to check after the event loop tick
+    process.nextTick(() => {
+      // This will correctly show 1
+      console.log('Call count after nextTick:', fs.writeFile.mock.callCount());
+
+      // Another approach is to use util.promisify
+      const writeFilePromise = util.promisify(fs.writeFile);
+
+      // With promises, the call count will be correctly updated
+      // after the promise is resolved
+      writeFilePromise('test.txt', 'world')
+        .then(() => {
+          console.log('Call count with promises:', fs.writeFile.mock.callCount());
+          done();
+        });
+    });
+  });
+});
+```
+
 ### Timers
 
 Mocking timers is a technique commonly used in software testing to simulate and
@@ -1886,6 +1966,9 @@ mock. Each entry in the array is an object with the following properties.
   `undefined`.
 * `this` {any} The mocked function's `this` value.
 
+> When mocking and testing callback-based APIs, please read the
+> [Mocking callback-based APIs][mocking callbacks] section.
+
 ### `ctx.callCount()`
 
 <!-- YAML
@@ -1899,6 +1982,9 @@ added:
 This function returns the number of times that this mock has been invoked. This
 function is more efficient than checking `ctx.calls.length` because `ctx.calls`
 is a getter that creates a copy of the internal call tracking array.
+
+> When mocking and testing callback-based APIs, please read the
+> [Mocking callback-based APIs][mocking callbacks] section.
 
 ### `ctx.mockImplementation(implementation)`
 
@@ -2068,6 +2154,9 @@ added:
 
 This function is used to create a mock function.
 
+> When mocking and testing callback-based APIs, please read the
+> [Mocking callback-based APIs][mocking callbacks] section.
+
 The following example creates a mock function that increments a counter by one
 on each invocation. The `times` option is used to modify the mock behavior such
 that the first two invocations add two to the counter instead of one.
@@ -2134,8 +2223,12 @@ added:
   `mock` property, which is an instance of [`MockFunctionContext`][], and can
   be used for inspecting and changing the behavior of the mocked method.
 
-This function is used to create a mock on an existing object method. The
-following example demonstrates how a mock is created on an existing object
+This function is used to create a mock on an existing object method.
+
+> When mocking and testing callback-based APIs, please read the
+> [Mocking callback-based APIs][mocking callbacks] section.
+
+The following example demonstrates how a mock is created on an existing object
 method.
 
 ```js
@@ -3761,6 +3854,8 @@ Can be used to abort test subtasks when the test has been aborted.
 [`--test-skip-pattern`]: cli.md#--test-skip-pattern
 [`--test-update-snapshots`]: cli.md#--test-update-snapshots
 [`--test`]: cli.md#--test
+[`process.nextTick()`]: process.md#processnexttickcallback-args
+[`util.promisify()`]: util.md#utilpromisifyoriginal
 [`MockFunctionContext`]: #class-mockfunctioncontext
 [`MockTimers`]: #class-mocktimers
 [`MockTracker.method`]: #mockmethodobject-methodname-implementation-options
@@ -3780,6 +3875,7 @@ Can be used to abort test subtasks when the test has been aborted.
 [code coverage]: #collecting-code-coverage
 [describe options]: #describename-options-fn
 [it options]: #testname-options-fn
+[mocking callbacks]: #mocking-callback-based-apis
 [stream.compose]: stream.md#streamcomposestreams
 [subtests]: #subtests
 [suite options]: #suitename-options-fn


### PR DESCRIPTION
This PR fixes https://github.com/nodejs/node/issues/58161.

When mocking synchronous callback-based APIs, the `MockFunctionContext` tracking mock calls won't be register until after the mock function finishes execution. Tests exercising callback-based code will likely not be written in a way to ensure this is the case. As such, call this out in the documentation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
