### PR TITLE
fs: normalize cpSync and related methods to accept Buffer and URL paths (#58634)

### DIFF
--- a/lib/internal/fs/cp/cp-sync.js
+++ b/lib/internal/fs/cp/cp-sync.js
@@ -1,7 +1,9 @@
 'use strict';
 
 // This file is a modified version of the fs-extra's copySync method.
-
+const { fileURLToPath } = require('url');
+const { isBuffer } = require('buffer');
+const { join } = require('path');
 const fsBinding = internalBinding('fs');
 const { isSrcSubdir } = require('internal/fs/cp/cp');
 const { codes: {
@@ -38,7 +40,16 @@ const {
 } = require('path');
 const { isPromise } = require('util/types');
 
+function normalizePath(p) {
+  if (isBuffer(p)) return p.toString();
+  if (p instanceof URL) return fileURLToPath(p);
+  return p;
+}
+
 function cpSyncFn(src, dest, opts) {
+  src = normalizePath(src);
+  dest = normalizePath(dest);
+  
   // Warn about using preserveTimestamps on 32-bit node
   if (opts.preserveTimestamps && process.arch === 'ia32') {
     const warning = 'Using the preserveTimestamps option in 32-bit ' +
@@ -138,6 +149,8 @@ function onDir(srcStat, destStat, src, dest, opts) {
 }
 
 function copyDir(src, dest, opts, mkDir, srcMode) {
+   src = normalizePath(src);
+   dest = normalizePath(dest);
   if (!opts.filter) {
     // The caller didn't provide a js filter function, in this case
     // we can run the whole function faster in C++


### PR DESCRIPTION
This patch ensures that fs.cpSync and copyDir handle Buffer and URL types for the src and dest arguments by normalizing them to string paths using toString() and fileURLToPath() respectively.

Previously, these inputs would cause type errors when passed to path.join(), as the implementation assumed string paths.

Fixes: #58634