### PR TITLE
permission: remove useless conditional

### DIFF
--- a/src/permission/fs_permission.cc
+++ b/src/permission/fs_permission.cc
@@ -45,9 +45,7 @@ void FreeRecursivelyNode(
     }
   }
 
-  if (node->wildcard_child != nullptr) {
-    delete node->wildcard_child;
-  }
+  delete node->wildcard_child;
   delete node;
 }
 


### PR DESCRIPTION
Deleting a null pointer has no effect. The check is not needed.