### PR TITLE
typings: improve internal binding types

### DIFF
--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -1,3 +1,4 @@
+import { AsyncContextFrameBinding } from './internalBinding/async_context_frame';
 import { AsyncWrapBinding } from './internalBinding/async_wrap';
 import { BlobBinding } from './internalBinding/blob';
 import { ConfigBinding } from './internalBinding/config';
@@ -7,11 +8,13 @@ import { HttpParserBinding } from './internalBinding/http_parser';
 import { InspectorBinding } from './internalBinding/inspector';
 import { FsBinding } from './internalBinding/fs';
 import { FsDirBinding } from './internalBinding/fs_dir';
+import { ICUBinding } from './internalBinding/icu';
 import { LocksBinding } from './internalBinding/locks';
 import { MessagingBinding } from './internalBinding/messaging';
 import { OptionsBinding } from './internalBinding/options';
 import { OSBinding } from './internalBinding/os';
 import { ProcessBinding } from './internalBinding/process';
+import { SeaBinding } from './internalBinding/sea';
 import { SerdesBinding } from './internalBinding/serdes';
 import { SymbolsBinding } from './internalBinding/symbols';
 import { TimersBinding } from './internalBinding/timers';
@@ -25,6 +28,7 @@ import { ModulesBinding } from './internalBinding/modules';
 import { ZlibBinding } from './internalBinding/zlib';
 
 interface InternalBindingMap {
+  async_context_frame: AsyncContextFrameBinding;
   async_wrap: AsyncWrapBinding;
   blob: BlobBinding;
   config: ConfigBinding;
@@ -33,6 +37,7 @@ interface InternalBindingMap {
   fs: FsBinding;
   fs_dir: FsDirBinding;
   http_parser: HttpParserBinding;
+  icu: ICUBinding;
   inspector: InspectorBinding;
   locks: LocksBinding;
   messaging: MessagingBinding;
@@ -40,6 +45,7 @@ interface InternalBindingMap {
   options: OptionsBinding;
   os: OSBinding;
   process: ProcessBinding;
+  sea: SeaBinding;
   serdes: SerdesBinding;
   symbols: SymbolsBinding;
   timers: TimersBinding;
@@ -65,6 +71,7 @@ declare global {
     | Int8Array
     | Int16Array
     | Int32Array
+    | Float16Array
     | Float32Array
     | Float64Array
     | BigUint64Array

--- a/typings/internalBinding/async_context_frame.d.ts
+++ b/typings/internalBinding/async_context_frame.d.ts
@@ -1,0 +1,4 @@
+export interface AsyncContextFrameBinding {
+  getContinuationPreservedEmbedderData(): unknown,
+  setContinuationPreservedEmbedderData(frame: unknown): void,
+}

--- a/typings/internalBinding/constants.d.ts
+++ b/typings/internalBinding/constants.d.ts
@@ -287,6 +287,9 @@ export interface ConstantsBinding {
     BROTLI_ENCODE: 9;
     ZSTD_COMPRESS: 10;
     ZSTD_DECOMPRESS: 11;
+    ZSTD_e_continue: 0;
+    ZSTD_e_flush: 1;
+    ZSTD_e_end: 2;
     Z_MIN_WINDOWBITS: 8;
     Z_MAX_WINDOWBITS: 15;
     Z_DEFAULT_WINDOWBITS: 15;

--- a/typings/internalBinding/http_parser.d.ts
+++ b/typings/internalBinding/http_parser.d.ts
@@ -2,6 +2,15 @@ declare namespace InternalHttpParserBinding {
   type Buffer = Uint8Array;
   type Stream = object;
 
+  class ConnectionsList {
+    constructor();
+
+    all(): HTTPParser[];
+    idle(): HTTPParser[];
+    active(): HTTPParser[];
+    expired(): HTTPParser[];
+  }
+
   class HTTPParser {
     static REQUEST: 1;
     static RESPONSE: 2;
@@ -40,6 +49,8 @@ declare namespace InternalHttpParserBinding {
 }
 
 export interface HttpParserBinding {
-  methods: string[];
+  ConnectionsList: typeof InternalHttpParserBinding.ConnectionsList;
   HTTPParser: typeof InternalHttpParserBinding.HTTPParser;
+  allMethods: string[];
+  methods: string[];
 }

--- a/typings/internalBinding/icu.d.ts
+++ b/typings/internalBinding/icu.d.ts
@@ -1,0 +1,18 @@
+export interface ICUBinding {
+  Converter: object;
+  decode(
+    converter: object,
+    input: ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+    flags: number,
+    fromEncoding: string,
+  ): string;
+  getConverter(label: string, flags: number): object | undefined;
+  getStringWidth(value: string, ambiguousAsFullWidth?: boolean, expandEmojiSequence?: boolean): number;
+  hasConverter(label: string): boolean;
+  icuErrName(status: number): string;
+  transcode(
+    input: ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+    fromEncoding: string,
+    toEncoding: string,
+  ): Buffer | number;
+}

--- a/typings/internalBinding/sea.d.ts
+++ b/typings/internalBinding/sea.d.ts
@@ -1,0 +1,5 @@
+export interface SeaBinding {
+  getAsset(key: string): ArrayBuffer | undefined;
+  isExperimentalSeaWarningNeeded(): boolean;
+  isSea(): boolean;
+}

--- a/typings/internalBinding/symbols.d.ts
+++ b/typings/internalBinding/symbols.d.ts
@@ -1,5 +1,6 @@
 export const async_id_symbol: unique symbol;
 export const handle_onclose_symbol: unique symbol;
+export const imported_cjs_symbol: unique symbol;
 export const no_message_symbol: unique symbol;
 export const messaging_deserialize_symbol: unique symbol;
 export const messaging_transfer_symbol: unique symbol;
@@ -13,6 +14,7 @@ export const trigger_async_id_symbol: unique symbol;
 export interface SymbolsBinding {
   async_id_symbol: typeof async_id_symbol;
   handle_onclose_symbol: typeof handle_onclose_symbol;
+  imported_cjs_symbol: typeof imported_cjs_symbol;
   no_message_symbol: typeof no_message_symbol;
   messaging_deserialize_symbol: typeof messaging_deserialize_symbol;
   messaging_transfer_symbol: typeof messaging_transfer_symbol;

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -46,4 +46,22 @@ export interface UtilBinding {
   parseEnv(content: string): Record<string, string>;
   styleText(format: Array<string> | string, text: string): string;
   isInsideNodeModules(frameLimit: number, defaultValue: unknown): boolean;
+
+  constants: {
+    kPending: 0;
+    kFulfilled: 1;
+    kRejected: 2;
+    kExiting: 0;
+    kExitCode: 1;
+    kHasExitCode: 2;
+    ALL_PROPERTIES: 0;
+    ONLY_WRITABLE: 1;
+    ONLY_ENUMERABLE: 2;
+    ONLY_CONFIGURABLE: 4;
+    SKIP_STRINGS: 8;
+    SKIP_SYMBOLS: 16;
+    kDisallowCloneAndTransfer: 0;
+    kTransferable: 1;
+    kCloneable: 2;
+  };
 }

--- a/typings/primordials.d.ts
+++ b/typings/primordials.d.ts
@@ -280,6 +280,7 @@ declare namespace primordials {
   export const FunctionPrototypeApply: UncurryThis<typeof Function.prototype.apply>
   export const FunctionPrototypeBind: UncurryThis<typeof Function.prototype.bind>
   export const FunctionPrototypeCall: UncurryThis<typeof Function.prototype.call>
+  export const FunctionPrototypeSymbolHasInstance: UncurryMethod<typeof Function.prototype, typeof Symbol.hasInstance>
   export const FunctionPrototypeToString: UncurryThis<typeof Function.prototype.toString>
   export import Int16Array = globalThis.Int16Array;
   export const Int16ArrayPrototype: typeof Int16Array.prototype
@@ -371,6 +372,8 @@ declare namespace primordials {
   export const RegExpPrototypeGetSource: UncurryGetter<typeof RegExp.prototype, "source">;
   export const RegExpPrototypeGetSticky: UncurryGetter<typeof RegExp.prototype, "sticky">;
   export const RegExpPrototypeGetUnicode: UncurryGetter<typeof RegExp.prototype, "unicode">;
+  export const RegExpPrototypeSymbolReplace: UncurryMethod<typeof RegExp.prototype, typeof Symbol.replace>
+  export const RegExpPrototypeSymbolSplit: UncurryMethod<typeof RegExp.prototype, typeof Symbol.split>
   export import Set = globalThis.Set;
   export const SetLength: typeof Set.length
   export const SetName: typeof Set.name


### PR DESCRIPTION
- Add typings for `async_context_frame`, `icu`, and `sea` bindings
- Add a few missing exports on other bindings
- Add a few missing primordials

