### PR TITLE
perf_hooks: make the event loop display histogram disposable

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1973,6 +1973,23 @@ added: v11.10.0
 Enables the update interval timer. Returns `true` if the timer was
 started, `false` if it was already started.
 
+### `histogram[Symbol.dispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Disables the update interval timer when the histogram is disposed.
+
+```js
+const { monitorEventLoopDelay } = require('node:perf_hooks');
+{
+  using hist = monitorEventLoopDelay({ resolution: 20 });
+  hist.enable();
+  // The histogram will be disabled when the block is exited.
+}
+```
+
 ### Cloning an `IntervalHistogram`
 
 {IntervalHistogram} instances can be cloned via {MessagePort}. On the receiving

--- a/lib/internal/perf/event_loop_delay.js
+++ b/lib/internal/perf/event_loop_delay.js
@@ -3,6 +3,7 @@ const {
   ReflectConstruct,
   SafeMap,
   Symbol,
+  SymbolDispose,
 } = primordials;
 
 const {
@@ -38,7 +39,7 @@ const {
 const kEnabled = Symbol('kEnabled');
 
 class ELDHistogram extends Histogram {
-  constructor(i) {
+  constructor() {
     throw new ERR_ILLEGAL_CONSTRUCTOR();
   }
 
@@ -64,6 +65,10 @@ class ELDHistogram extends Histogram {
     this[kEnabled] = false;
     this[kHandle].stop();
     return true;
+  }
+
+  [SymbolDispose]() {
+    this.disable();
   }
 }
 

--- a/test/parallel/test-perf-hooks-histogram.js
+++ b/test/parallel/test-perf-hooks-histogram.js
@@ -98,6 +98,17 @@ const { inspect } = require('util');
 }
 
 {
+  // Tests that the ELD histogram is disposable
+  let histogram;
+  {
+    using hi = monitorEventLoopDelay();
+    histogram = hi;
+  }
+  // The histogram should already be disabled.
+  strictEqual(histogram.disable(), false);
+}
+
+{
   const h = createHistogram();
   ok(inspect(h, { depth: null }).startsWith('Histogram'));
   strictEqual(inspect(h, { depth: -1 }), '[RecordableHistogram]');


### PR DESCRIPTION
Fairly self-explanatory, but see the test for an example.