### PR TITLE
test_runner: propagate --experimental-config-file to child processes

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -107,7 +107,6 @@ const kFilterArgs = [
 const kFilterArgValues = [
   '--test-reporter',
   '--test-reporter-destination',
-  '--experimental-config-file',
 ];
 const kDiagnosticsFilterArgs = ['tests', 'suites', 'pass', 'fail', 'cancelled', 'skipped', 'todo', 'duration_ms'];
 
@@ -389,6 +388,8 @@ function runTestFile(path, filesWatcher, opts) {
     if (opts.root.harness.shouldColorizeTestFiles) {
       env.FORCE_COLOR = '1';
     }
+    // Prevent coverage reporting in child processes to avoid duplication
+    env.NODE_TEST_DISABLE_COVERAGE = '1';
 
     const child = spawn(
       process.execPath, args,

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -196,7 +196,8 @@ function parseCommandLine() {
   }
 
   const isTestRunner = getOptionValue('--test');
-  const coverage = getOptionValue('--experimental-test-coverage');
+  const coverage = getOptionValue('--experimental-test-coverage') && 
+                   !process.env.NODE_TEST_DISABLE_COVERAGE;
   const forceExit = getOptionValue('--test-force-exit');
   const sourceMaps = getOptionValue('--enable-source-maps');
   const updateSnapshots = getOptionValue('--test-update-snapshots');

--- a/test/fixtures/test-runner/options-propagation/experimental-config-file.test.mjs
+++ b/test/fixtures/test-runner/options-propagation/experimental-config-file.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import { strictEqual } from 'node:assert';
 import internal from 'internal/options';
 
-test('it should not receive --experimental-config-file option', () => {
+test('it should receive --experimental-config-file option', () => {
     const optionValue = internal.getOptionValue("--experimental-config-file");
-    strictEqual(optionValue, '');
+    strictEqual(optionValue, 'node.config.json');
 })

--- a/test/parallel/test-runner-cli.js
+++ b/test/parallel/test-runner-cli.js
@@ -431,7 +431,7 @@ for (const isolation of ['none', 'process']) {
 }
 
 {
-  // Should not propagate --experimental-config-file option to sub test in isolation process
+  // Should propagate --experimental-config-file option to sub test in isolation process
   const fixturePath = join(testFixtures, 'options-propagation');
   const args = [
     '--test-reporter=tap',


### PR DESCRIPTION
## Summary

This PR fixes an issue where `--experimental-config-file` was not being propagated to child test processes, causing experimental features defined in the config file to not work in test isolation mode.

The solution implements a more nuanced approach that:
- Allows `--experimental-config-file` to be propagated to child processes
- Prevents duplicate coverage reports by disabling coverage in child processes via `NODE_TEST_DISABLE_COVERAGE` environment variable

## Changes

1. **lib/internal/test_runner/runner.js**:
   - Removed `--experimental-config-file` from `kFilterArgValues` to allow propagation
   - Added `NODE_TEST_DISABLE_COVERAGE=1` to child process environment

2. **lib/internal/test_runner/utils.js**:
   - Modified coverage detection to check `NODE_TEST_DISABLE_COVERAGE` environment variable

3. **test/parallel/test-runner-cli.js**:
   - Updated test expectations to verify config propagation works correctly
   - Maintained expectation of single coverage report

4. **test/fixtures/test-runner/options-propagation/experimental-config-file.test.mjs**:
   - Updated test to expect config file to be received in child process

## Test Plan

- [x] Verified that `--experimental-config-file` is now propagated to child processes
- [x] Confirmed that coverage reports are generated only once (no duplication)
- [x] All existing tests pass

Fixes: https://github.com/nodejs/node/issues/59021