### PR TITLE
doc: fix stability 1.x links excluding the decimal digit

### DIFF
--- a/tools/doc/html.mjs
+++ b/tools/doc/html.mjs
@@ -206,10 +206,11 @@ function linkJsTypeDocs(text) {
 
 const isJSFlavorSnippet = (node) => node.lang === 'cjs' || node.lang === 'mjs';
 
+const STABILITY_RE = /(.*:)\s*(\d(?:\.\d)?)([\s\S]*)/;
+
 // Preprocess headers, stability blockquotes, and YAML blocks.
 export function preprocessElements({ filename }) {
   return (tree) => {
-    const STABILITY_RE = /(.*:)\s*(\d)([\s\S]*)/;
     let headingIndex = -1;
     let heading = null;
 
@@ -325,7 +326,7 @@ export function preprocessElements({ filename }) {
           // Insert div with prefix and number
           node.children.unshift({
             type: 'html',
-            value: `<div class="api_stability api_stability_${number}">` +
+            value: `<div class="api_stability api_stability_${parseInt(number)}">` +
               (noLinking ? '' :
                 '<a href="documentation.html#stability-index">') +
               `${prefix} ${number}${noLinking ? '' : '</a>'}`


### PR DESCRIPTION
Pretty minor, this is just addressing a minimal UI quirk I noticed with the `Stability 1.x` links where the decimal digits are not included in the hyperlink

PS: I've also moved the regex outside of the `preprocessElements` function, as there is no reason/benefit to have the regex rebuilt for every file (having it outside might save some precious nanoseconds when building the docs :sweat_smile:).

## Before
![before](https://github.com/user-attachments/assets/9b6a12e8-70c2-474f-bb20-71922b53edd2) 

## After
 ![after](https://github.com/user-attachments/assets/2cf09f1d-254b-404b-a620-81d79ad9543d) 



<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
