### PR TITLE
lib:enable support for utf-16 encoding in blob

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -286,9 +286,14 @@ class Blob {
   /**
    * @returns {Promise<string>}
    */
-  text() {
+  text(charset='utf-8') {
     if (!isBlob(this))
       return PromiseReject(new ERR_INVALID_THIS('Blob'));
+
+    if(charset.toLowerCase() === 'utf-16'){
+      const decoder = new TextDecoder(charset);
+      return arrayBuffer(this).then(buf=> decoder.decode(buf));
+    }
 
     dec ??= new TextDecoder();
 


### PR DESCRIPTION
fixes: #58718

add support for utf-16 encoding in blog decoder.