### PR TITLE
tls: make Server.getTicketKeys throw instead of assert

### DIFF
--- a/lib/internal/tls/wrap.js
+++ b/lib/internal/tls/wrap.js
@@ -1531,8 +1531,9 @@ Server.prototype.getTicketKeys = function getTicketKeys() {
 
 Server.prototype.setTicketKeys = function setTicketKeys(keys) {
   validateBuffer(keys);
-  assert(keys.byteLength === 48,
-         'Session ticket keys must be a 48-byte buffer');
+  if (keys.byteLength !== 48) {
+    throw new ERR_INVALID_ARG_VALUE('keys', keys.byteLength, 'must be exactly 48 bytes');
+  }
   this._sharedCreds.context.setTicketKeys(keys);
 };
 

--- a/test/parallel/test-tls-ticket-invalid-arg.js
+++ b/test/parallel/test-tls-ticket-invalid-arg.js
@@ -13,12 +13,22 @@ const server = new tls.Server();
   .forEach((arg) =>
     assert.throws(
       () => server.setTicketKeys(arg),
-      { code: 'ERR_INVALID_ARG_TYPE' }
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: 'The "buffer" argument must be an instance of Buffer, TypedArray, or DataView.'
+                + common.invalidArgTypeHelper(arg),
+      }
     ));
 
 [new Uint8Array(1), Buffer.from([1]), new DataView(new ArrayBuffer(2))].forEach(
   (arg) =>
-    assert.throws(() => {
-      server.setTicketKeys(arg);
-    }, /Session ticket keys must be a 48-byte buffer/)
+    assert.throws(
+      () => server.setTicketKeys(arg),
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_ARG_VALUE',
+        message: `The argument 'keys' must be exactly 48 bytes. Received ${arg.byteLength}`,
+      }
+    )
 );


### PR DESCRIPTION
assert is for invariants and prints a message about the condition being a bug in Node.js if false.
throw ERR_INVALID_ARG_VALUE for publicly facing validation.
this brings it into sync with the validation done in configSecureContext.
