### PR TITLE
doc,lib: update source map links to ECMA426

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -749,7 +749,7 @@ changes:
     description: This API is no longer experimental.
 -->
 
-Enable [Source Map v3][Source Map] support for stack traces.
+Enable [Source Map][] support for stack traces.
 
 When using a transpiler, such as TypeScript, stack traces thrown by an
 application reference the transpiled code, not the original source position.
@@ -3883,7 +3883,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [REPL]: repl.md
 [ScriptCoverage]: https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ScriptCoverage
 [ShadowRealm]: https://github.com/tc39/proposal-shadowrealm
-[Source Map]: https://sourcemaps.info/spec.html
+[Source Map]: https://tc39.es/ecma426/
 [TypeScript type-stripping]: typescript.md#type-stripping
 [V8 Inspector integration for Node.js]: debugger.md#v8-inspector-integration-for-nodejs
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1568,7 +1568,7 @@ Running `node --import 'data:text/javascript,import { register } from "node:modu
 or `node --import ./import-map-sync-hooks.js main.js`
 should print `some module!`.
 
-## Source map v3 support
+## Source Map Support
 
 <!-- YAML
 added:
@@ -1578,13 +1578,17 @@ added:
 
 > Stability: 1 - Experimental
 
-Helpers for interacting with the source map cache. This cache is
-populated when source map parsing is enabled and
+Node.js supports TC39 ECMA-426 [Source Map][] format (it was called Source map
+revision 3 format).
+
+The APIs in this section are helpers for interacting with the source map
+cache. This cache is populated when source map parsing is enabled and
 [source map include directives][] are found in a modules' footer.
 
 To enable source map parsing, Node.js must be run with the flag
 [`--enable-source-maps`][], or with code coverage enabled by setting
-[`NODE_V8_COVERAGE=dir`][].
+[`NODE_V8_COVERAGE=dir`][], or be enabled programmatically via
+[`module.setSourceMapsSupport()`][].
 
 ```mjs
 // module.mjs
@@ -1682,7 +1686,7 @@ changes:
 
 Creates a new `sourceMap` instance.
 
-`payload` is an object with keys matching the [Source map v3 format][]:
+`payload` is an object with keys matching the [Source map format][]:
 
 * `file`: {string}
 * `version`: {number}
@@ -1773,8 +1777,8 @@ returned object contains the following keys:
 [Customization hooks]: #customization-hooks
 [ES Modules]: esm.md
 [Permission Model]: permissions.md#permission-model
-[Source Map]: https://sourcemaps.info/spec.html
-[Source map v3 format]: https://sourcemaps.info/spec.html#h.mofvlxcwqzej
+[Source Map]: https://tc39.es/ecma426/
+[Source map format]: https://tc39.es/ecma426/#sec-source-map-format
 [V8 JavaScript code coverage]: https://v8project.blogspot.com/2017/12/javascript-code-coverage.html
 [V8 code cache]: https://v8.dev/blog/code-caching-for-devs
 [`"exports"`]: packages.md#exports
@@ -1790,6 +1794,7 @@ returned object contains the following keys:
 [`module.enableCompileCache()`]: #moduleenablecompilecachecachedir
 [`module.flushCompileCache()`]: #moduleflushcompilecache
 [`module.getCompileCacheDir()`]: #modulegetcompilecachedir
+[`module.setSourceMapsSupport()`]: #modulesetsourcemapssupportenabled-options
 [`module`]: #the-module-object
 [`os.tmpdir()`]: os.md#ostmpdir
 [`registerHooks`]: #moduleregisterhooksoptions
@@ -1802,7 +1807,7 @@ returned object contains the following keys:
 [module wrapper]: modules.md#the-module-wrapper
 [realm]: https://tc39.es/ecma262/#realm
 [resolve hook]: #resolvespecifier-context-nextresolve
-[source map include directives]: https://sourcemaps.info/spec.html#h.lmz475t4mvbx
+[source map include directives]: https://tc39.es/ecma426/#sec-linking-generated-code
 [the documentation of `Worker`]: worker_threads.md#new-workerfilename-options
 [transferable objects]: worker_threads.md#portpostmessagevalue-transferlist
 [transform TypeScript features]: typescript.md#typescript-features

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -1267,7 +1267,7 @@ This section was moved to
 ## Source map v3 support
 
 This section was moved to
-[Modules: `module` core module](module.md#source-map-v3-support).
+[Modules: `module` core module](module.md#source-map-support).
 
 <!-- Anchors to make sure old links find a target -->
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -4075,7 +4075,7 @@ added:
 
 * `val` {boolean}
 
-This function enables or disables the [Source Map v3][Source Map] support for
+This function enables or disables the [Source Map][] support for
 stack traces.
 
 It provides same features as launching Node.js process with commandline options
@@ -4126,7 +4126,7 @@ added:
 * {boolean}
 
 The `process.sourceMapsEnabled` property returns whether the
-[Source Map v3][Source Map] support for stack traces is enabled.
+[Source Map][] support for stack traces is enabled.
 
 ## `process.stderr`
 
@@ -4586,7 +4586,7 @@ cases:
 [Permission Model]: permissions.md#permission-model
 [Readable]: stream.md#readable-streams
 [Signal Events]: #signal-events
-[Source Map]: https://sourcemaps.info/spec.html
+[Source Map]: https://tc39.es/ecma426/
 [Stream compatibility]: stream.md#compatibility-with-older-nodejs-versions
 [TTY]: tty.md#tty
 [Writable]: stream.md#writable-streams

--- a/lib/internal/source_map/source_map_cache.js
+++ b/lib/internal/source_map/source_map_cache.js
@@ -10,7 +10,7 @@ const {
   StringPrototypeSplit,
 } = primordials;
 
-// See https://sourcemaps.info/spec.html for SourceMap V3 specification.
+// See https://tc39.es/ecma426/ for SourceMap V3 specification.
 const { Buffer } = require('buffer');
 let debug = require('internal/util/debuglog').debuglog('source_map', (fn) => {
   debug = fn;

--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -273,7 +273,7 @@ function nextdir() {
 // Does not attempt to apply path resolution logic to absolute URLs
 // with schemes.
 // Refs: https://github.com/webpack/webpack/issues/9601
-// Refs: https://sourcemaps.info/spec.html#h.75yo6yoyk7x5
+// Refs: https://tc39.es/ecma426/#sec-sources
 {
   const output = spawnSync(process.execPath, [
     '--enable-source-maps',


### PR DESCRIPTION
Update links of source map specs to the standardized ECMA426, with proper IPR policies.