### PR TITLE
test: use mustSucceed instead of mustCall

### DIFF
--- a/test/parallel/test-fs-read-zero-length.js
+++ b/test/parallel/test-fs-read-zero-length.js
@@ -8,7 +8,7 @@ const fd = fs.openSync(filepath, 'r');
 const bufferAsync = Buffer.alloc(0);
 const bufferSync = Buffer.alloc(0);
 
-fs.read(fd, bufferAsync, 0, 0, 0, common.mustCall((err, bytesRead) => {
+fs.read(fd, bufferAsync, 0, 0, 0, common.mustSucceed((bytesRead) => {
   assert.strictEqual(bytesRead, 0);
   assert.deepStrictEqual(bufferAsync, Buffer.alloc(0));
 }));


### PR DESCRIPTION
Replace `mustCall((err, data) ...)` with `mustSucceed((data) ...)` in `test/parallel/test-fs-read-zero-length.js`.

This test is to verify a successful fs.read() operation, where no error is expected in the callback. Therefore, I think it is more appropriate to use [mustSucceed](https://github.com/nodejs/node/blob/main/test/common/README.md#mustsucceedfn).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
