### PR TITLE
readline: add stricter validation for functions called after closed (second attempt)

### DIFF
--- a/lib/internal/main/repl.js
+++ b/lib/internal/main/repl.js
@@ -45,7 +45,6 @@ if (process.env.NODE_REPL_EXTERNAL_MODULE) {
       }
       repl.on('exit', () => {
         if (repl._flushing) {
-          repl.pause();
           return repl.once('flushHistory', () => {
             process.exit();
           });

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -611,6 +611,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   pause() {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (this.paused) return;
     this.input.pause();
     this.paused = true;
@@ -623,6 +626,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void | Interface}
    */
   resume() {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (!this.paused) return;
     this.input.resume();
     this.paused = false;
@@ -643,6 +649,9 @@ class Interface extends InterfaceConstructor {
    * @returns {void}
    */
   write(d, key) {
+    if (this.closed) {
+      throw new ERR_USE_AFTER_CLOSE('readline');
+    }
     if (this.paused) this.resume();
     if (this.terminal) {
       this[kTtyWrite](d, key);

--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -116,8 +116,10 @@ function setupHistory(repl, historyPath, ready) {
 
       // Reading the file data out erases it
       repl.once('flushHistory', function() {
-        repl.resume();
-        ready(null, repl);
+        if (!repl.closed) {
+          repl.resume();
+          ready(null, repl);
+        }
       });
       flushHistory();
     });

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -974,9 +974,9 @@ function REPLServer(prompt,
         self.output.write(self.writer(ret) + '\n');
       }
 
-      // Display prompt again (unless we already did by emitting the 'error'
-      // event on the domain instance).
-      if (!e) {
+      // If the REPL sever hasn't closed display prompt again (unless we already
+      // did by emitting the 'error' event on the domain instance).
+      if (!self.closed && !e) {
         self[kLastCommandErrored] = false;
         self.displayPrompt();
       }

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -1202,6 +1202,47 @@ for (let i = 0; i < 12; i++) {
     fi.emit('data', 'Node.js\n');
   }
 
+  // Call write after close
+  {
+    const [rli, fi] = getInterface({ terminal });
+    rli.question('What\'s your name?', common.mustCall((name) => {
+      assert.strictEqual(name, 'Node.js');
+      rli.close();
+      assert.throws(() => {
+        rli.write('I said Node.js');
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+    }));
+    fi.emit('data', 'Node.js\n');
+  }
+
+  // Call pause/resume after close
+  {
+    const [rli, fi] = getInterface({ terminal });
+    rli.question('What\'s your name?', common.mustCall((name) => {
+      assert.strictEqual(name, 'Node.js');
+      rli.close();
+      // No 'resume' nor 'pause' event should be emitted after close
+      rli.on('resume', common.mustNotCall());
+      rli.on('pause', common.mustNotCall());
+      assert.throws(() => {
+        rli.pause();
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+      assert.throws(() => {
+        rli.resume();
+      }, {
+        name: 'Error',
+        code: 'ERR_USE_AFTER_CLOSE'
+      });
+    }));
+    fi.emit('data', 'Node.js\n');
+  }
+
   // Can create a new readline Interface with a null output argument
   {
     const [rli, fi] = getInterface({ output: null, terminal });

--- a/test/parallel/test-readline-promises-interface.js
+++ b/test/parallel/test-readline-promises-interface.js
@@ -204,7 +204,7 @@ function assertCursorRowsAndCols(rli, rows, cols) {
     fi.emit('data', character);
   }
   fi.emit('data', '\n');
-  rli.close();
+  fi.end();
 }
 
 // \t when there is no completer function should behave like an ordinary

--- a/test/parallel/test-readline-promises-tab-complete.js
+++ b/test/parallel/test-readline-promises-tab-complete.js
@@ -80,7 +80,7 @@ if (process.env.TERM === 'dumb') {
           output = '';
         });
       }
-      rli.close();
+      fi.end();
     });
   });
 });
@@ -114,5 +114,5 @@ if (process.env.TERM === 'dumb') {
     assert.match(output, /^Tab completion error: Error: message/);
     output = '';
   });
-  rli.close();
+  fi.end();
 }

--- a/test/parallel/test-repl-close.js
+++ b/test/parallel/test-repl-close.js
@@ -1,0 +1,18 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+const child = cp.spawn(process.execPath, ['--interactive']);
+
+let output = '';
+child.stdout.on('data', (data) => {
+  output += data;
+});
+
+child.on('exit', common.mustCall(() => {
+  assert.doesNotMatch(output, /Uncaught Error/);
+}));
+
+child.stdin.write('await null;\n');
+child.stdin.write('.exit\n');

--- a/test/parallel/test-repl-import-referrer.js
+++ b/test/parallel/test-repl-import-referrer.js
@@ -15,11 +15,11 @@ child.stdout.on('data', (data) => {
 });
 
 child.on('exit', common.mustCall(() => {
-  const results = output.replace(/^> /mg, '').split('\n').slice(2);
-  assert.deepStrictEqual(
-    results,
-    ['[Module: null prototype] { message: \'A message\' }', '']
-  );
+  const result = output.replace(/^> /mg, '').split('\n').slice(2);
+  assert.deepStrictEqual(result, [
+    '[Module: null prototype] { message: \'A message\' }',
+    '',
+  ]);
 }));
 
 child.stdin.write('await import(\'./message.mjs\');\n');

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -1,7 +1,12 @@
 'use strict';
 const common = require('../common');
-
+const ArrayStream = require('../common/arraystream');
 const repl = require('repl');
-const r = repl.start({ terminal: false });
-r.setupHistory('/nonexistent/file', common.mustSucceed());
-process.stdin.unref?.();
+
+const stream = new ArrayStream();
+
+const replServer = repl.start({ terminal: false, input: stream, output: stream });
+
+replServer.setupHistory('/nonexistent/file', common.mustSucceed(() => {
+  replServer.close();
+}));

--- a/test/parallel/test-repl-uncaught-exception-async.js
+++ b/test/parallel/test-repl-uncaught-exception-async.js
@@ -34,9 +34,9 @@ r.write(
   '  throw new RangeError("abc");\n' +
   '}, 1);console.log()\n'
 );
-r.close();
 
 setTimeout(() => {
+  r.close();
   const len = process.listenerCount('uncaughtException');
   process.removeAllListeners('uncaughtException');
   assert.strictEqual(len, 0);


### PR DESCRIPTION
This PR makes it so that calling `pause()`, `resume()` or `write()` on a closed readline interface results in `ERR_USE_AFTER_CLOSE` errors being thrown (following the same behavior as `question()`)
___

> [!Note]
> This PR reintroduces the changes committed in https://github.com/nodejs/node/pull/57680 but reverted in https://github.com/nodejs/node/pull/58024 they also include @lpinca's [suggested test changes](https://github.com/nodejs/node/pull/58014#issuecomment-2830647559) to prevent [test flakiness](https://github.com/nodejs/node/issues/58009).
>
> The reason why this was reverted was because of REPL still calling `pause()` and `resume()` even after it has been closed, which I am addressing that here (the lib repl files changes are specifically for that), just to be extra sure I am also adding the new `test/parallel/test-repl-close.js` test dedicated to making sure that closing a REPL does not result in errors (this test is not necessary since the error would be caught by `test/parallel/test-repl-import-referrer.js` anyways but I do think that it's nice to have a dedicated test just for this, if people disagree I'm happy to remove the new test file).

____

Fixes: https://github.com/nodejs/node/issues/57678

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
