### PR TITLE
fs: close dir before throwing if `options.bufferSize` is invalid

### DIFF
--- a/lib/internal/fs/dir.js
+++ b/lib/internal/fs/dir.js
@@ -59,7 +59,13 @@ class Dir {
       }),
     };
 
-    validateUint32(this.#options.bufferSize, 'options.bufferSize', true);
+    try {
+      validateUint32(this.#options.bufferSize, 'options.bufferSize', true);
+    } catch (validationError) {
+      // Userland won't be able to close handle if we throw, so we close it first
+      this.#handle.close();
+      throw validationError;
+    }
 
     this.#readPromisified = FunctionPrototypeBind(
       promisify(this.#readImpl), this, false);

--- a/test/parallel/test-fs-opendir.js
+++ b/test/parallel/test-fs-opendir.js
@@ -4,11 +4,19 @@ const common = require('../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const process = require('node:process');
 
 const tmpdir = require('../common/tmpdir');
 
 const testDir = tmpdir.path;
 const files = ['empty', 'files', 'for', 'just', 'testing'];
+
+process.on('warning', (cause) => {
+  // If any directory handle was left unclosed and then GC'd,
+  // it will emit `Warning: Closing directory handle on garbage collection`.
+  // Treat this warning as error.
+  throw new Error('Expected no warnings', { cause });
+});
 
 // Make sure tmp directory is clean
 tmpdir.refresh();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/58854

~~Test blocked on: https://github.com/nodejs/node/pull/58855~~