### PR TITLE
tools: ignore CVE mention when linting release proposals

### DIFF
--- a/.github/workflows/lint-release-proposal.yml
+++ b/.github/workflows/lint-release-proposal.yml
@@ -39,7 +39,7 @@ jobs:
           EXPECTED_TRAILER="^$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/[[:digit:]]+\$"
           echo "Expected trailer format: $EXPECTED_TRAILER"
           PR_URL="$(git --no-pager log -1 --format='%(trailers:key=PR-URL,valueonly)')"
-          echo "Actual: $ACTUAL"
+          echo "Actual: $PR_URL"
           echo "$PR_URL" | grep -E -q "$EXPECTED_TRAILER"
 
           PR_HEAD="$(gh pr view "$PR_URL" --json headRefOid -q .headRefOid)"

--- a/tools/actions/lint-release-proposal-commit-list.mjs
+++ b/tools/actions/lint-release-proposal-commit-list.mjs
@@ -34,6 +34,7 @@ if (commitListingStart === -1) {
 // Normalize for consistent comparison
 commitList = commitList
   .replaceAll('**(SEMVER-MINOR)** ', '')
+  .replaceAll(/(?<= - )\*\*\(CVE-\d{4}-\d+\)\*\* (?=\*\*)/g, '')
   .replaceAll('\\', '');
 
 let expectedNumberOfCommitsLeft = commitList.match(/\n\* \[/g)?.length ?? 0;


### PR DESCRIPTION
The job is failing on the security release proposal because it doesn't expect the CVE mention. A simple fix is to simply remove them.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
