### PR TITLE
test: fix test-buffer-tostring-range on allocation failure

### DIFF
--- a/test/parallel/test-buffer-tostring-4gb.js
+++ b/test/parallel/test-buffer-tostring-4gb.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// This tests that Buffer.prototype.toString() works with buffers over 4GB.
+const common = require('../common');
+
+// Must not throw when start and end are within kMaxLength
+// Cannot test on 32bit machine as we are testing the case
+// when start and end are above the threshold
+common.skipIf32Bits();
+const threshold = 0xFFFFFFFF; // 2^32 - 1
+let largeBuffer;
+try {
+  largeBuffer = Buffer.alloc(threshold + 20);
+} catch (e) {
+  if (e.code === 'ERR_MEMORY_ALLOCATION_FAILED' || /Array buffer allocation failed/.test(e.message)) {
+    common.skip('insufficient space for Buffer.alloc');
+  }
+  throw e;
+}
+largeBuffer.toString('utf8', threshold, threshold + 20);

--- a/test/parallel/test-buffer-tostring-range.js
+++ b/test/parallel/test-buffer-tostring-range.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const rangeBuffer = Buffer.from('abc');
@@ -98,11 +98,3 @@ assert.throws(() => {
   name: 'TypeError',
   message: 'Unknown encoding: null'
 });
-
-// Must not throw when start and end are within kMaxLength
-// Cannot test on 32bit machine as we are testing the case
-// when start and end are above the threshold
-common.skipIf32Bits();
-const threshold = 0xFFFFFFFF;
-const largeBuffer = Buffer.alloc(threshold + 20);
-largeBuffer.toString('utf8', threshold, threshold + 20);


### PR DESCRIPTION
If the test cannot allocate a buffer over 4GB, there is no point continue testing toString() on it.

This also split the test case to a different file for clarity and reduce interference with other cases.

Fixes: https://github.com/nodejs/node/issues/56726
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
