### PR TITLE
lib: graduate error codes that have been around for years

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1796,8 +1796,6 @@ time.
 
 ### `ERR_INPUT_TYPE_NOT_ALLOWED`
 
-> Stability: 1 - Experimental
-
 The `--input-type` flag was used to attempt to execute a file. This flag can
 only be used with input via `--eval`, `--print`, or `STDIN`.
 
@@ -3095,16 +3093,12 @@ An invalid or unknown encoding option was passed to an API.
 
 ### `ERR_UNKNOWN_FILE_EXTENSION`
 
-> Stability: 1 - Experimental
-
 An attempt was made to load a module with an unknown or unsupported file
 extension.
 
 <a id="ERR_UNKNOWN_MODULE_FORMAT"></a>
 
 ### `ERR_UNKNOWN_MODULE_FORMAT`
-
-> Stability: 1 - Experimental
 
 An attempt was made to load a module with an unknown or unsupported format.
 
@@ -3182,8 +3176,6 @@ transformation with [type-stripping][].
 <a id="ERR_USE_AFTER_CLOSE"></a>
 
 ### `ERR_USE_AFTER_CLOSE`
-
-> Stability: 1 - Experimental
 
 An attempt was made to use something that was already closed.
 


### PR DESCRIPTION
Handful of error messages that have been marked experimental for years... in one case 8 years! I think it's safe to mark them stable.