### PR TITLE
module: allow cycles in require() in the CJS handling in ESM loader

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -26,6 +26,7 @@ const {
   ModuleWrap,
   kErrored,
   kEvaluated,
+  kEvaluating,
   kEvaluationPhase,
   kInstantiated,
   kUninstantiated,
@@ -338,8 +339,14 @@ class ModuleJob extends ModuleJobBase {
         return { __proto__: null, module: this.module, namespace };
       }
       throw this.module.getError();
-
-    } else if (status === kEvaluated) {
+    } else if (status === kEvaluating || status === kEvaluated) {
+      // kEvaluating can show up when this is being used to deal with CJS <-> CJS cycles.
+      // Allow it for now, since we only need to ban ESM <-> CJS cycles which would be
+      // detected earlier during the linking phase, though the CJS handling in the ESM
+      // loader won't be able to emit warnings on pending circular exports like what
+      // the CJS loader does.
+      // TODO(joyeecheung): remove the re-invented require() in the ESM loader and
+      // always handle CJS using the CJS loader to eliminate the quirks.
       return { __proto__: null, module: this.module, namespace: this.module.getNamespaceSync() };
     }
     assert.fail(`Unexpected module status ${status}.`);

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -783,11 +783,10 @@ void ModuleWrap::GetNamespaceSync(const FunctionCallbackInfo<Value>& args) {
       return realm->env()->ThrowError(
           "Cannot get namespace, module has not been instantiated");
     case Module::Status::kInstantiated:
+    case Module::Status::kEvaluating:
     case Module::Status::kEvaluated:
     case Module::Status::kErrored:
       break;
-    case Module::Status::kEvaluating:
-      UNREACHABLE();
   }
 
   if (module->IsGraphAsync()) {

--- a/test/es-module/test-import-preload-require-cycle.js
+++ b/test/es-module/test-import-preload-require-cycle.js
@@ -11,7 +11,7 @@ spawnSyncAndAssert(
   process.execPath,
   [
     '--import',
-    fixtures.path('import-require-cycle/preload.mjs'),
+    fixtures.fileURL('import-require-cycle/preload.mjs'),
     fixtures.path('import-require-cycle/c.js'),
   ],
   {

--- a/test/es-module/test-import-preload-require-cycle.js
+++ b/test/es-module/test-import-preload-require-cycle.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// This tests that --import preload does not break CJS entry points that contains
+// require cycles.
+
+require('../common');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+
+spawnSyncAndAssert(
+  process.execPath,
+  [
+    '--import',
+    fixtures.path('import-require-cycle/preload.mjs'),
+    fixtures.path('import-require-cycle/c.js'),
+  ],
+  {
+    stdout: /cycle equality true/,
+  }
+);

--- a/test/fixtures/import-require-cycle/a.js
+++ b/test/fixtures/import-require-cycle/a.js
@@ -1,0 +1,1 @@
+module.exports.b = require('./b.js');

--- a/test/fixtures/import-require-cycle/b.js
+++ b/test/fixtures/import-require-cycle/b.js
@@ -1,0 +1,1 @@
+module.exports.a = require('./a.js');

--- a/test/fixtures/import-require-cycle/c.js
+++ b/test/fixtures/import-require-cycle/c.js
@@ -1,0 +1,3 @@
+const obj = require('./b.js');
+
+console.log('cycle equality', obj.a.b === obj);

--- a/test/fixtures/import-require-cycle/preload.mjs
+++ b/test/fixtures/import-require-cycle/preload.mjs
@@ -1,0 +1,7 @@
+import * as mod from "module";
+
+mod.registerHooks({
+  load(url, context, nextLoad) {
+    return nextLoad(url, context);
+  },
+});


### PR DESCRIPTION
When --import is used, the ESM loader is used to handle even pure CJS entry points, and it can run into CJS module facades in the evaluating state when the parent CJS module is being evaluated. In this case it should be allowed, since the ESM <-> CJS cycles that are meant to be disallowed (for the time being) should already be detected before evaluation and wouldn't get here, and CJS <-> CJS cycles are fine.

Fixes: https://github.com/nodejs/node/issues/58515

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
