### PR TITLE
test: add fs.rmSync regression test for Unicode filename crash on Windows

### DIFF
--- a/test/parallel/test-fs-rm-unicode-crash.js
+++ b/test/parallel/test-fs-rm-unicode-crash.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+if (process.platform !== 'win32') {
+  common.skip('This test only runs on Windows');
+}
+
+const filename = path.join(__dirname, '速');
+
+fs.writeFileSync(filename, 'hello');
+
+try {
+  fs.rmSync(filename);
+  assert(!fs.existsSync(filename), 'File should be deleted');
+} catch (err) {
+  assert.fail(`Unexpected error: ${err.message}`);
+}


### PR DESCRIPTION
Adds a regression test for a Windows-specific bug where `fs.rmSync('速')` crashes without throwing, observed in Node.js v23.3.0.

- Reproduces the issue in a controlled test.
- Skips the test on non-Windows platforms.
- Does not crash on older versions or Linux/macOS.
