### PR TITLE
fs: move fs stream open method to eol

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2807,12 +2807,15 @@ an officially supported API.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v13.0.0
     pr-url: https://github.com/nodejs/node/pull/29061
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 [`WriteStream.open()`][] and [`ReadStream.open()`][] are undocumented internal
 APIs that do not make sense to use in userland. File streams should always be

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -19,7 +19,6 @@ const {
   ERR_SYSTEM_ERROR,
 } = require('internal/errors').codes;
 const {
-  deprecate,
   kEmptyObject,
 } = require('internal/util');
 const {
@@ -52,7 +51,7 @@ function _construct(callback) {
     return;
   }
 
-  if (stream.open !== openWriteFs && stream.open !== openReadFs) {
+  if (typeof stream.open === 'function') {
     // Backwards compat for monkey patching open().
     const orgEmit = stream.emit;
     stream.emit = function(...args) {
@@ -238,11 +237,6 @@ ObjectDefineProperty(ReadStream.prototype, 'autoClose', {
   },
 });
 
-const openReadFs = deprecate(function() {
-  // Noop.
-}, 'ReadStream.prototype.open() is deprecated', 'DEP0135');
-ReadStream.prototype.open = openReadFs;
-
 ReadStream.prototype._construct = _construct;
 
 ReadStream.prototype._read = function(n) {
@@ -406,11 +400,6 @@ ObjectDefineProperty(WriteStream.prototype, 'autoClose', {
     this._writableState.autoDestroy = val;
   },
 });
-
-const openWriteFs = deprecate(function() {
-  // Noop.
-}, 'WriteStream.prototype.open() is deprecated', 'DEP0135');
-WriteStream.prototype.open = openWriteFs;
 
 WriteStream.prototype._construct = _construct;
 

--- a/test/parallel/test-fs-read-stream-patch-open.js
+++ b/test/parallel/test-fs-read-stream-patch-open.js
@@ -2,16 +2,5 @@
 const common = require('../common');
 const fs = require('fs');
 
-common.expectWarning(
-  'DeprecationWarning',
-  'ReadStream.prototype.open() is deprecated', 'DEP0135');
-const s = fs.createReadStream('asd')
-  // We don't care about errors in this test.
-  .on('error', () => {});
-s.open();
-
-process.nextTick(() => {
-  // Allow overriding open().
-  fs.ReadStream.prototype.open = common.mustCall();
-  fs.createReadStream('asd');
-});
+fs.ReadStream.prototype.open = common.mustCall();
+fs.createReadStream('asd');

--- a/test/parallel/test-fs-write-stream-patch-open.js
+++ b/test/parallel/test-fs-write-stream-patch-open.js
@@ -22,15 +22,6 @@ if (process.argv[2] !== 'child') {
 }
 
 // Child
-
-common.expectWarning(
-  'DeprecationWarning',
-  'WriteStream.prototype.open() is deprecated', 'DEP0135');
-const s = fs.createWriteStream(`${tmpdir.path}/out`);
-s.open();
-
-process.nextTick(() => {
-  // Allow overriding open().
-  fs.WriteStream.prototype.open = common.mustCall();
-  fs.createWriteStream('asd');
-});
+// Allow overriding open().
+fs.WriteStream.prototype.open = common.mustCall();
+fs.createWriteStream('asd');


### PR DESCRIPTION
The `open()` method on fs read and write streams has been deprecated for many years. It's time to remove it while still allowing the open method to be monkeypatched since that's still apparently a thing.
