### PR TITLE
src: remove duplicate assignment of `O_EXCL` in node_constants.cc

### DIFF
--- a/src/node_constants.cc
+++ b/src/node_constants.cc
@@ -1105,10 +1105,6 @@ NODE_DEFINE_CONSTANT(target, UV_FS_O_FILEMAP);
   NODE_DEFINE_CONSTANT(target, O_DIRECTORY);
 #endif
 
-#ifdef O_EXCL
-  NODE_DEFINE_CONSTANT(target, O_EXCL);
-#endif
-
 #ifdef O_NOATIME
   NODE_DEFINE_CONSTANT(target, O_NOATIME);
 #endif


### PR DESCRIPTION
Currently the `O_EXCL` constant is assigned twice in `DefineFsConstants` on these places:

https://github.com/nodejs/node/blob/049664bbdc421c63b2145c85a18c64d184b40aa5/src/node_constants.cc#L1086-L1088

https://github.com/nodejs/node/blob/049664bbdc421c63b2145c85a18c64d184b40aa5/src/node_constants.cc#L1108-L1110

Though it doesn't introduce any bugs, changes in this PR ensures `O_EXCL` is only defined once.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
