### PR TITLE
module: move Module._debug to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1769,14 +1769,17 @@ not handle all certificate subjects correctly and should not be used.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v9.0.0
     pr-url: https://github.com/nodejs/node/pull/13948
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-`Module._debug()` is deprecated.
+`Module._debug()` has been removed.
 
 The `Module._debug()` function was never documented as an officially
 supported API.

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -429,7 +429,6 @@ ObjectDefineProperty(Module.prototype, 'parent', {
     'DEP0144',
   ),
 });
-Module._debug = pendingDeprecate(debug, 'Module._debug is deprecated.', 'DEP0077');
 Module.isBuiltin = BuiltinModule.isBuiltin;
 
 /**


### PR DESCRIPTION
Was runtime deprecated 7 years ago. Probably safe to remove now.
