### PR TITLE
build,win: fix dll build

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -64,7 +64,8 @@ BuiltinLoader::BuiltinLoader()
 #endif  // HAVE_AMARO
 }
 
-auto BuiltinLoader::GetBuiltinIds() const -> decltype(auto) {
+std::ranges::keys_view<std::ranges::ref_view<const BuiltinSourceMap>>
+BuiltinLoader::GetBuiltinIds() const {
   return std::views::keys(*source_.read());
 }
 

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -127,7 +127,9 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
 
   void CopySourceAndCodeCacheReferenceFrom(const BuiltinLoader* other);
 
-  [[nodiscard]] auto GetBuiltinIds() const -> decltype(auto);
+  [[nodiscard]] std::ranges::keys_view<
+      std::ranges::ref_view<const BuiltinSourceMap>>
+  GetBuiltinIds() const;
 
   void SetEagerCompile() { should_eager_compile_ = true; }
 


### PR DESCRIPTION
Fixes a linker error when building Node.js DLL with ClangCL by moving `BuiltinLoader::GetBuiltinIds()` implementation from `.h` to `.cc` file.

This PR tries different approach from https://github.com/nodejs/node/pull/58235 based on @joyeecheung's [comment](https://github.com/nodejs/node/pull/58235#issuecomment-2866756274)

Fixes: https://github.com/nodejs/node/issues/58208