### PR TITLE
lib: validate AbortSignal.timeout delay per its WebIDL definition

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -120,7 +120,7 @@ added:
 changes:
  - version: REPLACEME
    pr-url: https://github.com/nodejs/node/pull/58648
-   description: Validate `delay` per its WebIDL definition
+   description: Validate `delay` per its WebIDL definition.
 -->
 
 * `delay` {number} The number of milliseconds to wait before triggering

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -117,6 +117,10 @@ Returns a new already aborted `AbortSignal`.
 added:
   - v17.3.0
   - v16.14.0
+changes:
+ - version: REPLACEME
+   pr-url: https://github.com/nodejs/node/pull/58648
+   description: Validate `delay` per its WebIDL definition
 -->
 
 * `delay` {number} The number of milliseconds to wait before triggering

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -46,11 +46,11 @@ const {
   converters,
   createInterfaceConverter,
   createSequenceConverter,
+  convertToInt,
 } = require('internal/webidl');
 
 const {
   validateObject,
-  validateUint32,
   kValidateObjectAllowObjects,
 } = require('internal/validators');
 
@@ -60,7 +60,6 @@ const {
 
 const {
   clearTimeout,
-  setTimeout,
 } = require('timers');
 const assert = require('internal/assert');
 
@@ -70,6 +69,7 @@ const {
   kTransferList,
   markTransferMode,
 } = require('internal/worker/js_transferable');
+const { Timeout, insert } = require('internal/timers');
 
 let _MessageChannel;
 
@@ -145,7 +145,7 @@ function validateThisAbortSignal(obj) {
 // the created timer object. Separately, we add the signal to a
 // FinalizerRegistry that will clear the timeout when the signal is gc'd.
 function setWeakAbortSignalTimeout(weakRef, delay) {
-  const timeout = setTimeout(() => {
+  const timeout = new Timeout(() => {
     const signal = weakRef.deref();
     if (signal !== undefined) {
       gcPersistentSignals.delete(signal);
@@ -155,8 +155,8 @@ function setWeakAbortSignalTimeout(weakRef, delay) {
           'The operation was aborted due to timeout',
           'TimeoutError'));
     }
-  }, delay);
-  timeout.unref();
+  }, delay, undefined, false, false);
+  insert(timeout, timeout._idleTimeout);
   return timeout;
 }
 
@@ -236,7 +236,8 @@ class AbortSignal extends EventTarget {
    * @returns {AbortSignal}
    */
   static timeout(delay) {
-    validateUint32(delay, 'delay', false);
+    const opts = { __proto__: null, enforceRange: true };
+    delay = convertToInt('delay', delay, 64, opts);
     const signal = new AbortSignal(kDontThrowSymbol);
     signal[kTimeout] = true;
     clearTimeoutRegistry.register(

--- a/lib/internal/abort_controller.js
+++ b/lib/internal/abort_controller.js
@@ -69,7 +69,7 @@ const {
   kTransferList,
   markTransferMode,
 } = require('internal/worker/js_transferable');
-const { Timeout, insert } = require('internal/timers');
+const { insert, InternalTimeout } = require('internal/timers');
 
 let _MessageChannel;
 
@@ -145,7 +145,7 @@ function validateThisAbortSignal(obj) {
 // the created timer object. Separately, we add the signal to a
 // FinalizerRegistry that will clear the timeout when the signal is gc'd.
 function setWeakAbortSignalTimeout(weakRef, delay) {
-  const timeout = new Timeout(() => {
+  const timeout = new InternalTimeout(() => {
     const signal = weakRef.deref();
     if (signal !== undefined) {
       gcPersistentSignals.delete(signal);

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -174,36 +174,9 @@ function initAsyncResource(resource, type) {
 let warnedNegativeNumber = false;
 let warnedNotNumber = false;
 
-class Timeout {
-  // Timer constructor function.
-  // The entire prototype is defined in lib/timers.js
+// Internal Timeout skips the `after` parameter validation, so we can use it for uint64 in `AbortSignal`
+class InternalTimeout {
   constructor(callback, after, args, isRepeat, isRefed) {
-    if (after === undefined) {
-      after = 1;
-    } else {
-      after *= 1; // Coalesce to number or NaN
-    }
-
-    if (!(after >= 1 && after <= TIMEOUT_MAX)) {
-      if (after > TIMEOUT_MAX) {
-        process.emitWarning(`${after} does not fit into` +
-                            ' a 32-bit signed integer.' +
-                            '\nTimeout duration was set to 1.',
-                            'TimeoutOverflowWarning');
-      } else if (after < 0 && !warnedNegativeNumber) {
-        warnedNegativeNumber = true;
-        process.emitWarning(`${after} is a negative number.` +
-                            '\nTimeout duration was set to 1.',
-                            'TimeoutNegativeWarning');
-      } else if (NumberIsNaN(after) && !warnedNotNumber) {
-        warnedNotNumber = true;
-        process.emitWarning(`${after} is not a number.` +
-                            '\nTimeout duration was set to 1.',
-                            'TimeoutNaNWarning');
-      }
-      after = 1; // Schedule on next tick, follows browser behavior
-    }
-
     this._idleTimeout = after;
     this._idlePrev = this;
     this._idleNext = this;
@@ -261,6 +234,39 @@ class Timeout {
 
   hasRef() {
     return this[kRefed];
+  }
+}
+
+class Timeout extends InternalTimeout {
+  // Timer constructor function.
+  // The entire prototype is defined in lib/timers.js
+  constructor(callback, after, args, isRepeat, isRefed) {
+    if (after === undefined) {
+      after = 1;
+    } else {
+      after *= 1; // Coalesce to number or NaN
+    }
+
+    if (!(after >= 1 && after <= TIMEOUT_MAX)) {
+      if (after > TIMEOUT_MAX) {
+        process.emitWarning(`${after} does not fit into` +
+          ' a 32-bit signed integer.' +
+          '\nTimeout duration was set to 1.',
+                            'TimeoutOverflowWarning');
+      } else if (after < 0 && !warnedNegativeNumber) {
+        warnedNegativeNumber = true;
+        process.emitWarning(`${after} is a negative number.` +
+          '\nTimeout duration was set to 1.',
+                            'TimeoutNegativeWarning');
+      } else if (NumberIsNaN(after) && !warnedNotNumber) {
+        warnedNotNumber = true;
+        process.emitWarning(`${after} is not a number.` +
+          '\nTimeout duration was set to 1.',
+                            'TimeoutNaNWarning');
+      }
+      after = 1; // Schedule on next tick, follows browser behavior
+    }
+    super(callback, after, args, isRepeat, isRefed);
   }
 }
 
@@ -702,6 +708,7 @@ module.exports = {
   kTimeout: Symbol('timeout'), // For hiding Timeouts on other internals.
   async_id_symbol,
   trigger_async_id_symbol,
+  InternalTimeout,
   Timeout,
   Immediate,
   kRefed,

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -274,3 +274,33 @@ test('abortSignal.throwIfAobrted() works as expected (3)', () => {
   throws(() => AbortSignal.abort(actualReason).throwIfAborted(), actualReason);
   Reflect.defineProperty(AbortSignal.prototype, 'reason', originalDesc);
 });
+
+test('abortSignal.timeout() works with special \'delay\' value', async () => {
+  const inputs = [
+    null,
+    true,
+    false,
+    '',
+    [],
+    0,
+    0.0,
+    0.1,
+    0.5,
+    1,
+    1.0,
+  ];
+
+  const signals = [];
+
+  for (let i = 0; i < inputs.length; i++) {
+    signals[i] = AbortSignal.timeout(inputs[i]);
+  }
+
+  await sleep(2);
+
+  for (let i = 0; i < inputs.length; i++) {
+    ok(signals[i].aborted);
+    ok(signals[i].reason instanceof DOMException);
+    strictEqual(signals[i].reason.name, 'TimeoutError');
+  }
+});


### PR DESCRIPTION
Divided from https://github.com/nodejs/node/pull/58594, this PR changes `Timeout` class to support unsigned long long as `after` parameter

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
