### PR TITLE
sqlite: fix aggregate step function undefined handling

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -158,7 +158,8 @@ Registers a new aggregate function with the SQLite database. This method is a wr
     function is initialized. When a {Function} is passed the identity will be its return value.
   * `step` {Function} The function to call for each row in the aggregation. The
     function receives the current state and the row value. The return value of
-    this function should be the new state.
+    this function should be the new state. Returning `undefined` preserves the
+    current state unchanged, while returning `null` explicitly sets the state to `null`.
   * `result` {Function} The function to call to get the result of the
     aggregation. The function receives the final state and should return the
     result of the aggregation.
@@ -178,15 +179,16 @@ db.exec(`
                         ('b', 5),
                         ('c', 3),
                         ('d', 8),
-                        ('e', 1);
+                        ('e', 1),
+                        ('f', -1);
 `);
 
-db.aggregate('sumint', {
+db.aggregate('sum_positive', {
   start: 0,
-  step: (acc, value) => acc + value,
+  step: (acc, value) => value < 0 ? undefined : acc + value, // Skip negative values
 });
 
-db.prepare('SELECT sumint(y) as total FROM t3').get(); // { total: 21 }
+db.prepare('SELECT sum_positive(y) as total FROM t3').get(); // { total: 21 }
 ```
 
 ```mjs
@@ -199,15 +201,16 @@ db.exec(`
                         ('b', 5),
                         ('c', 3),
                         ('d', 8),
-                        ('e', 1);
+                        ('e', 1),
+                        ('f', -1);
 `);
 
-db.aggregate('sumint', {
+db.aggregate('sum_positive', {
   start: 0,
-  step: (acc, value) => acc + value,
+  step: (acc, value) => value < 0 ? undefined : acc + value, // Skip negative values
 });
 
-db.prepare('SELECT sumint(y) as total FROM t3').get(); // { total: 21 }
+db.prepare('SELECT sum_positive(y) as total FROM t3').get(); // { total: 21 }
 ```
 
 ### `database.close()`

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -185,7 +185,7 @@ db.exec(`
 
 db.aggregate('sum_positive', {
   start: 0,
-  step: (acc, value) => value < 0 ? undefined : acc + value, // Skip negative values
+  step: (acc, value) => (value < 0 ? undefined : acc + value), // Skip negative values
 });
 
 db.prepare('SELECT sum_positive(y) as total FROM t3').get(); // { total: 21 }
@@ -207,7 +207,7 @@ db.exec(`
 
 db.aggregate('sum_positive', {
   start: 0,
-  step: (acc, value) => value < 0 ? undefined : acc + value, // Skip negative values
+  step: (acc, value) => (value < 0 ? undefined : acc + value), // Skip negative values
 });
 
 db.prepare('SELECT sum_positive(y) as total FROM t3').get(); // { total: 21 }

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -339,7 +339,9 @@ class CustomAggregate {
       return;
     }
 
-    agg->value.Reset(isolate, ret);
+    if (!ret->IsUndefined()) {
+      agg->value.Reset(isolate, ret);
+    }
   }
 
   static inline void xValueBase(sqlite3_context* ctx, bool is_final) {

--- a/test/parallel/test-sqlite-aggregate-function.mjs
+++ b/test/parallel/test-sqlite-aggregate-function.mjs
@@ -418,15 +418,15 @@ describe('step function undefined handling', () => {
   test('preserves accumulator when step returns undefined', (t) => {
     const db = new DatabaseSync(':memory:');
     t.after(() => db.close());
-    
+
     db.exec('CREATE TABLE numbers (n INTEGER)');
     db.exec('INSERT INTO numbers VALUES (1), (2), (3), (4), (5)');
-    
+
     db.aggregate('sum_skip_three', {
       start: 0,
-      step: (sum, n) => n === 3 ? undefined : sum + n
+      step: (sum, n) => (n === 3 ? undefined : sum + n)
     });
-    
+
     const result = db.prepare('SELECT sum_skip_three(n) as total FROM numbers').get();
     t.assert.strictEqual(result.total, 12); // Should sum 1+2+4+5, skipping 3
   });
@@ -434,23 +434,23 @@ describe('step function undefined handling', () => {
   test('distinguishes between undefined and null returns', (t) => {
     const db = new DatabaseSync(':memory:');
     t.after(() => db.close());
-    
+
     db.exec('CREATE TABLE test (val INTEGER)');
     db.exec('INSERT INTO test VALUES (1), (2), (3)');
-    
+
     // Test that null is stored when explicitly returned
     db.aggregate('explicit_null', {
       start: 10,
       step: (acc, val) => {
         if (val === 3) return null;  // Explicitly return null on last value
-        if (val === 2) return undefined;  // Skip middle value  
+        if (val === 2) return undefined;  // Skip middle value
         return acc + val;
       }
     });
-    
+
     const result = db.prepare('SELECT explicit_null(val) as result FROM test').get();
     t.assert.strictEqual(result.result, null);
-    
+
     // Test that undefined preserves the accumulator
     db.aggregate('preserve_on_undefined', {
       start: 10,
@@ -459,7 +459,7 @@ describe('step function undefined handling', () => {
         return acc + val;
       }
     });
-    
+
     const result2 = db.prepare('SELECT preserve_on_undefined(val) as result FROM test').get();
     t.assert.strictEqual(result2.result, 14); // Should preserve accumulator: 10+1+3=14
   });
@@ -467,10 +467,10 @@ describe('step function undefined handling', () => {
   test('handles implicit undefined returns', (t) => {
     const db = new DatabaseSync(':memory:');
     t.after(() => db.close());
-    
+
     db.exec('CREATE TABLE test (val INTEGER)');
     db.exec('INSERT INTO test VALUES (1), (2), (3)');
-    
+
     // Test step function with implicit undefined return
     db.aggregate('implicit_undefined', {
       start: 10,
@@ -479,16 +479,16 @@ describe('step function undefined handling', () => {
         return acc * val;
       }
     });
-    
+
     const result = db.prepare('SELECT implicit_undefined(val) as result FROM test').get();
     t.assert.strictEqual(result.result, 30); // Should calculate 10*1*3, skipping 2
-    
+
     // Test empty function body (always returns undefined)
     db.aggregate('empty_step', {
       start: 42,
       step: (acc, val) => {} // Always returns undefined
     });
-    
+
     const result2 = db.prepare('SELECT empty_step(val) as result FROM test').get();
     t.assert.strictEqual(result2.result, 42); // Start value should be preserved
   });


### PR DESCRIPTION
First off: kudos to the team for `node:sqlite`, it's a great thing for node.js to have built-in! (I'm a maintainer of better-sqlite3)

I was working on a bridge facade from better-sqlite to node:sqlite and found an edge case in the aggregate function callback.

When an aggregate step function returns undefined (not NULL), we should preserve the accumulator value instead of resetting it to null. This allows step functions to conditionally skip processing certain values while maintaining the current aggregate state.

Before this fix, returning undefined would incorrectly set the accumulator to null, breaking the aggregation logic.

This patch makes the step function behavior match (presumably) expected semantics, where undefined return values preserve state and only explicit null returns store null values.

This patch includes a bunch of new test coverage for:
  - Preserving accumulator when step returns undefined
  - Distinguishing between undefined and null returns
  - Handling implicit undefined returns (empty function bodies)

Here are the failing tests without the patch applied to node_sqlite.cc:

```
✖ failing tests:

test at test/parallel/test-sqlite-aggregate-function.mjs:418:3
✖ preserves accumulator when step returns undefined (0.937672ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  null !== 12
  
      at assert.<computed> [as strictEqual] (node:internal/test_runner/test:320:18)
      at TestContext.<anonymous> (file:///home/mrm/src/node/test/parallel/test-sqlite-aggregate-function.mjs:431:14)
      at Test.runInAsyncScope (node:async_hooks:213:14)
      at Test.run (node:internal/test_runner/test:1062:25)
      at Test.start (node:internal/test_runner/test:959:17)
      at node:internal/test_runner/test:1464:71
      at node:internal/per_context/primordials:483:82
      at new Promise (<anonymous>)
      at new SafePromise (node:internal/per_context/primordials:451:29)
      at node:internal/per_context/primordials:483:9 {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: null,
    expected: 12,
    operator: 'strictEqual'
  }

test at test/parallel/test-sqlite-aggregate-function.mjs:434:3
✖ distinguishes between undefined and null returns (0.445361ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  null !== 14
  
      at assert.<computed> [as strictEqual] (node:internal/test_runner/test:320:18)
      at TestContext.<anonymous> (file:///home/mrm/src/node/test/parallel/test-sqlite-aggregate-function.mjs:464:14)
      at Test.runInAsyncScope (node:async_hooks:213:14)
      at Test.run (node:internal/test_runner/test:1062:25)
      at Suite.processPendingSubtests (node:internal/test_runner/test:752:18)
      at Test.postRun (node:internal/test_runner/test:1191:19)
      at Test.run (node:internal/test_runner/test:1119:12)
      at async Promise.all (index 0)
      at async Suite.run (node:internal/test_runner/test:1466:7)
      at async Test.processPendingSubtests (node:internal/test_runner/test:752:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: null,
    expected: 14,
    operator: 'strictEqual'
  }

test at test/parallel/test-sqlite-aggregate-function.mjs:467:3
✖ handles implicit undefined returns (0.392371ms)
  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
  
  null !== 30
  
      at assert.<computed> [as strictEqual] (node:internal/test_runner/test:320:18)
      at TestContext.<anonymous> (file:///home/mrm/src/node/test/parallel/test-sqlite-aggregate-function.mjs:484:14)
      at Test.runInAsyncScope (node:async_hooks:213:14)
      at Test.run (node:internal/test_runner/test:1062:25)
      at Suite.processPendingSubtests (node:internal/test_runner/test:752:18)
      at Test.postRun (node:internal/test_runner/test:1191:19)
      at Test.run (node:internal/test_runner/test:1119:12)
      at async Suite.processPendingSubtests (node:internal/test_runner/test:752:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: null,
    expected: 30,
    operator: 'strictEqual'
  }
```

Cheers!