### PR TITLE
src: remove deprecated initialization APIs in node.h

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -583,26 +583,6 @@ MultiIsolatePlatform* GetMultiIsolatePlatform(IsolateData* env) {
   return env->platform();
 }
 
-MultiIsolatePlatform* CreatePlatform(
-    int thread_pool_size,
-    node::tracing::TracingController* tracing_controller) {
-  return CreatePlatform(
-      thread_pool_size,
-      static_cast<v8::TracingController*>(tracing_controller));
-}
-
-MultiIsolatePlatform* CreatePlatform(
-    int thread_pool_size,
-    v8::TracingController* tracing_controller) {
-  return MultiIsolatePlatform::Create(thread_pool_size,
-                                      tracing_controller)
-      .release();
-}
-
-void FreePlatform(MultiIsolatePlatform* platform) {
-  delete platform;
-}
-
 std::unique_ptr<MultiIsolatePlatform> MultiIsolatePlatform::Create(
     int thread_pool_size,
     v8::TracingController* tracing_controller,

--- a/src/node.cc
+++ b/src/node.cc
@@ -823,7 +823,7 @@ static ExitCode InitializeNodeWithArgsInternal(
     std::vector<std::string>* exec_argv,
     std::vector<std::string>* errors,
     ProcessInitializationFlags::Flags flags) {
-  // Make sure InitializeNodeWithArgs() is called only once.
+  // Make sure InitializeNodeWithArgsInternal() is called only once.
   CHECK(!init_called.exchange(true));
 
   // Initialize node_start_time to get relative uptime.
@@ -1019,14 +1019,6 @@ static ExitCode InitializeNodeWithArgsInternal(
   // able to set it and native addons will not load for them.
   node_is_initialized = true;
   return ExitCode::kNoFailure;
-}
-
-int InitializeNodeWithArgs(std::vector<std::string>* argv,
-                           std::vector<std::string>* exec_argv,
-                           std::vector<std::string>* errors,
-                           ProcessInitializationFlags::Flags flags) {
-  return static_cast<int>(
-      InitializeNodeWithArgsInternal(argv, exec_argv, errors, flags));
 }
 
 static std::shared_ptr<InitializationResultImpl>

--- a/src/node.h
+++ b/src/node.h
@@ -330,22 +330,6 @@ NODE_EXTERN int Stop(Environment* env,
                      StopFlags::Flags flags = StopFlags::kNoFlags);
 
 // Set up per-process state needed to run Node.js. This will consume arguments
-// from argv, fill exec_argv, and possibly add errors resulting from parsing
-// the arguments to `errors`. The return value is a suggested exit code for the
-// program; If it is 0, then initializing Node.js succeeded.
-// This runs a subset of the initialization performed by
-// InitializeOncePerProcess(), which supersedes this function.
-// The subset is roughly equivalent to the one given by
-// `ProcessInitializationFlags::kLegacyInitializeNodeWithArgsBehavior`.
-NODE_DEPRECATED("Use InitializeOncePerProcess() instead",
-                NODE_EXTERN int InitializeNodeWithArgs(
-                    std::vector<std::string>* argv,
-                    std::vector<std::string>* exec_argv,
-                    std::vector<std::string>* errors,
-                    ProcessInitializationFlags::Flags flags =
-                        ProcessInitializationFlags::kNoFlags));
-
-// Set up per-process state needed to run Node.js. This will consume arguments
 // from args, and return information about the initialization success,
 // including the arguments split into argv/exec_argv, a list of potential
 // errors encountered during initialization, and a potential suggested

--- a/src/node.h
+++ b/src/node.h
@@ -832,19 +832,12 @@ NODE_EXTERN void GetNodeReport(Environment* env,
 NODE_EXTERN MultiIsolatePlatform* GetMultiIsolatePlatform(Environment* env);
 NODE_EXTERN MultiIsolatePlatform* GetMultiIsolatePlatform(IsolateData* env);
 
-NODE_DEPRECATED("Use MultiIsolatePlatform::Create() instead",
-    NODE_EXTERN MultiIsolatePlatform* CreatePlatform(
-        int thread_pool_size,
-        v8::TracingController* tracing_controller));
-NODE_DEPRECATED("Use MultiIsolatePlatform::Create() instead",
-    NODE_EXTERN void FreePlatform(MultiIsolatePlatform* platform));
-
-// Get/set the currently active tracing controller. Using CreatePlatform()
-// will implicitly set this by default. This is global and should be initialized
-// along with the v8::Platform instance that is being used. `controller`
-// is allowed to be `nullptr`.
-// This is used for tracing events from Node.js itself. V8 uses the tracing
-// controller returned from the active `v8::Platform` instance.
+// Get/set the currently active tracing controller. Using
+// MultiIsolatePlatform::Create() will implicitly set this by default. This is
+// global and should be initialized along with the v8::Platform instance that is
+// being used. `controller` is allowed to be `nullptr`. This is used for tracing
+// events from Node.js itself. V8 uses the tracing controller returned from the
+// active `v8::Platform` instance.
 NODE_EXTERN v8::TracingController* GetTracingController();
 NODE_EXTERN void SetTracingController(v8::TracingController* controller);
 

--- a/test/cctest/node_test_fixture.h
+++ b/test/cctest/node_test_fixture.h
@@ -81,13 +81,15 @@ class NodeZeroIsolateTestFixture : public ::testing::Test {
     if (!node_initialized) {
       node_initialized = true;
       uv_os_unsetenv("NODE_OPTIONS");
-      std::vector<std::string> argv { "cctest" };
-      std::vector<std::string> exec_argv;
-      std::vector<std::string> errors;
+      std::vector<std::string> argv{"cctest"};
 
-      int exitcode = node::InitializeNodeWithArgs(&argv, &exec_argv, &errors);
-      CHECK_EQ(exitcode, 0);
-      CHECK(errors.empty());
+      std::shared_ptr<node::InitializationResult> result =
+          node::InitializeOncePerProcess(
+              argv,
+              node::ProcessInitializationFlags::
+                  kLegacyInitializeNodeWithArgsBehavior);
+      CHECK_EQ(result->exit_code(), 0);
+      CHECK(result->errors().empty());
     }
     CHECK_EQ(0, uv_loop_init(&current_loop));
   }


### PR DESCRIPTION
- `InitializeNodeWithArgs` has been deprecated in https://github.com/nodejs/node/pull/44121.
- `CreatePlatform`/`FreePlatform` have been deprecated in https://github.com/nodejs/node/pull/32858.
