### PR TITLE
test: fix watch tests not including completion messages

### DIFF
--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -810,14 +810,14 @@ process.on('message', (message) => {
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'no --watch args present',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'no --watch args present',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 
-  it('`--watch-path` ars without `=` used alongside `--watch` should not make it into the script', async () => {
+  it('`--watch-path` args without `=` used alongside `--watch` should not make it into the script', async () => {
     const projectDir = tmpdir.resolve('project-watch-watch-path-args');
     mkdirSync(projectDir);
 
@@ -835,10 +835,10 @@ process.on('message', (message) => {
     assert.strictEqual(stderr, '');
     assert.deepStrictEqual(stdout, [
       'no cli arg ends with .js',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
       `Restarting ${inspect(file)}`,
       'no cli arg ends with .js',
-      `Completed running ${inspect(file)}`,
+      `Completed running ${inspect(file)}. Waiting for file changes before restarting...`,
     ]);
   });
 });


### PR DESCRIPTION
Earlier I merged https://github.com/nodejs/node/pull/57936 which was out of sync with main so it didn't include the watch completion messages introduced in https://github.com/nodejs/node/pull/57926

This causes the watch tests to be failing on main, this PR is addressing this issue

I'm really sorry for the inconvenience :bow: 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
