### PR TITLE
test: deflake test-buffer-large-size-buffer-alloc-unsafe

### DIFF
--- a/test/pummel/test-buffer-large-size-buffer-alloc-unsafe.js
+++ b/test/pummel/test-buffer-large-size-buffer-alloc-unsafe.js
@@ -7,12 +7,22 @@ common.skipIf32Bits();
 const assert = require('node:assert');
 const size = 2 ** 31;
 
+let largeBuffer;
+
+// Test Buffer.allocUnsafe with size larger than integer range
 try {
-  // Test Buffer.allocUnsafe with size larger than integer range
-  assert.throws(() => Buffer.allocUnsafe(size).toString('utf8'), { code: 'ERR_STRING_TOO_LONG' });
+  largeBuffer = Buffer.allocUnsafe(size);
 } catch (e) {
-  if (e.code !== 'ERR_MEMORY_ALLOCATION_FAILED') {
-    throw e;
+  if (
+    e.code === 'ERR_MEMORY_ALLOCATION_FAILED' ||
+    /Array buffer allocation failed/.test(e.message)
+  ) {
+    common.skip('insufficient space for Buffer.allocUnsafe');
   }
-  common.skip('insufficient space for Buffer.allocUnsafe');
+
+  throw e;
 }
+
+assert.throws(() => largeBuffer.toString('utf8'), {
+  code: 'ERR_STRING_TOO_LONG',
+});


### PR DESCRIPTION
Use the error message as another condition to skip the test when the buffer allocation fails.

Refs: https://github.com/nodejs/node/pull/58738

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
