### PR TITLE
src: simplify adding fast APIs to ExternalReferenceRegistry

### DIFF
--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -68,16 +68,18 @@ bool FastTimingSafeEqual(Local<Value> receiver,
   return CRYPTO_memcmp(a.data(), b.data(), a.length()) == 0;
 }
 
-static CFunction fast_equal(CFunction::Make(FastTimingSafeEqual));
+static CFunction fast_timing_safe_equal(CFunction::Make(FastTimingSafeEqual));
 
 void Initialize(Environment* env, Local<Object> target) {
-  SetFastMethodNoSideEffect(
-      env->context(), target, "timingSafeEqual", TimingSafeEqual, &fast_equal);
+  SetFastMethodNoSideEffect(env->context(),
+                            target,
+                            "timingSafeEqual",
+                            TimingSafeEqual,
+                            &fast_timing_safe_equal);
 }
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(TimingSafeEqual);
-  registry->Register(FastTimingSafeEqual);
-  registry->Register(fast_equal.GetTypeInfo());
+  registry->Register(fast_timing_safe_equal);
 }
 }  // namespace Timing
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -117,22 +117,14 @@ void HistogramImpl::RegisterExternalReferences(
   registry->Register(GetPercentiles);
   registry->Register(GetPercentilesBigInt);
   registry->Register(DoReset);
-  registry->Register(fast_reset_.GetTypeInfo());
-  registry->Register(fast_get_count_.GetTypeInfo());
-  registry->Register(fast_get_min_.GetTypeInfo());
-  registry->Register(fast_get_max_.GetTypeInfo());
-  registry->Register(fast_get_mean_.GetTypeInfo());
-  registry->Register(fast_get_exceeds_.GetTypeInfo());
-  registry->Register(fast_get_stddev_.GetTypeInfo());
-  registry->Register(fast_get_percentile_.GetTypeInfo());
-  registry->Register(FastReset);
-  registry->Register(FastGetCount);
-  registry->Register(FastGetMin);
-  registry->Register(FastGetMax);
-  registry->Register(FastGetMean);
-  registry->Register(FastGetExceeds);
-  registry->Register(FastGetStddev);
-  registry->Register(FastGetPercentile);
+  registry->Register(fast_reset_);
+  registry->Register(fast_get_count_);
+  registry->Register(fast_get_min_);
+  registry->Register(fast_get_max_);
+  registry->Register(fast_get_mean_);
+  registry->Register(fast_get_exceeds_);
+  registry->Register(fast_get_stddev_);
+  registry->Register(fast_get_percentile_);
   is_registered = true;
 }
 
@@ -302,10 +294,8 @@ void HistogramBase::RegisterExternalReferences(
   registry->Register(Add);
   registry->Register(Record);
   registry->Register(RecordDelta);
-  registry->Register(fast_record_.GetTypeInfo());
-  registry->Register(fast_record_delta_.GetTypeInfo());
-  registry->Register(FastRecord);
-  registry->Register(FastRecordDelta);
+  registry->Register(fast_record_);
+  registry->Register(fast_record_delta_);
   HistogramImpl::RegisterExternalReferences(registry);
 }
 
@@ -356,10 +346,8 @@ void IntervalHistogram::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(Start);
   registry->Register(Stop);
-  registry->Register(fast_start_.GetTypeInfo());
-  registry->Register(fast_stop_.GetTypeInfo());
-  registry->Register(FastStart);
-  registry->Register(FastStop);
+  registry->Register(fast_start_);
+  registry->Register(fast_stop_);
   HistogramImpl::RegisterExternalReferences(registry);
 }
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1634,20 +1634,16 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetBufferPrototype);
 
   registry->Register(SlowByteLengthUtf8);
-  registry->Register(fast_byte_length_utf8.GetTypeInfo());
-  registry->Register(FastByteLengthUtf8);
+  registry->Register(fast_byte_length_utf8);
   registry->Register(SlowCopy);
-  registry->Register(fast_copy.GetTypeInfo());
-  registry->Register(FastCopy);
+  registry->Register(fast_copy);
   registry->Register(Compare);
-  registry->Register(FastCompare);
-  registry->Register(fast_compare.GetTypeInfo());
+  registry->Register(fast_compare);
   registry->Register(CompareOffset);
   registry->Register(Fill);
   registry->Register(IndexOfBuffer);
   registry->Register(SlowIndexOfNumber);
-  registry->Register(FastIndexOfNumber);
-  registry->Register(fast_index_of_number.GetTypeInfo());
+  registry->Register(fast_index_of_number);
   registry->Register(IndexOfString);
 
   registry->Register(Swap16);
@@ -1668,12 +1664,9 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SlowWriteString<ASCII>);
   registry->Register(SlowWriteString<LATIN1>);
   registry->Register(SlowWriteString<UTF8>);
-  registry->Register(FastWriteString<ASCII>);
-  registry->Register(fast_write_string_ascii.GetTypeInfo());
-  registry->Register(FastWriteString<LATIN1>);
-  registry->Register(fast_write_string_latin1.GetTypeInfo());
-  registry->Register(FastWriteString<UTF8>);
-  registry->Register(fast_write_string_utf8.GetTypeInfo());
+  registry->Register(fast_write_string_ascii);
+  registry->Register(fast_write_string_latin1);
+  registry->Register(fast_write_string_utf8);
   registry->Register(StringWrite<ASCII>);
   registry->Register(StringWrite<BASE64>);
   registry->Register(StringWrite<BASE64URL>);

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -10,90 +10,6 @@
 
 namespace node {
 
-using CFunctionCallbackWithalueAndOptions = bool (*)(
-    v8::Local<v8::Value>, v8::Local<v8::Value>, v8::FastApiCallbackOptions&);
-using CFunctionCallbackWithMultipleValueAndOptions =
-    bool (*)(v8::Local<v8::Value>,
-             v8::Local<v8::Value>,
-             v8::Local<v8::Value>,
-             v8::FastApiCallbackOptions&);
-using CFunctionA =
-    uint32_t (*)(v8::Local<v8::Value> receiver,
-                 v8::Local<v8::Value> sourceValue,
-                 // NOLINTNEXTLINE(runtime/references) This is V8 api.
-                 v8::FastApiCallbackOptions& options);
-using CFunctionCallbackWithOneByteString =
-    uint32_t (*)(v8::Local<v8::Value>, const v8::FastOneByteString&);
-
-using CFunctionCallbackReturnBool = bool (*)(v8::Local<v8::Value> unused,
-                                             v8::Local<v8::Value> receiver);
-using CFunctionCallback = void (*)(v8::Local<v8::Value> unused,
-                                   v8::Local<v8::Value> receiver);
-using CFunctionCallbackReturnDouble =
-    double (*)(v8::Local<v8::Object> unused, v8::Local<v8::Object> receiver);
-using CFunctionCallbackReturnInt32 =
-    int32_t (*)(v8::Local<v8::Value> receiver,
-                v8::Local<v8::Value> input,
-                // NOLINTNEXTLINE(runtime/references) This is V8 api.
-                v8::FastApiCallbackOptions& options);
-using CFunctionCallbackValueReturnDouble =
-    double (*)(v8::Local<v8::Value> receiver);
-using CFunctionCallbackValueReturnDoubleUnusedReceiver =
-    double (*)(v8::Local<v8::Value> unused, v8::Local<v8::Value> receiver);
-using CFunctionCallbackWithInt64 = void (*)(v8::Local<v8::Object> unused,
-                                            v8::Local<v8::Object> receiver,
-                                            int64_t);
-using CFunctionCallbackWithBool = void (*)(v8::Local<v8::Object> unused,
-                                           v8::Local<v8::Object> receiver,
-                                           bool);
-using CFunctionCallbackWithString =
-    bool (*)(v8::Local<v8::Value>, const v8::FastOneByteString& input);
-using CFunctionCallbackWithStrings =
-    bool (*)(v8::Local<v8::Value>,
-             const v8::FastOneByteString& input,
-             const v8::FastOneByteString& base);
-using CFunctionCallbackWithTwoUint8Arrays =
-    int32_t (*)(v8::Local<v8::Value>,
-                v8::Local<v8::Value>,
-                v8::Local<v8::Value>,
-                v8::FastApiCallbackOptions&);
-using CFunctionCallbackWithUint8ArrayUint32Int64Bool =
-    int32_t (*)(v8::Local<v8::Value>,
-                v8::Local<v8::Value>,
-                uint32_t,
-                int64_t,
-                bool,
-                v8::FastApiCallbackOptions&);
-using CFunctionWithUint32 = uint32_t (*)(v8::Local<v8::Value>,
-                                         const uint32_t input);
-using CFunctionWithReturnUint32 = uint32_t (*)(v8::Local<v8::Value>);
-using CFunctionWithReturnDouble = double (*)(v8::Local<v8::Value>);
-using CFunctionWithDoubleReturnDouble = double (*)(v8::Local<v8::Value>,
-                                                   v8::Local<v8::Value>,
-                                                   const double);
-using CFunctionWithInt64Fallback = void (*)(v8::Local<v8::Value>,
-                                            v8::Local<v8::Value>,
-                                            const int64_t,
-                                            v8::FastApiCallbackOptions&);
-using CFunctionWithBool = void (*)(v8::Local<v8::Value>,
-                                   v8::Local<v8::Value>,
-                                   bool);
-
-using CFunctionWriteString = uint32_t (*)(v8::Local<v8::Value>,
-                                          v8::Local<v8::Value>,
-                                          const v8::FastOneByteString&,
-                                          uint32_t,
-                                          uint32_t,
-                                          v8::FastApiCallbackOptions&);
-
-using CFunctionBufferCopy = uint32_t (*)(v8::Local<v8::Value>,
-                                         v8::Local<v8::Value>,
-                                         v8::Local<v8::Value>,
-                                         uint32_t,
-                                         uint32_t,
-                                         uint32_t,
-                                         v8::FastApiCallbackOptions&);
-
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
 class ExternalReferenceRegistry {
@@ -101,30 +17,6 @@ class ExternalReferenceRegistry {
   ExternalReferenceRegistry();
 
 #define ALLOWED_EXTERNAL_REFERENCE_TYPES(V)                                    \
-  V(CFunctionA)                                                                \
-  V(CFunctionCallback)                                                         \
-  V(CFunctionCallbackWithalueAndOptions)                                       \
-  V(CFunctionCallbackWithMultipleValueAndOptions)                              \
-  V(CFunctionCallbackWithOneByteString)                                        \
-  V(CFunctionCallbackReturnBool)                                               \
-  V(CFunctionCallbackReturnDouble)                                             \
-  V(CFunctionCallbackReturnInt32)                                              \
-  V(CFunctionWithReturnUint32)                                                 \
-  V(CFunctionCallbackValueReturnDouble)                                        \
-  V(CFunctionCallbackValueReturnDoubleUnusedReceiver)                          \
-  V(CFunctionCallbackWithInt64)                                                \
-  V(CFunctionCallbackWithBool)                                                 \
-  V(CFunctionCallbackWithString)                                               \
-  V(CFunctionCallbackWithStrings)                                              \
-  V(CFunctionCallbackWithTwoUint8Arrays)                                       \
-  V(CFunctionCallbackWithUint8ArrayUint32Int64Bool)                            \
-  V(CFunctionWithUint32)                                                       \
-  V(CFunctionWithDoubleReturnDouble)                                           \
-  V(CFunctionWithInt64Fallback)                                                \
-  V(CFunctionWithBool)                                                         \
-  V(CFunctionBufferCopy)                                                       \
-  V(CFunctionWriteString)                                                      \
-  V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \
   V(v8::AccessorNameSetterCallback)                                            \
@@ -145,6 +37,13 @@ class ExternalReferenceRegistry {
   void Register(ExternalReferenceType addr) { RegisterT(addr); }
   ALLOWED_EXTERNAL_REFERENCE_TYPES(V)
 #undef V
+
+  // Registers both the underlying function pointer
+  // and the corresponding CFunctionInfo.
+  void Register(const v8::CFunction& c_func) {
+    RegisterT(c_func.GetAddress());
+    RegisterT(c_func.GetTypeInfo());
+  }
 
   // This can be called only once.
   const std::vector<intptr_t>& external_references();

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -457,11 +457,9 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(GetLoadAvg);
   registry->Register(GetUptime);
   registry->Register(GetTotalMemory);
-  registry->Register(FastGetTotalMemory);
-  registry->Register(fast_get_total_memory.GetTypeInfo());
+  registry->Register(fast_get_total_memory);
   registry->Register(GetFreeMemory);
-  registry->Register(FastGetFreeMemory);
-  registry->Register(fast_get_free_memory.GetTypeInfo());
+  registry->Register(fast_get_free_memory);
   registry->Register(GetCPUInfo);
   registry->Register(GetInterfaceAddresses);
   registry->Register(GetHomeDirectory);
@@ -469,8 +467,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetPriority);
   registry->Register(GetPriority);
   registry->Register(GetAvailableParallelism);
-  registry->Register(FastGetAvailableParallelism);
-  registry->Register(fast_get_available_parallelism.GetTypeInfo());
+  registry->Register(fast_get_available_parallelism);
   registry->Register(GetOSInformation);
 }
 

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -410,8 +410,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(MarkBootstrapComplete);
   registry->Register(UvMetricsInfo);
   registry->Register(SlowPerformanceNow);
-  registry->Register(FastPerformanceNow);
-  registry->Register(fast_performance_now.GetTypeInfo());
+  registry->Register(fast_performance_now);
   HistogramBase::RegisterExternalReferences(registry);
   IntervalHistogram::RegisterExternalReferences(registry);
 }

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -666,10 +666,8 @@ void BindingData::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(SlowNumber);
   registry->Register(SlowBigInt);
-  registry->Register(FastNumber);
-  registry->Register(FastBigInt);
-  registry->Register(fast_number_.GetTypeInfo());
-  registry->Register(fast_bigint_.GetTypeInfo());
+  registry->Register(fast_number_);
+  registry->Register(fast_bigint_);
 }
 
 BindingData* BindingData::FromV8Value(Local<Value> value) {

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -113,18 +113,15 @@ void InitializeTypes(Local<Object> target,
 void RegisterTypesExternalReferences(ExternalReferenceRegistry* registry) {
 #define V(type)                                                                \
   registry->Register(Is##type);                                                \
-  registry->Register(Is##type##FastApi);                                       \
-  registry->Register(fast_is_##type##_.GetTypeInfo());
+  registry->Register(fast_is_##type##_);
 
   VALUE_METHOD_MAP(V)
 #undef V
 
   registry->Register(IsAnyArrayBuffer);
-  registry->Register(IsAnyArrayBufferFastApi);
-  registry->Register(fast_is_any_array_buffer_.GetTypeInfo());
+  registry->Register(fast_is_any_array_buffer_);
   registry->Register(IsBoxedPrimitive);
-  registry->Register(IsBoxedPrimitiveFastApi);
-  registry->Register(fast_is_boxed_primitive_.GetTypeInfo());
+  registry->Register(fast_is_boxed_primitive_);
 }
 }  // namespace node
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -544,11 +544,8 @@ void BindingData::RegisterExternalReferences(
   registry->Register(PathToFileURL);
   registry->Register(Update);
   registry->Register(CanParse);
-  registry->Register(FastCanParse);
-  registry->Register(FastCanParseWithBase);
-
   for (const CFunction& method : fast_can_parse_methods_) {
-    registry->Register(method.GetTypeInfo());
+    registry->Register(method);
   }
 }
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -442,8 +442,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Sleep);
   registry->Register(ArrayBufferViewHasBuffer);
   registry->Register(GuessHandleType);
-  registry->Register(FastGuessHandleType);
-  registry->Register(fast_guess_handle_type_.GetTypeInfo());
+  registry->Register(fast_guess_handle_type_);
   registry->Register(ParseEnv);
   registry->Register(IsInsideNodeModules);
   registry->Register(DefineLazyProperties);

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -725,8 +725,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(GCProfiler::Stop);
   registry->Register(GetCppHeapStatistics);
   registry->Register(IsStringOneByteRepresentation);
-  registry->Register(FastIsStringOneByteRepresentation);
-  registry->Register(fast_is_string_one_byte_representation_.GetTypeInfo());
+  registry->Register(fast_is_string_one_byte_representation_);
 }
 
 }  // namespace v8_utils

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -126,7 +126,7 @@ void BindingData::Deserialize(Local<Context> context,
 
 v8::CFunction BindingData::fast_get_libuv_now_(
     v8::CFunction::Make(FastGetLibuvNow));
-v8::CFunction BindingData::fast_schedule_timers_(
+v8::CFunction BindingData::fast_schedule_timer_(
     v8::CFunction::Make(FastScheduleTimer));
 v8::CFunction BindingData::fast_toggle_timer_ref_(
     v8::CFunction::Make(FastToggleTimerRef));
@@ -144,7 +144,7 @@ void BindingData::CreatePerIsolateProperties(IsolateData* isolate_data,
                 target,
                 "scheduleTimer",
                 SlowScheduleTimer,
-                &fast_schedule_timers_);
+                &fast_schedule_timer_);
   SetFastMethod(isolate,
                 target,
                 "toggleTimerRef",
@@ -185,20 +185,16 @@ void BindingData::RegisterTimerExternalReferences(
   registry->Register(SetupTimers);
 
   registry->Register(SlowGetLibuvNow);
-  registry->Register(FastGetLibuvNow);
-  registry->Register(fast_get_libuv_now_.GetTypeInfo());
+  registry->Register(fast_get_libuv_now_);
 
   registry->Register(SlowScheduleTimer);
-  registry->Register(FastScheduleTimer);
-  registry->Register(fast_schedule_timers_.GetTypeInfo());
+  registry->Register(fast_schedule_timer_);
 
   registry->Register(SlowToggleTimerRef);
-  registry->Register(FastToggleTimerRef);
-  registry->Register(fast_toggle_timer_ref_.GetTypeInfo());
+  registry->Register(fast_toggle_timer_ref_);
 
   registry->Register(SlowToggleImmediateRef);
-  registry->Register(FastToggleImmediateRef);
-  registry->Register(fast_toggle_immediate_ref_.GetTypeInfo());
+  registry->Register(fast_toggle_immediate_ref_);
 }
 
 }  // namespace timers

--- a/src/timers.h
+++ b/src/timers.h
@@ -61,7 +61,7 @@ class BindingData : public SnapshotableObject {
 
  private:
   static v8::CFunction fast_get_libuv_now_;
-  static v8::CFunction fast_schedule_timers_;
+  static v8::CFunction fast_schedule_timer_;
   static v8::CFunction fast_toggle_timer_ref_;
   static v8::CFunction fast_toggle_immediate_ref_;
 };


### PR DESCRIPTION
The process for adding a fast API to the external registry is currently rather cumbersome, and involves:

1. adding the fast callback typedef to the long and ugly list of "allowed" CFunction signatures in node\_external\_reference.h
2. registering the fast callback
3. registering the `v8::CFunctionInfo` object obtained from the corresponding CFunction

This PR adds a new registry overload which simply takes a reference to the CFunction and registers both the callback pointer and the info pointer, without requiring any additional typedefs.
