### PR TITLE
Update loader.js

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1792,6 +1792,16 @@ function reconstructErrorStack(err, parentPath, parentSource) {
     const frame = `${parentPath}:${line}\n${srcLine}\n${StringPrototypeRepeat(' ', col - 1)}^\n`;
     setArrowMessage(err, frame);
   }
+
+  // Trim internal frames from the stack trace
+  if (err.stack) {
+    const stack = StringPrototypeSplit(err.stack, '\n');
+    // Keep only user-land frames (those not from internal/modules or node:internal)
+    const filteredStack = ArrayPrototypeFilter(stack, (line) => {
+      return !RegExpPrototypeExec(/at.*(internal\/modules|node:internal)/, line);
+    });
+    err.stack = ArrayPrototypeJoin(filteredStack, '\n');
+  }
 }
 
 /**


### PR DESCRIPTION
**Description**:  
This PR improves error stack traces when an ES module is loaded via `require()` by removing internal Node.js module frames. Currently, error stacks include implementation details from Node's module system that aren't relevant to end users.

**Changes**:
1. Modified `reconstructErrorStack()` in `lib/internal/modules/cjs/loader.js` to filter out frames containing:
   - `internal/modules` (CommonJS loader internals)
   - `node:internal` (Node.js core internals)
2. Preserves all user-land stack frames for better debugging

**Benefits**:
- Cleaner error stacks that focus on application code
- Removes noise from internal Node.js operations
- Makes errors more actionable for developers
- Follows Node.js's principle of hiding implementation details

**Testing**:
- Verified error stacks now show only user code paths
- Confirmed existing error reconstruction still works
- Tested with both direct and nested requires

**Related Issues**:  
Addresses TODO comment at line 1823 about trimming internal frames.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
