### PR TITLE
bootstrap: initialize http proxy after user module loader setup

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -126,7 +126,6 @@ function prepareExecution(options) {
   initializeConfigFileSupport();
 
   require('internal/dns/utils').initializeDns();
-  setupHttpProxy();
 
   if (isMainThread) {
     assert(internalBinding('worker').isMainThread);
@@ -158,6 +157,10 @@ function prepareExecution(options) {
   if (initializeModules) {
     setupUserModules(forceDefaultLoader);
   }
+
+  // This has to be done after the user module loader is initialized,
+  // in case undici is externalized.
+  setupHttpProxy();
 
   return mainEntry;
 }


### PR DESCRIPTION
The externalized undici relies on the user module loader, so in the externalized build, initialization of http proxy which relies on undici needs to be deferred until after the user module loader is initialized.

Refs: https://github.com/nodejs/node/issues/58865
Refs: https://github.com/nodejs/node/issues/57872

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
