### PR TITLE
build: add support for OpenHarmony operating system

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -122,6 +122,7 @@ platforms. This is true regardless of entries in the table below.
 | SmartOS          | x64              | >= 18                             | Tier 2       |                                      |
 | AIX              | ppc64be >=power8 | >= 7.2 TL04                       | Tier 2       |                                      |
 | FreeBSD          | x64              | >= 13.2                           | Experimental |                                      |
+| OpenHarmony      | arm64            | >= 5.0                            | Experimental |                                      |
 
 <!--lint disable final-definition-->
 

--- a/common.gypi
+++ b/common.gypi
@@ -120,7 +120,7 @@
       ['target_arch in "ppc64 s390x"', {
         'v8_enable_backtrace': 1,
       }],
-      ['OS=="linux"', {
+      ['OS=="linux" or OS=="openharmony"', {
         'node_section_ordering_info%': ''
       }],
       ['OS == "zos"', {
@@ -202,7 +202,7 @@
               'LLVM_LTO': 'YES',
             },
           }],
-          ['OS=="linux"', {
+          ['OS=="linux" or OS=="openharmony"', {
             'conditions': [
               ['node_section_ordering_info!=""', {
                 'cflags': [
@@ -230,7 +230,7 @@
             # frames otherwise, even with --call-graph dwarf.
             'cflags': [ '-fno-omit-frame-pointer' ],
           }],
-          ['OS=="linux"', {
+          ['OS=="linux" or OS=="openharmony"', {
             'conditions': [
               ['enable_pgo_generate=="true"', {
                 'cflags': ['<(pgo_generate)'],
@@ -498,11 +498,11 @@
           'NOMINMAX',
         ],
       }],
-      [ 'OS in "linux freebsd openbsd solaris aix os400"', {
+      [ 'OS in "linux freebsd openbsd solaris aix os400 openharmony"', {
         'cflags': [ '-pthread' ],
         'ldflags': [ '-pthread' ],
       }],
-      [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi"', {
+      [ 'OS in "linux freebsd openbsd solaris android aix os400 cloudabi openharmony"', {
         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
         'cflags_cc': [
           '-fno-rtti',
@@ -535,7 +535,7 @@
                 'cflags': [ '-m64', '-mminimal-toc' ],
                 'ldflags': [ '-m64' ],
               }],
-              [ 'host_arch=="s390x" and OS=="linux"', {
+              [ 'host_arch=="s390x" and (OS=="linux" or OS=="openharmony")', {
                 'cflags': [ '-m64', '-march=z196' ],
                 'ldflags': [ '-m64', '-march=z196' ],
               }],
@@ -555,7 +555,7 @@
                 'cflags': [ '-m64', '-mminimal-toc' ],
                 'ldflags': [ '-m64' ],
               }],
-              [ 'target_arch=="s390x" and OS=="linux"', {
+              [ 'target_arch=="s390x" and (OS=="linux" or OS=="openharmony")', {
                 'cflags': [ '-m64', '-march=z196' ],
                 'ldflags': [ '-m64', '-march=z196' ],
               }],

--- a/common.gypi
+++ b/common.gypi
@@ -535,7 +535,7 @@
                 'cflags': [ '-m64', '-mminimal-toc' ],
                 'ldflags': [ '-m64' ],
               }],
-              [ 'host_arch=="s390x" and (OS=="linux" or OS=="openharmony")', {
+              [ 'host_arch=="s390x" and OS=="linux"', {
                 'cflags': [ '-m64', '-march=z196' ],
                 'ldflags': [ '-m64', '-march=z196' ],
               }],
@@ -555,7 +555,7 @@
                 'cflags': [ '-m64', '-mminimal-toc' ],
                 'ldflags': [ '-m64' ],
               }],
-              [ 'target_arch=="s390x" and (OS=="linux" or OS=="openharmony")', {
+              [ 'target_arch=="s390x" and OS=="linux"', {
                 'cflags': [ '-m64', '-march=z196' ],
                 'ldflags': [ '-m64', '-march=z196' ],
               }],

--- a/configure.py
+++ b/configure.py
@@ -45,7 +45,7 @@ from utils import SearchFiles
 parser = argparse.ArgumentParser()
 
 valid_os = ('win', 'mac', 'solaris', 'freebsd', 'openbsd', 'linux',
-            'android', 'aix', 'cloudabi', 'os400', 'ios')
+            'android', 'aix', 'cloudabi', 'os400', 'ios', 'openharmony')
 valid_arch = ('arm', 'arm64', 'ia32', 'mips', 'mipsel', 'mips64el',
               'ppc64', 'x64', 'x86', 'x86_64', 's390x', 'riscv64', 'loong64')
 valid_arm_float_abi = ('soft', 'softfp', 'hard')

--- a/deps/cares/cares.gyp
+++ b/deps/cares/cares.gyp
@@ -248,6 +248,10 @@
               '-lnsl'
             ]
           }
+        }],
+        [ 'OS=="openharmony"', {
+          'include_dirs': [ 'config/openharmony' ],
+          'sources': [ 'config/openharmony/ares_config.h' ],
         }]
       ]
     }

--- a/deps/cares/config/openharmony/ares_config.h
+++ b/deps/cares/config/openharmony/ares_config.h
@@ -1,0 +1,573 @@
+/* src/lib/ares_config.h.  Generated from ares_config.h.in by configure.  */
+/* src/lib/ares_config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* a suitable file/device to read random data from */
+#define CARES_RANDOM_FILE "/dev/urandom"
+
+/* Set to 1 if non-pubilc shared library symbols are hidden */
+#define CARES_SYMBOL_HIDING 1 
+
+/* Threading enabled */
+#define CARES_THREADS 1 
+
+/* the signed version of size_t */
+#define CARES_TYPEOF_ARES_SSIZE_T ssize_t
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
+
+/* if a /etc/inet dir is being used */
+/* #undef ETC_INET */
+
+/* gethostname() arg2 type */
+#define GETHOSTNAME_TYPE_ARG2 size_t 
+
+/* getnameinfo() arg1 type */
+#define GETNAMEINFO_TYPE_ARG1 struct sockaddr * 
+
+/* getnameinfo() arg2 type */
+#define GETNAMEINFO_TYPE_ARG2 socklen_t 
+
+/* getnameinfo() arg4 and 6 type */
+#define GETNAMEINFO_TYPE_ARG46 socklen_t 
+
+/* getnameinfo() arg7 type */
+#define GETNAMEINFO_TYPE_ARG7 int 
+
+/* number of arguments for getservbyname_r() */
+/* #undef GETSERVBYNAME_R_ARGS */
+
+/* number of arguments for getservbyport_r() */
+#define GETSERVBYPORT_R_ARGS 6 
+
+/* Define to 1 if you have AF_INET6 */
+#define HAVE_AF_INET6 1
+
+/* Define to 1 if you have `arc4random_buf` */
+/* #undef HAVE_ARC4RANDOM_BUF */
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
+#define HAVE_ARPA_NAMESER_COMPAT_H 1
+
+/* Define to 1 if you have the <arpa/nameser.h> header file. */
+#define HAVE_ARPA_NAMESER_H 1
+
+/* Define to 1 if you have the <assert.h> header file. */
+#define HAVE_ASSERT_H 1
+
+/* Define to 1 if you have the <AvailabilityMacros.h> header file. */
+/* #undef HAVE_AVAILABILITYMACROS_H */
+
+/* Define to 1 if you have `clock_gettime` */
+#define HAVE_CLOCK_GETTIME 1
+
+/* clock_gettime() with CLOCK_MONOTONIC support */
+#define HAVE_CLOCK_GETTIME_MONOTONIC 1 
+
+/* Define to 1 if you have `closesocket` */
+/* #undef HAVE_CLOSESOCKET */
+
+/* Define to 1 if you have `CloseSocket` */
+/* #undef HAVE_CLOSESOCKET_CAMEL */
+
+/* Define to 1 if you have `connect` */
+#define HAVE_CONNECT 1
+
+/* Define to 1 if you have `ConvertInterfaceIndexToLuid` */
+/* #undef HAVE_CONVERTINTERFACEINDEXTOLUID */
+
+/* Define to 1 if you have `ConvertInterfaceLuidToNameA` */
+/* #undef HAVE_CONVERTINTERFACELUIDTONAMEA */
+
+/* define if the compiler supports basic C++14 syntax */
+#define HAVE_CXX14 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have `epoll_{create1,ctl,wait}` */
+#define HAVE_EPOLL 1
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if you have `fcntl` */
+#define HAVE_FCNTL 1
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* fcntl() with O_NONBLOCK support */
+#define HAVE_FCNTL_O_NONBLOCK 1 
+
+/* Define to 1 if you have `getenv` */
+#define HAVE_GETENV 1
+
+/* Define to 1 if you have `gethostname` */
+#define HAVE_GETHOSTNAME 1
+
+/* Define to 1 if you have `getifaddrs` */
+#define HAVE_GETIFADDRS 1
+
+/* Define to 1 if you have `getnameinfo` */
+#define HAVE_GETNAMEINFO 1
+
+/* Define to 1 if you have `getrandom` */
+#define HAVE_GETRANDOM 1
+
+/* Define to 1 if you have `getservbyport_r` */
+/* #undef HAVE_GETSERVBYPORT_R 1 */
+
+/* Define to 1 if you have `gettimeofday` */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H 1
+
+/* Define to 1 if you have `if_indextoname` */
+#define HAVE_IF_INDEXTONAME 1
+
+/* Define to 1 if you have `if_nametoindex` */
+#define HAVE_IF_NAMETOINDEX 1
+
+/* Define to 1 if you have `inet_net_pton` */
+#define HAVE_INET_NET_PTON 1
+
+/* Define to 1 if you have `inet_ntop` */
+#define HAVE_INET_NTOP 1
+
+/* Define to 1 if you have `inet_pton` */
+#define HAVE_INET_PTON 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have `ioctl` */
+#define HAVE_IOCTL 1
+
+/* Define to 1 if you have `ioctlsocket` */
+/* #undef HAVE_IOCTLSOCKET */
+
+/* Define to 1 if you have `IoctlSocket` */
+/* #undef HAVE_IOCTLSOCKET_CAMEL */
+
+/* ioctlsocket() with FIONBIO support */
+/* #undef HAVE_IOCTLSOCKET_FIONBIO */
+
+/* ioctl() with FIONBIO support */
+#define HAVE_IOCTL_FIONBIO 1 
+
+/* Define to 1 if you have the <iphlpapi.h> header file. */
+/* #undef HAVE_IPHLPAPI_H */
+
+/* Define to 1 if you have `kqueue` */
+/* #undef HAVE_KQUEUE */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H 1
+
+/* Define to 1 if the compiler supports the 'long long' data type. */
+#define HAVE_LONGLONG 1
+
+/* Define to 1 if you have the <malloc.h> header file. */
+#define HAVE_MALLOC_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+/* #undef HAVE_MINIX_CONFIG_H */
+
+/* Define to 1 if you have the <mswsock.h> header file. */
+/* #undef HAVE_MSWSOCK_H */
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#define HAVE_NETINET_TCP_H 1
+
+/* Define to 1 if you have the <netioapi.h> header file. */
+/* #undef HAVE_NETIOAPI_H */
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#define HAVE_NET_IF_H 1
+
+/* Define to 1 if you have the <ntdef.h> header file. */
+/* #undef HAVE_NTDEF_H */
+
+/* Define to 1 if you have the <ntstatus.h> header file. */
+/* #undef HAVE_NTSTATUS_H */
+
+/* Define to 1 if you have PF_INET6 */
+#define HAVE_PF_INET6 1
+
+/* Define to 1 if you have `pipe` */
+#define HAVE_PIPE 1
+
+/* Define to 1 if you have `pipe2` */
+#define HAVE_PIPE2 1
+
+/* Define to 1 if you have `poll` */
+#define HAVE_POLL 1
+
+/* Define to 1 if you have the <poll.h> header file. */
+#define HAVE_POLL_H 1
+
+/* Define to 1 if you have the <pthread.h> header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Define to 1 if you have the <pthread_np.h> header file. */
+/* #undef HAVE_PTHREAD_NP_H */
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#define HAVE_PTHREAD_PRIO_INHERIT 1
+
+/* Define to 1 if you have `recv` */
+#define HAVE_RECV 1
+
+/* Define to 1 if you have `recvfrom` */
+#define HAVE_RECVFROM 1
+
+/* Define to 1 if you have `send` */
+#define HAVE_SEND 1
+
+/* Define to 1 if you have `setsockopt` */
+#define HAVE_SETSOCKOPT 1
+
+/* setsockopt() with SO_NONBLOCK support */
+/* #undef HAVE_SETSOCKOPT_SO_NONBLOCK */
+
+/* Define to 1 if you have `socket` */
+#define HAVE_SOCKET 1
+
+/* Define to 1 if you have the <socket.h> header file. */
+/* #undef HAVE_SOCKET_H */
+
+/* socklen_t */
+#define HAVE_SOCKLEN_T /**/
+
+/* Define to 1 if you have `stat` */
+#define HAVE_STAT 1
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#define HAVE_STDBOOL_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have `strcasecmp` */
+#define HAVE_STRCASECMP 1
+
+/* Define to 1 if you have `strdup` */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have `stricmp` */
+/* #undef HAVE_STRICMP */
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have `strncasecmp` */
+#define HAVE_STRNCASECMP 1
+
+/* Define to 1 if you have `strncmpi` */
+/* #undef HAVE_STRNCMPI */
+
+/* Define to 1 if you have `strnicmp` */
+/* #undef HAVE_STRNICMP */
+
+/* Define to 1 if the system has the type `struct addrinfo'. */
+#define HAVE_STRUCT_ADDRINFO 1
+
+/* Define to 1 if `ai_flags' is a member of `struct addrinfo'. */
+#define HAVE_STRUCT_ADDRINFO_AI_FLAGS 1
+
+/* Define to 1 if the system has the type `struct in6_addr'. */
+#define HAVE_STRUCT_IN6_ADDR 1
+
+/* Define to 1 if the system has the type `struct sockaddr_in6'. */
+#define HAVE_STRUCT_SOCKADDR_IN6 1
+
+/* Define to 1 if `sin6_scope_id' is a member of `struct sockaddr_in6'. */
+#define HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID 1
+
+/* Define to 1 if the system has the type `struct sockaddr_storage'. */
+#define HAVE_STRUCT_SOCKADDR_STORAGE 1
+
+/* Define to 1 if the system has the type `struct timeval'. */
+#define HAVE_STRUCT_TIMEVAL 1
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+#define HAVE_SYS_EPOLL_H 1
+
+/* Define to 1 if you have the <sys/event.h> header file. */
+/* #undef HAVE_SYS_EVENT_H */
+
+/* Define to 1 if you have the <sys/filio.h> header file. */
+/* #undef HAVE_SYS_FILIO_H */
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H 1
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/random.h> header file. */
+#define HAVE_SYS_RANDOM_H 1
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+#define HAVE_SYS_UIO_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Whether user namespaces are available */
+#define HAVE_USER_NAMESPACE 1
+
+/* Whether UTS namespaces are available */
+#define HAVE_UTS_NAMESPACE 1
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#define HAVE_WCHAR_H 1
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define to 1 if you have the <winsock2.h> header file. */
+/* #undef HAVE_WINSOCK2_H */
+
+/* Define to 1 if you have the <winternl.h> header file. */
+/* #undef HAVE_WINTERNL_H */
+
+/* Define to 1 if you have `writev` */
+#define HAVE_WRITEV 1
+
+/* Define to 1 if you have the <ws2ipdef.h> header file. */
+/* #undef HAVE_WS2IPDEF_H */
+
+/* Define to 1 if you have the <ws2tcpip.h> header file. */
+/* #undef HAVE_WS2TCPIP_H */
+
+/* Define to 1 if you have `__system_property_get` */
+/* #undef HAVE___SYSTEM_PROPERTY_GET */
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "c-ares"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "c-ares mailing list: http://lists.haxx.se/listinfo/c-ares"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "c-ares"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "c-ares 1.26.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "c-ares"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.26.0"
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* recvfrom() arg5 qualifier */
+#define RECVFROM_QUAL_ARG5 
+
+/* recvfrom() arg1 type */
+#define RECVFROM_TYPE_ARG1 int 
+
+/* recvfrom() arg2 type */
+#define RECVFROM_TYPE_ARG2 void * 
+
+/* recvfrom() arg3 type */
+#define RECVFROM_TYPE_ARG3 size_t 
+
+/* recvfrom() arg4 type */
+#define RECVFROM_TYPE_ARG4 int 
+
+/* recvfrom() arg5 type */
+#define RECVFROM_TYPE_ARG5 struct sockaddr * 
+
+/* recvfrom() return value */
+#define RECVFROM_TYPE_RETV ssize_t 
+
+/* recv() arg1 type */
+#define RECV_TYPE_ARG1 int 
+
+/* recv() arg2 type */
+#define RECV_TYPE_ARG2 void * 
+
+/* recv() arg3 type */
+#define RECV_TYPE_ARG3 size_t 
+
+/* recv() arg4 type */
+#define RECV_TYPE_ARG4 int 
+
+/* recv() return value */
+#define RECV_TYPE_RETV ssize_t 
+
+/* send() arg2 qualifier */
+#define SEND_QUAL_ARG2 
+
+/* send() arg1 type */
+#define SEND_TYPE_ARG1 int 
+
+/* send() arg2 type */
+#define SEND_TYPE_ARG2 void * 
+
+/* send() arg3 type */
+#define SEND_TYPE_ARG3 size_t 
+
+/* send() arg4 type */
+#define SEND_TYPE_ARG4 int 
+
+/* send() return value */
+#define SEND_TYPE_RETV ssize_t 
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# define _DARWIN_C_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# define _HPUX_ALT_XOPEN_SOCKET_API 1
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+/* # undef _MINIX */
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# define _NETBSD_SOURCE 1
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# define _OPENBSD_SOURCE 1
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+/* # undef _POSIX_SOURCE */
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+/* # undef _POSIX_1_SOURCE */
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# define __STDC_WANT_IEC_60559_BFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# define __STDC_WANT_IEC_60559_DFP_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# define __STDC_WANT_IEC_60559_TYPES_EXT__ 1
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# define __STDC_WANT_LIB_EXT2__ 1
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# define __STDC_WANT_MATH_SPEC_FUNCS__ 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+/* # undef _XOPEN_SOURCE */
+#endif
+
+
+/* Version number of package */
+#define VERSION "1.26.0"
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */

--- a/deps/openssl/openssl-cl_asm.gypi
+++ b/deps/openssl/openssl-cl_asm.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm/openssl-cl.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in "linux openharmony"', {
       'includes': ['config/archs/linux-aarch64/asm/openssl-cl.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/asm/openssl-cl.gypi'],

--- a/deps/openssl/openssl-cl_asm_avx2.gypi
+++ b/deps/openssl/openssl-cl_asm_avx2.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm_avx2/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm_avx2/openssl-cl.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in "linux openharmony"', {
       'includes': ['config/archs/linux-aarch64/asm_avx2/openssl-cl.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/asm_avx2/openssl-cl.gypi'],

--- a/deps/openssl/openssl-cl_no_asm.gypi
+++ b/deps/openssl/openssl-cl_no_asm.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/no-asm/openssl-cl.gypi'],
     }, 'target_arch=="arm" and OS in ("linux", "android")', {
       'includes': ['config/archs/linux-armv4/no-asm/openssl-cl.gypi'],
-    }, 'target_arch=="arm64" and OS in ("linux", "android")', {
+    }, 'target_arch=="arm64" and OS in ("linux", "android", "openharmony")', {
       'includes': ['config/archs/linux-aarch64/no-asm/openssl-cl.gypi'],
     }, 'target_arch=="arm64" and OS=="win"', {
       'includes': ['config/archs/VC-WIN64-ARM/no-asm/openssl-cl.gypi'],

--- a/deps/openssl/openssl-cli.gypi
+++ b/deps/openssl/openssl-cli.gypi
@@ -14,7 +14,7 @@
       'link_settings': {
         'libraries': ['<@(openssl_cli_libraries_win)'],
       },
-    }, 'OS in "linux android"', {
+    }, 'OS in "linux android openharmony"', {
       'link_settings': {
         'libraries': [
           '-ldl',

--- a/deps/openssl/openssl-fips_asm.gypi
+++ b/deps/openssl/openssl-fips_asm.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm/openssl-fips.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm/openssl-fips.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in "linux openharmony"', {
       'includes': ['config/archs/linux-aarch64/asm/openssl-fips.gypi'],
     }, 'target_arch=="arm64" and OS=="mac"', {
       'includes': ['config/archs/darwin64-arm64-cc/asm/openssl-fips.gypi'],

--- a/deps/openssl/openssl-fips_asm_avx2.gypi
+++ b/deps/openssl/openssl-fips_asm_avx2.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm_avx2/openssl-fips.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm_avx2/openssl-fips.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in "linux openharmony"', {
       'includes': ['config/archs/linux-aarch64/asm_avx2/openssl-fips.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/asm_avx2/openssl-fips.gypi'],

--- a/deps/openssl/openssl-fips_no_asm.gypi
+++ b/deps/openssl/openssl-fips_no_asm.gypi
@@ -9,7 +9,7 @@
       'includes': ['config/archs/linux64-s390x/no-asm/openssl-fips.gypi'],
     }, 'target_arch=="arm" and OS in ("linux", "android")', {
       'includes': ['config/archs/linux-armv4/no-asm/openssl-fips.gypi'],
-    }, 'target_arch=="arm64" and OS in ("linux", "android")', {
+    }, 'target_arch=="arm64" and OS in ("linux", "android", "openharmony")', {
       'includes': ['config/archs/linux-aarch64/no-asm/openssl-fips.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/no-asm/openssl-fips.gypi'],

--- a/deps/openssl/openssl_asm.gypi
+++ b/deps/openssl/openssl_asm.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm/openssl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm/openssl.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in "linux openharmony"', {
       'includes': ['config/archs/linux-aarch64/asm/openssl.gypi'],
     }, 'target_arch=="arm64" and OS=="mac"', {
       'includes': ['config/archs/darwin64-arm64-cc/asm/openssl.gypi'],

--- a/deps/openssl/openssl_asm_avx2.gypi
+++ b/deps/openssl/openssl_asm_avx2.gypi
@@ -8,7 +8,7 @@
       'includes': ['config/archs/linux64-s390x/asm_avx2/openssl.gypi'],
     }, 'target_arch=="arm" and OS=="linux"', {
       'includes': ['config/archs/linux-armv4/asm_avx2/openssl.gypi'],
-    }, 'target_arch=="arm64" and OS=="linux"', {
+    }, 'target_arch=="arm64" and OS in ("linux", "openharmony")', {
       'includes': ['config/archs/linux-aarch64/asm_avx2/openssl.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/asm_avx2/openssl.gypi'],

--- a/deps/openssl/openssl_no_asm.gypi
+++ b/deps/openssl/openssl_no_asm.gypi
@@ -9,7 +9,7 @@
       'includes': ['config/archs/linux64-s390x/no-asm/openssl.gypi'],
     }, 'target_arch=="arm" and OS in ("linux", "android")', {
       'includes': ['config/archs/linux-armv4/no-asm/openssl.gypi'],
-    }, 'target_arch=="arm64" and OS in ("linux", "android")', {
+    }, 'target_arch=="arm64" and OS in ("linux", "android", "openharmony")', {
       'includes': ['config/archs/linux-aarch64/no-asm/openssl.gypi'],
     }, 'target_arch=="ia32" and OS=="freebsd"', {
       'includes': ['config/archs/BSD-x86/no-asm/openssl.gypi'],

--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -173,7 +173,7 @@
         ],
         'include_dirs': [ 'include' ],
         'conditions': [
-          ['OS == "linux"', {
+          ['OS == "linux" or OS=="openharmony"', {
             'defines': [ '_POSIX_C_SOURCE=200112' ],
           }],
         ],
@@ -255,7 +255,7 @@
             }],
           ],
         }],
-        [ 'OS in "linux mac ios android zos"', {
+        [ 'OS in "linux mac ios android zos openharmony"', {
           'sources': [ 'src/unix/proctitle.c' ],
         }],
         [ 'OS != "zos"', {
@@ -279,7 +279,7 @@
             '_DARWIN_UNLIMITED_SELECT=1',
           ]
         }],
-        [ 'OS=="linux"', {
+        [ 'OS=="linux" or OS=="openharmony"', {
           'defines': [ '_GNU_SOURCE' ],
           'sources': [
             '<@(uv_sources_linux)',

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -75,7 +75,7 @@
                 ['OS=="android"', {
                   'defines': [ 'ARMV8_OS_ANDROID' ],
                 }],
-                ['OS=="linux"', {
+                ['OS=="linux" or OS=="openharmony"', {
                   'defines': [ 'ARMV8_OS_LINUX' ],
                 }],
                 ['OS=="mac"', {
@@ -93,7 +93,7 @@
                   ['OS=="android"', {
                     'defines': [ 'ARMV8_OS_ANDROID' ],
                   }],
-                  ['OS=="linux"', {
+                  ['OS=="linux" or OS=="openharmony"', {
                     'defines': [ 'ARMV8_OS_LINUX' ],
                   }],
                   ['OS=="mac"', {

--- a/node.gyp
+++ b/node.gyp
@@ -507,7 +507,7 @@
       'target_name': 'node_text_start',
       'type': 'none',
       'conditions': [
-        [ 'OS in "linux freebsd solaris" and '
+        [ 'OS in "linux freebsd solaris openharmony" and '
           'target_arch=="x64"', {
           'type': 'static_library',
           'sources': [
@@ -625,7 +625,7 @@
             'OTHER_LDFLAGS': [ '-Wl,-rpath,@loader_path', '-Wl,-rpath,@loader_path/../lib'],
           },
           'conditions': [
-            ['OS=="linux"', {
+            ['OS=="linux" or OS=="openharmony"', {
                'ldflags': [
                  '-Wl,-rpath,\\$$ORIGIN/../lib'
                ],
@@ -730,7 +730,7 @@
             'src/node_snapshot_stub.cc'
           ],
         }],
-        [ 'OS in "linux freebsd" and '
+        [ 'OS in "linux freebsd openharmony" and '
           'target_arch=="x64"', {
           'dependencies': [ 'node_text_start' ],
           'ldflags+': [
@@ -955,7 +955,7 @@
           ],
           'defines': [ 'HAVE_SQLITE=1' ],
         }],
-        [ 'OS in "linux freebsd mac solaris" and '
+        [ 'OS in "linux freebsd mac solaris openharmony" and '
           'target_arch=="x64" and '
           'node_target_type=="executable"', {
           'defines': [ 'NODE_ENABLE_LARGE_CODE_PAGES=1' ],
@@ -1064,11 +1064,11 @@
         'test/fuzzers/fuzz_env.cc',
       ],
       'conditions': [
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="openharmony"', {
           'ldflags': [ '-fsanitize=fuzzer' ]
         }],
         # Ensure that ossfuzz flag has been set and that we are on Linux
-        [ 'OS!="linux" or ossfuzz!="true"', {
+        [ 'OS not in "linux openharmony" or ossfuzz!="true"', {
           'type': 'none',
         }],
         # Avoid excessive LTO
@@ -1107,11 +1107,11 @@
         'test/fuzzers/fuzz_ClientHelloParser.cc',
       ],
       'conditions': [
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="openharmony"', {
           'ldflags': [ '-fsanitize=fuzzer' ]
         }],
         # Ensure that ossfuzz flag has been set and that we are on Linux
-        [ 'OS!="linux" or ossfuzz!="true"', {
+        [ 'OS not in "linux openharmony" or ossfuzz!="true"', {
           'type': 'none',
         }],
         # Avoid excessive LTO
@@ -1152,11 +1152,11 @@
         'test/fuzzers/fuzz_strings.cc',
       ],
       'conditions': [
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="openharmony"', {
           'ldflags': [ '-fsanitize=fuzzer' ]
         }],
         # Ensure that ossfuzz flag has been set and that we are on Linux
-        [ 'OS!="linux" or ossfuzz!="true"', {
+        [ 'OS not in "linux openharmony" or ossfuzz!="true"', {
           'type': 'none',
         }],
         # Avoid excessive LTO
@@ -1352,7 +1352,7 @@
         [ 'node_shared_libuv=="false"', {
           'dependencies': [ 'deps/uv/uv.gyp:libuv#host' ],
         }],
-        [ 'OS in "linux mac"', {
+        [ 'OS in "linux mac openharmony"', {
           'defines': ['NODE_JS2C_USE_STRING_LITERALS'],
         }],
         [ 'debug_node=="true"', {

--- a/node.gypi
+++ b/node.gypi
@@ -307,7 +307,7 @@
         'NODE_PLATFORM="sunos"',
       ],
     }],
-    [ '(OS=="freebsd" or OS=="linux") and node_shared=="false"'
+    [ '(OS=="freebsd" or OS=="linux" or OS=="openharmony") and node_shared=="false"'
         ' and force_load=="true"', {
       'ldflags': [
         '-Wl,-z,noexecstack',
@@ -332,7 +332,7 @@
         ],
       },
     }],
-    [ 'coverage=="true" and node_shared=="false" and OS in "mac freebsd linux"', {
+    [ 'coverage=="true" and node_shared=="false" and OS in "mac freebsd linux openharmony"', {
       'cflags!': [ '-O3' ],
       'ldflags': [ '--coverage',
                    '-g',
@@ -364,12 +364,12 @@
     [ 'OS=="sunos"', {
       'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
     }],
-    [ 'OS=="linux"', {
+    [ 'OS=="linux" or OS=="openharmony"', {
       'libraries!': [
         '-lrt'
       ],
     }],
-    [ 'OS in "freebsd linux"', {
+    [ 'OS in "freebsd linux openharmony"', {
       'ldflags': [ '-Wl,-z,relro',
                    '-Wl,-z,now' ]
     }],
@@ -401,7 +401,7 @@
                 },
               },
               'conditions': [
-                ['OS in "linux freebsd" and node_shared=="false"', {
+                ['OS in "linux freebsd openharmony" and node_shared=="false"', {
                   'ldflags': [
                     '-Wl,--whole-archive,'
                       '<(obj_dir)/deps/openssl/<(openssl_product)',

--- a/tools/v8_gypfiles/d8.gyp
+++ b/tools/v8_gypfiles/d8.gyp
@@ -41,7 +41,7 @@
         }],
         ['(OS=="linux" or OS=="mac" or OS=="freebsd" or OS=="netbsd" \
            or OS=="openbsd" or OS=="solaris" or OS=="android" \
-           or OS=="qnx" or OS=="aix" or OS=="os400")', {
+           or OS=="qnx" or OS=="aix" or OS=="os400" or OS=="openharmony")', {
              'sources': [ '<(V8_ROOT)/src/d8/d8-posix.cc', ]
            }],
         [ 'OS=="win"', {

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -73,7 +73,7 @@
       }, {
         'v8_enable_etw_stack_walking': 0,
       }],
-      ['OS=="linux"', {
+      ['OS=="linux" or OS=="openharmony"', {
         # Sets -dV8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION.
         #
         # This flag speeds up the performance of fork/execve on Linux systems for

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -86,10 +86,10 @@
     'binutils_dir%': '',
 
     'conditions': [
-      ['OS=="linux" and host_arch=="x64"', {
+      ['OS in "linux openharmony" and host_arch=="x64"', {
         'binutils_dir%': 'third_party/binutils/Linux_x64/Release/bin',
       }],
-      ['OS=="linux" and host_arch=="ia32"', {
+      ['OS in "linux openharmony" and host_arch=="ia32"', {
         'binutils_dir%': 'third_party/binutils/Linux_ia32/Release/bin',
       }],
     ],
@@ -530,7 +530,7 @@
           'V8_TARGET_OS_IOS',
         ]
       }],
-      ['OS=="linux"', {
+      ['OS=="linux" or OS=="openharmony"', {
         'defines': [
           'V8_HAVE_TARGET_OS',
           'V8_TARGET_OS_LINUX',
@@ -548,9 +548,7 @@
           'V8_TARGET_OS_WIN',
         ]
       }],
-      ['(OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="solaris" \
-         or OS=="netbsd" or OS=="mac" or OS=="android" or OS=="qnx") and \
-        v8_target_arch=="ia32"', {
+      ['OS in "linux freebsd openbsd solaris netbsd mac android qnx openharmony" and v8_target_arch=="ia32"', {
         'cflags': [
           '-msse2',
           '-mfpmath=sse',
@@ -591,7 +589,7 @@
           'DEBUG',
         ],
         'conditions': [
-          ['OS=="linux" and v8_enable_backtrace==1', {
+          ['OS in "linux openharmony" and v8_enable_backtrace==1', {
             # Support for backtrace_symbols.
             'ldflags': [ '-rdynamic' ],
           }],
@@ -638,8 +636,7 @@
               'v8_enable_slow_dchecks%': 1,
             },
             'conditions': [
-              ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix" or OS=="os400"', {
+              ['OS in "linux freebsd openbsd netbsd qnx aix os400 openharmony"', {
                 'cflags!': [
                   '-O3',
                   '-O2',
@@ -689,8 +686,7 @@
               'v8_enable_slow_dchecks%': 0,
             },
             'conditions': [
-              ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" or \
-            OS=="qnx" or OS=="aix" or OS=="os400"', {
+              ['OS in "linux freebsd openbsd netbsd qnx aix os400 openharmony"', {
                 'cflags!': [
                   '-O0',
                   '-O1',
@@ -741,8 +737,7 @@
          # Temporary refs: https://github.com/nodejs/node/pull/23801
         'defines!': ['ENABLE_HANDLE_ZAPPING',],
         'conditions': [
-          ['OS=="linux" or OS=="freebsd" or OS=="openbsd" or OS=="netbsd" \
-            or OS=="aix" or OS=="os400"', {
+          ['OS in "linux freebsd openbsd netbsd aix os400 openharmony"', {
             'cflags!': [
               '-Os',
             ],

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -724,7 +724,7 @@
               }],
               ['v8_enable_webassembly==1', {
                 'conditions': [
-                  ['OS=="linux" or OS=="mac" or OS=="ios" or OS=="freebsd"', {
+                  ['OS in "linux mac ios freebsd openharmony"', {
                     'sources': [
                       '<(V8_ROOT)/src/trap-handler/handler-inside-posix.h',
                     ],
@@ -767,12 +767,12 @@
               }],
               ['v8_enable_webassembly==1', {
                 'conditions': [
-                  ['((_toolset=="host" and host_arch=="arm64" or _toolset=="target" and target_arch=="arm64") and (OS=="linux" or OS=="mac")) or ((_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS=="linux" or OS=="mac"))', {
+                  ['((_toolset=="host" and host_arch=="arm64" or _toolset=="target" and target_arch=="arm64") and (OS in "linux mac openharmony")) or ((_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS in "linux mac openharmony"))', {
                     'sources': [
                       '<(V8_ROOT)/src/trap-handler/handler-inside-posix.h',
                     ],
                   }],
-                  ['(_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS=="linux" or OS=="mac" or OS=="win")', {
+                  ['(_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS in "linux mac win openharmony")', {
                     'sources': [
                       '<(V8_ROOT)/src/trap-handler/trap-handler-simulator.h',
                     ],
@@ -1139,7 +1139,7 @@
             }],
             ['v8_enable_webassembly==1', {
               'conditions': [
-                ['OS=="linux" or OS=="mac" or OS=="ios" or OS=="freebsd"', {
+                ['OS in "linux mac ios freebsd openharmony"', {
                   'sources': [
                     '<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc',
                     '<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc',
@@ -1167,7 +1167,7 @@
           'conditions': [
             ['v8_enable_webassembly==1', {
               'conditions': [
-                ['((_toolset=="host" and host_arch=="arm64" or _toolset=="target" and target_arch=="arm64") and (OS=="linux" or OS=="mac" or OS=="ios")) or ((_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS=="linux" or OS=="mac"))', {
+                ['((_toolset=="host" and host_arch=="arm64" or _toolset=="target" and target_arch=="arm64") and (OS in "linux mac ios openharmony")) or ((_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS in "linux mac openharmony"))', {
                   'sources': [
                     '<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc',
                     '<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc',
@@ -1179,7 +1179,7 @@
                     '<(V8_ROOT)/src/trap-handler/handler-outside-win.cc',
                   ],
                 }],
-                ['(_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS=="linux" or OS=="mac" or OS=="win")', {
+                ['(_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS in "linux mac win openharmony")', {
                   'sources': [
                     '<(V8_ROOT)/src/trap-handler/handler-outside-simulator.cc',
                   ],
@@ -1410,7 +1410,7 @@
             }],
           ],
         }],
-        ['OS=="linux"', {
+        ['OS=="linux" or OS=="openharmony"', {
           'sources': [
             '<(V8_ROOT)/src/base/debug/stack_trace_posix.cc',
             '<(V8_ROOT)/src/base/platform/platform-linux.cc',


### PR DESCRIPTION
[OpenHarmony](https://www.openharmony.cn/) is an open-source operating system. It supports running on hardware such as phones, tablets, PCs, and embedded devices.

OpenHarmony supports the following system types: 
* Mini system (device memory >= 128 KiB)
* Small system (device memory >=1 MiB)
* Standard system (device memory >= 128 MiB)

We only need to focus on the OpenHarmony standard system, as the other two types are insufficient in memory to run Node.js

The OpenHarmony standard system uses the Linux kernel but does not use the GNU userland. This architecture is similar to that of the Android operating system. Therefore, my adaptation process for OpenHarmony is also similar to that for Android.

This adaptation only focuses on the arm64 architecture, as I don't have other environments to test more architectures.