### PR TITLE
Fix typo in WebAssembly validation error message (“fallthru” → “fallthrough”)

### DIFF
--- a/deps/v8/src/wasm/function-body-decoder-impl.h
+++ b/deps/v8/src/wasm/function-body-decoder-impl.h
@@ -7159,7 +7159,7 @@ class WasmFullDecoder : public WasmDecoder<ValidationTag, decoding_mode> {
         merge_type == kBranchMerge     ? "branch"
         : merge_type == kReturnMerge   ? "return"
         : merge_type == kInitExprMerge ? "constant expression"
-                                       : "fallthru";
+                                       : "fallthrough";
     uint32_t arity = merge->arity;
     uint32_t actual = stack_.size() - control_.back().stack_depth;
     // Here we have to check for !unreachable(), because we need to typecheck as

--- a/deps/v8/test/message/fail/wasm-async-compile-fail.out
+++ b/deps/v8/test/message/fail/wasm-async-compile-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:9: CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.compile(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/deps/v8/test/message/fail/wasm-async-instantiate-fail.out
+++ b/deps/v8/test/message/fail/wasm-async-instantiate-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:9: CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.instantiate(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/deps/v8/test/message/fail/wasm-streaming-compile-fail.out
+++ b/deps/v8/test/message/fail/wasm-streaming-compile-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:11: CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:11: CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.compileStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/deps/v8/test/message/fail/wasm-streaming-instantiate-fail.out
+++ b/deps/v8/test/message/fail/wasm-streaming-instantiate-fail.out
@@ -1,5 +1,5 @@
-*%(basename)s:11: CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:11: CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 let rethrow = e => setTimeout(_ => {throw e}, 0);
                                     ^
-CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.instantiateStreaming(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 

--- a/deps/v8/test/message/fail/wasm-sync-compile-fail.out
+++ b/deps/v8/test/message/fail/wasm-sync-compile-fail.out
@@ -1,6 +1,6 @@
-*%(basename)s:9: CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+*%(basename)s:9: CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
 new WebAssembly.Module(builder.toBuffer());
 ^
-CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthru, found 0 @+24
+CompileError: WebAssembly.Module(): Compiling function #0:"f" failed: expected 1 elements on the stack for fallthrough, found 0 @+24
     at *%(basename)s:9:1
 

--- a/deps/v8/test/mjsunit/wasm/async-compile.js
+++ b/deps/v8/test/mjsunit/wasm/async-compile.js
@@ -70,7 +70,7 @@ assertPromiseResult(async function badFunctionInTheMiddle() {
   await assertCompileError(
       buffer,
       'Compiling function #10:\"bad\" failed: ' +
-          'expected 1 elements on the stack for fallthru, found 0 @+94');
+          'expected 1 elements on the stack for fallthrough, found 0 @+94');
 }());
 
 assertPromiseResult(async function importWithoutCode() {

--- a/deps/v8/test/unittests/wasm/function-body-decoder-unittest.cc
+++ b/deps/v8/test/unittests/wasm/function-body-decoder-unittest.cc
@@ -3089,16 +3089,16 @@ TEST_F(FunctionBodyDecoderTest, MultiValBlock1) {
       {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1)), kExprI32Add});
   ExpectFailure(sigs.i_ii(), {WASM_BLOCK_X(sig0, WASM_NOP), kExprI32Add},
                 kAppendEnd,
-                "expected 2 elements on the stack for fallthru, found 0");
+                "expected 2 elements on the stack for fallthrough, found 0");
   ExpectFailure(
       sigs.i_ii(), {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0)), kExprI32Add},
-      kAppendEnd, "expected 2 elements on the stack for fallthru, found 1");
+      kAppendEnd, "expected 2 elements on the stack for fallthrough, found 1");
   ExpectFailure(sigs.i_ii(),
                 {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1),
                               WASM_LOCAL_GET(0)),
                  kExprI32Add},
                 kAppendEnd,
-                "expected 2 elements on the stack for fallthru, found 3");
+                "expected 2 elements on the stack for fallthrough, found 3");
   ExpectFailure(
       sigs.i_ii(),
       {WASM_BLOCK_X(sig0, WASM_LOCAL_GET(0), WASM_LOCAL_GET(1)), kExprF32Add},
@@ -3994,7 +3994,7 @@ TEST_F(FunctionBodyDecoderTest, BrOnNonNull) {
 
     // br_on_non_null does not leave a value on the stack.
     ExpectFailure(&sig, {WASM_BR_ON_NON_NULL(0, WASM_LOCAL_GET(0))}, kAppendEnd,
-                  "expected 1 elements on the stack for fallthru, found 0");
+                  "expected 1 elements on the stack for fallthrough, found 0");
   }
 }
 
@@ -4028,7 +4028,7 @@ TEST_F(FunctionBodyDecoderTest, GCStruct) {
   ExpectFailure(
       &sig_r_v,
       {WASM_STRUCT_NEW(struct_type_index, WASM_I32V(0), WASM_I32V(1))},
-      kAppendEnd, "expected 1 elements on the stack for fallthru, found 2");
+      kAppendEnd, "expected 1 elements on the stack for fallthrough, found 2");
   // Mistyped arguments.
   ExpectFailure(&sig_v_r,
                 {WASM_STRUCT_NEW(struct_type_index, WASM_LOCAL_GET(0))},
@@ -4086,7 +4086,7 @@ TEST_F(FunctionBodyDecoderTest, GCStruct) {
                 {WASM_STRUCT_SET(struct_type_index, field_index,
                                  WASM_LOCAL_GET(0), WASM_I32V(0))},
                 kAppendEnd,
-                "expected 1 elements on the stack for fallthru, found 0");
+                "expected 1 elements on the stack for fallthrough, found 0");
   // Setting immutable field.
   ExpectFailure(sigs.v_v(),
                 {WASM_STRUCT_SET(
@@ -5977,7 +5977,7 @@ TEST_F(FunctionBodyDecoderTest, WasmSuspend) {
       sigs.v_v(), {WASM_SUSPEND(tag_i_i), WASM_DROP}, kAppendEnd,
       "not enough arguments on the stack for suspend (need 1, got 0)");
   ExpectFailure(sigs.v_v(), {WASM_I32V(42), WASM_SUSPEND(tag_i_i)}, kAppendEnd,
-                "expected 0 elements on the stack for fallthru, found 1");
+                "expected 0 elements on the stack for fallthrough, found 1");
   ExpectFailure(sigs.v_v(), {WASM_F64(42.0), WASM_SUSPEND(tag_i_i)}, kAppendEnd,
                 "suspend[0] expected type i32, found f64.const of type f64");
 }


### PR DESCRIPTION
This patch fixes a minor typo in the WebAssembly validation error message:

The change affects:
- `src/wasm/function-body-decoder-impl.h`
- related test expectations in `test/`

No behavioral changes.

fixes: #58805 