### PR TITLE
src: add cache to nearest parent package json

### DIFF
--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -5,6 +5,7 @@ const {
   JSONParse,
   ObjectDefineProperty,
   RegExpPrototypeExec,
+  SafeMap,
   StringPrototypeIndexOf,
   StringPrototypeSlice,
 } = primordials;
@@ -27,6 +28,8 @@ const modulesBinding = internalBinding('modules');
 const path = require('path');
 const { validateString } = require('internal/validators');
 const internalFsBinding = internalBinding('fs');
+
+const nearestParentPackageJSONCache = new SafeMap();
 
 /**
  * @typedef {import('typings/internalBinding/modules').DeserializedPackageConfig} DeserializedPackageConfig
@@ -131,13 +134,21 @@ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
  * @returns {undefined | DeserializedPackageConfig}
  */
 function getNearestParentPackageJSON(checkPath) {
+  if (nearestParentPackageJSONCache.has(checkPath)) {
+    return nearestParentPackageJSONCache.get(checkPath);
+  }
+
   const result = modulesBinding.getNearestParentPackageJSON(checkPath);
 
   if (result === undefined) {
+    nearestParentPackageJSONCache.set(checkPath, undefined);
     return undefined;
   }
 
-  return deserializePackageJSON(checkPath, result);
+  const packageConfig = deserializePackageJSON(checkPath, result);
+  nearestParentPackageJSONCache.set(checkPath, packageConfig);
+
+  return packageConfig;
 }
 
 /**


### PR DESCRIPTION
### Motivation

Fixes #58126. 
My benchmark was based on the example app shared by @BridgeAR 

### Description

In PR #50322, moving the `package_json_reader` cache from JS to C++ preserved the heavy JSON parsing in native code but removed the original JS level cache. As a result, the resolution logic now invokes the C++ binding more frequently.

The worst offender is `modulesBinding.getNearestParentPackageJSON` called ≈ 102 000 times during a typical run.

1. **Initial run (current main branch):**

   ```bash
   time ./node test.js 
   # ≈4.5s
   ```
2. **With a C++ side cache:**

   * Cache stats: 270 misses, \~101 700 hits
   * Run time `≈4.5s`, showing the bridge overhead remains.
  
3. **With a JS side cache:**

   ```bash
   time ./node test.js 
   # ≈0.5s
   ```


Introducing a JS level cache for `getNearestParentPackageJSON` to avoid repeated C++ crossings eliminates most of the overhead and reducing run time from `≈4.5s` to `≈0.5s`
