### PR TITLE
fs: avoid computing time coefficient constants in runtime

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -419,10 +419,10 @@ StatsBase.prototype.isSocket = function() {
   return this._checkModeProperty(S_IFSOCK);
 };
 
-const kNsPerMsBigInt = 10n ** 6n;
-const kNsPerSecBigInt = 10n ** 9n;
-const kMsPerSec = 10 ** 3;
-const kNsPerMs = 10 ** 6;
+const kNsPerMsBigInt = 1_000_000n;
+const kNsPerSecBigInt = 1_000_000_000n;
+const kMsPerSec = 1_000;
+const kNsPerMs = 1_000_000;
 function msFromTimeSpec(sec, nsec) {
   return sec * kMsPerSec + nsec / kNsPerMs;
 }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/58726 [^1]

These constants can be precomputed.

[^1]: even though it's not a Node.js bug