### PR TITLE
doc: add missing environment variables to manpage

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -693,11 +693,21 @@ disabled.
 .It Ev NO_COLOR
 Alias for NODE_DISABLE_COLORS
 .
+.It Ev NODE_COMPILE_CACHE Ar dir
+Enable the
+.Sy module compile cache
+for the Node.js instance.
+.
 .It Ev NODE_DEBUG Ar modules...
 Comma-separated list of core modules that should print debug information.
 .
 .It Ev NODE_DEBUG_NATIVE Ar modules...
 Comma-separated list of C++ core modules that should print debug information.
+.
+.It Ev NODE_DISABLE_COMPILE_CACHE
+Disable the
+.Sy module compile cache
+for the Node.js instance.
 .
 .It Ev NODE_DISABLE_COLORS
 When set to
@@ -754,6 +764,9 @@ When set to
 .Ar 1 ,
 emit pending deprecation warnings.
 .
+.It Ev NODE_PENDING_PIPE_INSTANCES
+Set the number of pending pipe instance handles when the pipe server is waiting for connections. This setting applies to Windows only.
+.
 .It Ev NODE_PRESERVE_SYMLINKS
 When set to
 .Ar 1 ,
@@ -787,10 +800,29 @@ the check for a supported platform is skipped during Node.js startup.
 Node.js might not execute correctly.
 Any issues encountered on unsupported platforms will not be fixed.
 .
+.It Ev NODE_TEST_CONTEXT
+When set to
+.Ar 'child'
+, test reporter options will be overridden and test output will be sent to stdout in the TAP format.
+If any other value is provided, Node.js makes no guarantees about the reporter format used or its stability.
+.
 .It Ev NODE_TLS_REJECT_UNAUTHORIZED
 When set to
 .Ar 0 ,
 TLS certificate validation is disabled.
+.
+.It Ev NODE_USE_ENV_PROXY
+When enabled, Node.js parses the
+.Ar HTTP_PROXY
+,
+.Ar HTTPS_PROXY
+and
+.Ar NO_PROXY
+environment variables during startup, and tunnels requests over the specified proxy.
+.Pp
+This currently only affects requests sent over
+.Ar fetch() .
+Support for other built-in http and https methods is under way.
 .
 .It Ev NODE_V8_COVERAGE Ar dir
 When set, Node.js writes JavaScript code coverage information to

--- a/test/parallel/test-cli-node-cli-manpage-env-vars.mjs
+++ b/test/parallel/test-cli-node-cli-manpage-env-vars.mjs
@@ -21,18 +21,8 @@ assert(manpageEnvVarNames.size > 0,
        'Unexpectedly not even a single env variable was detected when scanning the `doc/node.1` file'
 );
 
-// TODO(dario-piotrowicz): add the missing env variables to the manpage and remove this set
-//                         (refs: https://github.com/nodejs/node/issues/58894)
-const knownEnvVariablesMissingFromManPage = new Set([
-  'NODE_COMPILE_CACHE',
-  'NODE_DISABLE_COMPILE_CACHE',
-  'NODE_PENDING_PIPE_INSTANCES',
-  'NODE_TEST_CONTEXT',
-  'NODE_USE_ENV_PROXY',
-]);
-
 for (const envVarName of cliMdEnvVarNames) {
-  if (!manpageEnvVarNames.has(envVarName) && !knownEnvVariablesMissingFromManPage.has(envVarName)) {
+  if (!manpageEnvVarNames.has(envVarName)) {
     assert.fail(`The "${envVarName}" environment variable (present in \`doc/api/cli.md\`) is missing from the \`doc/node.1\` file`);
   }
   manpageEnvVarNames.delete(envVarName);


### PR DESCRIPTION
**Description:**
Adds missing environment variables to manpage:
- `NODE_COMPILE_CACHE`
- `NODE_DISABLE_COMPILE_CACHE` 
- `NODE_PENDING_PIPE_INSTANCES`
- `NODE_TEST_CONTEXT`
- `NODE_USE_ENV_PROXY`

**Reference:**
Fixes: #58894