### PR TITLE
child_process: move _channel to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2706,7 +2706,7 @@ Node.js versions.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/58527
     description: End-of-Life.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/27949

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2705,6 +2705,9 @@ Node.js versions.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/27949
     description: Runtime deprecation.
@@ -2713,7 +2716,7 @@ changes:
     description: Documentation-only.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 The `_channel` property of child process objects returned by `spawn()` and
 similar functions is not intended for public use. Use `ChildProcess.channel`

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -7,7 +7,6 @@ const {
   ArrayPrototypeSlice,
   FunctionPrototype,
   FunctionPrototypeCall,
-  ObjectDefineProperty,
   ObjectSetPrototypeOf,
   ReflectApply,
   StringPrototypeSlice,
@@ -56,7 +55,7 @@ const { TTY } = internalBinding('tty_wrap');
 const { UDP } = internalBinding('udp_wrap');
 const SocketList = require('internal/socket_list');
 const { owner_symbol } = require('internal/async_hooks').symbols;
-const { convertToValidSignal, deprecate } = require('internal/util');
+const { convertToValidSignal } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
 const spawn_sync = internalBinding('spawn_sync');
 const { kStateSymbol } = require('internal/dgram');
@@ -575,26 +574,11 @@ class Control extends EventEmitter {
   }
 }
 
-const channelDeprecationMsg = '_channel is deprecated. ' +
-                              'Use ChildProcess.channel instead.';
-
 let serialization;
 function setupChannel(target, channel, serializationMode) {
   const control = new Control(channel);
   target.channel = control;
   target[kChannelHandle] = channel;
-
-  ObjectDefineProperty(target, '_channel', {
-    __proto__: null,
-    get: deprecate(() => {
-      return target.channel;
-    }, channelDeprecationMsg, 'DEP0129'),
-    set: deprecate((val) => {
-      target.channel = val;
-    }, channelDeprecationMsg, 'DEP0129'),
-    configurable: true,
-    enumerable: false,
-  });
 
   target._handleQueue = null;
   target._pendingMessage = null;

--- a/test/parallel/test-child-process-fork.js
+++ b/test/parallel/test-child-process-fork.js
@@ -18,7 +18,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
-// Flags: --no-warnings
 'use strict';
 const common = require('../common');
 const assert = require('assert');
@@ -29,7 +28,6 @@ const debug = require('util').debuglog('test');
 
 const n = fork(fixtures.path('child-process-spawn-node.js'), args);
 
-assert.strictEqual(n.channel, n._channel);
 assert.deepStrictEqual(args, ['foo', 'bar']);
 
 n.on('message', (m) => {


### PR DESCRIPTION
The `._channel` property has been deprecated for many years now. It's time to remove it.
