### PR TITLE
watch: add `--watch-kill-signal` flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3132,6 +3132,19 @@ mode. If no file is provided, Node.js will exit with status code `9`.
 node --watch index.js
 ```
 
+### `--watch-kill-signal`
+
+<!-- YAML
+added:
+  - REPLACEME
+-->
+
+Customizes the signal sent to the process on watch mode restarts.
+
+```bash
+node --watch --watch-kill-signal SIGINT test.js
+```
+
 ### `--watch-path`
 
 <!-- YAML
@@ -3474,6 +3487,7 @@ one is included in the list below.
 * `--use-openssl-ca`
 * `--use-system-ca`
 * `--v8-pool-size`
+* `--watch-kill-signal`
 * `--watch-path`
 * `--watch-preserve-output`
 * `--watch`

--- a/doc/node-config-schema.json
+++ b/doc/node-config-schema.json
@@ -565,6 +565,9 @@
         "watch": {
           "type": "boolean"
         },
+        "watch-kill-signal": {
+          "type": "string"
+        },
         "watch-path": {
           "oneOf": [
             {

--- a/doc/node.1
+++ b/doc/node.1
@@ -621,6 +621,19 @@ Set V8's thread pool size which will be used to allocate background jobs.
 If set to 0 then V8 will choose an appropriate size of the thread pool based on the number of online processors.
 If the value provided is larger than V8's maximum, then the largest value will be chosen.
 .
+.It Fl -watch
+Starts Node.js in watch mode. When in watch mode, changes in the watched files cause the Node.js process to restart.
+
+By default, watch mode will watch the entry point and any required or imported module. Use --watch-path to specify what paths to watch.
+.
+.It Fl -watch-path
+Starts Node.js in watch mode and specifies what paths to watch. When in watch mode, changes in the watched paths cause the Node.js process to restart.
+
+This will turn off watching of required or imported modules, even when used in combination with --watch.
+.
+.It Fl -watch-kill-signal
+Customizes the signal sent to the process on watch mode restarts.
+.
 .It Fl -zero-fill-buffers
 Automatically zero-fills all newly allocated Buffer instances.
 .

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -20,6 +20,7 @@ const {
 const { getOptionValue } = require('internal/options');
 const { FilesWatcher } = require('internal/watch_mode/files_watcher');
 const { green, blue, red, white, clear } = require('internal/util/colors');
+const { convertToValidSignal } = require('internal/util');
 
 const { spawn } = require('child_process');
 const { inspect } = require('util');
@@ -30,8 +31,7 @@ const { once } = require('events');
 prepareMainThreadExecution(false, false);
 markBootstrapComplete();
 
-// TODO(MoLow): Make kill signal configurable
-const kKillSignal = 'SIGTERM';
+const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -957,6 +957,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,
             kAllowedInEnvvar);
+  AddOption("--watch-kill-signal",
+            "kill signal to send to the process on watch mode restarts"
+            "(default: SIGTERM)",
+            &EnvironmentOptions::watch_mode_kill_signal,
+            kAllowedInEnvvar);
   AddOption("--watch-preserve-output",
             "preserve outputs on watch mode restart",
             &EnvironmentOptions::watch_mode_preserve_output,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -232,6 +232,7 @@ class EnvironmentOptions : public Options {
   bool watch_mode = false;
   bool watch_mode_report_to_parent = false;
   bool watch_mode_preserve_output = false;
+  std::string watch_mode_kill_signal = "SIGTERM";
   std::vector<std::string> watch_mode_paths;
 
   bool syntax_check_only = false;

--- a/test/parallel/test-runner-watch-mode-kill-signal.mjs
+++ b/test/parallel/test-runner-watch-mode-kill-signal.mjs
@@ -1,0 +1,122 @@
+import * as common from '../common/index.mjs';
+import { describe, it, beforeEach } from 'node:test';
+import { once } from 'node:events';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import tmpdir from '../common/tmpdir.js';
+
+if (common.isWindows) {
+  common.skip('no signals on Windows');
+}
+
+if (common.isIBMi) {
+  common.skip('IBMi does not support `fs.watch()`');
+}
+
+if (common.isAIX) {
+  common.skip('folder watch capability is limited in AIX.');
+}
+
+const indexContents = `
+  const { setTimeout } = require("timers/promises");
+  (async () => {
+      // Wait a few milliseconds to make sure that the
+      // parent process has time to attach its listeners
+      await setTimeout(200);
+
+      process.on('SIGTERM', () => {
+          console.log('__SIGTERM received__');
+          process.exit(123);
+      });
+
+      process.on('SIGINT', () => {
+          console.log('__SIGINT received__');
+          process.exit(124);
+      });
+
+      console.log('ready!');
+
+      // Wait for a long time (just to keep the process alive)
+      await setTimeout(100_000_000);
+  })();
+`;
+
+let indexPath = '';
+
+function refresh() {
+  tmpdir.refresh();
+  indexPath = tmpdir.resolve('index.js');
+  writeFileSync(indexPath, indexContents);
+}
+
+describe('test runner watch mode with --watch-kill-signal', () => {
+  beforeEach(refresh);
+
+  it('defaults to SIGTERM', async () => {
+    let currentRun = Promise.withResolvers();
+    const child = spawn(process.execPath, ['--watch', indexPath], {
+      cwd: tmpdir.path,
+    });
+
+    let stdout = '';
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+      currentRun.resolve();
+    });
+
+    await currentRun.promise;
+
+    currentRun = Promise.withResolvers();
+    writeFileSync(indexPath, indexContents);
+
+    await currentRun.promise;
+    child.kill();
+    const [exitCode] = await once(child, 'exit');
+    assert.match(stdout, /__SIGTERM received__/);
+    assert.strictEqual(exitCode, 123);
+  });
+
+  it('can be overridden (to SIGINT)', async () => {
+    let currentRun = Promise.withResolvers();
+    const child = spawn(process.execPath, ['--watch', '--watch-kill-signal', 'SIGINT', indexPath], {
+      cwd: tmpdir.path,
+    });
+    let stdout = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+      if (stdout.includes('ready!')) {
+        currentRun.resolve();
+      }
+    });
+
+    await currentRun.promise;
+
+    currentRun = Promise.withResolvers();
+    writeFileSync(indexPath, indexContents);
+
+    await currentRun.promise;
+    child.kill();
+    const [exitCode] = await once(child, 'exit');
+    assert.match(stdout, /__SIGINT received__/);
+    assert.strictEqual(exitCode, 124);
+  });
+
+  it('errors if an invalid signal is provided', async () => {
+    const currentRun = Promise.withResolvers();
+    const child = spawn(process.execPath, ['--watch', '--watch-kill-signal', 'invalid_signal', indexPath], {
+      cwd: tmpdir.path,
+    });
+    let stdout = '';
+
+    child.stderr.on('data', (data) => {
+      stdout += data.toString();
+      currentRun.resolve();
+    });
+
+    await currentRun.promise;
+
+    assert.match(stdout, new RegExp(/TypeError \[ERR_UNKNOWN_SIGNAL\]: Unknown signal: invalid_signal/));
+  });
+});


### PR DESCRIPTION
add the new `--watch-kill-signal` to allow users to customize what signal is sent to the process on restarts during watch mode

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
