### PR TITLE
fs: glob is stable, so should not emit experimental warnings

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -84,7 +84,6 @@ const {
 const { toPathIfFileURL } = require('internal/url');
 const {
   customPromisifyArgs: kCustomPromisifyArgsSymbol,
-  emitExperimentalWarning,
   getLazy,
   kEmptyObject,
   promisify: {
@@ -3165,7 +3164,6 @@ function createWriteStream(path, options) {
 const lazyGlob = getLazy(() => require('internal/fs/glob').Glob);
 
 function glob(pattern, options, callback) {
-  emitExperimentalWarning('glob');
   if (typeof options === 'function') {
     callback = options;
     options = undefined;
@@ -3185,7 +3183,6 @@ function glob(pattern, options, callback) {
 }
 
 function globSync(pattern, options) {
-  emitExperimentalWarning('globSync');
   const Glob = lazyGlob();
   return new Glob(pattern, options).globSync();
 }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -93,7 +93,6 @@ const pathModule = require('path');
 const { isAbsolute } = pathModule;
 const { toPathIfFileURL } = require('internal/url');
 const {
-  emitExperimentalWarning,
   getLazy,
   kEmptyObject,
   lazyDOMException,
@@ -1261,7 +1260,6 @@ async function* _watch(filename, options = kEmptyObject) {
 
 const lazyGlob = getLazy(() => require('internal/fs/glob').Glob);
 async function* glob(pattern, options) {
-  emitExperimentalWarning('glob');
   const Glob = lazyGlob();
   yield* new Glob(pattern, options).glob();
 }

--- a/lib/path.js
+++ b/lib/path.js
@@ -53,7 +53,6 @@ const {
 } = require('internal/validators');
 
 const {
-  emitExperimentalWarning,
   isWindows,
   getLazy,
 } = require('internal/util');
@@ -1141,7 +1140,6 @@ const win32 = {
   },
 
   matchesGlob(path, pattern) {
-    emitExperimentalWarning('glob');
     return lazyMatchGlobPattern()(path, pattern, true);
   },
 
@@ -1618,7 +1616,6 @@ const posix = {
   },
 
   matchesGlob(path, pattern) {
-    emitExperimentalWarning('glob');
     return lazyMatchGlobPattern()(path, pattern, false);
   },
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

In #57513 `fs.glob` was marked as stable, but that was only in the documentation, so if it's considered stable, it should not emit experimental warnings.
