### PR TITLE
worker: add name for worker

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -721,6 +721,17 @@ An integer identifier for the current thread. On the corresponding worker object
 (if there is any), it is available as [`worker.threadId`][].
 This value is unique for each [`Worker`][] instance inside a single process.
 
+## `worker.threadName`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string|null}
+
+A string identifier for the current thread or null if the thread is not running.
+On the corresponding worker object (if there is any), it is available as [`worker.threadName`][].
+
 ## `worker.workerData`
 
 <!-- YAML
@@ -2015,6 +2026,17 @@ An integer identifier for the referenced thread. Inside the worker thread,
 it is available as [`require('node:worker_threads').threadId`][].
 This value is unique for each `Worker` instance inside a single process.
 
+### `worker.threadName`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {string|null}
+
+A string identifier for the referenced thread or null if the thread is not running.
+Inside the worker thread, it is available as [`require('node:worker_threads').threadName`][].
+
 ### `worker.unref()`
 
 <!-- YAML
@@ -2143,6 +2165,7 @@ thread spawned will spawn another until the application crashes.
 [`require('node:worker_threads').parentPort.postMessage()`]: #workerpostmessagevalue-transferlist
 [`require('node:worker_threads').parentPort`]: #workerparentport
 [`require('node:worker_threads').threadId`]: #workerthreadid
+[`require('node:worker_threads').threadName`]: #workerthreadname
 [`require('node:worker_threads').workerData`]: #workerworkerdata
 [`trace_events`]: tracing.md
 [`v8.getHeapSnapshot()`]: v8.md#v8getheapsnapshotoptions
@@ -2153,6 +2176,7 @@ thread spawned will spawn another until the application crashes.
 [`worker.postMessage()`]: #workerpostmessagevalue-transferlist
 [`worker.terminate()`]: #workerterminate
 [`worker.threadId`]: #workerthreadid_1
+[`worker.threadName`]: #workerthreadname_1
 [async-resource-worker-pool]: async_context.md#using-asyncresource-for-a-worker-thread-pool
 [browser `LockManager`]: https://developer.mozilla.org/en-US/docs/Web/API/LockManager
 [browser `MessagePort`]: https://developer.mozilla.org/en-US/docs/Web/API/MessagePort

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -73,6 +73,7 @@ const {
   isInternalThread,
   resourceLimits: resourceLimitsRaw,
   threadId,
+  threadName,
   Worker: WorkerImpl,
   kMaxYoungGenerationSizeMb,
   kMaxOldGenerationSizeMb,
@@ -425,6 +426,12 @@ class Worker extends EventEmitter {
     return this[kHandle].threadId;
   }
 
+  get threadName() {
+    if (this[kHandle] === null) return null;
+
+    return this[kHandle].threadName;
+  }
+
   get stdin() {
     return this[kParentSideStdio].stdin;
   }
@@ -589,6 +596,7 @@ module.exports = {
   getEnvironmentData,
   assignEnvironmentData,
   threadId,
+  threadName,
   InternalWorker,
   Worker,
 };

--- a/lib/worker_threads.js
+++ b/lib/worker_threads.js
@@ -8,6 +8,7 @@ const {
   setEnvironmentData,
   getEnvironmentData,
   threadId,
+  threadName,
   Worker,
 } = require('internal/worker');
 
@@ -44,6 +45,7 @@ module.exports = {
   resourceLimits,
   postMessageToThread,
   threadId,
+  threadName,
   SHARE_ENV,
   Worker,
   parentPort: null,

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -414,6 +414,25 @@ Environment* CreateEnvironment(
     EnvironmentFlags::Flags flags,
     ThreadId thread_id,
     std::unique_ptr<InspectorParentHandle> inspector_parent_handle) {
+  return CreateEnvironment(isolate_data,
+                           context,
+                           args,
+                           exec_args,
+                           flags,
+                           thread_id,
+                           std::move(inspector_parent_handle),
+                           {});
+}
+
+Environment* CreateEnvironment(
+    IsolateData* isolate_data,
+    Local<Context> context,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args,
+    EnvironmentFlags::Flags flags,
+    ThreadId thread_id,
+    std::unique_ptr<InspectorParentHandle> inspector_parent_handle,
+    std::string_view thread_name) {
   Isolate* isolate = isolate_data->isolate();
 
   Isolate::Scope isolate_scope(isolate);
@@ -434,7 +453,8 @@ Environment* CreateEnvironment(
                                      exec_args,
                                      env_snapshot_info,
                                      flags,
-                                     thread_id);
+                                     thread_id,
+                                     thread_name);
   CHECK_NOT_NULL(env);
 
   if (use_snapshot) {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -695,6 +695,10 @@ inline uint64_t Environment::thread_id() const {
   return thread_id_;
 }
 
+inline std::string_view Environment::thread_name() const {
+  return thread_name_;
+}
+
 inline worker::Worker* Environment::worker_context() const {
   return isolate_data()->worker_context();
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -784,7 +784,8 @@ Environment::Environment(IsolateData* isolate_data,
                          const std::vector<std::string>& exec_args,
                          const EnvSerializeInfo* env_info,
                          EnvironmentFlags::Flags flags,
-                         ThreadId thread_id)
+                         ThreadId thread_id,
+                         std::string_view thread_name)
     : isolate_(isolate),
       external_memory_accounter_(new ExternalMemoryAccounter()),
       isolate_data_(isolate_data),
@@ -811,7 +812,8 @@ Environment::Environment(IsolateData* isolate_data,
       flags_(flags),
       thread_id_(thread_id.id == static_cast<uint64_t>(-1)
                      ? AllocateEnvironmentThreadId().id
-                     : thread_id.id) {
+                     : thread_id.id),
+      thread_name_(thread_name) {
   if (!is_main_thread()) {
     // If this is a Worker thread, we can always safely use the parent's
     // Isolate's code cache because of the shared read-only heap.

--- a/src/env.h
+++ b/src/env.h
@@ -660,7 +660,8 @@ class Environment final : public MemoryRetainer {
               const std::vector<std::string>& exec_args,
               const EnvSerializeInfo* env_info,
               EnvironmentFlags::Flags flags,
-              ThreadId thread_id);
+              ThreadId thread_id,
+              std::string_view thread_name = "");
   void InitializeMainContext(v8::Local<v8::Context> context,
                              const EnvSerializeInfo* env_info);
   ~Environment() override;
@@ -807,6 +808,7 @@ class Environment final : public MemoryRetainer {
   inline bool should_start_debug_signal_handler() const;
   inline bool no_browser_globals() const;
   inline uint64_t thread_id() const;
+  inline std::string_view thread_name() const;
   inline worker::Worker* worker_context() const;
   Environment* worker_parent_env() const;
   inline void add_sub_worker_context(worker::Worker* context);
@@ -1172,6 +1174,7 @@ class Environment final : public MemoryRetainer {
 
   uint64_t flags_;
   uint64_t thread_id_;
+  std::string thread_name_;
   std::unordered_set<worker::Worker*> sub_worker_contexts_;
 
 #if HAVE_INSPECTOR

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -390,6 +390,7 @@
   V(table_string, "table")                                                     \
   V(target_string, "target")                                                   \
   V(thread_id_string, "threadId")                                              \
+  V(thread_name_string, "threadName")                                          \
   V(ticketkeycallback_string, "onticketkeycallback")                           \
   V(timeout_string, "timeout")                                                 \
   V(time_to_first_byte_string, "timeToFirstByte")                              \

--- a/src/node.h
+++ b/src/node.h
@@ -685,6 +685,16 @@ NODE_EXTERN Environment* CreateEnvironment(
     ThreadId thread_id = {} /* allocates a thread id automatically */,
     std::unique_ptr<InspectorParentHandle> inspector_parent_handle = {});
 
+NODE_EXTERN Environment* CreateEnvironment(
+    IsolateData* isolate_data,
+    v8::Local<v8::Context> context,
+    const std::vector<std::string>& args,
+    const std::vector<std::string>& exec_args,
+    EnvironmentFlags::Flags flags,
+    ThreadId thread_id,
+    std::unique_ptr<InspectorParentHandle> inspector_parent_handle,
+    std::string_view thread_name);
+
 // Returns a handle that can be passed to `LoadEnvironment()`, making the
 // child Environment accessible to the inspector as if it were a Node.js Worker.
 // `child_thread_id` can be created using `AllocateEnvironmentThreadId()`

--- a/test/parallel/test-worker-thread-name.js
+++ b/test/parallel/test-worker-thread-name.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker, threadName, workerData } = require('worker_threads');
+
+const name = 'test-worker-thread-name';
+
+if (workerData?.isWorker) {
+  assert.strictEqual(threadName, name);
+  process.exit(0);
+} else {
+  const w = new Worker(__filename, { name, workerData: { isWorker: true } });
+  assert.strictEqual(w.threadName, name);
+  w.on('exit', common.mustCall(() => {
+    assert.strictEqual(w.threadName, null);
+  }));
+}


### PR DESCRIPTION
In some scenarios, `name` is very useful(such as in the APM SDK) and easier to understand.
```js
const { Worker } = require('worker_threads');

process.on('worker', (worker) => {
  // output: test-worker-thread-name in main thread
  console.log(worker.threadName + " in main thread");
});

new Worker(`
  const { threadName } = require('worker_threads');
  // output: test-worker-thread-name in worker thread
  console.log(threadName + " in worker thread");
`, { eval: true, name: 'test-worker-thread-name' });
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
