### PR TITLE
doc: add correct argument types for fs.cp APIs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1048,8 +1048,8 @@ changes:
                  whether to perform path resolution for symlinks.
 -->
 
-* `src` {string|URL} source path to copy.
-* `dest` {string|URL} destination path to copy to.
+* `src` {string|URL|Buffer} source path to copy.
+* `dest` {string|URL|Buffer} destination path to copy to.
 * `options` {Object}
   * `dereference` {boolean} dereference symlinks. **Default:** `false`.
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
@@ -1058,8 +1058,8 @@ changes:
     `true` to copy the item, `false` to ignore it. When ignoring a directory,
     all of its contents will be skipped as well. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
-    * `src` {string} source path to copy.
-    * `dest` {string} destination path to copy to.
+    * `src` {string|URL|Buffer} source path to copy.
+    * `dest` {string|URL|Buffer} destination path to copy to.
     * Returns: {boolean|Promise} A value that is coercible to `boolean` or
       a `Promise` that fulfils with such value.
   * `force` {boolean} overwrite existing file or directory. The copy
@@ -2479,8 +2479,8 @@ changes:
                  whether to perform path resolution for symlinks.
 -->
 
-* `src` {string|URL} source path to copy.
-* `dest` {string|URL} destination path to copy to.
+* `src` {string|URL|Buffer} source path to copy.
+* `dest` {string|URL|Buffer} destination path to copy to.
 * `options` {Object}
   * `dereference` {boolean} dereference symlinks. **Default:** `false`.
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
@@ -2489,8 +2489,8 @@ changes:
     `true` to copy the item, `false` to ignore it. When ignoring a directory,
     all of its contents will be skipped as well. Can also return a `Promise`
     that resolves to `true` or `false` **Default:** `undefined`.
-    * `src` {string} source path to copy.
-    * `dest` {string} destination path to copy to.
+    * `src` {string|URL|Buffer} source path to copy.
+    * `dest` {string|URL|Buffer} destination path to copy to.
     * Returns: {boolean|Promise} A value that is coercible to `boolean` or
       a `Promise` that fulfils with such value.
   * `force` {boolean} overwrite existing file or directory. The copy
@@ -5535,8 +5535,8 @@ changes:
                  whether to perform path resolution for symlinks.
 -->
 
-* `src` {string|URL} source path to copy.
-* `dest` {string|URL} destination path to copy to.
+* `src` {string|URL|Buffer} source path to copy.
+* `dest` {string|URL|Buffer} destination path to copy to.
 * `options` {Object}
   * `dereference` {boolean} dereference symlinks. **Default:** `false`.
   * `errorOnExist` {boolean} when `force` is `false`, and the destination
@@ -5544,8 +5544,8 @@ changes:
   * `filter` {Function} Function to filter copied files/directories. Return
     `true` to copy the item, `false` to ignore it. When ignoring a directory,
     all of its contents will be skipped as well. **Default:** `undefined`
-    * `src` {string} source path to copy.
-    * `dest` {string} destination path to copy to.
+    * `src` {string|URL|Buffer} source path to copy.
+    * `dest` {string|URL|Buffer} destination path to copy to.
     * Returns: {boolean} Any non-`Promise` value that is coercible
       to `boolean`.
   * `force` {boolean} overwrite existing file or directory. The copy


### PR DESCRIPTION
The documentation was missing the fact that the src and dest arguments for fs.cpSync, etc can be string, URL, or Buffer, and that the filter option callback can be passed a string, URL, or Buffer.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
