### PR TITLE
test: reduce iteration count in test-child-process-stdout-flush-exit

### DIFF
--- a/test/parallel/test-child-process-stdout-flush-exit.js
+++ b/test/parallel/test-child-process-stdout-flush-exit.js
@@ -25,9 +25,14 @@ const assert = require('assert');
 
 // If child process output to console and exit
 // The console.log statements here are part of the test.
+// Note: This test verifies specific behavior that is *not* guaranteed
+// by Node.js's API contract. See https://nodejs.org/api/process.html#processexitcode.
+// We are still generally interested in knowing when this test breaks,
+// since applications may rely on the implicit behavior of stdout having
+// a buffer size up to which they can write data synchronously.
 if (process.argv[2] === 'child') {
   console.log('hello');
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < 100; i++) {
     console.log('filler');
   }
   console.log('goodbye');


### PR DESCRIPTION
This commit was added by @addaleax to fix the CI in https://github.com/nodejs/node/pull/58124, opening it as a separate PR as the automation keeps removing it from the other PR. This should be landed manually so the commit authorship is credited to Anna and not myself.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
