### PR TITLE
repl: fix tab completion not working with computer string properties

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1226,7 +1226,7 @@ const importRE = /\bimport\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])
 const requireRE = /\brequire\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])$/;
 const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
-    /(?:[\w$'"`[{(](?:\w|\$|['"`\]})])*\??\.)*[a-zA-Z_$](?:\w|\$)*\??\.?$/;
+    /(?:[\w$'"`[{(](?:\w|['"`](\w| |\t)*['"`]|\$|['"`\]})])*\??(?:\.|])?)*(?:[a-zA-Z_$])?(?:\w|\$)*\??\.?$/m;
 const versionedFileNamesRe = /-\d+\.\d+/;
 
 function isIdentifier(str) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1226,7 +1226,7 @@ const importRE = /\bimport\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])
 const requireRE = /\brequire\s*\(\s*['"`](([\w@./:-]+\/)?(?:[\w@./:-]*))(?![^'"`])$/;
 const fsAutoCompleteRE = /fs(?:\.promises)?\.\s*[a-z][a-zA-Z]+\(\s*["'](.*)/;
 const simpleExpressionRE =
-    /(?:[\w$'"`[{(](?:\w|['"`](\w| |\t)*['"`]|\$|['"`\]})])*\??(?:\.|])?)*(?:[a-zA-Z_$])?(?:\w|\$)*\??\.?$/m;
+    /(?:[\w$'"`[{(](?:(\w| |\t)*?['"`]|\$|['"`\]})])*\??(?:\.|])?)*?(?:[a-zA-Z_$])?(?:\w|\$)*\??\.?$/;
 const versionedFileNamesRe = /-\d+\.\d+/;
 
 function isIdentifier(str) {

--- a/test/parallel/test-repl-tab-complete-computed-props.js
+++ b/test/parallel/test-repl-tab-complete-computed-props.js
@@ -24,10 +24,10 @@ function prepareREPL() {
 
 function testCompletion(replServer, { input, expectedCompletions }) {
   replServer.complete(
-      input,
-      common.mustCall((_error, data) => {
-          assert.deepStrictEqual(data, [expectedCompletions, input]);
-      }),
+    input,
+    common.mustCall((_error, data) => {
+      assert.deepStrictEqual(data, [expectedCompletions, input]);
+    }),
   );
 };
 
@@ -90,6 +90,41 @@ describe('REPL tab object completion on computed properties', () => {
     it('works with strings with spaces', () => testCompletion(replServer, {
       input: 'obj["inner object"].th',
       expectedCompletions: ['obj["inner object"].three'],
+    }));
+  });
+
+  describe('variables as indexes', () => {
+    let replServer;
+
+    before(() => {
+      const { replServer: server, input } = prepareREPL();
+      replServer = server;
+
+      input.run([
+        `
+          const oneStr = 'One';
+          const helloWorldStr = 'Hello' + ' ' + 'World';
+
+          const obj = {
+            [oneStr]: 1,
+            ['Hello World']: 'hello world!',
+          };
+        `,
+      ]);
+    });
+
+    after(() => {
+      replServer.close();
+    });
+
+    it('works with a simple variable', () => testCompletion(replServer, {
+      input: 'obj[oneStr].toFi',
+      expectedCompletions: ['obj[oneStr].toFixed'],
+    }));
+
+    it('works with a computed variable', () => testCompletion(replServer, {
+      input: 'obj[helloWorldStr].tolocaleup',
+      expectedCompletions: ['obj[helloWorldStr].toLocaleUpperCase'],
     }));
   });
 });

--- a/test/parallel/test-repl-tab-complete-computed-props.js
+++ b/test/parallel/test-repl-tab-complete-computed-props.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const { describe, it, before, after } = require('node:test');
+const assert = require('assert');
+
+const repl = require('repl');
+
+function prepareREPL() {
+  const input = new ArrayStream();
+  const replServer = repl.start({
+    prompt: '',
+    input,
+    output: process.stdout,
+    allowBlockingCompletions: true,
+  });
+
+  // Some errors are passed to the domain, but do not callback
+  replServer._domain.on('error', assert.ifError);
+
+  return { replServer, input };
+}
+
+function testCompletion(replServer, { input, expectedCompletions }) {
+  replServer.complete(
+      input,
+      common.mustCall((_error, data) => {
+          assert.deepStrictEqual(data, [expectedCompletions, input]);
+      }),
+  );
+};
+
+describe('REPL tab object completion on computed properties', () => {
+  describe('simple string cases', () => {
+    let replServer;
+
+    before(() => {
+      const { replServer: server, input } = prepareREPL();
+      replServer = server;
+
+      input.run([
+        `
+          const obj = {
+            one: 1,
+            innerObj: { two: 2 },
+            'inner object': { three: 3 },
+          };
+
+          const oneStr = 'one';
+        `,
+      ]);
+    });
+
+    after(() => {
+      replServer.close();
+    });
+
+    it('works with double quoted strings', () => testCompletion(replServer, {
+      input: 'obj["one"].toFi',
+      expectedCompletions: ['obj["one"].toFixed'],
+    }));
+
+    it('works with single quoted strings', () => testCompletion(replServer, {
+      input: "obj['one'].toFi",
+      expectedCompletions: ["obj['one'].toFixed"],
+    }));
+
+    it('works with template strings', () => testCompletion(replServer, {
+      input: 'obj[`one`].toFi',
+      expectedCompletions: ['obj[`one`].toFixed'],
+    }));
+
+    it('works with nested objects', () => {
+      testCompletion(replServer, {
+        input: 'obj["innerObj"].tw',
+        expectedCompletions: ['obj["innerObj"].two'],
+      });
+      testCompletion(replServer, {
+        input: 'obj["innerObj"].two.tofi',
+        expectedCompletions: ['obj["innerObj"].two.toFixed'],
+      });
+    });
+
+    it('works with nested objects combining different type of strings', () => testCompletion(replServer, {
+      input: 'obj["innerObj"][`two`].tofi',
+      expectedCompletions: ['obj["innerObj"][`two`].toFixed'],
+    }));
+
+    it('works with strings with spaces', () => testCompletion(replServer, {
+      input: 'obj["inner object"].th',
+      expectedCompletions: ['obj["inner object"].three'],
+    }));
+  });
+});


### PR DESCRIPTION
I noticed that the repl tab completion doesn't correctly handle computed properties targeted by strings.

For example given the following context:
```js
const obj = { one: 1 };
```

The current repl would provide valid (number) completions for lines such as:
```js
obj.one.to
```

But would not provide correct completions for lines such as:
```js
obj['one'].to
```

In fact it would provide incorrect (string) completions.

See:
![Screenshot at 2025-06-15 01-03-50](https://github.com/user-attachments/assets/925d0ae0-acd3-4834-9fe0-467848df5398)

This PR addresses the above issue

> [!Note]
> This PR is not making everything work perfectly, for example it is not addressing lines such as
> `obj['o' + 'ne'].to` (but it's not making them any worse either).
> I think that a generally great solution would require more substantial code changes (potentially with some AST analysis).
> I am planning on keeping improving things here but I figured I could do it incrementally and that I'd open this PR to
> start moving things in the right direction anyways.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
