### PR TITLE
test: fix flaky test-worker-message-port-transfer-filehandle test

### DIFF
--- a/test/parallel/test-worker-message-port-transfer-filehandle.js
+++ b/test/parallel/test-worker-message-port-transfer-filehandle.js
@@ -86,6 +86,7 @@ const { once } = require('events');
   });
 
   assert.deepStrictEqual(await readPromise, await fs.readFile(__filename));
+  await fh.close();
 })().then(common.mustCall());
 
 (async function() {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes: https://github.com/nodejs/node/issues/59145


Wrap all script into `setInterval` and you will see the error

```js
'use strict';
const common = require('../common');
const assert = require('assert');
const fs = require('fs').promises;
const vm = require('vm');
const { MessageChannel, moveMessagePortToContext } = require('worker_threads');
const { once } = require('events');

setInterval(async () => {
  (async function() {
    const fh = await fs.open(__filename);

    const { port1, port2 } = new MessageChannel();

    assert.throws(() => {
      port1.postMessage(fh);
    }, {
      constructor: DOMException,
      name: 'DataCloneError',
      code: 25,
    });

    // Check that transferring FileHandle instances works.
    assert.notStrictEqual(fh.fd, -1);
    port1.postMessage(fh, [ fh ]);
    assert.strictEqual(fh.fd, -1);

    const [ fh2 ] = await once(port2, 'message');
    assert.strictEqual(Object.getPrototypeOf(fh2), Object.getPrototypeOf(fh));

    assert.deepStrictEqual(await fh2.readFile(), await fs.readFile(__filename));
    await fh2.close();

    await assert.rejects(() => fh.readFile(), { code: 'EBADF' });
  })().then(common.mustCall());

  (async function() {
    // Check that there is no crash if the message is never read.
    const fh = await fs.open(__filename);

    const { port1 } = new MessageChannel();

    assert.notStrictEqual(fh.fd, -1);
    port1.postMessage(fh, [ fh ]);
    assert.strictEqual(fh.fd, -1);
  })().then(common.mustCall());

  (async function() {
    // Check that in the case of a context mismatch the message is discarded.
    const fh = await fs.open(__filename);

    const { port1, port2 } = new MessageChannel();

    const ctx = vm.createContext();
    const port2moved = moveMessagePortToContext(port2, ctx);
    port2moved.onmessage = common.mustCall((msgEvent) => {
      assert.strictEqual(msgEvent.data, 'second message');
      port1.close();
    });
    // TODO(addaleax): Switch this to a 'messageerror' event once MessagePort
    // implements EventTarget fully and in a cross-context manner.
    port2moved.onmessageerror = common.mustCall((event) => {
      assert.strictEqual(event.data.code,
        'ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE');
    });
    port2moved.start();

    assert.notStrictEqual(fh.fd, -1);
    port1.postMessage(fh, [ fh ]);
    assert.strictEqual(fh.fd, -1);

    port1.postMessage('second message');
  })().then(common.mustCall());

  (async function() {
    // Check that a FileHandle with a read in progress cannot be transferred.
    const fh = await fs.open(__filename);

    const { port1 } = new MessageChannel();

    const readPromise = fh.readFile();
    assert.throws(() => {
      port1.postMessage(fh, [fh]);
    }, {
      message: 'Cannot transfer FileHandle while in use',
      name: 'DataCloneError'
    });

    assert.deepStrictEqual(await readPromise, await fs.readFile(__filename));
    // await fh.close();
  })().then(common.mustCall());

  (async function() {
    // Check that filehandles with a close in progress cannot be transferred.
    const fh = await fs.open(__filename);

    const { port1 } = new MessageChannel();

    const closePromise = fh.close();
    assert.throws(() => {
      port1.postMessage(fh, [fh]);
    }, {
      message: 'Cannot transfer FileHandle while in use',
      name: 'DataCloneError'
    });
    await closePromise;
  })().then(common.mustCall());
}, 10)
```