### PR TITLE
benchmark: fix sqlite-is-transaction

### DIFF
--- a/benchmark/sqlite/sqlite-is-transaction.js
+++ b/benchmark/sqlite/sqlite-is-transaction.js
@@ -16,7 +16,7 @@ function main(conf) {
   }
 
   let i;
-  let deadCodeElimination;
+  let deadCodeElimination = true;
 
   bench.start();
   for (i = 0; i < conf.n; i += 1)


### PR DESCRIPTION
The variable deadCodeElimination is declared
but not initialized, making it undefined by default. When using the &&= operator with an undefined left operand, the result will always remain undefined regardless of how many iterations run.

```js
let deadCodeElimination;
deadCodeElimination &&= true
deadCodeElimination // undefined
```
