### PR TITLE
test: correct SIMD support comment

### DIFF
--- a/test/es-module/test-esm-wasm.mjs
+++ b/test/es-module/test-esm-wasm.mjs
@@ -70,7 +70,7 @@ describe('ESM: WASM modules', { concurrency: !process.env.TEST_PARALLEL }, () =>
       [
         'import { strictEqual, deepStrictEqual, ok } from "node:assert";',
 
-        // SIMD is not supported on rhel8-ppc64le
+        // WASM SIMD is not supported on older architectures such as IBM Power8
         'let wasmExports;',
         'try {',
         `  wasmExports = await import(${JSON.stringify(fixtures.fileURL('es-modules/globals.wasm'))});`,


### PR DESCRIPTION
The comment in the test file stated that:
"SIMD is not supported on rhel8-ppc64le"

This is incorrect -- WASM SIMD support is dependent on the available instructions, not the operating system. So it is more correct to say that WASM SIMD is not supported on IBM Power8 architecture.

---

Currently in our CI, it just so happens that all of our `rhel8-ppc64le` machines are IBM Power8, while, for example, the `rhel9-ppc64le` machines were provisioned as IBM Power9, but AFAIK you could be running either RHEL 8/9 on either architecture (or newer).

FTR other (non-IBM) "older architectures" without WASM SIMD support include some Athlon chips (but we don't have any of those in our CI): https://github.com/nodejs/undici/issues/2934#issuecomment-1983774244

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
