### PR TITLE
dgram: improve get-send-queue-info performance

### DIFF
--- a/benchmark/dgram/get-send-queue-info.js
+++ b/benchmark/dgram/get-send-queue-info.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../common.js');
+const dgram = require('dgram');
+
+const bench = common.createBenchmark(main, {
+  n: [5e6],
+  method: ['size', 'count'],
+});
+
+function main({ n, method }) {
+  const server = dgram.createSocket('udp4');
+  const client = dgram.createSocket('udp4');
+
+  server.bind(0, () => {
+    client.connect(server.address().port, () => {
+      for (let i = 0; i < 999; i++) client.send('Hello');
+
+      bench.start();
+
+      if (method === 'size') {
+        for (let i = 0; i < n; ++i) server.getSendQueueSize();
+      } else {
+        for (let i = 0; i < n; ++i) server.getSendQueueCount();
+      }
+
+      bench.end(n);
+
+      client.close();
+      server.close();
+    });
+  });
+}

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -152,6 +152,9 @@ class UDPWrap final : public HandleWrap,
   static void GetSendQueueCount(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static double FastGetSendQueueSize(v8::Local<v8::Value> receiver);
+  static double FastGetSendQueueCount(v8::Local<v8::Value> receiver);
+
   // UDPListener implementation
   uv_buf_t OnAlloc(size_t suggested_size) override;
   void OnRecv(ssize_t nread,


### PR DESCRIPTION
Improve `dgram` `getSendQueueSize` and `getSendQueueCount` performance by using V8 fast API.

Local benchmark:
```
                                                      confidence improvement accuracy (*)   (**)  (***)
dgram/get-send-queue-info.js method='count' n=5000000        ***    127.63 %       ±1.01% ±1.35% ±1.77%
dgram/get-send-queue-info.js method='size' n=5000000         ***    127.77 %       ±2.18% ±2.92% ±3.86%

```