### PR TITLE
doc,src,test: fix typos

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2625,7 +2625,7 @@ changes:
     - v23.4.0
     - v22.13.0
     pr-url: https://github.com/nodejs/node/pull/55897
-    description: Snapsnot testing is no longer experimental.
+    description: Snapshot testing is no longer experimental.
 -->
 
 Regenerates the snapshot files used by the test runner for [snapshot testing][].

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1231,7 +1231,7 @@ added: v23.8.0
 
 * {bigint|number}
 
-Specifies the maxumum session flow-control window size.
+Specifies the maximum session flow-control window size.
 
 #### `sessionOptions.minVersion`
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -986,7 +986,7 @@ added: v22.3.0
 changes:
   - version: v23.4.0
     pr-url: https://github.com/nodejs/node/pull/55897
-    description: Snapsnot testing is no longer experimental.
+    description: Snapshot testing is no longer experimental.
 -->
 
 Snapshot tests allow arbitrary values to be serialized into string values and

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -30,7 +30,7 @@ struct has_priority<T, std::void_t<decltype(std::declval<T>().priority)>>
 template <class T>
 class TaskQueue {
  public:
-  // If the entry type has a priority memeber, order the priority queue by
+  // If the entry type has a priority member, order the priority queue by
   // that - higher priority first. Otherwise, maintain insertion order.
   struct EntryCompare {
     bool operator()(const std::unique_ptr<T>& a,

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2730,7 +2730,7 @@ void Session::EmitVersionNegotiation(const ngtcp2_pkt_hd& hd,
     versions[n] = Integer::NewFromUnsigned(env()->isolate(), sv[n]);
   }
 
-  // supported are the versions we acutually support expressed as a range.
+  // supported are the versions we actually support expressed as a range.
   // The first value is the minimum version, the second is the maximum.
   Local<Value> supported[] = {
       Integer::NewFromUnsigned(env()->isolate(), opts.min_version),

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -55,7 +55,7 @@ class Endpoint;
 // is created. This ngtcp2_conn is destroyed when the session object is freed.
 // However, the session can be in a closed/destroyed state and still have a
 // valid ngtcp2_conn pointer. This is important because the ngtcp2 still might
-// be processsing data within the scope of an ngtcp2_conn after the session
+// be procsessing data within the scope of an ngtcp2_conn after the session
 // object itself is closed/destroyed by user code.
 class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
  public:

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -55,7 +55,7 @@ class Endpoint;
 // is created. This ngtcp2_conn is destroyed when the session object is freed.
 // However, the session can be in a closed/destroyed state and still have a
 // valid ngtcp2_conn pointer. This is important because the ngtcp2 still might
-// be procsessing data within the scope of an ngtcp2_conn after the session
+// be processing data within the scope of an ngtcp2_conn after the session
 // object itself is closed/destroyed by user code.
 class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
  public:

--- a/src/quic/sessionticket.h
+++ b/src/quic/sessionticket.h
@@ -58,7 +58,7 @@ class SessionTicket final : public MemoryRetainer {
 };
 
 // SessionTicket::AppData is a utility class that is used only during the
-// generation or access of TLS stateless sesson tickets. It exists solely to
+// generation or access of TLS stateless session tickets. It exists solely to
 // provide a easier way for Session::Application instances to set relevant
 // metadata in the session ticket when it is created, and the extract and
 // subsequently verify that data when a ticket is received and is being

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -69,7 +69,7 @@ namespace quic {
   V(ACKED_AT, acked_at)                                                        \
   /* Marks the timestamp when the stream was destroyed */                      \
   V(DESTROYED_AT, destroyed_at)                                                \
-  /* Records the total number of bytes received by the stream */                \
+  /* Records the total number of bytes received by the stream */               \
   V(BYTES_RECEIVED, bytes_received)                                            \
   /* Records the total number of bytes sent by the stream */                   \
   V(BYTES_SENT, bytes_sent)                                                    \

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -69,7 +69,7 @@ namespace quic {
   V(ACKED_AT, acked_at)                                                        \
   /* Marks the timestamp when the stream was destroyed */                      \
   V(DESTROYED_AT, destroyed_at)                                                \
-  /* Records the total number of bytes receied by the stream */                \
+  /* Records the total number of bytes received by the stream */                \
   V(BYTES_RECEIVED, bytes_received)                                            \
   /* Records the total number of bytes sent by the stream */                   \
   V(BYTES_SENT, bytes_sent)                                                    \


### PR DESCRIPTION
fix typos
- `Snapsnot` → `Snapshot` 
- `maxumum` → `maximum `
- `memeber ` → `member`
- `acutually` → `actually`
- `processsing` → `processing`
- `sesson` → `session`
-  `receied` → `received`