### PR TITLE
test: add missing port=0 arg in test-debugger-extract-function-name

### DIFF
--- a/test/parallel/test-debugger-extract-function-name.mjs
+++ b/test/parallel/test-debugger-extract-function-name.mjs
@@ -7,7 +7,7 @@ import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const cli = startCLI([path('debugger', 'three-lines.js')]);
+const cli = startCLI(['--port=0', path('debugger', 'three-lines.js')]);
 
 try {
   await cli.waitForInitialBreak();


### PR DESCRIPTION
In the `test-debugger-extract-function-name` file the inspector port is not set to `0`, this causes the test (at least on my machine) to consistently (always) fail when run with the python runner with any repeat value greater than 1:
![test-debugger-fail](https://github.com/user-attachments/assets/8c3189f2-8a97-4ac4-b8dd-50f6b5ac4df4)

So I am making sure that the port is indeed set to `0` solving the issue.

Also the test has also been a bit flaky in the CI lately:
 - https://github.com/nodejs/reliability/issues/1246
 - https://github.com/nodejs/reliability/issues/1245
 - https://github.com/nodejs/reliability/issues/1244
 - https://github.com/nodejs/reliability/issues/1243
 - https://github.com/nodejs/reliability/issues/1242

So hopefully this change should address the flakiness :slightly_smiling_face: 

However I am not completely sure, since I did try to run some stress tests on the file on main:
- https://ci.nodejs.org/job/node-stress-single-test/591
- https://ci.nodejs.org/job/node-stress-single-test/592

But unfortunately they didn't show any flakes, so it is hard to confirm with full confidence whether
or not my changes are also addressing the CI flakes or not :confused: 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
