### PR TITLE
lib: include full module URL in ERR_UNSUPPORTED_ESM_URL_SCHEME message

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1864,7 +1864,7 @@ E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url, supported) => {
       '. On Windows, absolute paths must be valid file:// URLs';
   }
   msg += `. Received protocol '${url.protocol}'`;
-  if (url && url.href) {
+  if (url?.href) {
     msg += ` in module '${url.href}'`;
   }
   return msg;

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1864,6 +1864,9 @@ E('ERR_UNSUPPORTED_ESM_URL_SCHEME', (url, supported) => {
       '. On Windows, absolute paths must be valid file:// URLs';
   }
   msg += `. Received protocol '${url.protocol}'`;
+  if (url && url.href) {
+    msg += ` in module '${url.href}'`;
+  }
   return msg;
 }, Error);
 E('ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING',

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -61,7 +61,7 @@ function expectFsNamespace(result) {
     const msg =
       'Only URLs with a scheme in: file, data, and node are supported by the default ' +
       'ESM loader. On Windows, absolute paths must be valid file:// URLs. ' +
-      "Received protocol 'c:'";
+      "Received protocol 'c:' in module 'c:\\example\\foo.mjs'";
     expectModuleError(import('C:\\example\\foo.mjs'),
                       'ERR_UNSUPPORTED_ESM_URL_SCHEME',
                       msg);


### PR DESCRIPTION
Improve the error message for ERR_UNSUPPORTED_ESM_URL_SCHEME to include the full URL of the module that triggered the error. This makes debugging easier by clearly showing which import caused the failure, especially for non-file protocols.

Before, only the protocol was shown; now the message includes the entire `url.href` property.

Fixes: https://github.com/nodejs/node/issues/58215

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
