### PR TITLE
doc: fix return types for sync methods

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1196,7 +1196,8 @@ changes:
     `'/bin/sh'` on Unix, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell requirements][] and
     [Default Windows shell][]. **Default:** `false` (no shell).
-* Returns: {Buffer|string} The stdout from the command.
+* Returns: {Buffer|string|null} If `stdio` is `'pipe'`, the stdout from the
+  command, otherwise null.
 
 The `child_process.execFileSync()` method is generally identical to
 [`child_process.execFile()`][] with the exception that the method will not
@@ -1323,7 +1324,8 @@ changes:
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
-* Returns: {Buffer|string} The stdout from the command.
+* Returns: {Buffer|string|null} If `stdio` is `'pipe'`, the stdout from the
+  command, otherwise null.
 
 The `child_process.execSync()` method is generally identical to
 [`child_process.exec()`][] with the exception that the method will not return
@@ -1407,8 +1409,10 @@ changes:
 * Returns: {Object}
   * `pid` {number} Pid of the child process.
   * `output` {Array} Array of results from stdio output.
-  * `stdout` {Buffer|string} The contents of `output[1]`.
-  * `stderr` {Buffer|string} The contents of `output[2]`.
+  * `stdout` {Buffer|string|null} If `stdio` is `'pipe'`, the contents of
+    `output[1]`, otherwise null.
+  * `stderr` {Buffer|string|null} If `stdio` is `'pipe'`, the contents of
+    `output[2]`, otherwise null.
   * `status` {number|null} The exit code of the subprocess, or `null` if the
     subprocess terminated due to a signal.
   * `signal` {string|null} The signal used to kill the subprocess, or `null` if

--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -856,8 +856,8 @@ function spawn(file, args, options) {
  * @returns {{
  *   pid: number;
  *   output: Array;
- *   stdout: Buffer | string;
- *   stderr: Buffer | string;
+ *   stdout: Buffer | string | null;
+ *   stderr: Buffer | string | null;
  *   status: number | null;
  *   signal: string | null;
  *   error: Error;
@@ -945,7 +945,7 @@ function checkExecSyncError(ret, args, cmd) {
  *   windowsHide?: boolean;
  *   shell?: boolean | string;
  *   }} [options]
- * @returns {Buffer | string}
+ * @returns {Buffer | string | null}
  */
 function execFileSync(file, args, options) {
   ({ file, args, options } = normalizeExecFileArgs(file, args, options));
@@ -983,7 +983,7 @@ function execFileSync(file, args, options) {
  *   encoding?: string;
  *   windowsHide?: boolean;
  *   }} [options]
- * @returns {Buffer | string}
+ * @returns {Buffer | string | null}
  */
 function execSync(command, options) {
   const opts = normalizeExecArgs(command, options, null);


### PR DESCRIPTION
For the sync methods spawnSync(), execSync() and execFileSync(), when the stdio option is set to anything other than 'pipe', the stdout and stderr returned from the C++ code will be null, and not a string or Buffer as currently documented.

The null originates from the C++ code where:

- the C++ internal representation of the stdio pipes [defaults to a null pointer](https://github.com/nodejs/node/blob/v24.1.0/src/spawn_sync.cc#L972) and [only gets replaced with an SyncProcessStdioPipe instance for `'pipe'` `stdio` options](https://github.com/nodejs/node/blob/v24.1.0/src/spawn_sync.cc#L1045)
- when returning the output array from C++ to JavaScript, [C++ null pointer will be represented as JavaScript null](https://github.com/nodejs/node/blob/v24.1.0/src/spawn_sync.cc#L770)
- therefore for non-`'pipe'` `stdio` cases, it will be a null, and not a string or Buffer

We can confirm the current behavior with:

```javascript
const { execSync } = require('node:child_process');
const results = ["pipe", "ignore", "inherit"].map(option => {
  return execSync("pwd", { stdio: option });
});
console.log(results);
```

The output with a build of current `main` at 641653b2da1f7c698b8732e14ad45844d3932749 is:

```text
/Users/cflee/projects/node
[
  <Buffer 2f 55 73 65 72 73 2f 63 66 6c 65 65 2f 70 72 6f 6a 65 63 74 73 2f 6e 6f 64 65 0a>,
  null,
  null
]
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
