### PR TITLE
src: remove unused `checkMessagePort` internal binding

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1141,13 +1141,6 @@ void MessagePort::Stop(const FunctionCallbackInfo<Value>& args) {
   port->Stop();
 }
 
-void MessagePort::CheckType(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  args.GetReturnValue().Set(
-      GetMessagePortConstructorTemplate(env->isolate_data())
-          ->HasInstance(args[0]));
-}
-
 void MessagePort::Drain(const FunctionCallbackInfo<Value>& args) {
   MessagePort* port;
   ASSIGN_OR_RETURN_UNWRAP(&port, args[0].As<Object>());
@@ -1731,7 +1724,6 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   // These are not methods on the MessagePort prototype, because
   // the browser equivalents do not provide them.
   SetMethod(isolate, target, "stopMessagePort", MessagePort::Stop);
-  SetMethod(isolate, target, "checkMessagePort", MessagePort::CheckType);
   SetMethod(isolate, target, "drainMessagePort", MessagePort::Drain);
   SetMethod(
       isolate, target, "receiveMessageOnPort", MessagePort::ReceiveMessage);
@@ -1767,7 +1759,6 @@ static void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(MessagePort::PostMessage);
   registry->Register(MessagePort::Start);
   registry->Register(MessagePort::Stop);
-  registry->Register(MessagePort::CheckType);
   registry->Register(MessagePort::Drain);
   registry->Register(MessagePort::ReceiveMessage);
   registry->Register(MessagePort::MoveToContext);

--- a/src/node_messaging.h
+++ b/src/node_messaging.h
@@ -261,7 +261,6 @@ class MessagePort : public HandleWrap {
   static void PostMessage(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void CheckType(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Drain(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ReceiveMessage(const v8::FunctionCallbackInfo<v8::Value>& args);
 

--- a/typings/internalBinding/messaging.d.ts
+++ b/typings/internalBinding/messaging.d.ts
@@ -23,7 +23,6 @@ export interface MessagingBinding {
   MessagePort: typeof InternalMessagingBinding.MessagePort;
   JSTransferable: typeof InternalMessagingBinding.JSTransferable;
   stopMessagePort(port: typeof InternalMessagingBinding.MessagePort): void;
-  checkMessagePort(port: unknown): boolean;
   drainMessagePort(port: typeof InternalMessagingBinding.MessagePort): void;
   receiveMessageOnPort(port: typeof InternalMessagingBinding.MessagePort): any;
   moveMessagePortToContext(port: typeof InternalMessagingBinding.MessagePort, context: any): typeof InternalMessagingBinding.MessagePort;


### PR DESCRIPTION
This PR is removing the `checkMessagePort` internal binding, which I believe is no longer used.

I believe that the binding stopped being used in https://github.com/nodejs/node/pull/52370.


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
