### PR TITLE
test: remove reliance on in-tree `deps/undici`

### DIFF
--- a/test/parallel/test-inspector-network-fetch.js
+++ b/test/parallel/test-inspector-network-fetch.js
@@ -1,4 +1,4 @@
-// Flags: --inspect=0 --experimental-network-inspection
+// Flags: --inspect=0 --experimental-network-inspection --expose-internals
 'use strict';
 const common = require('../common');
 
@@ -12,8 +12,8 @@ const https = require('node:https');
 const inspector = require('node:inspector/promises');
 
 // Disable certificate validation for the global fetch.
-const undici = require('../../deps/undici/src/index.js');
-undici.setGlobalDispatcher(new undici.Agent({
+const undici = require('internal/deps/undici/undici');
+undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({
   connect: {
     rejectUnauthorized: false,
   },


### PR DESCRIPTION
Remove the dependency on the in-tree copy of Undici in `deps/undici` from `parallel/test-inspector-network-fetch`. For downstream rebuilders of Node.js using an externalized Undici it is not uncommon to remove `deps/undici` to ensure that the build is not using the in-tree copy.

Refs: https://github.com/nodejs/node/issues/58865

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
