### PR TITLE
test: add --test-files-glob flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2868,6 +2868,20 @@ added: v22.8.0
 Require a minimum percent of covered lines. If code coverage does not reach
 the threshold specified, the process will exit with code `1`.
 
+### `--test-files-glob=glob`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+Override the default test file glob patterns. This option is ignored if
+positional `arguments` are provided as well.
+
+See [running tests from the command line][] for more information on the
+default patterns.
+
 ### `--test-force-exit`
 
 <!-- YAML
@@ -3902,6 +3916,7 @@ one is included in the list below.
 * `--test-coverage-functions`
 * `--test-coverage-include`
 * `--test-coverage-lines`
+* `--test-files-glob`
 * `--test-global-setup`
 * `--test-isolation`
 * `--test-name-pattern`

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -674,7 +674,8 @@ The Node.js test runner can be invoked from the command line by passing the
 node --test
 ```
 
-By default, Node.js will run all files matching these patterns:
+Unless overridden with the [`--test-files-glob`][] flag, by default Node.js will
+run all files matching these patterns:
 
 * `**/*.test.{cjs,mjs,js}`
 * `**/*-test.{cjs,mjs,js}`
@@ -4866,6 +4867,7 @@ test.describe('my suite', (suite) => {
 [`--test-concurrency`]: cli.md#--test-concurrency
 [`--test-coverage-exclude`]: cli.md#--test-coverage-exclude
 [`--test-coverage-include`]: cli.md#--test-coverage-include
+[`--test-files-glob`]: cli.md#--test-files-globglob
 [`--test-name-pattern`]: cli.md#--test-name-pattern
 [`--test-only`]: cli.md#--test-only
 [`--test-reporter-destination`]: cli.md#--test-reporter-destination

--- a/doc/node-config-schema.json
+++ b/doc/node-config-schema.json
@@ -548,6 +548,10 @@
               "type": "number",
               "description": "the line coverage minimum threshold"
             },
+            "test-files-glob": {
+              "type": "string",
+              "description": "run test files matching this glob pattern"
+            },
             "test-global-setup": {
               "type": "string",
               "description": "specifies the path to the global setup file"
@@ -940,6 +944,10 @@
             "test-coverage-lines": {
               "type": "number",
               "description": "the line coverage minimum threshold"
+            },
+            "test-files-glob": {
+              "type": "string",
+              "description": "run test files matching this glob pattern"
             },
             "test-force-exit": {
               "type": "boolean",

--- a/doc/node.1
+++ b/doc/node.1
@@ -1404,6 +1404,10 @@ files must meet \fBboth\fR criteria to be included in the coverage report.
 Require a minimum percent of covered lines. If code coverage does not reach
 the threshold specified, the process will exit with code \fB1\fR.
 .
+.It Fl -test-files-glob
+A glob pattern that configures the test runner to only run tests whose filename
+matches the provided glob.
+.
 .It Fl -test-force-exit
 Configures the test runner to exit the process once all known tests have
 finished executing even if the event loop would otherwise remain active.

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -149,10 +149,10 @@ class WorkerIdPool {
   }
 }
 
-function createTestFileList(patterns, cwd) {
+function createTestFileList(patterns, cwd, defaultPattern) {
   const hasUserSuppliedPattern = patterns != null;
   if (!patterns || patterns.length === 0) {
-    patterns = [kDefaultPattern];
+    patterns = [defaultPattern || kDefaultPattern];
   }
   const glob = new Glob(patterns, {
     __proto__: null,
@@ -633,7 +633,7 @@ function watchFiles(testFiles, opts) {
   // Watch for changes in current filtered files
   const onChanged = ({ owners, eventType }) => {
     if (!opts.hasFiles && (eventType === 'rename' || eventType === 'change')) {
-      const updatedTestFiles = createTestFileList(opts.globPatterns, opts.cwd);
+      const updatedTestFiles = createTestFileList(opts.globPatterns, opts.cwd, opts.testFilesGlob);
       const newFileName = ArrayPrototypeFind(updatedTestFiles, (x) => !ArrayPrototypeIncludes(testFiles, x));
       const previousFileName = ArrayPrototypeFind(testFiles, (x) => !ArrayPrototypeIncludes(updatedTestFiles, x));
 
@@ -722,6 +722,7 @@ function run(options = kEmptyObject) {
     globalSetupPath,
     only,
     globPatterns,
+    testFilesGlob,
     coverage = false,
     lineCoverage = 0,
     branchCoverage = 0,
@@ -805,6 +806,9 @@ function run(options = kEmptyObject) {
   }
   if (randomize) {
     randomSeed ??= createRandomSeed();
+  }
+  if (testFilesGlob != null) {
+    validateString(testFilesGlob, 'options.testFilesGlob');
   }
 
   validateString(cwd, 'options.cwd');
@@ -937,7 +941,7 @@ function run(options = kEmptyObject) {
   };
 
   const root = createTestTree(rootTestOptions, globalOptions);
-  let testFiles = files ?? createTestFileList(globPatterns, cwd);
+  let testFiles = files ?? createTestFileList(globPatterns, cwd, testFilesGlob);
   const { isTestRunner } = globalOptions;
 
   if (randomize) {
@@ -980,6 +984,7 @@ function run(options = kEmptyObject) {
     testSkipPatterns,
     testTagFilters,
     testTagFilterExpressions,
+    testFilesGlob,
     hasFiles: files != null,
     globPatterns,
     only,

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -255,6 +255,7 @@ function parseCommandLine() {
   const randomSeedOption = getOptionValue('--test-random-seed');
   let randomSeed;
   const rerunFailuresFilePath = getOptionValue('--test-rerun-failures');
+  const testFilesGlob = getOptionValue('--test-files-glob') || null;
   const isChildProcess = process.env.NODE_TEST_CONTEXT === 'child';
   const isChildProcessV8 = process.env.NODE_TEST_CONTEXT === 'child-v8';
   let globalSetupPath;
@@ -377,7 +378,7 @@ function parseCommandLine() {
     if (!coverageExcludeGlobs || coverageExcludeGlobs.length === 0) {
       // TODO(pmarchini): this default should follow something similar to c8 defaults
       // Default exclusions should be also exported to be used by other tools / users
-      coverageExcludeGlobs = [kDefaultPattern];
+      coverageExcludeGlobs = [testFilesGlob || kDefaultPattern];
     }
     coverageIncludeGlobs = getOptionValue('--test-coverage-include');
 
@@ -429,6 +430,7 @@ function parseCommandLine() {
     globalSetupPath,
     shard,
     sourceMaps,
+    testFilesGlob,
     testNamePatterns,
     testSkipPatterns,
     testTagFilterExpressions,

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -993,6 +993,14 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::test_name_pattern,
             kAllowedInEnvvar,
             OptionNamespaces::kTestRunnerNamespace);
+  AddOption("--test-files-glob",
+            "set the default glob pattern for matching test files (default: "
+            "'**/{test,test/**/*,test-*,*[._-]test}.{<extensions>}' where "
+            "<extensions> is 'js,mjs,cjs' or 'js,mjs,cjs,ts,mts,cts' when using"
+            " --experimental-strip-types)",
+            &EnvironmentOptions::test_files_glob,
+            kAllowedInEnvvar,
+            OptionNamespaces::kTestRunnerNamespace);
   AddOption("--test-reporter",
             "report test output using the given reporter",
             &EnvironmentOptions::test_reporter,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -207,6 +207,7 @@ class EnvironmentOptions : public Options {
   bool test_runner_module_mocks = false;
   bool test_runner_update_snapshots = false;
   std::vector<std::string> test_name_pattern;
+  std::string test_files_glob;
   std::vector<std::string> test_reporter;
   std::string test_rerun_failures_path;
   std::vector<std::string> test_reporter_destination;

--- a/test/fixtures/test-runner/custom-files-glob/index-test.cjs
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.cjs
@@ -1,0 +1,4 @@
+'use strict';
+const test = require('node:test');
+
+test('index-test.cjs should not run');

--- a/test/fixtures/test-runner/custom-files-glob/index-test.js
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.js
@@ -1,0 +1,4 @@
+'use strict';
+const test = require('node:test');
+
+test('index-test.js should not run');

--- a/test/fixtures/test-runner/custom-files-glob/index-test.mjs
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.mjs
@@ -1,0 +1,4 @@
+'use strict';
+import test from 'node:test';
+
+test('index-test.mjs should not run');

--- a/test/fixtures/test-runner/custom-files-glob/index-test.spec.cjs
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.spec.cjs
@@ -1,0 +1,4 @@
+'use strict';
+const test = require('node:test');
+
+test('index-test.spec.cjs this should pass');

--- a/test/fixtures/test-runner/custom-files-glob/index-test.spec.js
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.spec.js
@@ -1,0 +1,4 @@
+'use strict';
+const test = require('node:test');
+
+test('index-test.spec.js this should pass');

--- a/test/fixtures/test-runner/custom-files-glob/index-test.spec.mjs
+++ b/test/fixtures/test-runner/custom-files-glob/index-test.spec.mjs
@@ -1,0 +1,4 @@
+'use strict';
+import test from 'node:test';
+
+test('index-test.spec.mjs this should pass');

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.cts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.cts
@@ -1,0 +1,4 @@
+const test = require('node:test');
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.cts should not run' as string);

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.mts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.mts
@@ -1,0 +1,4 @@
+import { test } from 'node:test';
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.mts should not run' as string);

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.cts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.cts
@@ -1,0 +1,4 @@
+const test = require('node:test');
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.spec.cts this should pass' as string);

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.mts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.mts
@@ -1,0 +1,4 @@
+import { test } from 'node:test';
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.spec.mts this should pass' as string);

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.ts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.spec.ts
@@ -1,0 +1,4 @@
+const test = require('node:test');
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.spec.ts this should pass' as string);

--- a/test/fixtures/test-runner/custom-files-glob/typescript-test.ts
+++ b/test/fixtures/test-runner/custom-files-glob/typescript-test.ts
@@ -1,0 +1,4 @@
+const test = require('node:test');
+
+// 'as string' ensures that type stripping actually occurs
+test('typescript-test.ts this should pass' as string);

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -24,6 +24,21 @@ for (const isolation of ['none', 'process']) {
   }
 
   {
+    // File not found (--test-files-glob).
+    const args = [
+      '--test',
+      `--test-isolation=${isolation}`,
+      '--test-files-glob=a-random-file-that-does-not-exist.js',
+    ];
+    const child = spawnSync(process.execPath, args);
+
+    assert.strictEqual(child.status, 1);
+    assert.strictEqual(child.signal, null);
+    assert.strictEqual(child.stdout.toString(), '');
+    assert.match(child.stderr.toString(), /^Could not find/);
+  }
+
+  {
     // Default behavior. node_modules is ignored. Files that don't match the
     // pattern are ignored except in test/ directories.
     const args = ['--test', '--test-reporter=tap',
@@ -63,26 +78,99 @@ for (const isolation of ['none', 'process']) {
   }
 
   {
-    // Should match files with "-test.(c|m)(t|j)s" suffix when typescript support is enabled
-    const args = ['--test', '--test-reporter=tap', '--no-warnings',
-                  '--experimental-strip-types', `--test-isolation=${isolation}`];
-    const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'matching-patterns') });
+    // Should override default file matching (**/{test,test/**/*,test-*,*[._-]test}.{js,mjs,cjs})
+    const args = [
+      '--test',
+      '--test-reporter=tap',
+      '--test-files-glob=**/*.spec.{js,mjs,cjs}',
+      `--test-isolation=${isolation}`,
+    ];
+    const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'custom-files-glob') });
 
-    if (!process.config.variables.node_use_amaro) {
-      // e.g. Compiled with `--without-amaro`.
-      assert.strictEqual(child.status, 1);
-    } else {
-      assert.strictEqual(child.stderr.toString(), '');
-      const stdout = child.stdout.toString();
+    assert.strictEqual(child.status, 0);
+    assert.strictEqual(child.signal, null);
+    assert.strictEqual(child.stderr.toString(), '');
+    const stdout = child.stdout.toString();
+    process.stderr.write(stdout);
 
-      assert.match(stdout, /ok 1 - this should pass/);
-      assert.match(stdout, /ok 2 - this should pass/);
-      assert.match(stdout, /ok 3 - this should pass/);
-      assert.match(stdout, /ok 4 - this should pass/);
-      assert.match(stdout, /ok 5 - this should pass/);
-      assert.match(stdout, /ok 6 - this should pass/);
-      assert.strictEqual(child.status, 0);
-      assert.strictEqual(child.signal, null);
+    assert.match(stdout, /ok 1 - index-test\.spec\.cjs this should pass/);
+    assert.match(stdout, /ok 2 - index-test\.spec\.js this should pass/);
+    assert.match(stdout, /ok 3 - index-test\.spec\.mjs this should pass/);
+    assert.doesNotMatch(stdout, /ok 4 - /);
+  }
+
+  {
+    // Should ignore glob override when targeted file passed in
+    const args = [
+      '--test',
+      '--test-reporter=tap',
+      '--test-files-glob=**/*.spec.{js,mjs,cjs}',
+      `--test-isolation=${isolation}`,
+      'index-test.js',
+    ];
+    const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'custom-files-glob') });
+
+    assert.strictEqual(child.status, 0);
+    assert.strictEqual(child.signal, null);
+    assert.strictEqual(child.stderr.toString(), '');
+    const stdout = child.stdout.toString();
+    process.stderr.write(stdout);
+
+    assert.match(stdout, /ok 1 - index-test\.js should not run/);
+    assert.doesNotMatch(stdout, /ok 2 - /);
+  }
+
+  for (const type of ['strip', 'transform']) {
+    {
+      // Should match files with "-test.(c|m)(t|j)s" suffix when typescript support is enabled
+      const args = ['--test', '--test-reporter=tap', '--no-warnings',
+                    `--experimental-${type}-types`, `--test-isolation=${isolation}`];
+      const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'matching-patterns') });
+
+      if (!process.config.variables.node_use_amaro) {
+        // e.g. Compiled with `--without-amaro`.
+        assert.strictEqual(child.status, 1);
+      } else {
+        assert.strictEqual(child.stderr.toString(), '');
+        const stdout = child.stdout.toString();
+
+        assert.match(stdout, /ok 1 - this should pass/);
+        assert.match(stdout, /ok 2 - this should pass/);
+        assert.match(stdout, /ok 3 - this should pass/);
+        assert.match(stdout, /ok 4 - this should pass/);
+        assert.match(stdout, /ok 5 - this should pass/);
+        assert.match(stdout, /ok 6 - this should pass/);
+        assert.strictEqual(child.status, 0);
+        assert.strictEqual(child.signal, null);
+      }
+    }
+
+    {
+      // Should override default file matching (**/{test,test/**/*,test-*,*[._-]test}.{js,mjs,cjs,ts,mts,cts})
+      const args = [
+        '--test',
+        '--test-reporter=tap',
+        '--no-warnings',
+        '--test-files-glob=*.spec.{ts,mts,cts}',
+        `--experimental-${type}-types`,
+        `--test-isolation=${isolation}`,
+      ];
+      const child = spawnSync(process.execPath, args, { cwd: join(testFixtures, 'custom-files-glob') });
+
+      if (!process.config.variables.node_use_amaro) {
+        // e.g. Compiled with `--without-amaro`.
+        assert.strictEqual(child.status, 1);
+      } else {
+        assert.strictEqual(child.status, 0);
+        assert.strictEqual(child.signal, null);
+        assert.strictEqual(child.stderr.toString(), '');
+        const stdout = child.stdout.toString();
+
+        assert.match(stdout, /ok 1 - typescript-test\.spec\.cts this should pass/);
+        assert.match(stdout, /ok 2 - typescript-test\.spec\.mts this should pass/);
+        assert.match(stdout, /ok 3 - typescript-test\.spec\.ts this should pass/);
+        assert.doesNotMatch(stdout, /ok 4 - /);
+      }
     }
   }
 
@@ -114,6 +202,24 @@ for (const isolation of ['none', 'process']) {
       '--test',
       '--test-reporter=tap',
       `--test-isolation=${isolation}`,
+      join(testFixtures, 'index.js'),
+    ];
+    const child = spawnSync(process.execPath, args, { cwd: testFixtures });
+
+    assert.strictEqual(child.stderr.toString(), '');
+    const stdout = child.stdout.toString();
+    assert.match(stdout, /not ok 1 - .+index\.js/);
+    assert.strictEqual(child.status, 1);
+    assert.strictEqual(child.signal, null);
+  }
+
+  {
+    // User specified files that don't match the --test-files-glob are still run.
+    const args = [
+      '--test',
+      '--test-reporter=tap',
+      `--test-isolation=${isolation}`,
+      '--test-files-glob=**/{test,test/**/*,test-*,*[._-]test}.{js,mjs,cjs}',
       join(testFixtures, 'index.js'),
     ];
     const child = spawnSync(process.execPath, args, { cwd: testFixtures });

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -584,66 +584,113 @@ test('coverage with directory and file named "file"', skipIfNoInspector, () => {
   assertIncludesReport(result, 'start of coverage report');
 });
 
-test('overrides default excludes when --test-files-glob is used', skipIfNoInspector, () => {
-  const report = [
-    '# start of coverage report',
-    '# ------------------------------------------------------------------',
-    '# file              | line % | branch % | funcs % | uncovered lines',
-    '# ------------------------------------------------------------------',
-    '# test              |        |          |         | ',
-    '#  fixtures         |        |          |         | ',
-    '#   test-runner     |        |          |         | ',
-    '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
-    '#   v8-coverage     |        |          |         | ',
-    '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
-    '# ------------------------------------------------------------------',
-    '# all files         |  75.00 |    66.67 |  100.00 | ',
-    '# ------------------------------------------------------------------',
-    '# end of coverage report',
-  ].join('\n');
+test('correctly prints coverage report with --test-files-glob pattern supplied', skipIfNoInspector, async (t) => {
+  await t.test('overrides default excludes when --test-files-glob is used', () => {
+    const report = [
+      '# start of coverage report',
+      '# ------------------------------------------------------------------',
+      '# file              | line % | branch % | funcs % | uncovered lines',
+      '# ------------------------------------------------------------------',
+      '# test              |        |          |         | ',
+      '#  fixtures         |        |          |         | ',
+      '#   test-runner     |        |          |         | ',
+      '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+      '#   v8-coverage     |        |          |         | ',
+      '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+      '# ------------------------------------------------------------------',
+      '# all files         |  75.00 |    66.67 |  100.00 | ',
+      '# ------------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
 
-  const args = [
-    '--test',
-    '--experimental-test-coverage',
-    '--test-files-glob=**/test-runner/coverage.js',
-    '--test-reporter=tap',
-  ];
-  const result = spawnSync(process.execPath, args);
+    if (common.isWindows) {
+      report = report.replaceAll('/', '\\');
+    }
 
-  assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
-  assert.strictEqual(result.status, 0);
-});
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--test-files-glob=**/test-runner/coverage.js',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args);
 
-test('does not override explicit excludes when --test-files-glob is used', skipIfNoInspector, () => {
-  const report = [
-    '# start of coverage report',
-    '# --------------------------------------------------------------------------------------------',
-    '# file              | line % | branch % | funcs % | uncovered lines',
-    '# --------------------------------------------------------------------------------------------',
-    '# test              |        |          |         | ',
-    '#  fixtures         |        |          |         | ',
-    '#   test-runner     |        |          |         | ',
-    '#    coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
-    '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
-    '#   v8-coverage     |        |          |         | ',
-    '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
-    '# --------------------------------------------------------------------------------------------',
-    '# all files         |  78.35 |    43.75 |   60.00 | ',
-    '# --------------------------------------------------------------------------------------------',
-    '# end of coverage report',
-  ].join('\n');
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
 
-  const args = [
-    '--test',
-    '--experimental-test-coverage',
-    '--test-files-glob=**/test-runner/coverage.js',
-    '--test-coverage-exclude=!test/**',
-    '--test-reporter=tap',
-  ];
-  const result = spawnSync(process.execPath, args);
+  await t.test('does not override excludes when --test-files-glob is used and --test-coverage-exclude is empty', () => {
+    const report = [
+      '# start of coverage report',
+      '# --------------------------------------------------------------------------------------------',
+      '# file              | line % | branch % | funcs % | uncovered lines',
+      '# --------------------------------------------------------------------------------------------',
+      '# test              |        |          |         | ',
+      '#  fixtures         |        |          |         | ',
+      '#   test-runner     |        |          |         | ',
+      '#    coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
+      '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+      '#   v8-coverage     |        |          |         | ',
+      '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+      '# --------------------------------------------------------------------------------------------',
+      '# all files         |  78.35 |    43.75 |   60.00 | ',
+      '# --------------------------------------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
 
-  assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
-  assert.strictEqual(result.status, 0);
+    if (common.isWindows) {
+      report = report.replaceAll('/', '\\');
+    }
+
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--test-files-glob=**/test-runner/coverage.js',
+      '--test-coverage-exclude=""',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args);
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
+
+  await t.test('does not override excludes when --test-files-glob and --test-coverage-exclude are used', () => {
+    const report = [
+      '# start of coverage report',
+      '# --------------------------------------------------------------------------------------------',
+      '# file              | line % | branch % | funcs % | uncovered lines',
+      '# --------------------------------------------------------------------------------------------',
+      '# test              |        |          |         | ',
+      '#  fixtures         |        |          |         | ',
+      '#   test-runner     |        |          |         | ',
+      '#    coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
+      '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+      '#   v8-coverage     |        |          |         | ',
+      '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+      '# --------------------------------------------------------------------------------------------',
+      '# all files         |  78.35 |    43.75 |   60.00 | ',
+      '# --------------------------------------------------------------------------------------------',
+      '# end of coverage report',
+    ].join('\n');
+
+    if (common.isWindows) {
+      report = report.replaceAll('/', '\\');
+    }
+
+    const args = [
+      '--test',
+      '--experimental-test-coverage',
+      '--test-files-glob=**/test-runner/coverage.js',
+      '--test-coverage-exclude=!test/**',
+      '--test-reporter=tap',
+    ];
+    const result = spawnSync(process.execPath, args);
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assert(result.stdout.toString().includes(report));
+    assert.strictEqual(result.status, 0);
+  });
 });

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -583,3 +583,67 @@ test('coverage with directory and file named "file"', skipIfNoInspector, () => {
   assert.strictEqual(result.status, 0);
   assertIncludesReport(result, 'start of coverage report');
 });
+
+test('overrides default excludes when --test-files-glob is used', skipIfNoInspector, () => {
+  const report = [
+    '# start of coverage report',
+    '# ------------------------------------------------------------------',
+    '# file              | line % | branch % | funcs % | uncovered lines',
+    '# ------------------------------------------------------------------',
+    '# test              |        |          |         | ',
+    '#  fixtures         |        |          |         | ',
+    '#   test-runner     |        |          |         | ',
+    '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+    '#   v8-coverage     |        |          |         | ',
+    '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+    '# ------------------------------------------------------------------',
+    '# all files         |  75.00 |    66.67 |  100.00 | ',
+    '# ------------------------------------------------------------------',
+    '# end of coverage report',
+  ].join('\n');
+
+  const args = [
+    '--test',
+    '--experimental-test-coverage',
+    '--test-files-glob=**/test-runner/coverage.js',
+    '--test-reporter=tap',
+  ];
+  const result = spawnSync(process.execPath, args);
+
+  assert.strictEqual(result.stderr.toString(), '');
+  assert(result.stdout.toString().includes(report));
+  assert.strictEqual(result.status, 0);
+});
+
+test('does not override explicit excludes when --test-files-glob is used', skipIfNoInspector, () => {
+  const report = [
+    '# start of coverage report',
+    '# --------------------------------------------------------------------------------------------',
+    '# file              | line % | branch % | funcs % | uncovered lines',
+    '# --------------------------------------------------------------------------------------------',
+    '# test              |        |          |         | ',
+    '#  fixtures         |        |          |         | ',
+    '#   test-runner     |        |          |         | ',
+    '#    coverage.js    |  78.65 |    38.46 |   60.00 | 12-13 16-22 27 39 43-44 61-62 66-67 71-72',
+    '#    invalid-tap.js | 100.00 |   100.00 |  100.00 | ',
+    '#   v8-coverage     |        |          |         | ',
+    '#    throw.js       |  71.43 |    50.00 |  100.00 | 5-6',
+    '# --------------------------------------------------------------------------------------------',
+    '# all files         |  78.35 |    43.75 |   60.00 | ',
+    '# --------------------------------------------------------------------------------------------',
+    '# end of coverage report',
+  ].join('\n');
+
+  const args = [
+    '--test',
+    '--experimental-test-coverage',
+    '--test-files-glob=**/test-runner/coverage.js',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter=tap',
+  ];
+  const result = spawnSync(process.execPath, args);
+
+  assert.strictEqual(result.stderr.toString(), '');
+  assert(result.stdout.toString().includes(report));
+  assert.strictEqual(result.status, 0);
+});


### PR DESCRIPTION
test: add --test-files-glob flag

Overrides the default `kDefaultPattern` for test file globs to allow for
default file pattern matching, while still allowing other options or
single, targeted file names for testing.

This also might resolve issues with the defaults when using strip-types
since the defaults can, currently, only be overridden using the positional
`arguments` (see #56546).

Fixes: #51384
Ref: #56546

I believe this is a notable-change, I'll leave that up the reviewers though.

I also [considered modifying the arg parser](https://github.com/nodejs/node/issues/51384#issuecomment-2994199816) when the `--test` flag is present to continue parsing options that come after positionals.
I think it's still (maybe) a decent solution (even if it behaves differently than other commands) since the test positionals are globs instead of files (like most other commands).

Happy to cleanup and push that up alternatively if that's preferred, or try something else if neither work - would like to resolve the current issues so that the default runner is a drop-in replacement for everything else.

Also note: still getting https://github.com/nodejs/node/issues/44003 locally, I believe the solution is to enable another interface but I didn't dig too far into it, admittedly.

```
Failed tests:
out/Release/node --expose-internals --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/patrickmcgowan/source/p-mcgowan/node/test/parallel/test-http2-invalid-last-stream-id.js
out/Release/node --expose-internals --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/patrickmcgowan/source/p-mcgowan/node/test/parallel/test-http2-premature-close.js
out/Release/node --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/patrickmcgowan/source/p-mcgowan/node/test/parallel/test-net-socket-connect-without-cb.js
out/Release/node --expose-internals --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/patrickmcgowan/source/p-mcgowan/node/test/parallel/test-tcp-wrap-listen.js
make[1]: *** [Makefile:315: jstest] Error 1
make: *** [Makefile:342: test] Error 2
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
