### PR TITLE
src,test: fix config file parsing for flags defaulted to true

### DIFF
--- a/src/node_config_file.cc
+++ b/src/node_config_file.cc
@@ -55,6 +55,10 @@ ParseResult ConfigReader::ProcessOptionValue(
       if (result) {
         // If the value is true, we need to set the flag
         output->push_back(option_name);
+      } else {
+        // Ensure negation is made putting the "--no-" prefix
+        output->push_back("--no-" +
+                          option_name.substr(2, option_name.size() - 2));
       }
 
       break;

--- a/test/fixtures/rc/warnings-false.json
+++ b/test/fixtures/rc/warnings-false.json
@@ -1,0 +1,5 @@
+{
+  "nodeOptions": {
+    "warnings": false
+  }
+}

--- a/test/parallel/test-config-file.js
+++ b/test/parallel/test-config-file.js
@@ -60,6 +60,17 @@ test('should parse boolean flag', async () => {
   strictEqual(result.code, 0);
 });
 
+test('should parse boolean flag defaulted to true', async () => {
+  const result = await spawnPromisified(process.execPath, [
+    '--experimental-config-file',
+    fixtures.path('rc/warnings-false.json'),
+    '-p', 'process.emitWarning("A warning")',
+  ]);
+  strictEqual(result.stderr, '');
+  strictEqual(result.stdout, 'undefined\n');
+  strictEqual(result.code, 0);
+});
+
 test('should throw an error when a flag is declared twice', async () => {
   const result = await spawnPromisified(process.execPath, [
     '--no-warnings',


### PR DESCRIPTION
Fixes #58929

This PR fixes config file parsing for boolean options that are enabled by default. 

In my last [PR](https://github.com/nodejs/node/pull/58039), I did a quick fix for boolean values. Such a fix missed the case where the flag is `true` by default, as `--warnings`. To ensure we're disabling a flag, we have to output that flag prefixed with `--no-`. 