### PR TITLE
benchmark: remove invalid-date on deepequal prims

### DIFF
--- a/benchmark/assert/deepequal-prims-and-objs-big-loop.js
+++ b/benchmark/assert/deepequal-prims-and-objs-big-loop.js
@@ -22,7 +22,6 @@ const primValues = {
   'empty_object': {},
   'regexp': /abc/i,
   'date': new Date(),
-  'invalidDate': new Date('foo'),
 };
 
 const primValues2 = {
@@ -35,7 +34,6 @@ const primValues2 = {
   'empty_object': {},
   'regexp': /abc/i,
   'date': new Date(primValues.date),
-  'invalidDate': new Date('foo'),
 };
 
 const primValuesUnequal = {
@@ -51,7 +49,6 @@ const primValuesUnequal = {
   'empty_object': [],
   'regexp': /abc/g,
   'date': new Date(primValues.date.getTime() + 1),
-  'invalidDate': new Date(),
 };
 
 const bench = common.createBenchmark(main, {


### PR DESCRIPTION
This benchmark file has been failing for a while
when asserting invalid date. Considering asserting an invalid date is usually out of deepEqual
performance scope. I propose to simply remove this.