### PR TITLE
doc: add missing `Class:` mentions

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -284,7 +284,7 @@ added: v16.0.0
 
 Global alias for [`buffer.atob()`][].
 
-## `BroadcastChannel`
+## Class: `BroadcastChannel`
 
 <!-- YAML
 added: v18.0.0
@@ -340,7 +340,7 @@ added: v0.0.1
 
 [`clearTimeout`][] is described in the [timers][] section.
 
-## `CloseEvent`
+## Class: `CloseEvent`
 
 <!-- YAML
 added: v23.0.0
@@ -397,7 +397,7 @@ changes:
 
 A browser-compatible implementation of [`CountQueuingStrategy`][].
 
-## `Crypto`
+## Class: `Crypto`
 
 <!-- YAML
 added:
@@ -437,7 +437,7 @@ changes:
 
 A browser-compatible implementation of the [Web Crypto API][].
 
-## `CryptoKey`
+## Class: `CryptoKey`
 
 <!-- YAML
 added:
@@ -458,7 +458,7 @@ A browser-compatible implementation of {CryptoKey}. This global is available
 only if the Node.js binary was compiled with including support for the
 `node:crypto` module.
 
-## `CustomEvent`
+## Class: `CustomEvent`
 
 <!-- YAML
 added:
@@ -498,7 +498,7 @@ changes:
 
 A browser-compatible implementation of [`DecompressionStream`][].
 
-## `Event`
+## Class: `Event`
 
 <!-- YAML
 added: v15.0.0
@@ -515,7 +515,7 @@ changes:
 A browser-compatible implementation of the `Event` class. See
 [`EventTarget` and `Event` API][] for more details.
 
-## `EventSource`
+## Class: `EventSource`
 
 <!-- YAML
 added:
@@ -528,7 +528,7 @@ added:
 
 A browser-compatible implementation of the [`EventSource`][] class.
 
-## `EventTarget`
+## Class: `EventTarget`
 
 <!-- YAML
 added: v15.0.0
@@ -581,7 +581,7 @@ The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.
 written from scratch for Node.js. You can figure out which version of `undici` is bundled
 in your Node.js process reading the `process.versions.undici` property.
 
-## Custom dispatcher
+### Custom dispatcher
 
 You can use a custom dispatcher to dispatch requests passing it in fetch's options object.
 The dispatcher must be compatible with `undici`'s
@@ -600,7 +600,7 @@ import { setGlobalDispatcher } from 'undici';
 setGlobalDispatcher(new MyAgent());
 ```
 
-## Related classes
+### Related classes
 
 The following globals are available to use with `fetch`:
 
@@ -696,7 +696,7 @@ Enable this API with the [`--experimental-webstorage`][] CLI flag.
 `localStorage` data is not stored per user or per request when used in the context
 of a server, it is shared across all users and requests.
 
-## `MessageChannel`
+## Class: `MessageChannel`
 
 <!-- YAML
 added: v15.0.0
@@ -708,7 +708,7 @@ added: v15.0.0
 
 The `MessageChannel` class. See [`MessageChannel`][] for more details.
 
-## `MessageEvent`
+## Class: `MessageEvent`
 
 <!-- YAML
 added: v15.0.0
@@ -720,7 +720,7 @@ added: v15.0.0
 
 The `MessageEvent` class. See [`MessageEvent`][] for more details.
 
-## `MessagePort`
+## Class: `MessagePort`
 
 <!-- YAML
 added: v15.0.0
@@ -736,7 +736,7 @@ The `MessagePort` class. See [`MessagePort`][] for more details.
 
 This variable may appear to be global but is not. See [`module`][].
 
-## `Navigator`
+## Class: `Navigator`
 
 <!-- YAML
 added: v21.0.0
@@ -844,7 +844,7 @@ consisting of the runtime name and major version number.
 console.log(`The user-agent is ${navigator.userAgent}`); // Prints "Node.js/21"
 ```
 
-## `PerformanceEntry`
+## Class: `PerformanceEntry`
 
 <!-- YAML
 added: v19.0.0
@@ -856,7 +856,7 @@ added: v19.0.0
 
 The `PerformanceEntry` class. See [`PerformanceEntry`][] for more details.
 
-## `PerformanceMark`
+## Class: `PerformanceMark`
 
 <!-- YAML
 added: v19.0.0
@@ -868,7 +868,7 @@ added: v19.0.0
 
 The `PerformanceMark` class. See [`PerformanceMark`][] for more details.
 
-## `PerformanceMeasure`
+## Class: `PerformanceMeasure`
 
 <!-- YAML
 added: v19.0.0
@@ -880,7 +880,7 @@ added: v19.0.0
 
 The `PerformanceMeasure` class. See [`PerformanceMeasure`][] for more details.
 
-## `PerformanceObserver`
+## Class: `PerformanceObserver`
 
 <!-- YAML
 added: v19.0.0
@@ -892,7 +892,7 @@ added: v19.0.0
 
 The `PerformanceObserver` class. See [`PerformanceObserver`][] for more details.
 
-## `PerformanceObserverEntryList`
+## Class: `PerformanceObserverEntryList`
 
 <!-- YAML
 added: v19.0.0
@@ -905,7 +905,7 @@ added: v19.0.0
 The `PerformanceObserverEntryList` class. See
 [`PerformanceObserverEntryList`][] for more details.
 
-## `PerformanceResourceTiming`
+## Class: `PerformanceResourceTiming`
 
 <!-- YAML
 added: v19.0.0
@@ -1072,7 +1072,7 @@ A browser-compatible implementation of [`ReadableStreamDefaultReader`][].
 
 This variable may appear to be global but is not. See [`require()`][].
 
-## `Response`
+## Class: `Response`
 
 <!-- YAML
 added:
@@ -1092,7 +1092,7 @@ changes:
 
 A browser-compatible implementation of {Response}.
 
-## `Request`
+## Class: `Request`
 
 <!-- YAML
 added:
@@ -1183,7 +1183,7 @@ added: v17.0.0
 
 The WHATWG [`structuredClone`][] method.
 
-## `SubtleCrypto`
+## Class: `SubtleCrypto`
 
 <!-- YAML
 added:
@@ -1201,7 +1201,7 @@ A browser-compatible implementation of {SubtleCrypto}. This global is available
 only if the Node.js binary was compiled with including support for the
 `node:crypto` module.
 
-## `DOMException`
+## Class: `DOMException`
 
 <!-- YAML
 added: v17.0.0
@@ -1213,7 +1213,7 @@ added: v17.0.0
 
 The WHATWG `DOMException` class. See [`DOMException`][] for more details.
 
-## `TextDecoder`
+## Class: `TextDecoder`
 
 <!-- YAML
 added: v11.0.0
@@ -1239,7 +1239,7 @@ changes:
 
 A browser-compatible implementation of [`TextDecoderStream`][].
 
-## `TextEncoder`
+## Class: `TextEncoder`
 
 <!-- YAML
 added: v11.0.0
@@ -1293,7 +1293,7 @@ changes:
 
 A browser-compatible implementation of [`TransformStreamDefaultController`][].
 
-## `URL`
+## Class: `URL`
 
 <!-- YAML
 added: v10.0.0
@@ -1305,7 +1305,7 @@ added: v10.0.0
 
 The WHATWG `URL` class. See the [`URL`][] section.
 
-## `URLPattern`
+## Class: `URLPattern`
 
 <!-- YAML
 added: v24.0.0
@@ -1317,7 +1317,7 @@ added: v24.0.0
 
 The WHATWG `URLPattern` class. See the [`URLPattern`][] section.
 
-## `URLSearchParams`
+## Class: `URLSearchParams`
 
 <!-- YAML
 added: v10.0.0
@@ -1329,7 +1329,7 @@ added: v10.0.0
 
 The WHATWG `URLSearchParams` class. See the [`URLSearchParams`][] section.
 
-## `WebAssembly`
+## Class: `WebAssembly`
 
 <!-- YAML
 added: v8.0.0
@@ -1345,7 +1345,7 @@ The object that acts as the namespace for all W3C
 [WebAssembly][webassembly-org] related functionality. See the
 [Mozilla Developer Network][webassembly-mdn] for usage and compatibility.
 
-## `WebSocket`
+## Class: `WebSocket`
 
 <!-- YAML
 added:

--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -581,7 +581,7 @@ The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.
 written from scratch for Node.js. You can figure out which version of `undici` is bundled
 in your Node.js process reading the `process.versions.undici` property.
 
-### Custom dispatcher
+## Custom dispatcher
 
 You can use a custom dispatcher to dispatch requests passing it in fetch's options object.
 The dispatcher must be compatible with `undici`'s
@@ -600,7 +600,7 @@ import { setGlobalDispatcher } from 'undici';
 setGlobalDispatcher(new MyAgent());
 ```
 
-### Related classes
+## Related classes
 
 The following globals are available to use with `fetch`:
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -4234,7 +4234,7 @@ added:
 
 Set the maximum number of idle HTTP parsers.
 
-## `WebSocket`
+## Class: `WebSocket`
 
 <!-- YAML
 added:


### PR DESCRIPTION
Our docs are inconsistent when it comes to `Class:` prefix for sections documenting classes. This PR adds the ones that were missing.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
