### PR TITLE
doc: update commit-queue documentation

### DIFF
--- a/doc/contributing/commit-queue.md
+++ b/doc/contributing/commit-queue.md
@@ -1,10 +1,8 @@
 # Commit queue
 
-> Stability: 1 - Experimental
-
 _tl;dr: You can land pull requests by adding the `commit-queue` label to it._
 
-Commit Queue is an experimental feature for the project which simplifies the
+Commit Queue is a feature for the project which simplifies the
 landing process by automating it via GitHub Actions. With it, collaborators can
 land pull requests by adding the `commit-queue` label to a PR. All
 checks will run via `@node-core/utils`, and if the pull request is ready to
@@ -18,7 +16,7 @@ implementation details, reasoning for design choices, and current limitations.
 From a high-level, the Commit Queue works as follow:
 
 1. Collaborators will add `commit-queue` label to pull requests ready to land
-2. Every five minutes the queue will do the following for each pull request
+2. Every five minutes the queue will do the following for each mergeable pull request
    with the label:
    1. Check if the PR also has a `request-ci` label (if it has, skip this PR
       since it's pending a CI run)


### PR DESCRIPTION
update the commit-queue contributing documentation by:
 - removing the references of the feature being experimental
 - clarifying that it applies to mergeable pull requests

> [!Note]
> I'm proposing to remove the references of the feature being experimental since it's been 
> implemented 5 years ago and I think that it's widely used, so I think that it can be considered
> stable at this point

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
