### PR TITLE
doc: remove comma delimiter mention on permissions doc

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -108,8 +108,8 @@ The valid arguments for both flags are:
 
 * `*` - To allow all `FileSystemRead` or `FileSystemWrite` operations,
   respectively.
-* Paths delimited by comma (`,`) to allow only matching `FileSystemRead` or
-  `FileSystemWrite` operations, respectively.
+* Relative paths to the current working directory.
+* Absolute paths.
 
 Example:
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/58287