### PR TITLE
test_runner: write timestamp as first line in watch mode

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -496,6 +496,12 @@ function watchFiles(testFiles, opts) {
     }
 
     await runningSubtests.get(file);
+
+    // Emit the 'test:restarted' event if a timeStamp reporter is available.
+    if (opts.root?.reporter?.timeStamp) {
+      opts.root.reporter.timeStamp('test:restarted', { __proto__: null, file });
+    }
+
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
 

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -2,6 +2,7 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
+  Date,
   NumberMAX_SAFE_INTEGER,
   Symbol,
 } = primordials;
@@ -147,6 +148,11 @@ class TestsStream extends Readable {
 
   end() {
     this.#tryPush(null);
+  }
+
+  // This event emitter logs a timestamp whenever a test restarts because of changes in any related files.
+  timeStamp(type, data) {
+    process.stdout.write(`\n[${new Date().toLocaleString('en-GB').replace(',', '')}] INFO: Test restarted\n`);
   }
 
   [kEmitMessage](type, data) {

--- a/test/parallel/test-runner-restart-timestamp.js
+++ b/test/parallel/test-runner-restart-timestamp.js
@@ -1,0 +1,31 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { TestsStream } = require('internal/test_runner/tests_stream');
+
+// ✅ Instantiate the TestsStream reporter directly
+const reporter = new TestsStream();
+
+// ✅ Patch to monitor the console output
+let consoleOutput = '';
+const originalWrite = process.stdout.write;
+process.stdout.write = (chunk, ...args) => {
+  consoleOutput += chunk;
+  return originalWrite.call(process.stdout, chunk, ...args);
+};
+
+// ✅ Wrap timeStamp with mustCall (this ensures it is invoked)
+common.mustCall(() => {
+  reporter.timeStamp('test:restarted', { file: 'dummy.js' });
+})();
+
+// ✅ Restore console
+process.stdout.write = originalWrite;
+
+// ✅ Assert output contains the timestamp message
+assert.ok(
+  consoleOutput.includes('INFO: Test restarted'),
+  'Expected timestamp message in console output'
+);


### PR DESCRIPTION
I added an event emitter ->timestamp in tests_stream.js file and then call the event emitter timestamp whenever the --watch is triggered through restartTestFile() in runner.js file

timestamp eventemitter being called then logs the timestamp message(current date and time) in this format

[21/07/2025 21:24:13] INFO: Test restarted

Refs: https://github.com/nodejs/node/issues/57206