### PR TITLE
repl: fix eval errors thrown after close throwing `ERR_USE_AFTER_CLOSE`

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -748,7 +748,9 @@ function REPLServer(prompt,
         process.emit('uncaughtException', e);
         self.clearBufferedCommand();
         self.lines.level = [];
-        self.displayPrompt();
+        if (!self.closed) {
+          self.displayPrompt();
+        }
       });
     } else {
       if (errStack === '') {
@@ -778,7 +780,9 @@ function REPLServer(prompt,
       self.output.write(errStack);
       self.clearBufferedCommand();
       self.lines.level = [];
-      self.displayPrompt();
+      if (!self.closed) {
+        self.displayPrompt();
+      }
     }
   });
 

--- a/test/parallel/test-repl-eval-error-after-close.js
+++ b/test/parallel/test-repl-eval-error-after-close.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const repl = require('node:repl');
+const stream = require('node:stream');
+const assert = require('node:assert');
+
+// This test checks that an eval function returning an error in its callback
+// after the repl server has been closed doesn't cause an ERR_USE_AFTER_CLOSE
+// error to be thrown (reference: https://github.com/nodejs/node/issues/58784)
+
+(async () => {
+  const close$ = Promise.withResolvers();
+  const eval$ = Promise.withResolvers();
+
+  const input = new stream.PassThrough();
+  const output = new stream.PassThrough();
+
+  const replServer = repl.start({
+    input,
+    output,
+    eval(_cmd, _context, _file, cb) {
+      close$.promise.then(() => {
+        cb(new Error('Error returned from the eval callback'));
+        eval$.resolve();
+      });
+    },
+  });
+
+  let outputStr = '';
+  output.on('data', (data) => {
+    outputStr += data;
+  });
+
+  input.write('\n');
+
+  replServer.close();
+  close$.resolve();
+
+  process.on('uncaughtException', common.mustNotCall());
+
+  await eval$.promise;
+
+  assert.match(outputStr, /Uncaught Error: Error returned from the eval callback/);
+})().then(common.mustCall());


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/58784

prevent incorrect throws of `ERR_USE_AFTER_CLOSE` errors when the eval function of a repl server returns an error after the repl server has been closed

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
