### PR TITLE
lib: prefer Atomics primordials

### DIFF
--- a/lib/internal/test_runner/mock/loader.js
+++ b/lib/internal/test_runner/mock/loader.js
@@ -1,13 +1,9 @@
 'use strict';
 const {
+  AtomicsNotify,
+  AtomicsStore,
   JSONStringify,
   SafeMap,
-  globalThis: {
-    Atomics: {
-      notify: AtomicsNotify,
-      store: AtomicsStore,
-    },
-  },
 } = primordials;
 const {
   kBadExportsMessage,

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -2,6 +2,8 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
+  AtomicsStore,
+  AtomicsWait,
   Error,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
@@ -18,10 +20,6 @@ const {
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   globalThis: {
-    Atomics: {
-      store: AtomicsStore,
-      wait: AtomicsWait,
-    },
     SharedArrayBuffer,
   },
 } = primordials;

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -46,6 +46,19 @@ declare namespace primordials {
   export import decodeURIComponent = globalThis.decodeURIComponent;
   export import encodeURI = globalThis.encodeURI;
   export import encodeURIComponent = globalThis.encodeURIComponent;
+  export const AtomicsAdd: typeof Atomics.add
+  export const AtomicsAnd: typeof Atomics.and
+  export const AtomicsCompareExchange: typeof Atomics.compareExchange
+  export const AtomicsExchange: typeof Atomics.exchange
+  export const AtomicsIsLockFree: typeof Atomics.isLockFree
+  export const AtomicsLoad: typeof Atomics.load
+  export const AtomicsNotify: typeof Atomics.notify
+  export const AtomicsOr: typeof Atomics.or
+  export const AtomicsStore: typeof Atomics.store
+  export const AtomicsSub: typeof Atomics.sub
+  export const AtomicsWait: typeof Atomics.wait
+  export const AtomicsWaitAsync: typeof Atomics.waitAsync
+  export const AtomicsXor: typeof Atomics.xor
   export const JSONParse: typeof JSON.parse
   export const JSONStringify: typeof JSON.stringify
   export const MathAbs: typeof Math.abs


### PR DESCRIPTION
#### typings: add Atomics primordials
Note that `Atomics.pause()` is still flagged.

#### lib: prefer Atomics primordials
The majority of cases already use primordials, but there are a couple of hangovers.