### PR TITLE
dgram: add option for using recvmmsg

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -968,6 +968,8 @@ changes:
     specified by the NAT.
   * `sendBlockList` {net.BlockList} `sendBlockList` can be used for disabling outbound
     access to specific IP addresses, IP ranges, or IP subnets.
+  * `msgCount` {integer} `msgCount` can be used to receive multiple messages at once via `recvmmsg`.
+    **Default:** `0`, disabled.
 * `callback` {Function} Attached as a listener for `'message'` events. Optional.
 * Returns: {dgram.Socket}
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -112,7 +112,7 @@ function Socket(type, listener) {
   let sendBufferSize;
   let receiveBlockList;
   let sendBlockList;
-
+  let msgCount;
   let options;
   if (type !== null && typeof type === 'object') {
     options = type;
@@ -138,9 +138,13 @@ function Socket(type, listener) {
       }
       sendBlockList = options.sendBlockList;
     }
+    if (options.msgCount !== undefined) {
+      validateUint32(options.msgCount, 'options.msgCount');
+      msgCount = options.msgCount;
+    }
   }
 
-  const handle = newHandle(type, lookup);
+  const handle = newHandle(type, lookup, msgCount);
   handle[owner_symbol] = this;
 
   this[async_id_symbol] = handle.getAsyncId();
@@ -162,6 +166,7 @@ function Socket(type, listener) {
     sendBufferSize,
     receiveBlockList,
     sendBlockList,
+    msgCount,
   };
 
   if (options?.signal !== undefined) {
@@ -380,6 +385,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
     }
 
     if (cluster.isWorker && !exclusive) {
+      // TODO(theanarkh): support recvmmsg
       bindServerHandle(this, {
         address: ip,
         port: port,

--- a/lib/internal/dgram.js
+++ b/lib/internal/dgram.js
@@ -28,7 +28,7 @@ function lookup6(lookup, address, callback) {
   return lookup(address || '::1', 6, callback);
 }
 
-function newHandle(type, lookup) {
+function newHandle(type, lookup, mmsgCount) {
   if (lookup === undefined) {
     if (dns === undefined) {
       dns = require('dns');
@@ -40,14 +40,14 @@ function newHandle(type, lookup) {
   }
 
   if (type === 'udp4') {
-    const handle = new UDP();
+    const handle = new UDP(mmsgCount);
 
     handle.lookup = FunctionPrototypeBind(lookup4, handle, lookup);
     return handle;
   }
 
   if (type === 'udp6') {
-    const handle = new UDP();
+    const handle = new UDP(mmsgCount);
 
     handle.lookup = FunctionPrototypeBind(lookup6, handle, lookup);
     handle.bind = handle.bind6;

--- a/test/parallel/test-dgram-udp-recvmmsg-close.js
+++ b/test/parallel/test-dgram-udp-recvmmsg-close.js
@@ -1,0 +1,30 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const message_to_send = 'A message to send';
+
+const server = dgram.createSocket({ type: 'udp4', msgCount: 3 });
+const client = dgram.createSocket({ type: 'udp4' });
+
+client.on('close', common.mustCall());
+server.on('close', common.mustCall());
+
+server.on('message', common.mustCall((msg) => {
+  assert.strictEqual(msg.toString(), message_to_send.toString());
+  // The server will release the memory which allocated by handle->alloc_cb
+  server.close();
+  client.close();
+}));
+
+server.on('listening', common.mustCall(() => {
+  for (let i = 0; i < 2; i++) {
+    client.send(message_to_send,
+                0,
+                message_to_send.length,
+                server.address().port,
+                server.address().address);
+  }
+}));
+
+server.bind(0);

--- a/test/parallel/test-dgram-udp-recvmmsg.js
+++ b/test/parallel/test-dgram-udp-recvmmsg.js
@@ -1,0 +1,61 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const message_to_send = 'A message to send';
+
+[
+  -1,
+  1.1,
+  NaN,
+  undefined,
+  {},
+  [],
+  null,
+  function() {},
+  Symbol(),
+  true,
+  Infinity,
+].forEach((msgCount) => {
+  try {
+    dgram.createSocket({ type: 'udp4', msgCount });
+  } catch (e) {
+    assert.ok(/ERR_OUT_OF_RANGE|ERR_INVALID_ARG_TYPE/i.test(e.code));
+  }
+});
+
+[
+  0,
+  1,
+].forEach((msgCount) => {
+  const socket = dgram.createSocket({ type: 'udp4', msgCount });
+  socket.close();
+});
+
+const server = dgram.createSocket({ type: 'udp4', msgCount: 3 });
+const client = dgram.createSocket({ type: 'udp4' });
+
+client.on('close', common.mustCall());
+server.on('close', common.mustCall());
+
+let done = 0;
+const count = 2;
+server.on('message', common.mustCall((msg) => {
+  assert.strictEqual(msg.toString(), message_to_send.toString());
+  if (++done === count) {
+    client.close();
+    server.close();
+  }
+}, count));
+
+server.on('listening', common.mustCall(() => {
+  for (let i = 0; i < count; i++) {
+    client.send(message_to_send,
+                0,
+                message_to_send.length,
+                server.address().port,
+                server.address().address);
+  }
+}));
+
+server.bind(0);


### PR DESCRIPTION
Add an option for using `recvmmsg`.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
