### PR TITLE
benchmark: add fs warmup to writefile-promises

### DIFF
--- a/benchmark/fs/writefile-promises.js
+++ b/benchmark/fs/writefile-promises.js
@@ -39,8 +39,17 @@ function main({ encodingType, duration, concurrent, size }) {
   let writes = 0;
   let waitConcurrent = 0;
 
-  const startedAt = Date.now();
-  const endAt = startedAt + (duration * 1000);
+  let startedAt = Date.now();
+  let endAt = startedAt + duration * 1000;
+
+  // fs warmup
+  for (let i = 0; i < concurrent; i++) write();
+
+  writes = 0;
+  waitConcurrent = 0;
+
+  startedAt = Date.now();
+  endAt = startedAt + duration * 1000;
 
   bench.start();
 
@@ -59,7 +68,8 @@ function main({ encodingType, duration, concurrent, size }) {
   }
 
   function write() {
-    fs.promises.writeFile(`${filename}-${filesWritten++}`, chunk, encoding)
+    fs.promises
+      .writeFile(`${filename}-${filesWritten++}`, chunk, encoding)
       .then(() => afterWrite())
       .catch((err) => afterWrite(err));
   }
@@ -72,7 +82,7 @@ function main({ encodingType, duration, concurrent, size }) {
     writes++;
     const benchEnded = Date.now() >= endAt;
 
-    if (benchEnded && (++waitConcurrent) === concurrent) {
+    if (benchEnded && ++waitConcurrent === concurrent) {
       stop();
     } else if (!benchEnded) {
       write();


### PR DESCRIPTION
Add file system warmup to benchmark `writefile-promises.js`

```bash

$ node benchmark/fs/writefile-promises.js

fs/writefile-promises.js concurrent=1 size=2 encodingType="buf" duration=5: 15,522.893788642756
fs/writefile-promises.js concurrent=10 size=2 encodingType="buf" duration=5: 18,385.621401001084
fs/writefile-promises.js concurrent=1 size=1024 encodingType="buf" duration=5: 15,941.96183276004
fs/writefile-promises.js concurrent=10 size=1024 encodingType="buf" duration=5: 17,732.973306593143
fs/writefile-promises.js concurrent=1 size=65535 encodingType="buf" duration=5: 11,277.442195395763
fs/writefile-promises.js concurrent=10 size=65535 encodingType="buf" duration=5: 14,349.130016160936
fs/writefile-promises.js concurrent=1 size=1048576 encodingType="buf" duration=5: 3,471.3987375777265
fs/writefile-promises.js concurrent=10 size=1048576 encodingType="buf" duration=5: 2,374.0714178791595
fs/writefile-promises.js concurrent=1 size=2 encodingType="asc" duration=5: 12,540.450307182413
fs/writefile-promises.js concurrent=10 size=2 encodingType="asc" duration=5: 17,260.661370311405
fs/writefile-promises.js concurrent=1 size=1024 encodingType="asc" duration=5: 16,232.128065269568
fs/writefile-promises.js concurrent=10 size=1024 encodingType="asc" duration=5: 19,247.61233160076
fs/writefile-promises.js concurrent=1 size=65535 encodingType="asc" duration=5: 11,660.957947695404
fs/writefile-promises.js concurrent=10 size=65535 encodingType="asc" duration=5: 13,294.157001400614
fs/writefile-promises.js concurrent=1 size=1048576 encodingType="asc" duration=5: 3,034.2808985541838
fs/writefile-promises.js concurrent=10 size=1048576 encodingType="asc" duration=5: 3,600.4345035710544
fs/writefile-promises.js concurrent=1 size=2 encodingType="utf" duration=5: 17,691.77367306544
fs/writefile-promises.js concurrent=10 size=2 encodingType="utf" duration=5: 20,191.29448264835
fs/writefile-promises.js concurrent=1 size=1024 encodingType="utf" duration=5: 17,717.87765208418
fs/writefile-promises.js concurrent=10 size=1024 encodingType="utf" duration=5: 20,257.297789176133
fs/writefile-promises.js concurrent=1 size=65535 encodingType="utf" duration=5: 9,726.079463331651
fs/writefile-promises.js concurrent=10 size=65535 encodingType="utf" duration=5: 16,046.031875145927
fs/writefile-promises.js concurrent=1 size=1048576 encodingType="utf" duration=5: 1,697.195657894629
fs/writefile-promises.js concurrent=10 size=1048576 encodingType="utf" duration=5: 2,118.778787994161

```