### PR TITLE
fs: add autoClose option to FileHandle readableWebStream

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -476,11 +476,14 @@ Reads data from the file and stores that in the given buffer.
 If the file is not modified concurrently, the end-of-file is reached when the
 number of bytes read is zero.
 
-#### `filehandle.readableWebStream()`
+#### `filehandle.readableWebStream([options])`
 
 <!-- YAML
 added: v17.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58548
+    description: Added the `autoClose` option.
   - version: v24.0.0
     pr-url: https://github.com/nodejs/node/pull/57513
     description: Marking the API stable.
@@ -496,6 +499,9 @@ changes:
     description: Added option to create a 'bytes' stream.
 -->
 
+* `options` {Object}
+  * `autoClose` {boolean} When true, causes the {FileHandle} to be closed when the
+    stream is closed. **Default:** `false`
 * Returns: {ReadableStream}
 
 Returns a byte-oriented `ReadableStream` that may be used to read the file's

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -86,7 +86,6 @@ const {
   validateInteger,
   validateObject,
   validateOneOf,
-  validateString,
   kValidateObjectAllowNullable,
 } = require('internal/validators');
 const pathModule = require('path');
@@ -279,9 +278,10 @@ class FileHandle extends EventEmitter {
   /**
    * @typedef {import('../webstreams/readablestream').ReadableStream
    * } ReadableStream
+   * @param {{ type?: 'bytes', autoClose?: boolean }} [options]
    * @returns {ReadableStream}
    */
-  readableWebStream(options = { __proto__: null, type: 'bytes' }) {
+  readableWebStream(options = kEmptyObject) {
     if (this[kFd] === -1)
       throw new ERR_INVALID_STATE('The FileHandle is closed');
     if (this[kClosePromise])
@@ -290,10 +290,15 @@ class FileHandle extends EventEmitter {
       throw new ERR_INVALID_STATE('The FileHandle is locked');
     this[kLocked] = true;
 
-    if (options.type !== undefined) {
-      validateString(options.type, 'options.type');
-    }
-    if (options.type !== 'bytes') {
+    validateObject(options, 'options');
+    const {
+      type = 'bytes',
+      autoClose = false,
+    } = options;
+
+    validateBoolean(autoClose, 'options.autoClose');
+
+    if (type !== 'bytes') {
       process.emitWarning(
         'A non-"bytes" options.type has no effect. A byte-oriented steam is ' +
         'always created.',
@@ -301,9 +306,11 @@ class FileHandle extends EventEmitter {
       );
     }
 
-
     const readFn = FunctionPrototypeBind(this.read, this);
-    const ondone = FunctionPrototypeBind(this[kUnref], this);
+    const ondone = async () => {
+      this[kUnref]();
+      if (autoClose) await this.close();
+    };
 
     const ReadableStream = lazyReadableStream();
     const readable = new ReadableStream({
@@ -315,15 +322,15 @@ class FileHandle extends EventEmitter {
         const { bytesRead } = await readFn(view, view.byteOffset, view.byteLength);
 
         if (bytesRead === 0) {
-          ondone();
           controller.close();
+          await ondone();
         }
 
         controller.byobRequest.respond(bytesRead);
       },
 
-      cancel() {
-        ondone();
+      async cancel() {
+        await ondone();
       },
     });
 

--- a/test/es-module/test-wasm-web-api.js
+++ b/test/es-module/test-wasm-web-api.js
@@ -106,7 +106,9 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
   // Response whose body is a ReadableStream instead of calling fetch().
   await testCompileStreamingSuccess(async () => {
     const handle = await fs.open(fixtures.path('simple.wasm'));
-    const stream = handle.readableWebStream();
+    // We set the autoClose option to true so that the file handle is closed
+    // automatically when the stream is completed or canceled.
+    const stream = handle.readableWebStream({ autoClose: true });
     return Promise.resolve(new Response(stream, {
       status: 200,
       headers: { 'Content-Type': 'application/wasm' }

--- a/test/parallel/test-filehandle-autoclose.mjs
+++ b/test/parallel/test-filehandle-autoclose.mjs
@@ -1,0 +1,30 @@
+import '../common/index.mjs';
+import { open } from 'node:fs/promises';
+import { rejects } from 'node:assert';
+
+{
+  const fh = await open(new URL(import.meta.url));
+
+  // TODO: remove autoClose option when it becomes default
+  const readableStream = fh.readableWebStream({ autoClose: true });
+
+  // Consume the stream
+  await new Response(readableStream).text();
+
+  // If reading the FileHandle after the stream is consumed fails,
+  // then we assume the autoClose option worked as expected.
+  await rejects(fh.read(), { code: 'EBADF' });
+}
+
+{
+  await using fh = await open(new URL(import.meta.url));
+
+  const readableStream = fh.readableWebStream({ autoClose: false });
+
+  // Consume the stream
+  await new Response(readableStream).text();
+
+  // Filehandle must be still open
+  await fh.read();
+  await fh.close();
+}


### PR DESCRIPTION
Separated out from #58536

By default, the `readableWebStream` method of `FileHandle` returns a ReadableStream that, when finished, does not close the underlying FileHandle. This can lead to issues if the stream is consumed without having a reference to the FileHandle to close after use. This commit adds an `autoClose` option to the `readableWebStream` method, which, when set to `true`, will automatically close the FileHandle when the stream is finished or canceled.

The test modified in this commit demonstrates one of the cases where this is necessary in that the stream is consumed by separate code than the FileHandle which was being left to close the underlying fd when it is garbage collected, which is a deprecated behavior.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
