### PR TITLE
deps: V8: cherry-pick 0ce2edb7adfd

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.13',
+    'v8_embedder_string': '-node.14',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.h
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.h
@@ -406,10 +406,7 @@ class V8_EXPORT_PRIVATE MacroAssembler : public MacroAssemblerBase {
     push_helper(rs...);
   }
 
-  template <>
-  void push_helper(Register r) {
-    StoreWord(r, MemOperand(sp, 0));
-  }
+  void push_helper() {}
 
  public:
   // Push a number of registers. The leftmost register first (to the highest
@@ -554,10 +551,7 @@ class V8_EXPORT_PRIVATE MacroAssembler : public MacroAssemblerBase {
     LoadWord(r, MemOperand(sp, sizeof...(rs) * kSystemPointerSize));
   }
 
-  template <>
-  void pop_helper(Register r) {
-    LoadWord(r, MemOperand(sp, 0));
-  }
+  void pop_helper() {}
 
  public:
   // Pop a number of registers. The leftmost register last (from the highest


### PR DESCRIPTION
Original commit message:

    Fix invalid template specialization

    Bug: chromium:40565911
    Change-Id: If206c140e99e24a6df4ee7351e8022748eabac22
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6491420
    Auto-Submit: Bruno Pitrus <brunopitrus@hotmail.com>
    Commit-Queue: Jakob Linke <jgruber@chromium.org>
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#99987}

Refs: https://github.com/v8/v8/commit/0ce2edb7adfd65d4a2272098080980e88933786c
Fixes: https://github.com/nodejs/node/issues/58485

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR fixes build error on riscv64 with gcc compiler(#58485).
This PR needs to be picked into v24.x. 

Note that this PR will conflict with https://github.com/nodejs/node/pull/58746. I will rebase #58746 once this one is merged.
