### PR TITLE
`http.OutgoingMessage` extends from `stream.Writable`, not `Stream`

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3003,7 +3003,7 @@ validation is used, as clients may specify a custom `Host` header.
 added: v0.1.17
 -->
 
-* Extends: {Stream}
+* Extends: {stream.Writable}
 
 This class serves as the parent class of [`http.ClientRequest`][]
 and [`http.ServerResponse`][]. It is an abstract outgoing message from


### PR DESCRIPTION
From @types/node:

![image](https://github.com/user-attachments/assets/19f957e4-8ec3-4164-8b47-aacca4703dde)


Also note that `http.IncomingMessage` on the same page is correctly said to extend from `stream.Readable` (https://nodejs.org/api/http.html#class-httpincomingmessage)