### PR TITLE
test: fix missing edge case in test-blob-slice-with-large-size

### DIFF
--- a/test/pummel/test-blob-slice-with-large-size.js
+++ b/test/pummel/test-blob-slice-with-large-size.js
@@ -1,4 +1,7 @@
 'use strict';
+
+// This tests that Blob.prototype.slice() works correctly when the size of the
+// Blob is outside the range of 32-bit signed integers.
 const common = require('../common');
 
 // Buffer with size > INT32_MAX
@@ -14,8 +17,11 @@ try {
   const slicedBlob = blob.slice(size - 1, size);
   assert.strictEqual(slicedBlob.size, 1);
 } catch (e) {
-  if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
-    throw e;
+  if (e.code === 'ERR_MEMORY_ALLOCATION_FAILED') {
+    common.skip('insufficient space for Buffer.allocUnsafe');
   }
-  common.skip('insufficient space for Buffer.allocUnsafe');
+  if (/Array buffer allocation failed/.test(e.message)) {
+    common.skip('insufficient space for Blob.prototype.slice()');
+  }
+  throw e;
 }


### PR DESCRIPTION
The test only cares about whether a size outside the range of the 32-bit signed integers works with Blob.prototype.slice(). If it fails due to allocation failure when the system does not have enough memory, the test should just be skipped. The test previously only skipped the test when the allocation failure happens during allocation of the buffer source, but it could also happen during Blob.prototype.slice().

Fixes: https://github.com/nodejs/node/issues/57235

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
