### PR TITLE
node-api: preserve URL filenames without conversion

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,3 +1,4 @@
+#include "ada.h"
 #include "async_context_frame.h"
 #include "async_wrap-inl.h"
 #include "env-inl.h"
@@ -723,7 +724,7 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
     node::Utf8Value filename(node_env->isolate(), filename_js);
 
     const auto filename_view = filename.ToStringView();
-    if (filename_view.find("://") != std::string_view::npos) {
+    if (ada::can_parse(filename_view)) {
       module_filename = filename_view;
     } else {
       module_filename = node::url::FromFilePath(filename_view);

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -722,11 +722,12 @@ void napi_module_register_by_symbol(v8::Local<v8::Object> exports,
       filename_js->IsString()) {
     node::Utf8Value filename(node_env->isolate(), filename_js);
 
-    // Turn the absolute path into a URL. Currently the absolute path is always
-    // a file system path.
-    // TODO(gabrielschulhof): Pass the `filename` through unchanged if/when we
-    // receive it as a URL already.
-    module_filename = node::url::FromFilePath(filename.ToStringView());
+    const auto filename_view = filename.ToStringView();
+    if (filename_view.find("://") != std::string_view::npos) {
+      module_filename = filename_view;
+    } else {
+      module_filename = node::url::FromFilePath(filename_view);
+    }
   }
 
   // Create a new napi_env for this specific module.


### PR DESCRIPTION
allows us to process filenames that are already URLs by passing them unchanged