### PR TITLE
benchmark: add dereference and force options to fs.cpSync

### DIFF
--- a/benchmark/fs/bench-cpSync.js
+++ b/benchmark/fs/bench-cpSync.js
@@ -19,7 +19,7 @@ function prepareTestDirectory() {
 
   fs.symlinkSync(
     path.join(testDir, 'source.txt'),
-    path.join(testDir, 'link.txt')
+    path.join(testDir, 'link.txt'),
   );
 
   return testDir;
@@ -47,7 +47,7 @@ function main({ n, dereference, force }) {
       fs.cpSync(src, dest, options);
     } else {
       const uniqueDest = tmpdir.resolve(
-        `${process.pid}/subdir/cp-bench-${process.pid}-${i}`
+        `${process.pid}/subdir/cp-bench-${process.pid}-${i}`,
       );
       fs.cpSync(src, uniqueDest, options);
     }

--- a/benchmark/fs/bench-cpSync.js
+++ b/benchmark/fs/bench-cpSync.js
@@ -4,20 +4,53 @@ const common = require('../common');
 const fs = require('fs');
 const path = require('path');
 const tmpdir = require('../../test/common/tmpdir');
-tmpdir.refresh();
 
 const bench = common.createBenchmark(main, {
   n: [1, 100, 10_000],
+  dereference: ['true', 'false'],
+  force: ['true', 'false'],
 });
 
-function main({ n }) {
+function prepareTestDirectory() {
+  const testDir = tmpdir.resolve(`test-cp-${process.pid}`);
+  fs.mkdirSync(testDir, { recursive: true });
+
+  fs.writeFileSync(path.join(testDir, 'source.txt'), 'test content');
+
+  fs.symlinkSync(
+    path.join(testDir, 'source.txt'),
+    path.join(testDir, 'link.txt')
+  );
+
+  return testDir;
+}
+
+function main({ n, dereference, force }) {
   tmpdir.refresh();
-  const options = { recursive: true };
-  const src = path.join(__dirname, '../../test/fixtures/copy');
+
+  const src = prepareTestDirectory();
   const dest = tmpdir.resolve(`${process.pid}/subdir/cp-bench-${process.pid}`);
+
+  const options = {
+    recursive: true,
+    dereference: dereference === 'true',
+    force: force === 'true',
+  };
+
+  if (options.force) {
+    fs.cpSync(src, dest, { recursive: true });
+  }
+
   bench.start();
   for (let i = 0; i < n; i++) {
-    fs.cpSync(src, dest, options);
+    if (options.force) {
+      fs.cpSync(src, dest, options);
+    } else {
+      const uniqueDest = tmpdir.resolve(
+        `${process.pid}/subdir/cp-bench-${process.pid}-${i}`
+      );
+      fs.cpSync(src, uniqueDest, options);
+    }
   }
   bench.end(n);
 }


### PR DESCRIPTION
This PR enhances the benchmark for the `fs.cpSync` function to measure the performance of the dereference and force options.

Key changes:

- Added `dereference` and `force` options to the `bench-cpSync.js` file.
- Implemented a `prepareTestDirectory` function that creates a test directory with symbolic links.
- Added pre-copy logic for testing the force option.
