### PR TITLE
lib: make domexception a native error

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/value-serializer.cc
+++ b/deps/v8/src/objects/value-serializer.cc
@@ -654,8 +654,17 @@ Maybe<bool> ValueSerializer::WriteJSReceiver(
     case JS_DATA_VIEW_TYPE:
     case JS_RAB_GSAB_DATA_VIEW_TYPE:
       return WriteJSArrayBufferView(Cast<JSArrayBufferView>(*receiver));
-    case JS_ERROR_TYPE:
-      return WriteJSError(Cast<JSObject>(receiver));
+    case JS_ERROR_TYPE: {
+      DirectHandle<JSObject> js_error = Cast<JSObject>(receiver);
+      Maybe<bool> is_host_object = IsHostObject(js_error);
+      if (is_host_object.IsNothing()) {
+        return is_host_object;
+      }
+      if (is_host_object.FromJust()) {
+        return WriteHostObject(js_error);
+      }
+      return WriteJSError(js_error);
+    }
     case JS_SHARED_ARRAY_TYPE:
       return WriteJSSharedArray(Cast<JSSharedArray>(receiver));
     case JS_SHARED_STRUCT_TYPE:

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  ErrorCaptureStackTrace,
+  Error,
   ErrorPrototype,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -60,20 +60,33 @@ const disusedNamesSet = new SafeSet()
   .add('NoDataAllowedError')
   .add('ValidationError');
 
+let DOMExceptionPrototype;
+// The DOMException WebIDL interface defines that:
+// - ObjectGetPrototypeOf(DOMException) === Function.
+// - ObjectGetPrototypeOf(DOMException.prototype) === Error.prototype.
+// Thus, we can not simply use the pattern of `class DOMException extends Error` and call
+// `super()` to construct an object. The `super` in `super()` call in the constructor will
+// be resolved to `Function`, instead of `Error`. Use the trick of return overriding to
+// create an object with the `[[ErrorData]]` internal slot.
+// Ref: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-getsuperconstructor
 class DOMException {
   constructor(message = '', options = 'Error') {
-    this[transfer_mode_private_symbol] = kCloneable;
-    ErrorCaptureStackTrace(this);
+    // Invokes the Error constructor to create an object with the [[ErrorData]]
+    // internal slot.
+    // eslint-disable-next-line no-restricted-syntax
+    const self = new Error();
+    ObjectSetPrototypeOf(self, DOMExceptionPrototype);
+    self[transfer_mode_private_symbol] = kCloneable;
 
     if (options && typeof options === 'object') {
       const { name } = options;
-      internalsMap.set(this, {
+      internalsMap.set(self, {
         message: `${message}`,
         name: `${name}`,
       });
 
       if ('cause' in options) {
-        ObjectDefineProperty(this, 'cause', {
+        ObjectDefineProperty(self, 'cause', {
           __proto__: null,
           value: options.cause,
           configurable: true,
@@ -82,11 +95,14 @@ class DOMException {
         });
       }
     } else {
-      internalsMap.set(this, {
+      internalsMap.set(self, {
         message: `${message}`,
         name: `${options}`,
       });
     }
+    // Return the error object as the return overriding of the constructor.
+    // eslint-disable-next-line no-constructor-return
+    return self;
   }
 
   [messaging_clone_symbol]() {
@@ -142,8 +158,9 @@ class DOMException {
   }
 }
 
-ObjectSetPrototypeOf(DOMException.prototype, ErrorPrototype);
-ObjectDefineProperties(DOMException.prototype, {
+DOMExceptionPrototype = DOMException.prototype;
+ObjectSetPrototypeOf(DOMExceptionPrototype, ErrorPrototype);
+ObjectDefineProperties(DOMExceptionPrototype, {
   [SymbolToStringTag]: { __proto__: null, configurable: true, value: 'DOMException' },
   name: { __proto__: null, enumerable: true, configurable: true },
   message: { __proto__: null, enumerable: true, configurable: true },
@@ -181,7 +198,7 @@ for (const { 0: name, 1: codeName, 2: value } of [
 ]) {
   const desc = { enumerable: true, value };
   ObjectDefineProperty(DOMException, codeName, desc);
-  ObjectDefineProperty(DOMException.prototype, codeName, desc);
+  ObjectDefineProperty(DOMExceptionPrototype, codeName, desc);
   nameToCodeMap.set(name, value);
 }
 

--- a/test/wpt/status/webidl/ecmascript-binding/es-exceptions.json
+++ b/test/wpt/status/webidl/ecmascript-binding/es-exceptions.json
@@ -1,10 +1,1 @@
-{
-  "DOMException-is-error.any.js": {
-    "fail": {
-      "note": "https://github.com/nodejs/node/issues/56497",
-      "expected": [
-        "DOMException-is-error"
-      ]
-    }
-  }
-}
+{}


### PR DESCRIPTION
#### deps: V8: cherry-pick e3df60f3f5ab

Original commit message:

    [objects] allow host defined serializer of JSError

    Allow host defined serializer and deserializer of JSError in
    ValueSerializer API. This allows hosts that implement DOMException
    in JS to support `Error.isError` proposal and `structuredClone`.

    Refs: https://github.com/nodejs/node/pull/58691
    Change-Id: I022821c9abd659970c4d449b3c69c5fb54d0618a
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6637876
    Reviewed-by: Camillo Bruni <cbruni@chromium.org>
    Commit-Queue: Chengzhong Wu <cwu631@bloomberg.net>
    Cr-Commit-Position: refs/heads/main@{#100894}

Refs: https://github.com/v8/v8/commit/e3df60f3f5abe85f819ff2fad6a41d0709e30a61

#### lib: make domexception a native error

`isolate->SetJSApiWrapperNativeErrorCallback(IsNodeError)` can not be used because V8 only invokes the callback for native objects:

https://github.com/nodejs/node/blob/708477bd8d68f3571b02bb311dccc3d892e447d1/deps/v8/src/builtins/builtins-error.cc#L72-L74

Setting this callback also requires embedders like electron to decide if they need to override blink's callback. So it is simpler to implement this in JS only.

Refs: https://github.com/nodejs/node/pull/58138
Fixes: https://github.com/nodejs/node/issues/56497