### PR TITLE
typings: add missing typings for `TypedArray`

### DIFF
--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -479,10 +479,29 @@ declare namespace primordials {
     constructor: new (length: number) => T,
     items: readonly TypedArrayContentType<T>[],
   ): T;
+  export const TypedArray: TypedArray;
+  export const TypedArrayPrototype:
+    | typeof Uint8Array.prototype
+    | typeof Int8Array.prototype
+    | typeof Uint16Array.prototype
+    | typeof Int16Array.prototype
+    | typeof Uint32Array.prototype
+    | typeof Int32Array.prototype
+    | typeof Float32Array.prototype
+    | typeof Float64Array.prototype
+    | typeof BigInt64Array.prototype
+    | typeof BigUint64Array.prototype
+    | typeof Uint8ClampedArray.prototype;
   export const TypedArrayPrototypeGetBuffer: UncurryGetter<TypedArray, "buffer">;
   export const TypedArrayPrototypeGetByteLength: UncurryGetter<TypedArray, "byteLength">;
   export const TypedArrayPrototypeGetByteOffset: UncurryGetter<TypedArray, "byteOffset">;
   export const TypedArrayPrototypeGetLength: UncurryGetter<TypedArray, "length">;
+  export function TypedArrayPrototypeAt<T extends TypedArray>(self: T, ...args: Parameters<T["at"]>): ReturnType<T["at"]>;
+  export function TypedArrayPrototypeIncludes<T extends TypedArray>(self: T, ...args: Parameters<T["includes"]>): ReturnType<T["includes"]>;
+  export function TypedArrayPrototypeFill<T extends TypedArray>(self: T, ...args: Parameters<T["fill"]>): ReturnType<T["fill"]>;
+  export function TypedArrayPrototypeSet<T extends TypedArray>(self: T, ...args: Parameters<T["set"]>): ReturnType<T["set"]>;
+  export function TypedArrayPrototypeSubarray<T extends TypedArray>(self: T, ...args: Parameters<T["subarray"]>): ReturnType<T["subarray"]>;
+  export function TypedArrayPrototypeSlice<T extends TypedArray>(self: T, ...args: Parameters<T["slice"]>): ReturnType<T["slice"]>;
   export function TypedArrayPrototypeGetSymbolToStringTag(self: unknown):
     | 'Int8Array'
     | 'Int16Array'


### PR DESCRIPTION
Add missing typings for the `TypedArray` domain we used in the codebase.

This enables typing intellisense for typed array. e.g. 

```
const buffer = Buffer.allocUnsafe(length); // FastBuffer extends Uint8Array
TypedArrayPrototypeFill(buffer, 0, pos, length);
```
will be evaluated to
```
const TypedArrayPrototypeFill: <FastBuffer>(self: FastBuffer, value: number, start?: number, end?: number) => FastBuffer
```