### PR TITLE
Add support to print help/usage of util.parseArgs

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1994,7 +1994,7 @@ changes:
   - version:
     - REPLACEME
     pr-url: https://github.com/nodejs/node/pull/58875
-    description: Add support for help text in options and enableHelpPrinting config.
+    description: Add support for help text in options and general help text.
   - version:
     - v22.4.0
     - v20.16.0
@@ -2058,8 +2058,8 @@ changes:
   * `positionals` {string\[]} Positional arguments.
   * `tokens` {Object\[] | undefined} See [parseArgs tokens](#parseargs-tokens)
     section. Only returned if `config` includes `tokens: true`.
-  * `printUsage` {string | undefined} Formatted help text for options that have
-    help text configured. Only included if help text is available and `enableHelpPrinting` is `false`.
+  * `printUsage` {string | undefined} Formatted help text for all options provided. Only included if general `help` text
+    is available.
 
 Provides a higher level API for command-line argument parsing than interacting
 with `process.argv` directly. Takes a specification for the expected arguments
@@ -2107,11 +2107,9 @@ console.log(values, positionals);
 
 ### `parseArgs` help text
 
-`parseArgs` supports automatic help text generation for command-line options. To use this feature, add a `help`
-property to each option and optionally provide general help text using the `help` config property.
-
-When both general help text is provided and `--help` is present in the `args`, `parseArgs`
-will automatically print the help message and exit with code 0.
+`parseArgs` supports automatic formatted help text generation for command-line options. To use this feature, provide
+general help text using the `help` config property, and also
+add a `help` property to each option can be optionally included.
 
 ```mjs
 import { parseArgs } from 'node:util';
@@ -2120,7 +2118,6 @@ const options = {
   verbose: {
     type: 'boolean',
     short: 'v',
-    help: 'Enable verbose output',
   },
   help: {
     type: 'boolean',
@@ -2145,26 +2142,10 @@ if (result.printUsage) {
   // My CLI Tool v1.0
   //
   // Process files with various options.
-  // -v, --verbose             Enable verbose output
+  // -v, --verbose
   // -h, --help.               Prints command line options
   // --output <arg>            Output directory
 }
-
-// Or automatically print help and exit
-const args = ['-h'];
-parseArgs({
-  args,
-  options,
-  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
-});
-// Prints:
-// My CLI Tool v1.0
-//
-// Process files with various options.
-// -v, --verbose             Enable verbose output
-// -h, --help.               Prints command line options
-// --output <arg>            Output directory
-// exit with code 0
 ```
 
 ```cjs
@@ -2174,7 +2155,6 @@ const options = {
   verbose: {
     type: 'boolean',
     short: 'v',
-    help: 'Enable verbose output',
   },
   help: {
     type: 'boolean',
@@ -2199,26 +2179,10 @@ if (result.printUsage) {
   // My CLI Tool v1.0
   //
   // Process files with various options.
-  // -v, --verbose             Enable verbose output
+  // -v, --verbose
   // -h, --help.               Prints command line options
   // --output <arg>            Output directory
 }
-
-// Or automatically print help and exit
-const args = ['-h'];
-parseArgs({
-  args,
-  options,
-  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
-});
-// Prints:
-// My CLI Tool v1.0
-//
-// Process files with various options.
-// -v, --verbose             Enable verbose output
-// -h, --help.               Prints command line options
-// --output <arg>            Output directory
-// exit with code 0
 ```
 
 ### `parseArgs` `tokens`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2055,11 +2055,11 @@ changes:
 * Returns: {Object} The parsed command line arguments:
   * `values` {Object} A mapping of parsed option names with their {string}
     or {boolean} values.
+    * `help` {string | undefined} Formatted help text for all options provided. Only included if general `help` text
+      is available.
   * `positionals` {string\[]} Positional arguments.
   * `tokens` {Object\[] | undefined} See [parseArgs tokens](#parseargs-tokens)
     section. Only returned if `config` includes `tokens: true`.
-  * `printUsage` {string | undefined} Formatted help text for all options provided. Only included if general `help` text
-    is available.
 
 Provides a higher level API for command-line argument parsing than interacting
 with `process.argv` directly. Takes a specification for the expected arguments
@@ -2109,7 +2109,7 @@ console.log(values, positionals);
 
 `parseArgs` supports automatic formatted help text generation for command-line options. To use this feature, provide
 general help text using the `help` config property, and also
-add a `help` property to each option can be optionally included.
+a `help` property to each option can be optionally included.
 
 ```mjs
 import { parseArgs } from 'node:util';

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2122,7 +2122,7 @@ const options = {
   help: {
     type: 'boolean',
     short: 'h',
-    help: 'Prints command line options',
+    help: 'Prints usage information',
   },
   output: {
     type: 'string',

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2061,7 +2061,7 @@ changes:
   * `positionals` {string\[]} Positional arguments.
   * `tokens` {Object\[] | undefined} See [parseArgs tokens](#parseargs-tokens)
     section. Only returned if `config` includes `tokens: true`.
-  * `printUsage` {string\[] | undefined} Formatted help text for options that have
+  * `printUsage` {string | undefined} Formatted help text for options that have
     help text configured. Only included if help text is available and `enableHelpPrinting` is `false`.
 
 Provides a higher level API for command-line argument parsing than interacting

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2051,9 +2051,6 @@ changes:
     the tokens in different ways.
     **Default:** `false`.
   * `help` {string} General help text to display at the beginning of help output.
-  * `enableHelpPrinting` {boolean} When `true`, if any options have help text
-    configured and a `--help` entry was provided, the help will be printed to stdout and the process will exit
-    with code 0. **Default:** `false`.
 
 * Returns: {Object} The parsed command line arguments:
   * `values` {Object} A mapping of parsed option names with their {string}
@@ -2110,9 +2107,11 @@ console.log(values, positionals);
 
 ### `parseArgs` help text
 
-`parseArgs` can generate and display help text for command-line options. To enable
-this functionality, add `help` text to individual options and optionally provide
-general help text via the `help` config property.
+`parseArgs` supports automatic help text generation for command-line options. To use this feature, add a `help`
+property to each option and optionally provide general help text using the `help` config property.
+
+When both general help text is provided and `--help` is present in the `args`, `parseArgs`
+will automatically print the help message and exit with code 0.
 
 ```mjs
 import { parseArgs } from 'node:util';
@@ -2152,12 +2151,20 @@ if (result.printUsage) {
 }
 
 // Or automatically print help and exit
+const args = ['-h'];
 parseArgs({
+  args,
   options,
   help: 'My CLI Tool v1.0\n\nProcess files with various options.',
-  enableHelpPrinting: true,
 });
-// Prints help and exits with code 0
+// Prints:
+// My CLI Tool v1.0
+//
+// Process files with various options.
+// -v, --verbose             Enable verbose output
+// -h, --help.               Prints command line options
+// --output <arg>            Output directory
+// exit with code 0
 ```
 
 ```cjs
@@ -2180,7 +2187,7 @@ const options = {
   },
 };
 
-// Get help text in result
+// Get serialized help text in result
 const result = parseArgs({
   options,
   help: 'My CLI Tool v1.0\n\nProcess files with various options.',
@@ -2198,12 +2205,20 @@ if (result.printUsage) {
 }
 
 // Or automatically print help and exit
+const args = ['-h'];
 parseArgs({
+  args,
   options,
   help: 'My CLI Tool v1.0\n\nProcess files with various options.',
-  enableHelpPrinting: true,
 });
-// Prints help and exits with code 0
+// Prints:
+// My CLI Tool v1.0
+//
+// Process files with various options.
+// -v, --verbose             Enable verbose output
+// -h, --help.               Prints command line options
+// --output <arg>            Output directory
+// exit with code 0
 ```
 
 ### `parseArgs` `tokens`

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1993,7 +1993,7 @@ added:
 changes:
   - version:
     - REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/000000
+    pr-url: https://github.com/nodejs/node/pull/58875
     description: Add support for help text in options and enableHelpPrinting config.
   - version:
     - v22.4.0
@@ -2147,8 +2147,8 @@ if (result.printUsage) {
   //
   // Process files with various options.
   // -v, --verbose             Enable verbose output
-  // -f, --file <arg>          Input file path
-  //     --output <arg>        Output directory
+  // -f, --file <arg>           Input file path
+  // --output <arg>            Output directory
 }
 
 // Or automatically print help and exit
@@ -2193,8 +2193,8 @@ if (result.printUsage) {
   //
   // Process files with various options.
   // -v, --verbose             Enable verbose output
-  // -f, --file <arg>          Input file path
-  //     --output <arg>        Output directory
+  // -f, --file <arg>           Input file path
+  // --output <arg>            Output directory
 }
 
 // Or automatically print help and exit

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2052,7 +2052,7 @@ changes:
     **Default:** `false`.
   * `help` {string} General help text to display at the beginning of help output.
   * `enableHelpPrinting` {boolean} When `true`, if any options have help text
-    configured, the help will be printed to stdout and the process will exit
+    configured and a `--help` entry was provided, the help will be printed to stdout and the process will exit
     with code 0. **Default:** `false`.
 
 * Returns: {Object} The parsed command line arguments:
@@ -2123,10 +2123,10 @@ const options = {
     short: 'v',
     help: 'Enable verbose output',
   },
-  file: {
-    type: 'string',
-    short: 'f',
-    help: 'Input file path',
+  help: {
+    type: 'boolean',
+    short: 'h',
+    help: 'Prints command line options',
   },
   output: {
     type: 'string',
@@ -2134,20 +2134,20 @@ const options = {
   },
 };
 
-// Get help text in result
+// Get serialized help text in result
 const result = parseArgs({
   options,
   help: 'My CLI Tool v1.0\n\nProcess files with various options.',
 });
 
 if (result.printUsage) {
-  console.log(result.printUsage.join('\n'));
+  console.log(result.printUsage);
   // Prints:
   // My CLI Tool v1.0
   //
   // Process files with various options.
   // -v, --verbose             Enable verbose output
-  // -f, --file <arg>           Input file path
+  // -h, --help.               Prints command line options
   // --output <arg>            Output directory
 }
 
@@ -2169,10 +2169,10 @@ const options = {
     short: 'v',
     help: 'Enable verbose output',
   },
-  file: {
-    type: 'string',
-    short: 'f',
-    help: 'Input file path',
+  help: {
+    type: 'boolean',
+    short: 'h',
+    help: 'Prints command line options',
   },
   output: {
     type: 'string',
@@ -2187,13 +2187,13 @@ const result = parseArgs({
 });
 
 if (result.printUsage) {
-  console.log(result.printUsage.join('\n'));
+  console.log(result.printUsage);
   // Prints:
   // My CLI Tool v1.0
   //
   // Process files with various options.
   // -v, --verbose             Enable verbose output
-  // -f, --file <arg>           Input file path
+  // -h, --help.               Prints command line options
   // --output <arg>            Output directory
 }
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2051,19 +2051,12 @@ changes:
     the tokens in different ways.
     **Default:** `false`.
   * `help` {string} General help text to display at the beginning of help output.
-  * `addHelpOption` {boolean} Whether to automatically add a help option to the
-    options if general help text is provided and no existing help option is defined.
-    The auto-added help option uses `-h` short flag and `--help` long flag.
-    **Default:** `true` if `help` is provided, `false` otherwise.
-  * `returnHelpText` {boolean} Whether to return formatted help text in the result.
-    **Default:** `true` if `help` is provided or `addHelpOption` is `true`, `false` otherwise.
 
 * Returns: {Object} The parsed command line arguments:
   * `values` {Object} A mapping of parsed option names with their {string}
     or {boolean} values.
   * `positionals` {string\[]} Positional arguments.
   * `helpText` {string | undefined} Formatted help text for all options provided.
-    Only included if `returnHelpText` is `true`.
   * `tokens` {Object\[] | undefined} See [parseArgs tokens](#parseargs-tokens)
     section. Only returned if `config` includes `tokens: true`.
 
@@ -2114,7 +2107,7 @@ console.log(values, positionals);
 ### `parseArgs` help text
 
 `parseArgs` supports automatic formatted help text generation for command-line options. When
-general help text is provided, a help option is automatically added unless disabled or already present.
+general help text is provided, a help option is automatically added unless already present.
 
 #### Simple usage
 
@@ -2187,72 +2180,6 @@ if (result.values.help) {
   // -f, --foo                     use the foo filter
   // --bar <arg>                   use the specified bar filter
   // -?, --help                    display help
-}
-```
-
-#### Advanced configuration
-
-Use `addHelpOption` and `returnHelpText` to customize help behavior:
-
-```mjs
-import { parseArgs } from 'node:util';
-
-const options = {
-  foo: {
-    type: 'boolean',
-    short: 'f',
-    help: 'use the foo filter',
-  },
-  assist: {
-    type: 'boolean',
-    short: '?',
-    help: 'display help',
-  },
-};
-
-const result = parseArgs({
-  addHelpOption: false, // Suppress auto help option
-  returnHelpText: true, // Generate help text anyway
-  options,
-});
-
-if (result.values.assist) {
-  console.log(result.helpText);
-  // Prints:
-  // -f, --foo                     use the foo filter
-  // -?, --assist                  display help
-}
-```
-
-#### Deferred help generation
-
-For performance, you can postpone help text generation until needed:
-
-```mjs
-import { parseArgs } from 'node:util';
-
-const options = {
-  foo: {
-    type: 'boolean',
-    short: 'f',
-    help: 'use the foo filter',
-  },
-};
-
-// First parse without generating help text
-const result = parseArgs({
-  addHelpOption: true,
-  returnHelpText: false,
-  options,
-});
-
-if (result.values.help) {
-  // Generate help text only when needed
-  const { helpText } = parseArgs({
-    help: 'utility to control filters',
-    options,
-  });
-  console.log(helpText);
 }
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1992,6 +1992,10 @@ added:
   - v16.17.0
 changes:
   - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/000000
+    description: Add support for help text in options and enableHelpPrinting config.
+  - version:
     - v22.4.0
     - v20.16.0
     pr-url: https://github.com/nodejs/node/pull/53107
@@ -2031,6 +2035,7 @@ changes:
       `true`, it must be an array. No default value is applied when the option
       does appear in the arguments to be parsed, even if the provided value
       is falsy.
+    * `help` {string} Descriptive text to display in help output for this option.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.
@@ -2045,6 +2050,10 @@ changes:
     the built-in behavior, from adding additional checks through to reprocessing
     the tokens in different ways.
     **Default:** `false`.
+  * `help` {string} General help text to display at the beginning of help output.
+  * `enableHelpPrinting` {boolean} When `true`, if any options have help text
+    configured, the help will be printed to stdout and the process will exit
+    with code 0. **Default:** `false`.
 
 * Returns: {Object} The parsed command line arguments:
   * `values` {Object} A mapping of parsed option names with their {string}
@@ -2052,6 +2061,8 @@ changes:
   * `positionals` {string\[]} Positional arguments.
   * `tokens` {Object\[] | undefined} See [parseArgs tokens](#parseargs-tokens)
     section. Only returned if `config` includes `tokens: true`.
+  * `printUsage` {string\[] | undefined} Formatted help text for options that have
+    help text configured. Only included if help text is available and `enableHelpPrinting` is `false`.
 
 Provides a higher level API for command-line argument parsing than interacting
 with `process.argv` directly. Takes a specification for the expected arguments
@@ -2095,6 +2106,104 @@ const {
 } = parseArgs({ args, options });
 console.log(values, positionals);
 // Prints: [Object: null prototype] { foo: true, bar: 'b' } []
+```
+
+### `parseArgs` help text
+
+`parseArgs` can generate and display help text for command-line options. To enable
+this functionality, add `help` text to individual options and optionally provide
+general help text via the `help` config property.
+
+```mjs
+import { parseArgs } from 'node:util';
+
+const options = {
+  verbose: {
+    type: 'boolean',
+    short: 'v',
+    help: 'Enable verbose output',
+  },
+  file: {
+    type: 'string',
+    short: 'f',
+    help: 'Input file path',
+  },
+  output: {
+    type: 'string',
+    help: 'Output directory',
+  },
+};
+
+// Get help text in result
+const result = parseArgs({
+  options,
+  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
+});
+
+if (result.printUsage) {
+  console.log(result.printUsage.join('\n'));
+  // Prints:
+  // My CLI Tool v1.0
+  //
+  // Process files with various options.
+  // -v, --verbose             Enable verbose output
+  // -f, --file <arg>          Input file path
+  //     --output <arg>        Output directory
+}
+
+// Or automatically print help and exit
+parseArgs({
+  options,
+  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
+  enableHelpPrinting: true,
+});
+// Prints help and exits with code 0
+```
+
+```cjs
+const { parseArgs } = require('node:util');
+
+const options = {
+  verbose: {
+    type: 'boolean',
+    short: 'v',
+    help: 'Enable verbose output',
+  },
+  file: {
+    type: 'string',
+    short: 'f',
+    help: 'Input file path',
+  },
+  output: {
+    type: 'string',
+    help: 'Output directory',
+  },
+};
+
+// Get help text in result
+const result = parseArgs({
+  options,
+  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
+});
+
+if (result.printUsage) {
+  console.log(result.printUsage.join('\n'));
+  // Prints:
+  // My CLI Tool v1.0
+  //
+  // Process files with various options.
+  // -v, --verbose             Enable verbose output
+  // -f, --file <arg>          Input file path
+  //     --output <arg>        Output directory
+}
+
+// Or automatically print help and exit
+parseArgs({
+  options,
+  help: 'My CLI Tool v1.0\n\nProcess files with various options.',
+  enableHelpPrinting: true,
+});
+// Prints help and exits with code 0
 ```
 
 ### `parseArgs` `tokens`

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -28,7 +28,6 @@ const {
 } = require('internal/validators');
 
 const {
-  findHelpValueForOption,
   findLongOptionForShort,
   isLoneLongOption,
   isLoneShortOption,
@@ -220,7 +219,6 @@ function argsToTokens(args, options) {
       // e.g. '-f'
       const shortOption = StringPrototypeCharAt(arg, 1);
       const longOption = findLongOptionForShort(shortOption, options);
-      const helpValue = findHelpValueForOption(longOption, options);
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
@@ -232,7 +230,7 @@ function argsToTokens(args, options) {
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue, ...(helpValue !== undefined && { help: helpValue }) });
+          index, value, inlineValue });
       if (value != null) ++index;
       continue;
     }
@@ -264,19 +262,16 @@ function argsToTokens(args, options) {
       const shortOption = StringPrototypeCharAt(arg, 1);
       const longOption = findLongOptionForShort(shortOption, options);
       const value = StringPrototypeSlice(arg, 2);
-      const helpValue = findHelpValueForOption(longOption, options);
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: `-${shortOption}`,
-          index, value, inlineValue: true,
-          ...(helpValue !== undefined && { help: helpValue }) });
+          index, value, inlineValue: true });
       continue;
     }
 
     if (isLoneLongOption(arg)) {
       // e.g. '--foo'
       const longOption = StringPrototypeSlice(arg, 2);
-      const helpValue = findHelpValueForOption(longOption, options);
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
@@ -288,7 +283,7 @@ function argsToTokens(args, options) {
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue, ...(helpValue !== undefined && { help: helpValue }) });
+          index, value, inlineValue });
       if (value != null) ++index;
       continue;
     }
@@ -298,11 +293,10 @@ function argsToTokens(args, options) {
       const equalIndex = StringPrototypeIndexOf(arg, '=');
       const longOption = StringPrototypeSlice(arg, 2, equalIndex);
       const value = StringPrototypeSlice(arg, equalIndex + 1);
-      const helpValue = findHelpValueForOption(longOption, options);
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: `--${longOption}`,
-          index, value, inlineValue: true, ...(helpValue !== undefined && { help: helpValue }) });
+          index, value, inlineValue: true });
       continue;
     }
 
@@ -456,24 +450,26 @@ const parseArgs = (config = kEmptyObject) => {
   });
 
   // Phase 4: generate print usage for each option
-  const printUsage = [];
+  let printUsage = '';
   if (help) {
-    ArrayPrototypePush(printUsage, help);
+    printUsage += help;
   }
   ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
     const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
 
     if (helpTextForPrint) {
-      ArrayPrototypePush(printUsage, helpTextForPrint);
+      if (printUsage.length > 0) {
+        printUsage += '\n';
+      }
+      printUsage += helpTextForPrint;
     }
   });
 
-  if (enableHelpPrinting) {
+  const helpRequested = result.values.help;
+  if (enableHelpPrinting && helpRequested) {
     const console = require('internal/console/global');
     if (printUsage.length > 0 || help) {
-      ArrayPrototypeForEach(printUsage, (line) => {
-        console.log(line);
-      });
+      console.log(printUsage);
     } else {
       console.log('No help text available.');
     }

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -350,7 +350,6 @@ const parseArgs = (config = kEmptyObject) => {
   const allowNegative = objectGetOwn(config, 'allowNegative') ?? false;
   const options = objectGetOwn(config, 'options') ?? { __proto__: null };
   const help = objectGetOwn(config, 'help') ?? '';
-  const enableHelpPrinting = objectGetOwn(config, 'enableHelpPrinting') ?? false;
   // Bundle these up for passing to strict-mode checks.
   const parseConfig = { args, strict, options, allowPositionals, allowNegative };
 
@@ -362,7 +361,6 @@ const parseArgs = (config = kEmptyObject) => {
   validateBoolean(allowNegative, 'allowNegative');
   validateObject(options, 'options');
   validateString(help, 'help');
-  validateBoolean(enableHelpPrinting, 'enableHelpPrinting');
   ArrayPrototypeForEach(
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
@@ -466,12 +464,10 @@ const parseArgs = (config = kEmptyObject) => {
   });
 
   const helpRequested = result.values.help;
-  if (enableHelpPrinting && helpRequested) {
+  if (help && helpRequested) {
     const console = require('internal/console/global');
-    if (printUsage.length > 0 || help) {
+    if (printUsage.length > 0) {
       console.log(printUsage);
-    } else {
-      console.log('No help text available.');
     }
     process.exit(0);
   } else if (printUsage.length > 0) {

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -28,6 +28,7 @@ const {
 } = require('internal/validators');
 
 const {
+  findHelpValueForOption,
   findLongOptionForShort,
   isLoneLongOption,
   isLoneShortOption,
@@ -219,6 +220,7 @@ function argsToTokens(args, options) {
       // e.g. '-f'
       const shortOption = StringPrototypeCharAt(arg, 1);
       const longOption = findLongOptionForShort(shortOption, options);
+      const helpValue = findHelpValueForOption(longOption, options);
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
@@ -230,7 +232,7 @@ function argsToTokens(args, options) {
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue });
+          index, value, inlineValue, ...(helpValue !== undefined && { help: helpValue }) });
       if (value != null) ++index;
       continue;
     }
@@ -262,16 +264,19 @@ function argsToTokens(args, options) {
       const shortOption = StringPrototypeCharAt(arg, 1);
       const longOption = findLongOptionForShort(shortOption, options);
       const value = StringPrototypeSlice(arg, 2);
+      const helpValue = findHelpValueForOption(longOption, options);
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: `-${shortOption}`,
-          index, value, inlineValue: true });
+          index, value, inlineValue: true,
+          ...(helpValue !== undefined && { help: helpValue }) });
       continue;
     }
 
     if (isLoneLongOption(arg)) {
       // e.g. '--foo'
       const longOption = StringPrototypeSlice(arg, 2);
+      const helpValue = findHelpValueForOption(longOption, options);
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
@@ -283,7 +288,7 @@ function argsToTokens(args, options) {
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue });
+          index, value, inlineValue, ...(helpValue !== undefined && { help: helpValue }) });
       if (value != null) ++index;
       continue;
     }
@@ -293,10 +298,11 @@ function argsToTokens(args, options) {
       const equalIndex = StringPrototypeIndexOf(arg, '=');
       const longOption = StringPrototypeSlice(arg, 2, equalIndex);
       const value = StringPrototypeSlice(arg, equalIndex + 1);
+      const helpValue = findHelpValueForOption(longOption, options);
       ArrayPrototypePush(
         tokens,
         { kind: 'option', name: longOption, rawName: `--${longOption}`,
-          index, value, inlineValue: true });
+          index, value, inlineValue: true, ...(helpValue !== undefined && { help: helpValue }) });
       continue;
     }
 
@@ -326,7 +332,6 @@ const parseArgs = (config = kEmptyObject) => {
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
       validateObject(optionConfig, `options.${longOption}`);
-
       // type is required
       const optionType = objectGetOwn(optionConfig, 'type');
       validateUnion(optionType, `options.${longOption}.type`, ['string', 'boolean']);
@@ -361,6 +366,11 @@ const parseArgs = (config = kEmptyObject) => {
             break;
         }
         validator(defaultValue, `options.${longOption}.default`);
+      }
+
+      const helpOption = objectGetOwn(optionConfig, 'help');
+      if (ObjectHasOwn(optionConfig, 'help')) {
+        validateString(helpOption, `options.${longOption}.help`);
       }
     },
   );
@@ -404,6 +414,34 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
+  const usage = [];
+  ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
+    const shortOption = objectGetOwn(optionConfig, 'short');
+    const type = objectGetOwn(optionConfig, 'type');
+    const help = objectGetOwn(optionConfig, 'help');
+
+    let usageLine = '';
+    if (help) {
+      if (shortOption) {
+        usageLine += `-${shortOption}, `;
+      }
+      usageLine += `--${longOption}`;
+      if (type === 'string') {
+        usageLine += ' <arg>';
+      } else if (type === 'boolean') {
+        usageLine += '';
+      }
+      usageLine = usageLine.padEnd(30) + help;
+    }
+
+    if (usageLine) {
+      ArrayPrototypePush(usage, usageLine);
+    }
+  });
+
+  if (usage.length > 0) {
+    result.usage = usage;
+  }
 
   return result;
 };

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -321,6 +321,8 @@ function argsToTokens(args, options) {
  * // returns '--foo <arg>                   help text'
  */
 function formatHelpTextForPrint(longOption, optionConfig) {
+  const layoutSpacing = 30;
+
   const shortOption = objectGetOwn(optionConfig, 'short');
   const type = objectGetOwn(optionConfig, 'type');
   const help = objectGetOwn(optionConfig, 'help');
@@ -336,7 +338,11 @@ function formatHelpTextForPrint(longOption, optionConfig) {
     } else if (type === 'boolean') {
       helpTextForPrint += '';
     }
-    helpTextForPrint = helpTextForPrint.padEnd(30) + help;
+    if (helpTextForPrint.length > layoutSpacing) {
+      helpTextForPrint += '\n' + ''.padEnd(layoutSpacing) + help;
+    } else {
+      helpTextForPrint = helpTextForPrint.padEnd(layoutSpacing) + help;
+    }
   }
 
   return helpTextForPrint;
@@ -350,6 +356,7 @@ const parseArgs = (config = kEmptyObject) => {
   const allowNegative = objectGetOwn(config, 'allowNegative') ?? false;
   const options = objectGetOwn(config, 'options') ?? { __proto__: null };
   const help = objectGetOwn(config, 'help') ?? '';
+  const enableHelpPrinting = objectGetOwn(config, 'enableHelpPrinting') ?? false;
   // Bundle these up for passing to strict-mode checks.
   const parseConfig = { args, strict, options, allowPositionals, allowNegative };
 
@@ -361,6 +368,7 @@ const parseArgs = (config = kEmptyObject) => {
   validateBoolean(allowNegative, 'allowNegative');
   validateObject(options, 'options');
   validateString(help, 'help');
+  validateBoolean(enableHelpPrinting, 'enableHelpPrinting');
   ArrayPrototypeForEach(
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
@@ -460,7 +468,14 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
-  if (printUsage.length > 0) {
+  if (enableHelpPrinting && printUsage.length > 0) {
+    const console = require('internal/console/global');
+    ArrayPrototypeForEach(printUsage, (line) => {
+      console.log(line);
+    });
+
+    process.exit(0);
+  } else if (printUsage.length > 0) {
     result.printUsage = printUsage;
   }
 

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -348,8 +348,25 @@ const parseArgs = (config = kEmptyObject) => {
   const allowPositionals = objectGetOwn(config, 'allowPositionals') ?? !strict;
   const returnTokens = objectGetOwn(config, 'tokens') ?? false;
   const allowNegative = objectGetOwn(config, 'allowNegative') ?? false;
-  const options = objectGetOwn(config, 'options') ?? { __proto__: null };
+  let options = objectGetOwn(config, 'options') ?? { __proto__: null };
   const help = objectGetOwn(config, 'help') ?? '';
+
+  const hasGenerateHelp = help.length > 0;
+  const addHelpOption = objectGetOwn(config, 'addHelpOption') ?? hasGenerateHelp;
+  const returnHelpText = objectGetOwn(config, 'returnHelpText') ?? (hasGenerateHelp || addHelpOption);
+
+  // Auto-inject help option if requested and not already present
+  if (addHelpOption && !ObjectHasOwn(options, 'help')) {
+    options = {
+      ...options,
+      __proto__: null,
+      help: {
+        type: 'boolean',
+        short: 'h',
+        help: 'Show help',
+      },
+    };
+  }
   // Bundle these up for passing to strict-mode checks.
   const parseConfig = { args, strict, options, allowPositionals, allowNegative };
 
@@ -361,6 +378,8 @@ const parseArgs = (config = kEmptyObject) => {
   validateBoolean(allowNegative, 'allowNegative');
   validateObject(options, 'options');
   validateString(help, 'help');
+  validateBoolean(addHelpOption, 'addHelpOption');
+  validateBoolean(returnHelpText, 'returnHelpText');
   ArrayPrototypeForEach(
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
@@ -447,22 +466,24 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
-  // Phase 4: generate print usage for each option
-  let printUsage = '';
-  if (help) {
-    printUsage += help;
-  }
-  ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
-    const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
+  // Phase 4: generate print usage for each option if requested
+  if (returnHelpText) {
+    let printUsage = '';
+    if (help) {
+      printUsage += help;
+    }
+    ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
+      const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
+
+      if (printUsage.length > 0) {
+        printUsage += '\n';
+      }
+      printUsage += helpTextForPrint;
+    });
 
     if (printUsage.length > 0) {
-      printUsage += '\n';
+      result.helpText = printUsage;
     }
-    printUsage += helpTextForPrint;
-  });
-
-  if (help && printUsage.length > 0) {
-    result.values.help = printUsage;
   }
 
   return result;

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -352,11 +352,7 @@ const parseArgs = (config = kEmptyObject) => {
   const help = objectGetOwn(config, 'help') ?? '';
 
   const hasGenerateHelp = help.length > 0;
-  const addHelpOption = objectGetOwn(config, 'addHelpOption') ?? hasGenerateHelp;
-  const returnHelpText = objectGetOwn(config, 'returnHelpText') ?? (hasGenerateHelp || addHelpOption);
-
-  // Auto-inject help option if requested and not already present
-  if (addHelpOption && !ObjectHasOwn(options, 'help')) {
+  if (hasGenerateHelp && !ObjectHasOwn(options, 'help')) {
     options = {
       ...options,
       __proto__: null,
@@ -378,8 +374,6 @@ const parseArgs = (config = kEmptyObject) => {
   validateBoolean(allowNegative, 'allowNegative');
   validateObject(options, 'options');
   validateString(help, 'help');
-  validateBoolean(addHelpOption, 'addHelpOption');
-  validateBoolean(returnHelpText, 'returnHelpText');
   ArrayPrototypeForEach(
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
@@ -466,24 +460,22 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
-  // Phase 4: generate print usage for each option if requested
-  if (returnHelpText) {
-    let printUsage = '';
-    if (help) {
-      printUsage += help;
-    }
-    ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
-      const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
-
-      if (printUsage.length > 0) {
-        printUsage += '\n';
-      }
-      printUsage += helpTextForPrint;
-    });
+  // Phase 4: generate print usage for each option
+  let printUsage = '';
+  if (help) {
+    printUsage += help;
+  }
+  ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
+    const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
 
     if (printUsage.length > 0) {
-      result.helpText = printUsage;
+      printUsage += '\n';
     }
+    printUsage += helpTextForPrint;
+  });
+
+  if (help && printUsage.length > 0) {
+    result.helpText = printUsage;
   }
 
   return result;

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -311,6 +311,37 @@ function argsToTokens(args, options) {
   return tokens;
 }
 
+/**
+ * Format help text for printing.
+ * @param {string} longOption - long option name e.g. 'foo'
+ * @param {Object} optionConfig - option config from parseArgs({ options })
+ * @returns {string} formatted help text for printing
+ * @example
+ * formatHelpTextForPrint('foo', { type: 'string', help: 'help text' })
+ * // returns '--foo <arg>                   help text'
+ */
+function formatHelpTextForPrint(longOption, optionConfig) {
+  const shortOption = objectGetOwn(optionConfig, 'short');
+  const type = objectGetOwn(optionConfig, 'type');
+  const help = objectGetOwn(optionConfig, 'help');
+
+  let helpTextForPrint = '';
+  if (help) {
+    if (shortOption) {
+      helpTextForPrint += `-${shortOption}, `;
+    }
+    helpTextForPrint += `--${longOption}`;
+    if (type === 'string') {
+      helpTextForPrint += ' <arg>';
+    } else if (type === 'boolean') {
+      helpTextForPrint += '';
+    }
+    helpTextForPrint = helpTextForPrint.padEnd(30) + help;
+  }
+
+  return helpTextForPrint;
+}
+
 const parseArgs = (config = kEmptyObject) => {
   const args = objectGetOwn(config, 'args') ?? getMainArgs();
   const strict = objectGetOwn(config, 'strict') ?? true;
@@ -414,33 +445,18 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
-  const usage = [];
+  // Phase 4: generate print usage for each option
+  const printUsage = [];
   ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
-    const shortOption = objectGetOwn(optionConfig, 'short');
-    const type = objectGetOwn(optionConfig, 'type');
-    const help = objectGetOwn(optionConfig, 'help');
+    const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
 
-    let usageLine = '';
-    if (help) {
-      if (shortOption) {
-        usageLine += `-${shortOption}, `;
-      }
-      usageLine += `--${longOption}`;
-      if (type === 'string') {
-        usageLine += ' <arg>';
-      } else if (type === 'boolean') {
-        usageLine += '';
-      }
-      usageLine = usageLine.padEnd(30) + help;
-    }
-
-    if (usageLine) {
-      ArrayPrototypePush(usage, usageLine);
+    if (helpTextForPrint) {
+      ArrayPrototypePush(printUsage, helpTextForPrint);
     }
   });
 
-  if (usage.length > 0) {
-    result.usage = usage;
+  if (printUsage.length > 0) {
+    result.printUsage = printUsage;
   }
 
   return result;

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -468,12 +468,15 @@ const parseArgs = (config = kEmptyObject) => {
     }
   });
 
-  if (enableHelpPrinting && printUsage.length > 0) {
+  if (enableHelpPrinting) {
     const console = require('internal/console/global');
-    ArrayPrototypeForEach(printUsage, (line) => {
-      console.log(line);
-    });
-
+    if (printUsage.length > 0 || help) {
+      ArrayPrototypeForEach(printUsage, (line) => {
+        console.log(line);
+      });
+    } else {
+      console.log('No help text available.');
+    }
     process.exit(0);
   } else if (printUsage.length > 0) {
     result.printUsage = printUsage;

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -322,16 +322,16 @@ function formatHelpTextForPrint(longOption, optionConfig) {
   const help = objectGetOwn(optionConfig, 'help');
 
   let helpTextForPrint = '';
+  if (shortOption) {
+    helpTextForPrint += `-${shortOption}, `;
+  }
+  helpTextForPrint += `--${longOption}`;
+  if (type === 'string') {
+    helpTextForPrint += ' <arg>';
+  } else if (type === 'boolean') {
+    helpTextForPrint += '';
+  }
   if (help) {
-    if (shortOption) {
-      helpTextForPrint += `-${shortOption}, `;
-    }
-    helpTextForPrint += `--${longOption}`;
-    if (type === 'string') {
-      helpTextForPrint += ' <arg>';
-    } else if (type === 'boolean') {
-      helpTextForPrint += '';
-    }
     if (helpTextForPrint.length > layoutSpacing) {
       helpTextForPrint += '\n' + ''.padEnd(layoutSpacing) + help;
     } else {
@@ -455,22 +455,13 @@ const parseArgs = (config = kEmptyObject) => {
   ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
     const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
 
-    if (helpTextForPrint) {
-      if (printUsage.length > 0) {
-        printUsage += '\n';
-      }
-      printUsage += helpTextForPrint;
+    if (printUsage.length > 0) {
+      printUsage += '\n';
     }
+    printUsage += helpTextForPrint;
   });
 
-  const helpRequested = result.values.help;
-  if (help && helpRequested) {
-    const console = require('internal/console/global');
-    if (printUsage.length > 0) {
-      console.log(printUsage);
-    }
-    process.exit(0);
-  } else if (printUsage.length > 0) {
+  if (help && printUsage.length > 0) {
     result.printUsage = printUsage;
   }
 

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -328,9 +328,8 @@ function formatHelpTextForPrint(longOption, optionConfig) {
   helpTextForPrint += `--${longOption}`;
   if (type === 'string') {
     helpTextForPrint += ' <arg>';
-  } else if (type === 'boolean') {
-    helpTextForPrint += '';
   }
+
   if (help) {
     if (helpTextForPrint.length > layoutSpacing) {
       helpTextForPrint += '\n' + ''.padEnd(layoutSpacing) + help;
@@ -462,7 +461,7 @@ const parseArgs = (config = kEmptyObject) => {
   });
 
   if (help && printUsage.length > 0) {
-    result.printUsage = printUsage;
+    result.values.help = printUsage;
   }
 
   return result;

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -314,7 +314,7 @@ function argsToTokens(args, options) {
 /**
  * Format help text for printing.
  * @param {string} longOption - long option name e.g. 'foo'
- * @param {Object} optionConfig - option config from parseArgs({ options })
+ * @param {object} optionConfig - option config from parseArgs({ options })
  * @returns {string} formatted help text for printing
  * @example
  * formatHelpTextForPrint('foo', { type: 'string', help: 'help text' })
@@ -349,6 +349,7 @@ const parseArgs = (config = kEmptyObject) => {
   const returnTokens = objectGetOwn(config, 'tokens') ?? false;
   const allowNegative = objectGetOwn(config, 'allowNegative') ?? false;
   const options = objectGetOwn(config, 'options') ?? { __proto__: null };
+  const help = objectGetOwn(config, 'help') ?? '';
   // Bundle these up for passing to strict-mode checks.
   const parseConfig = { args, strict, options, allowPositionals, allowNegative };
 
@@ -359,6 +360,7 @@ const parseArgs = (config = kEmptyObject) => {
   validateBoolean(returnTokens, 'tokens');
   validateBoolean(allowNegative, 'allowNegative');
   validateObject(options, 'options');
+  validateString(help, 'help');
   ArrayPrototypeForEach(
     ObjectEntries(options),
     ({ 0: longOption, 1: optionConfig }) => {
@@ -447,6 +449,9 @@ const parseArgs = (config = kEmptyObject) => {
 
   // Phase 4: generate print usage for each option
   const printUsage = [];
+  if (help) {
+    ArrayPrototypePush(printUsage, help);
+  }
   ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption, 1: optionConfig }) => {
     const helpTextForPrint = formatHelpTextForPrint(longOption, optionConfig);
 

--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -13,6 +13,7 @@ const {
   ObjectPrototypeHasOwnProperty: ObjectHasOwn,
   StringPrototypeCharAt,
   StringPrototypeIndexOf,
+  StringPrototypePadEnd,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
 } = primordials;
@@ -332,9 +333,9 @@ function formatHelpTextForPrint(longOption, optionConfig) {
 
   if (help) {
     if (helpTextForPrint.length > layoutSpacing) {
-      helpTextForPrint += '\n' + ''.padEnd(layoutSpacing) + help;
+      helpTextForPrint += `\n${StringPrototypePadEnd('', layoutSpacing)}${help}`;
     } else {
-      helpTextForPrint = helpTextForPrint.padEnd(layoutSpacing) + help;
+      helpTextForPrint = `${StringPrototypePadEnd(helpTextForPrint, layoutSpacing)}${help}`;
     }
   }
 

--- a/lib/internal/util/parse_args/utils.js
+++ b/lib/internal/util/parse_args/utils.js
@@ -193,6 +193,21 @@ function findLongOptionForShort(shortOption, options) {
 }
 
 /**
+ * Find the help value associated with a long option.
+ * @param {string} longOption
+ * @param {object} options
+ * @returns {string|undefined} - the help value or undefined if not found
+ */
+function findHelpValueForOption(longOption, options) {
+  validateObject(options, 'options');
+  if (ObjectHasOwn(options, longOption)) {
+    return objectGetOwn(options[longOption], 'help');
+  }
+
+  return undefined;
+}
+
+/**
  * Check if the given option includes a default value
  * and that option has not been set by the input args.
  * @param {string} longOption - long option name e.g. 'foo'
@@ -206,6 +221,7 @@ function useDefaultValueOption(longOption, optionConfig, values) {
 }
 
 module.exports = {
+  findHelpValueForOption,
   findLongOptionForShort,
   isLoneLongOption,
   isLoneShortOption,

--- a/lib/internal/util/parse_args/utils.js
+++ b/lib/internal/util/parse_args/utils.js
@@ -193,21 +193,6 @@ function findLongOptionForShort(shortOption, options) {
 }
 
 /**
- * Find the help value associated with a long option.
- * @param {string} longOption
- * @param {object} options
- * @returns {string|undefined} - the help value or undefined if not found
- */
-function findHelpValueForOption(longOption, options) {
-  validateObject(options, 'options');
-  if (ObjectHasOwn(options, longOption)) {
-    return objectGetOwn(options[longOption], 'help');
-  }
-
-  return undefined;
-}
-
-/**
  * Check if the given option includes a default value
  * and that option has not been set by the input args.
  * @param {string} longOption - long option name e.g. 'foo'
@@ -221,7 +206,6 @@ function useDefaultValueOption(longOption, optionConfig, values) {
 }
 
 module.exports = {
-  findHelpValueForOption,
   findLongOptionForShort,
   isLoneLongOption,
   isLoneShortOption,

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1082,7 +1082,7 @@ test('help value for option must be a string', () => {
   );
 });
 
-test('when help arg with help value for lone short option is added, then add help text', () => {
+test('when option has short and long flags, then both appear in usage', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = 'Description for some awesome stuff:';

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1063,7 +1063,7 @@ test('auto-detect --no-foo as negated when strict:false and allowNegative', () =
   process.execArgv = holdExecArgv;
 });
 
-test('help value must be a string', () => {
+test('help value for option must be a string', () => {
   const args = [];
   const options = { alpha: { type: 'string', help: true } };
   assert.throws(() => {
@@ -1086,7 +1086,7 @@ test('when help value for short group option is added, then add help text', () =
   const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
                     moo: { type: 'string', short: 'm', help: 'help text' } };
   const printUsage = ['-f, --foo                     help text',
-                 '-m, --moo <arg>               help text'];
+                      '-m, --moo <arg>               help text'];
   const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1116,5 +1116,25 @@ test('when help value for lone long option and value is added, then add help tex
   const printUsage = ['--foo <arg>                   help text'];
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('help value must be a string', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const help = true;
+  assert.throws(() => {
+    parseArgs({ args, options, help });
+  }, /The "help" argument must be of type string/
+  );
+});
+
+test('when help value is added, then add initial help text', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const printUsage = [help, '-f, --foo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const result = parseArgs({ args, options, help });
   assert.deepStrictEqual(result, expected);
 });

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1082,58 +1082,66 @@ test('help value for option must be a string', () => {
   );
 });
 
+test('when option has help text values but help arg value is not provided, then no help value appear', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text'} };
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: []};
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+})
+
 test('when option has short and long flags, then both appear in usage', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n-f, --foo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const expected = { values: { __proto__: null, foo: 'bar', help: printUsage }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-test('when help arg with help value for short group option is added, then add help text', () => {
+test('when options has short group flags, then both appear in usage', () => {
   const args = ['-fm', 'bar'];
   const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
                     moo: { type: 'string', short: 'm', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n-f, --foo                     help text\n-m, --moo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
+  const expected = { values: { help: printUsage, __proto__: null, foo: true, moo: 'bar' }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-test('when help arg with help value for short option and value is added, then add help text', () => {
+test('when options has short flag with value, then both appear in usage', () => {
   const args = ['-fFILE'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n-f, --foo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], printUsage };
+  const expected = { values: { help: printUsage, __proto__: null, foo: 'FILE' }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-test('when help arg with help value for lone long option is added, then add help text', () => {
+test('when options has long flag, then it appear in usage', () => {
   const args = ['--foo', 'bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n--foo <arg>                   help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const expected = { values: { help: printUsage, __proto__: null, foo: 'bar' }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-test('when help arg with help value for lone long option and value is added, then add help text', () => {
+test('when options has long flag with value, then both appear in usage', () => {
   const args = ['--foo=bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n--foo <arg>                   help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const expected = { values: { help: printUsage, __proto__: null, foo: 'bar' }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-test('when help arg with help values and without explicit help texts, then add help text', () => {
+test('when options has help values with and without explicit texts, then all appear in usage', () => {
   const args = [
     '-h', '-a', 'val1',
   ];
@@ -1174,10 +1182,10 @@ test('when help arg with help values and without explicit help texts, then add h
   '-L, --looooooooooooooongHelpText <arg>\n' +
   '                              Very long option help text for demonstration purposes';
 
-  assert.strictEqual(result.printUsage, printUsage);
+  assert.strictEqual(result.values.help, printUsage);
 });
 
-test('when help arg but no help text is available, then add help text', () => {
+test('when general help text and options with no help values, then all appear in usage', () => {
   const args = ['-a', 'val1', '--help'];
   const help = 'Description for some awesome stuff:';
   const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
@@ -1188,5 +1196,5 @@ test('when help arg but no help text is available, then add help text', () => {
 
   const result = parseArgs({ args, options, help });
 
-  assert.strictEqual(result.printUsage, printUsage);
+  assert.strictEqual(result.values.help, printUsage);
 });

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1063,62 +1063,7 @@ test('auto-detect --no-foo as negated when strict:false and allowNegative', () =
   process.execArgv = holdExecArgv;
 });
 
-test('help value for option must be a string', () => {
-  const args = [];
-  const options = { alpha: { type: 'string', help: true } };
-  assert.throws(() => {
-    parseArgs({ args, options });
-  }, /"options\.alpha\.help" property must be of type string/
-  );
-});
-
-test('when help value for lone short option is added, then add help text', () => {
-  const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const printUsage = '-f, --foo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
-
-test('when help value for short group option is added, then add help text', () => {
-  const args = ['-fm', 'bar'];
-  const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
-                    moo: { type: 'string', short: 'm', help: 'help text' } };
-  const printUsage = '-f, --foo                     help text\n-m, --moo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
-
-test('when help value for short option and value is added, then add help text', () => {
-  const args = ['-fFILE'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const printUsage = '-f, --foo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
-
-test('when help value for lone long option is added, then add help text', () => {
-  const args = ['--foo', 'bar'];
-  const options = { foo: { type: 'string', help: 'help text' } };
-  const printUsage = '--foo <arg>                   help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
-
-test('when help value for lone long option and value is added, then add help text', () => {
-  const args = ['--foo=bar'];
-  const options = { foo: { type: 'string', help: 'help text' } };
-  const printUsage = '--foo <arg>                   help text';
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
-
-test('help value config must be a string', () => {
+test('help arg value config must be a string', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = true;
@@ -1128,102 +1073,120 @@ test('help value config must be a string', () => {
   );
 });
 
-test('when help value is added, then add initial help text', () => {
+test('help value for option must be a string', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', help: true } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.help" property must be of type string/
+  );
+});
+
+test('when help arg with help value for lone short option is added, then add help text', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
   const printUsage = help + '\n-f, --foo <arg>               help text';
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
-  const result = parseArgs({ args, options, help });
+  const result = parseArgs({ args, options, allowPositionals: true, help });
   assert.deepStrictEqual(result, expected);
 });
 
-function setupConsoleAndExit() {
-  const originalLog = console.log;
-  const originalExit = process.exit;
+test('when help arg with help value for short group option is added, then add help text', () => {
+  const args = ['-fm', 'bar'];
+  const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
+                    moo: { type: 'string', short: 'm', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const printUsage = help + '\n-f, --foo                     help text\n-m, --moo <arg>               help text';
+  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
+  const result = parseArgs({ args, options, allowPositionals: true, help });
+  assert.deepStrictEqual(result, expected);
+});
 
-  let output = '';
-  let exitCode = null;
+test('when help arg with help value for short option and value is added, then add help text', () => {
+  const args = ['-fFILE'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const printUsage = help + '\n-f, --foo <arg>               help text';
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], printUsage };
+  const result = parseArgs({ args, options, allowPositionals: true, help });
+  assert.deepStrictEqual(result, expected);
+});
 
-  console.log = (message) => {
-    output += message + '\n';
+test('when help arg with help value for lone long option is added, then add help text', () => {
+  const args = ['--foo', 'bar'];
+  const options = { foo: { type: 'string', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const printUsage = help + '\n--foo <arg>                   help text';
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const result = parseArgs({ args, options, allowPositionals: true, help });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help arg with help value for lone long option and value is added, then add help text', () => {
+  const args = ['--foo=bar'];
+  const options = { foo: { type: 'string', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const printUsage = help + '\n--foo <arg>                   help text';
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
+  const result = parseArgs({ args, options, allowPositionals: true, help });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help arg with help values and without explicit help texts, then add help text', () => {
+  const args = [
+    '-h', '-a', 'val1',
+  ];
+  const options = {
+    help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
+    alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
+    beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
+    charlie: { type: 'string', short: 'c' },
+    delta: { type: 'string', help: 'Delta option help' },
+    echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
+    foxtrot: { type: 'string', help: 'Foxtrot option help' },
+    golf: { type: 'boolean', help: 'Golf option help' },
+    hotel: { type: 'string', help: 'Hotel option help' },
+    india: { type: 'string' },
+    juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
+    looooooooooooooongHelpText: {
+      type: 'string',
+      short: 'L',
+      help: 'Very long option help text for demonstration purposes'
+    }
   };
+  const help = 'Description for some awesome stuff:';
 
-  process.exit = (code) => {
-    exitCode = code;
-  };
-
-  function restore() {
-    console.log = originalLog;
-    process.exit = originalExit;
-  }
-
-  return { getOutput: () => output, getExitCode: () => exitCode, restore };
-}
-
-test('when --help flag is present with help arg, prints all help text and exit', () => {
-  const { getOutput, getExitCode, restore } = setupConsoleAndExit();
-
-  try {
-    const args = [
-      '-h', '-a', 'val1',
-    ];
-    const options = {
-      help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
-      alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
-      beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
-      charlie: { type: 'string', short: 'c' },
-      delta: { type: 'string', help: 'Delta option help' },
-      echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
-      foxtrot: { type: 'string', help: 'Foxtrot option help' },
-      golf: { type: 'boolean', help: 'Golf option help' },
-      hotel: { type: 'string', help: 'Hotel option help' },
-      india: { type: 'string' },
-      juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
-      looooooooooooooongHelpText: {
-        type: 'string',
-        short: 'L',
-        help: 'Very long option help text for demonstration purposes'
-      }
-    };
-    const help = 'Description for some awesome stuff:';
-
-    parseArgs({ args, options, help });
-  } finally {
-    restore();
-  }
-
-  const expectedOutput =
+  const result = parseArgs({ args, options, help });
+  const printUsage =
   'Description for some awesome stuff:\n' +
   '-h, --help                    Prints command line options\n' +
   '-a, --alpha <arg>             Alpha option help\n' +
   '-b, --beta                    Beta option help\n' +
+  '-c, --charlie <arg>\n' +
   '--delta <arg>                 Delta option help\n' +
   '-e, --echo                    Echo option help\n' +
   '--foxtrot <arg>               Foxtrot option help\n' +
   '--golf                        Golf option help\n' +
   '--hotel <arg>                 Hotel option help\n' +
+  '--india <arg>\n' +
   '-j, --juliet                  Juliet option help\n' +
   '-L, --looooooooooooooongHelpText <arg>\n' +
-  '                              Very long option help text for demonstration purposes\n';
+  '                              Very long option help text for demonstration purposes';
 
-  assert.strictEqual(getExitCode(), 0);
-  assert.strictEqual(getOutput(), expectedOutput);
+  assert.strictEqual(result.printUsage, printUsage);
 });
 
-test('when --help flag is present with help arg but no help text is available, prints help text and exit', () => {
-  const { getOutput, getExitCode, restore } = setupConsoleAndExit();
+test('when help arg but no help text is available, then add help text', () => {
+  const args = ['-a', 'val1', '--help'];
+  const help = 'Description for some awesome stuff:';
+  const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
+  const printUsage =
+    'Description for some awesome stuff:\n' +
+    '-a, --alpha <arg>\n' +
+    '--help';
 
-  try {
-    const args = ['-a', 'val1', '--help'];
-    const help = 'Description for some awesome stuff:';
-    const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
+  const result = parseArgs({ args, options, help });
 
-    parseArgs({ args, options, help });
-  } finally {
-    restore();
-  }
-
-  assert.strictEqual(getExitCode(), 0);
-  assert.strictEqual(getOutput(), 'Description for some awesome stuff:\n');
+  assert.strictEqual(result.printUsage, printUsage);
 });

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1062,3 +1062,59 @@ test('auto-detect --no-foo as negated when strict:false and allowNegative', () =
   process.argv = holdArgv;
   process.execArgv = holdExecArgv;
 });
+
+test('help value must be a string', () => {
+  const args = [];
+  const options = { alpha: { type: 'string', help: true } };
+  assert.throws(() => {
+    parseArgs({ args, options });
+  }, /"options\.alpha\.help" property must be of type string/
+  );
+});
+
+test('when help value for lone short option is added, then add help text', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const usage = ['-f, --foo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help value for short group option is added, then add help text', () => {
+  const args = ['-fm', 'bar'];
+  const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
+                    moo: { type: 'string', short: 'm', help: 'help text' } };
+  const usage = ['-f, --foo                     help text',
+                 '-m, --moo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], usage };
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help value for short option and value is added, then add help text', () => {
+  const args = ['-fFILE'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const usage = ['-f, --foo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], usage };
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help value for lone long option is added, then add help text', () => {
+  const args = ['--foo', 'bar'];
+  const options = { foo: { type: 'string', help: 'help text' } };
+  const usage = ['--foo <arg>                   help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});
+
+test('when help value for lone long option and value is added, then add help text', () => {
+  const args = ['--foo=bar'];
+  const options = { foo: { type: 'string', help: 'help text' } };
+  const usage = ['--foo <arg>                   help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const result = parseArgs({ args, options, allowPositionals: true });
+  assert.deepStrictEqual(result, expected);
+});

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1075,7 +1075,7 @@ test('help value for option must be a string', () => {
 test('when help value for lone short option is added, then add help text', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const printUsage = ['-f, --foo <arg>               help text'];
+  const printUsage = '-f, --foo <arg>               help text';
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1085,8 +1085,7 @@ test('when help value for short group option is added, then add help text', () =
   const args = ['-fm', 'bar'];
   const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
                     moo: { type: 'string', short: 'm', help: 'help text' } };
-  const printUsage = ['-f, --foo                     help text',
-                      '-m, --moo <arg>               help text'];
+  const printUsage = '-f, --foo                     help text\n-m, --moo <arg>               help text';
   const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1095,7 +1094,7 @@ test('when help value for short group option is added, then add help text', () =
 test('when help value for short option and value is added, then add help text', () => {
   const args = ['-fFILE'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const printUsage = ['-f, --foo <arg>               help text'];
+  const printUsage = '-f, --foo <arg>               help text';
   const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1104,7 +1103,7 @@ test('when help value for short option and value is added, then add help text', 
 test('when help value for lone long option is added, then add help text', () => {
   const args = ['--foo', 'bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
-  const printUsage = ['--foo <arg>                   help text'];
+  const printUsage = '--foo <arg>                   help text';
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1113,7 +1112,7 @@ test('when help value for lone long option is added, then add help text', () => 
 test('when help value for lone long option and value is added, then add help text', () => {
   const args = ['--foo=bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
-  const printUsage = ['--foo <arg>                   help text'];
+  const printUsage = '--foo <arg>                   help text';
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
@@ -1133,7 +1132,7 @@ test('when help value is added, then add initial help text', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = 'Description for some awesome stuff:';
-  const printUsage = [help, '-f, --foo <arg>               help text'];
+  const printUsage = help + '\n-f, --foo <arg>               help text';
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, help });
   assert.deepStrictEqual(result, expected);
@@ -1178,19 +1177,20 @@ test('when enableHelpPrinting config is true, print all help text and exit', () 
 
   try {
     const args = [
-      '-a', 'val1', '--beta', '-c', 'val3', '--delta', 'val4', '-e',
-      '--foxtrot', 'val6', '--golf', '-h', 'val8', '--india', 'val9', '-j',
+      '-h', '-a', 'val1', '--beta', '-c', 'val3', '--delta', 'val4', '-e',
+      '--foxtrot', 'val6', '--golf', '--hotel', 'val8', '--india', 'val9', '-j',
     ];
     const options = {
+      help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
       alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
       beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
-      charlie: { type: 'string', short: 'c', help: 'Charlie option help' },
+      charlie: { type: 'string', short: 'c' },
       delta: { type: 'string', help: 'Delta option help' },
       echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
       foxtrot: { type: 'string', help: 'Foxtrot option help' },
       golf: { type: 'boolean', help: 'Golf option help' },
-      hotel: { type: 'string', short: 'h', help: 'Hotel option help' },
-      india: { type: 'string', help: 'India option help' },
+      hotel: { type: 'string', help: 'Hotel option help' },
+      india: { type: 'string' },
       juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
       looooooooooooooongHelpText: {
         type: 'string',
@@ -1207,15 +1207,14 @@ test('when enableHelpPrinting config is true, print all help text and exit', () 
 
   const expectedOutput =
   'Description for some awesome stuff:\n' +
+  '-h, --help                    Prints command line options\n' +
   '-a, --alpha <arg>             Alpha option help\n' +
   '-b, --beta                    Beta option help\n' +
-  '-c, --charlie <arg>           Charlie option help\n' +
   '--delta <arg>                 Delta option help\n' +
   '-e, --echo                    Echo option help\n' +
   '--foxtrot <arg>               Foxtrot option help\n' +
   '--golf                        Golf option help\n' +
-  '-h, --hotel <arg>             Hotel option help\n' +
-  '--india <arg>                 India option help\n' +
+  '--hotel <arg>                 Hotel option help\n' +
   '-j, --juliet                  Juliet option help\n' +
   '-L, --looooooooooooooongHelpText <arg>\n' +
   '                              Very long option help text for demonstration purposes\n';
@@ -1228,8 +1227,8 @@ test('when enableHelpPrinting config is true, but no help text is available', ()
   const { getOutput, getExitCode, restore } = setupConsoleAndExit();
 
   try {
-    const args = ['-a', 'val1'];
-    const options = { alpha: { type: 'string', short: 'a' } };
+    const args = ['-a', 'val1', '--help'];
+    const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
 
     parseArgs({ args, options, enableHelpPrinting: true });
   } finally {

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1075,8 +1075,8 @@ test('help value must be a string', () => {
 test('when help value for lone short option is added, then add help text', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const usage = ['-f, --foo <arg>               help text'];
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const printUsage = ['-f, --foo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
 });
@@ -1085,9 +1085,9 @@ test('when help value for short group option is added, then add help text', () =
   const args = ['-fm', 'bar'];
   const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
                     moo: { type: 'string', short: 'm', help: 'help text' } };
-  const usage = ['-f, --foo                     help text',
+  const printUsage = ['-f, --foo                     help text',
                  '-m, --moo <arg>               help text'];
-  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], usage };
+  const expected = { values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
 });
@@ -1095,8 +1095,8 @@ test('when help value for short group option is added, then add help text', () =
 test('when help value for short option and value is added, then add help text', () => {
   const args = ['-fFILE'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const usage = ['-f, --foo <arg>               help text'];
-  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], usage };
+  const printUsage = ['-f, --foo <arg>               help text'];
+  const expected = { values: { __proto__: null, foo: 'FILE' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
 });
@@ -1104,8 +1104,8 @@ test('when help value for short option and value is added, then add help text', 
 test('when help value for lone long option is added, then add help text', () => {
   const args = ['--foo', 'bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
-  const usage = ['--foo <arg>                   help text'];
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const printUsage = ['--foo <arg>                   help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
 });
@@ -1113,8 +1113,8 @@ test('when help value for lone long option is added, then add help text', () => 
 test('when help value for lone long option and value is added, then add help text', () => {
   const args = ['--foo=bar'];
   const options = { foo: { type: 'string', help: 'help text' } };
-  const usage = ['--foo <arg>                   help text'];
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], usage };
+  const printUsage = ['--foo <arg>                   help text'];
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
 });

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1084,11 +1084,11 @@ test('help value for option must be a string', () => {
 
 test('when option has help text values but help arg value is not provided, then no help value appear', () => {
   const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text'} };
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: []};
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [] };
   const result = parseArgs({ args, options, allowPositionals: true });
   assert.deepStrictEqual(result, expected);
-})
+});
 
 test('when option has short and long flags, then both appear in usage', () => {
   const args = ['-f', 'bar'];

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1063,138 +1063,267 @@ test('auto-detect --no-foo as negated when strict:false and allowNegative', () =
   process.execArgv = holdExecArgv;
 });
 
-test('help arg value config must be a string', () => {
-  const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const help = true;
-  assert.throws(() => {
-    parseArgs({ args, options, help });
-  }, /The "help" argument must be of type string/
-  );
-});
+// Test help option
+{
+  test('help arg value config must be a string', () => {
+    const args = ['-f', 'bar'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+    const help = true;
+    assert.throws(() => {
+      parseArgs({ args, options, help });
+    }, /The "help" argument must be of type string/
+    );
+  });
 
-test('help value for option must be a string', () => {
-  const args = [];
-  const options = { alpha: { type: 'string', help: true } };
-  assert.throws(() => {
-    parseArgs({ args, options });
-  }, /"options\.alpha\.help" property must be of type string/
-  );
-});
+  test('help value for option must be a string', () => {
+    const args = [];
+    const options = { alpha: { type: 'string', help: true } };
+    assert.throws(() => {
+      parseArgs({ args, options });
+    }, /"options\.alpha\.help" property must be of type string/
+    );
+  });
 
-test('when option has help text values but help arg value is not provided, then no help value appear', () => {
-  const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when option has help text values but help arg value is not provided, then no help value appear', () => {
+    const args = ['-f', 'bar'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+    const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when option has short and long flags, then both appear in usage', () => {
-  const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const printUsage = help + '\n-f, --foo <arg>               help text';
-  const expected = { values: { __proto__: null, foo: 'bar', help: printUsage }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true, help });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when option has short and long flags, then both appear in usage with help option', () => {
+    const args = ['-f', 'bar'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+    const help = 'Description for some awesome stuff:';
+    const printUsage = help + '\n-f, --foo <arg>               help text\n-h, --help                    Show help';
+    const expected = { helpText: printUsage, values: { __proto__: null, foo: 'bar' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true, help });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when options has short group flags, then both appear in usage', () => {
-  const args = ['-fm', 'bar'];
-  const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
-                    moo: { type: 'string', short: 'm', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const printUsage = help + '\n-f, --foo                     help text\n-m, --moo <arg>               help text';
-  const expected = { values: { help: printUsage, __proto__: null, foo: true, moo: 'bar' }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true, help });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when options has short group flags, then both appear in usage with help option', () => {
+    const args = ['-fm', 'bar'];
+    const options = { foo: { type: 'boolean', short: 'f', help: 'help text' },
+                      moo: { type: 'string', short: 'm', help: 'help text' } };
+    const help = 'Description for some awesome stuff:';
+    const printUsage = help + '\n-f, --foo                     help text\n' +
+               '-m, --moo <arg>               help text\n' +
+               '-h, --help                    Show help';
+    const expected = { helpText: printUsage, values: { __proto__: null, foo: true, moo: 'bar' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true, help });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when options has short flag with value, then both appear in usage', () => {
-  const args = ['-fFILE'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const printUsage = help + '\n-f, --foo <arg>               help text';
-  const expected = { values: { help: printUsage, __proto__: null, foo: 'FILE' }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true, help });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when options has short flag with value, then both appear in usage with help option', () => {
+    const args = ['-fFILE'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+    const help = 'Description for some awesome stuff:';
+    const printUsage = help + '\n-f, --foo <arg>               help text\n-h, --help                    Show help';
+    const expected = { helpText: printUsage, values: { __proto__: null, foo: 'FILE' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true, help });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when options has long flag, then it appear in usage', () => {
-  const args = ['--foo', 'bar'];
-  const options = { foo: { type: 'string', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const printUsage = help + '\n--foo <arg>                   help text';
-  const expected = { values: { help: printUsage, __proto__: null, foo: 'bar' }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true, help });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when options has long flag, then it appear in usage with help option', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'help text' } };
+    const help = 'Description for some awesome stuff:';
+    const printUsage = help + '\n--foo <arg>                   help text\n-h, --help                    Show help';
+    const expected = { helpText: printUsage, values: { __proto__: null, foo: 'bar' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true, help });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when options has long flag with value, then both appear in usage', () => {
-  const args = ['--foo=bar'];
-  const options = { foo: { type: 'string', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const printUsage = help + '\n--foo <arg>                   help text';
-  const expected = { values: { help: printUsage, __proto__: null, foo: 'bar' }, positionals: [] };
-  const result = parseArgs({ args, options, allowPositionals: true, help });
-  assert.deepStrictEqual(result, expected);
-});
+  test('when options has long flag with value, then both appear in usage with help option', () => {
+    const args = ['--foo=bar'];
+    const options = { foo: { type: 'string', help: 'help text' } };
+    const help = 'Description for some awesome stuff:';
+    const printUsage = help + '\n--foo <arg>                   help text\n-h, --help                    Show help';
+    const expected = { helpText: printUsage, values: { __proto__: null, foo: 'bar' }, positionals: [] };
+    const result = parseArgs({ args, options, allowPositionals: true, help });
+    assert.deepStrictEqual(result, expected);
+  });
 
-test('when options has help values with and without explicit texts, then all appear in usage', () => {
-  const args = [
-    '-h', '-a', 'val1',
-  ];
-  const options = {
-    help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
-    alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
-    beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
-    charlie: { type: 'string', short: 'c' },
-    delta: { type: 'string', help: 'Delta option help' },
-    echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
-    foxtrot: { type: 'string', help: 'Foxtrot option help' },
-    golf: { type: 'boolean', help: 'Golf option help' },
-    hotel: { type: 'string', help: 'Hotel option help' },
-    india: { type: 'string' },
-    juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
-    looooooooooooooongHelpText: {
-      type: 'string',
-      short: 'L',
-      help: 'Very long option help text for demonstration purposes'
-    }
-  };
-  const help = 'Description for some awesome stuff:';
+  test('when options has help values with and without explicit texts, then all appear in usage', () => {
+    const args = [
+      '-h', '-a', 'val1',
+    ];
+    const options = {
+      help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
+      alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
+      beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
+      charlie: { type: 'string', short: 'c' },
+      delta: { type: 'string', help: 'Delta option help' },
+      echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
+      foxtrot: { type: 'string', help: 'Foxtrot option help' },
+      golf: { type: 'boolean', help: 'Golf option help' },
+      hotel: { type: 'string', help: 'Hotel option help' },
+      india: { type: 'string' },
+      juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
+      looooooooooooooongHelpText: {
+        type: 'string',
+        short: 'L',
+        help: 'Very long option help text for demonstration purposes'
+      }
+    };
+    const help = 'Description for some awesome stuff:';
 
-  const result = parseArgs({ args, options, help });
-  const printUsage =
-  'Description for some awesome stuff:\n' +
-  '-h, --help                    Prints command line options\n' +
-  '-a, --alpha <arg>             Alpha option help\n' +
-  '-b, --beta                    Beta option help\n' +
-  '-c, --charlie <arg>\n' +
-  '--delta <arg>                 Delta option help\n' +
-  '-e, --echo                    Echo option help\n' +
-  '--foxtrot <arg>               Foxtrot option help\n' +
-  '--golf                        Golf option help\n' +
-  '--hotel <arg>                 Hotel option help\n' +
-  '--india <arg>\n' +
-  '-j, --juliet                  Juliet option help\n' +
-  '-L, --looooooooooooooongHelpText <arg>\n' +
-  '                              Very long option help text for demonstration purposes';
-
-  assert.strictEqual(result.values.help, printUsage);
-});
-
-test('when general help text and options with no help values, then all appear in usage', () => {
-  const args = ['-a', 'val1', '--help'];
-  const help = 'Description for some awesome stuff:';
-  const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
-  const printUsage =
+    const result = parseArgs({ args, options, help });
+    const printUsage =
     'Description for some awesome stuff:\n' +
-    '-a, --alpha <arg>\n' +
-    '--help';
+    '-h, --help                    Prints command line options\n' +
+    '-a, --alpha <arg>             Alpha option help\n' +
+    '-b, --beta                    Beta option help\n' +
+    '-c, --charlie <arg>\n' +
+    '--delta <arg>                 Delta option help\n' +
+    '-e, --echo                    Echo option help\n' +
+    '--foxtrot <arg>               Foxtrot option help\n' +
+    '--golf                        Golf option help\n' +
+    '--hotel <arg>                 Hotel option help\n' +
+    '--india <arg>\n' +
+    '-j, --juliet                  Juliet option help\n' +
+    '-L, --looooooooooooooongHelpText <arg>\n' +
+    '                              Very long option help text for demonstration purposes';
 
-  const result = parseArgs({ args, options, help });
+    assert.strictEqual(result.helpText, printUsage);
+  });
 
-  assert.strictEqual(result.values.help, printUsage);
-});
+  test('when general help text and options with no help values, then all appear in usage', () => {
+    const args = ['-a', 'val1', '--help'];
+    const help = 'Description for some awesome stuff:';
+    const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
+    const printUsage =
+      'Description for some awesome stuff:\n' +
+      '-a, --alpha <arg>\n' +
+      '--help';
+
+    const result = parseArgs({ args, options, help });
+
+    assert.strictEqual(result.helpText, printUsage);
+  });
+
+  // Test addHelpOption behavior
+  test('addHelpOption validation must be boolean', () => {
+    const args = ['-f', 'bar'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+
+    assert.throws(() => {
+      parseArgs({ args, options, addHelpOption: 'true' });
+    }, /The "addHelpOption" argument must be of type boolean/
+    );
+  });
+
+  test('addHelpOption is true auto-injects help option when no existing help option', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'use the foo filter' } };
+    const help = 'utility to control filters';
+
+    const result = parseArgs({ args, options, help, addHelpOption: true });
+
+    assert.ok(result.helpText.includes('-h, --help                    Show help'));
+    const resultWithHelp = parseArgs({ args: ['--help'], options, help, addHelpOption: true });
+    assert.strictEqual(resultWithHelp.values.help, true);
+  });
+
+  test('addHelpOption is false prevents auto-injection of help option', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'use the foo filter' } };
+    const help = 'utility to control filters';
+
+    const result = parseArgs({ args, options, help, addHelpOption: false });
+
+    assert.ok(!result.helpText.includes('-h, --help'));
+    assert.throws(() => {
+      parseArgs({ args: ['--help'], options, help, addHelpOption: false });
+    }, { code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION' });
+  });
+
+  test('addHelpOption is false but existing help option should still work', () => {
+    const args = ['--help'];
+    const options = {
+      foo: { type: 'string', help: 'use the foo filter' },
+      help: { type: 'boolean', short: '?', help: 'display help' }
+    };
+    const help = 'utility to control filters';
+
+    const result = parseArgs({ args, options, help, addHelpOption: false });
+
+    assert.strictEqual(result.values.help, true);
+    assert.ok(result.helpText.includes('-?, --help                    display help'));
+  });
+
+  // Test returnHelpText behavior
+  test('returnHelpText validation must be boolean', () => {
+    const args = ['-f', 'bar'];
+    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+
+    assert.throws(() => {
+      parseArgs({ args, options, returnHelpText: 'true' });
+    }, /The "returnHelpText" argument must be of type boolean/
+    );
+  });
+
+  test('returnHelpText is false prevents help text generation', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'use the foo filter' } };
+    const help = 'utility to control filters';
+
+    const result = parseArgs({ args, options, help, returnHelpText: false });
+
+    assert.strictEqual(result.helpText, undefined);
+  });
+
+  test('returnHelpText is true forces help text generation even without general help', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'use the foo filter' } };
+
+    const result = parseArgs({ args, options, returnHelpText: true, addHelpOption: true });
+
+    assert.ok(result.helpText);
+    assert.ok(result.helpText.includes('--foo <arg>                   use the foo filter'));
+    assert.ok(result.helpText.includes('-h, --help                    Show help'));
+  });
+
+  test('postpone help generation until needed', () => {
+    const options = {
+      foo: { type: 'boolean', short: 'f', help: 'use the foo filter' },
+      bar: { type: 'string', help: 'use the specified bar filter' }
+    };
+
+    const result = parseArgs({
+      addHelpOption: true,
+      returnHelpText: false,
+      options
+    });
+
+    assert.strictEqual(result.helpText, undefined);
+
+    const { helpText } = parseArgs({
+      help: 'utility to control filters',
+      options
+    });
+
+    assert.ok(helpText);
+    assert.ok(helpText.includes('utility to control filters'));
+  });
+
+  test('when both addHelpOption and returnHelpText are false, no help functionality', () => {
+    const args = ['--foo', 'bar'];
+    const options = { foo: { type: 'string', help: 'help text' } };
+    const help = 'Description text';
+
+    const result = parseArgs({
+      args,
+      options,
+      help,
+      addHelpOption: false,
+      returnHelpText: false
+    });
+
+    assert.strictEqual(result.helpText, undefined);
+    assert.throws(() => {
+      parseArgs({ args: ['--help'], options, help, addHelpOption: false });
+    }, { code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION' });
+  });
+}

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1203,127 +1203,15 @@ test('auto-detect --no-foo as negated when strict:false and allowNegative', () =
     assert.strictEqual(result.helpText, printUsage);
   });
 
-  // Test addHelpOption behavior
-  test('addHelpOption validation must be boolean', () => {
-    const args = ['-f', 'bar'];
-    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-
-    assert.throws(() => {
-      parseArgs({ args, options, addHelpOption: 'true' });
-    }, /The "addHelpOption" argument must be of type boolean/
-    );
-  });
-
-  test('addHelpOption is true auto-injects help option when no existing help option', () => {
+  test('auto-injects help option when no existing help option', () => {
     const args = ['--foo', 'bar'];
     const options = { foo: { type: 'string', help: 'use the foo filter' } };
     const help = 'utility to control filters';
 
-    const result = parseArgs({ args, options, help, addHelpOption: true });
+    const result = parseArgs({ args, options, help });
 
     assert.ok(result.helpText.includes('-h, --help                    Show help'));
-    const resultWithHelp = parseArgs({ args: ['--help'], options, help, addHelpOption: true });
+    const resultWithHelp = parseArgs({ args: ['--help'], options, help });
     assert.strictEqual(resultWithHelp.values.help, true);
-  });
-
-  test('addHelpOption is false prevents auto-injection of help option', () => {
-    const args = ['--foo', 'bar'];
-    const options = { foo: { type: 'string', help: 'use the foo filter' } };
-    const help = 'utility to control filters';
-
-    const result = parseArgs({ args, options, help, addHelpOption: false });
-
-    assert.ok(!result.helpText.includes('-h, --help'));
-    assert.throws(() => {
-      parseArgs({ args: ['--help'], options, help, addHelpOption: false });
-    }, { code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION' });
-  });
-
-  test('addHelpOption is false but existing help option should still work', () => {
-    const args = ['--help'];
-    const options = {
-      foo: { type: 'string', help: 'use the foo filter' },
-      help: { type: 'boolean', short: '?', help: 'display help' }
-    };
-    const help = 'utility to control filters';
-
-    const result = parseArgs({ args, options, help, addHelpOption: false });
-
-    assert.strictEqual(result.values.help, true);
-    assert.ok(result.helpText.includes('-?, --help                    display help'));
-  });
-
-  // Test returnHelpText behavior
-  test('returnHelpText validation must be boolean', () => {
-    const args = ['-f', 'bar'];
-    const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-
-    assert.throws(() => {
-      parseArgs({ args, options, returnHelpText: 'true' });
-    }, /The "returnHelpText" argument must be of type boolean/
-    );
-  });
-
-  test('returnHelpText is false prevents help text generation', () => {
-    const args = ['--foo', 'bar'];
-    const options = { foo: { type: 'string', help: 'use the foo filter' } };
-    const help = 'utility to control filters';
-
-    const result = parseArgs({ args, options, help, returnHelpText: false });
-
-    assert.strictEqual(result.helpText, undefined);
-  });
-
-  test('returnHelpText is true forces help text generation even without general help', () => {
-    const args = ['--foo', 'bar'];
-    const options = { foo: { type: 'string', help: 'use the foo filter' } };
-
-    const result = parseArgs({ args, options, returnHelpText: true, addHelpOption: true });
-
-    assert.ok(result.helpText);
-    assert.ok(result.helpText.includes('--foo <arg>                   use the foo filter'));
-    assert.ok(result.helpText.includes('-h, --help                    Show help'));
-  });
-
-  test('postpone help generation until needed', () => {
-    const options = {
-      foo: { type: 'boolean', short: 'f', help: 'use the foo filter' },
-      bar: { type: 'string', help: 'use the specified bar filter' }
-    };
-
-    const result = parseArgs({
-      addHelpOption: true,
-      returnHelpText: false,
-      options
-    });
-
-    assert.strictEqual(result.helpText, undefined);
-
-    const { helpText } = parseArgs({
-      help: 'utility to control filters',
-      options
-    });
-
-    assert.ok(helpText);
-    assert.ok(helpText.includes('utility to control filters'));
-  });
-
-  test('when both addHelpOption and returnHelpText are false, no help functionality', () => {
-    const args = ['--foo', 'bar'];
-    const options = { foo: { type: 'string', help: 'help text' } };
-    const help = 'Description text';
-
-    const result = parseArgs({
-      args,
-      options,
-      help,
-      addHelpOption: false,
-      returnHelpText: false
-    });
-
-    assert.strictEqual(result.helpText, undefined);
-    assert.throws(() => {
-      parseArgs({ args: ['--help'], options, help, addHelpOption: false });
-    }, { code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION' });
   });
 }

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1138,17 +1138,6 @@ test('when help value is added, then add initial help text', () => {
   assert.deepStrictEqual(result, expected);
 });
 
-test('enableHelpPrinting config must be a boolean', () => {
-  const args = ['-f', 'bar'];
-  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
-  const help = 'Description for some awesome stuff:';
-  const enableHelpPrinting = 'not a boolean';
-  assert.throws(() => {
-    parseArgs({ args, options, help, enableHelpPrinting });
-  }, /The "enableHelpPrinting" argument must be of type boolean/
-  );
-});
-
 function setupConsoleAndExit() {
   const originalLog = console.log;
   const originalExit = process.exit;
@@ -1172,13 +1161,12 @@ function setupConsoleAndExit() {
   return { getOutput: () => output, getExitCode: () => exitCode, restore };
 }
 
-test('when enableHelpPrinting config is true, print all help text and exit', () => {
+test('when --help flag is present with help arg, prints all help text and exit', () => {
   const { getOutput, getExitCode, restore } = setupConsoleAndExit();
 
   try {
     const args = [
-      '-h', '-a', 'val1', '--beta', '-c', 'val3', '--delta', 'val4', '-e',
-      '--foxtrot', 'val6', '--golf', '--hotel', 'val8', '--india', 'val9', '-j',
+      '-h', '-a', 'val1',
     ];
     const options = {
       help: { type: 'boolean', short: 'h', help: 'Prints command line options' },
@@ -1200,7 +1188,7 @@ test('when enableHelpPrinting config is true, print all help text and exit', () 
     };
     const help = 'Description for some awesome stuff:';
 
-    parseArgs({ args, options, help, enableHelpPrinting: true });
+    parseArgs({ args, options, help });
   } finally {
     restore();
   }
@@ -1223,18 +1211,19 @@ test('when enableHelpPrinting config is true, print all help text and exit', () 
   assert.strictEqual(getOutput(), expectedOutput);
 });
 
-test('when enableHelpPrinting config is true, but no help text is available', () => {
+test('when --help flag is present with help arg but no help text is available, prints help text and exit', () => {
   const { getOutput, getExitCode, restore } = setupConsoleAndExit();
 
   try {
     const args = ['-a', 'val1', '--help'];
+    const help = 'Description for some awesome stuff:';
     const options = { alpha: { type: 'string', short: 'a' }, help: { type: 'boolean' } };
 
-    parseArgs({ args, options, enableHelpPrinting: true });
+    parseArgs({ args, options, help });
   } finally {
     restore();
   }
 
   assert.strictEqual(getExitCode(), 0);
-  assert.strictEqual(getOutput(), 'No help text available.\n');
+  assert.strictEqual(getOutput(), 'Description for some awesome stuff:\n');
 });

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1119,7 +1119,7 @@ test('when help value for lone long option and value is added, then add help tex
   assert.deepStrictEqual(result, expected);
 });
 
-test('help value must be a string', () => {
+test('help value config must be a string', () => {
   const args = ['-f', 'bar'];
   const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
   const help = true;
@@ -1137,4 +1137,79 @@ test('when help value is added, then add initial help text', () => {
   const expected = { values: { __proto__: null, foo: 'bar' }, positionals: [], printUsage };
   const result = parseArgs({ args, options, help });
   assert.deepStrictEqual(result, expected);
+});
+
+test('enableHelpPrinting config must be a boolean', () => {
+  const args = ['-f', 'bar'];
+  const options = { foo: { type: 'string', short: 'f', help: 'help text' } };
+  const help = 'Description for some awesome stuff:';
+  const enableHelpPrinting = 'not a boolean';
+  assert.throws(() => {
+    parseArgs({ args, options, help, enableHelpPrinting });
+  }, /The "enableHelpPrinting" argument must be of type boolean/
+  );
+});
+
+test('when enableHelpPrinting config is true, print all help text and exit', () => {
+  const originalLog = console.log;
+  const originalExit = process.exit;
+
+  let output = '';
+  let exitCode = null;
+
+  console.log = (message) => {
+    output += message + '\n';
+  };
+
+  process.exit = (code) => {
+    exitCode = code;
+  };
+
+  try {
+    const args = [
+      '-a', 'val1', '--beta', '-c', 'val3', '--delta', 'val4', '-e',
+      '--foxtrot', 'val6', '--golf', '-h', 'val8', '--india', 'val9', '-j',
+    ];
+    const options = {
+      alpha: { type: 'string', short: 'a', help: 'Alpha option help' },
+      beta: { type: 'boolean', short: 'b', help: 'Beta option help' },
+      charlie: { type: 'string', short: 'c', help: 'Charlie option help' },
+      delta: { type: 'string', help: 'Delta option help' },
+      echo: { type: 'boolean', short: 'e', help: 'Echo option help' },
+      foxtrot: { type: 'string', help: 'Foxtrot option help' },
+      golf: { type: 'boolean', help: 'Golf option help' },
+      hotel: { type: 'string', short: 'h', help: 'Hotel option help' },
+      india: { type: 'string', help: 'India option help' },
+      juliet: { type: 'boolean', short: 'j', help: 'Juliet option help' },
+      looooooooooooooongHelpText: {
+        type: 'string',
+        short: 'L',
+        help: 'Very long option help text for demonstration purposes'
+      }
+    };
+    const help = 'Description for some awesome stuff:';
+
+    parseArgs({ args, options, help, enableHelpPrinting: true });
+  } finally {
+    console.log = originalLog;
+    process.exit = originalExit;
+  }
+
+  const expectedOutput =
+  'Description for some awesome stuff:\n' +
+  '-a, --alpha <arg>             Alpha option help\n' +
+  '-b, --beta                    Beta option help\n' +
+  '-c, --charlie <arg>           Charlie option help\n' +
+  '--delta <arg>                 Delta option help\n' +
+  '-e, --echo                    Echo option help\n' +
+  '--foxtrot <arg>               Foxtrot option help\n' +
+  '--golf                        Golf option help\n' +
+  '-h, --hotel <arg>             Hotel option help\n' +
+  '--india <arg>                 India option help\n' +
+  '-j, --juliet                  Juliet option help\n' +
+  '-L, --looooooooooooooongHelpText <arg>\n' +
+  '                              Very long option help text for demonstration purposes\n';
+
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(output, expectedOutput);
 });


### PR DESCRIPTION
Issue: [56184](https://github.com/nodejs/node/issues/56184)

## Add support to print help/usage of `util.parseArgs`
This PR adds help text functionality to `util.parseArgs`, allowing developers to easily generate and display help information for their CLI applications.

### Checklist
* [X] Help Text for Individual Options
* [X] General Help Text
* [X] Help Text Generation with `printUsage` added to return object
* [X] Test coverage for all features
* [X] Documentation
