### PR TITLE
sqlite: handle thrown errors in result callback

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -373,7 +373,10 @@ class CustomAggregate {
       result = Local<Value>::New(isolate, agg->value);
     }
 
-    JSValueToSQLiteResult(isolate, ctx, result);
+    if (!result.IsEmpty()) {
+      JSValueToSQLiteResult(isolate, ctx, result);
+    }
+
     if (is_final) {
       DestroyAggregateData(ctx);
     }

--- a/test/parallel/test-sqlite-aggregate-function.mjs
+++ b/test/parallel/test-sqlite-aggregate-function.mjs
@@ -309,6 +309,27 @@ describe('step', () => {
 });
 
 describe('result', () => {
+  test('throws if result throws an error', (t) => {
+    const db = new DatabaseSync(':memory:');
+    t.after(() => db.close());
+    db.exec('CREATE TABLE data (value INTEGER)');
+    db.exec('INSERT INTO data VALUES (1), (2), (3)');
+    db.aggregate('sum_int', {
+      start: 0,
+      step: (acc, value) => {
+        return acc + value;
+      },
+      result: () => {
+        throw new Error('result error');
+      },
+    });
+    t.assert.throws(() => {
+      db.prepare('SELECT sum_int(value) as result FROM data').get();
+    }, {
+      message: 'result error'
+    });
+  });
+
   test('executes once when options.inverse is not present', (t) => {
     const db = new DatabaseSync(':memory:');
     t.after(() => db.close());


### PR DESCRIPTION
This commit updates the aggregate function 'result' callback handling to not crash when an exception is thrown.

Fixes: https://github.com/nodejs/node/issues/58425

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
