### PR TITLE
fs: return rejected promise when mkdtemp lacks permissions

### DIFF
--- a/test/parallel/test-permission-fs-promises-mkdtemp.js
+++ b/test/parallel/test-permission-fs-promises-mkdtemp.js
@@ -1,0 +1,19 @@
+// Flags: --permission --allow-fs-read=*
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+
+// This test verifies that fs.promises.mkdtemp() returns a proper rejected promise
+// when permissions are denied, instead of throwing a TypeError
+{
+  // Test with simple string path (reproduces the exact issue from GitHub)
+  assert.rejects(
+    fs.promises.mkdtemp('test'),
+    {
+      code: 'ERR_ACCESS_DENIED',
+      permission: 'FileSystemWrite',
+    }
+  ).then(common.mustCall());
+}


### PR DESCRIPTION
Previously, fs.promises.mkdtemp() would cause a TypeError "Method Promise.prototype.then called on incompatible receiver undefined" when called without write permissions. This happened because the promise was never returned to JavaScript after being rejected.

This commit ensures SetReturnValue() is called before returning from the function, so JavaScript receives a proper rejected promise with an ERR_ACCESS_DENIED error that can be caught and handled.

Fixes: #59023 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
