### PR TITLE
doc: clarify dynamic import() usage in CommonJS context

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -334,8 +334,8 @@ fs.readFileSync === readFileSync;
 
 ## `import()` expressions
 
-[Dynamic `import()`][] is supported in both CommonJS and ES modules. In CommonJS
-modules it can be used to load ES modules.
+[Dynamic `import()`][] is supported in both CommonJS and ES modules. In CommonJS, it can be used to load
+ES modules in certain configurations or with third-party loaders such as `esm`.
 
 ## `import.meta`
 


### PR DESCRIPTION
## Description

This PR updates the `import()` expressions section in `doc/api/esm.md` to clarify that dynamic `import()` can be used in CommonJS with appropriate configuration or loaders such as `esm`.

The previous description could be misinterpreted as implying universal support in CommonJS, which is not accurate without specific setup. 

## Linked Issues
Resolves #59077 
