### PR TITLE
dns: fix dns query cache implementation

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -879,9 +879,9 @@ void ChannelWrap::Setup() {
   }
 
   /* We do the call to ares_init_option for caller. */
-  const int optmask =
-      ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS |
-      ARES_OPT_SOCK_STATE_CB | ARES_OPT_TRIES;
+  const int optmask = ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS |
+                      ARES_OPT_SOCK_STATE_CB | ARES_OPT_TRIES |
+                      ARES_OPT_QUERY_CACHE;
   r = ares_init_options(&channel_, &options, optmask);
 
   if (r != ARES_SUCCESS) {

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -415,7 +415,7 @@ assert.throws(() => {
         (answer) => Object.assign({ domain }, answer)
       ),
     }), port, address);
-  }, cases.length * 2 - 1));
+  }, cases.length * 2));
 
   server.bind(0, common.mustCall(() => {
     const address = server.address();


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/57640

It turns out #57640 was incomplete and I missed including this option mask flag. Thank you to @augjoh for [pointing this out](https://github.com/nodejs/node/issues/57641#issuecomment-2888235890). 