### PR TITLE
src: fix possible dereference of NULL pointer

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -704,9 +704,9 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
                                     napi_addon_register_func init,
                                     int32_t module_api_version) {
   node::Environment* node_env = node::Environment::GetCurrent(context);
+  CHECK_NOT_NULL(node_env);
   std::string module_filename = "";
   if (init == nullptr) {
-    CHECK_NOT_NULL(node_env);
     node_env->ThrowError("Module has no declared entry point.");
     return;
   }


### PR DESCRIPTION
There is a CHECK_NOT_NULL check before dereferencing node_env on line 710 in the if block, but there is no CHECK_NOT_NULL check before dereferencing node_env on line 721. Maybe it makes sense to put CHECK_NOT_NULL right after calling the Environment::GetCurrent function?