### PR TITLE
test: fix flaky debugger test

### DIFF
--- a/test/parallel/test-debugger-break.js
+++ b/test/parallel/test-debugger-break.js
@@ -53,6 +53,7 @@ const cli = startCLI(['--port=0', script]);
     'marks the debugger line');
 
   await cli.command('sb("break.js", 6)');
+  await cli.waitFor(/> 6.*[.\s\S]*debug>/);
   assert.doesNotMatch(cli.output, /Could not resolve breakpoint/);
 
   await cli.command('sb("otherFunction()")');


### PR DESCRIPTION
For some reason, I’ve lost Jenkins permissions and can’t post the detailed URL, but I’m modifying the contents of this CI:
https://ci.nodejs.org/job/node-test-commit/79774/

I encountered this on my Windows machine when running this command.
``` sh
 python3 tools/test.py --repeat=10000 parallel/test-debugger-break
```

https://github.com/nodejs/node/blob/b1973550e09d5a2a07c70be5de6e3ae4722ad230/test/parallel/test-debugger-break.js#L37-L44

The cause was the output of the cont command.
Normally, it looks like this

``` sh
< Hello Robin
< 
break in test/fixtures/debugger/break.js:10
  8 }
  9 sayHello();
>10 debugger;
 11 setTimeout(sayHello, 10);
 12 
debug> 
```

However, on rare occasions, the order of the debugger output and standard output is reversed like this:

``` sh
break in test/fixtures/debugger/break.js:10
  8 }
  9 sayHello();
>10 debugger;
 11 setTimeout(sayHello, 10);
 12 
debug> 
< Hello Robin
< 
debug> 
```
So I modified it to wait for the corresponding response before proceeding to the next command.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
