### PR TITLE
src: pass resource on permission checks for spawn

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -518,9 +518,6 @@ static void Execve(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = env->isolate();
   Local<Context> context = env->context();
 
-  THROW_IF_INSUFFICIENT_PERMISSIONS(
-      env, permission::PermissionScope::kChildProcess, "");
-
   CHECK(args[0]->IsString());
   CHECK(args[1]->IsArray());
   CHECK(args[2]->IsArray());
@@ -530,6 +527,11 @@ static void Execve(const FunctionCallbackInfo<Value>& args) {
 
   // Copy arguments and environment
   Utf8Value executable(isolate, args[0]);
+
+  THROW_IF_INSUFFICIENT_PERMISSIONS(env,
+                                    permission::PermissionScope::kChildProcess,
+                                    executable.ToStringView());
+
   std::vector<std::string> argv_strings(argv_array->Length());
   std::vector<std::string> envp_strings(envp_array->Length());
   std::vector<char*> argv(argv_array->Length() + 1);

--- a/test/parallel/test-permission-child-process-cli.js
+++ b/test/parallel/test-permission-child-process-cli.js
@@ -29,12 +29,14 @@ if (process.argv[2] === 'child') {
     message: 'Access to this API has been restricted. Use --allow-child-process to manage permissions.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
+    resource: process.execPath,
   }));
   assert.throws(() => {
     childProcess.spawnSync(process.execPath, ['--version']);
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
+    resource: process.execPath,
   }));
   assert.throws(() => {
     childProcess.exec(...common.escapePOSIXShell`"${process.execPath}" --version`);
@@ -53,6 +55,7 @@ if (process.argv[2] === 'child') {
   }, common.expectsError({
     code: 'ERR_ACCESS_DENIED',
     permission: 'ChildProcess',
+    resource: process.execPath,
   }));
   assert.throws(() => {
     childProcess.execFile(...common.escapePOSIXShell`"${process.execPath}" --version`);

--- a/test/parallel/test-process-execve-permission-fail.js
+++ b/test/parallel/test-process-execve-permission-fail.js
@@ -17,5 +17,5 @@ if (process.argv[2] === 'replaced') {
 } else {
   throws(mustCall(() => {
     process.execve(process.execPath, [process.execPath, __filename, 'replaced'], process.env);
-  }), { code: 'ERR_ACCESS_DENIED', permission: 'ChildProcess' });
+  }), { code: 'ERR_ACCESS_DENIED', permission: 'ChildProcess', resource: process.execPath });
 }


### PR DESCRIPTION
**src: pass resource on permission checks for spawn**
```
This commit enhances the permission model errors
when no --allow-child-process is used and the error is emitted.
```
