### PR TITLE
test: allow `tmpDir.path` to be modified

### DIFF
--- a/test/common/tmpdir.js
+++ b/test/common/tmpdir.js
@@ -39,7 +39,7 @@ const testRoot = process.env.NODE_TEST_DIR ?
 // gets tools to ignore it by default or by simple rules, especially eslint.
 const tmpdirName = '.tmp.' +
   (process.env.TEST_SERIAL_ID || process.env.TEST_THREAD_ID || '0');
-const tmpPath = path.join(testRoot, tmpdirName);
+let tmpPath = path.join(testRoot, tmpdirName);
 
 let firstRefresh = true;
 function refresh(useSpawn = false) {
@@ -100,7 +100,13 @@ function fileURL(...paths) {
 module.exports = {
   fileURL,
   hasEnoughSpace,
-  path: tmpPath,
   refresh,
   resolve,
+
+  get path() {
+    return tmpPath;
+  },
+  set path(newPath) {
+    tmpPath = path.resolve(newPath);
+  },
 };


### PR DESCRIPTION
The behavior was changed in 8e872999c446617ce2cd429aa230203d57082937, which broke `make test-npm`, as it tries modifying the path used for tmpDir.