### PR TITLE
util: inspect: do not crash on an Error stack pointing to itself

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1319,9 +1319,12 @@ function getStackString(ctx, error) {
     if (typeof error.stack === 'string') {
       return error.stack;
     }
-    if (error.stack !== error) {
-      return formatValue(ctx, error.stack);
-    }
+    ctx.seen.push(error);
+    ctx.indentationLvl += 4;
+    const result = formatValue(ctx, error.stack);
+    ctx.indentationLvl -= 4;
+    ctx.seen.pop();
+    return `${ErrorPrototypeToString(error)}\n    ${result}`;
   }
   return ErrorPrototypeToString(error);
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -770,14 +770,14 @@ assert.strictEqual(util.inspect(-5e-324), '-5e-324');
 // Note: Symbols are not supported by `Error#toString()` which is called by
 // accessing the `stack` property.
 [
-  [404, '404 [RangeError]: foo', '[404]'],
+  [404, '404 [RangeError]: foo', '[RangeError: foo\n    404]'],
   [0, '0 [RangeError]: foo', '[RangeError: foo]'],
   [0n, '0 [RangeError]: foo', '[RangeError: foo]'],
   [null, 'null: foo', '[RangeError: foo]'],
   [undefined, 'RangeError: foo', '[RangeError: foo]'],
   [false, 'false [RangeError]: foo', '[RangeError: foo]'],
   ['', 'foo', '[RangeError: foo]'],
-  [[1, 2, 3], '1,2,3 [RangeError]: foo', '[[\n  1,\n  2,\n  3\n]]'],
+  [[1, 2, 3], '1,2,3 [RangeError]: foo', '[RangeError: foo\n    [\n      1,\n      2,\n      3\n    ]]'],
 ].forEach(([value, outputStart, stack]) => {
   let err = new RangeError('foo');
   err.name = value;
@@ -3457,7 +3457,7 @@ ${error.stack.split('\n').slice(1).join('\n')}`,
 
   assert.strictEqual(
     inspect(error),
-    '[[\n  Symbol(foo)\n]]'
+    '[Error\n    [\n      Symbol(foo)\n    ]]'
   );
 }
 
@@ -3468,7 +3468,7 @@ ${error.stack.split('\n').slice(1).join('\n')}`,
 
   const error = new Error('foo');
 
-  assert.strictEqual(inspect(error), '[Error: foo]');
+  assert.strictEqual(inspect(error), '[Error: foo\n    [Circular *1]]');
 
   Error.prepareStackTrace = prepareStackTrace;
 }
@@ -3477,5 +3477,14 @@ ${error.stack.split('\n').slice(1).join('\n')}`,
   const error = new Error('foo');
   error.stack = error;
 
-  assert.strictEqual(inspect(error), '[Error: foo]');
+  assert.strictEqual(inspect(error), '[Error: foo\n    [Circular *1]]');
+}
+
+{
+  const error = new Error('foo');
+  const error2 = new Error('bar');
+  error.stack = error2;
+  error2.stack = error;
+
+  assert.strictEqual(inspect(error), '[Error: foo\n    [Error: bar\n        [Circular *1]]]');
 }


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/58195

This avoids a maximum call stack size exceeded crash when the error stack is pointing to the error itself `error.stack = error`. This bug was introduced by https://github.com/nodejs/node/pull/56573.