### PR TITLE
http: deprecate writeHeader

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1480,12 +1480,15 @@ instead.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59060
+    description: Runtime deprecation.
   - version: v8.0.0
     pr-url: https://github.com/nodejs/node/pull/11355
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 The `node:http` module `ServerResponse.prototype.writeHeader()` API is
 deprecated. Please use `ServerResponse.prototype.writeHead()` instead.

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -81,6 +81,7 @@ const {
 } = require('internal/errors');
 const {
   assignFunctionName,
+  deprecate,
   kEmptyObject,
   promisify,
 } = require('internal/util');
@@ -439,8 +440,9 @@ function writeHead(statusCode, reason, obj) {
   return this;
 }
 
-// Docs-only deprecated: DEP0063
-ServerResponse.prototype.writeHeader = ServerResponse.prototype.writeHead;
+ServerResponse.prototype.writeHeader = deprecate(ServerResponse.prototype.writeHead,
+                                                 'ServerResponse.prototype.writeHeader is deprecated.',
+                                                 'DEP0063');
 
 function storeHTTPOptions(options) {
   this[kIncomingMessage] = options.IncomingMessage || IncomingMessage;

--- a/test/parallel/test-write-header.js
+++ b/test/parallel/test-write-header.js
@@ -1,0 +1,20 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+common.expectWarning('DeprecationWarning',
+                     'ServerResponse.prototype.writeHeader is deprecated.', 'DEP0063');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHeader(200, [ 'test', '2', 'test2', '2' ]);
+  res.end();
+})).listen(0, common.mustCall(() => {
+  http.get({ port: server.address().port }, common.mustCall((res) => {
+    assert.strictEqual(res.headers.test, '2');
+    assert.strictEqual(res.headers.test2, '2');
+    res.resume().on('end', common.mustCall(() => {
+      server.close();
+    }));
+  }));
+}));


### PR DESCRIPTION
It’s been over 7 years since it was deprecated in documentation only. I think it’s time to deprecate it at the runtime level.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
