### PR TITLE
doc: format safely for `doc-kit`

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3602,18 +3602,18 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `type`: {string} The intended use of the generated secret key. Currently
+* `type` {string} The intended use of the generated secret key. Currently
   accepted values are `'hmac'` and `'aes'`.
-* `options`: {Object}
-  * `length`: {number} The bit length of the key to generate. This must be a
+* `options` {Object}
+  * `length` {number} The bit length of the key to generate. This must be a
     value greater than 0.
     * If `type` is `'hmac'`, the minimum is 8, and the maximum length is
       2<sup>31</sup>-1. If the value is not a multiple of 8, the generated
       key will be truncated to `Math.floor(length / 8)`.
     * If `type` is `'aes'`, the length must be one of `128`, `192`, or `256`.
-* `callback`: {Function}
-  * `err`: {Error}
-  * `key`: {KeyObject}
+* `callback` {Function}
+  * `err` {Error}
+  * `key` {KeyObject}
 
 Asynchronously generates a new random secret key of the given `length`. The
 `type` will determine which validations will be performed on the `length`.
@@ -3677,30 +3677,30 @@ changes:
                  produce key objects if no encoding was specified.
 -->
 
-* `type`: {string} Must be `'rsa'`, `'rsa-pss'`, `'dsa'`, `'ec'`, `'ed25519'`,
+* `type` {string} Must be `'rsa'`, `'rsa-pss'`, `'dsa'`, `'ec'`, `'ed25519'`,
   `'ed448'`, `'x25519'`, `'x448'`, or `'dh'`.
-* `options`: {Object}
-  * `modulusLength`: {number} Key size in bits (RSA, DSA).
-  * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
-  * `hashAlgorithm`: {string} Name of the message digest (RSA-PSS).
-  * `mgf1HashAlgorithm`: {string} Name of the message digest used by
+* `options` {Object}
+  * `modulusLength` {number} Key size in bits (RSA, DSA).
+  * `publicExponent` {number} Public exponent (RSA). **Default:** `0x10001`.
+  * `hashAlgorithm` {string} Name of the message digest (RSA-PSS).
+  * `mgf1HashAlgorithm` {string} Name of the message digest used by
     MGF1 (RSA-PSS).
-  * `saltLength`: {number} Minimal salt length in bytes (RSA-PSS).
-  * `divisorLength`: {number} Size of `q` in bits (DSA).
-  * `namedCurve`: {string} Name of the curve to use (EC).
-  * `prime`: {Buffer} The prime parameter (DH).
-  * `primeLength`: {number} Prime length in bits (DH).
-  * `generator`: {number} Custom generator (DH). **Default:** `2`.
-  * `groupName`: {string} Diffie-Hellman group name (DH). See
+  * `saltLength` {number} Minimal salt length in bytes (RSA-PSS).
+  * `divisorLength` {number} Size of `q` in bits (DSA).
+  * `namedCurve` {string} Name of the curve to use (EC).
+  * `prime` {Buffer} The prime parameter (DH).
+  * `primeLength` {number} Prime length in bits (DH).
+  * `generator` {number} Custom generator (DH). **Default:** `2`.
+  * `groupName` {string} Diffie-Hellman group name (DH). See
     [`crypto.getDiffieHellman()`][].
-  * `paramEncoding`: {string} Must be `'named'` or `'explicit'` (EC).
+  * `paramEncoding` {string} Must be `'named'` or `'explicit'` (EC).
     **Default:** `'named'`.
-  * `publicKeyEncoding`: {Object} See [`keyObject.export()`][].
-  * `privateKeyEncoding`: {Object} See [`keyObject.export()`][].
-* `callback`: {Function}
-  * `err`: {Error}
-  * `publicKey`: {string | Buffer | KeyObject}
-  * `privateKey`: {string | Buffer | KeyObject}
+  * `publicKeyEncoding` {Object} See [`keyObject.export()`][].
+  * `privateKeyEncoding` {Object} See [`keyObject.export()`][].
+* `callback` {Function}
+  * `err` {Error}
+  * `publicKey` {string | Buffer | KeyObject}
+  * `privateKey` {string | Buffer | KeyObject}
 
 Generates a new asymmetric key pair of the given `type`. RSA, RSA-PSS, DSA, EC,
 Ed25519, Ed448, X25519, X448, and DH are currently supported.
@@ -3791,29 +3791,29 @@ changes:
                  produce key objects if no encoding was specified.
 -->
 
-* `type`: {string} Must be `'rsa'`, `'rsa-pss'`, `'dsa'`, `'ec'`, `'ed25519'`,
+* `type` {string} Must be `'rsa'`, `'rsa-pss'`, `'dsa'`, `'ec'`, `'ed25519'`,
   `'ed448'`, `'x25519'`, `'x448'`, or `'dh'`.
-* `options`: {Object}
-  * `modulusLength`: {number} Key size in bits (RSA, DSA).
-  * `publicExponent`: {number} Public exponent (RSA). **Default:** `0x10001`.
-  * `hashAlgorithm`: {string} Name of the message digest (RSA-PSS).
-  * `mgf1HashAlgorithm`: {string} Name of the message digest used by
+* `options` {Object}
+  * `modulusLength` {number} Key size in bits (RSA, DSA).
+  * `publicExponent` {number} Public exponent (RSA). **Default:** `0x10001`.
+  * `hashAlgorithm` {string} Name of the message digest (RSA-PSS).
+  * `mgf1HashAlgorithm` {string} Name of the message digest used by
     MGF1 (RSA-PSS).
-  * `saltLength`: {number} Minimal salt length in bytes (RSA-PSS).
-  * `divisorLength`: {number} Size of `q` in bits (DSA).
-  * `namedCurve`: {string} Name of the curve to use (EC).
-  * `prime`: {Buffer} The prime parameter (DH).
-  * `primeLength`: {number} Prime length in bits (DH).
-  * `generator`: {number} Custom generator (DH). **Default:** `2`.
-  * `groupName`: {string} Diffie-Hellman group name (DH). See
+  * `saltLength` {number} Minimal salt length in bytes (RSA-PSS).
+  * `divisorLength` {number} Size of `q` in bits (DSA).
+  * `namedCurve` {string} Name of the curve to use (EC).
+  * `prime` {Buffer} The prime parameter (DH).
+  * `primeLength` {number} Prime length in bits (DH).
+  * `generator` {number} Custom generator (DH). **Default:** `2`.
+  * `groupName` {string} Diffie-Hellman group name (DH). See
     [`crypto.getDiffieHellman()`][].
-  * `paramEncoding`: {string} Must be `'named'` or `'explicit'` (EC).
+  * `paramEncoding` {string} Must be `'named'` or `'explicit'` (EC).
     **Default:** `'named'`.
-  * `publicKeyEncoding`: {Object} See [`keyObject.export()`][].
-  * `privateKeyEncoding`: {Object} See [`keyObject.export()`][].
+  * `publicKeyEncoding` {Object} See [`keyObject.export()`][].
+  * `privateKeyEncoding` {Object} See [`keyObject.export()`][].
 * Returns: {Object}
-  * `publicKey`: {string | Buffer | KeyObject}
-  * `privateKey`: {string | Buffer | KeyObject}
+  * `publicKey` {string | Buffer | KeyObject}
+  * `privateKey` {string | Buffer | KeyObject}
 
 Generates a new asymmetric key pair of the given `type`. RSA, RSA-PSS, DSA, EC,
 Ed25519, Ed448, X25519, X448, and DH are currently supported.
@@ -3882,10 +3882,10 @@ it will be a buffer containing the data encoded as DER.
 added: v15.0.0
 -->
 
-* `type`: {string} The intended use of the generated secret key. Currently
+* `type` {string} The intended use of the generated secret key. Currently
   accepted values are `'hmac'` and `'aes'`.
-* `options`: {Object}
-  * `length`: {number} The bit length of the key to generate.
+* `options` {Object}
+  * `length` {number} The bit length of the key to generate.
     * If `type` is `'hmac'`, the minimum is 8, and the maximum length is
       2<sup>31</sup>-1. If the value is not a multiple of 8, the generated
       key will be truncated to `Math.floor(length / 8)`.
@@ -4026,10 +4026,10 @@ the process unresponsive.
 added: v15.0.0
 -->
 
-* `nameOrNid`: {string|number} The name or nid of the cipher to query.
-* `options`: {Object}
-  * `keyLength`: {number} A test key length.
-  * `ivLength`: {number} A test IV length.
+* `nameOrNid` {string|number} The name or nid of the cipher to query.
+* `options` {Object}
+  * `keyLength` {number} A test key length.
+  * `ivLength` {number} A test IV length.
 * Returns: {Object}
   * `name` {string} The name of the cipher
   * `nid` {number} The nid of the cipher

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1107,35 +1107,35 @@ for the sync error and one for the async error.
 
 > Stability: 1 - Experimental
 
-`console.log`
+##### Event: `'console.log'`
 
 * `args` {any\[]}
 
 Emitted when `console.log()` is called. Receives and array of the arguments
 passed to `console.log()`.
 
-`console.info`
+##### Event: `'console.info'`
 
 * `args` {any\[]}
 
 Emitted when `console.info()` is called. Receives and array of the arguments
 passed to `console.info()`.
 
-`console.debug`
+##### Event: `'console.debug'`
 
 * `args` {any\[]}
 
 Emitted when `console.debug()` is called. Receives and array of the arguments
 passed to `console.debug()`.
 
-`console.warn`
+##### Event: `'console.warn'`
 
 * `args` {any\[]}
 
 Emitted when `console.warn()` is called. Receives and array of the arguments
 passed to `console.warn()`.
 
-`console.error`
+##### Event: `'console.error'`
 
 * `args` {any\[]}
 
@@ -1146,34 +1146,34 @@ passed to `console.error()`.
 
 > Stability: 1 - Experimental
 
-`http.client.request.created`
+##### Event: `'http.client.request.created'`
 
 * `request` {http.ClientRequest}
 
 Emitted when client creates a request object.
 Unlike `http.client.request.start`, this event is emitted before the request has been sent.
 
-`http.client.request.start`
+##### Event: `'http.client.request.start'`
 
 * `request` {http.ClientRequest}
 
 Emitted when client starts a request.
 
-`http.client.request.error`
+##### Event: `'http.client.request.error'`
 
 * `request` {http.ClientRequest}
 * `error` {Error}
 
 Emitted when an error occurs during a client request.
 
-`http.client.response.finish`
+##### Event: `'http.client.response.finish'`
 
 * `request` {http.ClientRequest}
 * `response` {http.IncomingMessage}
 
 Emitted when client receives a response.
 
-`http.server.request.start`
+##### Event: `'http.server.request.start'`
 
 * `request` {http.IncomingMessage}
 * `response` {http.ServerResponse}
@@ -1182,7 +1182,7 @@ Emitted when client receives a response.
 
 Emitted when server receives a request.
 
-`http.server.response.created`
+##### Event: `'http.server.response.created'`
 
 * `request` {http.IncomingMessage}
 * `response` {http.ServerResponse}
@@ -1190,7 +1190,7 @@ Emitted when server receives a request.
 Emitted when server creates a response.
 The event is emitted before the response is sent.
 
-`http.server.response.finish`
+##### Event: `'http.server.response.finish'`
 
 * `request` {http.IncomingMessage}
 * `response` {http.ServerResponse}
@@ -1203,28 +1203,28 @@ Emitted when server sends a response.
 
 > Stability: 1 - Experimental
 
-`http2.client.stream.created`
+##### Event: `'http2.client.stream.created'`
 
 * `stream` {ClientHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
 
 Emitted when a stream is created on the client.
 
-`http2.client.stream.start`
+##### Event: `'http2.client.stream.start'`
 
 * `stream` {ClientHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
 
 Emitted when a stream is started on the client.
 
-`http2.client.stream.error`
+##### Event: `'http2.client.stream.error'`
 
 * `stream` {ClientHttp2Stream}
 * `error` {Error}
 
 Emitted when an error occurs during the processing of a stream on the client.
 
-`http2.client.stream.finish`
+##### Event: `'http2.client.stream.finish'`
 
 * `stream` {ClientHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
@@ -1232,35 +1232,35 @@ Emitted when an error occurs during the processing of a stream on the client.
 
 Emitted when a stream is received on the client.
 
-`http2.client.stream.close`
+##### Event: `'http2.client.stream.close'`
 
 * `stream` {ClientHttp2Stream}
 
 Emitted when a stream is closed on the client. The HTTP/2 error code used when
 closing the stream can be retrieved using the `stream.rstCode` property.
 
-`http2.server.stream.created`
+##### Event: `'http2.server.stream.created'`
 
 * `stream` {ServerHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
 
 Emitted when a stream is created on the server.
 
-`http2.server.stream.start`
+##### Event: `'http2.server.stream.start'`
 
 * `stream` {ServerHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
 
 Emitted when a stream is started on the server.
 
-`http2.server.stream.error`
+##### Event: `'http2.server.stream.error'`
 
 * `stream` {ServerHttp2Stream}
 * `error` {Error}
 
 Emitted when an error occurs during the processing of a stream on the server.
 
-`http2.server.stream.finish`
+##### Event: `'http2.server.stream.finish'`
 
 * `stream` {ServerHttp2Stream}
 * `headers` {HTTP/2 Headers Object}
@@ -1268,7 +1268,7 @@ Emitted when an error occurs during the processing of a stream on the server.
 
 Emitted when a stream is sent on the server.
 
-`http2.server.stream.close`
+##### Event: `'http2.server.stream.close'`
 
 * `stream` {ServerHttp2Stream}
 
@@ -1279,52 +1279,52 @@ closing the stream can be retrieved using the `stream.rstCode` property.
 
 > Stability: 1 - Experimental
 
-`module.require.start`
+##### Event: `'module.require.start'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `require()`. Module name.
-  * `parentFilename` - Name of the module that attempted to require(id).
+  * `id` Argument passed to `require()`. Module name.
+  * `parentFilename` Name of the module that attempted to require(id).
 
 Emitted when `require()` is executed. See [`start` event][].
 
-`module.require.end`
+##### Event: `'module.require.end'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `require()`. Module name.
-  * `parentFilename` - Name of the module that attempted to require(id).
+  * `id` Argument passed to `require()`. Module name.
+  * `parentFilename` Name of the module that attempted to require(id).
 
 Emitted when a `require()` call returns. See [`end` event][].
 
-`module.require.error`
+##### Event: `'module.require.error'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `require()`. Module name.
-  * `parentFilename` - Name of the module that attempted to require(id).
+  * `id` Argument passed to `require()`. Module name.
+  * `parentFilename` Name of the module that attempted to require(id).
 * `error` {Error}
 
 Emitted when a `require()` throws an error. See [`error` event][].
 
-`module.import.asyncStart`
+##### Event: `'module.import.asyncStart'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `import()`. Module name.
-  * `parentURL` - URL object of the module that attempted to import(id).
+  * `id` Argument passed to `import()`. Module name.
+  * `parentURL` URL object of the module that attempted to import(id).
 
 Emitted when `import()` is invoked. See [`asyncStart` event][].
 
-`module.import.asyncEnd`
+##### Event: `'module.import.asyncEnd'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `import()`. Module name.
-  * `parentURL` - URL object of the module that attempted to import(id).
+  * `id` Argument passed to `import()`. Module name.
+  * `parentURL` URL object of the module that attempted to import(id).
 
 Emitted when `import()` has completed. See [`asyncEnd` event][].
 
-`module.import.error`
+##### Event: `'module.import.error'`
 
 * `event` {Object} containing the following properties
-  * `id` - Argument passed to `import()`. Module name.
-  * `parentURL` - URL object of the module that attempted to import(id).
+  * `id` Argument passed to `import()`. Module name.
+  * `parentURL` URL object of the module that attempted to import(id).
 * `error` {Error}
 
 Emitted when a `import()` throws an error. See [`error` event][].
@@ -1333,32 +1333,32 @@ Emitted when a `import()` throws an error. See [`error` event][].
 
 > Stability: 1 - Experimental
 
-`net.client.socket`
+##### Event: `'net.client.socket'`
 
 * `socket` {net.Socket|tls.TLSSocket}
 
 Emitted when a new TCP or pipe client socket connection is created.
 
-`net.server.socket`
+##### Event: `'net.server.socket'`
 
 * `socket` {net.Socket}
 
 Emitted when a new TCP or pipe connection is received.
 
-`tracing:net.server.listen:asyncStart`
+##### Event: `'tracing:net.server.listen:asyncStart'`
 
 * `server` {net.Server}
 * `options` {Object}
 
 Emitted when [`net.Server.listen()`][] is invoked, before the port or pipe is actually setup.
 
-`tracing:net.server.listen:asyncEnd`
+##### Event: `'tracing:net.server.listen:asyncEnd'`
 
 * `server` {net.Server}
 
 Emitted when [`net.Server.listen()`][] has completed and thus the server is ready to accept connection.
 
-`tracing:net.server.listen:error`
+##### Event: `'tracing:net.server.listen:error'`
 
 * `server` {net.Server}
 * `error` {Error}
@@ -1369,7 +1369,7 @@ Emitted when [`net.Server.listen()`][] is returning an error.
 
 > Stability: 1 - Experimental
 
-`udp.socket`
+##### Event: `'udp.socket'`
 
 * `socket` {dgram.Socket}
 
@@ -1383,13 +1383,13 @@ Emitted when a new UDP socket is created.
 added: v16.18.0
 -->
 
-`child_process`
+##### Event: `'child_process'`
 
 * `process` {ChildProcess}
 
 Emitted when a new process is created.
 
-`execve`
+##### Event: `'execve'`
 
 * `execPath` {string}
 * `args` {string\[]}
@@ -1405,16 +1405,15 @@ Emitted when [`process.execve()`][] is invoked.
 added: v16.18.0
 -->
 
-`worker_threads`
+##### Event: `'worker_threads'`
 
-* `worker` [`Worker`][]
+* `worker` {Worker}
 
 Emitted when a new thread is created.
 
 [TracingChannel Channels]: #tracingchannel-channels
 [`'uncaughtException'`]: process.md#event-uncaughtexception
 [`TracingChannel`]: #class-tracingchannel
-[`Worker`]: worker_threads.md#class-worker
 [`asyncEnd` event]: #asyncendevent
 [`asyncStart` event]: #asyncstartevent
 [`channel.bindStore(store)`]: #channelbindstorestore-transform

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -856,14 +856,10 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-<!--lint disable no-undefined-references list-item-bullet-indent-->
-
 * `hostname` {string}
 * `callback` {Function}
   * `err` {Error}
-  * `records` <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#String_type" class="type">\<string\[]\[]></a>
-
-<!--lint enable no-undefined-references list-item-bullet-indent-->
+  * `records` {string\[]}
 
 Uses the DNS protocol to resolve text queries (`TXT` records) for the
 `hostname`. The `records` argument passed to the `callback` function is a

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1099,7 +1099,7 @@ changes:
     description: No longer experimental.
 -->
 
-* `err` Error
+* `err` {Error}
 * `eventName` {string|symbol}
 * `...args` {any}
 
@@ -1600,7 +1600,7 @@ changes:
     description: No longer experimental.
 -->
 
-Value: {boolean}
+* Type: {boolean}
 
 Change the default `captureRejections` option on all new `EventEmitter` objects.
 
@@ -1618,7 +1618,7 @@ changes:
     description: No longer experimental.
 -->
 
-Value: `Symbol.for('nodejs.rejection')`
+* Type: {symbol} `Symbol.for('nodejs.rejection')`
 
 See how to write a custom [rejection handler][rejection].
 
@@ -1681,12 +1681,12 @@ changes:
 * `eventName` {string|symbol} The name of the event being listened for
 * `options` {Object}
   * `signal` {AbortSignal} Can be used to cancel awaiting events.
-  * `close` - {string\[]} Names of events that will end the iteration.
-  * `highWaterMark` - {integer} **Default:** `Number.MAX_SAFE_INTEGER`
+  * `close` {string\[]} Names of events that will end the iteration.
+  * `highWaterMark` {integer} **Default:** `Number.MAX_SAFE_INTEGER`
     The high watermark. The emitter is paused every time the size of events
     being buffered is higher than it. Supported only on emitters implementing
     `pause()` and `resume()` methods.
-  * `lowWaterMark` - {integer} **Default:** `1`
+  * `lowWaterMark` {integer} **Default:** `1`
     The low watermark. The emitter is resumed every time the size of events
     being buffered is lower than it. Supported only on emitters implementing
     `pause()` and `resume()` methods.
@@ -1988,7 +1988,7 @@ same options as `EventEmitter` and `AsyncResource` themselves.
 
 ### `eventemitterasyncresource.asyncResource`
 
-* The underlying {AsyncResource}.
+* Type: {AsyncResource} The underlying {AsyncResource}.
 
 The returned `AsyncResource` object has an additional `eventEmitter` property
 that provides a reference to this `EventEmitterAsyncResource`.

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -2920,7 +2920,7 @@ changes:
     and trailing whitespace validation for HTTP/2 header field names and values
     as per [RFC-9113](https://www.rfc-editor.org/rfc/rfc9113.html#section-8.2.1).
     **Default:** `true`.
-  * ...: Any [`net.createServer()`][] option can be provided.
+  * `...options` {Object} Any [`net.createServer()`][] option can be provided.
 * `onRequestHandler` {Function} See [Compatibility API][]
 * Returns: {Http2Server}
 
@@ -3083,8 +3083,8 @@ changes:
     settings types, which are included in the `customSettings`-property of the
     received remoteSettings. Please see the `customSettings`-property of the
     `Http2Settings` object for more information, on the allowed setting types.
-  * ...: Any [`tls.createServer()`][] options can be provided. For
-    servers, the identity options (`pfx` or `key`/`cert`) are usually required.
+  * `...options` {Object} Any [`tls.createServer()`][] options can be provided.
+    For servers, the identity options (`pfx` or `key`/`cert`) are usually required.
   * `origins` {string\[]} An array of origin strings to send within an `ORIGIN`
     frame immediately following creation of a new server `Http2Session`.
   * `unknownProtocolTimeout` {number} Specifies a timeout in milliseconds that
@@ -3245,7 +3245,8 @@ changes:
   * `createConnection` {Function} An optional callback that receives the `URL`
     instance passed to `connect` and the `options` object, and returns any
     [`Duplex`][] stream that is to be used as the connection for this session.
-  * ...: Any [`net.connect()`][] or [`tls.connect()`][] options can be provided.
+  * `...options` {Object} Any [`net.connect()`][] or [`tls.connect()`][] options
+    can be provided.
   * `unknownProtocolTimeout` {number} Specifies a timeout in milliseconds that
     a server should wait when an [`'unknownProtocol'`][] event is emitted. If
     the socket has not been destroyed by that time the server will destroy it.
@@ -3370,8 +3371,7 @@ added:
 -->
 
 * `socket` {stream.Duplex}
-* `options` {Object}
-  * ...: Any [`http2.createServer()`][] option can be provided.
+* `options` {Object} Any [`http2.createServer()`][] option can be provided.
 * Returns: {ServerHttp2Session}
 
 Create an HTTP/2 server session from an existing socket.

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -79,7 +79,7 @@ session.on('inspectorNotification', (message) => console.log(message.method));
 
 It is also possible to subscribe only to notifications with specific method:
 
-#### Event: `<inspector-protocol-method>`;
+#### Event: `<inspector-protocol-method>`
 
 <!-- YAML
 added: v8.0.0

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -1722,17 +1722,17 @@ original file if found, or an empty object if not.
 
 The object returned contains the following keys:
 
-* generatedLine: {number} The line offset of the start of the
+* `generatedLine` {number} The line offset of the start of the
   range in the generated source
-* generatedColumn: {number} The column offset of start of the
+* `generatedColumn` {number} The column offset of start of the
   range in the generated source
-* originalSource: {string} The file name of the original source,
+* `originalSource` {string} The file name of the original source,
   as reported in the SourceMap
-* originalLine: {number} The line offset of the start of the
+* `originalLine` {number} The line offset of the start of the
   range in the original source
-* originalColumn: {number} The column offset of start of the
+* `originalColumn` {number} The column offset of start of the
   range in the original source
-* name: {string}
+* `name` {string}
 
 The returned value represents the raw range as it appears in the
 SourceMap, based on zero-indexed offsets, _not_ 1-indexed line and
@@ -1766,13 +1766,13 @@ If the `lineNumber` and `columnNumber` provided are not found in any
 source map, then an empty object is returned. Otherwise, the
 returned object contains the following keys:
 
-* name: {string | undefined} The name of the range in the
+* `name` {string|undefined} The name of the range in the
   source map, if one was provided
-* fileName: {string} The file name of the original source, as
+* `fileName` {string} The file name of the original source, as
   reported in the SourceMap
-* lineNumber: {number} The 1-indexed lineNumber of the
+* `lineNumber` {number} The 1-indexed lineNumber of the
   corresponding call site in the original source
-* columnNumber: {number} The 1-indexed columnNumber of the
+* `columnNumber` {number} The 1-indexed columnNumber of the
   corresponding call site in the original source
 
 [CommonJS]: modules.md

--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -773,8 +773,6 @@ By doing this, Node.js achieves a few things:
 added: v0.1.27
 -->
 
-<!-- type=var -->
-
 * Type: {string}
 
 The directory name of the current module. This is the same as the
@@ -794,8 +792,6 @@ console.log(path.dirname(__filename));
 <!-- YAML
 added: v0.0.1
 -->
-
-<!-- type=var -->
 
 * Type: {string}
 
@@ -834,8 +830,6 @@ References to `__filename` within `b.js` will return
 added: v0.1.12
 -->
 
-<!-- type=var -->
-
 * Type: {Object}
 
 A reference to the `module.exports` that is shorter to type.
@@ -848,8 +842,6 @@ See the section about the [exports shortcut][] for details on when to use
 added: v0.1.16
 -->
 
-<!-- type=var -->
-
 * Type: {module}
 
 A reference to the current module, see the section about the
@@ -861,8 +853,6 @@ a module exports and makes available through `require()`.
 <!-- YAML
 added: v0.1.13
 -->
-
-<!-- type=var -->
 
 * `id` {string} module name or path
 * Returns: {any} exported module content
@@ -1028,8 +1018,6 @@ Returns an array containing the paths searched during resolution of `request` or
 <!-- YAML
 added: v0.1.16
 -->
-
-<!-- type=var -->
 
 <!-- name=module -->
 

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -62,9 +62,9 @@ functions for streams that return `Promise` objects rather than using
 callbacks. The API is accessible via `require('node:stream/promises')`
 or `require('node:stream').promises`.
 
-### `stream.pipeline(source[, ...transforms], destination[, options])`
-
 ### `stream.pipeline(streams[, options])`
+
+### `stream.pipeline(source[, ...transforms], destination[, options])`
 
 <!-- YAML
 added: v15.0.0

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -193,7 +193,7 @@ the selected cipher's digest).
 
 It will be called first on the client:
 
-* hint: {string} optional message sent from the server to help the client
+* `hint` {string} optional message sent from the server to help the client
   decide which identity to use during negotiation.
   Always `null` if TLS 1.3 is used.
 * Returns: {Object} in the form
@@ -201,8 +201,8 @@ It will be called first on the client:
 
 Then on the server:
 
-* socket: {tls.TLSSocket} the server socket instance, equivalent to `this`.
-* identity: {string} identity parameter sent from the client.
+* `socket` {tls.TLSSocket} the server socket instance, equivalent to `this`.
+* `identity` {string} identity parameter sent from the client.
 * Returns: {Buffer|TypedArray|DataView} the PSK (or `null`).
 
 A return value of `null` stops the negotiation process and sends an
@@ -1705,7 +1705,7 @@ changes:
     verification fails; `err.code` contains the OpenSSL error code. **Default:**
     `true`.
   * `pskCallback` {Function} For TLS-PSK negotiation, see [Pre-shared keys][].
-  * `ALPNProtocols`: {string\[]|Buffer\[]|TypedArray\[]|DataView\[]|Buffer|
+  * `ALPNProtocols` {string\[]|Buffer\[]|TypedArray\[]|DataView\[]|Buffer|
     TypedArray|DataView}
     An array of strings, `Buffer`s, `TypedArray`s, or `DataView`s, or a
     single `Buffer`, `TypedArray`, or `DataView` containing the supported ALPN
@@ -1714,7 +1714,7 @@ changes:
     next protocol name. Passing an array is usually much simpler, e.g.
     `['http/1.1', 'http/1.0']`. Protocols earlier in the list have higher
     preference than those later.
-  * `servername`: {string} Server name for the SNI (Server Name Indication) TLS
+  * `servername` {string} Server name for the SNI (Server Name Indication) TLS
     extension. It is the name of the host being connected to, and must be a host
     name, and not an IP address. It can be used by a multi-homed server to
     choose the correct certificate to present to the client, see the
@@ -1730,7 +1730,7 @@ changes:
     TLS connection. When a server offers a DH parameter with a size less
     than `minDHSize`, the TLS connection is destroyed and an error is thrown.
     **Default:** `1024`.
-  * `highWaterMark`: {number} Consistent with the readable stream `highWaterMark` parameter.
+  * `highWaterMark` {number} Consistent with the readable stream `highWaterMark` parameter.
     **Default:** `16 * 1024`.
   * `secureContext`: TLS context object created with
     [`tls.createSecureContext()`][]. If a `secureContext` is _not_ provided, one
@@ -2051,7 +2051,7 @@ changes:
     **Default:** none, see `minVersion`.
   * `sessionIdContext` {string} Opaque identifier used by servers to ensure
     session state is not shared between applications. Unused by clients.
-  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudorandom
+  * `ticketKeys` {Buffer} 48-bytes of cryptographically strong pseudorandom
     data. See [Session Resumption][] for more information.
   * `sessionTimeout` {number} The number of seconds after which a TLS session
     created by the server will no longer be resumable. See
@@ -2120,7 +2120,7 @@ changes:
 -->
 
 * `options` {Object}
-  * `ALPNProtocols`: {string\[]|Buffer\[]|TypedArray\[]|DataView\[]|Buffer|
+  * `ALPNProtocols` {string\[]|Buffer\[]|TypedArray\[]|DataView\[]|Buffer|
     TypedArray|DataView}
     An array of strings, `Buffer`s, `TypedArray`s, or `DataView`s, or a single
     `Buffer`, `TypedArray`, or `DataView` containing the supported ALPN
@@ -2128,7 +2128,7 @@ changes:
     e.g. `0x05hello0x05world`, where the first byte is the length of the next
     protocol name. Passing an array is usually much simpler, e.g.
     `['hello', 'world']`. (Protocols should be ordered by their priority.)
-  * `ALPNCallback`: {Function} If set, this will be called when a
+  * `ALPNCallback` {Function} If set, this will be called when a
     client opens a connection using the ALPN extension. One argument will
     be passed to the callback: an object containing `servername` and
     `protocols` fields, respectively containing the server name from
@@ -2167,7 +2167,7 @@ changes:
     If `callback` is called with a falsy `ctx` argument, the default secure
     context of the server will be used. If `SNICallback` wasn't provided the
     default callback with high-level API will be used (see below).
-  * `ticketKeys`: {Buffer} 48-bytes of cryptographically strong pseudorandom
+  * `ticketKeys` {Buffer} 48-bytes of cryptographically strong pseudorandom
     data. See [Session Resumption][] for more information.
   * `pskCallback` {Function} For TLS-PSK negotiation, see [Pre-shared keys][].
   * `pskIdentityHint` {string} optional hint to send to a client to help

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -340,8 +340,8 @@ added:
 * `expected` {Array|string} The second value to compare
 
 * Returns: {Array} An array of difference entries. Each entry is an array with two elements:
-  * Index 0: {number} Operation code: `-1` for delete, `0` for no-op/unchanged, `1` for insert
-  * Index 1: {string} The value associated with the operation
+  * `0` {number} Operation code: `-1` for delete, `0` for no-op/unchanged, `1` for insert
+  * `1` {string} The value associated with the operation
 
 * Algorithm complexity: O(N\*D), where:
 
@@ -1305,19 +1305,19 @@ ignored, if not supported.
 * `reset` - Resets all (color) modifiers to their defaults
 * **bold** - Make text bold
 * _italic_ - Make text italic
-* <span style="border-bottom: 1px;">underline</span> - Make text underlined
+* <span style="border-bottom: 1px solid;">underline</span> - Make text underlined
 * ~~strikethrough~~ - Puts a horizontal line through the center of the text
   (Alias: `strikeThrough`, `crossedout`, `crossedOut`)
 * `hidden` - Prints the text, but makes it invisible (Alias: conceal)
 * <span style="opacity: 0.5;">dim</span> - Decreased color intensity (Alias:
   `faint`)
-* <span style="border-top: 1px">overlined</span> - Make text overlined
+* <span style="border-top: 1px solid;">overlined</span> - Make text overlined
 * blink - Hides and shows the text in an interval
-* <span style="filter: invert(100%)">inverse</span> - Swap foreground and
+* <span style="filter: invert(100%);">inverse</span> - Swap foreground and
   background colors (Alias: `swapcolors`, `swapColors`)
 * <span style="border-bottom: 1px double;">doubleunderline</span> - Make text
   double underlined (Alias: `doubleUnderline`)
-* <span style="border: 1px">framed</span> - Draw a frame around the text
+* <span style="border: 1px solid;">framed</span> - Draw a frame around the text
 
 #### Foreground colors
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -556,9 +556,9 @@ added: v15.0.0
 added: v15.0.0
 -->
 
-* `algorithm`: {RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
-* `key`: {CryptoKey}
-* `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
+* `algorithm` {RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
+* `key` {CryptoKey}
+* `data` {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 Using the method and parameters specified in `algorithm` and the keying
@@ -594,9 +594,9 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
-* `baseKey`: {CryptoKey}
-* `length`: {number|null} **Default:** `null`
+* `algorithm` {EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
+* `baseKey` {CryptoKey}
+* `length` {number|null} **Default:** `null`
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -634,11 +634,11 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
-* `baseKey`: {CryptoKey}
-* `derivedKeyAlgorithm`: {string|Algorithm|HmacImportParams|AesDerivedKeyParams}
-* `extractable`: {boolean}
-* `keyUsages`: {string\[]} See [Key usages][].
+* `algorithm` {EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params}
+* `baseKey` {CryptoKey}
+* `derivedKeyAlgorithm` {string|Algorithm|HmacImportParams|AesDerivedKeyParams}
+* `extractable` {boolean}
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with a {CryptoKey} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -666,8 +666,8 @@ The algorithms currently supported include:
 added: v15.0.0
 -->
 
-* `algorithm`: {string|Algorithm}
-* `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
+* `algorithm` {string|Algorithm}
+* `data` {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 Using the method identified by `algorithm`, `subtle.digest()` attempts to
@@ -690,9 +690,9 @@ whose value is one of the above.
 added: v15.0.0
 -->
 
-* `algorithm`: {RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
-* `key`: {CryptoKey}
-* `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
+* `algorithm` {RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
+* `key` {CryptoKey}
+* `data` {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 Using the method and parameters specified by `algorithm` and the keying
@@ -723,8 +723,8 @@ changes:
     description: Removed `'NODE-DSA'` JWK export.
 -->
 
-* `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
-* `key`: {CryptoKey}
+* `format` {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
+* `key` {CryptoKey}
 * Returns: {Promise} Fulfills with an {ArrayBuffer|Object} upon success.
 
 Exports the given key into the specified format, if supported.
@@ -762,12 +762,12 @@ added: v15.0.0
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {string|Algorithm|RsaHashedKeyGenParams|EcKeyGenParams|HmacKeyGenParams|AesKeyGenParams}
+* `algorithm` {string|Algorithm|RsaHashedKeyGenParams|EcKeyGenParams|HmacKeyGenParams|AesKeyGenParams}
 
 <!--lint enable maximum-line-length remark-lint-->
 
-* `extractable`: {boolean}
-* `keyUsages`: {string\[]} See [Key usages][].
+* `extractable` {boolean}
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with a {CryptoKey|CryptoKeyPair} upon success.
 
 Using the method and parameters provided in `algorithm`, `subtle.generateKey()`
@@ -811,17 +811,17 @@ changes:
     description: Removed `'NODE-DSA'` JWK import.
 -->
 
-* `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
-* `keyData`: {ArrayBuffer|TypedArray|DataView|Buffer|Object}
+* `format` {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
+* `keyData` {ArrayBuffer|TypedArray|DataView|Buffer|Object}
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams}
+* `algorithm` {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams}
 
 <!--lint enable maximum-line-length remark-lint-->
 
-* `extractable`: {boolean}
-* `keyUsages`: {string\[]} See [Key usages][].
+* `extractable` {boolean}
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with a {CryptoKey} upon success.
 
 The `subtle.importKey()` method attempts to interpret the provided `keyData`
@@ -866,9 +866,9 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {string|Algorithm|RsaPssParams|EcdsaParams|Ed448Params}
-* `key`: {CryptoKey}
-* `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
+* `algorithm` {string|Algorithm|RsaPssParams|EcdsaParams|Ed448Params}
+* `key` {CryptoKey}
+* `data` {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -893,19 +893,19 @@ The algorithms currently supported include:
 added: v15.0.0
 -->
 
-* `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
-* `wrappedKey`: {ArrayBuffer|TypedArray|DataView|Buffer}
-* `unwrappingKey`: {CryptoKey}
+* `format` {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
+* `wrappedKey` {ArrayBuffer|TypedArray|DataView|Buffer}
+* `unwrappingKey` {CryptoKey}
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `unwrapAlgo`: {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
-* `unwrappedKeyAlgo`: {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams}
+* `unwrapAlgo` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
+* `unwrappedKeyAlgo` {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams}
 
 <!--lint enable maximum-line-length remark-lint-->
 
-* `extractable`: {boolean}
-* `keyUsages`: {string\[]} See [Key usages][].
+* `extractable` {boolean}
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with a {CryptoKey} upon success.
 
 In cryptography, "wrapping a key" refers to exporting and then encrypting the
@@ -956,10 +956,10 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `algorithm`: {string|Algorithm|RsaPssParams|EcdsaParams|Ed448Params}
-* `key`: {CryptoKey}
-* `signature`: {ArrayBuffer|TypedArray|DataView|Buffer}
-* `data`: {ArrayBuffer|TypedArray|DataView|Buffer}
+* `algorithm` {string|Algorithm|RsaPssParams|EcdsaParams|Ed448Params}
+* `key` {CryptoKey}
+* `signature` {ArrayBuffer|TypedArray|DataView|Buffer}
+* `data` {ArrayBuffer|TypedArray|DataView|Buffer}
 * Returns: {Promise} Fulfills with a {boolean} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -986,10 +986,10 @@ added: v15.0.0
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `format`: {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
-* `key`: {CryptoKey}
-* `wrappingKey`: {CryptoKey}
-* `wrapAlgo`: {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
+* `format` {string} Must be one of `'raw'`, `'pkcs8'`, `'spki'`, or `'jwk'`.
+* `key` {CryptoKey}
+* `wrappingKey` {CryptoKey}
+* `wrapAlgo` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AesGcmParams}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -807,7 +807,7 @@ queue.
 added: v16.5.0
 -->
 
-* `chunk`: {Buffer|TypedArray|DataView}
+* `chunk` {Buffer|TypedArray|DataView}
 
 Appends a new chunk of data to the {ReadableStream}'s queue.
 
@@ -1077,7 +1077,7 @@ Releases this writer's lock on the underlying {ReadableStream}.
 added: v16.5.0
 -->
 
-* `chunk`: {any}
+* `chunk` {any}
 * Returns: A promise fulfilled with `undefined`.
 
 Appends a new chunk of data to the {WritableStream}'s queue.


### PR DESCRIPTION
After completing the web generator's initial implementation, it was easy to identify some slight inconsistencies that clashed.