### PR TITLE
n-api: fix dead lock if multi push events

### DIFF
--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -238,7 +238,7 @@ class ThreadSafeFunction : public node::AsyncResource {
   napi_status Push(void* data, napi_threadsafe_function_call_mode mode) {
     node::Mutex::ScopedLock lock(this->mutex);
 
-    while (queue.size() >= max_queue_size && max_queue_size > 0 &&
+    while (max_queue_size > 0 && queue.size() >= max_queue_size &&
            !is_closing) {
       if (mode == napi_tsfn_nonblocking) {
         return napi_queue_full;
@@ -385,7 +385,7 @@ class ThreadSafeFunction : public node::AsyncResource {
           data = queue.front();
           queue.pop();
           popped_value = true;
-          if (size == max_queue_size && max_queue_size > 0) {
+          if (max_queue_size > 0) {
             cond->Signal(lock);
           }
           size--;


### PR DESCRIPTION
fix #58723

- add waiting_task_size to record waiting push events
- compare max_queue_size before queue.size which would be faster

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
