### PR TITLE
meta: add ability to block issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ See [details on our policy on Code of Conduct](./doc/contributing/code-of-conduc
 * [Discussing non-technical topics](./doc/contributing/issues.md#discussing-non-technical-topics)
 * [Submitting a Bug Report](./doc/contributing/issues.md#submitting-a-bug-report)
 * [Triaging a Bug Report](./doc/contributing/issues.md#triaging-a-bug-report)
+* [Blocking Issues](./doc/contributing/issues.md#blocking-issues)
 
 ## [Pull Requests](./doc/contributing/pull-requests.md)
 

--- a/doc/contributing/issues.md
+++ b/doc/contributing/issues.md
@@ -4,6 +4,7 @@
 * [Discussing non-technical topics](#discussing-non-technical-topics)
 * [Submitting a bug report](#submitting-a-bug-report)
 * [Triaging a bug report](#triaging-a-bug-report)
+* [Blocking Issues](#blocking-issues)
 
 ## Asking for general help
 
@@ -71,6 +72,13 @@ When triagging issues and PRs:
   merged for pull requests). Closing an issue (or PR) earlier can be seen as
   dismissive from the point of view of the reporter/author.
   Always try to communicate the reason for closing the issue/PR.
+
+## Blocking Issues
+
+Collaborators have the ability to block issues from getting implemented and landed into
+the project by commenting and explicitly including "-1" in the comment.
+When doing so, explain why you believe the pull request should not land along with
+an explanation of what may be an acceptable alternative course, if any.
 
 [Node.js help repository]: https://github.com/nodejs/help/issues
 [Technical Steering Committee (TSC) repository]: https://github.com/nodejs/TSC/issues


### PR DESCRIPTION
I'm proposing the ability to block an issue from progressing by any collaborator. 

cc @nodejs/tsc