### PR TITLE
fs: runtime deprecate closing `fs.Dir` on garbage collection

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4109,11 +4109,14 @@ an internal nodejs implementation rather than a public facing API, use `node:htt
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58850
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/59839
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Allowing a [`fs.Dir`][] object to be closed on garbage collection is
 deprecated. In the future, doing so might result in a thrown error that will

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -919,6 +919,14 @@ inline void Environment::RemoveHeapSnapshotNearHeapLimitCallback(
                                         heap_limit);
 }
 
+bool Environment::dir_gc_close_warning() const {
+  return emit_dir_gc_warning_;
+}
+
+void Environment::set_dir_gc_close_warning(bool on) {
+  emit_dir_gc_warning_ = on;
+}
+
 }  // namespace node
 
 // These two files depend on each other. Including base_object-inl.h after this

--- a/src/env.h
+++ b/src/env.h
@@ -820,6 +820,9 @@ class Environment final : public MemoryRetainer {
   inline node_module* extra_linked_bindings_tail();
   inline const Mutex& extra_linked_bindings_mutex() const;
 
+  inline bool dir_gc_close_warning() const;
+  inline void set_dir_gc_close_warning(bool on);
+
   inline void set_source_maps_enabled(bool on);
   inline bool source_maps_enabled() const;
 
@@ -1103,6 +1106,7 @@ class Environment final : public MemoryRetainer {
   std::shared_ptr<KVStore> env_vars_;
   bool printed_error_ = false;
   bool trace_sync_io_ = false;
+  bool emit_dir_gc_warning_ = true;
   bool emit_env_nonstring_warning_ = true;
   bool emit_err_name_warning_ = true;
   bool source_maps_enabled_ = false;

--- a/test/parallel/test-fs-dir-close-gc-deprecation.mjs
+++ b/test/parallel/test-fs-dir-close-gc-deprecation.mjs
@@ -1,0 +1,42 @@
+// Flags: --expose-gc --no-warnings
+
+// Test that a runtime warning is emitted when a Dir object
+// is allowed to close on garbage collection. In the future, this
+// test should verify that closing on garbage collection throws a
+// process fatal exception.
+
+import { expectWarning, mustCall } from '../common/index.mjs';
+import { rejects } from 'node:assert';
+import { opendir } from 'node:fs/promises';
+import { setImmediate } from 'node:timers';
+
+const warning =
+  'Closing a Dir object on garbage collection is deprecated. ' +
+  'Please close Dir objects explicitly using Dir.prototype.close(), ' +
+  "or by using explicit resource management ('using' keyword). " +
+  'In the future, an error will be thrown if a directory is closed during garbage collection.';
+
+// Test that closing Dir automatically using iterator doesn't emit warning
+{
+  const dir = await opendir(import.meta.dirname);
+  await Array.fromAsync(dir);
+  await rejects(dir.close(), { code: 'ERR_DIR_CLOSED' });
+}
+
+{
+  expectWarning({
+    Warning: [['Closing directory handle on garbage collection']],
+    DeprecationWarning: [[warning, 'DEP0200']],
+  });
+
+  await opendir(import.meta.dirname).then(mustCall(() => {
+    setImmediate(() => {
+      // The dir is out of scope now
+      globalThis.gc();
+
+      // Wait an extra event loop turn, as the warning is emitted from the
+      // native layer in an unref()'ed setImmediate() callback.
+      setImmediate(mustCall());
+    });
+  }));
+}


### PR DESCRIPTION
The [DEP0137](https://nodejs.org/api/deprecations.html#dep0137-closing-fsfilehandle-on-garbage-collection) is going to be End-of-Life in the next major release.

I think we should align closing `fs.Dir` on GC and deprecate it as well. Now that explicit resource management is available, closing dirs properly should become easier for userland.

Given that it already spams `Warning`s in stderr, it would make sense to make this deprecation runtime right away.

cc @nodejs/fs @nodejs/tsc 