### PR TITLE
doc: update metadata for _transformState deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2959,12 +2959,15 @@ upon `require('node:module').builtinModules`.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v14.5.0
     pr-url: https://github.com/nodejs/node/pull/33126
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 `Transform._transformState` will be removed in future versions where it is
 no longer required due to simplification of the implementation.

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2959,7 +2959,7 @@ upon `require('node:module').builtinModules`.
 
 <!-- YAML
 changes:
-  - version: REPLACEME
+  - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/33105
     description: End-of-Life.
   - version: v14.5.0

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2960,7 +2960,7 @@ upon `require('node:module').builtinModules`.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/33105
     description: End-of-Life.
   - version: v14.5.0
     pr-url: https://github.com/nodejs/node/pull/33126


### PR DESCRIPTION
It seems that the deprecated `_transformState` property was removed at some point in the past but the deprecation metadata was not updated accordingly.

@ronag or @mcollina ... do you happen to know which PR and which release removed the `_transformState`?
