### PR TITLE
dns: move falsy hostname in lookup to end-of-life

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2521,17 +2521,18 @@ object can lead to crashing the application.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: End-of-Life.
   - version: v11.0.0
     pr-url: https://github.com/nodejs/node/pull/23173
     description: Runtime deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Previous versions of Node.js supported `dns.lookup()` with a falsy host name
-like `dns.lookup(false)` due to backward compatibility.
-This behavior is undocumented and is thought to be unused in real world apps.
-It will become an error in future versions of Node.js.
+like `dns.lookup(false)` due to backward compatibility. This has been removed.
 
 ### DEP0119: `process.binding('uv').errname()` private API
 

--- a/lib/dns.js
+++ b/lib/dns.js
@@ -42,7 +42,6 @@ const {
   bindDefaultResolver,
   setDefaultResolver,
   validateHints,
-  emitInvalidHostnameWarning,
   getDefaultResultOrder,
   setDefaultResultOrder,
   errorCodes: dnsErrorCodes,
@@ -199,13 +198,8 @@ function lookup(hostname, options, callback) {
   }
 
   if (!hostname) {
-    emitInvalidHostnameWarning(hostname);
-    if (all) {
-      process.nextTick(callback, null, []);
-    } else {
-      process.nextTick(callback, null, null, family === 6 ? 6 : 4);
-    }
-    return {};
+    throw new ERR_INVALID_ARG_VALUE('hostname', hostname,
+                                    'must be a non-empty string');
   }
 
   const matchedFamily = isIP(hostname);

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -11,7 +11,6 @@ const {
   bindDefaultResolver,
   createResolverClass,
   validateHints,
-  emitInvalidHostnameWarning,
   errorCodes: dnsErrorCodes,
   getDefaultResultOrder,
   setDefaultResultOrder,
@@ -135,8 +134,8 @@ function onlookupall(err, addresses) {
 function createLookupPromise(family, hostname, all, hints, dnsOrder) {
   return new Promise((resolve, reject) => {
     if (!hostname) {
-      emitInvalidHostnameWarning(hostname);
-      resolve(all ? [] : { address: null, family: family === 6 ? 6 : 4 });
+      reject(new ERR_INVALID_ARG_VALUE('hostname', hostname,
+                                       'must be a non-empty string'));
       return;
     }
 

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -269,19 +269,6 @@ function validateHints(hints) {
   }
 }
 
-let invalidHostnameWarningEmitted = false;
-function emitInvalidHostnameWarning(hostname) {
-  if (!invalidHostnameWarningEmitted) {
-    process.emitWarning(
-      `The provided hostname "${hostname}" is not a valid ` +
-      'hostname, and is supported in the dns module solely for compatibility.',
-      'DeprecationWarning',
-      'DEP0118',
-    );
-    invalidHostnameWarningEmitted = true;
-  }
-}
-
 function setDefaultResultOrder(value) {
   validateOneOf(value, 'dnsOrder', validDnsOrders);
   dnsOrder = value;
@@ -352,7 +339,6 @@ module.exports = {
   validateHints,
   validateTimeout,
   validateTries,
-  emitInvalidHostnameWarning,
   getDefaultResultOrder,
   setDefaultResultOrder,
   errorCodes,

--- a/test/parallel/test-dns-lookup.js
+++ b/test/parallel/test-dns-lookup.js
@@ -29,11 +29,6 @@ common.expectWarning({
   'internal/test/binding': [
     'These APIs are for internal testing only. Do not use them.',
   ],
-  // For calling `dns.lookup` with falsy `hostname`.
-  'DeprecationWarning': {
-    DEP0118: 'The provided hostname "false" is not a valid ' +
-      'hostname, and is supported in the dns module solely for compatibility.'
-  }
 });
 
 assert.throws(() => {
@@ -145,12 +140,13 @@ assert.throws(() => dnsPromises.lookup(false, () => {}),
 (async function() {
   let res;
 
-  res = await dnsPromises.lookup(false, {
+  await assert.rejects(dnsPromises.lookup(false, {
     hints: 0,
     family: 0,
     all: true
+  }), {
+    code: 'ERR_INVALID_ARG_VALUE',
   });
-  assert.deepStrictEqual(res, []);
 
   res = await dnsPromises.lookup('127.0.0.1', {
     hints: 0,
@@ -167,14 +163,13 @@ assert.throws(() => dnsPromises.lookup(false, () => {}),
   assert.deepStrictEqual(res, { address: '127.0.0.1', family: 4 });
 })().then(common.mustCall());
 
-dns.lookup(false, {
+assert.throws(() => dns.lookup(false, {
   hints: 0,
   family: 0,
   all: true
-}, common.mustSucceed((result, addressType) => {
-  assert.deepStrictEqual(result, []);
-  assert.strictEqual(addressType, undefined);
-}));
+}, common.mustNotCall()), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
 
 dns.lookup('127.0.0.1', {
   hints: 0,


### PR DESCRIPTION
It's been deprecated for ~7 years. It's time.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
