### PR TITLE
http,https,http2: make async disposers idempotent

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -29,7 +29,6 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   Symbol,
-  SymbolAsyncDispose,
   SymbolFor,
 } = primordials;
 
@@ -82,7 +81,6 @@ const {
 const {
   assignFunctionName,
   kEmptyObject,
-  promisify,
 } = require('internal/util');
 const {
   validateInteger,
@@ -579,10 +577,6 @@ Server.prototype.close = function close() {
   ReflectApply(net.Server.prototype.close, this, arguments);
   return this;
 };
-
-Server.prototype[SymbolAsyncDispose] = assignFunctionName(SymbolAsyncDispose, async function() {
-  await promisify(this.close).call(this);
-});
 
 Server.prototype.closeAllConnections = function closeAllConnections() {
   if (!this[kConnections]) {

--- a/lib/https.js
+++ b/lib/https.js
@@ -33,13 +33,11 @@ const {
   ObjectSetPrototypeOf,
   ReflectApply,
   ReflectConstruct,
-  SymbolAsyncDispose,
 } = primordials;
 
 const {
   assertCrypto,
   kEmptyObject,
-  promisify,
 } = require('internal/util');
 assertCrypto();
 
@@ -114,10 +112,6 @@ Server.prototype.close = function close() {
   httpServerPreClose(this);
   ReflectApply(tls.Server.prototype.close, this, arguments);
   return this;
-};
-
-Server.prototype[SymbolAsyncDispose] = async function() {
-  await FunctionPrototypeCall(promisify(this.close), this);
 };
 
 /**

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -18,7 +18,6 @@ const {
   SafeMap,
   SafeSet,
   Symbol,
-  SymbolAsyncDispose,
   SymbolDispose,
   Uint32Array,
   Uint8Array,
@@ -3345,10 +3344,6 @@ class Http2Server extends NETServer {
   close() {
     ReflectApply(NETServer.prototype.close, this, arguments);
     closeAllSessions(this);
-  }
-
-  async [SymbolAsyncDispose]() {
-    await promisify(super.close).call(this);
   }
 }
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -118,6 +118,7 @@ const {
 const { isUint8Array } = require('internal/util/types');
 const { queueMicrotask } = require('internal/process/task_queues');
 const {
+  assignFunctionName,
   guessHandleType,
   isWindows,
   kEmptyObject,
@@ -2391,12 +2392,12 @@ Server.prototype.close = function(cb) {
   return this;
 };
 
-Server.prototype[SymbolAsyncDispose] = async function() {
+Server.prototype[SymbolAsyncDispose] = assignFunctionName(SymbolAsyncDispose, async function() {
   if (!this._handle) {
     return;
   }
   await FunctionPrototypeCall(promisify(this.close), this);
-};
+});
 
 Server.prototype._emitCloseIfDrained = function() {
   debug('SERVER _emitCloseIfDrained');

--- a/test/parallel/test-http-server-async-dispose.js
+++ b/test/parallel/test-http-server-async-dispose.js
@@ -7,8 +7,12 @@ const { kConnectionsCheckingInterval } = require('_http_server');
 const server = createServer();
 
 server.listen(0, common.mustCall(() => {
+  assert.strictEqual(server[Symbol.asyncDispose].name, '[Symbol.asyncDispose]');
   server.on('close', common.mustCall());
   server[Symbol.asyncDispose]().then(common.mustCall(() => {
     assert(server[kConnectionsCheckingInterval]._destroyed);
+
+    // Disposer must be idempotent, subsequent call must not throw
+    server[Symbol.asyncDispose]().then(common.mustCall());
   }));
 }));

--- a/test/parallel/test-http2-server-async-dispose.js
+++ b/test/parallel/test-http2-server-async-dispose.js
@@ -6,10 +6,17 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const http2 = require('http2');
+const assert = require('node:assert');
 
 const server = http2.createServer();
 
 server.listen(0, common.mustCall(() => {
+  assert.strictEqual(server[Symbol.asyncDispose].name, '[Symbol.asyncDispose]');
   server.on('close', common.mustCall());
-  server[Symbol.asyncDispose]().then(common.mustCall());
+  server[Symbol.asyncDispose]().then(common.mustCall(() => {
+    assert.strictEqual(server._handle, null);
+
+    // Disposer must be idempotent, subsequent call must not throw
+    server[Symbol.asyncDispose]().then(common.mustCall());
+  }));
 }));

--- a/test/parallel/test-https-server-async-dispose.js
+++ b/test/parallel/test-https-server-async-dispose.js
@@ -12,8 +12,12 @@ const { kConnectionsCheckingInterval } = require('_http_server');
 const server = createServer();
 
 server.listen(0, common.mustCall(() => {
+  assert.strictEqual(server[Symbol.asyncDispose].name, '[Symbol.asyncDispose]');
   server.on('close', common.mustCall());
   server[Symbol.asyncDispose]().then(common.mustCall(() => {
     assert(server[kConnectionsCheckingInterval]._destroyed);
+
+    // Disposer must be idempotent, subsequent call must not throw
+    server[Symbol.asyncDispose]().then(common.mustCall());
   }));
 }));


### PR DESCRIPTION
This PR makes `server[Symbol.asyncDispose]` calls not throw after the server is already closed.
```mjs
{
  await using server = {http,https,http2}.createServer();
  server.listen();
  await server.close(); // close explicitly, throws if server is not running
} // close implicitly, does nothing if server is not running
```