### PR TITLE
benchmark: adjust configuration for string-decoder bench

### DIFF
--- a/benchmark/string_decoder/string-decoder.js
+++ b/benchmark/string_decoder/string-decoder.js
@@ -1,11 +1,12 @@
 'use strict';
 const common = require('../common.js');
 const StringDecoder = require('string_decoder').StringDecoder;
+const assert = require('node:assert');
 
 const bench = common.createBenchmark(main, {
   encoding: ['ascii', 'utf8', 'base64-utf8', 'base64-ascii', 'utf16le'],
-  inLen: [32, 128, 1024, 4096],
-  chunkLen: [16, 64, 256, 1024],
+  inLen: [32, 128, 1024],
+  chunkLen: [16, 256, 1024],
   n: [25e5],
 });
 
@@ -75,10 +76,13 @@ function main({ encoding, inLen, chunkLen, n }) {
 
   const nChunks = chunks.length;
 
+  let avoidDeadCode;
   bench.start();
   for (let i = 0; i < n; ++i) {
+    avoidDeadCode = '';
     for (let j = 0; j < nChunks; ++j)
-      sd.write(chunks[j]);
+      avoidDeadCode += sd.write(chunks[j]);
   }
   bench.end(n);
+  assert.ok(avoidDeadCode);
 }


### PR DESCRIPTION
**benchmark: adjust configuration for string-decoder bench**

According to https://github.com/nodejs/node/pull/59186 this benchmark file takes 6 hours to complete a full benchmark/compare.js script (60 runs in total) and these regression tests unrealitics to do between Node.js releases. By using calibrate-n scripts I could find a better N also ajusting some bench configs. e.g: avoid dead code elimination by V8.


Refs: https://github.com/nodejs/node/pull/59186

Results from `calibrate-n.js`

```
Overall average CV: 3.57%
  ✓ Overall CV is below 5% and no configuration has CV above 10%
  → New best n: 400000 with average CV: 3.57%

✓ Found optimal n=400000 (Overall CV=3.57% < 5% and no configuration has CV > 10%)

Final CV for each configuration:
  {"n":400000,"chunkLen":16,"inLen":32,"encoding":"ascii"}: 5.11%
  {"n":400000,"chunkLen":256,"inLen":32,"encoding":"ascii"}: 7.24%
  {"n":400000,"chunkLen":1024,"inLen":32,"encoding":"ascii"}: 2.60%
  {"n":400000,"chunkLen":16,"inLen":128,"encoding":"ascii"}: 2.64%
  {"n":400000,"chunkLen":256,"inLen":128,"encoding":"ascii"}: 3.88%
  {"n":400000,"chunkLen":1024,"inLen":128,"encoding":"ascii"}: 3.33%
  {"n":400000,"chunkLen":16,"inLen":1024,"encoding":"ascii"}: 2.54%
  {"n":400000,"chunkLen":256,"inLen":1024,"encoding":"ascii"}: 5.85%
  {"n":400000,"chunkLen":1024,"inLen":1024,"encoding":"ascii"}: 4.53%
  {"n":400000,"chunkLen":16,"inLen":32,"encoding":"utf8"}: 3.51%
  {"n":400000,"chunkLen":256,"inLen":32,"encoding":"utf8"}: 4.27%
  {"n":400000,"chunkLen":1024,"inLen":32,"encoding":"utf8"}: 5.20%
  {"n":400000,"chunkLen":16,"inLen":128,"encoding":"utf8"}: 2.98%
  {"n":400000,"chunkLen":256,"inLen":128,"encoding":"utf8"}: 1.68%
  {"n":400000,"chunkLen":1024,"inLen":128,"encoding":"utf8"}: 2.14%
  {"n":400000,"chunkLen":16,"inLen":1024,"encoding":"utf8"}: 1.36%
  {"n":400000,"chunkLen":256,"inLen":1024,"encoding":"utf8"}: 1.15%
  {"n":400000,"chunkLen":1024,"inLen":1024,"encoding":"utf8"}: 1.12%
  {"n":400000,"chunkLen":16,"inLen":32,"encoding":"base64-utf8"}: 3.61%
  {"n":400000,"chunkLen":256,"inLen":32,"encoding":"base64-utf8"}: 3.86%
  {"n":400000,"chunkLen":1024,"inLen":32,"encoding":"base64-utf8"}: 4.45%
  {"n":400000,"chunkLen":16,"inLen":128,"encoding":"base64-utf8"}: 3.34%
  {"n":400000,"chunkLen":256,"inLen":128,"encoding":"base64-utf8"}: 4.50%
  {"n":400000,"chunkLen":1024,"inLen":128,"encoding":"base64-utf8"}: 5.32%
  {"n":400000,"chunkLen":16,"inLen":1024,"encoding":"base64-utf8"}: 1.65%
  {"n":400000,"chunkLen":256,"inLen":1024,"encoding":"base64-utf8"}: 2.55%
  {"n":400000,"chunkLen":1024,"inLen":1024,"encoding":"base64-utf8"}: 3.67%
  {"n":400000,"chunkLen":16,"inLen":32,"encoding":"base64-ascii"}: 5.55%
  {"n":400000,"chunkLen":256,"inLen":32,"encoding":"base64-ascii"}: 3.76%
  {"n":400000,"chunkLen":1024,"inLen":32,"encoding":"base64-ascii"}: 2.42%
  {"n":400000,"chunkLen":16,"inLen":128,"encoding":"base64-ascii"}: 2.14%
  {"n":400000,"chunkLen":256,"inLen":128,"encoding":"base64-ascii"}: 4.13%
  {"n":400000,"chunkLen":1024,"inLen":128,"encoding":"base64-ascii"}: 3.57%
  {"n":400000,"chunkLen":16,"inLen":1024,"encoding":"base64-ascii"}: 3.01%
  {"n":400000,"chunkLen":256,"inLen":1024,"encoding":"base64-ascii"}: 2.71%
  {"n":400000,"chunkLen":1024,"inLen":1024,"encoding":"base64-ascii"}: 3.61%
  {"n":400000,"chunkLen":16,"inLen":32,"encoding":"utf16le"}: 3.76%
  {"n":400000,"chunkLen":256,"inLen":32,"encoding":"utf16le"}: 5.35%
  {"n":400000,"chunkLen":1024,"inLen":32,"encoding":"utf16le"}: 7.25%
  {"n":400000,"chunkLen":16,"inLen":128,"encoding":"utf16le"}: 2.68%
  {"n":400000,"chunkLen":256,"inLen":128,"encoding":"utf16le"}: 5.67%
  {"n":400000,"chunkLen":1024,"inLen":128,"encoding":"utf16le"}: 4.26%
  {"n":400000,"chunkLen":16,"inLen":1024,"encoding":"utf16le"}: 1.32%
  {"n":400000,"chunkLen":256,"inLen":1024,"encoding":"utf16le"}: 2.69%
  {"n":400000,"chunkLen":1024,"inLen":1024,"encoding":"utf16le"}: 2.46%
```