### PR TITLE
buffer: avoid unnecessary copy in Buffer.concat for single FastBuffer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -593,6 +593,15 @@ Buffer.concat = function concat(list, length) {
     validateOffset(length, 'length');
   }
 
+  // If there is only one FastBuffer, rotate without copying
+  if (
+    list.length === 1 &&
+    list[0] instanceof FastBuffer &&
+    list[0].length === length
+  ) {
+    return Buffer.from(list[0]);
+  }
+
   const buffer = Buffer.allocUnsafe(length);
   let pos = 0;
   for (let i = 0; i < list.length; i++) {

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -44,6 +44,15 @@ assert.notStrictEqual(flatOne, one[0]);
 assert.strictEqual(flatLong.toString(), check);
 assert.strictEqual(flatLongLen.toString(), check);
 
+{
+  const original = Buffer.from('fast');
+  const result = Buffer.concat([original], original.length);
+  assert.notStrictEqual(result, original,
+    'Buffer.concat should return a new Buffer instance even with single FastBuffer');
+  assert.deepStrictEqual(result, original,
+    'Buffer.concat output should equal original content');
+}
+
 [undefined, null, Buffer.from('hello')].forEach((value) => {
   assert.throws(() => {
     Buffer.concat(value);


### PR DESCRIPTION
If there's only one FastBuffer and its length matches the total length,
we don't need to manually allocate and copy — we can just return
Buffer.from(buf) to keep the semantics (new buffer) but avoid extra work.

my local result: 

```js
                                                                            confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-concat-fill.js n=800000 extraSize=1                                         -0.37 %       ±0.78% ±1.04% ±1.36%
buffers/buffer-concat-fill.js n=800000 extraSize=1024                                       0.22 %       ±1.08% ±1.44% ±1.89%
buffers/buffer-concat-fill.js n=800000 extraSize=256                                       -0.88 %       ±1.40% ±1.87% ±2.45%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=16                  -0.30 %       ±0.52% ±0.69% ±0.89%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=4                    0.11 %       ±0.66% ±0.88% ±1.14%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=16                 -0.18 %       ±1.44% ±1.92% ±2.50%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=4                  -0.30 %       ±0.67% ±0.89% ±1.16%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=16                -0.38 %       ±0.54% ±0.72% ±0.94%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=4                 -0.44 %       ±0.65% ±0.87% ±1.13%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=16           **      1.02 %       ±0.62% ±0.82% ±1.07%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=4             *     -0.83 %       ±0.69% ±0.92% ±1.19%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=16                  0.08 %       ±1.18% ±1.58% ±2.07%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=4                  -0.25 %       ±0.67% ±0.90% ±1.17%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=16                -0.19 %       ±0.56% ±0.74% ±0.97%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=4                 -0.25 %       ±0.56% ±0.75% ±0.97%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 15 comparisons, you can thus expect the following amount of false-positive results:
  0.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.15 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```