### PR TITLE
[riscv] Fix check failed in bind_to

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
@@ -720,8 +720,8 @@ void Assembler::bind_to(Label* L, int pos) {
             trampoline_pos = get_trampoline_entry(fixup_pos);
             CHECK_NE(trampoline_pos, kInvalidSlotPos);
           }
-          CHECK((trampoline_pos - fixup_pos) <= kMaxBranchOffset);
           DEBUG_PRINTF("\t\ttrampolining: %d\n", trampoline_pos);
+          CHECK((trampoline_pos - fixup_pos) <= kMaxBranchOffset);
           target_at_put(fixup_pos, trampoline_pos, false);
           fixup_pos = trampoline_pos;
         }
@@ -1498,6 +1498,7 @@ void Assembler::BlockTrampolinePoolFor(int instructions) {
 }
 
 void Assembler::CheckTrampolinePool() {
+  if (trampoline_emitted_) return;
   // Some small sequences of instructions must not be broken up by the
   // insertion of a trampoline pool; such sequences are protected by setting
   // either trampoline_pool_blocked_nesting_ or no_trampoline_pool_before_,
@@ -1519,7 +1520,6 @@ void Assembler::CheckTrampolinePool() {
     return;
   }
 
-  DCHECK(!trampoline_emitted_);
   DCHECK_GE(unbound_labels_count_, 0);
   if (unbound_labels_count_ > 0) {
     // First we emit jump, then we emit trampoline pool.

--- a/deps/v8/src/codegen/riscv/assembler-riscv.h
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.h
@@ -303,6 +303,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
   // See Assembler::CheckConstPool for more info.
   void EmitPoolGuard();
 
+  void FinishCode() { ForceConstantPoolEmissionWithoutJump(); }
+
 #if defined(V8_TARGET_ARCH_RISCV64)
   static void set_target_value_at(
       Address pc, uint64_t target,
@@ -618,6 +620,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
     }
   }
 
+  inline int next_buffer_check() { return next_buffer_check_; }
+
   friend class VectorUnit;
   class VectorUnit {
    public:
@@ -729,16 +733,19 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
 
   // Block the emission of the trampoline pool before pc_offset.
   void BlockTrampolinePoolBefore(int pc_offset) {
-    if (no_trampoline_pool_before_ < pc_offset)
+    if (no_trampoline_pool_before_ < pc_offset) {
+      DEBUG_PRINTF("\tBlockTrampolinePoolBefore %d\n", pc_offset);
       no_trampoline_pool_before_ = pc_offset;
+    }
   }
 
   void StartBlockTrampolinePool() {
-    DEBUG_PRINTF("\tStartBlockTrampolinePool\n");
+    DEBUG_PRINTF("\tStartBlockTrampolinePool %d\n", pc_offset());
     trampoline_pool_blocked_nesting_++;
   }
 
   void EndBlockTrampolinePool() {
+    DEBUG_PRINTF("\tEndBlockTrampolinePool\n");
     trampoline_pool_blocked_nesting_--;
     DEBUG_PRINTF("\ttrampoline_pool_blocked_nesting:%d\n",
                  trampoline_pool_blocked_nesting_);
@@ -767,6 +774,10 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
   }
 
   bool is_buffer_growth_blocked() const { return block_buffer_growth_; }
+
+  inline int ConstpoolComputesize() {
+    return constpool_.ComputeSize(Jump::kOmitted, Alignment::kOmitted);
+  }
 
  private:
   // Avoid overflows for displacements etc.

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
@@ -4941,10 +4941,9 @@ void MacroAssembler::Jump(Register target, Condition cond, Register rs,
     jr(target);
     DEBUG_PRINTF("\tCheckTrampolinePool pc_offset:%d %d\n", pc_offset(),
                  next_buffer_check() - ConstpoolComputesize());
-    if (!is_trampoline_emitted() && v8_flags.debug_code &&
+    if (!is_trampoline_emitted() &&
         pc_offset() >= (next_buffer_check() - ConstpoolComputesize())) {
-      // Debug mode will emit more instrs than Release mode.
-      // so we need to check trampoline pool before Constant pool.
+      // We need to check trampoline pool before Constant pool.
       // Here need to emit trampoline first.
       // Jump(ra, al) will block trampoline pool for 1 instr.
       nop();


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Backport two V8 commits to fix a crash found while building Adguard Home using webpack https://github.com/riscv-forks/electron/issues/9.

This PR needs to be backported to Node.js v24.x