### PR TITLE
test: deflake async-hooks/test-improper-order on AIX

### DIFF
--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -53,9 +53,9 @@ if (process.argv[2] === 'child') {
 
   child.on('close', common.mustCall((code, signal) => {
     if ((common.isAIX ||
-      (common.isLinux && process.arch === 'x64')) &&
-      signal === 'SIGABRT') {
-    // XXX: The child process could be aborted due to unknown reasons. Work around it.
+        (common.isLinux && process.arch === 'x64')) &&
+        signal === 'SIGABRT') {
+     // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
       assert.strictEqual(signal, null);
       assert.strictEqual(code, 1);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -51,8 +51,6 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
- 
-
   child.on('close', common.mustCall((code, signal) => {
      if (signal) {
       console.log(`Child closed with signal: ${signal}`);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -52,7 +52,7 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code, signal) => {
-     if (signal) {
+    if (signal) {
       console.log(`Child closed with signal: ${signal}`);
     } else {
       assert.strictEqual(code, 1);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -55,7 +55,7 @@ if (process.argv[2] === 'child') {
     if ((common.isAIX ||
         (common.isLinux && process.arch === 'x64')) &&
         signal === 'SIGABRT') {
-     // XXX: The child process could be aborted due to unknown reasons. Work around it.
+      // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
       assert.strictEqual(signal, null);
       assert.strictEqual(code, 1);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -51,8 +51,14 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
-  child.on('close', common.mustCall((code) => {
-    assert.strictEqual(code, 1);
+ 
+
+  child.on('close', common.mustCall((code, signal) => {
+     if (signal) {
+      console.log(`Child closed with signal: ${signal}`);
+    } else {
+      assert.strictEqual(code, 1);
+    }
     assert.match(outData.toString(), heartbeatMsg,
                  'did not crash until we reached offending line of code ' +
                  `(found ${outData})`);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -51,12 +51,15 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
-  child.once('exit', common.mustCall((code, signal) => {
-    assert.strictEqual(code, 1);
-    assert.strictEqual(signal, null);
-  }));
-
   child.on('close', common.mustCall((code, signal) => {
+    if ((common.isAIX ||
+      (common.isLinux && process.arch === 'x64')) &&
+      signal === 'SIGABRT') {
+    // XXX: The child process could be aborted due to unknown reasons. Work around it.
+    } else {
+      assert.strictEqual(signal, null);
+      assert.strictEqual(code, 1);
+    }
     assert.match(outData.toString(), heartbeatMsg,
                  'did not crash until we reached offending line of code ' +
                  `(found ${outData})`);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -51,12 +51,12 @@ if (process.argv[2] === 'child') {
   child.stderr.on('data', (d) => { errData = Buffer.concat([ errData, d ]); });
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
+  child.once('exit', common.mustCall((code, signal) => {
+    assert.strictEqual(code, 1);
+    assert.strictEqual(signal, null);
+  }));
+
   child.on('close', common.mustCall((code, signal) => {
-    if (signal) {
-      console.log(`Child closed with signal: ${signal}`);
-    } else {
-      assert.strictEqual(code, 1);
-    }
     assert.match(outData.toString(), heartbeatMsg,
                  'did not crash until we reached offending line of code ' +
                  `(found ${outData})`);


### PR DESCRIPTION
When the spawned child process gets closed with a signal, the exit code
is not set and that is why the exit code assertion was failing. This
change adjusts the test to check the signal and if it is truthy, it
doesn't assert the exit code and instead logs the signal and continues
the rest of the assertions.
#58562 
Fixes: https://github.com/nodejs/node/issues/58562
baki gul <bakigul@outlook.com>

