### PR TITLE
worker: give names to `MessagePort` functions

### DIFF
--- a/lib/internal/worker/io.js
+++ b/lib/internal/worker/io.js
@@ -18,6 +18,7 @@ const {
 } = primordials;
 
 const {
+  assignFunctionName,
   kEnumerableProperty,
   setOwnProperty,
 } = require('internal/util');
@@ -121,7 +122,7 @@ ObjectSetPrototypeOf(MessagePort.prototype, NodeEventTarget.prototype);
 // changing the prototype of MessagePort.prototype implicitly removed them.
 MessagePort.prototype.ref = MessagePortPrototype.ref;
 MessagePort.prototype.unref = MessagePortPrototype.unref;
-MessagePort.prototype.hasRef = function() {
+MessagePort.prototype.hasRef = function hasRef() {
   return !!FunctionPrototypeCall(MessagePortPrototype.hasRef, this);
 };
 
@@ -131,14 +132,14 @@ ObjectDefineProperty(
   kCreateEvent,
   {
     __proto__: null,
-    value: function(data, type) {
+    value: assignFunctionName(kCreateEvent, function(data, type) {
       if (type !== 'message' && type !== 'messageerror') {
         return ReflectApply(originalCreateEvent, this, arguments);
       }
       const ports = this[kCurrentlyReceivingPorts];
       this[kCurrentlyReceivingPorts] = undefined;
       return lazyMessageEvent(type, { data, ports });
-    },
+    }),
     configurable: false,
     writable: false,
     enumerable: false,
@@ -179,7 +180,7 @@ ObjectDefineProperty(MessagePort.prototype, handleOnCloseSymbol, {
   value: onclose,
 });
 
-MessagePort.prototype.close = function(cb) {
+MessagePort.prototype.close = function close(cb) {
   if (typeof cb === 'function')
     this.once('close', cb);
   FunctionPrototypeCall(MessagePortPrototype.close, this);


### PR DESCRIPTION
This fixes names for:
- `worker_threads.MessagePort.prototype.hasRef` (was: anonymous)
- `worker_threads.MessagePort.prototype.close` (was: anonymous)
- `worker_threads.MessagePort.prototype.[kCreateEvent]` (was: `value`)