### PR TITLE
Slightly improve module deprecation warnings

### DIFF
--- a/lib/_stream_duplex.js
+++ b/lib/_stream_duplex.js
@@ -2,5 +2,5 @@
 
 module.exports = require('stream').Duplex;
 
-process.emitWarning('The _stream_duplex module is deprecated.',
+process.emitWarning('The _stream_duplex module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0193');

--- a/lib/_stream_passthrough.js
+++ b/lib/_stream_passthrough.js
@@ -2,5 +2,5 @@
 
 module.exports = require('stream').PassThrough;
 
-process.emitWarning('The _stream_passthrough module is deprecated.',
+process.emitWarning('The _stream_passthrough module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0193');

--- a/lib/_stream_readable.js
+++ b/lib/_stream_readable.js
@@ -2,5 +2,5 @@
 
 module.exports = require('stream').Readable;
 
-process.emitWarning('The _stream_readable module is deprecated.',
+process.emitWarning('The _stream_readable module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0193');

--- a/lib/_stream_transform.js
+++ b/lib/_stream_transform.js
@@ -2,5 +2,5 @@
 
 module.exports = require('stream').Transform;
 
-process.emitWarning('The _stream_transform module is deprecated.',
+process.emitWarning('The _stream_transform module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0193');

--- a/lib/_stream_wrap.js
+++ b/lib/_stream_wrap.js
@@ -2,5 +2,5 @@
 
 module.exports = require('internal/js_stream_socket');
 
-process.emitWarning('The _stream_wrap module is deprecated.',
+process.emitWarning('The _stream_wrap module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0125');

--- a/lib/_stream_writable.js
+++ b/lib/_stream_writable.js
@@ -2,5 +2,5 @@
 
 module.exports = require('stream').Writable;
 
-process.emitWarning('The _stream_writable module is deprecated.',
+process.emitWarning('The _stream_writable module is deprecated. Use `node:stream` instead.',
                     'DeprecationWarning', 'DEP0193');

--- a/lib/_tls_common.js
+++ b/lib/_tls_common.js
@@ -6,5 +6,5 @@ module.exports = {
   createSecureContext,
   translatePeerCertificate,
 };
-process.emitWarning('The _tls_common module is deprecated.',
+process.emitWarning('The _tls_common module is deprecated. Use `node:tls` instead.',
                     'DeprecationWarning', 'DEP0192');

--- a/lib/_tls_wrap.js
+++ b/lib/_tls_wrap.js
@@ -7,5 +7,5 @@ module.exports = {
   createServer,
   connect,
 };
-process.emitWarning('The _tls_wrap module is deprecated.',
+process.emitWarning('The _tls_wrap module is deprecated. Use `node:tls` instead.',
                     'DeprecationWarning', 'DEP0192');

--- a/lib/sys.js
+++ b/lib/sys.js
@@ -27,5 +27,5 @@
 // Note to maintainers: Although this module has been deprecated for a while
 // we do not plan to remove it. See: https://github.com/nodejs/node/pull/35407#issuecomment-700693439
 module.exports = require('util');
-process.emitWarning('sys is deprecated. Use util instead.',
+process.emitWarning('sys is deprecated. Use `node:util` instead.',
                     'DeprecationWarning', 'DEP0025');

--- a/test/parallel/test-warn-stream-duplex-deprecation.js
+++ b/test/parallel/test-warn-stream-duplex-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_duplex is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_duplex module is deprecated.', 'DEP0193');
+                     'The _stream_duplex module is deprecated. Use `node:stream` instead.', 'DEP0193');
 
 require('_stream_duplex');

--- a/test/parallel/test-warn-stream-passthrough-deprecation.js
+++ b/test/parallel/test-warn-stream-passthrough-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_passthrough is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_passthrough module is deprecated.', 'DEP0193');
+                     'The _stream_passthrough module is deprecated. Use `node:stream` instead.', 'DEP0193');
 
 require('_stream_passthrough');

--- a/test/parallel/test-warn-stream-readable-deprecation.js
+++ b/test/parallel/test-warn-stream-readable-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_readable is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_readable module is deprecated.', 'DEP0193');
+                     'The _stream_readable module is deprecated. Use `node:stream` instead.', 'DEP0193');
 
 require('_stream_readable');

--- a/test/parallel/test-warn-stream-transform-deprecation.js
+++ b/test/parallel/test-warn-stream-transform-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_transform is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_transform module is deprecated.', 'DEP0193');
+                     'The _stream_transform module is deprecated. Use `node:stream` instead.', 'DEP0193');
 
 require('_stream_transform');

--- a/test/parallel/test-warn-stream-wrap-deprecation.js
+++ b/test/parallel/test-warn-stream-wrap-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_wrap is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_wrap module is deprecated.', 'DEP0125');
+                     'The _stream_wrap module is deprecated. Use `node:stream` instead.', 'DEP0125');
 
 require('_stream_wrap');

--- a/test/parallel/test-warn-stream-writable-deprecation.js
+++ b/test/parallel/test-warn-stream-writable-deprecation.js
@@ -5,6 +5,6 @@ const common = require('../common');
 // _stream_writable is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _stream_writable module is deprecated.', 'DEP0193');
+                     'The _stream_writable module is deprecated. Use `node:stream` instead.', 'DEP0193');
 
 require('_stream_writable');

--- a/test/parallel/test-warn-tls-common-deprecation.js
+++ b/test/parallel/test-warn-tls-common-deprecation.js
@@ -6,6 +6,6 @@ if (!common.hasCrypto) common.skip('missing crypto');
 // _tls_common is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _tls_common module is deprecated.', 'DEP0192');
+                     'The _tls_common module is deprecated. Use `node:tls` instead.', 'DEP0192');
 
 require('_tls_common');

--- a/test/parallel/test-warn-tls-wrap-deprecation.js
+++ b/test/parallel/test-warn-tls-wrap-deprecation.js
@@ -6,6 +6,6 @@ if (!common.hasCrypto) common.skip('missing crypto');
 // _tls_wrap is deprecated.
 
 common.expectWarning('DeprecationWarning',
-                     'The _tls_wrap module is deprecated.', 'DEP0192');
+                     'The _tls_wrap module is deprecated. Use `node:tls` instead.', 'DEP0192');
 
 require('_tls_wrap');


### PR DESCRIPTION
As [suggested](https://github.com/nodejs/node/pull/58337#issuecomment-2889120851) by @shivarm I'm adding to all the various module deprecation warnings the suggestion of what alternative module should be used instead, I am also updating the sys warning to refer to `node:util` instead of `util`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
