### PR TITLE
[v24.x] Backport doc deprecations

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3926,7 +3926,7 @@ The `node:_stream_duplex`, `node:_stream_passthrough`, `node:_stream_readable`, 
 `node:_stream_wrap` and `node:_stream_writable` modules are deprecated as they should be considered
 an internal nodejs implementation rather than a public facing API, use `node:stream` instead.
 
-### DEP0194: `require('node:http2').Http2Stream.priority`
+### DEP0194: HTTP/2 priority signaling
 
 <!-- YAML
 changes:

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3897,10 +3897,54 @@ of built-in modules. This was incomplete and matched the already deprecated
 `repl._builtinLibs` ([DEP0142][]) instead it's better to rely
 upon `require('node:module').builtinModules`.
 
+### DEP0192: `require('node:_tls_common')` and `require('node:_tls_wrap')`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/57643
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The `node:_tls_common` and `node:_tls_wrap` modules are deprecated as they should be considered
+an internal nodejs implementation rather than a public facing API, use `node:tls` instead.
+
+### DEP0193: `require('node:_stream_*')`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58337
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The `node:_stream_duplex`, `node:_stream_passthrough`, `node:_stream_readable`, `node:_stream_transform`,
+`node:_stream_wrap` and `node:_stream_writable` modules are deprecated as they should be considered
+an internal nodejs implementation rather than a public facing API, use `node:stream` instead.
+
+### DEP0194: `require('node:http2').Http2Stream.priority`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58313
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+The support for priority signaling has been deprecated in the [RFC 9113][], and
+will be removed in future versions of Node.js.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
 [RFC 8247 Section 2.4]: https://www.rfc-editor.org/rfc/rfc8247#section-2.4
+[RFC 9113]: https://datatracker.ietf.org/doc/html/rfc9113#section-5.3.1
 [WHATWG URL API]: url.md#the-whatwg-url-api
 [`"exports"` or `"main"` entry]: packages.md#main-entry-point-export
 [`'uncaughtException'`]: process.md#event-uncaughtexception

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1457,6 +1457,7 @@ numeric stream identifier.
 
 <!-- YAML
 added: v8.4.0
+deprecated: REPLACEME
 -->
 
 * `options` {Object}
@@ -1473,6 +1474,9 @@ added: v8.4.0
     sending a `PRIORITY` frame to the connected peer.
 
 Updates the priority for this `Http2Stream` instance.
+
+The support for priority signaling has been deprecated in the [RFC 9113][], and
+will be removed in future versions of Node.js.
 
 #### `http2stream.rstCode`
 
@@ -1583,8 +1587,11 @@ Provides miscellaneous information about the current state of the
     remotely.
   * `sumDependencyWeight` {number} The sum weight of all `Http2Stream`
     instances that depend on this `Http2Stream` as specified using
-    `PRIORITY` frames.
-  * `weight` {number} The priority weight of this `Http2Stream`.
+    `PRIORITY` frames. This has been **deprecated** in [RFC 9113][], and
+    support for it will be removed in future versions of Node.js.
+  * `weight` {number} The priority weight of this `Http2Stream`. This has been
+    **deprecated** in [RFC 9113][], and support for it will be removed in future
+    versions of Node.js.
 
 A current state of this `Http2Stream`.
 
@@ -4883,6 +4890,7 @@ you need to implement any fall-back behavior yourself.
 [RFC 7838]: https://tools.ietf.org/html/rfc7838
 [RFC 8336]: https://tools.ietf.org/html/rfc8336
 [RFC 8441]: https://tools.ietf.org/html/rfc8441
+[RFC 9113]: https://datatracker.ietf.org/doc/html/rfc9113#section-5.3.1
 [Sensitive headers]: #sensitive-headers
 [`'checkContinue'`]: #event-checkcontinue
 [`'connect'`]: #event-connect

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -1071,6 +1071,11 @@ The `'origin'` event is only emitted when using a secure TLS connection.
 
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58313
+    description: Following the deprecation of priority signaling as of RFC 1993,
+                 `weight` option is deprecated.
 -->
 
 * `headers` {HTTP/2 Headers Object} | {Array}
@@ -1087,7 +1092,8 @@ added: v8.4.0
     created stream is dependent on.
   * `weight` {number} Specifies the relative dependency of a stream in relation
     to other streams with the same `parent`. The value is a number between `1`
-    and `256` (inclusive).
+    and `256` (inclusive). This has been **deprecated** in [RFC 9113][], and
+    support for it will be removed in future versions of Node.js.
   * `waitForTrailers` {boolean} When `true`, the `Http2Stream` will emit the
     `'wantTrailers'` event after the final `DATA` frame has been sent.
   * `signal` {AbortSignal} An AbortSignal that may be used to abort an ongoing
@@ -1460,6 +1466,9 @@ added: v8.4.0
 deprecated: REPLACEME
 -->
 
+> Stability: 0 - Deprecated: support for priority signaling has been deprecated
+> in the [RFC 9113][] and is no longer supported in Node.js.
+
 * `options` {Object}
   * `exclusive` {boolean} When `true` and `parent` identifies a parent Stream,
     this stream is made the sole direct dependency of the parent, with
@@ -1474,9 +1483,6 @@ deprecated: REPLACEME
     sending a `PRIORITY` frame to the connected peer.
 
 Updates the priority for this `Http2Stream` instance.
-
-The support for priority signaling has been deprecated in the [RFC 9113][], and
-will be removed in future versions of Node.js.
 
 #### `http2stream.rstCode`
 
@@ -1572,6 +1578,11 @@ req.setTimeout(5000, () => req.close(NGHTTP2_CANCEL));
 
 <!-- YAML
 added: v8.4.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58313
+    description: Following the deprecation of priority signaling as of RFC 1993,
+                 `weight` and `sumDependencyWeight` options are deprecated.
 -->
 
 Provides miscellaneous information about the current state of the


### PR DESCRIPTION
Includes:
- **doc: deprecate HTTP/2 priority signaling**
- **doc: clarify DEP0194 scope**
- Doc-only deprecations from https://github.com/nodejs/node/pull/57643 and https://github.com/nodejs/node/pull/58337

