### PR TITLE
typings: remove blob extra typings

### DIFF
--- a/typings/internalBinding/blob.d.ts
+++ b/typings/internalBinding/blob.d.ts
@@ -15,5 +15,4 @@ export interface BlobBinding {
   FixedSizeBlobCopyJob: typeof InternalBlobBinding.FixedSizeBlobCopyJob;
   getDataObject(id: string): [handle: InternalBlobBinding.BlobHandle | undefined, length: number, type: string] | undefined;
   storeDataObject(id: string, handle: InternalBlobBinding.BlobHandle, size: number, type: string): void;
-  revokeDataObject(id: string): void;
 }

--- a/typings/internalBinding/blob.d.ts
+++ b/typings/internalBinding/blob.d.ts
@@ -2,17 +2,10 @@ declare namespace InternalBlobBinding {
   interface BlobHandle {
     slice(start: number, end: number): BlobHandle;
   }
-
-  class FixedSizeBlobCopyJob {
-    constructor(handle: BlobHandle);
-    run(): ArrayBuffer | undefined;
-    ondone: (err: unknown, res?: ArrayBuffer) => void;
-  }
 }
 
 export interface BlobBinding {
   createBlob(sources: Array<Uint8Array | InternalBlobBinding.BlobHandle>, length: number): InternalBlobBinding.BlobHandle;
-  FixedSizeBlobCopyJob: typeof InternalBlobBinding.FixedSizeBlobCopyJob;
   getDataObject(id: string): [handle: InternalBlobBinding.BlobHandle | undefined, length: number, type: string] | undefined;
   storeDataObject(id: string, handle: InternalBlobBinding.BlobHandle, size: number, type: string): void;
 }


### PR DESCRIPTION
This PR is removing two types present in the `blob.d.ts` file that I believe are no longer valid since their C++ implementations have been removed:
 - `revokeDataObject` which implementation was removed in https://github.com/nodejs/node/pull/47728
 - `FixedSizeBlobCopyJob` which implementation was removed in https://github.com/nodejs/node/pull/45258


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
