### PR TITLE
meta: clarify pr objection process further

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -180,13 +180,14 @@ All Collaborator objections are considered equal. There is no greater weight giv
 objections from TSC members than from any other Collaborator.
 
 Mistakes do happen from time-to-time. If a pull request is merged with an
-outstanding objection, corrective action must be taken. Any Collaborator
-can open a pull request that either reverts the change or makes an additional
-follow-up change that addresses the objection. While an automatic or immediate
-revert is not always necessary or ideal, such corrections are typically
-subject to (but not required to) be fast-tracked. There are times in which
-taking a slower path may be preferable to ensure appropriate consensus
-moving forward.
+unresolved objection, corrective action must be taken. What corrective
+action to take will vary on the nature of that objection. Some might be
+simple to resolve just by opening a follow-up PR that addresses it; others
+may require a full revert. When in doubt, it's likely best to propose a full
+revert, but use your judgement as other options might be available. In every
+case it is most likely the correction will be fast-tracked. There are times,
+however, when taking a slower path may be preferable, or even necessary, to
+ensure appropriate consensus or stability moving forward.
 
 Collaborators objecting to a pull request can best ensure their objections
 are addressed by remaining actively engaged and responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -182,7 +182,8 @@ objections from TSC members than from any other collaborator.
 Mistakes do happen from time to time. If a pull request is merged with an
 outstanding objection, any collaborator can open an issue or pull request
 proposing to revert the change or to make a follow-up change that addresses
-the objection. Such reverts / follow-ups will typically be subject to fast-tracking, particularly if they are uncontroversial, but an
+the objection. Such reverts / follow-ups will typically be subject to
+fast-tracking, particularly if they are uncontroversial, but an
 automatic, immediate revert is not always necessary and, in some
 cases might not be ideal.
 It is most likely that any outstanding objection was simply

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -183,9 +183,10 @@ Mistakes do happen from time-to-time. If a pull request is merged with an
 outstanding objection, corrective action must be taken. Any Collaborator
 can open a pull request that either reverts the change or makes an additional
 follow-up change that addresses the objection. While an automatic or immediate
-revert is not always necessary or ideal, such corrections are typically subject to
-fast-tracking, but are not required to be fast-tracked. There are
-times in which taking a slower path may be preferable.
+revert is not always necessary or ideal, such corrections are typically
+subject to (but not required to) be fast-tracked. There are times in which
+taking a slower path may be preferable to ensure appropriate consensus
+moving forward.
 
 Collaborators objecting to a pull request can best ensure their objections
 are addressed by remaining actively engaged and responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -174,7 +174,7 @@ collaborator can escalate the issue to the TSC by pinging `@nodejs/tsc` and
 adding the `tsc-agenda` label to the issue and the TSC may choose to overrule
 or dismiss an objection. When the TSC does choose to overrule an objection,
 the TSC must provide a clear explanation of its reasoning in the pull request
-either before or when the pull request lands.
+before the pull request lands.
 
 All objections are considered equal. There is no greater weight given to
 objections from TSC members than from any other collaborator.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -154,10 +154,13 @@ requirements. If a pull request meets all requirements except the
 
 Collaborators can object to a pull request by using the "Request
 Changes" GitHub feature. Dissent comments alone don't constitute an
-objection. Any pull request objection must include a clear reason for that
-objection, and the objector must remain responsive for further discussion
-towards consensus about the direction of the pull request. Where possible,
-provide a set of actionable steps alongside the objection.
+objection, nor do dissenting comments made in any associated issue.
+A blocking objection to a change must be made in the pull request that
+specifically proposes that change. Any pull request objection must include
+a clear reason for that objection, and the objector must remain responsive
+for further discussion towards consensus about the direction of the pull
+request. Where possible, provide a set of actionable steps alongside the
+objection.
 
 If the objection is not clear to others, another collaborator can ask an
 objecting collaborator to explain their objection or to provide actionable
@@ -168,7 +171,24 @@ dismiss the objection.
 Pull requests with outstanding objections must remain open until all
 objections are satisfied. If reaching consensus is not possible, a
 collaborator can escalate the issue to the TSC by pinging `@nodejs/tsc` and
-adding the `tsc-agenda` label to the issue.
+adding the `tsc-agenda` label to the issue and the TSC may choose to overrule
+or dismiss an objection. When the TSC does choose to overrule an objection,
+the TSC must provide a clear explanation of its reasoning in the pull request
+either before or when the pull request lands.
+
+All objections are considered equal. There is no greater weight given to
+objections from TSC members than from any other collaborator.
+
+Mistakes do happen from time to time. If a pull request is merged with an
+outstanding objection, any collaborator can open an issue or pull request
+proposing to revert the change or to make a follow-up change that addresses
+the objection. Such reverts / follow-ups are subject to the same review process
+as any other pull request but may be fast-tracked if uncontroversial.
+Collaborators should always assume good faith on the part of the merging
+collaborator as it is most likely any outstanding objection was simply
+overlooked by mistake. Collaborators objecting to a pull request can best
+ensure their objections are addressed by remaining actively engaged and
+responsive in the discussion.
 
 #### Helpful resources
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -182,9 +182,9 @@ objections from TSC members than from any other Collaborator.
 Mistakes do happen from time-to-time. If a pull request is merged with an
 outstanding objection, corrective action should be taken. Any Collaborator
 can open a pull request that either reverts the change or makes an additional
-follow-up change that addresses the objection. Such corrections will typically
-be subject to fast-tracking. An automatic, immediate revert is not always
-necessary or ideal.
+follow-up change that addresses the objection. While an automatic or immediate
+revert is not always necessary or ideal, such corrections are typically subject to
+fast-tracking.
 
 Collaborators objecting to a pull request can best ensure their objections
 are addressed by remaining actively engaged and responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -180,7 +180,7 @@ All Collaborator objections are considered equal. There is no greater weight giv
 objections from TSC members than from any other Collaborator.
 
 Mistakes do happen from time-to-time. If a pull request is merged with an
-outstanding objection, corrective action should be taken. Any Collaborator
+outstanding objection, corrective action must be taken. Any Collaborator
 can open a pull request that either reverts the change or makes an additional
 follow-up change that addresses the objection. While an automatic or immediate
 revert is not always necessary or ideal, such corrections are typically subject to

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -180,7 +180,7 @@ All Collaborator objections are considered equal. There is no greater weight giv
 objections from TSC members than from any other Collaborator.
 
 Mistakes do happen from time-to-time. If a pull request is merged with an
-outstanding objection, corrective action should be taken. Any collaborator
+outstanding objection, corrective action should be taken. Any Collaborator
 can open a pull request that either reverts the change or makes an additional
 follow-up change that addresses the objection. Such corrections will typically
 be subject to fast-tracking. An automatic, immediate revert is not always

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -184,7 +184,8 @@ outstanding objection, corrective action must be taken. Any Collaborator
 can open a pull request that either reverts the change or makes an additional
 follow-up change that addresses the objection. While an automatic or immediate
 revert is not always necessary or ideal, such corrections are typically subject to
-fast-tracking.
+fast-tracking, but are not required to be fast-tracked. There are
+times in which taking a slower path may be preferable.
 
 Collaborators objecting to a pull request can best ensure their objections
 are addressed by remaining actively engaged and responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -171,10 +171,10 @@ dismiss the objection.
 Pull requests with outstanding objections must remain open until all
 objections are satisfied. If reaching consensus is not possible, a
 collaborator can escalate the issue to the TSC by pinging `@nodejs/tsc` and
-adding the `tsc-agenda` label to the issue and the TSC may choose to overrule
-or dismiss an objection. When the TSC does choose to overrule an objection,
-the TSC must provide a clear explanation of its reasoning in the pull request
-before the pull request lands.
+adding the `tsc-agenda` label to the issue. The change cannot proceed without
+either reaching consensus or a TSC decision to dismiss the objection(s). If the
+TSC does choose to dismiss any objections, a clear explanation of the reasoning
+must be given in the pull request before it lands.
 
 All Collaborator objections are considered equal. There is no greater weight given to
 objections from TSC members than from any other Collaborator.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -184,8 +184,7 @@ outstanding objection, any collaborator can open an issue or pull request
 proposing to revert the change or to make a follow-up change that addresses
 the objection. Such reverts / follow-ups are subject to the same review process
 as any other pull request but may be fast-tracked if uncontroversial.
-Collaborators should always assume good faith on the part of the merging
-collaborator as it is most likely any outstanding objection was simply
+It is most likely that any outstanding objection was simply
 overlooked by mistake. Collaborators objecting to a pull request can best
 ensure their objections are addressed by remaining actively engaged and
 responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -179,15 +179,11 @@ or a link to the public vote must be given in the pull request before it lands.
 All Collaborator objections are considered equal. There is no greater weight given to
 objections from TSC members than from any other Collaborator.
 
-Mistakes do happen from time-to-time. If a pull request is merged with an
-unresolved objection, corrective action must be taken. What corrective
-action to take will vary on the nature of that objection. Some might be
-simple to resolve just by opening a follow-up PR that addresses it; others
-may require a full revert. When in doubt, it's likely best to propose a full
-revert, but use your judgement as other options might be available. In every
-case it is most likely the correction will be fast-tracked. There are times,
-however, when taking a slower path may be preferable, or even necessary, to
-ensure appropriate consensus or stability moving forward.
+Mistakes do happen. If a pull request is merged with an unresolved objection,
+submit a fix. Simple issues may be fixed with a follow-up PR that addresses
+the concern. More difficult issues may require a full revert. Most corrections
+can be fast-tracked. If deemed necessary take a slower route to ensure stability
+and consensus.
 
 Collaborators objecting to a pull request can best ensure their objections
 are addressed by remaining actively engaged and responsive in the discussion.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -174,7 +174,7 @@ collaborator can escalate the issue to the TSC by pinging `@nodejs/tsc` and
 adding the `tsc-agenda` label to the issue. The change cannot proceed without
 either reaching consensus or a TSC decision to dismiss the objection(s). If the
 TSC does choose to dismiss any objections, a clear explanation of the reasoning
-must be given in the pull request before it lands.
+or a link to the public vote must be given in the pull request before it lands.
 
 All Collaborator objections are considered equal. There is no greater weight given to
 objections from TSC members than from any other Collaborator.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -182,8 +182,9 @@ objections from TSC members than from any other collaborator.
 Mistakes do happen from time to time. If a pull request is merged with an
 outstanding objection, any collaborator can open an issue or pull request
 proposing to revert the change or to make a follow-up change that addresses
-the objection. Such reverts / follow-ups are subject to the same review process
-as any other pull request but may be fast-tracked if uncontroversial.
+the objection. Such reverts / follow-ups will typically be subject to fast-tracking, particularly if they are uncontroversial, but an
+automatic, immediate revert is not always necessary and, in some
+cases might not be ideal.
 It is most likely that any outstanding objection was simply
 overlooked by mistake. Collaborators objecting to a pull request can best
 ensure their objections are addressed by remaining actively engaged and

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -179,17 +179,15 @@ before the pull request lands.
 All Collaborator objections are considered equal. There is no greater weight given to
 objections from TSC members than from any other Collaborator.
 
-Mistakes do happen from time to time. If a pull request is merged with an
-outstanding objection, any collaborator can open an issue or pull request
-proposing to revert the change or to make a follow-up change that addresses
-the objection. Such reverts / follow-ups will typically be subject to
-fast-tracking, particularly if they are uncontroversial, but an
-automatic, immediate revert is not always necessary and, in some
-cases might not be ideal.
-It is most likely that any outstanding objection was simply
-overlooked by mistake. Collaborators objecting to a pull request can best
-ensure their objections are addressed by remaining actively engaged and
-responsive in the discussion.
+Mistakes do happen from time-to-time. If a pull request is merged with an
+outstanding objection, corrective action should be taken. Any collaborator
+can open a pull request that either reverts the change or makes an additional
+follow-up change that addresses the objection. Such corrections will typically
+be subject to fast-tracking. An automatic, immediate revert is not always
+necessary or ideal.
+
+Collaborators objecting to a pull request can best ensure their objections
+are addressed by remaining actively engaged and responsive in the discussion.
 
 #### Helpful resources
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -176,8 +176,8 @@ or dismiss an objection. When the TSC does choose to overrule an objection,
 the TSC must provide a clear explanation of its reasoning in the pull request
 before the pull request lands.
 
-All objections are considered equal. There is no greater weight given to
-objections from TSC members than from any other collaborator.
+All Collaborator objections are considered equal. There is no greater weight given to
+objections from TSC members than from any other Collaborator.
 
 Mistakes do happen from time to time. If a pull request is merged with an
 outstanding objection, any collaborator can open an issue or pull request

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -186,7 +186,7 @@ can be fast-tracked. If deemed necessary take a slower route to ensure stability
 and consensus.
 
 Collaborators objecting to a pull request can best ensure their objections
-are addressed by remaining actively engaged and responsive in the discussion.
+are addressed by remaining engaged and responsive in the discussion.
 
 #### Helpful resources
 


### PR DESCRIPTION
Based on some recent confusion around the objection process for PRs, this commit adds some additional
clarification to the collaborator guide.

Specifically, it clarifies that:

* Objections must be made in the PR itself
* All objections are considered equal... no special additional weight is given to objections from TSC members.
* When mistakes happen and a PR lands despite having an unresolved objection, any revert or fixup PR is subject to the same regular objection process, albeit with a callout that fast-tracking is possible if uncontroversial.

@nodejs/tsc 