### PR TITLE
crypto: runtime deprecate ECDH.setPublicKey()

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -718,6 +718,9 @@ The `SlowBuffer` class has been removed. Please use
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Runtime deprecation.
   - version: v6.12.0
     pr-url: https://github.com/nodejs/node/pull/10116
     description: A deprecation code has been assigned.
@@ -726,10 +729,10 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
-The [`ecdh.setPublicKey()`][] method is now deprecated as its inclusion in the
-API is not useful.
+The [`ecdh.setPublicKey()`][] method is now deprecated as its inclusion in
+the API is not useful.
 
 ### DEP0032: `node:domain` module
 

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -46,6 +46,7 @@ const {
 } = require('internal/util/types');
 
 const {
+  deprecate,
   lazyDOMException,
 } = require('internal/util');
 
@@ -228,7 +229,9 @@ function ECDH(curve) {
 
 ECDH.prototype.computeSecret = DiffieHellman.prototype.computeSecret;
 ECDH.prototype.setPrivateKey = DiffieHellman.prototype.setPrivateKey;
-ECDH.prototype.setPublicKey = DiffieHellman.prototype.setPublicKey;
+ECDH.prototype.setPublicKey = deprecate(DiffieHellman.prototype.setPublicKey,
+                                        'ecdh.setPublicKey() is deprecated.',
+                                        'DEP0031');
 ECDH.prototype.getPrivateKey = DiffieHellman.prototype.getPrivateKey;
 
 ECDH.prototype.generateKeys = function generateKeys(encoding, format) {

--- a/test/parallel/test-crypto-ecdh-setpublickey-deprecation.js
+++ b/test/parallel/test-crypto-ecdh-setpublickey-deprecation.js
@@ -1,0 +1,24 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const crypto = require('crypto');
+
+common.expectWarning(
+  'DeprecationWarning',
+  'ecdh.setPublicKey() is deprecated.', 'DEP0031');
+
+const ec = crypto.createECDH('secp256k1');
+try {
+  // This will throw but we don't care about the error,
+  // we just want to verify that the deprecation warning
+  // is emitter.
+  ec.setPublicKey(Buffer.from([123]));
+} catch {
+  // Intentionally ignore the error
+}


### PR DESCRIPTION
It's been "pending" deprecation since 6.12.0.
I think that's long enough.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
