### PR TITLE
tty: use terminal VT mode on Windows

### DIFF
--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -116,7 +116,17 @@ void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
   TTYWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(
       &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
-  int err = uv_tty_set_mode(&wrap->handle_, args[0]->IsTrue());
+  // UV_TTY_MODE_RAW_VT is a variant of UV_TTY_MODE_RAW that
+  // enables control sequence processing on the TTY implementer side,
+  // rather than having libuv translate keypress events into
+  // control sequences, aligning behavior more closely with
+  // POSIX platforms. This is also required to support some control
+  // sequences at all on Windows, such as bracketed paste mode.
+  // The Node.js readline implementation handles differences between
+  // these modes.
+  int err = uv_tty_set_mode(
+      &wrap->handle_,
+      args[0]->IsTrue() ? UV_TTY_MODE_RAW_VT : UV_TTY_MODE_NORMAL);
   args.GetReturnValue().Set(err);
 }
 


### PR DESCRIPTION
As of 0315283cbd, the libuv `UV_TTY_MODE_RAW_VT` flag is available for applications on Windows in order to have the terminal itself translate keypresses into control sequences, rather than libuv. This aligns the TTY setup more closely with POSIX platforms, and enables handling of control sequences in applications which libuv is not able to emit at all.

Since the Node.js `readline` implementation already handles divergences between different control character sequences for the same keypresses (e.g. `<ESC>[[A` vs `<ESC>OP` for the F1 key), this should not present a visible change for typical Node.js TTY applications.

Testing is handled on the libuv side, and not easily feasible with Node.js’s current TTY test setup.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
