### PR TITLE
doc: link to `TypedArray.from()` in signature

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -405,7 +405,7 @@ implementations. Specifically, the {TypedArray} variants accept a second
 argument that is a mapping function that is invoked on every element of the
 typed array:
 
-* `TypedArray.from(source[, mapFn[, thisArg]])`
+* [`TypedArray.from(source[, mapFn[, thisArg]])`][`TypedArray.from()`]
 
 The `Buffer.from()` method, however, does not support the use of a mapping
 function:


### PR DESCRIPTION
I've been going through the beta documentation generator looking for any bugs, and in the process, I noticed that this should be linked, right?