### PR TITLE
test: remove loop over single element

### DIFF
--- a/test/parallel/test-crypto-authenticated.js
+++ b/test/parallel/test-crypto-authenticated.js
@@ -561,17 +561,14 @@ for (const test of TEST_CASES) {
   const iv = Buffer.alloc(12);
   const opts = { authTagLength: 10 };
 
-  for (const cipher of [
-    crypto.createCipheriv(algo, key, iv, opts),
-  ]) {
-    assert.throws(() => {
-      cipher.final();
-    }, hasOpenSSL3 ? {
-      code: 'ERR_OSSL_TAG_NOT_SET'
-    } : {
-      message: /Unsupported state/
-    });
-  }
+  const cipher = crypto.createCipheriv(algo, key, iv, opts);
+  assert.throws(() => {
+    cipher.final();
+  }, hasOpenSSL3 ? {
+    code: 'ERR_OSSL_TAG_NOT_SET'
+  } : {
+    message: /Unsupported state/
+  });
 }
 
 {


### PR DESCRIPTION
This loop used to iterate over two elements, but since commit 215f4d04b7a9de0b04bb430d191abf5f79d3494d, it only iterates over a single element. Therefore, move the test out of the loop body and remove the loop itself.

Refs: https://github.com/nodejs/node/pull/50973

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
