### PR TITLE
src: remove deprecated process exit APIs in node.h

### DIFF
--- a/src/api/hooks.cc
+++ b/src/api/hooks.cc
@@ -26,10 +26,6 @@ void AtExit(Environment* env, void (*cb)(void* arg), void* arg) {
   env->AtExit(cb, arg);
 }
 
-void EmitBeforeExit(Environment* env) {
-  USE(EmitProcessBeforeExit(env));
-}
-
 Maybe<bool> EmitProcessBeforeExit(Environment* env) {
   TRACE_EVENT0(TRACING_CATEGORY_NODE1(environment), "BeforeExit");
   if (!env->destroy_async_id_list()->empty())
@@ -48,14 +44,6 @@ Maybe<bool> EmitProcessBeforeExit(Environment* env) {
 
   return ProcessEmit(env, "beforeExit", exit_code).IsEmpty() ? Nothing<bool>()
                                                              : Just(true);
-}
-
-static ExitCode EmitExitInternal(Environment* env) {
-  return EmitProcessExitInternal(env).FromMaybe(ExitCode::kGenericUserError);
-}
-
-int EmitExit(Environment* env) {
-  return static_cast<int>(EmitExitInternal(env));
 }
 
 Maybe<ExitCode> EmitProcessExitInternal(Environment* env) {

--- a/src/node.h
+++ b/src/node.h
@@ -867,13 +867,9 @@ NODE_EXTERN void SetTracingController(v8::TracingController* controller);
 // Run `process.emit('beforeExit')` as it would usually happen when Node.js is
 // run in standalone mode.
 NODE_EXTERN v8::Maybe<bool> EmitProcessBeforeExit(Environment* env);
-NODE_DEPRECATED("Use Maybe version (EmitProcessBeforeExit) instead",
-    NODE_EXTERN void EmitBeforeExit(Environment* env));
 // Run `process.emit('exit')` as it would usually happen when Node.js is run
 // in standalone mode. The return value corresponds to the exit code.
 NODE_EXTERN v8::Maybe<int> EmitProcessExit(Environment* env);
-NODE_DEPRECATED("Use Maybe version (EmitProcessExit) instead",
-    NODE_EXTERN int EmitExit(Environment* env));
 
 // Runs hooks added through `AtExit()`. This is part of `FreeEnvironment()`,
 // so calling it manually is typically not necessary.


### PR DESCRIPTION
The APIs have been deprecated for 5 years.

Refs: https://github.com/nodejs/node/pull/35486