### PR TITLE
doc: remove `--expose-gc` flag from CLI documentation

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1262,25 +1262,6 @@ added:
 
 Enable experimental support for the worker inspection with Chrome DevTools.
 
-### `--expose-gc`
-
-<!-- YAML
-added:
-  - v22.3.0
-  - v20.18.0
--->
-
-> Stability: 1 - Experimental. This flag is inherited from V8 and is subject to
-> change upstream.
-
-This flag will expose the gc extension from V8.
-
-```js
-if (globalThis.gc) {
-  globalThis.gc();
-}
-```
-
 ### `--force-context-aware`
 
 <!-- YAML


### PR DESCRIPTION
The CLI documentation for `--expose-gc` has been added in https://github.com/nodejs/node/pull/53078

However it's removal was requested in https://github.com/nodejs/node/pull/53078#discussion_r1609831586 (since this is not something users should generally rely on), but the documentation wasn't fully removed from the PR before it landed.

So I believe that the flag being documented might have been an oversight.

Original context: https://github.com/nodejs/node/pull/58878#discussion_r2173911155

___

Note: I'm trying to figure out here if `--expose-gc` should or not be documented in the CLI documentation, and if it should be I would be inclined to also include it in the manpage for consistency :thinking: 

___

Note: I wanted to also mention that the flag is also included in the [allowed v8 options](https://github.com/nodejs/node/blob/4b4aaf921fda21c329caf349b23c0620867e4e6c/doc/api/cli.md?plain=1#L3505) and the [useful v8 options](https://github.com/nodejs/node/blob/4b4aaf921fda21c329caf349b23c0620867e4e6c/doc/api/cli.md?plain=1#L3842)
(meaning that even after removing the cli flag section some references to it, for advanced users, will still be present in the document)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
