### PR TITLE
test_runner: correct "already mocked" error punctuation placement

### DIFF
--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -671,7 +671,7 @@ class MockTracker {
 
     if (baseURL.searchParams.has(kMockSearchParam)) {
       throw new ERR_INVALID_STATE(
-        `Cannot mock '${specifier}.' The module is already mocked.`,
+        `Cannot mock '${specifier}'. The module is already mocked.`,
       );
     }
 


### PR DESCRIPTION
The current message contains a period within the quotes around the specifier, making it look malformed.