### PR TITLE
[v22.x backport] doc: add missing section for setReturnArrays in sqlite.md

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -634,6 +634,17 @@ added: v22.15.0
 By default, if an unknown name is encountered while binding parameters, an
 exception is thrown. This method allows unknown named parameters to be ignored.
 
+### `statement.setReturnArrays(enabled)`
+
+<!-- YAML
+added: v22.16.0
+-->
+
+* `enabled` {boolean} Enables or disables the return of query results as arrays.
+
+When enabled, query results returned by the `all()`, `get()`, and `iterate()` methods will be returned as arrays instead
+of objects.
+
 ### `statement.setReadBigInts(enabled)`
 
 <!-- YAML


### PR DESCRIPTION
This PR is a manual backport of https://github.com/nodejs/node/pull/59074. It adds a missing documentation.

Release reference: https://github.com/nodejs/node/pull/58388