### PR TITLE
test: account for truthy signal in flaky async_hooks tests

### DIFF
--- a/test/async-hooks/test-emit-after-on-destroyed.js
+++ b/test/async-hooks/test-emit-after-on-destroyed.js
@@ -52,8 +52,12 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
-  child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1);
+  child.on('close', common.mustCall((code, signal) => {
+    if (signal) {
+      console.log(`Child closed with signal: ${signal}`);
+    } else {
+      assert.strictEqual(code, 1);
+    }
     assert.match(outData.toString(), heartbeatMsg,
                  'did not crash until we reached offending line of code ' +
                  `(found ${outData})`);

--- a/test/async-hooks/test-improper-unwind.js
+++ b/test/async-hooks/test-improper-unwind.js
@@ -55,8 +55,12 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
-  child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1);
+  child.on('close', common.mustCall((code, signal) => {
+    if (signal) {
+      console.log(`Child closed with signal: ${signal}`);
+    } else {
+      assert.strictEqual(code, 1);
+    }
     assert.match(outData.toString(), heartbeatMsg,
                  'did not crash until we reached offending line of code ' +
                  `(found ${outData})`);


### PR DESCRIPTION
When the spawned child process gets closed with a signal, the exit code is not set and that is why the exit code assertion was failing. This change adjusts the test to check the signal and if it is truthy, it doesn't assert the exit code and instead logs the signal and continues the rest of the assertions.

Refs: https://github.com/nodejs/node/issues/58463#issuecomment-2911460454
Refs: https://github.com/nodejs/node/issues/58199
Refs: https://github.com/nodejs/node/issues/58463

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
