### PR TITLE
test: deflake test-config-file

### DIFF
--- a/test/fixtures/rc/non-readable/node.config.json
+++ b/test/fixtures/rc/non-readable/node.config.json
@@ -1,5 +1,0 @@
-{
-    "nodeOptions": {
-        "max-http-header-size": 10
-    }
-}

--- a/test/parallel/test-config-file.js
+++ b/test/parallel/test-config-file.js
@@ -239,6 +239,7 @@ test('--inspect=true should be parsed correctly', { skip: !process.features.insp
     '--no-warnings',
     '--experimental-config-file',
     fixtures.path('rc/inspect-true.json'),
+    '--inspect-port', '0',
     '-p', 'require("node:inspector").url()',
   ]);
   match(result.stderr, /^Debugger listening on (ws:\/\/[^\s]+)/);


### PR DESCRIPTION
**test: deflake test-config-file**

Port 9229 may already be used by another process. Use a random
available one.

**test: save the config file in a temporary directory**

Allow the test to be run in parallel.

Refs: https://github.com/nodejs/node/pull/58799#issuecomment-2995684216

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
