### PR TITLE
test: use `common.skipIfInspectorDisabled()` to skip tests

### DIFF
--- a/test/parallel/test-source-map-enable.js
+++ b/test/parallel/test-source-map-enable.js
@@ -1,7 +1,5 @@
 'use strict';
 
-if (!process.features.inspector) return;
-
 const common = require('../common');
 const assert = require('assert');
 const { dirname } = require('path');
@@ -9,6 +7,8 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { pathToFileURL } = require('url');
+
+common.skipIfInspectorDisabled();
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();

--- a/test/parallel/test-v8-coverage.js
+++ b/test/parallel/test-v8-coverage.js
@@ -1,12 +1,12 @@
 'use strict';
 
-if (!process.features.inspector) return;
-
 const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+
+common.skipIfInspectorDisabled();
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();

--- a/test/parallel/test-v8-stop-coverage.js
+++ b/test/parallel/test-v8-stop-coverage.js
@@ -1,13 +1,13 @@
 'use strict';
 
-if (!process.features.inspector) return;
-
-require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+
+common.skipIfInspectorDisabled();
 
 tmpdir.refresh();
 const intervals = 20;

--- a/test/parallel/test-v8-take-coverage-noop.js
+++ b/test/parallel/test-v8-take-coverage-noop.js
@@ -1,13 +1,13 @@
 'use strict';
 
-if (!process.features.inspector) return;
-
-require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+
+common.skipIfInspectorDisabled();
 
 tmpdir.refresh();
 

--- a/test/parallel/test-v8-take-coverage.js
+++ b/test/parallel/test-v8-take-coverage.js
@@ -1,13 +1,13 @@
 'use strict';
 
-if (!process.features.inspector) return;
-
-require('../common');
+const common = require('../common');
 const fixtures = require('../common/fixtures');
 const tmpdir = require('../common/tmpdir');
 const assert = require('assert');
 const fs = require('fs');
 const { spawnSync } = require('child_process');
+
+common.skipIfInspectorDisabled();
 
 tmpdir.refresh();
 const intervals = 40;


### PR DESCRIPTION
some test files manually check for `!process.features.inspector` to to see if the tests should be skipped, the changes here update those checks to instead use the more appropriate `common.skipIfInspectorDisabled()`

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
