### PR TITLE
http,https: give names to anonymous or misnamed functions

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -70,6 +70,7 @@ const {
   hideStackFrames,
 } = require('internal/errors');
 const { validateString } = require('internal/validators');
+const { assignFunctionName } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
@@ -254,14 +255,14 @@ OutgoingMessage.prototype._renderHeaders = function _renderHeaders() {
   return headers;
 };
 
-OutgoingMessage.prototype.cork = function() {
+OutgoingMessage.prototype.cork = function cork() {
   this[kCorked]++;
   if (this[kSocket]) {
     this[kSocket].cork();
   }
 };
 
-OutgoingMessage.prototype.uncork = function() {
+OutgoingMessage.prototype.uncork = function uncork() {
   this[kCorked]--;
   if (this[kSocket]) {
     this[kSocket].uncork();
@@ -606,13 +607,13 @@ function matchHeader(self, state, field, value) {
   }
 }
 
-const validateHeaderName = hideStackFrames((name, label) => {
+const validateHeaderName = assignFunctionName('validateHeaderName', hideStackFrames((name, label) => {
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
     throw new ERR_INVALID_HTTP_TOKEN.HideStackFramesError(label || 'Header name', name);
   }
-});
+}));
 
-const validateHeaderValue = hideStackFrames((name, value) => {
+const validateHeaderValue = assignFunctionName('validateHeaderValue', hideStackFrames((name, value) => {
   if (value === undefined) {
     throw new ERR_HTTP_INVALID_HEADER_VALUE.HideStackFramesError(value, name);
   }
@@ -620,7 +621,7 @@ const validateHeaderValue = hideStackFrames((name, value) => {
     debug('Header "%s" contains invalid characters', name);
     throw new ERR_INVALID_CHAR.HideStackFramesError('header content', name);
   }
-});
+}));
 
 function parseUniqueHeadersOption(headers) {
   if (!ArrayIsArray(headers)) {

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -80,6 +80,7 @@ const {
   },
 } = require('internal/errors');
 const {
+  assignFunctionName,
   kEmptyObject,
   promisify,
 } = require('internal/util');
@@ -573,17 +574,17 @@ function Server(options, requestListener) {
 ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);
 
-Server.prototype.close = function() {
+Server.prototype.close = function close() {
   httpServerPreClose(this);
   ReflectApply(net.Server.prototype.close, this, arguments);
   return this;
 };
 
-Server.prototype[SymbolAsyncDispose] = async function() {
+Server.prototype[SymbolAsyncDispose] = assignFunctionName(SymbolAsyncDispose, async function() {
   return promisify(this.close).call(this);
-};
+});
 
-Server.prototype.closeAllConnections = function() {
+Server.prototype.closeAllConnections = function closeAllConnections() {
   if (!this[kConnections]) {
     return;
   }
@@ -595,7 +596,7 @@ Server.prototype.closeAllConnections = function() {
   }
 };
 
-Server.prototype.closeIdleConnections = function() {
+Server.prototype.closeIdleConnections = function closeIdleConnections() {
   if (!this[kConnections]) {
     return;
   }
@@ -618,7 +619,8 @@ Server.prototype.setTimeout = function setTimeout(msecs, callback) {
   return this;
 };
 
-Server.prototype[EE.captureRejectionSymbol] = function(err, event, ...args) {
+Server.prototype[EE.captureRejectionSymbol] =
+assignFunctionName(EE.captureRejectionSymbol, function(err, event, ...args) {
   switch (event) {
     case 'request': {
       const { 1: res } = args;
@@ -639,7 +641,7 @@ Server.prototype[EE.captureRejectionSymbol] = function(err, event, ...args) {
       net.Server.prototype[SymbolFor('nodejs.rejection')]
         .apply(this, arguments);
   }
-};
+});
 
 function checkConnections() {
   if (this.headersTimeout === 0 && this.requestTimeout === 0) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -110,7 +110,7 @@ Server.prototype.closeIdleConnections = HttpServer.prototype.closeIdleConnection
 
 Server.prototype.setTimeout = HttpServer.prototype.setTimeout;
 
-Server.prototype.close = function() {
+Server.prototype.close = function close() {
   httpServerPreClose(this);
   ReflectApply(tls.Server.prototype.close, this, arguments);
   return this;


### PR DESCRIPTION
Before this change, the following functions had either empty string or `wrappedFn` as function name:

- http.OutgoingMessage.prototype.cork
- http.OutgoingMessage.prototype.uncork
- http.Server.prototype.close
- http.Server.prototype.closeAllConnections
- http.Server.prototype.closeIdleConnections
- http.Server.prototype[Symbol.asyncDispose]
- http.Server.prototype[nodejs.rejection]
- http.validateHeaderName
- http.validateHeaderValue
- https.Server.prototype.closeAllConnections
- https.Server.prototype.closeIdleConnections
- https.Server.prototype.close
