### PR TITLE
meta: ignore mailmap changes in linux ci

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -3,6 +3,7 @@ name: Test Linux
 on:
   pull_request:
     paths-ignore:
+      - .mailmap
       - README.md
       - .github/**
       - '!.github/workflows/test-linux.yml'
@@ -14,6 +15,7 @@ on:
       - v[0-9]+.x-staging
       - v[0-9]+.x
     paths-ignore:
+      - .mailmap
       - README.md
       - .github/**
       - '!.github/workflows/test-linux.yml'


### PR DESCRIPTION
This is ignored in test-macos, however the change was not ported to test-linux.