### PR TITLE
url: move bad port deprecation in legacy url to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3546,7 +3546,7 @@ issued for `url.parse()` vulnerabilities.
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/58617
     description: End-of-Life.
   - version:
     - v20.0.0

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3563,7 +3563,7 @@ Type: End-of-Life
 
 [`url.parse()`][] used to accept URLs with ports that are not numbers. This
 behavior might result in host name spoofing with unexpected input. These URLs
-will throw an error as the [WHATWG URL API][] does already.
+will throw an error (which the [WHATWG URL API][] also does).
 
 ### DEP0171: Setters for `http.IncomingMessage` headers and trailers
 

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3545,6 +3545,9 @@ issued for `url.parse()` vulnerabilities.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version:
     - v20.0.0
     pr-url: https://github.com/nodejs/node/pull/45526
@@ -3556,11 +3559,11 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-[`url.parse()`][] accepts URLs with ports that are not numbers. This behavior
-might result in host name spoofing with unexpected input. These URLs will throw
-an error in future versions of Node.js, as the [WHATWG URL API][] does already.
+[`url.parse()`][] used to accept URLs with ports that are not numbers. This
+behavior might result in host name spoofing with unexpected input. These URLs
+will throw an error as the [WHATWG URL API][] does already.
 
 ### DEP0171: Setters for `http.IncomingMessage` headers and trailers
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -41,6 +41,7 @@ const querystring = require('querystring');
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_INVALID_URL,
+  ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 const {
   validateString,
@@ -501,7 +502,6 @@ Url.prototype.parse = function parse(url, parseQueryString, slashesDenoteHost) {
   return this;
 };
 
-let warnInvalidPort = true;
 function getHostname(self, rest, hostname, url) {
   for (let i = 0; i < hostname.length; ++i) {
     const code = hostname.charCodeAt(i);
@@ -513,12 +513,8 @@ function getHostname(self, rest, hostname, url) {
 
     if (!isValid) {
       // If leftover starts with :, then it represents an invalid port.
-      // But url.parse() is lenient about it for now.
-      // Issue a warning and continue.
-      if (warnInvalidPort && code === CHAR_COLON) {
-        const detail = `The URL ${url} is invalid. Future versions of Node.js will throw an error.`;
-        process.emitWarning(detail, 'DeprecationWarning', 'DEP0170');
-        warnInvalidPort = false;
+      if (code === CHAR_COLON) {
+        throw new ERR_INVALID_ARG_VALUE('url', 'Invalid port in url', url);
       }
       self.hostname = hostname.slice(0, i);
       return `/${hostname.slice(i)}${rest}`;

--- a/test/parallel/test-url-parse-format.js
+++ b/test/parallel/test-url-parse-format.js
@@ -862,22 +862,6 @@ const parseTests = {
     href: 'http://a%22%20%3C\'b:b@cd/e?f'
   },
 
-  // Git urls used by npm
-  'git+ssh://git@github.com:npm/npm': {
-    protocol: 'git+ssh:',
-    slashes: true,
-    auth: 'git',
-    host: 'github.com',
-    port: null,
-    hostname: 'github.com',
-    hash: null,
-    search: null,
-    query: null,
-    pathname: '/:npm/npm',
-    path: '/:npm/npm',
-    href: 'git+ssh://git@github.com/:npm/npm'
-  },
-
   'https://*': {
     protocol: 'https:',
     slashes: true,

--- a/test/parallel/test-url-parse-invalid-input.js
+++ b/test/parallel/test-url-parse-invalid-input.js
@@ -83,9 +83,7 @@ if (common.hasIntl) {
   badURLs.forEach((badURL) => {
     common.spawnPromisified(process.execPath, ['-e', `url.parse(${JSON.stringify(badURL)})`])
       .then(common.mustCall(({ code, stdout, stderr }) => {
-        assert.strictEqual(code, 0);
-        assert.strictEqual(stdout, '');
-        assert.match(stderr, /\[DEP0170\] DeprecationWarning:/);
+        assert.strictEqual(code, 1);
       }));
   });
 
@@ -94,10 +92,11 @@ if (common.hasIntl) {
     DeprecationWarning: {
       // eslint-disable-next-line @stylistic/js/max-len
       DEP0169: '`url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
-      DEP0170: `The URL ${badURLs[0]} is invalid. Future versions of Node.js will throw an error.`,
     },
   });
   badURLs.forEach((badURL) => {
-    url.parse(badURL);
+    assert.throws(() => url.parse(badURL), {
+      code: 'ERR_INVALID_ARG_VALUE',
+    });
   });
 }


### PR DESCRIPTION
Calling `url.parse()` with a URL that has a bad port will now throw an error instead of emitting a deprecation warning. It's been deprecated for ~ 3 years now.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
