### PR TITLE
doc: update the instruction on how to verify releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,12 @@ Alternatively, you can import the releaser keys in your default keyring, see
 [Release keys](#release-keys) for commands to how to do that.
 
 Then, you can verify the files you've downloaded locally
-(if you're using your default keyring, do not pass `--keyring`):
+(if you're using your default keyring, pass `--keyring="${GNUPGHOME:-~/.gnupg}/pubring.kbx"`):
 
 ```bash
-set -e
-set -o pipefail
-
-curl -fs "https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc" \
-| gpgv --keyring="/path/to/nodejs-keyring.kbx" --output - \
-| shasum --check --ignore-missing
+curl -fsO "https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc" \
+&& gpgv --keyring="/path/to/nodejs-keyring.kbx" --output SHASUMS256.txt < SHASUMS256.txt.asc \
+&& shasum --check SHASUMS256.txt --ignore-missing
 ```
 
 ## Building Node.js

--- a/README.md
+++ b/README.md
@@ -801,8 +801,8 @@ Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):
 
 You can use the keyring the project maintains at
 <https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg-only-active-keys/pubring.kbx>.
-Alternatively, you can import them from a public key server, have in mind that
-the project cannot guarantee the disponibility of the server nor the keys on
+Alternatively, you can import them from a public key server. Have in mind that
+the project cannot guarantee the availability of the server nor the keys on
 that server.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -95,36 +95,29 @@ _docs_ subdirectory. Version-specific documentation is also at
 
 ### Verifying binaries
 
-Download directories contain a `SHASUMS256.txt` file with SHA checksums for the
-files.
+Download directories contain a `SHASUMS256.txt.asc` file with SHA checksums for the
+files and the releaser PGP signature.
 
-To download `SHASUMS256.txt` using `curl`:
-
-```bash
-curl -O https://nodejs.org/dist/vx.y.z/SHASUMS256.txt
-```
-
-To check that downloaded files match the checksum, use `sha256sum`:
+You can get a trusted keyring from nodejs/release-keys, e.g. using `curl`:
 
 ```bash
-sha256sum -c SHASUMS256.txt --ignore-missing
+curl -fsLo "/path/to/nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/HEAD/gpg/pubring.kbx"
 ```
 
-For Current and LTS, the GPG detached signature of `SHASUMS256.txt` is in
-`SHASUMS256.txt.sig`. You can use it with `gpg` to verify the integrity of
-`SHASUMS256.txt`. You will first need to import
-[the GPG keys of individuals authorized to create releases](#release-keys).
+Alternatively, you can import the releaser keys in your default keyring, see
+[Release keys](#release-keys) for commands to how to do that.
 
-See [Release keys](#release-keys) for commands to import active release keys.
-
-Next, download the `SHASUMS256.txt.sig` for the release:
+Then, you can verify the files you've downloaded locally
+(if you're using your default keyring, do not pass `--keyring`):
 
 ```bash
-curl -O https://nodejs.org/dist/vx.y.z/SHASUMS256.txt.sig
-```
+set -e
+set -o pipefail
 
-Then use `gpg --verify SHASUMS256.txt.sig SHASUMS256.txt` to verify
-the file's signature.
+curl -fs "https://nodejs.org/dist/${VERSION}/SHASUMS256.txt.asc" \
+| gpgv --keyring="/path/to/nodejs-keyring.kbx" --output - \
+| shasum --check --ignore-missing
+```
 
 ## Building Node.js
 
@@ -806,8 +799,11 @@ Primary GPG keys for Node.js Releasers (some Releasers sign with subkeys):
 * **Ulises Gascón** <<ulisesgascongonzalez@gmail.com>>
   `A363A499291CBBC940DD62E41F10027AF002F8B0`
 
-To import the full set of trusted release keys (including subkeys possibly used
-to sign releases):
+You can use the keyring the project maintains at
+<https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg-only-active-keys/pubring.kbx>.
+Alternatively, you can import them from a public key server, have in mind that
+the project cannot guarantee the disponibility of the server nor the keys on
+that server.
 
 ```bash
 gpg --keyserver hkps://keys.openpgp.org --recv-keys 5BE8A3F6C8A5C01D106C0AD820B1A390B168D356 # Antoine du Hamel
@@ -866,6 +862,9 @@ verify a downloaded file.
   `B9E2F5981AA6E0CD28160D9FF13993A75599653C`
 * **Timothy J Fontaine** <<tjfontaine@gmail.com>>
   `7937DFD2AB06298B2293C3187D33FF9D0246406D`
+
+The project maintains a keyring able to verify all past releases of Node.js at
+<https://github.com/nodejs/release-keys/raw/refs/heads/main/gpg/pubring.kbx>.
 
 </details>
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/58904

Currently, the only documented way relies on third-party server, albeit a well-trusted one, but one that the project doesn't control, and one that's not very convenient to use for consumers. Instead, let's document nodejs/release-keys as the trusted source of truth when it comes to verifying Node.js releases.
I'm keeping the instructions on how to download the keys from key.openPGP.org as some tools out there might be scraping our README looking for that, and it's still a valid way to get the release keys, simply not the preferred one.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
