### PR TITLE
perf_hooks: move deprecated accessors to EOF

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3137,18 +3137,21 @@ an explicit [`"exports"` or `"main"` entry][] with the exact file extension.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v16.0.0
     pr-url: https://github.com/nodejs/node/pull/37136
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-The `'gc'`, `'http2'`, and `'http'` {PerformanceEntry} object types have
+The `'gc'`, `'http2'`, and `'http'` {PerformanceEntry} object types used to have
 additional properties assigned to them that provide additional information.
 These properties are now available within the standard `detail` property
-of the `PerformanceEntry` object. The existing accessors have been
-deprecated and should no longer be used.
+of the `PerformanceEntry` object. The deprecated accessors have been
+removed.
 
 ### DEP0153: `dns.lookup` and `dnsPromises.lookup` options type coercion
 

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -14,7 +14,6 @@ const {
   MathMin,
   ObjectDefineProperties,
   ObjectFreeze,
-  ObjectKeys,
   SafeMap,
   SafeSet,
   Symbol,
@@ -57,7 +56,6 @@ const {
 
 const {
   customInspectSymbol: kInspect,
-  deprecate,
   lazyDOMException,
   kEmptyObject,
   kEnumerableProperty,
@@ -74,11 +72,6 @@ const { now } = require('internal/perf/utils');
 const kBuffer = Symbol('kBuffer');
 const kDispatch = Symbol('kDispatch');
 const kMaybeBuffer = Symbol('kMaybeBuffer');
-const kDeprecatedFields = Symbol('kDeprecatedFields');
-
-const kDeprecationMessage =
-  'Custom PerformanceEntry accessors are deprecated. ' +
-  'Please use the detail property.';
 
 const kTypeSingle = 0;
 const kTypeMultiple = 1;
@@ -535,32 +528,6 @@ function observerCallback(name, type, startTime, duration, details) {
       startTime,
       duration,
       details);
-
-  if (details !== undefined) {
-    // GC, HTTP2, and HTTP PerformanceEntry used additional
-    // properties directly off the entry. Those have been
-    // moved into the details property. The existing accessors
-    // are still included but are deprecated.
-    entry[kDeprecatedFields] = new SafeMap();
-
-    const detailKeys = ObjectKeys(details);
-    const props = {};
-    for (let n = 0; n < detailKeys.length; n++) {
-      const key = detailKeys[n];
-      entry[kDeprecatedFields].set(key, details[key]);
-      props[key] = {
-        configurable: true,
-        enumerable: true,
-        get: deprecate(() => {
-          return entry[kDeprecatedFields].get(key);
-        }, kDeprecationMessage, 'DEP0152'),
-        set: deprecate((value) => {
-          entry[kDeprecatedFields].set(key, value);
-        }, kDeprecationMessage, 'DEP0152'),
-      };
-    }
-    ObjectDefineProperties(entry, props);
-  }
 
   enqueue(entry);
 }

--- a/test/parallel/test-http2-perf_hooks.js
+++ b/test/parallel/test-http2-perf_hooks.js
@@ -16,14 +16,6 @@ const obs = new PerformanceObserver(common.mustCallAtLeast((items) => {
   assert.strictEqual(typeof entry.duration, 'number');
   switch (entry.name) {
     case 'Http2Session':
-      assert.strictEqual(typeof entry.pingRTT, 'number');
-      assert.strictEqual(typeof entry.streamAverageDuration, 'number');
-      assert.strictEqual(typeof entry.streamCount, 'number');
-      assert.strictEqual(typeof entry.framesReceived, 'number');
-      assert.strictEqual(typeof entry.framesSent, 'number');
-      assert.strictEqual(typeof entry.bytesWritten, 'number');
-      assert.strictEqual(typeof entry.bytesRead, 'number');
-      assert.strictEqual(typeof entry.maxConcurrentStreams, 'number');
       assert.strictEqual(typeof entry.detail.pingRTT, 'number');
       assert.strictEqual(typeof entry.detail.streamAverageDuration, 'number');
       assert.strictEqual(typeof entry.detail.streamCount, 'number');
@@ -32,7 +24,7 @@ const obs = new PerformanceObserver(common.mustCallAtLeast((items) => {
       assert.strictEqual(typeof entry.detail.bytesWritten, 'number');
       assert.strictEqual(typeof entry.detail.bytesRead, 'number');
       assert.strictEqual(typeof entry.detail.maxConcurrentStreams, 'number');
-      switch (entry.type) {
+      switch (entry.detail.type) {
         case 'server':
           assert.strictEqual(entry.detail.streamCount, 1);
           assert(entry.detail.framesReceived >= 3);
@@ -46,11 +38,6 @@ const obs = new PerformanceObserver(common.mustCallAtLeast((items) => {
       }
       break;
     case 'Http2Stream':
-      assert.strictEqual(typeof entry.timeToFirstByte, 'number');
-      assert.strictEqual(typeof entry.timeToFirstByteSent, 'number');
-      assert.strictEqual(typeof entry.timeToFirstHeader, 'number');
-      assert.strictEqual(typeof entry.bytesWritten, 'number');
-      assert.strictEqual(typeof entry.bytesRead, 'number');
       assert.strictEqual(typeof entry.detail.timeToFirstByte, 'number');
       assert.strictEqual(typeof entry.detail.timeToFirstByteSent, 'number');
       assert.strictEqual(typeof entry.detail.timeToFirstHeader, 'number');

--- a/test/parallel/test-performance-gc.js
+++ b/test/parallel/test-performance-gc.js
@@ -30,9 +30,7 @@ const kinds = [
     assert(entry);
     assert.strictEqual(entry.name, 'gc');
     assert.strictEqual(entry.entryType, 'gc');
-    assert(kinds.includes(entry.kind));
     assert(kinds.includes(entry.detail.kind));
-    assert.strictEqual(entry.flags, NODE_PERFORMANCE_GC_FLAGS_FORCED);
     assert.strictEqual(entry.detail.flags, NODE_PERFORMANCE_GC_FLAGS_FORCED);
     assert.strictEqual(typeof entry.startTime, 'number');
     assert(entry.startTime < 1e4, 'startTime should be relative to performance.timeOrigin.');


### PR DESCRIPTION
Additional accessors on PerformanceEntry objects
have been deprecated in favor of the detail property for a number of years now. This removes them.

