### PR TITLE
crypto: runtime-deprecate default shake128/256 output lengths

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4065,12 +4065,15 @@ The [`util.types.isNativeError`][] API is deprecated. Please use [`Error.isError
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59008
+    description: Runtime deprecation.
   - version: v24.4.0
     pr-url: https://github.com/nodejs/node/pull/58942
     description: Documentation-only deprecation with support for `--pending-deprecation`.
 -->
 
-Type: Documentation-only (supports [`--pending-deprecation`][])
+Type: Runtime
 
 Creating SHAKE-128 and SHAKE-256 digests without an explicit `options.outputLength` is deprecated.
 

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -34,7 +34,6 @@ const {
   lazyDOMException,
   normalizeEncoding,
   encodingsMap,
-  isPendingDeprecation,
   getDeprecationWarningEmitter,
 } = require('internal/util');
 
@@ -80,7 +79,6 @@ const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
   undefined,
   false,
   (algorithm) => {
-    if (!isPendingDeprecation()) return false;
     const normalized = normalizeAlgorithm(algorithm);
     return normalized === 'shake128' || normalized === 'shake256';
   },

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -251,6 +251,7 @@ void Hash::OneShotDigest(const FunctionCallbackInfo<Value>& args) {
     } else if (output_length == 0) {
       // This is to handle OpenSSL 3.4's breaking change in SHAKE128/256
       // default lengths
+      // TODO(@panva): remove this behaviour when DEP0198 is End-Of-Life
       const char* name = OBJ_nid2sn(EVP_MD_type(md));
       if (name != nullptr) {
         if (strcmp(name, "SHAKE128") == 0) {
@@ -379,6 +380,9 @@ bool Hash::HashInit(const EVP_MD* md, Maybe<unsigned int> xof_md_len) {
   }
 
   md_len_ = mdctx_.getDigestSize();
+
+  // This is to handle OpenSSL 3.4's breaking change in SHAKE128/256
+  // default lengths
   // TODO(@panva): remove this behaviour when DEP0198 is End-Of-Life
   if (mdctx_.hasXofFlag() && !xof_md_len.IsJust() && md_len_ == 0) {
     const char* name = OBJ_nid2sn(EVP_MD_type(md));

--- a/test/parallel/test-crypto-default-shake-lengths-oneshot.js
+++ b/test/parallel/test-crypto-default-shake-lengths-oneshot.js
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-crypto-default-shake-lengths.js
+++ b/test/parallel/test-crypto-default-shake-lengths.js
@@ -1,4 +1,3 @@
-// Flags: --pending-deprecation
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -4,6 +4,15 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
+common.expectWarning({
+  DeprecationWarning: [
+    ['crypto.Hash constructor is deprecated.',
+     'DEP0179'],
+    ['Creating SHAKE128/256 digests without an explicit options.outputLength is deprecated.',
+     'DEP0198'],
+  ]
+});
+
 const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
@@ -280,10 +289,4 @@ assert.throws(
 
 {
   crypto.Hash('sha256');
-  common.expectWarning({
-    DeprecationWarning: [
-      ['crypto.Hash constructor is deprecated.',
-       'DEP0179'],
-    ]
-  });
 }


### PR DESCRIPTION
Follow up to #58942.

I wish to move forward with runtime deprecation straight away since the default lengths are half the size necessary for full collision resistance supported by these algorithms.