### PR TITLE
webstorage: unflag --experimental-webstorage

### DIFF
--- a/benchmark/webstorage/getItem.js
+++ b/benchmark/webstorage/getItem.js
@@ -12,7 +12,7 @@ function nextLocalStorage() {
 }
 
 const options = {
-  flags: ['--experimental-webstorage', `--localstorage-file=${nextLocalStorage()}`],
+  flags: [`--localstorage-file=${nextLocalStorage()}`],
 };
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/webstorage/removeItem.js
+++ b/benchmark/webstorage/removeItem.js
@@ -12,7 +12,7 @@ function nextLocalStorage() {
 }
 
 const options = {
-  flags: ['--experimental-webstorage', `--localstorage-file=${nextLocalStorage()}`],
+  flags: [`--localstorage-file=${nextLocalStorage()}`],
 };
 
 const bench = common.createBenchmark(main, {

--- a/benchmark/webstorage/setItem.js
+++ b/benchmark/webstorage/setItem.js
@@ -12,7 +12,7 @@ function nextLocalStorage() {
 }
 
 const options = {
-  flags: ['--experimental-webstorage', `--localstorage-file=${nextLocalStorage()}`],
+  flags: [`--localstorage-file=${nextLocalStorage()}`],
 };
 
 const bench = common.createBenchmark(main, {

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1212,9 +1212,13 @@ Enable experimental WebAssembly module support.
 
 <!-- YAML
 added: v22.4.0
+changes:
+  - version: v25.0.0
+    pr-url: https://github.com/nodejs/node/pull/57666
+    description: Web Storage is now enabled by default. This flag is now a no-op.
 -->
 
-Enable experimental [`Web Storage`][] support.
+This flag is now a no-op as [`Web Storage`][] is enabled by default.
 
 ### `--experimental-worker-inspection`
 
@@ -1649,12 +1653,15 @@ surface on other platforms, but the performance impact may be severe.
 
 <!-- YAML
 added: v22.4.0
+changes:
+  - version: v25.0.0
+    pr-url: https://github.com/nodejs/node/pull/57666
+    description: Web Storage is now enabled by default.
 -->
 
 The file used to store `localStorage` data. If the file does not exist, it is
 created the first time `localStorage` is accessed. The same file may be shared
-between multiple Node.js processes concurrently. This flag is a no-op unless
-Node.js is started with the `--experimental-webstorage` flag.
+between multiple Node.js processes concurrently.
 
 ### `--max-http-header-size=size`
 

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -684,15 +684,18 @@ A browser-compatible implementation of {Headers}.
 
 <!-- YAML
 added: v22.4.0
+changes:
+  - version: v25.0.0
+    pr-url: https://github.com/nodejs/node/pull/57666
+    description: No longer requires the `--experimental-webstorage` flag.
 -->
 
-> Stability: 1.0 - Early development.
+> Stability: 2 - Stable
 
 A browser-compatible implementation of [`localStorage`][]. Data is stored
 unencrypted in the file specified by the [`--localstorage-file`][] CLI flag.
 The maximum amount of data that can be stored is 10 MB.
 Any modification of this data outside of the Web Storage API is not supported.
-Enable this API with the [`--experimental-webstorage`][] CLI flag.
 `localStorage` data is not stored per user or per request when used in the context
 of a server, it is shared across all users and requests.
 
@@ -1116,9 +1119,13 @@ A browser-compatible implementation of {Request}.
 
 <!-- YAML
 added: v22.4.0
+changes:
+  - version: v25.0.0
+    pr-url: https://github.com/nodejs/node/pull/57666
+    description: No longer requires the `--experimental-webstorage` flag.
 -->
 
-> Stability: 1.0 - Early development.
+> Stability: 2 - Stable
 
 A browser-compatible implementation of [`sessionStorage`][]. Data is stored in
 memory, with a storage quota of 10 MB. `sessionStorage` data persists only within
@@ -1164,12 +1171,15 @@ added: v0.0.1
 
 <!-- YAML
 added: v22.4.0
+changes:
+  - version: v25.0.0
+    pr-url: https://github.com/nodejs/node/pull/57666
+    description: No longer requires the `--experimental-webstorage` flag.
 -->
 
-> Stability: 1.0 - Early development.
+> Stability: 2 - Stable
 
-A browser-compatible implementation of [`Storage`][]. Enable this API with the
-[`--experimental-webstorage`][] CLI flag.
+A browser-compatible implementation of [`Storage`][].
 
 ## `structuredClone(value[, options])`
 

--- a/doc/node.1
+++ b/doc/node.1
@@ -202,7 +202,7 @@ Enable experimental support for the EventSource Web API.
 Disable experimental support for the WebSocket API.
 .
 .It Fl -experimental-webstorage
-Enable experimental support for the Web Storage API.
+Web Storage API (enabled by default, use --no-experimental-webstorage to disable).
 .
 .It Fl -no-experimental-repl-await
 Disable top-level await keyword support in REPL.

--- a/lib/internal/webstorage.js
+++ b/lib/internal/webstorage.js
@@ -4,12 +4,9 @@ const {
 } = primordials;
 const { ERR_INVALID_ARG_VALUE } = require('internal/errors').codes;
 const { getOptionValue } = require('internal/options');
-const { emitExperimentalWarning } = require('internal/util');
 const { kConstructorKey, Storage } = internalBinding('webstorage');
 const { getValidatedPath } = require('internal/fs/utils');
 const kInMemoryPath = ':memory:';
-
-emitExperimentalWarning('Web Storage');
 
 module.exports = { Storage };
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -516,9 +516,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
 #endif
             kAllowedInEnvvar);
   AddOption("--experimental-webstorage",
-            "experimental Web Storage API",
+            "Web Storage API (enabled by default, use --no-experimental-webstorage to disable)",
             &EnvironmentOptions::experimental_webstorage,
-            kAllowedInEnvvar);
+            kAllowedInEnvvar,
+            true);
   AddOption("--localstorage-file",
             "file used to persist localStorage data",
             &EnvironmentOptions::localstorage_file,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -126,7 +126,7 @@ class EnvironmentOptions : public Options {
   bool experimental_fetch = true;
   bool experimental_websocket = true;
   bool experimental_sqlite = true;
-  bool experimental_webstorage = false;
+  bool experimental_webstorage = true;
 #ifdef NODE_OPENSSL_HAS_QUIC
   bool experimental_quic = false;
 #endif

--- a/test/wpt/test-webstorage.js
+++ b/test/wpt/test-webstorage.js
@@ -9,7 +9,6 @@ const runner = new WPTRunner('webstorage', { concurrency: 1 });
 tmpdir.refresh();
 
 runner.setFlags([
-  '--experimental-webstorage',
   '--localstorage-file', join(tmpdir.path, 'wpt-tests.localstorage'),
 ]);
 runner.setInitScript(`


### PR DESCRIPTION
## Description

This PR unflags the `--experimental-webstorage` option, making Web Storage (localStorage and sessionStorage) available by default in Node.js v25.

## Changes Made

- **Core Implementation**: Changed `experimental_webstorage` default from `false` to `true` in `src/node_options.h`
- **Setup Logic**: Updated webstorage setup to work by default while maintaining disable option
- **Experimental Warning**: Removed experimental warning from `lib/internal/webstorage.js`
- **Documentation**: Updated API docs, CLI docs, and man pages to reflect stable status
- **Tests**: Updated all test files to work without experimental flag requirement
- **Benchmarks**: Updated benchmark files to remove experimental flag requirement

## Backward Compatibility

- Maintains full backward compatibility
- `--experimental-webstorage` flag still works (now a no-op)
- Users can disable with `--no-experimental-webstorage` if needed

## Testing

- All existing tests pass (webstorage tests require SQLite)
- Updated tests reflect new default behavior
- Benchmarks work without experimental flag

Fixes #57658

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
