### PR TITLE
doc: remove remaining uses of `@@wellknown` syntax

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1040,7 +1040,7 @@ Returns an ES6 `Iterator` over each of the name-value pairs in the query.
 Each item of the iterator is a JavaScript `Array`. The first item of the `Array`
 is the `name`, the second item of the `Array` is the `value`.
 
-Alias for [`urlSearchParams[@@iterator]()`][`urlSearchParams@@iterator()`].
+Alias for [`urlSearchParams[Symbol.iterator]()`][`urlSearchParamsSymbol.iterator()`].
 
 #### `urlSearchParams.forEach(fn[, thisArg])`
 
@@ -1965,7 +1965,7 @@ console.log(myURL.origin);
 [`url.toJSON()`]: #urltojson
 [`url.toString()`]: #urltostring
 [`urlSearchParams.entries()`]: #urlsearchparamsentries
-[`urlSearchParams@@iterator()`]: #urlsearchparamssymboliterator
+[`urlSearchParamsSymbol.iterator()`]: #urlsearchparamssymboliterator
 [converted to a string]: https://tc39.es/ecma262/#sec-tostring
 [examples of parsed URLs]: https://url.spec.whatwg.org/#example-url-parsing
 [host name spoofing]: https://hackerone.com/reports/678487

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -973,8 +973,8 @@ The `util.inspect()` method returns a string representation of `object` that is
 intended for debugging. The output of `util.inspect` may change at any time
 and should not be depended upon programmatically. Additional `options` may be
 passed that alter the result.
-`util.inspect()` will use the constructor's name and/or `@@toStringTag` to make
-an identifiable tag for an inspected value.
+`util.inspect()` will use the constructor's name and/or `Symbol.toStringTag`
+property to make an identifiable tag for an inspected value.
 
 ```js
 class Foo {
@@ -1884,7 +1884,7 @@ console.log(params.toString());
 
 Returns an iterator over the values of each name-value pair.
 
-### `mimeParams[@@iterator]()`
+### `mimeParams[Symbol.iterator]()`
 
 * Returns: {Iterator}
 

--- a/doc/contributing/primordials.md
+++ b/doc/contributing/primordials.md
@@ -161,8 +161,9 @@ This code is internally expanded into something that looks like:
 
 ```js
 {
-  // 1. Lookup @@iterator property on `array` (user-mutable if user-provided).
-  // 2. Lookup @@iterator property on %Array.prototype% (user-mutable).
+  // 1. Lookup %Symbol.iterator% property on `array` (user-mutable if
+  //    user-provided).
+  // 2. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
   // 3. Call that function.
   const iterator = array[Symbol.iterator]();
   // 1. Lookup `next` property on `iterator` (doesn't exist).
@@ -226,8 +227,9 @@ const [first, second] = array;
 This is roughly equivalent to:
 
 ```js
-// 1. Lookup @@iterator property on `array` (user-mutable if user-provided).
-// 2. Lookup @@iterator property on %Array.prototype% (user-mutable).
+// 1. Lookup %Symbol.iterator% property on `array` (user-mutable if
+//    user-provided).
+// 2. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
 // 3. Call that function.
 const iterator = array[Symbol.iterator]();
 // 1. Lookup `next` property on `iterator` (doesn't exist).
@@ -262,8 +264,9 @@ best choice.
 <summary>Avoid spread operator on arrays</summary>
 
 ```js
-// 1. Lookup @@iterator property on `array` (user-mutable if user-provided).
-// 2. Lookup @@iterator property on %Array.prototype% (user-mutable).
+// 1. Lookup %Symbol.iterator% property on `array` (user-mutable if
+//    user-provided).
+// 2. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
 // 3. Lookup `next` property on %ArrayIteratorPrototype% (user-mutable).
 const arrayCopy = [...array];
 func(...array);
@@ -281,17 +284,17 @@ ReflectApply(func, null, array);
 <details>
 
 <summary><code>%Array.prototype.concat%</code> looks up
-         <code>@@isConcatSpreadable</code> property of the passed
-         arguments and the <code>this</code> value.</summary>
+         <code>%Symbol.isConcatSpreadable%</code> property of the passed
+         arguments and the <code>this</code> value</summary>
 
 ```js
 {
   // Unsafe code example:
-  // 1. Lookup @@isConcatSpreadable property on `array` (user-mutable if
-  //    user-provided).
-  // 2. Lookup @@isConcatSpreadable property on `%Array.prototype%
+  // 1. Lookup %Symbol.isConcatSpreadable% property on `array`
+  //    (user-mutable if user-provided).
+  // 2. Lookup %Symbol.isConcatSpreadable% property on `%Array.prototype%
   //    (user-mutable).
-  // 2. Lookup @@isConcatSpreadable property on `%Object.prototype%
+  // 2. Lookup %Symbol.isConcatSpreadable% property on `%Object.prototype%
   //    (user-mutable).
   const array = [];
   ArrayPrototypeConcat(array);
@@ -340,8 +343,9 @@ Object.defineProperty(Object.prototype, Symbol.isConcatSpreadable, {
 ```js
 {
   // Unsafe code example:
-  // 1. Lookup @@iterator property on `array` (user-mutable if user-provided).
-  // 2. Lookup @@iterator property on %Array.prototype% (user-mutable).
+  // 1. Lookup %Symbol.iterator% property on `array` (user-mutable if
+  //    user-provided).
+  // 2. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
   // 3. Lookup `next` property on %ArrayIteratorPrototype% (user-mutable).
   const obj = ObjectFromEntries(array);
 }
@@ -371,8 +375,9 @@ Object.defineProperty(Object.prototype, Symbol.isConcatSpreadable, {
          <code>%Promise.race%</code> iterate over an array</summary>
 
 ```js
-// 1. Lookup @@iterator property on `array` (user-mutable if user-provided).
-// 2. Lookup @@iterator property on %Array.prototype% (user-mutable).
+// 1. Lookup %Symbol.iterator% property on `array` (user-mutable if
+//    user-provided).
+// 2. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
 // 3. Lookup `next` property on %ArrayIteratorPrototype% (user-mutable).
 // 4. Lookup `then` property on %Array.Prototype% (user-mutable).
 // 5. Lookup `then` property on %Object.Prototype% (user-mutable).
@@ -437,7 +442,7 @@ Array.prototype[Symbol.iterator] = () => ({
 
 // Core
 
-// 1. Lookup @@iterator property on %Array.prototype% (user-mutable).
+// 1. Lookup %Symbol.iterator% property on %Array.prototype% (user-mutable).
 // 2. Lookup `next` property on %ArrayIteratorPrototype% (user-mutable).
 const set = new SafeSet([1, 2, 3]);
 
@@ -684,14 +689,14 @@ can be reset from user-land.
 <summary>List of <code>RegExp</code> methods that look up properties from
          mutable getters</summary>
 
-| `RegExp` method                | looks up the following flag-related properties                     |
-| ------------------------------ | ------------------------------------------------------------------ |
-| `get RegExp.prototype.flags`   | `global`, `ignoreCase`, `multiline`, `dotAll`, `unicode`, `sticky` |
-| `RegExp.prototype[@@match]`    | `global`, `unicode`                                                |
-| `RegExp.prototype[@@matchAll]` | `flags`                                                            |
-| `RegExp.prototype[@@replace]`  | `global`, `unicode`                                                |
-| `RegExp.prototype[@@split]`    | `flags`                                                            |
-| `RegExp.prototype.toString`    | `flags`                                                            |
+| `RegExp` method                     | looks up the following flag-related properties                     |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| `get RegExp.prototype.flags`        | `global`, `ignoreCase`, `multiline`, `dotAll`, `unicode`, `sticky` |
+| `RegExp.prototype[Symbol.match]`    | `global`, `unicode`                                                |
+| `RegExp.prototype[Symbol.matchAll]` | `flags`                                                            |
+| `RegExp.prototype[Symbol.replace]`  | `global`, `unicode`                                                |
+| `RegExp.prototype[Symbol.split]`    | `flags`                                                            |
+| `RegExp.prototype.toString`         | `flags`                                                            |
 
 </details>
 
@@ -786,7 +791,7 @@ console.log(proxyWithNullPrototypeObject.someProperty); // genuine value
 
 ### Checking if an object is an instance of a class
 
-#### Using `instanceof` looks up the `@@hasInstance` property of the class
+#### Using `instanceof` looks up the `%Symbol.hasInstance%` property of the class
 
 ```js
 // User-land


### PR DESCRIPTION
The use of `@@` to describe well-known symbols in ecma-262 is now historical. This patch removes the last few uses within the docs.