### PR TITLE
tools: allow selecting test subsystems with numbers in their names

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1605,7 +1605,7 @@ def ArgsToTestPaths(test_root, args, suites):
   if len(args) == 0 or 'default' in args:
     def_suites = [s for s in suites if s not in IGNORED_SUITES]
     args = [a for a in args if a != 'default'] + def_suites
-  subsystem_regex = re.compile(r'^[a-zA-Z-]*$')
+  subsystem_regex = re.compile(r'^[a-zA-Z0-9-]*$')
   check = lambda arg: subsystem_regex.match(arg) and (arg not in suites)
   mapped_args = ["*/test*-%s-*" % arg if check(arg) else arg for arg in args]
   paths = [SplitPath(NormalizePath(a)) for a in mapped_args]


### PR DESCRIPTION
Previously, selecting subsystems with numbers in their names, like http2, weren't matched due to a restrictive regex:

```
$ tools/test.py http2
No tests to run.
```

The regex now allows digits, so these tests run as expected:

```
$ tools/test.py http2
[00:17|% 100|+ 286|-   0]: Done

All tests passed.
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
