### PR TITLE
workers: make Worker async disposable

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1863,6 +1863,21 @@ Calling `unref()` on a worker allows the thread to exit if this is the only
 active handle in the event system. If the worker is already `unref()`ed calling
 `unref()` again has no effect.
 
+### `worker[Symbol.asyncDispose]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Calls [`worker.terminate()`][] when the dispose scope is exited.
+
+```js
+async function example() {
+  await using worker = new Worker('for (;;) {}', { eval: true });
+  // Worker is automatically terminate when the scope is exited.
+}
+```
+
 ## Notes
 
 ### Synchronous blocking of stdio

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -19,6 +19,7 @@ const {
   String,
   StringPrototypeTrim,
   Symbol,
+  SymbolAsyncDispose,
   SymbolFor,
   TypedArrayPrototypeFill,
   Uint32Array,
@@ -405,6 +406,10 @@ class Worker extends EventEmitter {
     return new Promise((resolve) => {
       this.once('exit', resolve);
     });
+  }
+
+  async [SymbolAsyncDispose]() {
+    await this.terminate();
   }
 
   ref() {

--- a/test/parallel/test-worker-dispose.mjs
+++ b/test/parallel/test-worker-dispose.mjs
@@ -1,0 +1,8 @@
+import * as common from '../common/index.mjs';
+import { Worker } from 'node:worker_threads';
+
+{
+  // Verifies that the worker is async disposable
+  await using worker = new Worker('for(;;) {}', { eval: true });
+  worker.on('exit', common.mustCall());
+}


### PR DESCRIPTION
```js
await using worker = new Worker(...);
```

