### PR TITLE
benchmark: fix broken fs.cpSync benchmark

### DIFF
--- a/benchmark/fs/bench-cpSync.js
+++ b/benchmark/fs/bench-cpSync.js
@@ -8,7 +8,10 @@ const tmpdir = require('../../test/common/tmpdir');
 const bench = common.createBenchmark(main, {
   n: [1, 100, 10_000],
   dereference: ['true', 'false'],
-  force: ['true', 'false'],
+  // When `force` is `true` the `cpSync` function is called twice the second
+  // time however an `ERR_FS_CP_EINVAL` is thrown, so skip `true` for the time being
+  // TODO: allow `force` to also be `true` once https://github.com/nodejs/node/issues/58468 is addressed
+  force: ['false'],
 });
 
 function prepareTestDirectory() {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/58278 added some options to `benchmark/fs/bench-cpSync.js`, however after the changes the benchmark fails with an `ERR_FS_CP_EINVAL` error:
![Screenshot at 2025-05-26 18-23-13](https://github.com/user-attachments/assets/169aa5e2-70d0-4180-93d4-558a39a0899e)

I believe this is surfacing an actual bug in the cp/cpSync logic (see: https://github.com/nodejs/node/issues/58468) (please check out the issue and let me know if I am getting something wrong here :pray:) so here I am simply skipping the `force: true` option in the benchmarking file to make the benchmark actually work until the underlying issue is resolved.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
