### PR TITLE
test: leverage process.features.openssl_is_boringssl in test

### DIFF
--- a/test/parallel/test-crypto-x509.js
+++ b/test/parallel/test-crypto-x509.js
@@ -97,8 +97,6 @@ const der = Buffer.from(
   assert.strictEqual(x509.infoAccess, infoAccessCheck);
   assert.strictEqual(x509.validFrom, 'Sep  3 21:40:37 2022 GMT');
   assert.strictEqual(x509.validTo, 'Jun 17 21:40:37 2296 GMT');
-  assert.deepStrictEqual(x509.validFromDate, new Date('2022-09-03T21:40:37Z'));
-  assert.deepStrictEqual(x509.validToDate, new Date('2296-06-17T21:40:37Z'));
   assert.strictEqual(
     x509.fingerprint,
     '8B:89:16:C4:99:87:D2:13:1A:64:94:36:38:A5:32:01:F0:95:3B:53');
@@ -117,6 +115,11 @@ const der = Buffer.from(
   assert.strictEqual(x509.serialNumber.toUpperCase(), '147D36C1C2F74206DE9FAB5F2226D78ADB00A426');
 
   assert.deepStrictEqual(x509.raw, der);
+
+  if (!process.features.openssl_is_boringssl) {
+    assert.deepStrictEqual(x509.validFromDate, new Date('2022-09-03T21:40:37Z'));
+    assert.deepStrictEqual(x509.validToDate, new Date('2296-06-17T21:40:37Z'));
+  }
 
   assert(x509.publicKey);
   assert.strictEqual(x509.publicKey.type, 'public');
@@ -356,13 +359,15 @@ tAt3hIKFD1bJt6c6WtMH2Su3syosWxmdmGk5ihslB00lvLpfj/wed8i3bkcB1doq
 UcXd/5qu2GhokrKU2cPttU+XAN2Om6a0
 -----END CERTIFICATE-----`;
 
-  const cert = new X509Certificate(certPem);
-  assert.throws(() => cert.publicKey, {
-    message: hasOpenSSL3 ? /decode error/ : /wrong tag/,
-    name: 'Error'
-  });
+  if (!process.features.openssl_is_boringssl) {
+    const cert = new X509Certificate(certPem);
+    assert.throws(() => cert.publicKey, {
+      message: hasOpenSSL3 ? /decode error/ : /wrong tag/,
+      name: 'Error'
+    });
 
-  assert.strictEqual(cert.checkIssued(cert), false);
+    assert.strictEqual(cert.checkIssued(cert), false);
+  }
 }
 
 {
@@ -401,8 +406,10 @@ UidvpWWipVLZgK+oDks+bKTobcoXGW9oXobiIYqslXPy
 -----END CERTIFICATE-----`.trim();
   const c1 = new X509Certificate(certPemUTCTime);
 
-  assert.deepStrictEqual(c1.validFromDate, new Date('1949-12-25T23:59:58Z'));
-  assert.deepStrictEqual(c1.validToDate, new Date('1950-01-01T23:59:58Z'));
+  if (!process.features.openssl_is_boringssl) {
+    assert.deepStrictEqual(c1.validFromDate, new Date('1949-12-25T23:59:58Z'));
+    assert.deepStrictEqual(c1.validToDate, new Date('1950-01-01T23:59:58Z'));
+  }
 
   // The GeneralizedTime format is used for dates in 2050 or later.
   const certPemGeneralizedTime = `-----BEGIN CERTIFICATE-----
@@ -436,6 +443,8 @@ CWwQO8JZjJqFtqtuzy2n+gLCvqePgG/gmSqHOPm2ZbLW
 -----END CERTIFICATE-----`.trim();
   const c2 = new X509Certificate(certPemGeneralizedTime);
 
-  assert.deepStrictEqual(c2.validFromDate, new Date('2049-12-26T00:00:01Z'));
-  assert.deepStrictEqual(c2.validToDate, new Date('2050-01-02T00:00:01Z'));
+  if (!process.features.openssl_is_boringssl) {
+    assert.deepStrictEqual(c2.validFromDate, new Date('2049-12-26T00:00:01Z'));
+    assert.deepStrictEqual(c2.validToDate, new Date('2050-01-02T00:00:01Z'));
+  }
 }

--- a/test/parallel/test-https-agent-additional-options.js
+++ b/test/parallel/test-https-agent-additional-options.js
@@ -13,8 +13,11 @@ const options = {
   cert: fixtures.readKey('agent1-cert.pem'),
   ca: fixtures.readKey('ca1-cert.pem'),
   minVersion: 'TLSv1.1',
-  ciphers: 'ALL@SECLEVEL=0'
 };
+
+if (!process.features.openssl_is_boringssl) {
+  options.ciphers = 'ALL@SECLEVEL=0';
+}
 
 const server = https.Server(options, (req, res) => {
   res.writeHead(200);
@@ -22,14 +25,19 @@ const server = https.Server(options, (req, res) => {
 });
 
 function getBaseOptions(port) {
-  return {
+  const baseOptions = {
     path: '/',
     port: port,
     ca: options.ca,
     rejectUnauthorized: true,
     servername: 'agent1',
-    ciphers: 'ALL@SECLEVEL=0'
   };
+
+  if (!process.features.openssl_is_boringssl) {
+    baseOptions.ciphers = 'ALL@SECLEVEL=0';
+  }
+
+  return baseOptions;
 }
 
 const updatedValues = new Map([

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -17,8 +17,11 @@ const options = {
   key: readKey('agent1-key.pem'),
   cert: readKey('agent1-cert.pem'),
   secureOptions: SSL_OP_NO_TICKET,
-  ciphers: 'RSA@SECLEVEL=0'
 };
+
+if (!process.features.openssl_is_boringssl) {
+  options.ciphers = 'RSA@SECLEVEL=0';
+}
 
 // Create TLS1.2 server
 https.createServer(options, function(req, res) {

--- a/test/parallel/test-webcrypto-derivebits.js
+++ b/test/parallel/test-webcrypto-derivebits.js
@@ -123,6 +123,8 @@ const { subtle } = globalThis.crypto;
     assert.deepStrictEqual(secret1, secret2);
   }
 
-  test('X25519').then(common.mustCall());
-  test('X448').then(common.mustCall());
+  if (!process.features.openssl_is_boringssl) {
+    test('X25519').then(common.mustCall());
+    test('X448').then(common.mustCall());
+  }
 }

--- a/test/parallel/test-webcrypto-derivekey.js
+++ b/test/parallel/test-webcrypto-derivekey.js
@@ -206,6 +206,8 @@ const { KeyObject } = require('crypto');
     assert.deepStrictEqual(raw1, raw2);
   }
 
-  test('X25519').then(common.mustCall());
-  test('X448').then(common.mustCall());
+  if (!process.features.openssl_is_boringssl) {
+    test('X25519').then(common.mustCall());
+    test('X448').then(common.mustCall());
+  }
 }

--- a/test/parallel/test-webcrypto-sign-verify.js
+++ b/test/parallel/test-webcrypto-sign-verify.js
@@ -121,8 +121,9 @@ const { subtle } = globalThis.crypto;
       name: 'Ed25519',
     }, publicKey, signature, ec.encode(data)));
   }
-
-  test('hello world').then(common.mustCall());
+  if (!process.features.openssl_is_boringssl) {
+    test('hello world').then(common.mustCall());
+  }
 }
 
 // Test Sign/Verify Ed448
@@ -142,5 +143,7 @@ const { subtle } = globalThis.crypto;
     }, publicKey, signature, ec.encode(data)));
   }
 
-  test('hello world').then(common.mustCall());
+  if (!process.features.openssl_is_boringssl) {
+    test('hello world').then(common.mustCall());
+  }
 }


### PR DESCRIPTION
Follow up to https://github.com/nodejs/node/pull/58387 - Adapt some tests to let us remove patch surface.

See [our patch](https://github.com/electron/electron/blob/7cc76c094a38e350045c1346bfe8ce6ebf6f1c44/patches/node/fix_crypto_tests_to_run_with_bssl.patch)
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
