### PR TITLE
lib: make `validateInternalField()` throw `ERR_INVALID_THIS`

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1541,7 +1541,7 @@ E('ERR_INVALID_SYNC_FORK_INPUT',
   'Asynchronous forks do not support ' +
     'Buffer, TypedArray, DataView or string input: %s',
   TypeError);
-E('ERR_INVALID_THIS', 'Value of "this" must be of type %s', TypeError);
+E('ERR_INVALID_THIS', 'Value of "this" must be of type %s', TypeError, HideStackFramesError);
 E('ERR_INVALID_TUPLE', '%s must be an iterable %s tuple', TypeError);
 E('ERR_INVALID_TYPESCRIPT_SYNTAX', '%s', SyntaxError);
 E('ERR_INVALID_URI', 'URI malformed', URIError);

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -35,7 +35,7 @@ const {
   validateAbortSignal,
   validateObject,
   validateString,
-  validateInternalField,
+  validateThisInternalField,
   kValidateObjectAllowObjects,
 } = require('internal/validators');
 
@@ -1118,7 +1118,7 @@ function defineEventHandler(emitter, name, event = name) {
   // 8.1.5.1 Event handlers - basically `on[eventName]` attributes
   const propName = `on${name}`;
   function get() {
-    validateInternalField(this, kHandlers, 'EventTarget');
+    validateThisInternalField(this, kHandlers, 'EventTarget');
     return this[kHandlers]?.get(event)?.handler ?? null;
   }
   ObjectDefineProperty(get, 'name', {
@@ -1127,7 +1127,7 @@ function defineEventHandler(emitter, name, event = name) {
   });
 
   function set(value) {
-    validateInternalField(this, kHandlers, 'EventTarget');
+    validateThisInternalField(this, kHandlers, 'EventTarget');
     let wrappedHandler = this[kHandlers]?.get(event);
     if (wrappedHandler) {
       if (typeof wrappedHandler.handler === 'function') {

--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -51,7 +51,7 @@ const {
 const {
   validateFunction,
   validateObject,
-  validateInternalField,
+  validateThisInternalField,
 } = require('internal/validators');
 
 const {
@@ -178,12 +178,12 @@ class PerformanceObserverEntryList {
   }
 
   getEntries() {
-    validateInternalField(this, kBuffer, 'PerformanceObserverEntryList');
+    validateThisInternalField(this, kBuffer, 'PerformanceObserverEntryList');
     return ArrayPrototypeSlice(this[kBuffer]);
   }
 
   getEntriesByType(type) {
-    validateInternalField(this, kBuffer, 'PerformanceObserverEntryList');
+    validateThisInternalField(this, kBuffer, 'PerformanceObserverEntryList');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('type');
     }
@@ -194,7 +194,7 @@ class PerformanceObserverEntryList {
   }
 
   getEntriesByName(name, type = undefined) {
-    validateInternalField(this, kBuffer, 'PerformanceObserverEntryList');
+    validateThisInternalField(this, kBuffer, 'PerformanceObserverEntryList');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('name');
     }

--- a/lib/internal/perf/performance.js
+++ b/lib/internal/perf/performance.js
@@ -43,7 +43,7 @@ const nodeTiming = require('internal/perf/nodetiming');
 const timerify = require('internal/perf/timerify');
 const { customInspectSymbol: kInspect, kEnumerableProperty, kEmptyObject } = require('internal/util');
 const { inspect } = require('util');
-const { validateInternalField } = require('internal/validators');
+const { validateThisInternalField } = require('internal/validators');
 const { convertToInt } = require('internal/webidl');
 
 const kPerformanceBrand = Symbol('performance');
@@ -68,7 +68,7 @@ class Performance extends EventTarget {
   }
 
   clearMarks(name = undefined) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (name !== undefined) {
       name = `${name}`;
     }
@@ -77,7 +77,7 @@ class Performance extends EventTarget {
   }
 
   clearMeasures(name = undefined) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (name !== undefined) {
       name = `${name}`;
     }
@@ -85,7 +85,7 @@ class Performance extends EventTarget {
   }
 
   clearResourceTimings(name = undefined) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (name !== undefined) {
       name = `${name}`;
     }
@@ -93,12 +93,12 @@ class Performance extends EventTarget {
   }
 
   getEntries() {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     return filterBufferMapByNameAndType();
   }
 
   getEntriesByName(name, type = undefined) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -110,7 +110,7 @@ class Performance extends EventTarget {
   }
 
   getEntriesByType(type) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('type');
     }
@@ -119,7 +119,7 @@ class Performance extends EventTarget {
   }
 
   mark(name, options = kEmptyObject) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -127,7 +127,7 @@ class Performance extends EventTarget {
   }
 
   measure(name, startOrMeasureOptions = kEmptyObject, endMark = undefined) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('name');
     }
@@ -135,12 +135,12 @@ class Performance extends EventTarget {
   }
 
   now() {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     return now();
   }
 
   setResourceTimingBufferSize(maxSize) {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     if (arguments.length === 0) {
       throw new ERR_MISSING_ARGS('maxSize');
     }
@@ -150,12 +150,12 @@ class Performance extends EventTarget {
   }
 
   get timeOrigin() {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     return getTimeOriginTimestamp();
   }
 
   toJSON() {
-    validateInternalField(this, kPerformanceBrand, 'Performance');
+    validateThisInternalField(this, kPerformanceBrand, 'Performance');
     return {
       nodeTiming: this.nodeTiming,
       timeOrigin: this.timeOrigin,

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -15,7 +15,7 @@ const {
   customInspectSymbol: kInspect,
   kEnumerableProperty,
 } = require('internal/util');
-const { validateInternalField } = require('internal/validators');
+const { validateThisInternalField } = require('internal/validators');
 
 const { inspect } = require('util');
 
@@ -49,22 +49,22 @@ class PerformanceEntry {
   }
 
   get name() {
-    validateInternalField(this, kName, 'PerformanceEntry');
+    validateThisInternalField(this, kName, 'PerformanceEntry');
     return this[kName];
   }
 
   get entryType() {
-    validateInternalField(this, kEntryType, 'PerformanceEntry');
+    validateThisInternalField(this, kEntryType, 'PerformanceEntry');
     return this[kEntryType];
   }
 
   get startTime() {
-    validateInternalField(this, kStartTime, 'PerformanceEntry');
+    validateThisInternalField(this, kStartTime, 'PerformanceEntry');
     return this[kStartTime];
   }
 
   get duration() {
-    validateInternalField(this, kDuration, 'PerformanceEntry');
+    validateThisInternalField(this, kDuration, 'PerformanceEntry');
     return this[kDuration];
   }
 
@@ -80,7 +80,7 @@ class PerformanceEntry {
   }
 
   toJSON() {
-    validateInternalField(this, kName, 'PerformanceEntry');
+    validateThisInternalField(this, kName, 'PerformanceEntry');
     return {
       name: this[kName],
       entryType: this[kEntryType],
@@ -106,12 +106,12 @@ function createPerformanceEntry(name, type, start, duration) {
  */
 class PerformanceNodeEntry extends PerformanceEntry {
   get detail() {
-    validateInternalField(this, kDetail, 'NodePerformanceEntry');
+    validateThisInternalField(this, kDetail, 'NodePerformanceEntry');
     return this[kDetail];
   }
 
   toJSON() {
-    validateInternalField(this, kName, 'PerformanceEntry');
+    validateThisInternalField(this, kName, 'PerformanceEntry');
     return {
       name: this[kName],
       entryType: this[kEntryType],

--- a/lib/internal/perf/resource_timing.js
+++ b/lib/internal/perf/resource_timing.js
@@ -14,7 +14,7 @@ const {
 const { PerformanceEntry, kSkipThrow } = require('internal/perf/performance_entry');
 const assert = require('internal/assert');
 const { enqueue, bufferResourceTiming } = require('internal/perf/observe');
-const { validateInternalField } = require('internal/validators');
+const { validateThisInternalField } = require('internal/validators');
 const { kEnumerableProperty } = require('internal/util');
 
 const kCacheMode = Symbol('kCacheMode');
@@ -34,104 +34,104 @@ class PerformanceResourceTiming extends PerformanceEntry {
   }
 
   get name() {
-    validateInternalField(this, kRequestedUrl, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kRequestedUrl, 'PerformanceResourceTiming');
     return this[kRequestedUrl];
   }
 
   get startTime() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].startTime;
   }
 
   get duration() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].endTime - this[kTimingInfo].startTime;
   }
 
   get initiatorType() {
-    validateInternalField(this, kInitiatorType, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kInitiatorType, 'PerformanceResourceTiming');
     return this[kInitiatorType];
   }
 
   get workerStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalServiceWorkerStartTime;
   }
 
   get redirectStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].redirectStartTime;
   }
 
   get redirectEnd() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].redirectEndTime;
   }
 
   get fetchStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].postRedirectStartTime;
   }
 
   get domainLookupStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalConnectionTimingInfo?.domainLookupStartTime;
   }
 
   get domainLookupEnd() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalConnectionTimingInfo?.domainLookupEndTime;
   }
 
   get connectStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalConnectionTimingInfo?.connectionStartTime;
   }
 
   get connectEnd() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalConnectionTimingInfo?.connectionEndTime;
   }
 
   get secureConnectionStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo]
       .finalConnectionTimingInfo?.secureConnectionStartTime;
   }
 
   get nextHopProtocol() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo]
       .finalConnectionTimingInfo?.ALPNNegotiatedProtocol;
   }
 
   get requestStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalNetworkRequestStartTime;
   }
 
   get responseStart() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalNetworkResponseStartTime;
   }
 
   get responseEnd() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].endTime;
   }
 
   get encodedBodySize() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].encodedBodySize;
   }
 
   get decodedBodySize() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].decodedBodySize;
   }
 
   get transferSize() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     if (this[kCacheMode] === 'local') return 0;
     if (this[kCacheMode] === 'validated') return 300;
 
@@ -139,17 +139,17 @@ class PerformanceResourceTiming extends PerformanceEntry {
   }
 
   get deliveryType() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kDeliveryType];
   }
 
   get responseStatus() {
-    validateInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kResponseStatus];
   }
 
   toJSON() {
-    validateInternalField(this, kInitiatorType, 'PerformanceResourceTiming');
+    validateThisInternalField(this, kInitiatorType, 'PerformanceResourceTiming');
     return {
       name: this.name,
       entryType: this.entryType,

--- a/lib/internal/perf/usertiming.js
+++ b/lib/internal/perf/usertiming.js
@@ -18,7 +18,7 @@ const {
   validateNumber,
   validateObject,
   validateString,
-  validateInternalField,
+  validateThisInternalField,
 } = require('internal/validators');
 
 const {
@@ -93,7 +93,7 @@ class PerformanceMark extends PerformanceEntry {
   }
 
   get detail() {
-    validateInternalField(this, kDetail, 'PerformanceMark');
+    validateThisInternalField(this, kDetail, 'PerformanceMark');
     return this[kDetail];
   }
 
@@ -133,7 +133,7 @@ class PerformanceMeasure extends PerformanceEntry {
   }
 
   get detail() {
-    validateInternalField(this, kDetail, 'PerformanceMeasure');
+    validateThisInternalField(this, kDetail, 'PerformanceMeasure');
     return this[kDetail];
   }
 

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -533,7 +533,7 @@ const validateLinkHeaderFormat = hideStackFrames((value, name) => {
  * @param {string|symbol} fieldKey
  * @param {string} className
  */
-const validateInternalField = hideStackFrames((object, fieldKey, className) => {
+const validateThisInternalField = hideStackFrames((object, fieldKey, className) => {
   if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, fieldKey)) {
     throw new ERR_INVALID_THIS(className);
   }
@@ -648,7 +648,7 @@ module.exports = {
   validateUnion,
   validateAbortSignal,
   validateLinkHeaderValue,
-  validateInternalField,
+  validateThisInternalField,
   validateFiniteNumber,
   checkRangesOrGetDefault,
 };

--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -24,6 +24,7 @@ const {
   codes: {
     ERR_INVALID_ARG_TYPE: { HideStackFramesError: ERR_INVALID_ARG_TYPE },
     ERR_INVALID_ARG_VALUE: { HideStackFramesError: ERR_INVALID_ARG_VALUE },
+    ERR_INVALID_THIS: { HideStackFramesError: ERR_INVALID_THIS },
     ERR_OUT_OF_RANGE: { HideStackFramesError: ERR_OUT_OF_RANGE },
     ERR_SOCKET_BAD_PORT: { HideStackFramesError: ERR_SOCKET_BAD_PORT },
     ERR_UNKNOWN_SIGNAL: { HideStackFramesError: ERR_UNKNOWN_SIGNAL },
@@ -526,9 +527,15 @@ const validateLinkHeaderFormat = hideStackFrames((value, name) => {
   }
 });
 
+/**
+ * Validate provided `this` object by checking that it has specific own property
+ * @param {any} object
+ * @param {string|symbol} fieldKey
+ * @param {string} className
+ */
 const validateInternalField = hideStackFrames((object, fieldKey, className) => {
   if (typeof object !== 'object' || object === null || !ObjectPrototypeHasOwnProperty(object, fieldKey)) {
-    throw new ERR_INVALID_ARG_TYPE('this', className, object);
+    throw new ERR_INVALID_THIS(className);
   }
 });
 

--- a/lib/internal/vm/module.js
+++ b/lib/internal/vm/module.js
@@ -49,7 +49,7 @@ const {
   validateObject,
   validateUint32,
   validateString,
-  validateInternalField,
+  validateThisInternalField,
 } = require('internal/validators');
 
 const binding = internalBinding('module_wrap');
@@ -162,17 +162,17 @@ class Module {
   }
 
   get identifier() {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     return this[kWrap].url;
   }
 
   get context() {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     return this[kContext];
   }
 
   get namespace() {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     if (this[kWrap].getStatus() < kInstantiated) {
       throw new ERR_VM_MODULE_STATUS('must not be unlinked or linking');
     }
@@ -180,12 +180,12 @@ class Module {
   }
 
   get status() {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     return STATUS_MAP[this[kWrap].getStatus()];
   }
 
   get error() {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     if (this[kWrap].getStatus() !== kErrored) {
       throw new ERR_VM_MODULE_STATUS('must be errored');
     }
@@ -193,7 +193,7 @@ class Module {
   }
 
   async link(linker) {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     validateFunction(linker, 'linker');
     if (this.status === 'linked') {
       throw new ERR_VM_MODULE_ALREADY_LINKED();
@@ -206,7 +206,7 @@ class Module {
   }
 
   async evaluate(options = kEmptyObject) {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     validateObject(options, 'options');
 
     let timeout = options.timeout;
@@ -229,7 +229,7 @@ class Module {
   }
 
   [customInspectSymbol](depth, options) {
-    validateInternalField(this, kWrap, 'Module');
+    validateThisInternalField(this, kWrap, 'Module');
     if (typeof depth === 'number' && depth < 0)
       return this;
 
@@ -350,7 +350,7 @@ class SourceTextModule extends Module {
   }
 
   get dependencySpecifiers() {
-    validateInternalField(this, kDependencySpecifiers, 'SourceTextModule');
+    validateThisInternalField(this, kDependencySpecifiers, 'SourceTextModule');
     // TODO(legendecas): add a new getter to expose the import attributes as the value type
     // of [[RequestedModules]] is changed in https://tc39.es/proposal-import-attributes/#table-cyclic-module-fields.
     this[kDependencySpecifiers] ??= ObjectFreeze(
@@ -359,7 +359,7 @@ class SourceTextModule extends Module {
   }
 
   get status() {
-    validateInternalField(this, kDependencySpecifiers, 'SourceTextModule');
+    validateThisInternalField(this, kDependencySpecifiers, 'SourceTextModule');
     if (this.#error !== kNoError) {
       return 'errored';
     }
@@ -370,7 +370,7 @@ class SourceTextModule extends Module {
   }
 
   get error() {
-    validateInternalField(this, kDependencySpecifiers, 'SourceTextModule');
+    validateThisInternalField(this, kDependencySpecifiers, 'SourceTextModule');
     if (this.#error !== kNoError) {
       return this.#error;
     }
@@ -423,7 +423,7 @@ class SyntheticModule extends Module {
   }
 
   setExport(name, value) {
-    validateInternalField(this, kWrap, 'SyntheticModule');
+    validateThisInternalField(this, kWrap, 'SyntheticModule');
     validateString(name, 'name');
     if (this[kWrap].getStatus() < kInstantiated) {
       throw new ERR_VM_MODULE_STATUS('must be linked');

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -87,10 +87,7 @@ const util = require('util');
   for (const value of [null, { __proto__: null }, SourceTextModule.prototype]) {
     assert.throws(
       () => m[util.inspect.custom].call(value),
-      {
-        code: 'ERR_INVALID_ARG_TYPE',
-        message: /The "this" argument must be an instance of Module/,
-      },
+      { code: 'ERR_INVALID_THIS' },
     );
   }
 }

--- a/test/parallel/test-vm-module-errors.js
+++ b/test/parallel/test-vm-module-errors.js
@@ -215,10 +215,7 @@ async function checkInvalidOptionForEvaluate() {
     ['link', 'evaluate'].forEach(async (method) => {
       await assert.rejects(async () => {
         await Module.prototype[method]();
-      }, {
-        code: 'ERR_INVALID_ARG_TYPE',
-        message: /The "this" argument must be an instance of Module/
-      });
+      }, { code: 'ERR_INVALID_THIS' });
     });
   }
 }
@@ -240,10 +237,7 @@ function checkInvalidCachedData() {
 }
 
 function checkGettersErrors() {
-  const expectedError = {
-    code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "this" argument must be an instance of (?:Module|SourceTextModule)/,
-  };
+  const expectedError = { code: 'ERR_INVALID_THIS' };
   const getters = ['identifier', 'context', 'namespace', 'status', 'error'];
   getters.forEach((getter) => {
     assert.throws(() => {

--- a/test/parallel/test-vm-module-synthetic.js
+++ b/test/parallel/test-vm-module-synthetic.js
@@ -69,10 +69,7 @@ const assert = require('assert');
   for (const value of [null, {}, SyntheticModule.prototype]) {
     assert.throws(() => {
       SyntheticModule.prototype.setExport.call(value, 'foo');
-    }, {
-      code: 'ERR_INVALID_ARG_TYPE',
-      message: /The "this" argument must be an instance of SyntheticModule/
-    });
+    }, { code: 'ERR_INVALID_THIS' });
   }
 
 })().then(common.mustCall());


### PR DESCRIPTION
`internal/validators.validateInternalField()` has no other purpose than to validate `this` value.
It must throw `ERR_INVALID_THIS` rather than `ERR_INVALID_ARG_TYPE`, and ideally have more appropriate name (used `validateThisInternalField`).