### PR TITLE
src: add an option to make compile cache path relative

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3181,6 +3181,10 @@ added: v22.1.0
 Enable the [module compile cache][] for the Node.js instance. See the documentation of
 [module compile cache][] for details.
 
+### `NODE_COMPILE_CACHE_RELATIVE_PATH=0`
+
+When set to 1, the path for [module compile cache][] is considered relative.
+
 ### `NODE_DEBUG=module[,…]`
 
 <!-- YAML

--- a/src/compile_cache.cc
+++ b/src/compile_cache.cc
@@ -13,8 +13,14 @@
 #include <unistd.h>  // getuid
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
 namespace node {
 
+#ifdef _WIN32
+using fs::ConvertWideToUTF8;
+#endif
 using v8::Function;
 using v8::Local;
 using v8::Module;
@@ -223,13 +229,109 @@ void CompileCacheHandler::ReadCacheFile(CompileCacheEntry* entry) {
   Debug(" success, size=%d\n", total_read);
 }
 
+#ifdef _WIN32
+constexpr bool IsWindowsDeviceRoot(const char c) noexcept {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+}
+#endif
+
+static std::string NormalisePath(std::string_view path) {
+  std::string normalised_string(path);
+  constexpr std::string_view file_scheme = "file://";
+  if (normalised_string.rfind(file_scheme, 0) == 0) {
+    normalised_string.erase(0, file_scheme.size());
+  }
+
+#ifdef _WIN32
+  if (normalised_string.size() > 2 &&
+      IsWindowsDeviceRoot(normalised_string[0]) &&
+      normalised_string[1] == ':' &&
+      (normalised_string[2] == '/' || normalised_string[2] == '\\')) {
+    normalised_string[0] = ToLower(normalised_string[0]);
+  }
+#endif
+  for (char& c : normalised_string) {
+    if (c == '\\') {
+      c = '/';
+    }
+  }
+
+  if (!normalised_string.empty() && normalised_string.back() == '/') {
+    normalised_string.pop_back();
+  }
+
+  normalised_string = NormalizeString(normalised_string, false, "/");
+  return normalised_string;
+}
+
+// Check if a path looks like an absolute path or file URL.
+static bool IsAbsoluteFilePath(std::string_view path) {
+  if (path.rfind("file://", 0) == 0) {
+    return true;
+  }
+#ifdef _WIN32
+  if (path.size() > 2 && IsWindowsDeviceRoot(path[0]) &&
+      (path[1] == ':' && (path[2] == '/' || path[2] == '\\')))
+    return true;
+  if (path.size() > 1 && path[0] == '\\' && path[1] == '\\') return true;
+#else
+  if (path.size() > 0 && path[0] == '/') return true;
+#endif
+  return false;
+}
+
+static std::string GetRelativePath(std::string_view path,
+                                   std::string_view base) {
+// On Windows, the native encoding is UTF-16, so we need to convert
+// the paths to wide strings before using std::filesystem::path.
+// On other platforms, std::filesystem::path can handle UTF-8 directly.
+#ifdef _WIN32
+  std::wstring wpath = ConvertToWideString(std::string(path), CP_UTF8);
+  std::wstring wbase = ConvertToWideString(std::string(base), CP_UTF8);
+  std::filesystem::path relative =
+      std::filesystem::path(wpath).lexically_relative(
+          std::filesystem::path(wbase));
+  if (relative.empty()) {
+    return std::string();
+  }
+  std::string relative_path = ConvertWideToUTF8(relative.wstring());
+  return relative_path;
+#else
+  std::filesystem::path relative =
+      std::filesystem::path(path).lexically_relative(
+          std::filesystem::path(base));
+  if (relative.empty()) {
+    return std::string();
+  }
+  return relative.generic_string();
+#endif
+}
+
 CompileCacheEntry* CompileCacheHandler::GetOrInsert(Local<String> code,
                                                     Local<String> filename,
                                                     CachedCodeType type) {
   DCHECK(!compile_cache_dir_.empty());
 
   Utf8Value filename_utf8(isolate_, filename);
-  uint32_t key = GetCacheKey(filename_utf8.ToStringView(), type);
+  std::string file_path = filename_utf8.ToString();
+  // If the relative path is enabled, we try to use a relative path
+  // from the compile cache directory to the file path
+  if (use_relative_ && IsAbsoluteFilePath(file_path)) {
+    // Normalise the paths to ensure they are consistent.
+    std::string normalised_file_path = NormalisePath(file_path);
+    std::string normalised_cache_dir =
+        NormalisePath(absolute_compile_cache_dir_);
+
+    std::string relative_path =
+        GetRelativePath(normalised_file_path, normalised_cache_dir);
+    if (!relative_path.empty()) {
+      file_path = relative_path;
+      Debug("[compile cache] using relative path %s from %s\n",
+            file_path.c_str(),
+            absolute_compile_cache_dir_.c_str());
+    }
+  }
+  uint32_t key = GetCacheKey(file_path, type);
 
   // TODO(joyeecheung): don't encode this again into UTF8. If we read the
   // UTF8 content on disk as raw buffer (from the JS layer, while watching out
@@ -500,11 +602,15 @@ CompileCacheHandler::CompileCacheHandler(Environment* env)
 //   - $NODE_VERSION-$ARCH-$CACHE_DATA_VERSION_TAG-$UID
 //     - $FILENAME_AND_MODULE_TYPE_HASH.cache: a hash of filename + module type
 CompileCacheEnableResult CompileCacheHandler::Enable(Environment* env,
-                                                     const std::string& dir) {
+                                                     const std::string& dir,
+                                                     bool use_relative) {
   std::string cache_tag = GetCacheVersionTag();
-  std::string absolute_cache_dir_base = PathResolve(env, {dir});
-  std::string cache_dir_with_tag =
-      absolute_cache_dir_base + kPathSeparator + cache_tag;
+  std::string base_dir = dir;
+  if (!use_relative) {
+    base_dir = PathResolve(env, {dir});
+  }
+
+  std::string cache_dir_with_tag = base_dir + kPathSeparator + cache_tag;
   CompileCacheEnableResult result;
   Debug("[compile cache] resolved path %s + %s -> %s\n",
         dir,
@@ -546,8 +652,10 @@ CompileCacheEnableResult CompileCacheHandler::Enable(Environment* env,
     return result;
   }
 
-  result.cache_directory = absolute_cache_dir_base;
+  result.cache_directory = base_dir;
   compile_cache_dir_ = cache_dir_with_tag;
+  absolute_compile_cache_dir_ = PathResolve(env, {compile_cache_dir_});
+  use_relative_ = use_relative;
   result.status = CompileCacheEnableStatus::ENABLED;
   return result;
 }

--- a/src/compile_cache.h
+++ b/src/compile_cache.h
@@ -65,7 +65,9 @@ struct CompileCacheEnableResult {
 class CompileCacheHandler {
  public:
   explicit CompileCacheHandler(Environment* env);
-  CompileCacheEnableResult Enable(Environment* env, const std::string& dir);
+  CompileCacheEnableResult Enable(Environment* env,
+                                  const std::string& dir,
+                                  bool use_relative);
 
   void Persist();
 
@@ -103,6 +105,8 @@ class CompileCacheHandler {
   bool is_debug_ = false;
 
   std::string compile_cache_dir_;
+  std::string absolute_compile_cache_dir_;
+  bool use_relative_ = false;
   std::unordered_map<uint32_t, std::unique_ptr<CompileCacheEntry>>
       compiler_cache_store_;
 };

--- a/src/env.cc
+++ b/src/env.cc
@@ -1135,10 +1135,22 @@ CompileCacheEnableResult Environment::EnableCompileCache(
     return result;
   }
 
+  bool cache_path_is_relative = false;
+  std::string relative_path;
+  credentials::SafeGetenv(
+      "NODE_COMPILE_CACHE_RELATIVE_PATH", &relative_path, this);
+  if (!relative_path.empty() && relative_path != "0" &&
+      relative_path != "false") {
+    cache_path_is_relative = true;
+    Debug(this,
+          DebugCategory::COMPILE_CACHE,
+          "[compile cache] use relative path\n");
+  }
+
   if (!compile_cache_handler_) {
     std::unique_ptr<CompileCacheHandler> handler =
         std::make_unique<CompileCacheHandler>(this);
-    result = handler->Enable(this, cache_dir);
+    result = handler->Enable(this, cache_dir, cache_path_is_relative);
     if (result.status == CompileCacheEnableStatus::ENABLED) {
       compile_cache_handler_ = std::move(handler);
       AtExit(

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -531,6 +531,8 @@ int SyncCallAndThrowOnError(Environment* env,
                             FSReqWrapSync* req_wrap,
                             Func fn,
                             Args... args);
+
+std::string ConvertWideToUTF8(const std::wstring& wstr);
 }  // namespace fs
 
 }  // namespace node

--- a/test/parallel/test-compile-cache-relative-path.js
+++ b/test/parallel/test-compile-cache-relative-path.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE works with the NODE_COMPILE_CACHE_RELATIVE_PATH
+// environment variable.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+const path = require('path');
+
+tmpdir.refresh();
+const workDir = path.join(tmpdir.path, 'work');
+const cacheRel = '.compile_cache_dir';
+const cacheAbs = path.join(workDir, cacheRel);
+fs.mkdirSync(workDir, { recursive: true });
+const script = path.join(workDir, 'test.js');
+fs.writeFileSync(script, '');
+
+{
+  fs.mkdirSync(cacheAbs, { recursive: true });
+  spawnSyncAndAssert(
+    process.execPath,
+    [script],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: cacheRel,
+        NODE_COMPILE_CACHE_RELATIVE_PATH: true,
+      },
+      cwd: workDir,
+    },
+    {
+      stderr(output) {
+        assert.match(
+          output,
+          /test\.js was not initialized, initializing the in-memory entry/
+        );
+        assert.match(output, /writing cache for .*test\.js.*success/);
+        return true;
+      },
+    }
+  );
+}
+{
+  const movedWorkDir = `${workDir}_moved`;
+  fs.renameSync(workDir, movedWorkDir);
+  spawnSyncAndAssert(
+    process.execPath,
+    [path.join(movedWorkDir, 'test.js')],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: cacheRel,
+        NODE_COMPILE_CACHE_RELATIVE_PATH: true,
+      },
+      cwd: movedWorkDir,
+    },
+    {
+      stderr(output) {
+        assert.match(
+          output,
+          /cache for .*test\.js was accepted, keeping the in-memory entry/
+        );
+        assert.match(output, /.*skip .*test\.js because cache was the same/);
+        return true;
+      },
+    }
+  );
+}


### PR DESCRIPTION
Adds an option (NODE_COMPILE_CACHE_RELATIVE_PATH) for the built-in compile cache to encode the hashes with relative file paths. On enabling the option,
the source directory along with cache directory can be bundled and moved, and the cache continues to work.

When enabled, paths encoded in hash are relative to compile cache directory.

Fixes: https://github.com/nodejs/node/issues/58755

