### PR TITLE
tools: edit commit-queue workflow file

### DIFF
--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -1,6 +1,6 @@
 # This action requires the following secrets to be set on the repository:
-#   GH_USER_NAME: GitHub user whose Jenkins and GitHub token are defined below
 #   GH_USER_TOKEN: GitHub user token, to be used by ncu and to push changes
+#   JENKINS_USER: GitHub user whose Jenkins token is defined below
 #   JENKINS_TOKEN: Jenkins token, to be used to check CI status
 
 name: Commit Queue
@@ -34,16 +34,16 @@ jobs:
         id: get_mergeable_prs
         run: |
           prs=$(gh pr list \
-                  --repo ${{ github.repository }} \
-                  --base ${{ github.ref_name }} \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "$GITHUB_REF_NAME" \
                   --label 'commit-queue' \
                   --json 'number' \
                   --search "created:<=$(date --date="2 days ago"  +"%Y-%m-%dT%H:%M:%S%z") -label:blocked" \
                   -t '{{ range . }}{{ .number }} {{ end }}' \
                   --limit 100)
           fast_track_prs=$(gh pr list \
-                  --repo ${{ github.repository }} \
-                  --base ${{ github.ref_name }} \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --base "$GITHUB_REF_NAME" \
                   --label 'commit-queue' \
                   --label 'fast-track' \
                   --search "-label:blocked" \
@@ -51,7 +51,7 @@ jobs:
                   -t '{{ range . }}{{ .number }} {{ end }}' \
                   --limit 100)
           numbers=$(echo $prs' '$fast_track_prs | jq -r -s 'unique | join(" ")')
-          echo "numbers=$numbers" >> $GITHUB_OUTPUT
+          echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   commitQueue:
@@ -61,9 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          # Needs the whole git history for ncu to work
-          # See https://github.com/nodejs/node-core-utils/pull/486
-          fetch-depth: 0
           # A personal token is required because pushing with GITHUB_TOKEN will
           # prevent commits from running CI after they land. It needs
           # to be set here because `checkout` configures GitHub authentication
@@ -80,24 +77,23 @@ jobs:
 
       - name: Set variables
         run: |
-          echo "REPOSITORY=$(echo ${{ github.repository }} | cut -d/ -f2)" >> $GITHUB_ENV
-          echo "OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
+          echo "REPOSITORY=$(echo "$GITHUB_REPOSITORY" | cut -d/ -f2)" >> "$GITHUB_ENV"
 
       - name: Configure @node-core/utils
         run: |
-          ncu-config set branch ${GITHUB_REF_NAME}
+          ncu-config set branch "${GITHUB_REF_NAME}"
           ncu-config set upstream origin
           ncu-config set username "$USERNAME"
-          ncu-config set token "$GH_TOKEN"
+          ncu-config set token "$GITHUB_TOKEN"
           ncu-config set jenkins_token "$JENKINS_TOKEN"
           ncu-config set repo "${REPOSITORY}"
-          ncu-config set owner "${OWNER}"
+          ncu-config set owner "${GITHUB_REPOSITORY_OWNER}"
         env:
           USERNAME: ${{ secrets.JENKINS_USER }}
-          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
           JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
 
       - name: Start the Commit Queue
-        run: ./tools/actions/commit-queue.sh ${{ env.OWNER }} ${{ env.REPOSITORY }} ${{ needs.get_mergeable_prs.outputs.numbers }}
+        run: ./tools/actions/commit-queue.sh "${GITHUB_REPOSITORY_OWNER}" "${REPOSITORY}" ${{ needs.get_mergeable_prs.outputs.numbers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}


### PR DESCRIPTION
With https://github.com/nodejs/node-core-utils/pull/918, we no longer need to preemptively fetch the full history. There are also a bunch of nits to make the code more consistent with the rest of the code base.

Tested with https://github.com/nodejs/node-auto-test/actions/runs/15568681251

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
