### PR TITLE
crypto: expose `process.features.openssl_is_boringssl`

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -266,7 +266,7 @@ ObjectDefineProperty(process, 'allowedNodeEnvironmentFlags', {
 
 // TODO(joyeecheung): this property has not been well-maintained, should we
 // deprecate it in favor of a better API?
-const { isDebugBuild, hasOpenSSL, hasInspector } = config;
+const { isDebugBuild, hasOpenSSL, openSSLIsBoringSSL, hasInspector } = config;
 const features = {
   inspector: hasInspector,
   debug: isDebugBuild,
@@ -276,6 +276,7 @@ const features = {
   tls_sni: hasOpenSSL,
   tls_ocsp: hasOpenSSL,
   tls: hasOpenSSL,
+  openssl_is_boringssl: openSSLIsBoringSSL,
   // This needs to be dynamic because --no-node-snapshot disables the
   // code cache even if the binary is built with embedded code cache.
   get cached_builtins() {

--- a/src/node_config.cc
+++ b/src/node_config.cc
@@ -48,6 +48,12 @@ static void InitConfig(Local<Object> target,
   READONLY_FALSE_PROPERTY(target, "isDebugBuild");
 #endif  // defined(DEBUG) && DEBUG
 
+#ifdef OPENSSL_IS_BORINGSSL
+  READONLY_TRUE_PROPERTY(target, "openSSLIsBoringSSL");
+#else
+  READONLY_FALSE_PROPERTY(target, "openSSLIsBoringSSL");
+#endif  // OPENSSL_IS_BORINGSSL
+
 #if HAVE_OPENSSL
   READONLY_TRUE_PROPERTY(target, "hasOpenSSL");
 #else

--- a/test/parallel/test-crypto-getcipherinfo.js
+++ b/test/parallel/test-crypto-getcipherinfo.js
@@ -62,9 +62,13 @@ assert(getCipherInfo('aes-128-cbc', { ivLength: 16 }));
 
 assert(!getCipherInfo('aes-128-ccm', { ivLength: 1 }));
 assert(!getCipherInfo('aes-128-ccm', { ivLength: 14 }));
-for (let n = 7; n <= 13; n++)
-  assert(getCipherInfo('aes-128-ccm', { ivLength: n }));
+if (!process.features.openssl_is_boringssl) {
+  for (let n = 7; n <= 13; n++)
+    assert(getCipherInfo('aes-128-ccm', { ivLength: n }));
+}
 
 assert(!getCipherInfo('aes-128-ocb', { ivLength: 16 }));
-for (let n = 1; n < 16; n++)
-  assert(getCipherInfo('aes-128-ocb', { ivLength: n }));
+if (!process.features.openssl_is_boringssl) {
+  for (let n = 1; n < 16; n++)
+    assert(getCipherInfo('aes-128-ocb', { ivLength: n }));
+}

--- a/test/parallel/test-crypto-hkdf.js
+++ b/test/parallel/test-crypto-hkdf.js
@@ -125,7 +125,7 @@ const algorithms = [
   ['sha256', '', 'salt', '', 10],
   ['sha512', 'secret', 'salt', '', 15],
 ];
-if (!hasOpenSSL3)
+if (!hasOpenSSL3 && !process.features.openssl_is_boringssl)
   algorithms.push(['whirlpool', 'secret', '', 'info', 20]);
 
 algorithms.forEach(([ hash, secret, salt, info, length ]) => {

--- a/test/parallel/test-process-features.js
+++ b/test/parallel/test-process-features.js
@@ -9,6 +9,7 @@ const expectedKeys = new Map([
   ['debug', ['boolean']],
   ['uv', ['boolean']],
   ['ipv6', ['boolean']],
+  ['openssl_is_boringssl', ['boolean']],
   ['tls_alpn', ['boolean']],
   ['tls_sni', ['boolean']],
   ['tls_ocsp', ['boolean']],

--- a/test/parallel/test-tls-getprotocol.js
+++ b/test/parallel/test-tls-getprotocol.js
@@ -29,10 +29,13 @@ const clientConfigs = [
 
 const serverConfig = {
   secureProtocol: 'TLS_method',
-  ciphers: 'RSA@SECLEVEL=0',
   key: fixtures.readKey('agent2-key.pem'),
   cert: fixtures.readKey('agent2-cert.pem')
 };
+
+if (!process.features.openssl_is_boringssl) {
+  serverConfig.ciphers = 'RSA@SECLEVEL=0';
+}
 
 const server = tls.createServer(serverConfig, common.mustCall(clientConfigs.length))
 .listen(0, common.localhostIPv4, function() {

--- a/test/parallel/test-tls-write-error.js
+++ b/test/parallel/test-tls-write-error.js
@@ -17,8 +17,11 @@ const server_cert = fixtures.readKey('agent1-cert.pem');
 const opts = {
   key: server_key,
   cert: server_cert,
-  ciphers: 'ALL@SECLEVEL=0'
 };
+
+if (!process.features.openssl_is_boringssl) {
+  opts.ciphers = 'ALL@SECLEVEL=0';
+}
 
 const server = https.createServer(opts, (req, res) => {
   res.write('hello');


### PR DESCRIPTION
This PR exposes `process.features.openssl_is_boringssl`. This allows knowing which crypto library is in use at the JS level - previously the only way to know was to check the version string, which would be `0.0.0` when built with BoringSSL.

This also sets the stage for adapting some of Node.js' crypto tests to run and pass with both BoringSSL and OpenSSL.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
