### PR TITLE
test: improve flakiness detection on stack corruption tests

### DIFF
--- a/test/async-hooks/test-emit-after-on-destroyed.js
+++ b/test/async-hooks/test-emit-after-on-destroyed.js
@@ -53,9 +53,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code, signal) => {
-    if (signal) {
-      console.log(`Child closed with signal: ${signal}`);
+    if ((common.isAIX ||
+         (common.isLinux && process.arch === 'x64')) &&
+         signal === 'SIGABRT') {
+      // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
+      assert.strictEqual(signal, null);
       assert.strictEqual(code, 1);
     }
     assert.match(outData.toString(), heartbeatMsg,

--- a/test/async-hooks/test-improper-unwind.js
+++ b/test/async-hooks/test-improper-unwind.js
@@ -56,9 +56,12 @@ if (process.argv[2] === 'child') {
   child.stdout.on('data', (d) => { outData = Buffer.concat([ outData, d ]); });
 
   child.on('close', common.mustCall((code, signal) => {
-    if (signal) {
-      console.log(`Child closed with signal: ${signal}`);
+    if ((common.isAIX ||
+         (common.isLinux && process.arch === 'x64')) &&
+         signal === 'SIGABRT') {
+      // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
+      assert.strictEqual(signal, null);
       assert.strictEqual(code, 1);
     }
     assert.match(outData.toString(), heartbeatMsg,


### PR DESCRIPTION
This change skips asserting the exit code of the child process with the corrupted async hooks stack only on those platforms where termination via a signal has been observed.

Refs: https://github.com/nodejs/node/pull/58478#discussion_r2132170010

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
