### PR TITLE
util: add 'none' style to styleText

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2408,6 +2408,9 @@ added:
   - v21.7.0
   - v20.12.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58437
+    description: Added the `'none'` format as a non-op format.
   - version:
     - v23.5.0
     - v22.13.0
@@ -2482,6 +2485,8 @@ console.log(
   util.styleText(['red', 'green'], 'text'), // green
 );
 ```
+
+The special format value `none` applies no additional styling to the text.
 
 The full list of formats can be found in [modifiers][].
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,10 +100,11 @@ function lazyAbortController() {
 let internalDeepEqual;
 
 /**
- * @param {string} code
+ * @param {string} [code]
  * @returns {string}
  */
 function escapeStyleCode(code) {
+  if (code === undefined) return '';
   return `\u001b[${code}m`;
 }
 
@@ -139,6 +140,7 @@ function styleText(format, text, { validateStream = true, stream = process.stdou
   let left = '';
   let right = '';
   for (const key of formatArray) {
+    if (key === 'none') continue;
     const formatCodes = inspect.colors[key];
     // If the format is not a valid style, throw an error
     if (formatCodes == null) {

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -75,6 +75,8 @@ assert.strictEqual(
   styled,
 );
 
+assert.strictEqual(util.styleText('none', 'test'), 'test');
+
 const fd = common.getTTYfd();
 if (fd !== -1) {
   const writeStream = new WriteStream(fd);


### PR DESCRIPTION
For cases where the style is not needed but code still calls styleText unconditionally, this adds a `none` style that not not apply any styling to the text.
