### PR TITLE
doc: update "Spawning `.bat` and `.cmd` files on Windows" section

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -118,16 +118,13 @@ operating systems (Unix, Linux, macOS) [`child_process.execFile()`][] can be
 more efficient because it does not spawn a shell by default. On Windows,
 however, `.bat` and `.cmd` files are not executable on their own without a
 terminal, and therefore cannot be launched using [`child_process.execFile()`][].
-When running on Windows, `.bat` and `.cmd` files can be invoked using
-[`child_process.spawn()`][] with the `shell` option set, with
-[`child_process.exec()`][], or by spawning `cmd.exe` and passing the `.bat` or
-`.cmd` file as an argument (which is what the `shell` option and
-[`child_process.exec()`][] do). In any case, if the script filename contains
-spaces it needs to be quoted.
+When running on Windows, `.bat` and `.cmd` files should only be invoked using
+[`child_process.exec()`][] and if the script filename contains spaces it needs
+to be quoted.
 
 ```cjs
 // OR...
-const { exec, spawn } = require('node:child_process');
+const { exec } = require('node:child_process');
 
 exec('my.bat', (err, stdout, stderr) => {
   if (err) {
@@ -138,8 +135,6 @@ exec('my.bat', (err, stdout, stderr) => {
 });
 
 // Script with spaces in the filename:
-const bat = spawn('"my script.cmd" a b', { shell: true });
-// or:
 exec('"my script.cmd" a b', (err, stdout, stderr) => {
   // ...
 });
@@ -147,7 +142,7 @@ exec('"my script.cmd" a b', (err, stdout, stderr) => {
 
 ```mjs
 // OR...
-import { exec, spawn } from 'node:child_process';
+import { exec } from 'node:child_process';
 
 exec('my.bat', (err, stdout, stderr) => {
   if (err) {
@@ -158,8 +153,6 @@ exec('my.bat', (err, stdout, stderr) => {
 });
 
 // Script with spaces in the filename:
-const bat = spawn('"my script.cmd" a b', { shell: true });
-// or:
 exec('"my script.cmd" a b', (err, stdout, stderr) => {
   // ...
 });


### PR DESCRIPTION
Remove the suggestion to use `spawn` following DEP0190.
    
Fixes: https://github.com/nodejs/node/issues/58735
Refs: https://nodejs.org/docs/latest-v24.x/api/child_process.html
