### PR TITLE
[v20.x] deps: V8: backport build fixes for Xcode 16.3

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.26',
+    'v8_embedder_string': '-node.27',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.28',
+    'v8_embedder_string': '-node.29',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.27',
+    'v8_embedder_string': '-node.28',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -188,6 +188,7 @@ Matt Hanselman <mjhanselman@gmail.com>
 Matthew Sporleder <msporleder@gmail.com>
 Maxim Mazurok <maxim@mazurok.com>
 Maxim Mossienko <maxim.mossienko@gmail.com>
+Meir Shpilraien <meir@redis.com>
 Michael Lutz <michi@icosahedron.de>
 Michael Mclaughlin <m8ch88l@gmail.com>
 Michael Smith <mike@w3.org>

--- a/deps/v8/src/inspector/string-16.cc
+++ b/deps/v8/src/inspector/string-16.cc
@@ -27,7 +27,7 @@ bool isSpaceOrNewLine(UChar c) {
   return isASCII(c) && c <= ' ' && (c == ' ' || (c <= 0xD && c >= 0x9));
 }
 
-int64_t charactersToInteger(const UChar* characters, size_t length,
+int64_t charactersToInteger(const uint16_t* characters, size_t length,
                             bool* ok = nullptr) {
   std::vector<char> buffer;
   buffer.reserve(length + 1);
@@ -50,6 +50,8 @@ int64_t charactersToInteger(const UChar* characters, size_t length,
 
 String16::String16(const UChar* characters, size_t size)
     : m_impl(characters, size) {}
+String16::String16(const uint16_t* characters, size_t size)
+    : m_impl(reinterpret_cast<const UChar*>(characters), size) {}
 
 String16::String16(const UChar* characters) : m_impl(characters) {}
 
@@ -239,6 +241,10 @@ String16 String16::fromUTF16LE(const UChar* stringStart, size_t length) {
   // No need to do anything on little endian machines.
   return String16(stringStart, length);
 #endif  // V8_TARGET_BIG_ENDIAN
+}
+
+String16 String16::fromUTF16LE(const uint16_t* stringStart, size_t length) {
+  return fromUTF16LE(reinterpret_cast<const UChar*>(stringStart), length);
 }
 
 std::string String16::utf8() const {

--- a/deps/v8/src/inspector/string-16.h
+++ b/deps/v8/src/inspector/string-16.h
@@ -6,6 +6,7 @@
 #define V8_INSPECTOR_STRING_16_H_
 
 #include <stdint.h>
+#include <uchar.h>
 
 #include <cctype>
 #include <climits>
@@ -17,7 +18,7 @@
 
 namespace v8_inspector {
 
-using UChar = uint16_t;
+using UChar = char16_t;
 
 class String16 {
  public:
@@ -27,6 +28,7 @@ class String16 {
   String16(const String16&) V8_NOEXCEPT = default;
   String16(String16&&) V8_NOEXCEPT = default;
   String16(const UChar* characters, size_t size);
+  String16(const uint16_t* characters, size_t size);
   V8_EXPORT String16(const UChar* characters);
   V8_EXPORT String16(const char* characters);
   String16(const char* characters, size_t size);
@@ -48,7 +50,9 @@ class String16 {
   int toInteger(bool* ok = nullptr) const;
   std::pair<size_t, size_t> getTrimmedOffsetAndLength() const;
   String16 stripWhiteSpace() const;
-  const UChar* characters16() const { return m_impl.c_str(); }
+  const uint16_t* characters16() const {
+    return reinterpret_cast<const uint16_t*>(m_impl.c_str());
+  }
   size_t length() const { return m_impl.length(); }
   bool isEmpty() const { return !m_impl.length(); }
   UChar operator[](size_t index) const { return m_impl[index]; }
@@ -77,6 +81,8 @@ class String16 {
   // Instantiates a String16 in native endianness from UTF16 LE.
   // On Big endian architectures, byte order needs to be flipped.
   V8_EXPORT static String16 fromUTF16LE(const UChar* stringStart,
+                                        size_t length);
+  V8_EXPORT static String16 fromUTF16LE(const uint16_t* stringStart,
                                         size_t length);
 
   std::size_t hash() const {

--- a/deps/v8/src/inspector/string-16.h
+++ b/deps/v8/src/inspector/string-16.h
@@ -6,7 +6,6 @@
 #define V8_INSPECTOR_STRING_16_H_
 
 #include <stdint.h>
-#include <uchar.h>
 
 #include <cctype>
 #include <climits>

--- a/deps/v8/src/inspector/v8-string-conversions.cc
+++ b/deps/v8/src/inspector/v8-string-conversions.cc
@@ -12,7 +12,7 @@
 
 namespace v8_inspector {
 namespace {
-using UChar = uint16_t;
+using UChar = char16_t;
 using UChar32 = uint32_t;
 
 bool isASCII(UChar c) { return !(c & ~0x7F); }
@@ -386,7 +386,7 @@ std::string UTF16ToUTF8(const UChar* stringStart, size_t length) {
 
 std::basic_string<UChar> UTF8ToUTF16(const char* stringStart, size_t length) {
   if (!stringStart || !length) return std::basic_string<UChar>();
-  std::vector<uint16_t> buffer(length);
+  std::vector<UChar> buffer(length);
   UChar* bufferStart = buffer.data();
 
   UChar* bufferCurrent = bufferStart;
@@ -395,7 +395,7 @@ std::basic_string<UChar> UTF8ToUTF16(const char* stringStart, size_t length) {
                          reinterpret_cast<const char*>(stringStart + length),
                          &bufferCurrent, bufferCurrent + buffer.size(), nullptr,
                          true) != conversionOK)
-    return std::basic_string<uint16_t>();
+    return std::basic_string<UChar>();
   size_t utf16Length = bufferCurrent - bufferStart;
   return std::basic_string<UChar>(bufferStart, bufferStart + utf16Length);
 }

--- a/deps/v8/src/inspector/v8-string-conversions.h
+++ b/deps/v8/src/inspector/v8-string-conversions.h
@@ -5,7 +5,6 @@
 #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 
-#include <uchar.h>
 
 #include <cstdint>
 #include <string>

--- a/deps/v8/src/inspector/v8-string-conversions.h
+++ b/deps/v8/src/inspector/v8-string-conversions.h
@@ -5,14 +5,16 @@
 #ifndef V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 #define V8_INSPECTOR_V8_STRING_CONVERSIONS_H_
 
+#include <uchar.h>
+
 #include <cstdint>
 #include <string>
 
 // Conversion routines between UT8 and UTF16, used by string-16.{h,cc}. You may
 // want to use string-16.h directly rather than these.
 namespace v8_inspector {
-std::basic_string<uint16_t> UTF8ToUTF16(const char* stringStart, size_t length);
-std::string UTF16ToUTF8(const uint16_t* stringStart, size_t length);
+std::basic_string<char16_t> UTF8ToUTF16(const char* stringStart, size_t length);
+std::string UTF16ToUTF8(const char16_t* stringStart, size_t length);
 }  // namespace v8_inspector
 
 #endif  // V8_INSPECTOR_V8_STRING_CONVERSIONS_H_

--- a/deps/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc
+++ b/deps/v8/third_party/inspector_protocol/crdtp/test_platform_v8.cc
@@ -11,13 +11,16 @@
 namespace v8_crdtp {
 
 std::string UTF16ToUTF8(span<uint16_t> in) {
-  return v8_inspector::UTF16ToUTF8(in.data(), in.size());
+  return v8_inspector::UTF16ToUTF8(reinterpret_cast<const char16_t*>(in.data()),
+                                   in.size());
 }
 
 std::vector<uint16_t> UTF8ToUTF16(span<uint8_t> in) {
-  std::basic_string<uint16_t> utf16 = v8_inspector::UTF8ToUTF16(
+  std::basic_string<char16_t> utf16 = v8_inspector::UTF8ToUTF16(
       reinterpret_cast<const char*>(in.data()), in.size());
-  return std::vector<uint16_t>(utf16.begin(), utf16.end());
+  return std::vector<uint16_t>(
+      reinterpret_cast<const uint16_t*>(utf16.data()),
+      reinterpret_cast<const uint16_t*>(utf16.data()) + utf16.size());
 }
 
 }  // namespace v8_crdtp

--- a/deps/v8/third_party/zlib/zutil.h
+++ b/deps/v8/third_party/zlib/zutil.h
@@ -152,17 +152,8 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if defined(MACOS)
 #  define OS_CODE  7
-#  ifndef Z_SOLO
-#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
-#      include <unix.h> /* for fdopen */
-#    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
-#      endif
-#    endif
-#  endif
 #endif
 
 #ifdef __acorn
@@ -183,18 +174,6 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 
 #ifdef __APPLE__
 #  define OS_CODE 19
-#endif
-
-#if defined(_BEOS_) || defined(RISCOS)
-#  define fdopen(fd,mode) NULL /* No fdopen() */
-#endif
-
-#if (defined(_MSC_VER) && (_MSC_VER > 600)) && !defined __INTERIX
-#  if defined(_WIN32_WCE)
-#    define fdopen(fd,mode) NULL /* No fdopen() */
-#  else
-#    define fdopen(fd,type)  _fdopen(fd,type)
-#  endif
 #endif
 
 #if defined(__BORLANDC__) && !defined(MSDOS)


### PR DESCRIPTION
Node 20.19.2 currently fails to build from source since Xcode 16.3 (and LLVM Clang 18). This pull request backports three v8 commits that fix the issue:

* [deps: V8: cherry-pick third_party/zlib@646b7f569718](https://github.com/nodejs/node/commit/3b5eb14cad3a493e99f84ca45871bd37570cae3d)
  - The bundled zlib had code that assumed `fdopen` is a definition if `TARGET_OS_MAC` is defined, but `fdopen` has never been a definition in the macOS SDK. The latest Clang compiler now defines `TARGET_OS_MAC` globally, triggering this code and causing a compile error.
  - Cherry-pick of https://chromium.googlesource.com/chromium/src/third_party/zlib/+/646b7f569718921d7d4b5b8e22572ff6c76f2596
  - Note that `git-node` doesn't do backports of `third_party` repos so I did this one manually
* [deps: V8: cherry-pick 182d9c05e78b](https://github.com/nodejs/node/commit/e2ab76c1aeceaf866b8c5053cf71f199706d621d)
  - `std::basic_string<uint16_t>` is invalid C++ without a custom `std::char_traits`. This is now enforced in the latest libc++.
  - Cherry-pick of https://github.com/v8/v8/commit/182d9c05e78b1ddb1cb8242cd3628a7855a0336f
* [deps: V8: cherry-pick 1a3ecc2483b2](https://github.com/nodejs/node/commit/a56d782971c30164545e76a97b07ade373a3a565)
  - Cherry-picking the fix above alone (https://github.com/v8/v8/commit/182d9c05e78b1ddb1cb8242cd3628a7855a0336f) regresses older versions of Xcode. Ensure we don't carry that regression by backporting a change that was already cherry-picked to Node 21 and later.
  - Backport of Node commit https://github.com/nodejs/node/commit/4ad3479ba7f01415c3cbdcbec0e617c6085002d8, which is a cherry-pick of https://github.com/v8/v8/commit/1a3ecc2483b2dba6ab9f7e9f8f4b60dbfef504b7

All of the above commits are already included in Node 22 and later, hence the 20.x-only PR.