### PR TITLE
doc: fix the order of the process API doc

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -982,6 +982,28 @@ $ bash -c 'exec -a customArgv0 ./node'
 'customArgv0'
 ```
 
+## `process.availableMemory()`
+
+<!-- YAML
+added:
+  - v22.0.0
+  - v20.13.0
+changes:
+  - version:
+    - v24.0.0
+    - v22.16.0
+    pr-url: https://github.com/nodejs/node/pull/57765
+    description: Change stability index for this feature from Experimental to Stable.
+-->
+
+* {number}
+
+Gets the amount of free memory that is still available to the process
+(in bytes).
+
+See [`uv_get_available_memory`][uv_get_available_memory] for more
+information.
+
 ## `process.channel`
 
 <!-- YAML
@@ -1155,28 +1177,6 @@ limits imposed by the OS. If there is no such constraint, or the constraint
 is unknown, `0` is returned.
 
 See [`uv_get_constrained_memory`][uv_get_constrained_memory] for more
-information.
-
-## `process.availableMemory()`
-
-<!-- YAML
-added:
-  - v22.0.0
-  - v20.13.0
-changes:
-  - version:
-    - v24.0.0
-    - v22.16.0
-    pr-url: https://github.com/nodejs/node/pull/57765
-    description: Change stability index for this feature from Experimental to Stable.
--->
-
-* {number}
-
-Gets the amount of free memory that is still available to the process
-(in bytes).
-
-See [`uv_get_available_memory`][uv_get_available_memory] for more
 information.
 
 ## `process.cpuUsage([previousValue])`

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1780,6 +1780,35 @@ that started the Node.js process. Symbolic links, if any, are resolved.
 '/usr/local/bin/node'
 ```
 
+## `process.execve(file[, args[, env]])`
+
+<!-- YAML
+added:
+  - v23.11.0
+  - v22.15.0
+-->
+
+> Stability: 1 - Experimental
+
+* `file` {string} The name or path of the executable file to run.
+* `args` {string\[]} List of string arguments. No argument can contain a null-byte (`\u0000`).
+* `env` {Object} Environment key-value pairs.
+  No key or value can contain a null-byte (`\u0000`).
+  **Default:** `process.env`.
+
+Replaces the current process with a new process.
+
+This is achieved by using the `execve` POSIX function and therefore no memory or other
+resources from the current process are preserved, except for the standard input,
+standard output and standard error file descriptor.
+
+All other resources are discarded by the system when the processes are swapped, without triggering
+any exit or close events and without running any cleanup handler.
+
+This function will never return, unless an error occurred.
+
+This function is not available on Windows or IBM i.
+
 ## `process.exit([code])`
 
 <!-- YAML
@@ -3359,35 +3388,6 @@ tarball.
 In custom builds from non-release versions of the source tree, only the
 `name` property may be present. The additional properties should not be
 relied upon to exist.
-
-## `process.execve(file[, args[, env]])`
-
-<!-- YAML
-added:
-  - v23.11.0
-  - v22.15.0
--->
-
-> Stability: 1 - Experimental
-
-* `file` {string} The name or path of the executable file to run.
-* `args` {string\[]} List of string arguments. No argument can contain a null-byte (`\u0000`).
-* `env` {Object} Environment key-value pairs.
-  No key or value can contain a null-byte (`\u0000`).
-  **Default:** `process.env`.
-
-Replaces the current process with a new process.
-
-This is achieved by using the `execve` POSIX function and therefore no memory or other
-resources from the current process are preserved, except for the standard input,
-standard output and standard error file descriptor.
-
-All other resources are discarded by the system when the processes are swapped, without triggering
-any exit or close events and without running any cleanup handler.
-
-This function will never return, unless an error occurred.
-
-This function is not available on Windows or IBM i.
 
 ## `process.report`
 


### PR DESCRIPTION
This PR fixes the order of functions in the `process` API documentation. 
Specifically, it moves the documentation of `availableMemory` and `execve` to the right place, so the functions documented in this document are ordered alphabetically.

Fixes: https://github.com/nodejs/node/issues/58402

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
