### PR TITLE
build: look for libnode.so in lib subdirectory

### DIFF
--- a/tools/install.py
+++ b/tools/install.py
@@ -181,9 +181,19 @@ def files(options, action):
       link_path = abspath(options.install_path, 'lib/libnode.so')
       try_symlink(options, so_name, link_path)
     else:
-      output_lib = 'libnode.' + options.variables.get('shlib_suffix')
-      action(options, [os.path.join(options.build_dir, output_lib)],
-             os.path.join(options.variables.get('libdir'), output_lib))
+      # Ninja and Makefile generators output the library in different directories;
+      # find out which one we have, and install first found
+      output_lib_name = 'libnode.' + options.variables.get('shlib_suffix')
+      output_lib_candidate_paths = [
+        os.path.join(options.build_dir, output_lib_name),
+        os.path.join(options.build_dir, "lib", output_lib_name),
+      ]
+      try:
+        output_lib = next(filter(os.path.exists, output_lib_candidate_paths))
+      except StopIteration as not_found:
+        raise RuntimeError("No libnode.so to install!") from not_found
+      action(options, [output_lib],
+             os.path.join(options.variables.get('libdir'), output_lib_name))
 
   action(options, [os.path.join(options.v8_dir, 'tools/gdbinit')], 'share/doc/node/')
   action(options, [os.path.join(options.v8_dir, 'tools/lldb_commands.py')], 'share/doc/node/')


### PR DESCRIPTION
When building with `--shared`, `ninja` will output the `libnode.so` into a `{build_dir}/lib` directory, not in the root `{build_dir}`. This fixes the install script to look for it in the correct place.

---

Found during review of a Fedora rpm, where we apparently been moving the `libnode.so` manually to the root of the build directory manually this entire time. Let's see if we can stop doing that. :sweat_smile: 
