### PR TITLE
doc: clarify http.request supports headers as array

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3822,17 +3822,14 @@ changes:
     v6 will be used.
   * `headers` {Object | Array} Request headers to send with the request. This can be:
     * An object like `{ 'Content-Type': 'application/json' }`.
-    * A flat array of header name/value pairs like 
-        `[ 'Content-Type', 'text/plain', 'X-Custom', 'yes' ]`. This format is
-        the same as used in [`response.writeHead()`][] and exposed in
-        [`request.rawHeaders`][].
-
-    When passing `headers` as an array, it must be a flat list of alternating
-    header names and values. Nested arrays or objects are not supported in this
-    form. This array format is identical to that used in [`response.writeHead()`][]
-    and [`request.rawHeaders`][], and is often useful when working with raw header
-    data directly.
-
+    * A flat array of header name/value pairs like `[ 'Content-Type', 'text/plain', 'X-Custom',
+      'yes' ]`. This format is the same as used in [`response.writeHead()`][] and exposed in
+      request.rawHeaders.
+      When passing `headers` as an array, it must be a flat list of alternating
+      header names and values. Nested arrays or objects are not supported in this
+      form. This array format is identical to that used in [`response.writeHead()`][]
+      and request.rawHeaders, and is often useful when working with raw header
+      data directly.
   * `hints` {number} Optional [`dns.lookup()` hints][].
   * `host` {string} A domain name or IP address of the server to issue the
     request to. **Default:** `'localhost'`.
@@ -4341,4 +4338,3 @@ A browser-compatible implementation of [`WebSocket`][].
 [`writable.uncork()`]: stream.md#writableuncork
 [`writable.write()`]: stream.md#writablewritechunk-encoding-callback
 [initial delay]: net.md#socketsetkeepaliveenable-initialdelay
-[`request.rawHeaders`]: #requestrawheaders

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3821,8 +3821,18 @@ changes:
     `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and
     v6 will be used.
   * `headers` {Object | Array} Request headers to send with the request. This can be:
-    * An object like `{ 'Content-Type': 'application/json' }`, or
-    * An array of key-value pairs like `[ 'Content-Type', 'text/plain', 'X-Custom', 'yes' ]`,  similar to how headers are          passed to `response.writeHead()`.
+    * An object like `{ 'Content-Type': 'application/json' }`.
+    * A flat array of header name/value pairs like 
+        `[ 'Content-Type', 'text/plain', 'X-Custom', 'yes' ]`. This format is
+        the same as used in [`response.writeHead()`][] and exposed in
+        [`request.rawHeaders`][].
+
+    When passing `headers` as an array, it must be a flat list of alternating
+    header names and values. Nested arrays or objects are not supported in this
+    form. This array format is identical to that used in [`response.writeHead()`][]
+    and [`request.rawHeaders`][], and is often useful when working with raw header
+    data directly.
+
   * `hints` {number} Optional [`dns.lookup()` hints][].
   * `host` {string} A domain name or IP address of the server to issue the
     request to. **Default:** `'localhost'`.
@@ -4331,3 +4341,6 @@ A browser-compatible implementation of [`WebSocket`][].
 [`writable.uncork()`]: stream.md#writableuncork
 [`writable.write()`]: stream.md#writablewritechunk-encoding-callback
 [initial delay]: net.md#socketsetkeepaliveenable-initialdelay
+[`response.writeHead()`]: https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers  
+[`request.rawHeaders`]: https://nodejs.org/api/http.html#requestrawheaders
+

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3824,11 +3824,11 @@ changes:
     * An object like `{ 'Content-Type': 'application/json' }`.
     * A flat array of header name/value pairs like `[ 'Content-Type', 'text/plain', 'X-Custom',
       'yes' ]`. This format is the same as used in [`response.writeHead()`][] and exposed in
-      request.rawHeaders.
+      `request.rawHeaders`.
       When passing `headers` as an array, it must be a flat list of alternating
       header names and values. Nested arrays or objects are not supported in this
       form. This array format is identical to that used in [`response.writeHead()`][]
-      and request.rawHeaders, and is often useful when working with raw header
+      and `request.rawHeaders`, and is often useful when working with raw header
       data directly.
   * `hints` {number} Optional [`dns.lookup()` hints][].
   * `host` {string} A domain name or IP address of the server to issue the

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3820,7 +3820,9 @@ changes:
   * `family` {number} IP address family to use when resolving `host` or
     `hostname`. Valid values are `4` or `6`. When unspecified, both IP v4 and
     v6 will be used.
-  * `headers` {Object} An object containing request headers.
+  * `headers` {Object | Array} Request headers to send with the request. This can be:
+    * An object like `{ 'Content-Type': 'application/json' }`, or
+    * An array of key-value pairs like `[ 'Content-Type', 'text/plain', 'X-Custom', 'yes' ]`,  similar to how headers are          passed to `response.writeHead()`.
   * `hints` {number} Optional [`dns.lookup()` hints][].
   * `host` {string} A domain name or IP address of the server to issue the
     request to. **Default:** `'localhost'`.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -4341,6 +4341,4 @@ A browser-compatible implementation of [`WebSocket`][].
 [`writable.uncork()`]: stream.md#writableuncork
 [`writable.write()`]: stream.md#writablewritechunk-encoding-callback
 [initial delay]: net.md#socketsetkeepaliveenable-initialdelay
-[`response.writeHead()`]: https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers  
-[`request.rawHeaders`]: https://nodejs.org/api/http.html#requestrawheaders
-
+[`request.rawHeaders`]: #requestrawheaders


### PR DESCRIPTION
Updated the documentation for http.request to clarify the array format for headers.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
