### PR TITLE
fs: correct error message when FileHandle is transferred

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -111,6 +111,7 @@ const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
 const kRefs = Symbol('kRefs');
 const kClosePromise = Symbol('kClosePromise');
+const kCloseReason = Symbol('kCloseReason');
 const kCloseResolve = Symbol('kCloseResolve');
 const kCloseReject = Symbol('kCloseReject');
 const kRef = Symbol('kRef');
@@ -389,6 +390,7 @@ class FileHandle extends EventEmitter {
 
     const handle = this[kHandle];
     this[kFd] = -1;
+    this[kCloseReason] = 'The FileHandle has been transferred';
     this[kHandle] = null;
     this[kRefs] = 0;
 
@@ -455,7 +457,7 @@ async function fsCall(fn, handle, ...args) {
 
   if (handle.fd === -1) {
     // eslint-disable-next-line no-restricted-syntax
-    const err = new Error('file closed');
+    const err = new Error(handle[kCloseReason] ?? 'file closed');
     err.code = 'EBADF';
     err.syscall = fn.name;
     throw err;

--- a/test/parallel/test-worker-message-port-transfer-filehandle.js
+++ b/test/parallel/test-worker-message-port-transfer-filehandle.js
@@ -69,6 +69,11 @@ const { once } = require('events');
   assert.strictEqual(fh.fd, -1);
 
   port1.postMessage('second message');
+  await assert.rejects(() => fh.read(), {
+    code: 'EBADF',
+    message: 'The FileHandle has been transferred',
+    syscall: 'read'
+  });
 })().then(common.mustCall());
 
 (async function() {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/59155

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
