### PR TITLE
src: add env->cppgc_allocation_handle() convenience method

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1193,7 +1193,7 @@ MyWrap* MyWrap::New(Environment* env, v8::Local<v8::Object> object) {
   // pointer with this, as this is not managed by the native memory
   // allocator but by V8.
   return cppgc::MakeGarbageCollected<MyWrap>(
-      env->isolate()->GetCppHeap()->GetAllocationHandle(), env, object);
+      env->cppgc_allocation_handle(), env, object);
 }
 
 // Binding method to be invoked by JavaScript.

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -205,6 +205,10 @@ inline v8::Isolate* Environment::isolate() const {
   return isolate_;
 }
 
+inline cppgc::AllocationHandle& Environment::cppgc_allocation_handle() const {
+  return isolate_->GetCppHeap()->GetAllocationHandle();
+}
+
 inline v8::ExternalMemoryAccounter* Environment::external_memory_accounter()
     const {
   return external_memory_accounter_;

--- a/src/env.h
+++ b/src/env.h
@@ -692,6 +692,7 @@ class Environment final : public MemoryRetainer {
   void StartProfilerIdleNotifier();
 
   inline v8::Isolate* isolate() const;
+  inline cppgc::AllocationHandle& cppgc_allocation_handle() const;
   inline v8::ExternalMemoryAccounter* external_memory_accounter() const;
   inline uv_loop_t* event_loop() const;
   void TryLoadAddon(const char* filename,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -330,11 +330,7 @@ ContextifyContext* ContextifyContext::New(Local<Context> v8_context,
     }
     DCHECK_NOT_NULL(env->isolate()->GetCppHeap());
     result = cppgc::MakeGarbageCollected<ContextifyContext>(
-        env->isolate()->GetCppHeap()->GetAllocationHandle(),
-        env,
-        wrapper,
-        v8_context,
-        options);
+        env->cppgc_allocation_handle(), env, wrapper, v8_context, options);
   }
 
   Local<Object> wrapper_holder =
@@ -975,7 +971,7 @@ ContextifyScript* ContextifyScript::New(Environment* env,
                                         Local<Object> object) {
   DCHECK_NOT_NULL(env->isolate()->GetCppHeap());
   return cppgc::MakeGarbageCollected<ContextifyScript>(
-      env->isolate()->GetCppHeap()->GetAllocationHandle(), env, object);
+      env->cppgc_allocation_handle(), env, object);
 }
 
 void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Reduce some of the boilerplate code needed to access the cppgc::AllocationHandle from the Node.js Environment.

