### PR TITLE
url: replaced slice with at

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -22,7 +22,6 @@
 'use strict';
 
 const {
-  ArrayPrototypeAt,
   ArrayPrototypeJoin,
   Boolean,
   Int8Array,
@@ -922,7 +921,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // If a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
-  let last = ArrayPrototypeAt(srcPath, -1);
+  let last = srcPath[srcPath.length - 1];
   const hasTrailingSlash = (
     ((result.host || relative.host || srcPath.length > 1) &&
     (last === '.' || last === '..')) || last === '');

--- a/lib/url.js
+++ b/lib/url.js
@@ -919,7 +919,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // If a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
-  let last = srcPath.slice(-1)[0];
+  let last = srcPath.at(-1);
   const hasTrailingSlash = (
     ((result.host || relative.host || srcPath.length > 1) &&
     (last === '.' || last === '..')) || last === '');
@@ -952,7 +952,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     srcPath.unshift('');
   }
 
-  if (hasTrailingSlash && (srcPath.join('/').slice(-1) !== '/')) {
+  if (hasTrailingSlash && (srcPath.join('/').at(-1) !== '/')) {
     srcPath.push('');
   }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -28,6 +28,7 @@ const {
   Int8Array,
   ObjectAssign,
   ObjectKeys,
+  StringPrototypeAt,
   StringPrototypeCharCodeAt,
   StringPrototypeIndexOf,
   StringPrototypeReplaceAll,
@@ -954,7 +955,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     srcPath.unshift('');
   }
 
-  if (hasTrailingSlash && ArrayPrototypeAt(ArrayPrototypeJoin(srcPath,'/'), -1) !== '/')) {
+  if (hasTrailingSlash && StringPrototypeAt(ArrayPrototypeJoin(srcPath, '/'), -1) !== '/') {
     srcPath.push('');
   }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -22,6 +22,8 @@
 'use strict';
 
 const {
+  ArrayPrototypeAt,
+  ArrayPrototypeJoin,
   Boolean,
   Int8Array,
   ObjectAssign,
@@ -919,7 +921,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
   // If a url ENDs in . or .., then it must get a trailing slash.
   // however, if it ends in anything else non-slashy,
   // then it must NOT get a trailing slash.
-  let last = srcPath.at(-1);
+  let last = ArrayPrototypeAt(srcPath, -1);
   const hasTrailingSlash = (
     ((result.host || relative.host || srcPath.length > 1) &&
     (last === '.' || last === '..')) || last === '');
@@ -952,7 +954,7 @@ Url.prototype.resolveObject = function resolveObject(relative) {
     srcPath.unshift('');
   }
 
-  if (hasTrailingSlash && (srcPath.join('/').at(-1) !== '/')) {
+  if (hasTrailingSlash && ArrayPrototypeAt(ArrayPrototypeJoin(srcPath,'/'), -1) !== '/')) {
     srcPath.push('');
   }
 


### PR DESCRIPTION
I replaced slice(-1) with at(-1) to avoid creating a new collection, since at() directly accesses the element without copying the array.
I did the same for a string in another place — replaced slice(-1) with at(-1) for consistency and simplicity.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
