### PR TITLE
repl: avoid deprecated `require.extensions` in tab completion

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1360,7 +1360,11 @@ function complete(line, callback) {
     filter = completeOn;
     if (this.allowBlockingCompletions) {
       const subdir = match[2] || '';
-      const extensions = ObjectKeys(this.context.require.extensions);
+      // `require.extensions` is runtime-deprecated (DEP0039).
+      // Use `Module._extensions` to access the same extension map
+      // without triggering the deprecation warning.
+      const Module = require('module');
+      const extensions = ObjectKeys(Module._extensions);
       const indexes = ArrayPrototypeMap(extensions,
                                         (extension) => `index${extension}`);
       ArrayPrototypePush(indexes, 'package.json', 'index');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -202,7 +202,6 @@ const {
   kLastCommandErrored,
 } = require('internal/readline/interface');
 let nextREPLResourceNumber = 1;
-const Module = require('module');
 // This prevents v8 code cache from getting confused and using a different
 // cache from a resource of the same name
 function getREPLResourceName() {
@@ -1361,7 +1360,7 @@ function complete(line, callback) {
     filter = completeOn;
     if (this.allowBlockingCompletions) {
       const subdir = match[2] || '';
-      const extensions = ObjectKeys(Module._extensions);
+      const extensions = ObjectKeys(CJSModule._extensions);
       const indexes = ArrayPrototypeMap(extensions,
                                         (extension) => `index${extension}`);
       ArrayPrototypePush(indexes, 'package.json', 'index');

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -202,6 +202,7 @@ const {
   kLastCommandErrored,
 } = require('internal/readline/interface');
 let nextREPLResourceNumber = 1;
+const Module = require('module');
 // This prevents v8 code cache from getting confused and using a different
 // cache from a resource of the same name
 function getREPLResourceName() {
@@ -1360,10 +1361,6 @@ function complete(line, callback) {
     filter = completeOn;
     if (this.allowBlockingCompletions) {
       const subdir = match[2] || '';
-      // `require.extensions` is runtime-deprecated (DEP0039).
-      // Use `Module._extensions` to access the same extension map
-      // without triggering the deprecation warning.
-      const Module = require('module');
       const extensions = ObjectKeys(Module._extensions);
       const indexes = ArrayPrototypeMap(extensions,
                                         (extension) => `index${extension}`);


### PR DESCRIPTION
This PR replaces the usage of require.extensions in the REPL autocompletion logic with Module._extensions.

require.extensions has been runtime-deprecated under [DEP0039](https://nodejs.org/api/deprecations.html#requireextensions), and its usage triggers a warning in recent Node.js versions. Since require.extensions is just a user-land alias for Module._extensions, we can safely access the same object via Module._extensions without any behavioral change or deprecation warning.

### Changes:
- this.context.require.extensions → Module._extensions in the REPL complete() function
- Adds an inline comment explaining the deprecation and replacement
- No functional behavior change



Fixes: https://github.com/nodejs/node/issues/58641

