### PR TITLE
doc: mark Node.js 23 as End-of-Life

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Select a Node.js version below to view the changelog history:
 
 * [Node.js 24](doc/changelogs/CHANGELOG_V24.md) **Current**
-* [Node.js 23](doc/changelogs/CHANGELOG_V23.md) **Current**
+* [Node.js 23](doc/changelogs/CHANGELOG_V23.md) End-of-Life
 * [Node.js 22](doc/changelogs/CHANGELOG_V22.md) **Long Term Support**
 * [Node.js 21](doc/changelogs/CHANGELOG_V21.md) End-of-Life
 * [Node.js 20](doc/changelogs/CHANGELOG_V20.md) Long Term Support
@@ -34,7 +34,6 @@ release.
 <table>
 <tr>
   <th title="Current"><a href="doc/changelogs/CHANGELOG_V24.md">24</a> (Current)</th>
-  <th title="Current"><a href="doc/changelogs/CHANGELOG_V23.md">23</a> (Current)</th>
   <th title="LTS Until 2027-04"><a href="doc/changelogs/CHANGELOG_V22.md">22</a> (LTS)</th>
   <th title="LTS Until 2026-04"><a href="doc/changelogs/CHANGELOG_V20.md">20</a> (LTS)</th>
 </tr>
@@ -44,22 +43,6 @@ release.
 <a href="doc/changelogs/CHANGELOG_V24.md#24.0.2">24.0.2</a><br/>
 <a href="doc/changelogs/CHANGELOG_V24.md#24.0.1">24.0.1</a><br/>
 <a href="doc/changelogs/CHANGELOG_V24.md#24.0.0">24.0.0</a><br/>
-  </td>
-  <td valign="top">
-<b><a href="doc/changelogs/CHANGELOG_V23.md#23.11.1">23.11.1</a></b><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.11.0">23.11.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.10.0">23.10.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.9.0">23.9.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.8.0">23.8.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.7.0">23.7.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.6.1">23.6.1</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.6.0">23.6.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.5.0">23.5.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.4.0">23.4.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.3.0">23.3.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.2.0">23.2.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.1.0">23.1.0</a><br/>
-<a href="doc/changelogs/CHANGELOG_V23.md#23.0.0">23.0.0</a><br/>
   </td>
   <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V22.md#22.16.0">22.16.0</a></b><br/>


### PR DESCRIPTION
As of June 1st, Node.js 23 has reached End-of-Life.

Refs: https://github.com/nodejs/Release/blob/main/schedule.json

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
