### PR TITLE
doc: add scroll margin to links

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -373,7 +373,7 @@ p {
   padding-bottom: 2rem;
 }
 
-/* prevent the sticky stability header from overlapping the section header */
+/* prevent the module-level sticky stability header from overlapping the section headers when clicked */
 #apicontent:has(> .api_stability) a {
   scroll-margin-top: 50px;
 }


### PR DESCRIPTION
Before: Opening a section link like [this one](https://nodejs.org/docs/latest/api/os.html#oscpus) would hide the section title behind the sticky stability header:

<img width="312" alt="Screenshot 2025-07-07 at 15 45 46" src="https://github.com/user-attachments/assets/862647fa-500d-4e45-af19-e05c30b59505" />

After: Page scroll is offset by 50px so the section header is visible:

<img width="312" alt="Screenshot 2025-07-07 at 15 45 57" src="https://github.com/user-attachments/assets/97ceb6b3-6650-4e44-a601-8bd32aead833" />

The value change is undone below 600px where it is not an issue because the page header is not sticky.