### PR TITLE
doc: clarify ERR_FS_FILE_TOO_LARGE explanation to reflect fs.readFile() I/O limit

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1362,8 +1362,10 @@ Path is a directory.
 
 ### `ERR_FS_FILE_TOO_LARGE`
 
-An attempt was made to read a file larger than the supported 2 GiB limit for `fs.readFile()`. This is not a limitation of `Buffer`, but an internal I/O constraint.
-For handling larger files, consider using `fs.createReadStream()` to read the file in chunks.
+An attempt was made to read a file larger than the supported 2 GiB limit for
+`fs.readFile()`. This is not a limitation of `Buffer`, but an internal I/O constraint.
+For handling larger files, consider using `fs.createReadStream()` to read the
+file in chunks.
 
 <a id="ERR_FS_WATCH_QUEUE_OVERFLOW"></a>
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1362,8 +1362,8 @@ Path is a directory.
 
 ### `ERR_FS_FILE_TOO_LARGE`
 
-An attempt has been made to read a file whose size is larger than the maximum
-allowed size for a `Buffer`.
+An attempt was made to read a file larger than the supported 2 GiB limit for `fs.readFile()`. This is not a limitation of `Buffer`, but an internal I/O constraint.
+For handling larger files, consider using `fs.createReadStream()` to read the file in chunks.
 
 <a id="ERR_FS_WATCH_QUEUE_OVERFLOW"></a>
 


### PR DESCRIPTION
Fix: clarify ERR_FS_FILE_TOO_LARGE message to reflect fs.readFile() I/O limit

The error previously suggested the issue might be due to Buffer limitations,
but in fact it's an internal constraint of fs.readFile(). Updated the
documentation to avoid confusion and guide users toward fs.createReadStream()
for large files.

ref #55864 


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
