### PR TITLE
build: fix pointer compression builds

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -82,6 +82,7 @@
     'v8_enable_direct_local%': 0,
     'v8_enable_map_packing%': 0,
     'v8_enable_pointer_compression_shared_cage%': 0,
+    'v8_enable_external_code_space%': 0,
     'v8_enable_sandbox%': 0,
     'v8_enable_v8_checks%': 0,
     'v8_enable_zone_compression%': 0,
@@ -115,6 +116,7 @@
       ['target_arch in "arm ia32 mips mipsel"', {
         'v8_enable_pointer_compression': 0,
         'v8_enable_31bit_smis_on_64bit_arch': 0,
+        'v8_enable_external_code_space': 0,
         'v8_enable_sandbox': 0
       }],
       ['target_arch in "ppc64 s390x"', {
@@ -454,6 +456,9 @@
       }],
       ['v8_enable_sandbox == 1', {
         'defines': ['V8_ENABLE_SANDBOX',],
+      }],
+      ['v8_enable_external_code_space == 1', {
+        'defines': ['V8_EXTERNAL_CODE_SPACE',],
       }],
       ['v8_deprecation_warnings == 1', {
         'defines': ['V8_DEPRECATION_WARNINGS',],

--- a/configure.py
+++ b/configure.py
@@ -1712,7 +1712,15 @@ def configure_v8(o, configs):
   o['variables']['v8_enable_maglev'] = B(not options.v8_disable_maglev and
                                          o['variables']['target_arch'] in maglev_enabled_architectures)
   o['variables']['v8_enable_pointer_compression'] = 1 if options.enable_pointer_compression else 0
-  o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
+  # Using the sandbox requires always allocating array buffer backing stores in the sandbox.
+  # We currently have many backing stores tied to pointers from C++ land that are not
+  # even necessarily dynamic (e.g. in static storage) for fast communication between JS and C++.
+  # Until we manage to get rid of all those, v8_enable_sandbox cannot be used.
+  # Note that enabling pointer compression without enabling sandbox is unsupported by V8,
+  # so this can be broken at any time.
+  o['variables']['v8_enable_sandbox'] = 0
+  o['variables']['v8_enable_pointer_compression_shared_cage'] = 1 if options.enable_pointer_compression else 0
+  o['variables']['v8_enable_external_code_space'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_enable_31bit_smis_on_64bit_arch'] = 1 if options.enable_pointer_compression else 0
   o['variables']['v8_enable_extensible_ro_snapshot'] = 0
   o['variables']['v8_trace_maps'] = 1 if options.trace_maps else 0

--- a/test/cctest/node_test_fixture.cc
+++ b/test/cctest/node_test_fixture.cc
@@ -21,9 +21,6 @@ void NodeTestEnvironment::SetUp() {
   NodeZeroIsolateTestFixture::platform.reset(
       new node::NodePlatform(kV8ThreadPoolSize, tracing_controller));
   v8::V8::InitializePlatform(NodeZeroIsolateTestFixture::platform.get());
-#ifdef V8_ENABLE_SANDBOX
-  ASSERT_TRUE(v8::V8::InitializeSandbox());
-#endif
   cppgc::InitializeProcess(
       NodeZeroIsolateTestFixture::platform->GetPageAllocator());
 

--- a/test/wasm-allocation/wasm-allocation.status
+++ b/test/wasm-allocation/wasm-allocation.status
@@ -6,5 +6,5 @@ prefix wasm-allocation
 
 [true] # This section applies to all platforms
 
-[$system!=linux || $asan==on]
+[$system!=linux || $asan==on || $pointer_compression==on]
 test-wasm-allocation: SKIP

--- a/tools/test.py
+++ b/tools/test.py
@@ -1619,6 +1619,9 @@ def get_asan_state(vm, context):
   asan = Execute([vm, '-p', 'process.config.variables.asan'], context).stdout.strip()
   return "on" if asan == "1" else "off"
 
+def get_pointer_compression_state(vm, context):
+  pointer_compression = Execute([vm, '-p', 'process.config.variables.v8_enable_pointer_compression'], context).stdout.strip()
+  return "on" if pointer_compression == "1" else "off"
 
 def Main():
   parser = BuildOptions()
@@ -1717,6 +1720,7 @@ def Main():
           'arch': vmArch,
           'type': get_env_type(vm, options.type, context),
           'asan': get_asan_state(vm, context),
+          'pointer_compression': get_pointer_compression_state(vm, context),
         }
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -248,6 +248,11 @@
     # Sets -DV8_ENABLE_SANDBOX.
     'v8_enable_sandbox%': 0,
 
+    # Enable support for external code range relative to the pointer compression
+    # cage.
+    # Sets -DV8_EXTERNAL_CODE_SPACE.
+    'v8_enable_external_code_space%': 0,
+
     # Experimental feature for collecting per-class zone memory stats.
     # Requires use_rtti = true
     'v8_enable_precise_zone_stats%': 0,
@@ -379,6 +384,9 @@
       }],
       ['v8_enable_sandbox==1', {
         'defines': ['V8_ENABLE_SANDBOX',],
+      }],
+      ['v8_enable_external_code_space==1', {
+        'defines': ['V8_EXTERNAL_CODE_SPACE',],
       }],
       ['v8_enable_object_print==1', {
         'defines': ['OBJECT_PRINT',],


### PR DESCRIPTION
### build: fix pointer compression builds

- Remove usage of deprecated V8::InitializeSandbox().
- External code space and pointer compression shared cage must
  be enabled when pointer compression builds are enabled.
- We cannot enable the sandbox because that requires allocating
  the array buffer backing stores in the sandbox - we currently
  have many backing stores tied to pointers from C++ land that
  are not even necessarily dynamic (e.g. in static storage).
  Until we manage to get rid of all those, sandbox cannot be
  enabled. Note that enabling pointer compression without
  enabling sandbox is unsupported by V8, and can be broken
  at any time.

### test: skip wasm-allocation tests for pointer compression builds

V8 isolate group initialization forces allocation of the virtual
memory cage with pointer compression builds and simply would not
work when there is a smaller hard limit on the virtual memory.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
