### PR TITLE
fix: fallback for TextEncoder using util.TextEncoder

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -85,7 +85,9 @@ const disallowedTypeCharacters = /[^\u{0020}-\u{007E}]/u;
 
 let ReadableStream;
 
-const enc = new TextEncoder();
+const { TextEncoder: UtilTextEncoder } = require('util');
+const enc = typeof TextEncoder !== 'undefined' ? new TextEncoder() : new UtilTextEncoder();
+
 let dec;
 
 // Yes, lazy loading is annoying but because of circular

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -649,7 +649,9 @@ async function wrapKey(format, key, wrappingKey, algorithm) {
   let keyData = await ReflectApply(exportKey, this, [format, key]);
 
   if (format === 'jwk') {
-    const ec = new TextEncoder();
+    const { TextEncoder: UtilTextEncoder } = require('util');
+    const ec = typeof TextEncoder !== 'undefined' ? new TextEncoder() : new UtilTextEncoder();
+
     const raw = JSONStringify(keyData);
     // As per the NOTE in step 13 https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey
     // we're padding AES-KW wrapped JWK to make sure it is always a multiple of 8 bytes

--- a/lib/internal/data_url.js
+++ b/lib/internal/data_url.js
@@ -19,7 +19,10 @@ let encoder;
 function lazyEncoder() {
   if (encoder === undefined) {
     const { TextEncoder } = require('internal/encoding');
-    encoder = new TextEncoder();
+    const { TextEncoder: UtilTextEncoder } = require('util');
+    const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : new UtilTextEncoder();
+
+  
   }
 
   return encoder;

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -86,8 +86,10 @@ const {
 const finished = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
+const { TextEncoder: UtilTextEncoder } = require('util');
+const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : new UtilTextEncoder();
 
-const encoder = new TextEncoder();
+
 
 // Collect all negative (error) ZLIB codes and Z_NEED_DICT
 const ZLIB_FAILURES = new SafeSet([

--- a/lib/internal/webstreams/encoding.js
+++ b/lib/internal/webstreams/encoding.js
@@ -42,7 +42,10 @@ class TextEncoderStream {
   #transform;
 
   constructor() {
-    this.#handle = new TextEncoder();
+    const { TextEncoder: UtilTextEncoder } = require('util');
+    this.#handle = typeof TextEncoder !== 'undefined' ? new TextEncoder() : new UtilTextEncoder();
+
+    
     this.#transform = new TransformStream({
       transform: (chunk, controller) => {
         // https://encoding.spec.whatwg.org/#encode-and-enqueue-a-chunk


### PR DESCRIPTION
## Problem
In some environments or versions of Node.js, "TextEncoder" may not be available globally. This can cause issues when trying to encode text using "TextEncoder". This PR introduces a fallback mechanism to ensure `TextEncoder` is available in all environments by using "util.TextEncoder" when the global `TextEncoder` is undefined.

## Solution
The code checks if the global "TextEncoder" is available. If it's undefined, it falls back to using `util.TextEncoder`. This ensures compatibility with environments where the global `TextEncoder` might not exist.

## Use Case
- **Older versions of Node.js**: Where `TextEncoder` might not be available globally.
- **Custom Node.js builds**: That don't include global `TextEncoder`.

This change ensures consistent behavior across different environments and Node.js versions.


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
