### PR TITLE
http2: fix DEP0194 message

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -752,7 +752,7 @@ function onGoawayData(code, lastStreamID, buf) {
 
 // TODO(aduh95): remove this in future semver-major
 const deprecateWeight = deprecateProperty('weight',
-                                          'Priority signaling has been deprecated as of RFC 1993.',
+                                          'Priority signaling has been deprecated as of RFC 9113.',
                                           'DEP0194');
 
 // When a ClientHttp2Session is first created, the socket may not yet be
@@ -2476,7 +2476,7 @@ class Http2Stream extends Duplex {
 Http2Stream.prototype.priority = deprecate(function priority(options) {
   if (this.destroyed)
     throw new ERR_HTTP2_INVALID_STREAM();
-}, 'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 1993', 'DEP0194');
+}, 'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113', 'DEP0194');
 
 function callTimeout(self, session) {
   // If the session is destroyed, this should never actually be invoked,

--- a/test/parallel/test-http2-client-priority-before-connect.js
+++ b/test/parallel/test-http2-client-priority-before-connect.js
@@ -7,7 +7,7 @@ const h2 = require('http2');
 
 common.expectWarning(
   'DeprecationWarning',
-  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 1993',
+  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113',
   'DEP0194');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-client-set-priority.js
+++ b/test/parallel/test-http2-client-set-priority.js
@@ -8,7 +8,7 @@ const http2 = require('http2');
 
 common.expectWarning(
   'DeprecationWarning',
-  'Priority signaling has been deprecated as of RFC 1993.',
+  'Priority signaling has been deprecated as of RFC 9113.',
   'DEP0194');
 
 const checkWeight = (actual, expect) => {

--- a/test/parallel/test-http2-priority-cycle-.js
+++ b/test/parallel/test-http2-priority-cycle-.js
@@ -9,7 +9,7 @@ const Countdown = require('../common/countdown');
 
 common.expectWarning(
   'DeprecationWarning',
-  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 1993',
+  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113',
   'DEP0194');
 
 const server = http2.createServer();

--- a/test/parallel/test-http2-priority-event.js
+++ b/test/parallel/test-http2-priority-event.js
@@ -7,7 +7,7 @@ const h2 = require('http2');
 
 common.expectWarning(
   'DeprecationWarning',
-  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 1993',
+  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113',
   'DEP0194');
 
 const server = h2.createServer();

--- a/test/parallel/test-http2-server-stream-session-destroy.js
+++ b/test/parallel/test-http2-server-stream-session-destroy.js
@@ -8,7 +8,7 @@ const h2 = require('http2');
 
 common.expectWarning(
   'DeprecationWarning',
-  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 1993',
+  'http2Stream.priority is longer supported after priority signalling was deprecated in RFC 9113',
   'DEP0194');
 
 const server = h2.createServer();


### PR DESCRIPTION
Refs #58293 

Noticed the mentioned RFC in deprecation warning is typed as `1993`, and the correct one should be `9113`.
