### PR TITLE
v8: fix missing callback in heap utils destroy

### DIFF
--- a/lib/internal/heap_utils.js
+++ b/lib/internal/heap_utils.js
@@ -53,11 +53,12 @@ class HeapSnapshotStream extends Readable {
       this[kHandle].readStart();
   }
 
-  _destroy() {
+  _destroy(err, callback) {
     // Release the references on the handle so that
     // it can be garbage collected.
     this[kHandle][owner_symbol] = undefined;
     this[kHandle] = undefined;
+    callback(err);
   }
 
   [kUpdateTimer]() {

--- a/test/sequential/test-heapdump.js
+++ b/test/sequential/test-heapdump.js
@@ -10,6 +10,7 @@ if (!isMainThread) {
 const { writeHeapSnapshot, getHeapSnapshot } = require('v8');
 const assert = require('assert');
 const fs = require('fs');
+const { promises: { pipeline }, PassThrough } = require('stream');
 const tmpdir = require('../common/tmpdir');
 
 tmpdir.refresh();
@@ -77,4 +78,16 @@ process.chdir(tmpdir.path);
   snapshot.on('end', common.mustCall(() => {
     JSON.parse(data);
   }));
+}
+
+{
+  const passthrough = new PassThrough();
+  passthrough.on('data', common.mustCallAtLeast(()=> {
+    // Do nothing, just consume the data
+  }, 1));
+
+  pipeline(
+    getHeapSnapshot(),
+    passthrough,
+  ).then(common.mustCall());
 }


### PR DESCRIPTION
This fixes the v8.getHeapSnapshot() calls not properly being destroyed. Pipeline calls would for example not properly end without the callback being in place.

Thanks to @ronag to look into this!