### PR TITLE
fix: avoid false DEP0155 warning for "./*" exports on Windows (#58650)

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -621,7 +621,7 @@ function packageExportsResolve(
       //   throwInvalidSubpath(packageSubpath)
       //
       // To match "imports" and the spec.
-      if (StringPrototypeEndsWith(packageSubpath, '/')) {
+      if (key === './' && StringPrototypeEndsWith(packageSubpath, '/')) {
         emitTrailingSlashPatternDeprecation(packageSubpath, packageJSONUrl,
                                             base);
       }


### PR DESCRIPTION
- The logic for emitting the DEP0155 warning now checks that the export key is exactly `"./"` before displaying the warning.
- Pattern mappings such as `"./*"` and valid subpath exports are no longer affected.

**Fixes #58650**
