### PR TITLE
dns: set timeout to 1000ms when timeout <= 0

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -902,8 +902,7 @@ void ChannelWrap::StartTimer() {
     return;
   }
   int timeout = timeout_;
-  if (timeout == 0) timeout = 1;
-  if (timeout < 0 || timeout > 1000) timeout = 1000;
+  if (timeout <= 0 || timeout > 1000) timeout = 1000;
   uv_timer_start(timer_handle_, AresTimeout, timeout, timeout);
 }
 


### PR DESCRIPTION
c-ares set `timeout` to  DEFAULT_TIMEOUT(2000ms) When timeout is <= 0, so we should schedule timer every 1000ms.
```c
if (optmask & ARES_OPT_TIMEOUTMS) {
    /* Apparently some integrations were passing -1 to tell c-ares to use
     * the default instead of just omitting the optmask */
    if (options->timeout <= 0) {
      optmask &= ~(ARES_OPT_TIMEOUTMS);
    } else {
      channel->timeout = (unsigned int)options->timeout;
    }
}

if (channel->timeout == 0) {
  channel->timeout = DEFAULT_TIMEOUT;
}
```
cc @jasnell 
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
