### PR TITLE
[v24.x] deps: V8: cherry-pick 3d750c2aa9ef

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.21',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/interpreter/bytecode-generator.h
+++ b/deps/v8/src/interpreter/bytecode-generator.h
@@ -294,6 +294,7 @@ class BytecodeGenerator final : public AstVisitor<BytecodeGenerator> {
 
   Variable* GetPotentialVariableInAccumulator();
 
+  void AddDisposableValue(VariableMode mode);
   void BuildVariableLoad(Variable* variable, HoleCheckMode hole_check_mode,
                          TypeofMode typeof_mode = TypeofMode::kNotInside);
   void BuildVariableLoadForAccumulatorValue(

--- a/deps/v8/test/mjsunit/harmony/regress/regress-409478039.js
+++ b/deps/v8/test/mjsunit/harmony/regress/regress-409478039.js
@@ -1,0 +1,24 @@
+// Copyright 2025 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --js-staging
+
+var log = [];
+class Test {
+  [Symbol.dispose]() {
+    log.push(42);
+  }
+
+  f() {
+    log.push(43);
+  }
+}
+
+{
+  using listener = new Test();
+  g = () => listener;
+}
+g().f();
+
+assertEquals(log, [42, 43]);


### PR DESCRIPTION
Original commit message:

    [explicit-resource-management] Fix disposal for context variable

    This CL adds disposable variable when `using` or `await_using` is
    referenced by the closure.

    Bug: 409478039
    Change-Id: I162915ea53f5b9f17892fa88d288a94bd50cc46f
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6444591
    Reviewed-by: Shu-yu Guo <syg@chromium.org>
    Commit-Queue: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#99746}

Refs: https://github.com/v8/v8/commit/3d750c2aa9ef3d44660a977baf4839fc1e9df217
Closes: https://github.com/nodejs/node/issues/58744
