### PR TITLE
lib: make ERM functions into wrappers returning undefined

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -863,7 +863,8 @@ added:
 
 > Stability: 1 - Experimental
 
-An alias for `filehandle.close()`.
+Calls `filehandle.close()` and returns a promise that fulfills when the
+filehandle is closed.
 
 ### `fsPromises.access(path[, mode])`
 
@@ -6757,7 +6758,8 @@ added: REPLACEME
 
 > Stability: 1 - Experimental
 
-An alias for `dir.close()`.
+Calls `dir.close()` and returns a promise that fulfills when the
+dir is closed.
 
 #### `dir[Symbol.Dispose]()`
 
@@ -6767,7 +6769,7 @@ added: REPLACEME
 
 > Stability: 1 - Experimental
 
-An alias for `dir.closeSync()`.
+Calls `dir.closeSync()` and returns `undefined`.
 
 ### Class: `fs.Dirent`
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -581,7 +581,7 @@ Server.prototype.close = function close() {
 };
 
 Server.prototype[SymbolAsyncDispose] = assignFunctionName(SymbolAsyncDispose, async function() {
-  return promisify(this.close).call(this);
+  await promisify(this.close).call(this);
 });
 
 Server.prototype.closeAllConnections = function closeAllConnections() {

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -802,7 +802,7 @@ Socket.prototype[SymbolAsyncDispose] = async function() {
   if (!this[kStateSymbol].handle) {
     return;
   }
-  return FunctionPrototypeCall(promisify(this.close), this);
+  await FunctionPrototypeCall(promisify(this.close), this);
 };
 
 

--- a/lib/https.js
+++ b/lib/https.js
@@ -117,7 +117,7 @@ Server.prototype.close = function close() {
 };
 
 Server.prototype[SymbolAsyncDispose] = async function() {
-  return FunctionPrototypeCall(promisify(this.close), this);
+  await FunctionPrototypeCall(promisify(this.close), this);
 };
 
 /**

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -23,7 +23,10 @@ const {
 } = require('internal/errors');
 
 const { FSReqCallback } = binding;
-const internalUtil = require('internal/util');
+const {
+  assignFunctionName,
+  promisify,
+} = require('internal/util');
 const {
   getDirent,
   getOptions,
@@ -59,9 +62,9 @@ class Dir {
     validateUint32(this.#options.bufferSize, 'options.bufferSize', true);
 
     this.#readPromisified = FunctionPrototypeBind(
-      internalUtil.promisify(this.#readImpl), this, false);
+      promisify(this.#readImpl), this, false);
     this.#closePromisified = FunctionPrototypeBind(
-      internalUtil.promisify(this.close), this);
+      promisify(this.close), this);
   }
 
   get path() {
@@ -304,12 +307,16 @@ ObjectDefineProperties(Dir.prototype, {
   [SymbolDispose]: {
     __proto__: null,
     ...nonEnumerableDescriptor,
-    value: Dir.prototype.closeSync,
+    value: assignFunctionName(SymbolDispose, function() {
+      this.closeSync();
+    }),
   },
   [SymbolAsyncDispose]: {
     __proto__: null,
     ...nonEnumerableDescriptor,
-    value: Dir.prototype.close,
+    value: assignFunctionName(SymbolAsyncDispose, function() {
+      this.close();
+    }),
   },
   [SymbolAsyncIterator]: {
     __proto__: null,

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -273,7 +273,7 @@ class FileHandle extends EventEmitter {
   };
 
   async [SymbolAsyncDispose]() {
-    return this.close();
+    await this.close();
   }
 
   /**

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3319,7 +3319,7 @@ class Http2Server extends NETServer {
   }
 
   async [SymbolAsyncDispose]() {
-    return promisify(super.close).call(this);
+    await promisify(super.close).call(this);
   }
 }
 

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -51,7 +51,10 @@ const {
   validateString,
   validateUint32,
 } = require('internal/validators');
-const { kEmptyObject } = require('internal/util');
+const {
+  assignFunctionName,
+  kEmptyObject,
+} = require('internal/util');
 const {
   inspect,
   getStringWidth,
@@ -1637,7 +1640,9 @@ class Interface extends InterfaceConstructor {
     return this[kLineObjectStream];
   }
 }
-Interface.prototype[SymbolDispose] = Interface.prototype.close;
+Interface.prototype[SymbolDispose] = assignFunctionName(SymbolDispose, function() {
+  this.close();
+});
 
 module.exports = {
   Interface,

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -369,13 +369,13 @@ Readable.prototype[EE.captureRejectionSymbol] = function(err) {
   this.destroy(err);
 };
 
-Readable.prototype[SymbolAsyncDispose] = function() {
+Readable.prototype[SymbolAsyncDispose] = async function() {
   let error;
   if (!this.destroyed) {
     error = this.readableEnded ? null : new AbortError();
     this.destroy(error);
   }
-  return new Promise((resolve, reject) => eos(this, (err) => (err && err !== error ? reject(err) : resolve(null))));
+  await new Promise((resolve, reject) => eos(this, (err) => (err && err !== error ? reject(err) : resolve(null))));
 };
 
 // Manually shove something into the read() buffer.

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -1149,13 +1149,13 @@ Writable.toWeb = function(streamWritable) {
   return lazyWebStreams().newWritableStreamFromStreamWritable(streamWritable);
 };
 
-Writable.prototype[SymbolAsyncDispose] = function() {
+Writable.prototype[SymbolAsyncDispose] = async function() {
   let error;
   if (!this.destroyed) {
     error = this.writableFinished ? null : new AbortError();
     this.destroy(error);
   }
-  return new Promise((resolve, reject) =>
+  await new Promise((resolve, reject) =>
     eos(this, (err) => (err && err.name !== 'AbortError' ? reject(err) : resolve(null))),
   );
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -2395,7 +2395,7 @@ Server.prototype[SymbolAsyncDispose] = async function() {
   if (!this._handle) {
     return;
   }
-  return FunctionPrototypeCall(promisify(this.close), this);
+  await FunctionPrototypeCall(promisify(this.close), this);
 };
 
 Server.prototype._emitCloseIfDrained = function() {


### PR DESCRIPTION
This brings more consistency to `[Symbol.dispose]` and `[Symbol.asyncDispose]` functions across the core, and fulfills two things:

1. [The description of the `Disposable` Interface](https://github.com/tc39/proposal-explicit-resource-management?tab=readme-ov-file#the-disposable-interface) states that the function should return `undefined`. This PR removes `return`s that resolve with `null` or even pass the value returned by the named cleanup function.
2. The dispose function should explicitly appear in the stack trace, hence it should not be an alias to the named function.

Consider this snippet:
```mjs
import { opendir } from 'node:fs/promises';

{
  await using dir = await opendir('.');
  try {
    // lots of code
  } finally {
    await dir.close(); // line 8
  }
} // line 10
```

With this change, the thrown error looks like this:
```r
node:internal/fs/dir:238
        return PromiseReject(new ERR_DIR_CLOSED());
                             ^

Error [ERR_DIR_CLOSED]: Directory handle was closed
    at Dir.close (node:internal/fs/dir:238:30)
    at [Symbol.asyncDispose] (node:internal/fs/dir:318:12)
    at file:///tmp/test.mjs:8:5 {
  code: 'ERR_DIR_CLOSED'
}

Node.js v25.0.0-pre
```
Before this change, it looks like this:
```r
node:internal/fs/dir:235
        return PromiseReject(new ERR_DIR_CLOSED());
                             ^

Error [ERR_DIR_CLOSED]: Directory handle was closed
    at Dir.close (node:internal/fs/dir:235:30)
    at file:///tmp/test.mjs:8:5 {
  code: 'ERR_DIR_CLOSED'
}
```
Note that it points on the last code line before the block with `using` ends (which happens to be explicit `dir.close()`) rather than on the `}`, which makes the stack trace even more misleading.