### PR TITLE
doc: correct formatting of example definitions for `--test-shard`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2578,8 +2578,9 @@ added:
 
 Test suite shard to execute in a format of `<index>/<total>`, where
 
-`index` is a positive integer, index of divided parts
-`total` is a positive integer, total of divided part
+* `index` is a positive integer, index of divided parts.
+* `total` is a positive integer, total of divided part.
+
 This command will divide all tests files into `total` equal parts,
 and will run only those that happen to be in an `index` part.
 


### PR DESCRIPTION
The original formatting intention was pretty clear in the raw markdown, but it doesn't render that way.