### PR TITLE
fs: fix for FileHandle.readableWebStream

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -363,7 +363,7 @@ class FileHandle extends EventEmitter {
 
       async pull(controller) {
         const view = controller.byobRequest.view;
-        const { bytesRead } = await readFn(view, view.byteOffset, view.byteLength);
+        const { bytesRead } = await readFn(view, 0, view.byteLength);
 
         if (bytesRead === 0) {
           controller.close();

--- a/test/parallel/test-filehandle-readablestream.js
+++ b/test/parallel/test-filehandle-readablestream.js
@@ -114,6 +114,37 @@ const check = readFileSync(__filename, { encoding: 'utf8' });
   await file.close();
 })().then(common.mustCall());
 
+// Make sure 'byob' reader works with views into
+// different parts of a single ArrayBuffer
+(async () => {
+  const file = await open(__filename);
+  const dec = new TextDecoder();
+  const readable = file.readableWebStream();
+  const reader = readable.getReader({ mode: 'byob' });
+  const size = (await file.stat()).size;
+
+  let buff = new ArrayBuffer(size);
+  let offset = 0;
+  let result;
+  do {
+    result = await reader.read(new DataView(buff, offset, Math.min(100, buff.byteLength - offset)));
+    if (result.value !== undefined) {
+      buff = result.value.buffer;
+      offset += result.value.byteLength;
+      assert.ok(result.value.byteLength <= 100);
+    }
+  } while (!result.done && (offset < buff.byteLength));
+  const data = dec.decode(new Uint8Array(buff));
+
+  assert.strictEqual(check, data);
+
+  assert.throws(() => file.readableWebStream(), {
+    code: 'ERR_INVALID_STATE',
+  });
+
+  await file.close();
+})().then(common.mustCall());
+
 // Make sure a warning is logged if a non-'bytes' type is passed.
 (async () => {
   const file = await open(__filename);


### PR DESCRIPTION
Fixes FileHandle.readableWebStream in mode "byob" when reading into a view that has a byteOffset>0 into the underlying ArrayBuffer.

Fixes: https://github.com/nodejs/node/issues/58817

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
