### PR TITLE
src: enhance error messages for unknown options

### DIFF
--- a/src/node_config_file.cc
+++ b/src/node_config_file.cc
@@ -200,7 +200,7 @@ ParseResult ConfigReader::ParseOptions(
     } else {
       FPrintF(stderr,
               "Unknown or not allowed option %s for namespace %s\n",
-              option_key.data(),
+              option_key,
               namespace_name.c_str());
       return ParseResult::InvalidContent;
     }

--- a/test/parallel/test-config-file.js
+++ b/test/parallel/test-config-file.js
@@ -154,7 +154,7 @@ test('should throw at unknown flag', async () => {
     fixtures.path('rc/unknown-flag.json'),
     '-p', '"Hello, World!"',
   ]);
-  match(result.stderr, /Unknown or not allowed option some-unknown-flag/);
+  match(result.stderr, /Unknown or not allowed option some-unknown-flag for namespace nodeOptions/);
   strictEqual(result.stdout, '');
   strictEqual(result.code, 9);
 });
@@ -166,7 +166,7 @@ test('should throw at flag not available in NODE_OPTIONS', async () => {
     fixtures.path('rc/not-node-options-flag.json'),
     '-p', '"Hello, World!"',
   ]);
-  match(result.stderr, /Unknown or not allowed option test/);
+  match(result.stderr, /Unknown or not allowed option test for namespace nodeOptions/);
   strictEqual(result.stdout, '');
   strictEqual(result.code, 9);
 });
@@ -398,7 +398,7 @@ describe('namespace-scoped options', () => {
       fixtures.path('rc/unknown-flag-namespace.json'),
       '-p', '"Hello, World!"',
     ]);
-    match(result.stderr, /Unknown or not allowed option unknown-flag/);
+    match(result.stderr, /Unknown or not allowed option unknown-flag for namespace testRunner/);
     strictEqual(result.stdout, '');
     strictEqual(result.code, 9);
   });


### PR DESCRIPTION
Before this PR, the error was being printed in a malformed way, containing part of the JSON content

<img width="620" alt="Screenshot 2025-06-11 at 15 18 05" src="https://github.com/user-attachments/assets/8a3a78a3-95f7-44d7-9f99-1f5fdeb5fc1c" />