### PR TITLE
test: skip in test-buffer-tostring-rangeerror on allocation failure

### DIFF
--- a/test/parallel/test-buffer-tostring-rangeerror.js
+++ b/test/parallel/test-buffer-tostring-rangeerror.js
@@ -23,8 +23,22 @@ const message = {
   code: 'ERR_STRING_TOO_LONG',
   name: 'Error',
 };
-assert.throws(() => Buffer(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);
-assert.throws(() => Buffer.alloc(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafe(len).toString('utf8'), message);
-assert.throws(() => Buffer.allocUnsafeSlow(len).toString('utf8'), message);
+
+function test(getBuffer) {
+  let buf;
+  try {
+    buf = getBuffer();
+  } catch (e) {
+    // If the buffer allocation fails, we skip the test.
+    if (e.code === 'ERR_MEMORY_ALLOCATION_FAILED' || /Array buffer allocation failed/.test(e.message)) {
+      return;
+    }
+  }
+  assert.throws(() => { buf.toString('utf8'); }, message);
+}
+
+test(() => Buffer(len));
+test(() => Buffer.allocUnsafeSlow(len));
+test(() => Buffer.alloc(len));
+test(() => Buffer.allocUnsafe(len));
+test(() => Buffer.allocUnsafeSlow(len));


### PR DESCRIPTION
If the buffer allocation fails due to insufficient memory, there is no point continue testing toString().

https://github.com/nodejs/node/pull/58142 is not sufficient to skip the test because `require('os').totalmem()` > 1.75GB is not sufficient to safe guard from allocation failure. It's better to directly skip on a case-by-case basis.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
