### PR TITLE
src: prepare for v8 sandboxing

### DIFF
--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -34,6 +34,8 @@ using ncrypto::EnginePointer;
 using ncrypto::SSLPointer;
 using v8::ArrayBuffer;
 using v8::BackingStore;
+using v8::BackingStoreInitializationMode;
+using v8::BackingStoreOnFailureMode;
 using v8::BigInt;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -339,16 +341,37 @@ ByteSource& ByteSource::operator=(ByteSource&& other) noexcept {
   return *this;
 }
 
-std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore() {
+std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore(
+    Environment* env) {
   // It's ok for allocated_data_ to be nullptr but
   // only if size_ is zero.
   CHECK_IMPLIES(size_ > 0, allocated_data_ != nullptr);
+#ifdef V8_ENABLE_SANDBOX
+  // If the v8 sandbox is enabled, then all array buffers must be allocated
+  // via the isolate. External buffers are not allowed. So, instead of wrapping
+  // the allocated data we'll copy it instead.
+
+  // TODO(@jasnell): It would be nice to use an abstracted utility to do this
+  // branch instead of duplicating the V8_ENABLE_SANDBOX check each time.
+  std::unique_ptr<BackingStore> ptr = ArrayBuffer::NewBackingStore(
+      env->isolate(),
+      size(),
+      BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
+  if (!ptr) {
+    THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
+    return nullptr;
+  }
+  memcpy(ptr->Data(), allocated_data_, size());
+  OPENSSL_clear_free(allocated_data_, size_);
+#else
   std::unique_ptr<BackingStore> ptr = ArrayBuffer::NewBackingStore(
       allocated_data_,
       size(),
       [](void* data, size_t length, void* deleter_data) {
         OPENSSL_clear_free(deleter_data, length);
       }, allocated_data_);
+#endif  // V8_ENABLE_SANDBOX
   CHECK(ptr);
   allocated_data_ = nullptr;
   data_ = nullptr;
@@ -357,7 +380,7 @@ std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore() {
 }
 
 Local<ArrayBuffer> ByteSource::ToArrayBuffer(Environment* env) {
-  std::unique_ptr<BackingStore> store = ReleaseToBackingStore();
+  std::unique_ptr<BackingStore> store = ReleaseToBackingStore(env);
   return ArrayBuffer::New(env->isolate(), std::move(store));
 }
 
@@ -648,8 +671,19 @@ namespace {
 // using OPENSSL_malloc. However, if the secure heap is
 // initialized, SecureBuffer will automatically use it.
 void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsUint32());
   Environment* env = Environment::GetCurrent(args);
+#ifdef V8_ENABLE_SANDBOX
+  // The v8 sandbox is enabled, so we cannot use the secure heap because
+  // the sandbox requires that all array buffers be allocated via the isolate.
+  // That is fundamentally incompatible with the secure heap which allocates
+  // in openssl's secure heap area. Instead we'll just throw an error here.
+  //
+  // That said, we really shouldn't get here in the first place since the
+  // option to enable the secure heap is only available when the sandbox
+  // is disabled.
+  UNREACHABLE();
+#else
+  CHECK(args[0]->IsUint32());
   uint32_t len = args[0].As<Uint32>()->Value();
 
   auto data = DataPointer::SecureAlloc(len);
@@ -676,6 +710,7 @@ void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
 
   Local<ArrayBuffer> buffer = ArrayBuffer::New(env->isolate(), store);
   args.GetReturnValue().Set(Uint8Array::New(buffer, 0, len));
+#endif  // V8_ENABLE_SANDBOX
 }
 
 void SecureHeapUsed(const FunctionCallbackInfo<Value>& args) {

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -185,7 +185,7 @@ class ByteSource final {
   // Creates a v8::BackingStore that takes over responsibility for
   // any allocated data. The ByteSource will be reset with size = 0
   // after being called.
-  std::unique_ptr<v8::BackingStore> ReleaseToBackingStore();
+  std::unique_ptr<v8::BackingStore> ReleaseToBackingStore(Environment* env);
 
   v8::Local<v8::ArrayBuffer> ToArrayBuffer(Environment* env);
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -114,7 +114,7 @@ napi_status NewExternalString(napi_env env,
   CHECK_NEW_STRING_ARGS(env, str, length, result);
 
   napi_status status;
-#if defined(V8_ENABLE_SANDBOX)
+#ifdef V8_ENABLE_SANDBOX
   status = create_api(env, str, length, result);
   if (status == napi_ok) {
     if (copied != nullptr) {

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1056,9 +1056,9 @@ napi_create_external_buffer(napi_env env,
   NAPI_PREAMBLE(env);
   CHECK_ARG(env, result);
 
-#if defined(V8_ENABLE_SANDBOX)
+#ifdef V8_ENABLE_SANDBOX
   return napi_set_last_error(env, napi_no_external_buffers_allowed);
-#endif
+#endif  // V8_ENABLE_SANDBOX
 
   v8::Isolate* isolate = env->isolate;
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -81,6 +81,8 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors,
   }
 
   // Any value less than 2 disables use of the secure heap.
+#ifndef V8_ENABLE_SANDBOX
+  // The secure heap is not supported when V8_ENABLE_SANDBOX is enabled.
   if (secure_heap >= 2) {
     if ((secure_heap & (secure_heap - 1)) != 0)
       errors->push_back("--secure-heap must be a power of 2");
@@ -93,6 +95,7 @@ void PerProcessOptions::CheckOptions(std::vector<std::string>* errors,
     if ((secure_heap_min & (secure_heap_min - 1)) != 0)
       errors->push_back("--secure-heap-min must be a power of 2");
   }
+#endif  // V8_ENABLE_SANDBOX
 #endif  // HAVE_OPENSSL
 
   if (use_largepages != "off" &&
@@ -1172,6 +1175,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "force FIPS crypto (cannot be disabled)",
             &PerProcessOptions::force_fips_crypto,
             kAllowedInEnvvar);
+#ifndef V8_ENABLE_SANDBOX
   AddOption("--secure-heap",
             "total size of the OpenSSL secure heap",
             &PerProcessOptions::secure_heap,
@@ -1180,6 +1184,7 @@ PerProcessOptionsParser::PerProcessOptionsParser(
             "minimum allocation size from the OpenSSL secure heap",
             &PerProcessOptions::secure_heap_min,
             kAllowedInEnvvar);
+#endif  // V8_ENABLE_SANDBOX
 #endif  // HAVE_OPENSSL
 #if OPENSSL_VERSION_MAJOR >= 3
   AddOption("--openssl-legacy-provider",


### PR DESCRIPTION
When the v8 sandbox is enabled (possibly at some point in the future) all ArrayBuffer allocations must be done within the isolate. Externally allocated backing stores are not permitted. This starts to prepare for that by adding some compile time branches to copy some external buffers rather than wrapping them. We also disable the `--secure-heap` feature since that fundamentally doesn't make sense and can't be supported with v8 sandbox enabled.

This PR cannot yet include additional tests for the new branches largely because we cannot yet build node with v8 sandbox enabled.