### PR TITLE
doc: fix the version tls.DEFAULT_CIPHERS was added

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2427,9 +2427,7 @@ added: v11.4.0
 ## `tls.DEFAULT_CIPHERS`
 
 <!-- YAML
-added:
- - v19.8.0
- - v18.16.0
+added: v0.11.3
 -->
 
 * Type: {string} The default value of the `ciphers` option of


### PR DESCRIPTION
42be7f6a0335c396810be91c3f3724007029f83d (originally included in 19.8.0 and later backported to 18.16.0) added documentation on how to use `tls.DEFAULT_CIPHERS`.
However, that commit added the documentation with the version specified as `REAPLCEME`, causing the published documentation to state that `tls.DEFAULT_CIPHERS` was added in 19.8.0 and 18.16.0, which is incorrect - that commit states that `tls.DEFAULT_CIPHERS` already existed, and the only thing it added was an explanation on how to use it.

In fact, by examining the git log, it can be seen that `tls.DEFAULT_CIPHERS` was added by commit
af80e7bc6e6f33c582eb1f7d37c7f5bbe9f910f7, which was included in 0.11.3.

Fixes: https://github.com/nodejs/node/issues/59246

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
