### PR TITLE
doc: "if and only if" should be "if" in util.parseArgs default value

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1956,7 +1956,7 @@ changes:
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
     * `default` {string | boolean | string\[] | boolean\[]} The default value to
-      be used if (and only if) the option does not appear in the arguments to be
+      be used if the option does not appear in the arguments to be
       parsed. It must be of the same type as the `type` property. When `multiple`
       is `true`, it must be an array.
   * `strict` {boolean} Should an error be thrown when unknown arguments

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1955,10 +1955,12 @@ changes:
       times. If `true`, all values will be collected in an array. If
       `false`, values for the option are last-wins. **Default:** `false`.
     * `short` {string} A single character alias for the option.
-    * `default` {string | boolean | string\[] | boolean\[]} The default value to
-      be used if the option does not appear in the arguments to be
-      parsed. It must be of the same type as the `type` property. When `multiple`
-      is `true`, it must be an array.
+    * `default` {string | boolean | string\[] | boolean\[]} The value to assign to
+      the option if it does not appear in the arguments to be parsed. The value
+      must match the type specified by the `type` property. If `multiple` is
+      `true`, it must be an array. No default value is applied when the option
+      does appear in the arguments to be parsed, even if the provided value
+      is falsey.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1960,7 +1960,7 @@ changes:
       must match the type specified by the `type` property. If `multiple` is
       `true`, it must be an array. No default value is applied when the option
       does appear in the arguments to be parsed, even if the provided value
-      is falsey.
+      is falsy.
   * `strict` {boolean} Should an error be thrown when unknown arguments
     are encountered, or when arguments are passed that do not match the
     `type` configured in `options`.


### PR DESCRIPTION
The default value is legal by means other than defaulting.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
