### PR TITLE
child_process: validate exec's `options.shell` as string

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -199,7 +199,13 @@ function normalizeExecArgs(command, options, callback) {
 
   // Make a shallow copy so we don't clobber the user's options object.
   options = { __proto__: null, ...options };
-  options.shell = typeof options.shell === 'string' ? options.shell : true;
+
+  // Validate the shell, if present, otherwise request the default shell.
+  if (options.shell != null) {
+    validateString(options.shell, 'options.shell');
+  } else {
+    options.shell = true;
+  }
 
   return {
     file: command,
@@ -613,11 +619,12 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   // Validate the shell, if present.
-  if (options.shell != null &&
-      typeof options.shell !== 'boolean' &&
-      typeof options.shell !== 'string') {
-    throw new ERR_INVALID_ARG_TYPE('options.shell',
-                                   ['boolean', 'string'], options.shell);
+  if (options.shell != null) {
+    if (typeof options.shell !== 'boolean' && typeof options.shell !== 'string') {
+      throw new ERR_INVALID_ARG_TYPE('options.shell',
+                                     ['boolean', 'string'], options.shell);
+    }
+    validateArgumentNullCheck(options.shell, 'options.shell');
   }
 
   // Validate argv0, if present.
@@ -639,7 +646,6 @@ function normalizeSpawnArguments(file, args, options) {
   }
 
   if (options.shell) {
-    validateArgumentNullCheck(options.shell, 'options.shell');
     if (args.length > 0 && !emittedDEP0190Already) {
       process.emitWarning(
         'Passing args to a child process with shell option true can lead to security ' +

--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -33,7 +33,7 @@ const testCopy = (shellName, shellPath) => {
 const system32 = `${process.env.SystemRoot}\\System32`;
 
 // Test CMD
-test(true);
+test(null);
 test('cmd');
 testCopy('cmd.exe', `${system32}\\cmd.exe`);
 test('cmd.exe');

--- a/test/parallel/test-child-process-exec-shell.js
+++ b/test/parallel/test-child-process-exec-shell.js
@@ -1,0 +1,15 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { exec, execSync } = require('child_process');
+
+const invalidArgTypeError = {
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError'
+};
+
+for (const fn of [exec, execSync]) {
+  assert.throws(() => fn('should-throw-on-boolean-shell-option', { shell: false }), invalidArgTypeError);
+}
+
+// TODO: add DEP0196 tests following runtime deprecation


### PR DESCRIPTION
`exec()` is documented to only take a string, but this is not validated; passing something like `{ shell: false }` (or any other invalid value) is currently silently ignored. This adds explicit validation.

Replaces #54623.