### PR TITLE
src: clear all linked module caches once instantiated

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -1063,14 +1063,14 @@ Maybe<ModuleWrap*> ModuleWrap::ResolveModule(
     return Nothing<ModuleWrap*>();
   }
 
-  if (dependent->resolve_cache_.count(cache_key) != 1) {
+  auto it = dependent->resolve_cache_.find(cache_key);
+  if (it == dependent->resolve_cache_.end()) {
     THROW_ERR_VM_MODULE_LINK_FAILURE(
         env, "request for '%s' is not in cache", cache_key.specifier);
     return Nothing<ModuleWrap*>();
   }
 
-  ModuleWrap* module_wrap =
-      dependent->GetLinkedRequest(dependent->resolve_cache_[cache_key]);
+  ModuleWrap* module_wrap = dependent->GetLinkedRequest(it->second);
   CHECK_NOT_NULL(module_wrap);
   return Just(module_wrap);
 }

--- a/test/parallel/test-internal-module-wrap.js
+++ b/test/parallel/test-internal-module-wrap.js
@@ -6,6 +6,21 @@ const assert = require('assert');
 const { internalBinding } = require('internal/test/binding');
 const { ModuleWrap } = internalBinding('module_wrap');
 
+const unlinked = new ModuleWrap('unlinked', undefined, 'export * from "bar";', 0, 0);
+assert.throws(() => {
+  unlinked.instantiate();
+}, {
+  code: 'ERR_VM_MODULE_LINK_FAILURE',
+});
+
+const dependsOnUnlinked = new ModuleWrap('dependsOnUnlinked', undefined, 'export * from "unlinked";', 0, 0);
+dependsOnUnlinked.link([unlinked]);
+assert.throws(() => {
+  dependsOnUnlinked.instantiate();
+}, {
+  code: 'ERR_VM_MODULE_LINK_FAILURE',
+});
+
 const foo = new ModuleWrap('foo', undefined, 'export * from "bar";', 0, 0);
 const bar = new ModuleWrap('bar', undefined, 'export const five = 5', 0, 0);
 
@@ -22,4 +37,5 @@ const bar = new ModuleWrap('bar', undefined, 'export const five = 5', 0, 0);
 
   // Check that the module requests are the same after linking, instantiate, and evaluation.
   assert.deepStrictEqual(moduleRequests, foo.getModuleRequests());
+
 })().then(common.mustCall());


### PR DESCRIPTION
There are two phases in module linking: link, and instantiate. These
two operations are required to be separated to allow cyclic
dependencies.

`v8::Module::InstantiateModule` is only required to be invoked on the
root module. The global references created by `ModuleWrap::Link` are
only cleared at `ModuleWrap::Instantiate`. So the global references
created for depended modules are usually not cleared because
`ModuleWrap::Instantiate` is not invoked for each of depended modules,
and caused memory leak.

The change references the linked modules in an object internal slot.

This is not an issue for Node.js ESM support as these modules can not be
off-loaded. However, this could be outstanding for `vm.Module`.

Fixes: https://github.com/nodejs/node/issues/50113