### PR TITLE
[22.x] win,build: Fix MSVS v17.14 compilation issue on v22

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.26',
+    'v8_embedder_string': '-node.27',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/cppgc/marking-state.h
+++ b/deps/v8/src/heap/cppgc/marking-state.h
@@ -342,7 +342,7 @@ class MutatorMarkingState final : public BasicMarkingState {
   ~MutatorMarkingState() override = default;
 
   inline bool MarkNoPush(HeapObjectHeader& header) {
-    return MutatorMarkingState::BasicMarkingState::MarkNoPush(header);
+    return BasicMarkingState::MarkNoPush(header);
   }
 
   inline void ReTraceMarkedWeakContainer(cppgc::Visitor&, HeapObjectHeader&);


### PR DESCRIPTION
This prevents updating VS 2022 to the latest version (v17.14), in the release CI. We had similar issues with few VS updates in the past too (17.10 and 17.12 IIRC.

Fixes: https://github.com/nodejs/node/issues/58801