### PR TITLE
deps: update OpenSSL gen container to Ubuntu 22.04

### DIFF
--- a/deps/openssl/config/Dockerfile
+++ b/deps/openssl/config/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 VOLUME /node
 


### PR DESCRIPTION
`make gen-openssl` generates the same assembly files on my computer.
