### PR TITLE
fs: make `processReadResult()` and `readSyncRecursive()` private

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -82,7 +82,7 @@ class Dir {
       );
 
       if (result !== null) {
-        this.processReadResult(path, result);
+        this.#processReadResult(path, result);
         if (result.length > 0) {
           ArrayPrototypePush(this.#handlerQueue, handler);
         }
@@ -125,7 +125,7 @@ class Dir {
         const dirent = ArrayPrototypeShift(this.#bufferedEntries);
 
         if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+          this.#readSyncRecursive(dirent);
         }
 
         if (maybeSync)
@@ -151,10 +151,10 @@ class Dir {
       }
 
       try {
-        this.processReadResult(this.#path, result);
+        this.#processReadResult(this.#path, result);
         const dirent = ArrayPrototypeShift(this.#bufferedEntries);
         if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+          this.#readSyncRecursive(dirent);
         }
         callback(null, dirent);
       } catch (error) {
@@ -170,7 +170,7 @@ class Dir {
     );
   }
 
-  processReadResult(path, result) {
+  #processReadResult(path, result) {
     for (let i = 0; i < result.length; i += 2) {
       ArrayPrototypePush(
         this.#bufferedEntries,
@@ -183,7 +183,7 @@ class Dir {
     }
   }
 
-  readSyncRecursive(dirent) {
+  #readSyncRecursive(dirent) {
     const path = pathModule.join(dirent.parentPath, dirent.name);
     const handle = dirBinding.opendir(
       path,
@@ -209,7 +209,7 @@ class Dir {
     if (this.#processHandlerQueue()) {
       const dirent = ArrayPrototypeShift(this.#bufferedEntries);
       if (this.#options.recursive && dirent.isDirectory()) {
-        this.readSyncRecursive(dirent);
+        this.#readSyncRecursive(dirent);
       }
       return dirent;
     }
@@ -223,11 +223,11 @@ class Dir {
       return result;
     }
 
-    this.processReadResult(this.#path, result);
+    this.#processReadResult(this.#path, result);
 
     const dirent = ArrayPrototypeShift(this.#bufferedEntries);
     if (this.#options.recursive && dirent.isDirectory()) {
-      this.readSyncRecursive(dirent);
+      this.#readSyncRecursive(dirent);
     }
     return dirent;
   }


### PR DESCRIPTION
These two methods are for internal use only. They alter `dir`'s internal state and don't return anything, i.e. can't be used in userland in meaningful way.
Unless there are objections, these can be unexposed without deprecation cycle.

Closes: https://github.com/nodejs/node/issues/58671
Refs: https://github.com/nodejs/node/pull/41439