### PR TITLE
test: mark `test-http2-debug` as flaky on LinuxONE

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -41,6 +41,10 @@ test-esm-loader-hooks-inspect-wait: PASS, FLAKY
 # https://github.com/nodejs/node/issues/54534
 test-runner-run-watch: PASS, FLAKY
 
+[$system==linux && $arch==s390x]
+# https://github.com/nodejs/node/issues/58353
+test-http2-debug: PASS, FLAKY
+
 [$system==linux || $system==win32]
 # https://github.com/nodejs/node/issues/49605
 test-runner-watch-mode: PASS,FLAKY


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/58353

---

This test is [currently failing 20 out of 100 CI runs](https://github.com/nodejs/reliability/issues/1214).