### PR TITLE
src: remove unused `internalVerifyIntegrity` internal binding

### DIFF
--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -279,9 +279,6 @@ void Hash::Initialize(Environment* env, Local<Object> target) {
   SetMethodNoSideEffect(context, target, "oneShotDigest", OneShotDigest);
 
   HashJob::Initialize(env, target);
-
-  SetMethodNoSideEffect(
-      context, target, "internalVerifyIntegrity", InternalVerifyIntegrity);
 }
 
 void Hash::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
@@ -293,8 +290,6 @@ void Hash::RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(OneShotDigest);
 
   HashJob::RegisterExternalReferences(registry);
-
-  registry->Register(InternalVerifyIntegrity);
 }
 
 // new Hash(algorithm, algorithmId, xofLen, algorithmCache)
@@ -504,44 +499,5 @@ bool HashTraits::DeriveBits(
   return true;
 }
 
-void InternalVerifyIntegrity(const v8::FunctionCallbackInfo<v8::Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
-  CHECK_EQ(args.Length(), 3);
-
-  CHECK(args[0]->IsString());
-  Utf8Value algorithm(env->isolate(), args[0]);
-
-  CHECK(args[1]->IsString() || IsAnyBufferSource(args[1]));
-  ByteSource content = ByteSource::FromStringOrBuffer(env, args[1]);
-
-  CHECK(args[2]->IsArrayBufferView());
-  ArrayBufferOrViewContents<unsigned char> expected(args[2]);
-
-  const EVP_MD* md_type = ncrypto::getDigestByName(*algorithm);
-  unsigned char digest[EVP_MAX_MD_SIZE];
-  unsigned int digest_size;
-  if (md_type == nullptr || EVP_Digest(content.data(),
-                                       content.size(),
-                                       digest,
-                                       &digest_size,
-                                       md_type,
-                                       nullptr) != 1) [[unlikely]] {
-    return ThrowCryptoError(
-        env, ERR_get_error(), "Digest method not supported");
-  }
-
-  if (digest_size != expected.size() ||
-      CRYPTO_memcmp(digest, expected.data(), digest_size) != 0) {
-    Local<Value> ret;
-    if (StringBytes::Encode(env->isolate(),
-                            reinterpret_cast<const char*>(digest),
-                            digest_size,
-                            BASE64)
-            .ToLocal(&ret)) {
-      args.GetReturnValue().Set(ret);
-    }
-  }
-}
 }  // namespace crypto
 }  // namespace node

--- a/src/crypto/crypto_hash.h
+++ b/src/crypto/crypto_hash.h
@@ -82,8 +82,6 @@ struct HashTraits final {
 
 using HashJob = DeriveBitsJob<HashTraits>;
 
-void InternalVerifyIntegrity(const v8::FunctionCallbackInfo<v8::Value>& args);
-
 }  // namespace crypto
 }  // namespace node
 


### PR DESCRIPTION
This PR is removing the `internalVerifyIntegrity` internal binding, which I believe is no longer used.

I believe that the binding stopped being used in https://github.com/nodejs/node/pull/52583 (see [`lib/internal/policy/manifest.js` line 30](https://github.com/nodejs/node/pull/52583/files#diff-2f71d951c9d2207a687adc8c02df2cd06c725d0a2fae6e02c6c57ba14a28c807L30)).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
