### PR TITLE
deps: use proper C standard when building libuv

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -190,7 +190,7 @@
           '-Wno-unused-parameter',
           '-Wstrict-prototypes',
         ],
-        'OTHER_CFLAGS': [ '-g', '--std=gnu89' ],
+        'OTHER_CFLAGS': [ '-g', '--std=gnu11' ],
       },
       'conditions': [
         [ 'OS=="win"', {
@@ -262,7 +262,7 @@
           'cflags': [
             '-fvisibility=hidden',
             '-g',
-            '--std=gnu89',
+            '--std=gnu11',
             '-Wall',
             '-Wextra',
             '-Wno-unused-parameter',


### PR DESCRIPTION
Upstream libuv commits:
https://github.com/libuv/libuv/commit/bb706f5fe71827f667f0bce532e95ce0698a498d
https://github.com/libuv/libuv/commit/018363a163e8901ac2b90100ee436d9472847ffa

libuv was updated to 1.51.0 in 0315283cbdb7745c7e35bb49ac48b0ebcadcb228. v1.51.0 was the release updating from c90 to c11. The standard was back then also updated from c89 to c90. and C89 was never an official standard to begin with. So, I wonder how this managed to stay without breaking anyone's builds for this long. This atleast breaks the builds for Android using NDK r28b and r28a, as LLONG_MAX is not defined by the Clang compiler for older C standards with the newer NDK.

Fixes:
```
FAILED: obj/deps/uv/src/unix/libuv.linux.o
aarch64-linux-android-clang -MMD -MF obj/deps/uv/src/unix/libuv.linux.o.d -D_GLIBCXX_USE_CXX11_ABI=1 -D_FILE_OFFSET_BITS=64 -DNODE_OPENSSL_CONF_NAME=nodejs_conf -DICU_NO_USER_DATA_OVERRIDE -D__STDC_FORMAT_MACROS -D_LARGEFILE_SOURCE -D_GNU_SOURCE -D_GLIBCXX_USE_C99_MATH -I../../deps/uv/include -I../../deps/uv/src -I/data/data/com.termux/files/usr/include -Wall -Wextra -Wno-unused-parameter -fvisibility=hidden -g --std=gnu89 -Wall -Wextra -Wno-unused-parameter -Wstrict-prototypes -fno-strict-aliasing -O3 -fno-omit-frame-pointer -isystem/data/data/com.termux/files/usr/include/c++/v1 -isystem/data/data/com.termux/files/usr/include -fstack-protector-strong -Oz  -c ../../deps/uv/src/unix/linux.c -o obj/deps/uv/src/unix/libuv.linux.o
../../deps/uv/src/unix/linux.c:2331:36: error: use of undeclared identifier 'LLONG_MAX'
 2331 |     constraint->quota_per_period = LLONG_MAX;
      |                                    ^
1 error generated.
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
