### PR TITLE
[v22.x backport] crypto: fix SHAKE128/256 breaking change introduced with OpenSSL 3.4

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3850,6 +3850,21 @@ To make [`child_process.exec`][] invoke the default shell, either omit the
 `shell` option, or set it to a nullish value. If the intention is not to invoke
 a shell, use [`child_process.execFile`][] instead.
 
+<!-- md-lint skip-deprecation DEP0197 -->
+
+### DEP0198: Creating SHAKE-128 and SHAKE-256 digests without an explicit `options.outputLength`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58942
+    description: Documentation-only deprecation with support for `--pending-deprecation`.
+-->
+
+Type: Documentation-only (supports [`--pending-deprecation`][])
+
+Creating SHAKE-128 and SHAKE-256 digests without an explicit `options.outputLength` is deprecated.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -3,6 +3,7 @@
 const {
   ObjectSetPrototypeOf,
   ReflectApply,
+  StringPrototypeReplace,
   StringPrototypeToLowerCase,
   Symbol,
 } = primordials;
@@ -33,6 +34,8 @@ const {
   lazyDOMException,
   normalizeEncoding,
   encodingsMap,
+  isPendingDeprecation,
+  getDeprecationWarningEmitter,
 } = require('internal/util');
 
 const {
@@ -63,6 +66,25 @@ const LazyTransform = require('internal/streams/lazy_transform');
 const kState = Symbol('kState');
 const kFinalized = Symbol('kFinalized');
 
+/**
+ * @param {string} name
+ */
+function normalizeAlgorithm(name) {
+  return StringPrototypeReplace(StringPrototypeToLowerCase(name), '-', '');
+}
+
+const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
+  'DEP0198',
+  'Creating SHAKE128/256 digests without an explicit options.outputLength is deprecated.',
+  undefined,
+  false,
+  (algorithm) => {
+    if (!isPendingDeprecation()) return false;
+    const normalized = normalizeAlgorithm(algorithm);
+    return normalized === 'shake128' || normalized === 'shake256';
+  },
+);
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -80,6 +102,9 @@ function Hash(algorithm, options) {
   this[kState] = {
     [kFinalized]: false,
   };
+  if (!isCopy && xofLen === undefined) {
+    maybeEmitDeprecationWarning(algorithm);
+  }
   ReflectApply(LazyTransform, this, [options]);
 }
 
@@ -212,6 +237,12 @@ function hash(algorithm, input, outputEncoding = 'hex') {
         throw new ERR_INVALID_ARG_VALUE('outputEncoding', outputEncoding);
       }
     }
+  }
+  // TODO: ideally we have to ship https://github.com/nodejs/node/pull/58121 so
+  // that a proper DEP0198 deprecation can be done here as well.
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm);
+  if (normalizedAlgorithm === 'shake128' || normalizedAlgorithm === 'shake256') {
+    return new Hash(algorithm).update(input).digest(normalized);
   }
   return oneShotDigest(algorithm, getCachedHashId(algorithm), getHashCache(),
                        input, normalized, encodingsMap[normalized]);

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -110,8 +110,8 @@ function getDeprecationWarningEmitter(
   shouldEmitWarning = () => true,
 ) {
   let warned = false;
-  return function() {
-    if (!warned && shouldEmitWarning()) {
+  return function(arg) {
+    if (!warned && shouldEmitWarning(arg)) {
       warned = true;
       if (code === 'ExperimentalWarning') {
         process.emitWarning(msg, code, deprecated);
@@ -998,4 +998,6 @@ module.exports = {
   setOwnProperty,
   pendingDeprecate,
   WeakReference,
+  isPendingDeprecation,
+  getDeprecationWarningEmitter,
 };

--- a/test/parallel/test-crypto-default-shake-lengths.js
+++ b/test/parallel/test-crypto-default-shake-lengths.js
@@ -1,0 +1,18 @@
+// Flags: --pending-deprecation
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const { createHash } = require('crypto');
+
+common.expectWarning({
+  DeprecationWarning: {
+    DEP0198: 'Creating SHAKE128/256 digests without an explicit options.outputLength is deprecated.',
+  }
+});
+
+{
+  createHash('shake128').update('test').digest();
+}

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -8,7 +8,6 @@ const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
 
-const { hasOpenSSL } = require('../common/crypto');
 const fixtures = require('../common/fixtures');
 
 let cryptoType;
@@ -184,21 +183,19 @@ assert.throws(
 
 // Test XOF hash functions and the outputLength option.
 {
-  // Default outputLengths. Since OpenSSL 3.4 an outputLength is mandatory
-  if (!hasOpenSSL(3, 4)) {
-    assert.strictEqual(crypto.createHash('shake128').digest('hex'),
-                       '7f9c2ba4e88f827d616045507605853e');
-    assert.strictEqual(crypto.createHash('shake128', null).digest('hex'),
-                       '7f9c2ba4e88f827d616045507605853e');
-    assert.strictEqual(crypto.createHash('shake256').digest('hex'),
-                       '46b9dd2b0ba88d13233b3feb743eeb24' +
-                       '3fcd52ea62b81b82b50c27646ed5762f');
-    assert.strictEqual(crypto.createHash('shake256', { outputLength: 0 })
-                             .copy()  // Default outputLength.
-                             .digest('hex'),
-                       '46b9dd2b0ba88d13233b3feb743eeb24' +
-                       '3fcd52ea62b81b82b50c27646ed5762f');
-  }
+  // Default outputLengths.
+  assert.strictEqual(crypto.createHash('shake128').digest('hex'),
+                     '7f9c2ba4e88f827d616045507605853e');
+  assert.strictEqual(crypto.createHash('shake128', null).digest('hex'),
+                     '7f9c2ba4e88f827d616045507605853e');
+  assert.strictEqual(crypto.createHash('shake256').digest('hex'),
+                     '46b9dd2b0ba88d13233b3feb743eeb24' +
+                     '3fcd52ea62b81b82b50c27646ed5762f');
+  assert.strictEqual(crypto.createHash('shake256', { outputLength: 0 })
+                           .copy()  // Default outputLength.
+                           .digest('hex'),
+                     '46b9dd2b0ba88d13233b3feb743eeb24' +
+                     '3fcd52ea62b81b82b50c27646ed5762f');
 
   // Short outputLengths.
   assert.strictEqual(crypto.createHash('shake128', { outputLength: 0 })

--- a/test/parallel/test-crypto-oneshot-hash.js
+++ b/test/parallel/test-crypto-oneshot-hash.js
@@ -8,7 +8,6 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 const fixtures = require('../common/fixtures');
-const { hasOpenSSL } = require('../common/crypto');
 const fs = require('fs');
 
 // Test errors for invalid arguments.
@@ -32,9 +31,6 @@ const methods = crypto.getHashes();
 const input = fs.readFileSync(fixtures.path('utf8_test_text.txt'));
 
 for (const method of methods) {
-  // Skip failing tests on OpenSSL 3.4.0
-  if (method.startsWith('shake') && hasOpenSSL(3, 4))
-    continue;
   for (const outputEncoding of ['buffer', 'hex', 'base64', undefined]) {
     const oldDigest = crypto.createHash(method).update(input).digest(outputEncoding || 'hex');
     const digestFromBuffer = crypto.hash(method, input, outputEncoding);


### PR DESCRIPTION
Backports https://github.com/nodejs/node/pull/58942 to v22.x