### PR TITLE
test_runner: fix timeout not propagated to the child process in run

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -145,6 +145,7 @@ function getRunArgs(path, { forceExit,
                             only,
                             argv: suppliedArgs,
                             execArgv,
+                            root: { timeout },
                             cwd }) {
   const argv = ArrayPrototypeFilter(process.execArgv, filterExecArgv);
   if (forceExit === true) {
@@ -161,6 +162,9 @@ function getRunArgs(path, { forceExit,
   }
   if (only === true) {
     ArrayPrototypePush(argv, '--test-only');
+  }
+  if (timeout != null) {
+    ArrayPrototypePush(argv, `--test-timeout=${timeout}`);
   }
 
   ArrayPrototypePushApply(argv, execArgv);

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -88,9 +88,11 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
 
   it('should support timeout', async () => {
     const stream = run({ timeout: 50, files: [
-      fixtures.path('test-runner', 'timeout-basic.mjs'),
+      fixtures.path('test-runner', 'plan', 'timeout-basic.mjs'),
     ] });
-    stream.on('test:fail', common.mustCall(1));
+    stream.on('test:fail', common.mustCall((data) => {
+      assert.strictEqual(data.details.error.failureType, 'testTimeoutFailure');
+    }));
     stream.on('test:pass', common.mustNotCall());
     // eslint-disable-next-line no-unused-vars
     for await (const _ of stream);


### PR DESCRIPTION
We do have test coverage for this case, however, the test failed due to an incorrect file path, not due to the intended `testTimeoutFailure`. The key takeaway is that we should make the assertion more explicit to avoid such regression.

Fixes: https://github.com/nodejs/node/issues/58802
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
