### PR TITLE
module: runtime deprecate require.extensions

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -878,7 +878,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The [`require.extensions`][] property is deprecated.
 

--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -26,7 +26,7 @@ const { pathToFileURL, fileURLToPath } = require('internal/url');
 const assert = require('internal/assert');
 
 const { getOptionValue } = require('internal/options');
-const { setOwnProperty, getLazy } = require('internal/util');
+const { setOwnProperty, getLazy, deprecate } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
 
 const lazyTmpdir = getLazy(() => require('os').tmpdir());
@@ -160,8 +160,19 @@ function makeRequireFunction(mod) {
 
   setOwnProperty(require, 'main', process.mainModule);
 
+  let extensions = Module._extensions;
   // Enable support to add extra extension types.
-  require.extensions = Module._extensions;
+  ObjectDefineProperty(require, 'extensions', {
+    __proto__: null,
+    get: deprecate(() => {
+      return extensions;
+    }, 'require.extensions is deprecated', 'DEP0039'),
+    set: deprecate((value) => {
+      extensions = value;
+    }, 'require.extensions is deprecated', 'DEP0039'),
+    configurable: true,
+    enumerable: true,
+  });
 
   require.cache = Module._cache;
 


### PR DESCRIPTION
I'm opening this as draft PR to discuss if we should do runtime deprecate require.extensions.
It has been deprecated since v0.10.6.
This might have a large impact.
It's causing some issues for type stripping https://github.com/nodejs/typescript/issues/37