### PR TITLE
doc: make Stability labels not sticky in Stability index

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -299,6 +299,10 @@ li.picker-header a span {
   z-index: 1;
 }
 
+#api-section-documentation .api_stability {
+  position: static;
+}
+
 .api_stability * {
   color: var(--white) !important;
 }


### PR DESCRIPTION
This should make https://nodejs.org/api/documentation.html look less weird.