### PR TITLE
[v24.x] deps: V8: backport 1c3e018e7d48

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-primitive.h
+++ b/deps/v8/include/v8-primitive.h
@@ -819,6 +819,8 @@ class V8_EXPORT Symbol : public Name {
   static Local<Symbol> GetToPrimitive(Isolate* isolate);
   static Local<Symbol> GetToStringTag(Isolate* isolate);
   static Local<Symbol> GetUnscopables(Isolate* isolate);
+  static Local<Symbol> GetDispose(Isolate* isolate);
+  static Local<Symbol> GetAsyncDispose(Isolate* isolate);
 
   V8_INLINE static Symbol* Cast(Data* data) {
 #ifdef V8_ENABLE_CHECKS

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -9548,7 +9548,9 @@ Local<Symbol> v8::Symbol::ForApi(Isolate* v8_isolate, Local<String> name) {
   V(Split, split)                             \
   V(ToPrimitive, to_primitive)                \
   V(ToStringTag, to_string_tag)               \
-  V(Unscopables, unscopables)
+  V(Unscopables, unscopables)                 \
+  V(Dispose, dispose)                         \
+  V(AsyncDispose, async_dispose)
 
 #define SYMBOL_GETTER(Name, name)                                      \
   Local<Symbol> v8::Symbol::Get##Name(Isolate* v8_isolate) {           \

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -4006,6 +4006,8 @@ THREADED_TEST(WellKnownSymbols) {
   CheckWellKnownSymbol(v8::Symbol::GetSplit, "Symbol.split");
   CheckWellKnownSymbol(v8::Symbol::GetToPrimitive, "Symbol.toPrimitive");
   CheckWellKnownSymbol(v8::Symbol::GetToStringTag, "Symbol.toStringTag");
+  CheckWellKnownSymbol(v8::Symbol::GetDispose, "Symbol.dispose");
+  CheckWellKnownSymbol(v8::Symbol::GetAsyncDispose, "Symbol.asyncDispose");
 }
 
 


### PR DESCRIPTION
This backport from 13.7 facilitates defining ERM disposal methods within the C++ layer.

Original commit message:

```
Expose dispose and asyncDispose symbols to C++

Since `Symbol.dispose` has been exposed to JS we need to be able to
access the native v8::Symbol too.

Change-Id: I9111d2806630efdd8bb5f931effa9adad3c85ae5
Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6410112
Commit-Queue: Erik Corry <erikcorry@chromium.org>
Reviewed-by: Erik Corry <erikcorry@chromium.org>
Reviewed-by: Leszek Swirski <leszeks@chromium.org>
Cr-Commit-Position: refs/heads/main@{#99590}
```

refs: v8/v8@1c3e018e7d488d43b97b4e30f77b50070c456473