### PR TITLE
doc: add --diagnostic-dir to manpage

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -127,16 +127,10 @@ File name of the V8 CPU profile generated with
 .Fl -cpu-prof .
 .
 .It Fl -diagnostic-dir
-Set the directory for all diagnostic output files.
-Default is current working directory.
-Set the directory to which all diagnostic output files will be written to.
-Defaults to current working directory.
-.
-Affects the default output directory of:
-.Fl -cpu-prof-dir .
-.Fl -heap-prof-dir .
-.Fl -redirect-warnings .
-.
+.TP
+\fB--diagnostic-dir\fR
+Set the directory for all diagnostic output files (default: current working directory).
+
 .It Fl -disable-proto Ns = Ns Ar mode
 Disable the `Object.prototype.__proto__` property. If
 .Ar mode


### PR DESCRIPTION
This PR adds the missing `--diagnostic-dir` CLI flag to the `man node` page.

The flag appears in the `--help` output but was missing from the manpage.

Fixes part of issue [#58895](https://github.com/nodejs/node/issues/58895).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
