### PR TITLE
dns: fix parse memory leaky

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1565,6 +1565,8 @@ Maybe<int> SoaTraits::Parse(QuerySoaWrap* wrap,
 
   if (status != ARES_SUCCESS) return Just<int>(status);
 
+  auto cleanup = OnScopeLeave([&]() { ares_free_data(soa_out); });
+
   Local<Object> soa_record = Object::New(env->isolate());
 
   if (soa_record
@@ -1604,8 +1606,6 @@ Maybe<int> SoaTraits::Parse(QuerySoaWrap* wrap,
           .IsNothing()) {
     return Nothing<int>();
   }
-
-  ares_free_data(soa_out);
 
   wrap->CallOnComplete(soa_record);
   return Just<int>(ARES_SUCCESS);


### PR DESCRIPTION
Fix `SoaTraits::Parse` memory leaky.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
