### PR TITLE
test: close dirs in `fs-opendir` test

### DIFF
--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -219,6 +219,7 @@ for (const bufferSize of ['', '1', null]) {
 async function doAsyncIterInvalidCallbackTest() {
   const dir = await fs.promises.opendir(testDir);
   assert.throws(() => dir.close('not function'), invalidCallbackObj);
+  dir.close()
 }
 doAsyncIterInvalidCallbackTest().then(common.mustCall());
 
@@ -247,6 +248,7 @@ doConcurrentAsyncAndSyncOps().then(common.mustCall());
 {
   const dir = fs.opendirSync(testDir);
   assert.throws(() => dir.read('INVALID_CALLBACK'), /ERR_INVALID_ARG_TYPE/);
+  dir.close();
 }
 
 // Check that concurrent read() operations don't do weird things.

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -219,7 +219,7 @@ for (const bufferSize of ['', '1', null]) {
 async function doAsyncIterInvalidCallbackTest() {
   const dir = await fs.promises.opendir(testDir);
   assert.throws(() => dir.close('not function'), invalidCallbackObj);
-  dir.close()
+  dir.close();
 }
 doAsyncIterInvalidCallbackTest().then(common.mustCall());
 


### PR DESCRIPTION
Two subtests in `test-fs-opendir.js` are not closing dir. Let's fix it.