### PR TITLE
docs: fix tty.ReadStream constructor placement

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -44,6 +44,22 @@ Represents the readable side of a TTY. In normal circumstances
 [`process.stdin`][] will be the only `tty.ReadStream` instance in a Node.js
 process and there should be no reason to create additional instances.
 
+### `new tty.ReadStream(fd[, options])`
+
+<!-- YAML
+added: v0.5.8
+changes:
+  - version: v0.9.4
+    description: The `options` argument is supported.
+-->
+
+* `fd` {number} A file descriptor associated with a TTY.
+* `options` {Object} Options passed to parent `net.Socket`,
+  see `options` of [`net.Socket` constructor][].
+* Returns {tty.ReadStream}
+
+Creates a `ReadStream` for `fd` associated with a TTY.
+
 ### `readStream.isRaw`
 
 <!-- YAML
@@ -97,22 +113,6 @@ Represents the writable side of a TTY. In normal circumstances,
 [`process.stdout`][] and [`process.stderr`][] will be the only
 `tty.WriteStream` instances created for a Node.js process and there
 should be no reason to create additional instances.
-
-### `new tty.ReadStream(fd[, options])`
-
-<!-- YAML
-added: v0.5.8
-changes:
-  - version: v0.9.4
-    description: The `options` argument is supported.
--->
-
-* `fd` {number} A file descriptor associated with a TTY.
-* `options` {Object} Options passed to parent `net.Socket`,
-  see `options` of [`net.Socket` constructor][].
-* Returns {tty.ReadStream}
-
-Creates a `ReadStream` for `fd` associated with a TTY.
 
 ### `new tty.WriteStream(fd)`
 


### PR DESCRIPTION
The `new tty.ReadStream(fd[, options])` constructor documentation was incorrectly placed under the `tty.WriteStream` class heading.

This commit moves the documentation for the `tty.ReadStream` constructor to its correct location under the `tty.ReadStream` class heading, improving the accuracy and readability of the `tty` module documentation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
