### PR TITLE
[20.x] tools: disable failing test envs in `test-linux` CI

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -35,16 +35,11 @@ permissions:
 jobs:
   test-linux:
     if: github.event.pull_request.draft == false
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
-          path: node
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
         with:
@@ -56,13 +51,6 @@ jobs:
       - name: Environment Information
         run: npx envinfo
       - name: Build
-        run: make -C node build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
+        run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test
-        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
-      - name: Re-run test in a folder whose name contains unusual chars
-        run: |
-          mv node "$DIR"
-          cd "$DIR"
-          ./tools/test.py --flaky-tests keep_retrying -p actions -j 4
-        env:
-          DIR: dir%20with $unusual"chars?'åß∂ƒ©∆¬…`
+        run: make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"


### PR DESCRIPTION
29c032403cb6 added a few test environments that are simply not working 20.x branch. Let's disable them to get more useful CI results.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
