### PR TITLE
doc: avoid suggesting testing fast api with intense loop

### DIFF
--- a/doc/contributing/adding-v8-fast-api.md
+++ b/doc/contributing/adding-v8-fast-api.md
@@ -26,7 +26,7 @@ for example, they may not trigger garbage collection.
   in a snapshot (either the built-in or a user-land one). Please refer to the
   [binding functions documentation](../../src/README.md#binding-functions) for more
   information.
-* The fast API function must be tested following with the example in
+* Fast API functions must be tested following the example in
   [Test with Fast API path](#test-with-fast-api-path).
 * The fast callback must be idempotent up to the point where error and fallback
   conditions are checked, because otherwise executing the slow callback might


### PR DESCRIPTION
Update the doc to suggest testing a fast api with V8 `%PrepareFunctionForOptimization` native syntax.

Also, make this a requirement.

Refs: https://github.com/nodejs/node/pull/59055