### PR TITLE
doc: clarify DEP0194 scope

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3935,7 +3935,7 @@ The `node:_stream_duplex`, `node:_stream_passthrough`, `node:_stream_readable`, 
 `node:_stream_wrap` and `node:_stream_writable` modules are deprecated as they should be considered
 an internal nodejs implementation rather than a public facing API, use `node:stream` instead.
 
-### DEP0194: `require('node:http2').Http2Stream.priority`
+### DEP0194: HTTP/2 priority signaling
 
 <!-- YAML
 changes:

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1071,6 +1071,11 @@ The `'origin'` event is only emitted when using a secure TLS connection.
 
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58313
+    description: Following the deprecation of priority signaling as of RFC 1993,
+                 `weight` option is deprecated.
 -->
 
 * `headers` {HTTP/2 Headers Object} | {Array}
@@ -1087,7 +1092,8 @@ added: v8.4.0
     created stream is dependent on.
   * `weight` {number} Specifies the relative dependency of a stream in relation
     to other streams with the same `parent`. The value is a number between `1`
-    and `256` (inclusive).
+    and `256` (inclusive). This has been **deprecated** in [RFC 9113][], and
+    support for it will be removed in future versions of Node.js.
   * `waitForTrailers` {boolean} When `true`, the `Http2Stream` will emit the
     `'wantTrailers'` event after the final `DATA` frame has been sent.
   * `signal` {AbortSignal} An AbortSignal that may be used to abort an ongoing
@@ -1460,6 +1466,9 @@ added: v8.4.0
 deprecated: REPLACEME
 -->
 
+> Stability: 0 - Deprecated: support for priority signaling has been deprecated
+> in the [RFC 9113][] and is no longer supported in Node.js.
+
 * `options` {Object}
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     this stream is made the sole direct dependency of the parent, with
@@ -1474,9 +1483,6 @@ deprecated: REPLACEME
     sending a `PRIORITY` frame to the connected peer.
 
 Updates the priority for this `Http2Stream` instance.
-
-The support for priority signaling has been deprecated in the [RFC 9113][], and
-will be removed in future versions of Node.js.
 
 #### `http2stream.rstCode`
 
@@ -1572,6 +1578,11 @@ req.setTimeout(5000, () => req.close(NGHTTP2_CANCEL));
 
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58313
+    description: Following the deprecation of priority signaling as of RFC 1993,
+                 `weight` and `sumDependencyWeight` options are deprecated.
 -->
 
 Provides miscellaneous information about the current state of the


### PR DESCRIPTION
Since priority signaling covers more than `http2Stream.priority`, it makes more sense to rename the section.

There were also a few missing mentions in `http2.md`.

Refs: https://github.com/nodejs/node/pull/58313

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
