### PR TITLE
dns: support IPv6-only and IPv4-only in setLocalAddress()

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -16,6 +16,7 @@ const {
     ERR_DNS_SET_SERVERS_FAILED,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_IP_ADDRESS,
+    ERR_MISSING_ARGS,
   },
 } = require('internal/errors');
 const { isIP } = require('internal/net');
@@ -162,10 +163,15 @@ class ResolverBase {
     }
   }
 
-
   setLocalAddress(ipv4, ipv6) {
-    validateString(ipv4, 'ipv4');
+    // Allow setting either IPv4 or IPv6 (or both). Throw if both are omitted.
+    if (ipv4 === undefined && ipv6 === undefined) {
+      throw new ERR_MISSING_ARGS('ipv4', 'ipv6');
+    }
 
+    if (ipv4 !== undefined) {
+      validateString(ipv4, 'ipv4');
+    }
     if (ipv6 !== undefined) {
       validateString(ipv6, 'ipv6');
     }


### PR DESCRIPTION
## What was fixed
`Resolver.prototype.setLocalAddress(ipv4, ipv6)` incorrectly required an IPv4 string even when callers only wanted to set an IPv6 local address.  
Calling `resolver.setLocalAddress(undefined, '::1')` threw `ERR_INVALID_ARG_TYPE`, breaking the documented API and blocking IPv6-only use-cases.

## Changes
* [lib/internal/dns/utils.js](cci:7://file:///d:/Github/node/lib/internal/dns/utils.js:0:0-0:0)
  * Added `ERR_MISSING_ARGS` to imported error codes.
  * Re-implemented argument validation:
    * Now validates each address only when provided.
    * Throws `ERR_MISSING_ARGS('ipv4','ipv6')` when both arguments are omitted.
  * Keeps snapshot state logic unchanged.

## Impact
Restores conformance with public documentation:
* Users can bind a resolver to IPv6 only, IPv4 only, or both.
* No breaking change for existing valid code; previously invalid calls now work as intended.

Refs: documentation for `resolver.setLocalAddress`  