### PR TITLE
inspector: add protocol methods retrieving sent/received data

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -524,6 +524,20 @@ This feature is only available with the `--experimental-network-inspection` flag
 Broadcasts the `Network.dataReceived` event to connected frontends, or buffers the data if
 `Network.streamResourceContent` command was not invoked for the given request yet.
 
+Also enables `Network.getResponseBody` command to retrieve the response data.
+
+### `inspector.Network.dataSent([params])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `params` {Object}
+
+This feature is only available with the `--experimental-network-inspection` flag enabled.
+
+Enables `Network.getRequestPostData` command to retrieve the request data.
+
 ### `inspector.Network.requestWillBeSent([params])`
 
 <!-- YAML

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -214,6 +214,7 @@ const Network = {
   responseReceived: (params) => broadcastToFrontend('Network.responseReceived', params),
   loadingFinished: (params) => broadcastToFrontend('Network.loadingFinished', params),
   loadingFailed: (params) => broadcastToFrontend('Network.loadingFailed', params),
+  dataSent: (params) => broadcastToFrontend('Network.dataSent', params),
   dataReceived: (params) => broadcastToFrontend('Network.dataReceived', params),
 };
 

--- a/lib/internal/inspector/network.js
+++ b/lib/internal/inspector/network.js
@@ -6,6 +6,7 @@ const {
 } = primordials;
 
 const { now } = require('internal/perf/utils');
+const { MIMEType } = require('internal/mime');
 const kInspectorRequestId = Symbol('kInspectorRequestId');
 
 // https://chromedevtools.github.io/devtools-protocol/1-3/Network/#type-ResourceType
@@ -46,9 +47,29 @@ function getNextRequestId() {
   return `node-network-event-${++requestId}`;
 };
 
+function sniffMimeType(contentType) {
+  let mimeType;
+  let charset;
+  try {
+    const mimeTypeObj = new MIMEType(contentType);
+    mimeType = mimeTypeObj.essence || '';
+    charset = mimeTypeObj.params.get('charset') || '';
+  } catch {
+    mimeType = '';
+    charset = '';
+  }
+
+  return {
+    __proto__: null,
+    mimeType,
+    charset,
+  };
+}
+
 module.exports = {
   kInspectorRequestId,
   kResourceType,
   getMonotonicTime,
   getNextRequestId,
+  sniffMimeType,
 };

--- a/lib/internal/inspector/network_http.js
+++ b/lib/internal/inspector/network_http.js
@@ -13,10 +13,10 @@ const {
   kResourceType,
   getMonotonicTime,
   getNextRequestId,
+  sniffMimeType,
 } = require('internal/inspector/network');
 const dc = require('diagnostics_channel');
 const { Network } = require('inspector');
-const { MIMEType } = require('internal/mime');
 
 const kRequestUrl = Symbol('kRequestUrl');
 
@@ -24,24 +24,32 @@ const kRequestUrl = Symbol('kRequestUrl');
 const convertHeaderObject = (headers = {}) => {
   // The 'host' header that contains the host and port of the URL.
   let host;
+  let charset;
+  let mimeType;
   const dict = {};
   for (const { 0: key, 1: value } of ObjectEntries(headers)) {
-    if (key.toLowerCase() === 'host') {
+    const lowerCasedKey = key.toLowerCase();
+    if (lowerCasedKey === 'host') {
       host = value;
+    }
+    if (lowerCasedKey === 'content-type') {
+      const result = sniffMimeType(value);
+      charset = result.charset;
+      mimeType = result.mimeType;
     }
     if (typeof value === 'string') {
       dict[key] = value;
     } else if (ArrayIsArray(value)) {
-      if (key.toLowerCase() === 'cookie') dict[key] = value.join('; ');
+      if (lowerCasedKey === 'cookie') dict[key] = value.join('; ');
       // ChromeDevTools frontend treats 'set-cookie' as a special case
       // https://github.com/ChromeDevTools/devtools-frontend/blob/4275917f84266ef40613db3c1784a25f902ea74e/front_end/core/sdk/NetworkRequest.ts#L1368
-      else if (key.toLowerCase() === 'set-cookie') dict[key] = value.join('\n');
+      else if (lowerCasedKey === 'set-cookie') dict[key] = value.join('\n');
       else dict[key] = value.join(', ');
     } else {
       dict[key] = String(value);
     }
   }
-  return [host, dict];
+  return [dict, host, charset, mimeType];
 };
 
 /**
@@ -52,7 +60,7 @@ const convertHeaderObject = (headers = {}) => {
 function onClientRequestCreated({ request }) {
   request[kInspectorRequestId] = getNextRequestId();
 
-  const { 0: host, 1: headers } = convertHeaderObject(request.getHeaders());
+  const { 0: headers, 1: host, 2: charset } = convertHeaderObject(request.getHeaders());
   const url = `${request.protocol}//${host}${request.path}`;
   request[kRequestUrl] = url;
 
@@ -60,6 +68,7 @@ function onClientRequestCreated({ request }) {
     requestId: request[kInspectorRequestId],
     timestamp: getMonotonicTime(),
     wallTime: DateNow(),
+    charset,
     request: {
       url,
       method: request.method,
@@ -95,16 +104,7 @@ function onClientResponseFinish({ request, response }) {
     return;
   }
 
-  let mimeType;
-  let charset;
-  try {
-    const mimeTypeObj = new MIMEType(response.headers['content-type']);
-    mimeType = mimeTypeObj.essence || '';
-    charset = mimeTypeObj.params.get('charset') || '';
-  } catch {
-    mimeType = '';
-    charset = '';
-  }
+  const { 0: headers, 2: charset, 3: mimeType } = convertHeaderObject(response.headers);
 
   Network.responseReceived({
     requestId: request[kInspectorRequestId],
@@ -114,7 +114,7 @@ function onClientResponseFinish({ request, response }) {
       url: request[kRequestUrl],
       status: response.statusCode,
       statusText: response.statusMessage ?? '',
-      headers: convertHeaderObject(response.headers)[1],
+      headers,
       mimeType,
       charset,
     },

--- a/lib/internal/inspector/network_undici.js
+++ b/lib/internal/inspector/network_undici.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  ArrayPrototypeFindIndex,
   DateNow,
 } = primordials;
 
@@ -10,10 +9,10 @@ const {
   kResourceType,
   getMonotonicTime,
   getNextRequestId,
+  sniffMimeType,
 } = require('internal/inspector/network');
 const dc = require('diagnostics_channel');
 const { Network } = require('inspector');
-const { MIMEType } = require('internal/mime');
 
 // Convert an undici request headers array to a plain object (Map<string, string>)
 function requestHeadersArrayToDictionary(headers) {
@@ -29,21 +28,30 @@ function requestHeadersArrayToDictionary(headers) {
 // Convert an undici response headers array to a plain object (Map<string, string>)
 function responseHeadersArrayToDictionary(headers) {
   const dict = {};
+  let charset;
+  let mimeType;
   for (let idx = 0; idx < headers.length; idx += 2) {
     const key = `${headers[idx]}`;
+    const lowerCasedKey = key.toLowerCase();
     const value = `${headers[idx + 1]}`;
     const prevValue = dict[key];
+
+    if (lowerCasedKey === 'content-type') {
+      const result = sniffMimeType(value);
+      charset = result.charset;
+      mimeType = result.mimeType;
+    }
 
     if (typeof prevValue === 'string') {
       // ChromeDevTools frontend treats 'set-cookie' as a special case
       // https://github.com/ChromeDevTools/devtools-frontend/blob/4275917f84266ef40613db3c1784a25f902ea74e/front_end/core/sdk/NetworkRequest.ts#L1368
-      if (key.toLowerCase() === 'set-cookie') dict[key] = `${prevValue}\n${value}`;
+      if (lowerCasedKey === 'set-cookie') dict[key] = `${prevValue}\n${value}`;
       else dict[key] = `${prevValue}, ${value}`;
     } else {
       dict[key] = value;
     }
   }
-  return dict;
+  return [dict, charset, mimeType];
 };
 
 /**
@@ -54,10 +62,15 @@ function responseHeadersArrayToDictionary(headers) {
 function onClientRequestStart({ request }) {
   const url = `${request.origin}${request.path}`;
   request[kInspectorRequestId] = getNextRequestId();
+
+  const headers = requestHeadersArrayToDictionary(request.headers);
+  const { charset } = sniffMimeType(headers);
+
   Network.requestWillBeSent({
     requestId: request[kInspectorRequestId],
     timestamp: getMonotonicTime(),
     wallTime: DateNow(),
+    charset,
     request: {
       url,
       method: request.method,
@@ -94,19 +107,7 @@ function onClientResponseHeaders({ request, response }) {
     return;
   }
 
-  let mimeType;
-  let charset;
-  try {
-    const contentTypeKeyIndex =
-      ArrayPrototypeFindIndex(response.headers, (header) => header.toString().toLowerCase() === 'content-type');
-    const contentType = contentTypeKeyIndex !== -1 ? response.headers[contentTypeKeyIndex + 1].toString() : '';
-    const mimeTypeObj = new MIMEType(contentType);
-    mimeType = mimeTypeObj.essence || '';
-    charset = mimeTypeObj.params.get('charset') || '';
-  } catch {
-    mimeType = '';
-    charset = '';
-  }
+  const { 0: headers, 1: charset, 2: mimeType } = responseHeadersArrayToDictionary(response.headers);
 
   const url = `${request.origin}${request.path}`;
   Network.responseReceived({
@@ -118,7 +119,7 @@ function onClientResponseHeaders({ request, response }) {
       url,
       status: response.statusCode,
       statusText: response.statusText,
-      headers: responseHeadersArrayToDictionary(response.headers),
+      headers,
       mimeType,
       charset,
     },

--- a/src/inspector/node_protocol.pdl
+++ b/src/inspector/node_protocol.pdl
@@ -165,6 +165,7 @@ experimental domain Network
       string url
       string method
       Headers headers
+      boolean hasPostData
 
   # HTTP response data.
   type Response extends object
@@ -184,6 +185,26 @@ experimental domain Network
 
   # Enables network tracking, network events will now be delivered to the client.
   command enable
+
+  # Returns post data sent with the request. Returns an error when no data was sent with the request.
+  command getRequestPostData
+    parameters
+      # Identifier of the network request to get content for.
+      RequestId requestId
+    returns
+      # Request body string, omitting files from multipart requests
+      string postData
+
+  # Returns content served for the given request.
+  command getResponseBody
+    parameters
+      # Identifier of the network request to get content for.
+      RequestId requestId
+    returns
+      # Response body.
+      string body
+      # True, if content was sent as base64.
+      boolean base64Encoded
 
   # Enables streaming of the response for the given requestId.
   # If enabled, the dataReceived event contains the data that was received during streaming.

--- a/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/parallel/test-inspector-emit-protocol-event.js
@@ -63,7 +63,12 @@ const EXPECTED_EVENTS = {
     },
     {
       name: 'dataReceived',
-      // Network.dataReceived is buffered until Network.streamResourceContent is invoked.
+      // Network.dataReceived is buffered until Network.streamResourceContent/Network.getResponseBody is invoked.
+      skip: true,
+    },
+    {
+      name: 'dataSent',
+      // Network.dataSent is buffered until Network.getRequestPostData is invoked.
       skip: true,
     },
     {

--- a/test/parallel/test-inspector-network-data-sent.js
+++ b/test/parallel/test-inspector-network-data-sent.js
@@ -1,0 +1,136 @@
+// Flags: --inspect=0 --experimental-network-inspection
+'use strict';
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const inspector = require('node:inspector/promises');
+const { Network } = require('node:inspector');
+const test = require('node:test');
+const assert = require('node:assert');
+const { waitUntil } = require('../common/inspector-helper');
+const { setTimeout } = require('node:timers/promises');
+
+const session = new inspector.Session();
+session.connect();
+session.post('Network.enable');
+
+async function triggerNetworkEvents(requestId, requestCharset) {
+  const url = 'https://example.com';
+  Network.requestWillBeSent({
+    requestId,
+    timestamp: 1,
+    wallTime: 1,
+    request: {
+      url,
+      method: 'PUT',
+      headers: {
+        mKey: 'mValue',
+      },
+      hasPostData: true,
+    },
+    charset: requestCharset,
+  });
+  await setTimeout(1);
+
+  const chunk1 = Buffer.from('Hello, ');
+  Network.dataSent({
+    requestId,
+    timestamp: 2,
+    dataLength: chunk1.byteLength,
+    data: chunk1,
+  });
+  await setTimeout(1);
+
+  const chunk2 = Buffer.from('world');
+  Network.dataSent({
+    requestId,
+    timestamp: 3,
+    dataLength: chunk2.byteLength,
+    data: chunk2,
+  });
+  await setTimeout(1);
+
+  Network.dataSent({
+    requestId,
+    finished: true,
+  });
+  await setTimeout(1);
+
+  Network.responseReceived({
+    requestId,
+    timestamp: 4,
+    type: 'Fetch',
+    response: {
+      url,
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        mKey: 'mValue',
+      },
+    },
+  });
+  await setTimeout(1);
+
+  Network.loadingFinished({
+    requestId,
+    timestamp: 5,
+  });
+}
+
+function assertNetworkEvents(session, requestId) {
+  session.on('Network.requestWillBeSent', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  session.on('Network.responseReceived', common.mustCall(({ params }) => {
+    assert.strictEqual(params.requestId, requestId);
+  }));
+  const loadingFinishedFuture = waitUntil(session, 'Network.loadingFinished')
+    .then(async ([{ params }]) => {
+      assert.strictEqual(params.requestId, requestId);
+    });
+
+  return loadingFinishedFuture;
+}
+
+test('Network.getRequestPostData should send all buffered text data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-1';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId, 'utf-8');
+  await loadingFinishedFuture;
+
+  const { postData } = await session.post('Network.getRequestPostData', {
+    requestId,
+  });
+  assert.strictEqual(postData, 'Hello, world');
+});
+
+test('Network.getRequestPostData does not support binary data', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'my-req-id-2';
+  const loadingFinishedFuture = assertNetworkEvents(session, requestId);
+
+  await triggerNetworkEvents(requestId);
+  await loadingFinishedFuture;
+
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});
+
+test('Network.getRequestPostData should reject if request id not found', async () => {
+  session.removeAllListeners();
+
+  const requestId = 'unknown-request-id';
+  await assert.rejects(session.post('Network.getRequestPostData', {
+    requestId,
+  }), {
+    code: 'ERR_INSPECTOR_COMMAND',
+  });
+});


### PR DESCRIPTION
Add protocol method `Network.dataSent` to buffer request data. And
expose protocol methods `Network.getRequestPostData` and
`Network.getResponseBody` allowing devtool to retrieve buffered data.