### PR TITLE
fix return value of fs APIs

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2473,8 +2473,6 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
       uv_req->path = nullptr;
       AfterInteger(uv_req);  // after may delete req_wrap_async if there is
                              // an error
-    } else {
-      req_wrap_async->SetReturnValue(args);
     }
   } else {  // write(fd, string, pos, enc, undefined, ctx)
     CHECK_EQ(argc, 6);

--- a/test/fixtures/permission/fs-write.js
+++ b/test/fixtures/permission/fs-write.js
@@ -211,6 +211,12 @@ const relativeProtectedFolder = process.env.RELATIVEBLOCKEDFOLDER;
     code: 'ERR_ACCESS_DENIED',
     permission: 'FileSystemWrite',
   }));
+  assert.rejects(async () => {
+    await fs.promises.mkdtemp(path.join(blockedFolder, 'any-folder'));
+  }, {
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  });
 }
 
 // fs.mkdtempDisposableSync


### PR DESCRIPTION
Fixed: https://github.com/nodejs/node/issues/58747

The C++ layer just reject the Promise but does not return the Promise to JS layer when an error occurs(Libuv error or permission error).

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
