### PR TITLE
test: dispose of filehandles in filehandle.read tests

### DIFF
--- a/test/parallel/test-fs-read-empty-buffer.js
+++ b/test/parallel/test-fs-read-empty-buffer.js
@@ -29,7 +29,7 @@ assert.throws(
 );
 
 (async () => {
-  const filehandle = await fsPromises.open(filepath, 'r');
+  await using filehandle = await fsPromises.open(filepath, 'r');
   assert.rejects(
     () => filehandle.read(buffer, 0, 1, 0),
     {

--- a/test/parallel/test-fs-read-offset-null.js
+++ b/test/parallel/test-fs-read-offset-null.js
@@ -35,30 +35,25 @@ fs.open(filepath, 'r', common.mustSucceed((fd) => {
           }));
 }));
 
-let filehandle = null;
-
 // Tests for promises api
 (async () => {
-  filehandle = await fsPromises.open(filepath, 'r');
+  await using filehandle = await fsPromises.open(filepath, 'r');
   const readObject = await filehandle.read(buf, { offset: null });
   assert.strictEqual(readObject.buffer[0], 120);
 })()
-.finally(() => filehandle?.close())
 .then(common.mustCall());
 
 // Undocumented: omitted position works the same as position === null
 (async () => {
-  filehandle = await fsPromises.open(filepath, 'r');
+  await using filehandle = await fsPromises.open(filepath, 'r');
   const readObject = await filehandle.read(buf, null, buf.length);
   assert.strictEqual(readObject.buffer[0], 120);
 })()
-.finally(() => filehandle?.close())
 .then(common.mustCall());
 
 (async () => {
-  filehandle = await fsPromises.open(filepath, 'r');
+  await using filehandle = await fsPromises.open(filepath, 'r');
   const readObject = await filehandle.read(buf, null, buf.length, 0);
   assert.strictEqual(readObject.buffer[0], 120);
 })()
-.finally(() => filehandle?.close())
 .then(common.mustCall());


### PR DESCRIPTION
`test-fs-read-empty-buffer.js` did not close used filehandle.
`test-fs-read-offset-null` reused same variable in async tests, creating potential race condition.