### PR TITLE
test: remove Float16Array flag

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -126,6 +126,7 @@ export default [
         DecompressionStream: 'readonly',
         EventSource: 'readable',
         fetch: 'readonly',
+        Float16Array: 'readonly',
         FormData: 'readonly',
         navigator: 'readonly',
         ReadableStream: 'readonly',

--- a/test/parallel/test-assert-partial-deep-equal.js
+++ b/test/parallel/test-assert-partial-deep-equal.js
@@ -1,14 +1,9 @@
-// Flags: --js-float16array
-// TODO(LiviaMedeiros): once `Float16Array` is unflagged in v8, remove the line above
 'use strict';
 
 const common = require('../common');
 const vm = require('node:vm');
 const assert = require('node:assert');
 const { describe, it } = require('node:test');
-
-// TODO(LiviaMedeiros): once linter recognizes `Float16Array`, remove next line
-const { Float16Array } = globalThis;
 
 const x = ['x'];
 

--- a/test/parallel/test-assert-typedarray-deepequal.js
+++ b/test/parallel/test-assert-typedarray-deepequal.js
@@ -1,13 +1,8 @@
-// Flags: --js-float16array
-// TODO(LiviaMedeiros): once `Float16Array` is unflagged in v8, remove the line above
 'use strict';
 
 require('../common');
 const assert = require('assert');
 const { test, suite } = require('node:test');
-
-// TODO(LiviaMedeiros): once linter recognizes `Float16Array`, remove next line
-const { Float16Array } = globalThis;
 
 function makeBlock(f) {
   const args = Array.prototype.slice.call(arguments, 1);

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -1,5 +1,4 @@
-// Flags: --experimental-vm-modules --expose-internals --allow-natives-syntax --js-float16array
-// TODO(LiviaMedeiros): once `Float16Array` is unflagged in v8, remove `--js-float16array` above
+// Flags: --experimental-vm-modules --expose-internals --allow-natives-syntax
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -9,9 +8,6 @@ const { internalBinding } = require('internal/test/binding');
 const { JSStream } = internalBinding('js_stream');
 
 const external = (new JSStream())._externalStream;
-
-// TODO(LiviaMedeiros): once linter recognizes `Float16Array`, remove next line
-const { Float16Array } = globalThis;
 
 for (const [ value, _method ] of [
   [ external, 'isExternal' ],

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --js-float16array
+// Flags: --expose-internals
 
 'use strict';
 
@@ -7,9 +7,6 @@ const { internalBinding } = require('internal/test/binding');
 const assert = require('assert');
 const v8 = require('v8');
 const os = require('os');
-// TODO(bartlomieju): once `Float16Array` is available in stable V8,
-// remove this line and `--js-float16array` flag up top
-const { Float16Array } = globalThis;
 
 const circular = {};
 circular.circular = circular;

--- a/test/wpt/test-webcrypto.js
+++ b/test/wpt/test-webcrypto.js
@@ -1,5 +1,3 @@
-// Flags: --js-float16array
-// TODO(LiviaMedeiros): once `Float16Array` is unflagged in v8, remove the line above
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
No `dont-land-on-v24.x` assuming that https://github.com/nodejs/node/commit/f75a1265a8eef5c2058be1fde6eefa4ca0b5990f gets included in v24.x