### PR TITLE
doc: remove broken link to permission model source code

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -2,8 +2,6 @@
 
 <!--introduced_in=v20.0.0-->
 
-<!-- source_link=src/permission.cc -->
-
 Permissions can be used to control what system resources the
 Node.js process has access to or what actions the process can take
 with those resources.


### PR DESCRIPTION
The permission model grew enough to be splited into multiple files, the link in the md file is broken. And as it is not part of a single file, the best way to fix this is just remove the link, many APIs in Node.js does not have the source code linked, this is not bad for our docs.

---
The link is pointing to https://github.com/nodejs/node/blob/v24.3.0/src/permission.cc, which is a "404". Everything is under `src/permission/*.{cc,h}` not a single file.
