### PR TITLE
src: move cpSync dir copy logic completely to C++

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -22,8 +22,6 @@ const {
   chmodSync,
   copyFileSync,
   lstatSync,
-  mkdirSync,
-  opendirSync,
   readlinkSync,
   statSync,
   symlinkSync,
@@ -33,7 +31,6 @@ const {
 const {
   dirname,
   isAbsolute,
-  join,
   resolve,
 } = require('path');
 const { isPromise } = require('util/types');
@@ -65,7 +62,13 @@ function getStats(src, dest, opts) {
   const destStat = statSyncFn(dest, { bigint: true, throwIfNoEntry: false });
 
   if (srcStat.isDirectory() && opts.recursive) {
-    return onDir(srcStat, destStat, src, dest, opts);
+    return fsBinding.cpSyncCopyDir(src, dest,
+                                   opts.force,
+                                   opts.dereference,
+                                   opts.errorOnExist,
+                                   opts.verbatimSymlinks,
+                                   opts.preserveTimestamps,
+                                   opts.filter);
   } else if (srcStat.isFile() ||
            srcStat.isCharacterDevice() ||
            srcStat.isBlockDevice()) {
@@ -129,60 +132,6 @@ function setDestTimestamps(src, dest) {
   // (See https://nodejs.org/api/fs.html#fs_stat_time_values)
   const updatedSrcStat = statSync(src);
   return utimesSync(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
-}
-
-// TODO(@anonrig): Move this function to C++.
-function onDir(srcStat, destStat, src, dest, opts) {
-  if (!destStat) return copyDir(src, dest, opts, true, srcStat.mode);
-  return copyDir(src, dest, opts);
-}
-
-function copyDir(src, dest, opts, mkDir, srcMode) {
-  if (!opts.filter) {
-    // The caller didn't provide a js filter function, in this case
-    // we can run the whole function faster in C++
-    // TODO(dario-piotrowicz): look into making cpSyncCopyDir also accept the potential filter function
-    return fsBinding.cpSyncCopyDir(src, dest,
-                                   opts.force,
-                                   opts.dereference,
-                                   opts.errorOnExist,
-                                   opts.verbatimSymlinks,
-                                   opts.preserveTimestamps);
-  }
-
-  if (mkDir) {
-    mkdirSync(dest);
-  }
-
-  const dir = opendirSync(src);
-
-  try {
-    let dirent;
-
-    while ((dirent = dir.readSync()) !== null) {
-      const { name } = dirent;
-      const srcItem = join(src, name);
-      const destItem = join(dest, name);
-      let shouldCopy = true;
-
-      if (opts.filter) {
-        shouldCopy = opts.filter(srcItem, destItem);
-        if (isPromise(shouldCopy)) {
-          throw new ERR_INVALID_RETURN_VALUE('boolean', 'filter', shouldCopy);
-        }
-      }
-
-      if (shouldCopy) {
-        getStats(srcItem, destItem, opts);
-      }
-    }
-  } finally {
-    dir.closeSync();
-
-    if (srcMode !== undefined) {
-      setDestMode(dest, srcMode);
-    }
-  }
 }
 
 // TODO(@anonrig): Move this function to C++.

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3517,7 +3517,8 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
       auto dest_file_path_str = PathToString(dest_file_path);
 
       if (filter_fn &&
-          !(*filter_fn)(dir_entry_path_str.c_str(), dest_file_path_str.c_str())) {
+          !(*filter_fn)(dir_entry_path_str.c_str(),
+                        dest_file_path_str.c_str())) {
         continue;
       }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3516,9 +3516,8 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
       auto dest_file_path = dest / dir_entry.path().filename();
       auto dest_file_path_str = PathToString(dest_file_path);
 
-      if (filter_fn &&
-          !(*filter_fn)(dir_entry_path_str.c_str(),
-                        dest_file_path_str.c_str())) {
+      if (filter_fn && !(*filter_fn)(dir_entry_path_str.c_str(),
+                                     dest_file_path_str.c_str())) {
         continue;
       }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3512,10 +3512,12 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
                                    std::filesystem::path dest) {
     std::error_code error;
     for (auto dir_entry : std::filesystem::directory_iterator(src)) {
+      auto dir_entry_path_str = PathToString(dir_entry.path());
       auto dest_file_path = dest / dir_entry.path().filename();
+      auto dest_file_path_str = PathToString(dest_file_path);
 
       if (filter_fn &&
-          !(*filter_fn)(dir_entry.path().c_str(), dest_file_path.c_str())) {
+          !(*filter_fn)(dir_entry_path_str.c_str(), dest_file_path_str.c_str())) {
         continue;
       }
 
@@ -3582,7 +3584,6 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
               }
             } else if (std::filesystem::is_regular_file(dest_file_path)) {
               if (!dereference || (!force && error_on_exist)) {
-                auto dest_file_path_str = PathToString(dest_file_path);
                 env->ThrowStdErrException(
                     std::make_error_code(std::errc::file_exists),
                     "cp",

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3502,7 +3502,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
     for (auto dir_entry : std::filesystem::directory_iterator(src)) {
       auto dest_file_path = dest / dir_entry.path().filename();
 
-      if (filter_fn.has_value() && !filter_fn.value()(dir_entry.path().c_str(),
+      if (filter_fn && !filter_fn->(dir_entry.path().c_str(),
                                                       dest_file_path.c_str())) {
         continue;
       }

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3449,7 +3449,8 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
   bool verbatim_symlinks = args[5]->IsTrue();
   bool preserve_timestamps = args[6]->IsTrue();
 
-  std::optional<std::function<bool(std::string, std::string)>> filter_fn;
+  std::optional<std::function<bool(std::string_view, std::string_view)>>
+      filter_fn;
 
   if (args[7]->IsFunction()) {
     Local<v8::Function> args_filter_fn = args[7].As<v8::Function>();
@@ -3516,8 +3517,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
       auto dest_file_path = dest / dir_entry.path().filename();
       auto dest_file_path_str = PathToString(dest_file_path);
 
-      if (filter_fn && !(*filter_fn)(dir_entry_path_str.c_str(),
-                                     dest_file_path_str.c_str())) {
+      if (filter_fn && !(*filter_fn)(dir_entry_path_str, dest_file_path_str)) {
         continue;
       }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3503,7 +3503,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
       auto dest_file_path = dest / dir_entry.path().filename();
 
       if (filter_fn &&
-          !filter_fn->(dir_entry.path().c_str(), dest_file_path.c_str())) {
+          !(*filter_fn)(dir_entry.path().c_str(), dest_file_path.c_str())) {
         continue;
       }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3502,8 +3502,8 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
     for (auto dir_entry : std::filesystem::directory_iterator(src)) {
       auto dest_file_path = dest / dir_entry.path().filename();
 
-      if (filter_fn && !filter_fn->(dir_entry.path().c_str(),
-                                                      dest_file_path.c_str())) {
+      if (filter_fn &&
+          !filter_fn->(dir_entry.path().c_str(), dest_file_path.c_str())) {
         continue;
       }
 

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3454,14 +3454,14 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
   if (args[7]->IsFunction()) {
     Local<v8::Function> args_filter_fn = args[7].As<v8::Function>();
 
-    filter_fn = [env, args_filter_fn](std::string src,
-                                      std::string dest) -> bool {
+    filter_fn = [env, args_filter_fn](std::string_view src,
+                                      std::string_view dest) -> bool {
       Local<Value> argv[] = {
           String::NewFromUtf8(
-              env->isolate(), src.c_str(), v8::NewStringType::kNormal)
+              env->isolate(), src.data(), v8::NewStringType::kNormal)
               .ToLocalChecked(),
           String::NewFromUtf8(
-              env->isolate(), dest.c_str(), v8::NewStringType::kNormal)
+              env->isolate(), dest.data(), v8::NewStringType::kNormal)
               .ToLocalChecked()};
       auto result =
           args_filter_fn->Call(env->context(), Null(env->isolate()), 2, argv)


### PR DESCRIPTION
prior to these changes cpSync would copy directories using C++ logic only if the user didn't provide a filtering function to the cpSync call, the changes here make it so that instead C++ is used to copy directories even when a filtering function is provided

___

Some benchmarking I performed locally:
![benchmark](https://github.com/user-attachments/assets/139e0e2e-0f27-4a4b-b878-f00943792148)

> [!Note]
> The perf gain is nice (although not huge), the biggest benefit of this change for me is code improvement, since with these changes we no longer need to have the same exact functionality implemented in both JS and C++, also this should help moving more cpSync code over C++ :slightly_smiling_face:  


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
