### PR TITLE
async_hooks: move `asyncResource` property on bound function to EOL

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3583,15 +3583,18 @@ In a future version of Node.js, [`message.headers`][],
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v20.0.0
     pr-url: https://github.com/nodejs/node/pull/46432
     description: Runtime-deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-In a future version of Node.js, the `asyncResource` property will no longer
-be added when a function is bound to an `AsyncResource`.
+Older versions of Node.js would add the `asyncResource` when a function is
+bound to an `AsyncResource`. It no longer does.
 
 ### DEP0173: the `assert.CallTracker` class
 

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -20,7 +20,6 @@ const {
   ERR_INVALID_ASYNC_ID,
 } = require('internal/errors').codes;
 const {
-  deprecate,
   kEmptyObject,
 } = require('internal/util');
 const {
@@ -247,7 +246,6 @@ class AsyncResource {
     } else {
       bound = FunctionPrototypeBind(this.runInAsyncScope, this, fn, thisArg);
     }
-    let self = this;
     ObjectDefineProperties(bound, {
       'length': {
         __proto__: null,
@@ -255,17 +253,6 @@ class AsyncResource {
         enumerable: false,
         value: fn.length,
         writable: false,
-      },
-      'asyncResource': {
-        __proto__: null,
-        configurable: true,
-        enumerable: true,
-        get: deprecate(function() {
-          return self;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
-        set: deprecate(function(val) {
-          self = val;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
       },
     });
     return bound;


### PR DESCRIPTION
Attaching the `asyncResource` property to a bound function has been deprecated for several years now. It's time.