### PR TITLE
doc: graduate Symbol.dispose/asyncDispose from experimental

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1766,7 +1766,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -382,7 +382,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -861,7 +861,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 
@@ -6758,7 +6758,7 @@ included in the iteration results.
 added: v24.1.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 
@@ -6771,7 +6771,7 @@ dir is closed.
 added: v24.1.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1938,7 +1938,7 @@ affects new connections to the server, not any existing connections.
 added: v20.4.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2423,7 +2423,7 @@ closed, although the server has already stopped allowing new sessions. See
 added: v20.4.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/https.md
+++ b/doc/api/https.md
@@ -139,7 +139,7 @@ See [`server.close()`][] in the `node:http` module.
 added: v20.4.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -404,7 +404,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -426,7 +426,7 @@ added:
   - v22.15.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -985,7 +985,7 @@ added:
 - v20.16.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 
@@ -2000,7 +2000,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -71,7 +71,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 
@@ -179,7 +179,7 @@ added:
  - v18.18.0
 changes:
  - version: REPLACEME
-   pr-url: https://github.com/nodejs/node/pull/00000
+   pr-url: https://github.com/nodejs/node/pull/58467
    description: No longer experimental.
 -->
 


### PR DESCRIPTION
Now that Symbol.dispose and Symbol.asyncDispose have been enabled by default and are expected to likely advance to stage 4 this week, let's graduate them from experimental status.

