### PR TITLE
src: ERR_ILLEGAL_CONSTRUCTOR thrown from c++ had the wrong constructor

### DIFF
--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -82,7 +82,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
   V(ERR_FS_CP_SOCKET, Error)                                                   \
   V(ERR_FS_CP_FIFO_PIPE, Error)                                                \
   V(ERR_FS_CP_UNKNOWN, Error)                                                  \
-  V(ERR_ILLEGAL_CONSTRUCTOR, Error)                                            \
+  V(ERR_ILLEGAL_CONSTRUCTOR, TypeError)                                        \
   V(ERR_INVALID_ADDRESS, Error)                                                \
   V(ERR_INVALID_ARG_VALUE, TypeError)                                          \
   V(ERR_OSSL_EVP_INVALID_DIGEST, Error)                                        \

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -81,6 +81,7 @@ test('AbortSignal is impossible to construct manually', () => {
   // Tests that AbortSignal is impossible to construct manually
   const ac = new AbortController();
   throws(() => new ac.signal.constructor(), {
+    name: 'TypeError',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 });

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -19,8 +19,9 @@ suite('StatementSync() constructor', () => {
     t.assert.throws(() => {
       new StatementSync();
     }, {
+      name: 'TypeError',
       code: 'ERR_ILLEGAL_CONSTRUCTOR',
-      message: /Illegal constructor/,
+      message: 'Illegal constructor',
     });
   });
 });

--- a/test/parallel/test-timers-promises-scheduler.js
+++ b/test/parallel/test-timers-promises-scheduler.js
@@ -51,5 +51,6 @@ async function testCancelableWait2() {
 testCancelableWait2().then(common.mustCall());
 
 throws(() => new scheduler.constructor(), {
+  name: 'TypeError',
   code: 'ERR_ILLEGAL_CONSTRUCTOR',
 });

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -611,7 +611,10 @@ const vectors = {
 }
 
 // End user code cannot create CryptoKey directly
-assert.throws(() => new CryptoKey(), { code: 'ERR_ILLEGAL_CONSTRUCTOR' });
+assert.throws(() => new CryptoKey(), {
+  name: 'TypeError',
+  code: 'ERR_ILLEGAL_CONSTRUCTOR',
+});
 
 {
   const buffer = Buffer.from('Hello World');

--- a/test/parallel/test-webstorage.js
+++ b/test/parallel/test-webstorage.js
@@ -14,6 +14,19 @@ function nextLocalStorage() {
   return join(tmpdir.path, `${++cnt}.localstorage`);
 }
 
+test('constructor is illegal', async () => {
+  const cp = await spawnPromisified(process.execPath, [
+    '--experimental-webstorage',
+    '--localstorage-file', nextLocalStorage(),
+    '-e', 'new Storage',
+  ]);
+  assert.strictEqual(cp.code, 1);
+  assert.strictEqual(cp.signal, null);
+  assert.strictEqual(cp.stdout, '');
+  assert(cp.stderr.includes(`TypeError: Illegal constructor\n`));
+  assert(cp.stderr.includes(`code: 'ERR_ILLEGAL_CONSTRUCTOR'\n`));
+});
+
 test('disabled without --experimental-webstorage', async () => {
   for (const api of ['Storage', 'localStorage', 'sessionStorage']) {
     const cp = await spawnPromisified(process.execPath, ['-e', api]);

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -1444,14 +1444,17 @@ class Source {
   });
 
   assert.throws(() => new ReadableStreamBYOBRequest(), {
+    name: 'TypeError',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 
   assert.throws(() => new ReadableStreamDefaultController(), {
+    name: 'TypeError',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 
   assert.throws(() => new ReadableByteStreamController(), {
+    name: 'TypeError',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 }

--- a/test/parallel/test-whatwg-transformstream.js
+++ b/test/parallel/test-whatwg-transformstream.js
@@ -196,6 +196,7 @@ class Source {
   });
 
   assert.throws(() => new TransformStreamDefaultController(), {
+    name: 'TypeError',
     code: 'ERR_ILLEGAL_CONSTRUCTOR',
   });
 }


### PR DESCRIPTION
this brings it into sync with the definition of this error in `lib/internal/errors.js`.
