### PR TITLE
test: show more information in test-http2-debug upon failure

### DIFF
--- a/test/parallel/test-http2-debug.js
+++ b/test/parallel/test-http2-debug.js
@@ -1,27 +1,31 @@
 'use strict';
+
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
-const child_process = require('child_process');
+const { spawnSyncAndAssert } = require('../common/child_process');
 const path = require('path');
 
-process.env.NODE_DEBUG_NATIVE = 'http2';
-process.env.NODE_DEBUG = 'http2';
-const { stdout, stderr } = child_process.spawnSync(process.execPath, [
+spawnSyncAndAssert(process.execPath, [
   path.resolve(__dirname, 'test-http2-ping.js'),
-], { encoding: 'utf8' });
-
-assert(stderr.match(/Setting the NODE_DEBUG environment variable to 'http2' can expose sensitive data \(such as passwords, tokens and authentication headers\) in the resulting log\.\r?\n/),
-       stderr);
-assert(stderr.match(/Http2Session client \(\d+\) handling data frame for stream \d+\r?\n/),
-       stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] reading starting\r?\n/),
-       stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] closed with code 0\r?\n/),
-       stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] closed with code 0\r?\n/),
-       stderr);
-assert(stderr.match(/HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] tearing down stream\r?\n/),
-       stderr);
-assert.strictEqual(stdout.trim(), '');
+], {
+  env: {
+    ...process.env,
+    NODE_DEBUG: 'http2',
+    NODE_DEBUG_NATIVE: 'http2',
+  },
+}, {
+  trim: true,
+  stderr(output) {
+    assert.match(output,
+                 /Setting the NODE_DEBUG environment variable to 'http2' can expose sensitive data/);
+    assert.match(output, /\(such as passwords, tokens and authentication headers\) in the resulting log\.\r?\n/);
+    assert.match(output, /Http2Session client \(\d+\) handling data frame for stream \d+\r?\n/);
+    assert.match(output, /HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] reading starting\r?\n/);
+    assert.match(output, /HttpStream \d+ \(\d+\) \[Http2Session client \(\d+\)\] closed with code 0\r?\n/);
+    assert.match(output, /HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] closed with code 0\r?\n/);
+    assert.match(output, /HttpStream \d+ \(\d+\) \[Http2Session server \(\d+\)\] tearing down stream\r?\n/);
+  },
+  stdout: ''
+});


### PR DESCRIPTION
Use spawnSyncAndAssert() so that the stderr is logged when it doesn't match expectations.

Refs: https://github.com/nodejs/node/issues/58353

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
