### PR TITLE
test,crypto: handle a few more BoringSSL tests

### DIFF
--- a/test/parallel/test-crypto-async-sign-verify.js
+++ b/test/parallel/test-crypto-async-sign-verify.js
@@ -88,18 +88,21 @@ test('rsa_public.pem', 'rsa_private.pem', 'sha256', false,
 
 // ED25519
 test('ed25519_public.pem', 'ed25519_private.pem', undefined, true);
-// ED448
-test('ed448_public.pem', 'ed448_private.pem', undefined, true);
 
-// ECDSA w/ der signature encoding
-test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-     false);
-test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
-     false, { dsaEncoding: 'der' });
+if (!process.features.openssl_is_boringssl) {
+  // ED448
+  test('ed448_public.pem', 'ed448_private.pem', undefined, true);
 
-// ECDSA w/ ieee-p1363 signature encoding
-test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
-     { dsaEncoding: 'ieee-p1363' });
+  // ECDSA w/ der signature encoding
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+      false);
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384',
+      false, { dsaEncoding: 'der' });
+
+  // ECDSA w/ ieee-p1363 signature encoding
+  test('ec_secp256k1_public.pem', 'ec_secp256k1_private.pem', 'sha384', false,
+      { dsaEncoding: 'ieee-p1363' });
+}
 
 // DSA w/ der signature encoding
 test('dsa_public.pem', 'dsa_private.pem', 'sha256',
@@ -150,7 +153,10 @@ MCowBQYDK2VuAyEA6pwGRbadNQAI/tYN8+/p/0/hbsdHfOEGr1ADiLVk/Gc=
   const data = crypto.randomBytes(32);
   const signature = crypto.randomBytes(16);
 
-  const expected = hasOpenSSL3 ? /operation not supported for this keytype/ : /no default digest/;
+  let expected = /no default digest/;
+  if (hasOpenSSL3 || !process.features.openssl_is_boringssl) {
+    expected = /operation[\s_]not[\s_]supported[\s_]for[\s_]this[\s_]keytype/i;
+  }
 
   crypto.verify(undefined, data, untrustedKey, signature, common.mustCall((err) => {
     assert.ok(err);
@@ -164,6 +170,6 @@ MCowBQYDK2VuAyEA6pwGRbadNQAI/tYN8+/p/0/hbsdHfOEGr1ADiLVk/Gc=
   });
   crypto.sign('sha512', 'message', privateKey, common.mustCall((err) => {
     assert.ok(err);
-    assert.match(err.message, /digest too big for rsa key/);
+    assert.match(err.message, /digest[\s_]too[\s_]big[\s_]for[\s_]rsa[\s_]key/i);
   }));
 }

--- a/test/parallel/test-crypto-certificate.js
+++ b/test/parallel/test-crypto-certificate.js
@@ -41,7 +41,8 @@ function copyArrayBuffer(buf) {
 
 function checkMethods(certificate) {
 
-  assert.strictEqual(certificate.verifySpkac(spkacValid), true);
+  if (!process.features.openssl_is_boringssl)
+    assert.strictEqual(certificate.verifySpkac(spkacValid), true);
   assert.strictEqual(certificate.verifySpkac(spkacFail), false);
 
   assert.strictEqual(
@@ -56,10 +57,12 @@ function checkMethods(certificate) {
   );
   assert.strictEqual(certificate.exportChallenge(spkacFail), '');
 
-  const ab = copyArrayBuffer(spkacValid);
-  assert.strictEqual(certificate.verifySpkac(ab), true);
-  assert.strictEqual(certificate.verifySpkac(new Uint8Array(ab)), true);
-  assert.strictEqual(certificate.verifySpkac(new DataView(ab)), true);
+  if (!process.features.openssl_is_boringssl) {
+    const ab = copyArrayBuffer(spkacValid);
+    assert.strictEqual(certificate.verifySpkac(ab), true);
+    assert.strictEqual(certificate.verifySpkac(new Uint8Array(ab)), true);
+    assert.strictEqual(certificate.verifySpkac(new DataView(ab)), true);
+  }
 }
 
 {

--- a/test/parallel/test-crypto-dh-errors.js
+++ b/test/parallel/test-crypto-dh-errors.js
@@ -35,7 +35,7 @@ for (const bits of [-1, 0, 1]) {
     assert.throws(() => crypto.createDiffieHellman(bits), {
       code: 'ERR_OSSL_BN_BITS_TOO_SMALL',
       name: 'Error',
-      message: /bits too small/,
+      message: /bits[\s_]too[\s_]small/i,
     });
   }
 }

--- a/test/parallel/test-crypto-dh.js
+++ b/test/parallel/test-crypto-dh.js
@@ -60,18 +60,17 @@ const {
   let wrongBlockLength;
   if (hasOpenSSL3) {
     wrongBlockLength = {
-      message: 'error:1C80006B:Provider routines::wrong final block length',
-      code: 'ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH',
-      library: 'Provider routines',
-      reason: 'wrong final block length'
+      message: /wrong[\s_]final[\s_]block[\s_]length/i,
+      code: /ERR_OSSL_(EVP_)?WRONG_FINAL_BLOCK_LENGTH/,
+      library: /Provider routines|Cipher functions/,
+      reason: /wrong[\s_]final[\s_]block[\s_]length/i,
     };
   } else {
     wrongBlockLength = {
-      message: 'error:0606506D:digital envelope' +
-        ' routines:EVP_DecryptFinal_ex:wrong final block length',
-      code: 'ERR_OSSL_EVP_WRONG_FINAL_BLOCK_LENGTH',
-      library: 'digital envelope routines',
-      reason: 'wrong final block length'
+      message: /wrong[\s_]final[\s_]block[\s_]length/i,
+      code: /ERR_OSSL_(EVP_)?WRONG_FINAL_BLOCK_LENGTH/,
+      library: /digital envelope routines|Cipher functions/,
+      reason: /wrong[\s_]final[\s_]block[\s_]length/i,
     };
   }
 

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -182,7 +182,7 @@ assert.throws(
 }
 
 // Test XOF hash functions and the outputLength option.
-{
+if (!process.features.openssl_is_boringssl) {
   // Default outputLengths.
   assert.strictEqual(crypto.createHash('shake128').digest('hex'),
                      '7f9c2ba4e88f827d616045507605853e');

--- a/test/parallel/test-crypto-padding.js
+++ b/test/parallel/test-crypto-padding.js
@@ -84,14 +84,13 @@ assert.throws(function() {
   // Input must have block length %.
   enc(ODD_LENGTH_PLAIN, false);
 }, hasOpenSSL3 ? {
-  message: 'error:1C80006B:Provider routines::wrong final block length',
-  code: 'ERR_OSSL_WRONG_FINAL_BLOCK_LENGTH',
-  reason: 'wrong final block length',
+  message: /wrong[\s_]final[\s_]block[\s_]length/i,
+  code: /ERR_OSSL(_EVP)?_WRONG_FINAL_BLOCK_LENGTH/,
+  message: /wrong[\s_]final[\s_]block[\s_]length/i,
 } : {
-  message: 'error:0607F08A:digital envelope routines:EVP_EncryptFinal_ex:' +
-    'data not multiple of block length',
-  code: 'ERR_OSSL_EVP_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH',
-  reason: 'data not multiple of block length',
+  message: /data[\s_]not[\s_]multiple[\s_]of[\s_]block[\s_]length/i,
+  code: /ERR_OSSL(_EVP)?_DATA_NOT_MULTIPLE_OF_BLOCK_LENGTH/,
+  reason: /data[\s_]not[\s_]multiple[\s_]of[\s_]block[\s_]length/i,
 }
 );
 
@@ -110,15 +109,10 @@ assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED, false).length, 48);
 assert.throws(function() {
   // Must have at least 1 byte of padding (PKCS):
   assert.strictEqual(dec(EVEN_LENGTH_ENCRYPTED_NOPAD, true), EVEN_LENGTH_PLAIN);
-}, hasOpenSSL3 ? {
-  message: 'error:1C800064:Provider routines::bad decrypt',
-  reason: 'bad decrypt',
-  code: 'ERR_OSSL_BAD_DECRYPT',
-} : {
-  message: 'error:06065064:digital envelope routines:EVP_DecryptFinal_ex:' +
-    'bad decrypt',
-  reason: 'bad decrypt',
-  code: 'ERR_OSSL_EVP_BAD_DECRYPT',
+}, {
+  message: /bad[\s_]decrypt/i,
+  reason: /bad[\s_]decrypt/i,
+  code: /ERR_OSSL(_EVP)?_BAD_DECRYPT/,
 });
 
 // No-pad encrypted string should return the same:

--- a/test/parallel/test-crypto-stream.js
+++ b/test/parallel/test-crypto-stream.js
@@ -73,9 +73,9 @@ const cipher = crypto.createCipheriv('aes-128-cbc', key, iv);
 const decipher = crypto.createDecipheriv('aes-128-cbc', badkey, iv);
 
 cipher.pipe(decipher)
-  .on('error', common.expectsError(hasOpenSSL3 ? {
-    message: /bad[\s_]decrypt/,
-    library: 'Provider routines',
+  .on('error', common.expectsError((hasOpenSSL3 || process.features.openssl_is_boringssl) ? {
+    message: /bad[\s_]decrypt/i,
+    library: /Provider routines|Cipher functions/,
     reason: /bad[\s_]decrypt/i,
   } : {
     message: /bad[\s_]decrypt/i,

--- a/test/parallel/test-tls-alert-handling.js
+++ b/test/parallel/test-tls-alert-handling.js
@@ -43,7 +43,8 @@ const errorHandler = common.mustCall((err) => {
 
   assert.strictEqual(err.code, expectedErrorCode);
   assert.strictEqual(err.library, 'SSL routines');
-  if (!hasOpenSSL3) assert.strictEqual(err.function, 'ssl3_get_record');
+  if (!hasOpenSSL3 && !process.features.openssl_is_boringssl)
+    assert.strictEqual(err.function, 'ssl3_get_record');
   assert.match(err.reason, expectedErrorReason);
   errorReceived = true;
   if (canCloseServer())
@@ -105,7 +106,7 @@ function sendBADTLSRecord() {
     }
     assert.strictEqual(err.code, expectedErrorCode);
     assert.strictEqual(err.library, 'SSL routines');
-    if (!hasOpenSSL3)
+    if (!hasOpenSSL3 && !process.features.openssl_is_boringssl)
       assert.strictEqual(err.function, 'ssl3_read_bytes');
     assert.match(err.reason, expectedErrorReason);
   }));

--- a/test/parallel/test-x509-escaping.js
+++ b/test/parallel/test-x509-escaping.js
@@ -438,7 +438,7 @@ const { hasOpenSSL3 } = require('../common/crypto');
   const cert = fixtures.readKey('incorrect_san_correct_subject-cert.pem');
 
   // The hostname is the CN, but not a SAN entry.
-  const servername = 'good.example.com';
+  const servername = process.features.openssl_is_boringssl ? undefined : 'good.example.com';
   const certX509 = new X509Certificate(cert);
   assert.strictEqual(certX509.subject, `CN=${servername}`);
   assert.strictEqual(certX509.subjectAltName, 'DNS:evil.example.com');


### PR DESCRIPTION
Modify a few more crypto tests to work with BoringSSL as well as OpenSSL.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
