### PR TITLE
doc: mark the callback argument of crypto.generatePrime as mandatory

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3900,7 +3900,7 @@ console.log(key.export().toString('hex'));  // e89..........41e
 The size of a generated HMAC key should not exceed the block size of the
 underlying hash function. See [`crypto.createHmac()`][] for more information.
 
-### `crypto.generatePrime(size[, options[, callback]])`
+### `crypto.generatePrime(size[, options], callback)`
 
 <!-- YAML
 added: v15.8.0


### PR DESCRIPTION
The current documentation lists the `callback` argument of `crypto.generatePrime` as optional (it's surrounded by square brackets), but this is incorrect - calling the function without a callback will result in an error:

```
> crypto.generatePrime(3)
Uncaught:
TypeError [ERR_INVALID_ARG_TYPE]: The "callback" argument must be of type function. Received undefined
    at Object.generatePrime (node:internal/crypto/random:476:3) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

For the record, the correct way to generate a prime synchronously, without a callback, is to use the `generatePrimeSync` API.

This PR fixes the documentation and marks the callback argument as mandatory. The `options` (second) argument, is indeed optional, and is marked as such.

Fixes: https://github.com/nodejs/node/issues/58298

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
