### PR TITLE
src: update std::vector<v8::Local<T>> to use v8::LocalVector<T>

### DIFF
--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -332,7 +332,7 @@ class Stream final : public AsyncWrap,
   // The headers_ field holds a block of headers that have been received and
   // are being buffered for delivery to the JavaScript side.
   // TODO(@jasnell): Use v8::Global instead of v8::Local here.
-  std::vector<v8::Local<v8::Value>> headers_;
+  v8::LocalVector<v8::Value> headers_;
 
   // The headers_kind_ field indicates the kind of headers that are being
   // buffered.

--- a/test/addons/make-callback/binding.cc
+++ b/test/addons/make-callback/binding.cc
@@ -11,7 +11,7 @@ void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
   assert(args[1]->IsFunction() || args[1]->IsString());
   auto isolate = args.GetIsolate();
   auto recv = args[0].As<v8::Object>();
-  std::vector<v8::Local<v8::Value>> argv;
+  v8::LocalVector<v8::Value> argv(isolate);
   for (size_t n = 2; n < static_cast<size_t>(args.Length()); n += 1) {
     argv.push_back(args[n]);
   }

--- a/test/addons/openssl-providers/binding.cc
+++ b/test/addons/openssl-providers/binding.cc
@@ -13,6 +13,7 @@ using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
+using v8::LocalVector;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -26,7 +27,7 @@ int collectProviders(OSSL_PROVIDER* provider, void* cbdata) {
 
 inline void GetProviders(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  std::vector<Local<Value>> arr = {};
+  LocalVector<Value> arr(isolate, 0);
 #if OPENSSL_VERSION_MAJOR >= 3
   std::vector<OSSL_PROVIDER*> providers;
   OSSL_PROVIDER_do_all(nullptr, &collectProviders, &providers);


### PR DESCRIPTION
Continuing the clean up of std::vector<v8::Local<T>> we did before. Discovered in https://github.com/nodejs/node/pull/58497
From pull request: https://github.com/nodejs/node/pull/57578:

> According to V8's public API documentation, local handles (i.e., objects of type v8::Local) "should never be allocated on the heap". This replaces the usage of heap-allocated data structures containing instances of v8::Local, specifically the std::vector<v8::Localv8::String> with recently introduced v8::LocalVector.

