### PR TITLE
src: fix FIPS init error handling

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1175,10 +1175,7 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
     }
 #endif
     if (!crypto::ProcessFipsOptions()) {
-      // XXX: ERR_GET_REASON does not return something that is
-      // useful as an exit code at all.
-      result->exit_code_ =
-          static_cast<ExitCode>(ERR_GET_REASON(ERR_peek_error()));
+      result->exit_code_ = ExitCode::kGenericUserError;
       result->early_return_ = true;
       result->errors_.emplace_back(
           "OpenSSL error when trying to enable FIPS:\n" +


### PR DESCRIPTION
If `--enable-fips` or `--force-fips` fails to be applied during `ProcessFipsOptions()`, the node process might exit with `ExitCode::kNoFailure` because `ERR_GET_REASON(ERR_peek_error())` can return `0` since `ncrypto::testFipsEnabled()` does not populate the OpenSSL error queue.

This is problematic because an exit code of `0` (i.e., `kNoFailure`) indicates successful execution of the `node` command, even though it already failed during initialization. (Error messages also appear to be broken, but fixing that is not as urgent as not pretending that the command succeeded.)

For example, if a user invokes `node` from within a bash script and `NODE_OPTIONS` includes `--force-fips`, the execution of the command will appear to have succeeded even if the actual user script was never executed due to a configuration error.

You can likely test this locally by running

    ./node --enable-fips ; echo $?

with the current `node` binary from the main branch if compiled without support for FIPS.

As confirmed by the `XXX` comment here, which was added three years ago in commit b6971602564fc93c536ad469947536b487c968ea, even if the error queue was populated properly, the OpenSSL reason codes are not really related to the Node.js `ExitCode` enumeration.

This commit changes the initialization logic to exit with `kGenericUserError` in this case, since such errors are most likely due to incorrect configuration. It also modifies the existing test case to actually check the exit code of the process, which would have prevented this recent regression.

Considering that the current behavior is incorrect, I'd prefer to merge this as a bugfix rather than a semver-major change.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
