### PR TITLE
buffer: implement native C++ fast-path for Buffer.concat

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -58,6 +58,7 @@ const {
   byteLengthUtf8,
   compare: _compare,
   compareOffset,
+  concatNative,
   copy: _copy,
   fill: bindingFill,
   isAscii: bindingIsAscii,
@@ -570,18 +571,30 @@ Buffer.concat = function concat(list, length) {
   if (list.length === 0)
     return new FastBuffer();
 
-  if (length === undefined) {
-    length = 0;
-    for (let i = 0; i < list.length; i++) {
-      if (list[i].length) {
-        length += list[i].length;
-      }
+  let totalLen = length;
+  if (totalLen === undefined) {
+    totalLen = 0;
+    for (const buf of list) {
+      if (buf.length) totalLen += buf.length;
     }
   } else {
-    validateOffset(length, 'length');
+    validateOffset(totalLen, 'length');
   }
 
-  const buffer = Buffer.allocUnsafe(length);
+  let allValid = true;
+  for (let i = 0; i < list.length; i++) {
+    if (!isUint8Array(list[i])) {
+      allValid = false;
+      break;
+    }
+  }
+  if (allValid) {
+    return concatNative(list, totalLen);
+  }
+
+  // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
+  // Instead, find the proper error code for this.
+  const buffer = Buffer.allocUnsafe(totalLen);
   let pos = 0;
   for (let i = 0; i < list.length; i++) {
     const buf = list[i];
@@ -589,7 +602,7 @@ Buffer.concat = function concat(list, length) {
       // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
       // Instead, find the proper error code for this.
       throw new ERR_INVALID_ARG_TYPE(
-        `list[${i}]`, ['Buffer', 'Uint8Array'], list[i]);
+        `list[${i}]`, ['Buffer', 'Uint8Array'], buf);
     }
     pos += _copyActual(buf, buffer, pos, 0, buf.length);
   }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1512,12 +1512,11 @@ void ConcatNative(const FunctionCallbackInfo<Value>& args) {
 
   if (!args[0]->IsArray()) {
     isolate->ThrowException(Exception::TypeError(
-      v8::String::NewFromUtf8(
-        isolate,
-        "First argument must be an Array of Buffer or Uint8Array",
-        v8::NewStringType::kNormal
-      ).ToLocalChecked()
-    ));
+        v8::String::NewFromUtf8(
+            isolate,
+            "First argument must be an Array of Buffer or Uint8Array",
+            v8::NewStringType::kNormal)
+            .ToLocalChecked()));
     return;
   }
   Local<Array> list = args[0].As<Array>();
@@ -1546,12 +1545,9 @@ void ConcatNative(const FunctionCallbackInfo<Value>& args) {
       std::string msg = "Element at index " + std::to_string(i) +
                         " is not a Buffer or Uint8Array";
       isolate->ThrowException(Exception::TypeError(
-        v8::String::NewFromUtf8(
-          isolate,
-          msg.c_str(),
-          v8::NewStringType::kNormal
-        ).ToLocalChecked()
-      ));
+          v8::String::NewFromUtf8(
+              isolate, msg.c_str(), v8::NewStringType::kNormal)
+              .ToLocalChecked()));
       return;
     }
     Local<Object> obj = v.As<Object>();

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -55,6 +55,7 @@
 namespace node {
 namespace Buffer {
 
+using v8::Array;
 using v8::ArrayBuffer;
 using v8::ArrayBufferView;
 using v8::BackingStore;
@@ -62,6 +63,7 @@ using v8::BackingStoreInitializationMode;
 using v8::CFunction;
 using v8::Context;
 using v8::EscapableHandleScope;
+using v8::Exception;
 using v8::FastApiCallbackOptions;
 using v8::FastOneByteString;
 using v8::FunctionCallbackInfo;
@@ -83,8 +85,6 @@ using v8::Uint32;
 using v8::Uint32Array;
 using v8::Uint8Array;
 using v8::Value;
-using v8::Array;
-using v8::Exception;
 
 
 namespace {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -86,7 +86,6 @@ using v8::Uint32Array;
 using v8::Uint8Array;
 using v8::Value;
 
-
 namespace {
 
 class CallbackInfo : public Cleanable {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1509,15 +1509,15 @@ void SlowWriteString(const FunctionCallbackInfo<Value>& args) {
 void ConcatNative(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Context> ctx = isolate->GetCurrentContext();
-  Environment* env = Environment::GetCurrent(args);
 
   if (!args[0]->IsArray()) {
     isolate->ThrowException(Exception::TypeError(
-        v8::String::NewFromUtf8(
-            isolate,
-            "First argument must be an Array of Buffer or Uint8Array",
-            v8::NewStringType::kNormal)
-            .ToLocalChecked()));
+      v8::String::NewFromUtf8(
+        isolate,
+        "First argument must be an Array of Buffer or Uint8Array",
+        v8::NewStringType::kNormal
+      ).ToLocalChecked()
+    ));
     return;
   }
   Local<Array> list = args[0].As<Array>();
@@ -1546,9 +1546,12 @@ void ConcatNative(const FunctionCallbackInfo<Value>& args) {
       std::string msg = "Element at index " + std::to_string(i) +
                         " is not a Buffer or Uint8Array";
       isolate->ThrowException(Exception::TypeError(
-          v8::String::NewFromUtf8(
-              isolate, msg.c_str(), v8::NewStringType::kNormal)
-              .ToLocalChecked()));
+        v8::String::NewFromUtf8(
+          isolate,
+          msg.c_str(),
+          v8::NewStringType::kNormal
+        ).ToLocalChecked()
+      ));
       return;
     }
     Local<Object> obj = v.As<Object>();


### PR DESCRIPTION
added fast path for ```Buffer.concat```

node-main benchmark result:
```
                                                                            confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-concat-fill.js n=800000 extraSize=1                                 ***    -62.84 %       ±2.39% ±3.21% ±4.26%
buffers/buffer-concat-fill.js n=800000 extraSize=1024                              ***    -56.12 %       ±2.62% ±3.52% ±4.65%
buffers/buffer-concat-fill.js n=800000 extraSize=256                               ***    -60.57 %       ±2.27% ±3.05% ±4.03%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=16          ***    -55.03 %       ±0.70% ±0.93% ±1.21%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=4           ***    -81.81 %       ±2.59% ±3.49% ±4.63%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=16         ***    -52.95 %       ±2.28% ±3.07% ±4.04%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=4          ***    -80.98 %       ±0.63% ±0.84% ±1.10%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=16        ***    -20.61 %       ±2.81% ±3.77% ±4.97%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=4         ***    -71.75 %       ±1.50% ±2.02% ±2.66%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=16          ***    -55.56 %       ±1.07% ±1.43% ±1.86%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=4           ***    -81.98 %       ±1.25% ±1.68% ±2.23%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=16         ***    -54.23 %       ±1.08% ±1.44% ±1.87%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=4          ***    -80.96 %       ±1.68% ±2.26% ±2.99%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=16        ***    -18.87 %       ±2.88% ±3.86% ±5.09%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=4         ***    -71.40 %       ±2.44% ±3.29% ±4.36%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 15 comparisons, you can thus expect the following amount of false-positive results:
  0.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.15 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```