### PR TITLE
stream: test explicit resource management implicitly

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ import nodeCore from './tools/eslint/eslint-plugin-node-core.js';
 const { globalIgnores } = await importEslintTool('eslint/config');
 const { default: js } = await importEslintTool('@eslint/js');
 const { default: babelEslintParser } = await importEslintTool('@babel/eslint-parser');
+const babelPluginProposalExplicitResourceManagement =
+  resolveEslintTool('@babel/plugin-proposal-explicit-resource-management');
 const babelPluginSyntaxImportAttributes = resolveEslintTool('@babel/plugin-syntax-import-attributes');
 const babelPluginSyntaxImportSource = resolveEslintTool('@babel/plugin-syntax-import-source');
 const { default: jsdoc } = await importEslintTool('eslint-plugin-jsdoc');
@@ -103,6 +105,7 @@ export default [
       parserOptions: {
         babelOptions: {
           plugins: [
+            babelPluginProposalExplicitResourceManagement,
             babelPluginSyntaxImportAttributes,
             babelPluginSyntaxImportSource,
           ],

--- a/test/parallel/test-stream-duplex-destroy.js
+++ b/test/parallel/test-stream-duplex-destroy.js
@@ -284,3 +284,17 @@ const assert = require('assert');
   duplex.on('close', common.mustCall());
   duplex[Symbol.asyncDispose]().then(common.mustCall());
 }
+
+(async () => {
+  // Check Symbol.asyncDispose implicitly
+  await using duplex = new Duplex({
+    write(chunk, enc, cb) { cb(); },
+    read() {},
+  });
+  duplex.on('error', common.mustCall(function(e) {
+    assert.strictEqual(e.name, 'AbortError');
+    assert.strictEqual(this.destroyed, true);
+    assert.strictEqual(this.errored.name, 'AbortError');
+  }));
+  duplex.on('close', common.mustCall());
+})().then(common.mustCall());

--- a/test/parallel/test-stream-readable-dispose.js
+++ b/test/parallel/test-stream-readable-dispose.js
@@ -21,3 +21,18 @@ const assert = require('assert');
     assert.strictEqual(read.destroyed, true);
   }));
 }
+
+(async () => {
+  await using read = new Readable({
+    read() {}
+  });
+  read.resume();
+
+  read.on('end', common.mustNotCall('no end event'));
+  read.on('close', common.mustCall());
+  read.on('error', common.mustCall(function(err) {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(this.errored.name, 'AbortError');
+    assert.strictEqual(this.destroyed, true);
+  }));
+})().then(common.mustCall());

--- a/test/parallel/test-stream-transform-destroy.js
+++ b/test/parallel/test-stream-transform-destroy.js
@@ -152,3 +152,15 @@ const assert = require('assert');
   transform.on('close', common.mustCall());
   transform[Symbol.asyncDispose]().then(common.mustCall());
 }
+
+(async () => {
+  await using transform = new Transform({
+    transform(chunk, enc, cb) {}
+  });
+  transform.on('error', common.mustCall(function(err) {
+    assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(this.destroyed, true);
+    assert.strictEqual(this.errored.name, 'AbortError');
+  }));
+  transform.on('close', common.mustCall());
+})().then(common.mustCall());

--- a/test/parallel/test-stream-writable-destroy.js
+++ b/test/parallel/test-stream-writable-destroy.js
@@ -499,3 +499,17 @@ const assert = require('assert');
   }));
   write[Symbol.asyncDispose]().then(common.mustCall());
 }
+
+(async () => {
+  await using write = new Writable({
+    write(chunk, enc, cb) { cb(); }
+  });
+
+  write.on('error', common.mustCall(function(e) {
+    assert.strictEqual(e.name, 'AbortError');
+    assert.strictEqual(this.destroyed, true);
+    assert.strictEqual(this.errored.name, 'AbortError');
+  }));
+  write.on('close', common.mustCall());
+  write.on('finish', common.mustNotCall('no finish event'));
+})().then(common.mustCall());

--- a/tools/eslint/package-lock.json
+++ b/tools/eslint/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@babel/core": "^7.27.1",
         "@babel/eslint-parser": "^7.27.1",
+        "@babel/plugin-proposal-explicit-resource-management": "^7.27.1",
         "@babel/plugin-syntax-import-attributes": "^7.27.1",
         "@babel/plugin-syntax-import-source": "^7.27.1",
         "@stylistic/eslint-plugin-js": "^4.2.0",
@@ -228,6 +229,21 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-explicit-resource-management": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-explicit-resource-management/-/plugin-proposal-explicit-resource-management-7.27.1.tgz",
+      "integrity": "sha512-XYOgHCv2IO+OtCjttDzuXLgHQEaPq8tdDGdeXRNRK4XobeXSF/SuMKndvdgvzQbMzKGQ1ANkjFICA5BS55rCMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {

--- a/tools/eslint/package.json
+++ b/tools/eslint/package.json
@@ -7,6 +7,7 @@
     "@babel/eslint-parser": "^7.27.1",
     "@babel/plugin-syntax-import-attributes": "^7.27.1",
     "@babel/plugin-syntax-import-source": "^7.27.1",
+    "@babel/plugin-proposal-explicit-resource-management": "^7.27.1",
     "@stylistic/eslint-plugin-js": "^4.2.0",
     "eslint": "^9.25.1",
     "eslint-formatter-tap": "^8.40.0",


### PR DESCRIPTION
In v24.x and later, we can test `[Symbol.asyncDispose]()` using `using`.