### PR TITLE
test: close FileHandle objects in tests explicitly

### DIFF
--- a/test/parallel/test-fs-open.js
+++ b/test/parallel/test-fs-open.js
@@ -49,8 +49,8 @@ fs.open(__filename, 'r', 0, common.mustSucceed());
 fs.open(__filename, 'r', null, common.mustSucceed());
 
 async function promise() {
-  await fs.promises.open(__filename);
-  await fs.promises.open(__filename, 'r');
+  await (await fs.promises.open(__filename)).close();
+  await (await fs.promises.open(__filename, 'r')).close();
 }
 
 promise().then(common.mustCall()).catch(common.mustNotCall());

--- a/test/parallel/test-whatwg-readablebytestream.js
+++ b/test/parallel/test-whatwg-readablebytestream.js
@@ -80,6 +80,10 @@ class Source {
     this.controller = controller;
   }
 
+  async cancel() {
+    await this.file.close();
+  }
+
   async pull(controller) {
     const byobRequest = controller.byobRequest;
     assert.match(inspect(byobRequest), /ReadableStreamBYOBRequest/);


### PR DESCRIPTION
Separated out from #58536. Specifically *not* using `using` so the test changes can be backported.

This is in preparation for moving the close-filehandle-on-gc to EOL.