### PR TITLE
perf_hooks: do not expose SafeMap via Histogram wrapper

### DIFF
--- a/lib/internal/histogram.js
+++ b/lib/internal/histogram.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const {
+  Map,
+  MapPrototypeClear,
   MapPrototypeEntries,
   NumberIsNaN,
   NumberMAX_SAFE_INTEGER,
   ObjectFromEntries,
   ReflectConstruct,
-  SafeMap,
   Symbol,
 } = primordials;
 
@@ -216,7 +217,7 @@ class Histogram {
   get percentiles() {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    this[kMap].clear();
+    MapPrototypeClear(this[kMap]);
     this[kHandle]?.percentiles(this[kMap]);
     return this[kMap];
   }
@@ -228,7 +229,7 @@ class Histogram {
   get percentilesBigInt() {
     if (!isHistogram(this))
       throw new ERR_INVALID_THIS('Histogram');
-    this[kMap].clear();
+    MapPrototypeClear(this[kMap]);
     this[kHandle]?.percentilesBigInt(this[kMap]);
     return this[kMap];
   }
@@ -331,7 +332,7 @@ function ClonedHistogram(handle) {
     function() {
       markTransferMode(this, true, false);
       this[kHandle] = handle;
-      this[kMap] = new SafeMap();
+      this[kMap] = new Map();
     }, [], Histogram);
 }
 
@@ -342,7 +343,7 @@ function ClonedRecordableHistogram(handle) {
 
   markTransferMode(histogram, true, false);
   histogram[kRecordable] = true;
-  histogram[kMap] = new SafeMap();
+  histogram[kMap] = new Map();
   histogram[kHandle] = handle;
   histogram.constructor = RecordableHistogram;
 

--- a/test/parallel/test-perf-hooks-histogram.js
+++ b/test/parallel/test-perf-hooks-histogram.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 
 const {
+  deepStrictEqual,
   ok,
   strictEqual,
   throws,
@@ -57,6 +58,10 @@ const { inspect } = require('util');
 
   strictEqual(h.percentileBigInt(1), 1n);
   strictEqual(h.percentileBigInt(100), 1n);
+
+  deepStrictEqual(h.percentiles, new Map([[0, 1], [100, 1]]));
+
+  deepStrictEqual(h.percentilesBigInt, new Map([[0, 1n], [100, 1n]]));
 
   const mc = new MessageChannel();
   mc.port1.onmessage = common.mustCall(({ data }) => {


### PR DESCRIPTION
#36455 replaced the use of Map with SafeMap for the percentiles store in internal/histogram, however:

- the map property is exposed to the user via `percentiles`/`percentilesBigInt` (in fact, that's its only purpose), so SafeMap should not be used here;
- the binding uses `v8::Map::Set()`, which is invulnerable to prototype pollution.

It's debatable whether `percentiles` should return a reused-but-only-updated-on-getter-access Map or just an anonymous object, but the non-breaking change is just to revert to using a plain old Map.