### PR TITLE
esm: WebAssembly.namespaceInstance

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3266,6 +3266,13 @@ The WASI instance has already started.
 
 The WASI instance has not been started.
 
+<a id="ERR_WEBASSEMBLY_NOT_MODULE_RECORD_NAMESPACE"></a>
+
+### `ERR_WEBASSEMBLY_NOT_MODULE_RECORD_NAMESPACE`
+
+The object passed to `WebAssembly.moduleInstance` was not a valid WebAssembly
+Module Record namespace object.
+
 <a id="ERR_WEBASSEMBLY_RESPONSE"></a>
 
 ### `ERR_WEBASSEMBLY_RESPONSE`

--- a/lib/internal/bootstrap/web/exposed-window-or-worker.js
+++ b/lib/internal/bootstrap/web/exposed-window-or-worker.js
@@ -102,6 +102,7 @@ internalBinding('wasm_web_api').setImplementation((streamState, source) => {
   require('internal/wasm_web_api').wasmStreamingCallback(streamState, source);
 });
 
+
 // WebCryptoAPI
 if (internalBinding('config').hasOpenSSL) {
   defineReplaceableLazyAttribute(

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1892,6 +1892,7 @@ E('ERR_VM_MODULE_NOT_MODULE',
   'Provided module is not an instance of Module', Error);
 E('ERR_VM_MODULE_STATUS', 'Module status %s', Error);
 E('ERR_WASI_ALREADY_STARTED', 'WASI instance has already started', Error);
+E('ERR_WEBASSEMBLY_NOT_MODULE_RECORD_NAMESPACE', 'Not a WebAssembly Module Record namespace object.', TypeError);
 E('ERR_WEBASSEMBLY_RESPONSE', 'WebAssembly response %s', TypeError);
 E('ERR_WORKER_INIT_FAILED', 'Worker initialization failure: %s', Error);
 E('ERR_WORKER_INVALID_EXEC_ARGV', (errors, msg = 'invalid execArgv flags') =>

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -10,7 +10,6 @@ const {
   SafeArrayIterator,
   SafeMap,
   SafeSet,
-  SafeWeakMap,
   StringPrototypeIncludes,
   StringPrototypeReplaceAll,
   StringPrototypeSlice,
@@ -55,6 +54,7 @@ const {
   ERR_UNKNOWN_BUILTIN_MODULE,
 } = require('internal/errors').codes;
 const { maybeCacheSourceMap } = require('internal/source_map/source_map_cache');
+const { wasmInstances } = require('internal/wasm_web_api');
 const moduleWrap = internalBinding('module_wrap');
 const { ModuleWrap } = moduleWrap;
 
@@ -491,7 +491,6 @@ translators.set('json', function jsonStrategy(url, source) {
  *   WebAssembly.Instance
  * >} [[Instance]] slot proxy for WebAssembly Module Record
  */
-const wasmInstances = new SafeWeakMap();
 translators.set('wasm', async function(url, source) {
   emitExperimentalWarning('Importing WebAssembly modules');
 
@@ -533,7 +532,7 @@ translators.set('wasm', async function(url, source) {
   const { module } = createDynamicModule([...importsList], [...exportsList], url, (reflect) => {
     for (const impt of importsList) {
       const importNs = reflect.imports[impt];
-      const wasmInstance = wasmInstances.get(importNs);
+      const wasmInstance = wasmInstances.get(importNs)?.exports;
       if (wasmInstance) {
         const wrappedModule = ObjectAssign({ __proto__: null }, reflect.imports[impt]);
         for (const { module, name } of wasmGlobalImports) {
@@ -549,8 +548,9 @@ translators.set('wasm', async function(url, source) {
     }
     // In cycles importing unexecuted Wasm, wasmInstance will be undefined, which will fail during
     // instantiation, since all bindings will be in the Temporal Deadzone (TDZ).
-    const { exports } = new WebAssembly.Instance(compiled, reflect.imports);
-    wasmInstances.set(module.getNamespace(), exports);
+    const instance = new WebAssembly.Instance(compiled, reflect.imports);
+    const { exports } = instance;
+    wasmInstances.set(module.getNamespace(), instance);
     for (const expt of exportsList) {
       let val = exports[expt];
       // Unwrap WebAssembly.Global for JS bindings

--- a/lib/internal/wasm_web_api.js
+++ b/lib/internal/wasm_web_api.js
@@ -2,10 +2,13 @@
 
 const {
   PromiseResolve,
+  SafeWeakMap,
+  globalThis,
 } = primordials;
 const {
   ERR_INVALID_ARG_TYPE,
   ERR_WEBASSEMBLY_RESPONSE,
+  ERR_WEBASSEMBLY_NOT_MODULE_RECORD_NAMESPACE,
 } = require('internal/errors').codes;
 
 let undici;
@@ -61,6 +64,21 @@ function wasmStreamingCallback(streamState, source) {
   });
 }
 
+// WebAssembly ESM Integration extension pending V8 support - namespaceInstance property:
+// see https://webassembly.github.io/esm-integration/js-api/index.html#dom-webassembly-namespaceinstance.
+const wasmInstances = new SafeWeakMap();
+const { WebAssembly } = globalThis;
+if (WebAssembly && !WebAssembly.namespaceInstance) {
+  WebAssembly.namespaceInstance = function namespaceInstance(ns) {
+    const instance = wasmInstances.get(ns);
+    if (!instance) {
+      throw new ERR_WEBASSEMBLY_NOT_MODULE_RECORD_NAMESPACE();
+    }
+    return instance;
+  };
+}
+
 module.exports = {
   wasmStreamingCallback,
+  wasmInstances,
 };


### PR DESCRIPTION
This implements the `WebAssembly.namespaceInstance` function as defined in https://webassembly.github.io/esm-integration/js-api/index.html#dom-webassembly-namespaceinstance-namespace.

This function can be used to obtain the underlying `WebAssembly.Instance` object for a WebAssembly module record module namespace. 

Ideally this would be implemented in V8, but they are not currently implementing the instance phase, so this is left for us to patch here.

Example:

```js
import * as mod from './mod.wasm';
WebAssembly.namespaceInstance(mod) instanceof WebAssembly.Instance // true
```

Internally this then shares the existing weakmap lookup that was already previously implemented.