### PR TITLE
doc: enhance glob pattern documentation in fs.md

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1430,7 +1430,7 @@ changes:
     description: Add support for `withFileTypes` as an option.
 -->
 
-* `pattern` {string|string\[]}
+* `pattern` {string|string\[]} The glob pattern(s) to match against.
 * `options` {Object}
   * `cwd` {string|URL} current working directory. **Default:** `process.cwd()`
   * `exclude` {Function|string\[]} Function to filter out files/directories or a
@@ -1446,8 +1446,51 @@ changes:
 * Returns: {AsyncIterator} An AsyncIterator that yields the paths of files
   that match the pattern.
 
+Retrieves the file paths matching the specified pattern(s).
+
 When `followSymlinks` is enabled, detected symbolic link cycles are not
 traversed recursively.
+
+#### Pattern Syntax
+
+The glob implementation supports the following pattern syntax:
+
+**Basic Wildcards:**
+
+| Pattern              | Description                                                    |
+| -------------------- | -------------------------------------------------------------- |
+| `*`                  | Matches any number of characters within a single path segment. |
+| `?`                  | Matches exactly one character.                                 |
+| `[abc]`              | Matches any character in the brackets.                         |
+| `[a-z]`              | Matches any character in the range.                            |
+| `[!abc]` or `[^abc]` | Matches any character not in the brackets.                     |
+| `[!a-z]` or `[^a-z]` | Matches any character not in the range.                        |
+
+**Globstar:**
+
+| Pattern   | Description                                   |
+| --------- | --------------------------------------------- |
+| `**`      | Matches zero or more directories recursively. |
+| `**/*.js` | Matches all `.js` files in any subdirectory.  |
+
+**Brace Expansion:**
+
+| Pattern     | Description                                      |
+| ----------- | ------------------------------------------------ |
+| `{a,b,c}`   | Matches any of the comma-separated patterns.     |
+| `{1..5}`    | Matches any number in the range (1, 2, 3, 4, 5). |
+| `*.{js,ts}` | Matches files with `.js` or `.ts` extensions.    |
+
+**Extended Glob Patterns:**
+
+| Pattern      | Description                                      |
+| ------------ | ------------------------------------------------ |
+| `+(pattern)` | Matches one or more occurrences of the pattern.  |
+| `*(pattern)` | Matches zero or more occurrences of the pattern. |
+| `?(pattern)` | Matches zero or one occurrence of the pattern.   |
+| `!(pattern)` | Matches anything except the pattern.             |
+
+#### Examples
 
 ```mjs
 import { glob } from 'node:fs/promises';
@@ -1464,6 +1507,40 @@ const { glob } = require('node:fs/promises');
     console.log(entry);
 })();
 ```
+
+To collect all results into an array, use `Array.fromAsync`:
+
+```mjs
+const files = await Array.fromAsync(glob('src/**/*.js'));
+```
+
+**Common patterns:**
+
+| Pattern                                             | Description                                      |
+| --------------------------------------------------- | ------------------------------------------------ |
+| `glob('*.js')`                                      | All `.js` files in the current directory.        |
+| `glob('**/*.{js,ts}')`                              | All `.js` and `.ts` files recursively.           |
+| `glob('src/{components,utils}/**/*.js')`            | `.js` files in `src/components` or `src/utils`.  |
+| `glob('test/**/*.{spec,test}.js')`                  | Test files ending with `.spec.js` or `.test.js`. |
+| `glob('**/*.js', { exclude: ['node_modules/**'] })` | All `.js` files except those in `node_modules`.  |
+| `glob(['src/**/*.js', 'lib/**/*.js'])`              | `.js` files in both `src` and `lib` directories. |
+
+#### Platform Considerations
+
+* **Case sensitivity**: Glob patterns are case-insensitive on Windows and macOS,
+  case-sensitive on other platforms.
+* **Path separators**: Forward slashes (`/`) are used in patterns regardless of
+  platform; they are automatically converted to the appropriate separator.
+* **Returned paths**: Results use platform-specific path separators (`\` on Windows,
+  `/` on POSIX). Paths are relative to `options.cwd` if provided, otherwise
+  relative to the current working directory.
+* **Symlinks**: Symbolic links to directories are not traversed while expanding
+  `**` patterns unless `followSymlinks` is `true`.
+* **Hidden files**: Files starting with `.` are included in results when explicitly
+  matched, but not when using `*` or `**` patterns.
+
+[`path.matchesGlob()`][] supports the same basic glob pattern syntax for
+in-memory path matching, but does not include the `exclude` option.
 
 ### `fsPromises.lchmod(path, mode)`
 
@@ -3586,8 +3663,7 @@ changes:
     description: Add support for `withFileTypes` as an option.
 -->
 
-* `pattern` {string|string\[]}
-
+* `pattern` {string|string\[]} The glob pattern(s) to match against.
 * `options` {Object}
   * `cwd` {string|URL} current working directory. **Default:** `process.cwd()`
   * `exclude` {Function|string\[]} Function to filter out files/directories or a
@@ -3597,11 +3673,17 @@ changes:
     followed while expanding `**` patterns. **Default:** `false`.
   * `withFileTypes` {boolean} `true` if the glob should return paths as Dirents,
     `false` otherwise. **Default:** `false`.
-
 * `callback` {Function}
   * `err` {Error}
+  * `matches` {string\[]|fs.Dirent\[]} An array of paths or Dirent objects that
+    match the pattern. String paths use platform-specific separators (`\` on
+    Windows, `/` on POSIX) and are relative to `options.cwd` if provided,
+    otherwise relative to the current working directory.
 
-* Retrieves the files matching the specified pattern.
+Retrieves the file paths matching the specified pattern(s).
+
+See `fsPromises.glob()` for detailed information about pattern syntax,
+examples, and behavior.
 
 When `followSymlinks` is enabled, detected symbolic link cycles are not
 traversed recursively.
@@ -6217,7 +6299,7 @@ changes:
     description: Add support for `withFileTypes` as an option.
 -->
 
-* `pattern` {string|string\[]}
+* `pattern` {string|string\[]} The glob pattern(s) to match against.
 * `options` {Object}
   * `cwd` {string|URL} current working directory. **Default:** `process.cwd()`
   * `exclude` {Function|string\[]} Function to filter out files/directories or a
@@ -6227,7 +6309,15 @@ changes:
     followed while expanding `**` patterns. **Default:** `false`.
   * `withFileTypes` {boolean} `true` if the glob should return paths as Dirents,
     `false` otherwise. **Default:** `false`.
-* Returns: {string\[]} paths of files that match the pattern.
+* Returns: {string\[]|fs.Dirent\[]} An array of paths or Dirent objects that
+  match the pattern. String paths use platform-specific separators (`\` on
+  Windows, `/` on POSIX) and are relative to `options.cwd` if provided,
+  otherwise relative to the current working directory.
+
+Retrieves the file paths matching the specified pattern(s).
+
+See `fsPromises.glob()` for detailed information about pattern syntax,
+examples, and behavior.
 
 When `followSymlinks` is enabled, detected symbolic link cycles are not
 traversed recursively.
@@ -9329,6 +9419,7 @@ the file contents.
 [`kqueue(2)`]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
 [`minimatch`]: https://github.com/isaacs/minimatch
 [`node:stream/iter`]: stream_iter.md
+[`path.matchesGlob()`]: path.md#pathmatchesglobpath-pattern
 [`statfs.bsize`]: #statfsbsize
 [`stream/iter pipeTo()`]: stream_iter.md#pipetosource-transforms-writer-options
 [`stream/iter pull()`]: stream_iter.md#pullsource-transforms-options


### PR DESCRIPTION
The `pattern` parameter of the `fs.glob()` family was documented as a type only; nothing described which syntax the matcher accepts, what the calls return, or how matching differs across platforms. #58981 asked for exactly that.

`fsPromises.glob()` now carries the reference:

- **Pattern syntax** — wildcards (`*`, `?`, `[abc]`), globstar (`**`), brace expansion (`{a,b,c}`), and extended patterns (`+(...)`, `!(...)`)
- **Examples** — including collecting results with `Array.fromAsync`, and a table of common patterns
- **Platform considerations** — case sensitivity, path separators, the shape of returned paths, symlink traversal, and hidden files

`fs.glob()` and `fs.globSync()` cross-reference that section instead of repeating it, and the values they produce are now described.

Fixes: https://github.com/nodejs/node/issues/58981
