### PR TITLE
fs: add support to `Dir` for explicit resource management

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -6740,6 +6740,26 @@ provided by the operating system's underlying directory mechanisms.
 Entries added or removed while iterating over the directory might not be
 included in the iteration results.
 
+#### `dir[Symbol.asyncDispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An alias for `dir.close()`.
+
+#### `dir[Symbol.Dispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+An alias for `dir.closeSync()`.
+
 ### Class: `fs.Dirent`
 
 <!-- YAML

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -4,9 +4,11 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
   FunctionPrototypeBind,
-  ObjectDefineProperty,
+  ObjectDefineProperties,
   PromiseReject,
+  SymbolAsyncDispose,
   SymbolAsyncIterator,
+  SymbolDispose,
 } = primordials;
 
 const pathModule = require('path');
@@ -293,12 +295,27 @@ class Dir {
   }
 }
 
-ObjectDefineProperty(Dir.prototype, SymbolAsyncIterator, {
-  __proto__: null,
-  value: Dir.prototype.entries,
+const nonEnumerableDescriptor = {
   enumerable: false,
   writable: true,
   configurable: true,
+};
+ObjectDefineProperties(Dir.prototype, {
+  [SymbolDispose]: {
+    __proto__: null,
+    ...nonEnumerableDescriptor,
+    value: Dir.prototype.closeSync,
+  },
+  [SymbolAsyncDispose]: {
+    __proto__: null,
+    ...nonEnumerableDescriptor,
+    value: Dir.prototype.close,
+  },
+  [SymbolAsyncIterator]: {
+    __proto__: null,
+    ...nonEnumerableDescriptor,
+    value: Dir.prototype.entries,
+  },
 });
 
 function opendir(path, options, callback) {


### PR DESCRIPTION

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
