### PR TITLE
crypto: add memory tracking for secureContext openssl objects

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -2095,6 +2095,12 @@ void SecureContext::GetCertificate(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(buff);
 }
 
+void SecureContext::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackFieldWithSize("ctx", ctx_ ? kSizeOf_SSL_CTX : 0);
+  tracker->TrackFieldWithSize("cert", cert_ ? kSizeOf_X509 : 0);
+  tracker->TrackFieldWithSize("issuer", issuer_ ? kSizeOf_X509 : 0);
+}
+
 // UseExtraCaCerts is called only once at the start of the Node.js process.
 void UseExtraCaCerts(std::string_view file) {
   extra_root_certs_file = file;

--- a/src/crypto/crypto_context.h
+++ b/src/crypto/crypto_context.h
@@ -67,8 +67,7 @@ class SecureContext final : public BaseObject {
   void SetX509StoreFlag(unsigned long flags);  // NOLINT(runtime/int)
   X509_STORE* GetCertStoreOwnedByThisSecureContext();
 
-  // TODO(joyeecheung): track the memory used by OpenSSL types
-  SET_NO_MEMORY_INFO()
+  void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(SecureContext)
   SET_SELF_SIZE(SecureContext)
 

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -36,6 +36,8 @@ constexpr size_t kSizeOf_EVP_MD_CTX = 48;
 constexpr size_t kSizeOf_EVP_PKEY = 72;
 constexpr size_t kSizeOf_EVP_PKEY_CTX = 80;
 constexpr size_t kSizeOf_HMAC_CTX = 32;
+constexpr size_t kSizeOf_SSL_CTX = 240;
+constexpr size_t kSizeOf_X509 = 128;
 
 bool ProcessFipsOptions();
 

--- a/test/cctest/test_node_crypto.cc
+++ b/test/cctest/test_node_crypto.cc
@@ -21,3 +21,30 @@ TEST(NodeCrypto, NewRootCertStore) {
                                       "any errors on the OpenSSL error stack\n";
   X509_STORE_free(store);
 }
+
+/*
+ * This test verifies that OpenSSL memory tracking constants are properly
+ * defined.
+ */
+TEST(NodeCrypto, MemoryTrackingConstants) {
+  // Verify that our memory tracking constants are defined and reasonable
+  EXPECT_GT(node::crypto::kSizeOf_SSL_CTX, 0)
+      << "SSL_CTX size constant should be positive";
+  EXPECT_GT(node::crypto::kSizeOf_X509, 0)
+      << "X509 size constant should be positive";
+  EXPECT_GT(node::crypto::kSizeOf_EVP_MD_CTX, 0)
+      << "EVP_MD_CTX size constant should be positive";
+
+  // Verify reasonable size ranges (basic sanity check)
+  EXPECT_LT(node::crypto::kSizeOf_SSL_CTX, 10000)
+      << "SSL_CTX size should be reasonable";
+  EXPECT_LT(node::crypto::kSizeOf_X509, 10000)
+      << "X509 size should be reasonable";
+  EXPECT_LT(node::crypto::kSizeOf_EVP_MD_CTX, 1000)
+      << "EVP_MD_CTX size should be reasonable";
+
+  // Specific values we expect based on our implementation
+  EXPECT_EQ(node::crypto::kSizeOf_SSL_CTX, 240);
+  EXPECT_EQ(node::crypto::kSizeOf_X509, 128);
+  EXPECT_EQ(node::crypto::kSizeOf_EVP_MD_CTX, 48);
+}


### PR DESCRIPTION
add memory tracking for secureContext openssl objects