### PR TITLE
src: remove overzealous tcsetattr error check

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -712,9 +712,11 @@ void ResetStdio() {
       while (err == -1 && errno == EINTR);  // NOLINT
       CHECK_EQ(0, pthread_sigmask(SIG_UNBLOCK, &sa, nullptr));
 
-      // Normally we expect err == 0. But if macOS App Sandbox is enabled,
-      // tcsetattr will fail with err == -1 and errno == EPERM.
-      CHECK_IMPLIES(err != 0, err == -1 && errno == EPERM);
+      // We don't check the return value of tcsetattr() because it can fail
+      // for a number of reasons, none that we can do anything about. Examples:
+      // - if macOS App Sandbox is enabled, tcsetattr fails with EPERM
+      // - if the process group is orphaned, e.g. because the user logged out,
+      //   tcsetattr fails with EIO
     }
   }
 #endif  // __POSIX__


### PR DESCRIPTION
Node calls tcsetattr on exit to reset the tty to its state on program start. Good idea in general but tcsetattr can fail for a number of reasons and since there really isn't anything we can do about it at that point, simply ignore the error instead of aborting with an inscrutable error message.

Most of the time it'll be fine because the most common failure is when the user has already logged off and there isn't anything to restore in the first place.

Fixes: https://github.com/nodejs/node/issues/51519