### PR TITLE
fix(crypto): add handling for CA_MD_TOO_WEAK

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -1358,6 +1358,7 @@ const char* X509Pointer::ErrorCode(int32_t err) {  // NOLINT(runtime/int)
     CASE(CERT_UNTRUSTED)
     CASE(CERT_REJECTED)
     CASE(HOSTNAME_MISMATCH)
+    CASE(CA_MD_TOO_WEAK)
   }
 #undef CASE
   return "UNSPECIFIED";


### PR DESCRIPTION
With this PR, the error code for ``CA_MD_TOO_WEAK`` is returned correctly.
Previously, only ``UNSPECIFIED`` was returned.

For example, ``CA_MD_TOO_WEAK'' can be read using the following code:
```
stream.session?.socket.authorizationError
```