### PR TITLE
test_runner: correctly filter --experimental-config-file

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -103,9 +103,12 @@ const kFilterArgs = [
   '--experimental-test-coverage',
   '--watch',
   '--experimental-default-config-file',
+];
+const kFilterArgValues = [
+  '--test-reporter',
+  '--test-reporter-destination',
   '--experimental-config-file',
 ];
-const kFilterArgValues = ['--test-reporter', '--test-reporter-destination'];
 const kDiagnosticsFilterArgs = ['tests', 'suites', 'pass', 'fail', 'cancelled', 'skipped', 'todo', 'duration_ms'];
 
 const kCanceledTests = new SafeSet()

--- a/test/fixtures/test-runner/options-propagation/experimental-config-file.test.mjs
+++ b/test/fixtures/test-runner/options-propagation/experimental-config-file.test.mjs
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import { strictEqual } from 'node:assert';
+import internal from 'internal/options';
+
+test('it should not receive --experimental-config-file option', () => {
+    const optionValue = internal.getOptionValue("--experimental-config-file");
+    strictEqual(optionValue, '');
+})

--- a/test/fixtures/test-runner/options-propagation/node.config.json
+++ b/test/fixtures/test-runner/options-propagation/node.config.json
@@ -1,0 +1,5 @@
+{
+    "testRunner": {
+        "experimental-test-coverage": true
+    }
+}


### PR DESCRIPTION
Fixes #58828


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
