### PR TITLE
test: force slow `JSON.stringify` path for overflow

### DIFF
--- a/test/fixtures/console/stack_overflow.js
+++ b/test/fixtures/console/stack_overflow.js
@@ -26,11 +26,15 @@ Error.stackTraceLimit = 0;
 
 console.error('before');
 
+// Invalidate elements protector to force slow-path.
+// The fast-path of JSON.stringify is iterative and won't throw.
+Array.prototype[2] = 'foo';
+
 // Trigger stack overflow by stringifying a deeply nested array.
-let array = [];
-for (let i = 0; i < 100000; i++) {
-  array = [ array ];
-}
+// eslint-disable-next-line no-sparse-arrays
+let array = [,];
+for (let i = 0; i < 10000; i++)
+  array = [array];
 
 JSON.stringify(array);
 


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/v8/v8/+/6011806

The V8 team just enabled the `JSON.stringify` fast path by default, which is iterative and won't throw. Pre-emptively preserve test functionality by forcing the slow path. See above linked PR for approach this is borrowed from.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
