### PR TITLE
fs: runtime deprecate mistakenly exposed `fs.Dir` methods

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4039,6 +4039,22 @@ Type: Documentation-only
 
 The [`util.types.isNativeError`][] API is deprecated. Please use [`Error.isError`][] instead.
 
+### DEP0198: `fs.Dir.prototype.readSyncRecursive()` and `fs.Dir.prototype.processReadResult`
+
+<!--
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `fs.Dir.prototype.readSyncRecursive()` and `fs.Dir.prototype.processReadResult`
+methods are deprecated. They were intended as internal-only APIs and were never
+documented. However, they were exposed by mistake. They will be removed in future
+releases.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -82,7 +82,7 @@ class Dir {
       );
 
       if (result !== null) {
-        this.processReadResult(path, result);
+        this.#processReadResult(path, result);
         if (result.length > 0) {
           ArrayPrototypePush(this.#handlerQueue, handler);
         }
@@ -125,7 +125,7 @@ class Dir {
         const dirent = ArrayPrototypeShift(this.#bufferedEntries);
 
         if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+          this.#readSyncRecursive(dirent);
         }
 
         if (maybeSync)
@@ -151,10 +151,10 @@ class Dir {
       }
 
       try {
-        this.processReadResult(this.#path, result);
+        this.#processReadResult(this.#path, result);
         const dirent = ArrayPrototypeShift(this.#bufferedEntries);
         if (this.#options.recursive && dirent.isDirectory()) {
-          this.readSyncRecursive(dirent);
+          this.#readSyncRecursive(dirent);
         }
         callback(null, dirent);
       } catch (error) {
@@ -170,7 +170,7 @@ class Dir {
     );
   }
 
-  processReadResult(path, result) {
+  #processReadResult(path, result) {
     for (let i = 0; i < result.length; i += 2) {
       ArrayPrototypePush(
         this.#bufferedEntries,
@@ -182,8 +182,16 @@ class Dir {
       );
     }
   }
+  processReadResult(path, result) {
+    process.emitWarning(
+      'Dir.prototype.processReadResult is deprecated.',
+      'DeprecationWarning',
+      'DEP0198',
+    );
+    return this.#processReadResult(path, result);
+  }
 
-  readSyncRecursive(dirent) {
+  #readSyncRecursive(dirent) {
     const path = pathModule.join(dirent.parentPath, dirent.name);
     const handle = dirBinding.opendir(
       path,
@@ -195,6 +203,15 @@ class Dir {
     }
 
     ArrayPrototypePush(this.#handlerQueue, { handle, path });
+  }
+
+  readSyncRecursive(dirent) {
+    process.emitWarning(
+      'Dir.prototype.readSyncRecursive is deprecated.',
+      'DeprecationWarning',
+      'DEP0198',
+    );
+    return this.#readSyncRecursive(dirent);
   }
 
   readSync() {
@@ -209,7 +226,7 @@ class Dir {
     if (this.#processHandlerQueue()) {
       const dirent = ArrayPrototypeShift(this.#bufferedEntries);
       if (this.#options.recursive && dirent.isDirectory()) {
-        this.readSyncRecursive(dirent);
+        this.#readSyncRecursive(dirent);
       }
       return dirent;
     }
@@ -223,11 +240,11 @@ class Dir {
       return result;
     }
 
-    this.processReadResult(this.#path, result);
+    this.#processReadResult(this.#path, result);
 
     const dirent = ArrayPrototypeShift(this.#bufferedEntries);
     if (this.#options.recursive && dirent.isDirectory()) {
-      this.readSyncRecursive(dirent);
+      this.#readSyncRecursive(dirent);
     }
     return dirent;
   }

--- a/test/parallel/test-fs-dir-deprecations.js
+++ b/test/parallel/test-fs-dir-deprecations.js
@@ -1,0 +1,32 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+
+const { Dir } = require('fs');
+
+const DeprecationWarning = [];
+DeprecationWarning.push([
+  'Dir.prototype.processReadResult is deprecated.',
+  'DEP0198']);
+DeprecationWarning.push([
+  'Dir.prototype.readSyncRecursive is deprecated.',
+  'DEP0198']);
+
+common.expectWarning({ DeprecationWarning });
+
+const dir = new Dir({});
+
+// Verify that the expected deprecation warnings are emitted.
+
+try {
+  dir.processReadResult('/', []);
+} catch {
+  // We expect these to throw. We don't care about the error.
+}
+
+try {
+  dir.readSyncRecursive({ path: '/' });
+} catch {
+  // We expect these to throw. We don't care about the error.
+}


### PR DESCRIPTION
The `processReadResult` and `readSyncRecursive` methods on the `fs.Dir` class were mistakenly exposed as public APIs. These methods are intended only for internal use. They are now runtime deprecated and will be removed.

There is an *extremely* slim possibility that this change could be breaking in that if someone out there happened to be monkeypatching these then the approach taken in this PR would break that. A github code search revealed no such cases and I believe it's unlikely enough that we shouldn't need to worry about it.