### PR TITLE
worker: move terminate callback to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2764,12 +2764,15 @@ legacy parser.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v12.5.0
     pr-url: https://github.com/nodejs/node/pull/28021
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Passing a callback to [`worker.terminate()`][] is deprecated. Use the returned
 `Promise` instead, or a listener to the worker's `'exit'` event.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -11,6 +11,7 @@ const {
   ObjectEntries,
   Promise,
   PromiseResolve,
+  PromiseWithResolvers,
   ReflectApply,
   RegExpPrototypeExec,
   SafeArrayIterator,
@@ -381,19 +382,10 @@ class Worker extends EventEmitter {
     ReflectApply(this[kPublicPort].postMessage, this[kPublicPort], args);
   }
 
-  terminate(callback) {
+  terminate() {
     debug(`[${threadId}] terminates Worker with ID ${this.threadId}`);
 
     this.ref();
-
-    if (typeof callback === 'function') {
-      process.emitWarning(
-        'Passing a callback to worker.terminate() is deprecated. ' +
-        'It returns a Promise instead.',
-        'DeprecationWarning', 'DEP0132');
-      if (this[kHandle] === null) return PromiseResolve();
-      this.once('exit', (exitCode) => callback(null, exitCode));
-    }
 
     if (this[kHandle] === null) return PromiseResolve();
 
@@ -402,9 +394,9 @@ class Worker extends EventEmitter {
     // Do not use events.once() here, because the 'exit' event will always be
     // emitted regardless of any errors, and the point is to only resolve
     // once the thread has actually stopped.
-    return new Promise((resolve) => {
-      this.once('exit', resolve);
-    });
+    const { promise, resolve } = PromiseWithResolvers();
+    this.once('exit', resolve);
+    return promise;
   }
 
   async [SymbolAsyncDispose]() {

--- a/test/parallel/test-worker-nexttick-terminate.js
+++ b/test/parallel/test-worker-nexttick-terminate.js
@@ -13,13 +13,6 @@ process.nextTick(() => {
 `, { eval: true });
 
 // Test deprecation of .terminate() with callback.
-common.expectWarning(
-  'DeprecationWarning',
-  'Passing a callback to worker.terminate() is deprecated. ' +
-  'It returns a Promise instead.', 'DEP0132');
-
 w.on('message', common.mustCall(() => {
-  setTimeout(() => {
-    w.terminate(common.mustCall()).then(common.mustCall());
-  }, 1);
+  setTimeout(() => w.terminate().then(common.mustCall()), 1);
 }));

--- a/test/parallel/test-worker-terminate-null-handler.js
+++ b/test/parallel/test-worker-terminate-null-handler.js
@@ -15,9 +15,7 @@ process.once('beforeExit', common.mustCall(() => worker.ref()));
 
 worker.on('exit', common.mustCall(() => {
   worker.terminate().then((res) => assert.strictEqual(res, undefined));
-  worker.terminate(() => null).then(
-    (res) => assert.strictEqual(res, undefined)
-  );
+
 }));
 
 worker.unref();


### PR DESCRIPTION
Passing a callback to worker.terminate() has been deprecated for about six years now. It's time to remove it.
