### PR TITLE
assert: remove dead code

### DIFF
--- a/lib/internal/assert/utils.js
+++ b/lib/internal/assert/utils.js
@@ -197,25 +197,24 @@ function getErrMessage(message, fn) {
     // errors are handled faster.
     if (errorStackTraceLimitIsWritable) Error.stackTraceLimit = 0;
 
-    {
-      if (decoder === undefined) {
-        const { StringDecoder } = require('string_decoder');
-        decoder = new StringDecoder('utf8');
-      }
-
-      // ESM file prop is a file proto. Convert that to path.
-      // This ensure opensync will not throw ENOENT for ESM files.
-      const fileProtoPrefix = 'file://';
-      if (StringPrototypeStartsWith(filename, fileProtoPrefix)) {
-        filename = fileURLToPath(filename);
-      }
-
-      fd = openSync(filename, 'r', 0o666);
-      // Reset column and message.
-      ({ 0: column, 1: message } = getCode(fd, line, column));
-      // Flush unfinished multi byte characters.
-      decoder.end();
+    if (decoder === undefined) {
+      const { StringDecoder } = require('string_decoder');
+      decoder = new StringDecoder('utf8');
     }
+
+    // ESM file prop is a file proto. Convert that to path.
+    // This ensure opensync will not throw ENOENT for ESM files.
+    const fileProtoPrefix = 'file://';
+    if (StringPrototypeStartsWith(filename, fileProtoPrefix)) {
+      filename = fileURLToPath(filename);
+    }
+
+    fd = openSync(filename, 'r', 0o666);
+    // Reset column and message.
+    ({ 0: column, 1: message } = getCode(fd, line, column));
+    // Flush unfinished multi byte characters.
+    decoder.end();
+
     // Always normalize indentation, otherwise the message could look weird.
     if (StringPrototypeIncludes(message, '\n')) {
       if (EOL === '\r\n') {


### PR DESCRIPTION
`code` variable in `getErrMessage` util is not initialized anymore since this commit https://github.com/nodejs/node/commit/43c380e9b6307514668809f18fc2e181247047e4 and the handling of it is now dead code. This PR removes them.