### PR TITLE
tools: make nodedownload module compatible with Python 3.14

### DIFF
--- a/tools/configure.d/nodedownload.py
+++ b/tools/configure.d/nodedownload.py
@@ -7,10 +7,7 @@ import sys
 import zipfile
 import tarfile
 import contextlib
-try:
-    from urllib.request import FancyURLopener, URLopener
-except ImportError:
-    from urllib import FancyURLopener, URLopener
+from urllib.request import build_opener, install_opener, urlretrieve
 
 def formatSize(amt):
     """Format a size as a string in MB"""
@@ -20,11 +17,6 @@ def spin(c):
     """print out an ASCII 'spinner' based on the value of counter 'c'"""
     spin = ".:|'"
     return (spin[c % len(spin)])
-
-class ConfigOpener(FancyURLopener):
-    """fancy opener used by retrievefile. Set a UA"""
-    # append to existing version (UA)
-    version = '%s node.js/configure' % URLopener.version
 
 def reporthook(count, size, total):
     """internal hook used by retrievefile"""
@@ -38,7 +30,10 @@ def retrievefile(url, targetfile):
     try:
         sys.stdout.write(' <%s>\nConnecting...\r' % url)
         sys.stdout.flush()
-        ConfigOpener().retrieve(url, targetfile, reporthook=reporthook)
+        opener = build_opener()
+        opener.addheaders = [('User-agent', f'Python-urllib/{sys.version_info.major}.{sys.version_info.minor} node.js/configure')]
+        install_opener(opener)
+        urlretrieve(url, targetfile, reporthook=reporthook)
         print('')  # clear the line
         return targetfile
     except IOError as err:


### PR DESCRIPTION
FancyURLopener and URLopener have been deprecated since Python 3.3 and they are removed completely from 3.14.

Fixes: https://github.com/nodejs/node/issues/58740

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
