### PR TITLE
[v22.x backport] Backport 57519 and 57479 

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -761,7 +761,7 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
   if (InitializeBaseContextForSnapshot(context).IsNothing()) {
     return Nothing<void>();
   }
-  return InitializePrimordials(context);
+  return JustVoid();
 }
 
 Maybe<void> InitializePrimordials(Local<Context> context) {
@@ -770,13 +770,17 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
   Context::Scope context_scope(context);
   Local<Object> exports;
 
+  if (!GetPerContextExports(context).ToLocal(&exports)) {
+    return Nothing<void>();
+  }
   Local<String> primordials_string =
       FIXED_ONE_BYTE_STRING(isolate, "primordials");
+  // Ensure that `InitializePrimordials` is called exactly once on a given
+  // context.
+  CHECK(!exports->Has(context, primordials_string).FromJust());
 
-  // Create primordials first and make it available to per-context scripts.
   Local<Object> primordials = Object::New(isolate);
-  if (primordials->SetPrototype(context, Null(isolate)).IsNothing() ||
-      !GetPerContextExports(context).ToLocal(&exports) ||
+  if (primordials->SetPrototype(context, Null(isolate)).IsNothing() || 
       exports->Set(context, primordials_string, primordials).IsNothing()) {
     return Nothing<void>();
   }

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1,4 +1,5 @@
 #include <cstdlib>
+#include "env_properties.h"
 #include "node.h"
 #include "node_builtins.h"
 #include "node_context_data.h"
@@ -602,7 +603,8 @@ std::unique_ptr<MultiIsolatePlatform> MultiIsolatePlatform::Create(
                                         page_allocator);
 }
 
-MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
+MaybeLocal<Object> GetPerContextExports(Local<Context> context,
+                                        IsolateData* isolate_data) {
   Isolate* isolate = context->GetIsolate();
   EscapableHandleScope handle_scope(isolate);
 
@@ -616,10 +618,14 @@ MaybeLocal<Object> GetPerContextExports(Local<Context> context) {
   if (existing_value->IsObject())
     return handle_scope.Escape(existing_value.As<Object>());
 
+  // To initialize the per-context binding exports, a non-nullptr isolate_data
+  // is needed
+  CHECK(isolate_data);
   Local<Object> exports = Object::New(isolate);
   if (context->Global()->SetPrivate(context, key, exports).IsNothing() ||
-      InitializePrimordials(context).IsNothing())
+      InitializePrimordials(context, isolate_data).IsNothing()) {
     return MaybeLocal<Object>();
+  }
   return handle_scope.Escape(exports);
 }
 
@@ -764,7 +770,32 @@ Maybe<void> InitializeMainContextForSnapshot(Local<Context> context) {
   return JustVoid();
 }
 
-Maybe<void> InitializePrimordials(Local<Context> context) {
+MaybeLocal<Object> InitializePrivateSymbols(Local<Context> context,
+                                            IsolateData* isolate_data) {
+  CHECK(isolate_data);
+  Isolate* isolate = context->GetIsolate();
+  EscapableHandleScope scope(isolate);
+  Context::Scope context_scope(context);
+
+  Local<ObjectTemplate> private_symbols = ObjectTemplate::New(isolate);
+  Local<Object> private_symbols_object;
+#define V(PropertyName, _)                                                     \
+  private_symbols->Set(isolate, #PropertyName, isolate_data->PropertyName());
+
+  PER_ISOLATE_PRIVATE_SYMBOL_PROPERTIES(V)
+#undef V
+
+  if (!private_symbols->NewInstance(context).ToLocal(&private_symbols_object) ||
+      private_symbols_object->SetPrototype(context, Null(isolate))
+          .IsNothing()) {
+    return MaybeLocal<Object>();
+  }
+
+  return scope.Escape(private_symbols_object);
+}
+
+Maybe<void> InitializePrimordials(Local<Context> context,
+                                  IsolateData* isolate_data) {
   // Run per-context JS files.
   Isolate* isolate = context->GetIsolate();
   Context::Scope context_scope(context);
@@ -780,8 +811,14 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
   CHECK(!exports->Has(context, primordials_string).FromJust());
 
   Local<Object> primordials = Object::New(isolate);
-  if (primordials->SetPrototype(context, Null(isolate)).IsNothing() || 
+  if (primordials->SetPrototype(context, Null(isolate)).IsNothing() ||
       exports->Set(context, primordials_string, primordials).IsNothing()) {
+    return Nothing<void>();
+  }
+
+  Local<Object> private_symbols;
+  if (!InitializePrivateSymbols(context, isolate_data)
+           .ToLocal(&private_symbols)) {
     return Nothing<void>();
   }
 
@@ -800,7 +837,8 @@ Maybe<void> InitializePrimordials(Local<Context> context) {
   builtin_loader.SetEagerCompile();
 
   for (const char** module = context_files; *module != nullptr; module++) {
-    Local<Value> arguments[] = {exports, primordials};
+    Local<Value> arguments[] = {exports, primordials, private_symbols};
+
     if (builtin_loader
             .CompileAndCall(
                 context, *module, arraysize(arguments), arguments, nullptr)

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -412,6 +412,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompile(Local<Context> context,
     parameters = {
         FIXED_ONE_BYTE_STRING(isolate, "exports"),
         FIXED_ONE_BYTE_STRING(isolate, "primordials"),
+        FIXED_ONE_BYTE_STRING(isolate, "privateSymbols"),
     };
   } else if (strncmp(id, "internal/main/", strlen("internal/main/")) == 0 ||
              strncmp(id,

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -113,7 +113,10 @@ std::string GetHumanReadableProcessName();
 v8::Maybe<void> InitializeBaseContextForSnapshot(
     v8::Local<v8::Context> context);
 v8::Maybe<void> InitializeContextRuntime(v8::Local<v8::Context> context);
-v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context);
+v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context,
+                                      IsolateData* isolate_data);
+v8::MaybeLocal<v8::Object> InitializePrivateSymbols(
+    v8::Local<v8::Context> context, IsolateData* isolate_data);
 
 class NodeArrayBufferAllocator : public ArrayBufferAllocator {
  public:
@@ -340,7 +343,8 @@ v8::Isolate* NewIsolate(v8::Isolate::CreateParams* params,
 // was provided by the embedder.
 v8::MaybeLocal<v8::Value> StartExecution(Environment* env,
                                          StartExecutionCallback cb = nullptr);
-v8::MaybeLocal<v8::Object> GetPerContextExports(v8::Local<v8::Context> context);
+v8::MaybeLocal<v8::Object> GetPerContextExports(
+    v8::Local<v8::Context> context, IsolateData* isolate_data = nullptr);
 void MarkBootstrapComplete(const v8::FunctionCallbackInfo<v8::Value>& args);
 
 class InitializationResultImpl final : public InitializationResult {

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -252,14 +252,16 @@ void Message::AdoptSharedValueConveyor(SharedValueConveyor&& conveyor) {
 
 namespace {
 
-MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context) {
+MaybeLocal<Function> GetEmitMessageFunction(Local<Context> context,
+                                            IsolateData* isolate_data) {
   Isolate* isolate = context->GetIsolate();
   Local<Object> per_context_bindings;
   Local<Value> emit_message_val;
-  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
-      !per_context_bindings->Get(context,
-                                FIXED_ONE_BYTE_STRING(isolate, "emitMessage"))
-          .ToLocal(&emit_message_val)) {
+  if (!GetPerContextExports(context, isolate_data)
+           .ToLocal(&per_context_bindings) ||
+      !per_context_bindings
+           ->Get(context, FIXED_ONE_BYTE_STRING(isolate, "emitMessage"))
+           .ToLocal(&emit_message_val)) {
     return MaybeLocal<Function>();
   }
   CHECK(emit_message_val->IsFunction());
@@ -688,7 +690,8 @@ MessagePort::MessagePort(Environment* env,
   }
 
   Local<Function> emit_message_fn;
-  if (!GetEmitMessageFunction(context).ToLocal(&emit_message_fn))
+  if (!GetEmitMessageFunction(context, env->isolate_data())
+           .ToLocal(&emit_message_fn))
     return;
   emit_message_fn_.Reset(env->isolate(), emit_message_fn);
 

--- a/src/node_realm.cc
+++ b/src/node_realm.cc
@@ -45,7 +45,7 @@ void Realm::CreateProperties() {
 
   // Store primordials setup by the per-context script in the environment.
   Local<Object> per_context_bindings =
-      GetPerContextExports(ctx).ToLocalChecked();
+      GetPerContextExports(ctx, env_->isolate_data()).ToLocalChecked();
   Local<Value> primordials =
       per_context_bindings->Get(ctx, env_->primordials_string())
           .ToLocalChecked();


### PR DESCRIPTION
Backport 2 commits where the second one was rebased on the first one.

src: ensure primordials are initialized exactly once
src: initialize privateSymbols for per_context

The manual backport bypassed the usage of Get/SetPrototypeV2 that does not exist on v22.x.

Refs: https://github.com/nodejs/node/pull/57519
Refs: https://github.com/nodejs/node/pull/57479