### PR TITLE
build: remove suppressions.supp

### DIFF
--- a/suppressions.supp
+++ b/suppressions.supp
@@ -1,6 +1,0 @@
-vptr:deps/icu-small/source/common/uloc_tag.cpp
-vptr:deps/icu-small/source/common/unistr.cpp
-shift-base:deps/v8/src/wasm/decoder.h
-vptr:deps/icu-small/source/common/sharedobject.cpp
-vptr:deps/icu-small/source/i18n/coll.cpp
-nonnull-attribute:deps/v8/src/snapshot/snapshot-source-sink.h


### PR DESCRIPTION
**build: remove suppressions.supp**
```
We have removed the UBSan workflow
and there's no ongoing initiative to
bring it back.
```
