### PR TITLE
lib: deserialize to native errors in error_serdes

### DIFF
--- a/lib/internal/error_serdes.js
+++ b/lib/internal/error_serdes.js
@@ -6,7 +6,7 @@ const {
   EvalError,
   FunctionPrototypeCall,
   ObjectAssign,
-  ObjectCreate,
+  ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertyNames,
@@ -15,11 +15,12 @@ const {
   ObjectPrototypeToString,
   RangeError,
   ReferenceError,
+  ReflectConstruct,
+  ReflectDeleteProperty,
   SafeSet,
   StringFromCharCode,
   StringPrototypeSubstring,
   SymbolFor,
-  SymbolToStringTag,
   SyntaxError,
   TypeError,
   TypedArrayPrototypeGetBuffer,
@@ -27,6 +28,8 @@ const {
   TypedArrayPrototypeGetByteOffset,
   URIError,
 } = primordials;
+
+const assert = require('internal/assert');
 
 const { Buffer } = require('buffer');
 const { inspect: { custom: customInspectSymbol } } = require('util');
@@ -40,6 +43,7 @@ const kCircularReference = 5;
 
 const kSymbolStringLength = 'Symbol('.length;
 
+// TODO: implement specific logic for AggregateError/SuppressedError
 const errors = {
   Error, TypeError, RangeError, URIError, SyntaxError, ReferenceError, EvalError,
 };
@@ -166,16 +170,17 @@ function deserializeError(error) {
   switch (error[0]) {
     case kSerializedError: {
       const { constructor, properties } = deserialize(error.subarray(1));
-      const ctor = errors[constructor];
-      ObjectDefineProperty(properties, SymbolToStringTag, {
-        __proto__: null,
-        value: { __proto__: null, value: 'Error', configurable: true },
-        enumerable: true,
-      });
+      assert(errorConstructorNames.has(constructor), 'Invalid constructor');
       if ('cause' in properties && 'value' in properties.cause) {
         properties.cause.value = deserializeError(properties.cause.value);
       }
-      return ObjectCreate(ctor.prototype, properties);
+      // Invoke the Error constructor to gain an object with an [[ErrorData]] internal slot
+      const ret = ReflectConstruct(Error, [], errors[constructor]);
+      // Delete any properties defined by the Error constructor before assigning from source
+      ArrayPrototypeForEach(ObjectGetOwnPropertyNames(ret), (key) => {
+        ReflectDeleteProperty(ret, key);
+      });
+      return ObjectDefineProperties(ret, properties);
     }
     case kSerializedObject:
       return deserialize(error.subarray(1));
@@ -196,7 +201,7 @@ function deserializeError(error) {
         [customInspectSymbol]: () => '[Circular object]',
       };
   }
-  require('assert').fail('This should not happen');
+  assert.fail('Unknown serializer flag');
 }
 
 module.exports = { serializeError, deserializeError };

--- a/test/parallel/test-worker-error-serdes.js
+++ b/test/parallel/test-worker-error-serdes.js
@@ -1,0 +1,34 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { isNativeError } = require('util/types');
+const { Worker } = require('worker_threads');
+
+const validateError = (error, ctor) => {
+  assert.strictEqual(error.constructor, ctor);
+  assert.strictEqual(Object.getPrototypeOf(error), ctor.prototype);
+  assert(isNativeError(error));
+};
+
+{
+  const w = new Worker('throw new Error()', { eval: true });
+  w.on('error', common.mustCall((error) => {
+    validateError(error, Error);
+  }));
+}
+
+{
+  const w = new Worker('throw new RangeError()', { eval: true });
+  w.on('error', common.mustCall((error) => {
+    validateError(error, RangeError);
+  }));
+}
+
+{
+  const w = new Worker('throw new Error(undefined, { cause: new TypeError() })', { eval: true });
+  w.on('error', common.mustCall((error) => {
+    validateError(error, Error);
+    assert.notStrictEqual(error.cause, undefined);
+    validateError(error.cause, TypeError);
+  }));
+}

--- a/test/parallel/test-worker-error-serdes.js
+++ b/test/parallel/test-worker-error-serdes.js
@@ -4,31 +4,33 @@ const assert = require('assert');
 const { isNativeError } = require('util/types');
 const { Worker } = require('worker_threads');
 
-const validateError = (error, ctor) => {
-  assert.strictEqual(error.constructor, ctor);
-  assert.strictEqual(Object.getPrototypeOf(error), ctor.prototype);
-  assert(isNativeError(error));
-};
-
 {
   const w = new Worker('throw new Error()', { eval: true });
   w.on('error', common.mustCall((error) => {
-    validateError(error, Error);
+    assert(isNativeError(error));
+    assert.strictEqual(error.constructor, Error);
+    assert.strictEqual(Object.getPrototypeOf(error), Error.prototype);
   }));
 }
 
 {
   const w = new Worker('throw new RangeError()', { eval: true });
   w.on('error', common.mustCall((error) => {
-    validateError(error, RangeError);
+    assert(isNativeError(error));
+    assert.strictEqual(error.constructor, RangeError);
+    assert.strictEqual(Object.getPrototypeOf(error), RangeError.prototype);
   }));
 }
 
 {
   const w = new Worker('throw new Error(undefined, { cause: new TypeError() })', { eval: true });
   w.on('error', common.mustCall((error) => {
-    validateError(error, Error);
-    assert.notStrictEqual(error.cause, undefined);
-    validateError(error.cause, TypeError);
+    assert(isNativeError(error));
+    assert.strictEqual(error.constructor, Error);
+    assert.strictEqual(Object.getPrototypeOf(error), Error.prototype);
+
+    assert(isNativeError(error.cause));
+    assert.strictEqual(error.cause.constructor, TypeError);
+    assert.strictEqual(Object.getPrototypeOf(error.cause), TypeError.prototype);
   }));
 }


### PR DESCRIPTION
Currently, errors deserialised by error_serdes are recreated using `Object.create()` with the source error's prototype. The objects created using this technique are not considered native errors.

This was always observable using `util.types.isNativeError()`, but with `Error.isError()` now being exposed, this becomes more readily apparent.

Fixes: #48716