### PR TITLE
`http.OutgoingMessage` extends `stream.Writable`, not `Stream`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3003,7 +3003,7 @@ validation is used, as clients may specify a custom `Host` header.
 added: v0.1.17
 -->
 
-* Extends: {Stream}
+* Extends: {stream.Readable}
 
 This class serves as the parent class of [`http.ClientRequest`][]
 and [`http.ServerResponse`][]. It is an abstract outgoing message from


### PR DESCRIPTION
Note how by contrast `http.IncomingMessage` (https://nodejs.org/api/http.html#class-httpincomingmessage) is correctly stated to extend from `stream.Readable`. 

Also, from @types/node:

![image](https://github.com/user-attachments/assets/86d1734e-5813-43fb-9cfe-0f8cd90e0c00)
