### PR TITLE
feat: add support for 'electron' condition in conditional exports

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -638,6 +638,12 @@ const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
  */
 function resolveExports(nmPath, request, conditions) {
   // The implementation's behavior is meant to mirror resolution in ESM.
+
+  //Add electron 
+  if (process.versions?.electron && conditions?.add) {
+    conditions.add('electron');
+  }
+
   const { 1: name, 2: expansion = '' } =
     RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
   if (!name) { return; }

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -978,6 +978,10 @@ function defaultResolve(specifier, context = {}) {
   }
 
   conditions = getConditionsSet(conditions);
+  if (process.versions?.electron) {
+  conditions.add('electron');
+  }
+
   let url;
   try {
     url = moduleResolve(


### PR DESCRIPTION
### Description

This PR adds support for resolving "electron" condition in both ESM and CommonJS module resolution, based on process.versions.electron. Useful for runtime-specific exports for Electron apps. 

Resolves electron/electron#47670