### PR TITLE
doc: update buffer examples to use subarray instead of slice

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1979,7 +1979,7 @@ console.log(b.toString());
 // Fill a buffer with empty string
 const c = Buffer.allocUnsafe(5).fill('');
 
-console.log(c.fill(''));
+console.log(c);
 // Prints: <Buffer 00 00 00 00 00>
 ```
 
@@ -1996,7 +1996,7 @@ console.log(b.toString());
 // Fill a buffer with empty string
 const c = Buffer.allocUnsafe(5).fill('');
 
-console.log(c.fill(''));
+console.log(c);
 // Prints: <Buffer 00 00 00 00 00>
 ```
 
@@ -2084,7 +2084,7 @@ console.log(buf.includes(97));
 // Prints: true (97 is the decimal ASCII value for 'a')
 console.log(buf.includes(Buffer.from('a buffer example')));
 // Prints: false
-console.log(buf.includes(Buffer.from('a buffer example').slice(0, 8)));
+console.log(buf.includes(Buffer.from('a buffer example').subarray(0, 8)));
 // Prints: true
 console.log(buf.includes('this', 4));
 // Prints: false
@@ -2105,7 +2105,7 @@ console.log(buf.includes(97));
 // Prints: true (97 is the decimal ASCII value for 'a')
 console.log(buf.includes(Buffer.from('a buffer example')));
 // Prints: false
-console.log(buf.includes(Buffer.from('a buffer example').slice(0, 8)));
+console.log(buf.includes(Buffer.from('a buffer example').subarray(0, 8)));
 // Prints: true
 console.log(buf.includes('this', 4));
 // Prints: false
@@ -2160,7 +2160,7 @@ console.log(buf.indexOf(97));
 // Prints: 8 (97 is the decimal ASCII value for 'a')
 console.log(buf.indexOf(Buffer.from('a buffer example')));
 // Prints: -1
-console.log(buf.indexOf(Buffer.from('a buffer example').slice(0, 8)));
+console.log(buf.indexOf(Buffer.from('a buffer example').subarray(0, 8)));
 // Prints: 8
 
 const utf16Buffer = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'utf16le');
@@ -2186,7 +2186,7 @@ console.log(buf.indexOf(97));
 // Prints: 8 (97 is the decimal ASCII value for 'a')
 console.log(buf.indexOf(Buffer.from('a buffer example')));
 // Prints: -1
-console.log(buf.indexOf(Buffer.from('a buffer example').slice(0, 8)));
+console.log(buf.indexOf(Buffer.from('a buffer example').subarray(0, 8)));
 // Prints: 8
 
 const utf16Buffer = Buffer.from('\u039a\u0391\u03a3\u03a3\u0395', 'utf16le');


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

- Updated example code to use `subarray` instead of `slice` for Buffer operations.
- Removed redundant `fill` call that was no longer needed.

