### PR TITLE
lib: remove no-mixed-operators eslint rule

### DIFF
--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -370,16 +370,6 @@ export default [
         },
       ],
 
-      // Stylistic rules.
-      '@stylistic/js/no-mixed-operators': [
-        'error',
-        {
-          groups: [
-            ['&&', '||'],
-          ],
-        },
-      ],
-
       // Custom rules in tools/eslint-rules.
       'node-core/alphabetize-errors': 'error',
       'node-core/alphabetize-primordials': 'error',


### PR DESCRIPTION
The rule often makes code less readable by requiring the additional brackets. I am also not aware that this rule ever caught a real issue in our code.

I have definitely stumbled upon it multiple times and I had to adjust my code to add the brackets due to not thinking about that initially.

If we want to have this rule, I would suggest to check for tenaries with other operators such as `['?:', '||']`, `['?:', '&&']`.

Refs: https://eslint.org/docs/latest/rules/no-mixed-operators