### PR TITLE
[v24.x] lib: do not modify prototype deprecated asyncResource

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -262,10 +262,10 @@ class AsyncResource {
         enumerable: true,
         get: deprecate(function() {
           return self;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false),
         set: deprecate(function(val) {
           self = val;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172'),
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false),
       },
     });
     return bound;


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/58218

In this specific benchmark, the performance difference between `modifyPrototype=0` and `modifyPrototype=1` is marginally significant at the 5% level:

* **Mean (modifyPrototype=0)**: 390,196.99 ops/sec
* **Mean (modifyPrototype=1)**: 382,521.21 ops/sec
* **p-value**: 0.05087