### PR TITLE
test_runner: emit 'test:restarted' event when tests are restarted

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -496,6 +496,11 @@ function watchFiles(testFiles, opts) {
     }
 
     await runningSubtests.get(file);
+
+    // Emit the 'test:restarted' event if a timeStamp reporter is available.
+    if (opts.root?.reporter?.timeStamp) {
+      opts.root.reporter.timeStamp('test:restarted', { __proto__: null, file });
+    }
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
 

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -149,6 +149,11 @@ class TestsStream extends Readable {
     this.#tryPush(null);
   }
 
+  // This event emitter logs a timestamp whenever a test restarts because of changes in any related files.
+  timeStamp(type, data) {
+    process.stdout.write(`\n[${new Date().toLocaleString('en-GB').replace(',', '')}] INFO: Test restarted\n`);
+  }
+
   [kEmitMessage](type, data) {
     this.emit(type, data);
     // Disabling as this going to the user-land

--- a/test/parallel/test-runner-restart-timestamp.js
+++ b/test/parallel/test-runner-restart-timestamp.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { TestsStream } = require('../../lib/internal/test_runner/tests_stream');
+
+{
+  const stream = new TestsStream();
+
+  let called = false;
+
+  // Wrap the timeStamp method to check it was called
+  stream.timeStamp = common.mustCall((type, data) => {
+    assert.strictEqual(type, 'test:restarted');
+    assert.ok(data.file);
+    called = true;
+  });
+
+  // Simulate emitting the event
+  stream.emit('test:restarted', { file: 'timestamp.test.js' });
+
+  // Optionally check manually if needed
+  assert.ok(called, 'timeStamp should be called on test:restarted event');
+}


### PR DESCRIPTION
Refs:  https://github.com/nodejs/node/issues/57206