### PR TITLE
test: make test-debug-process locale-independent

### DIFF
--- a/test/parallel/test-debug-process.js
+++ b/test/parallel/test-debug-process.js
@@ -16,6 +16,6 @@ cp.on('exit', common.mustCall(function() {
   try {
     process._debugProcess(cp.pid);
   } catch (error) {
-    assert.strictEqual(error.message, 'The system cannot find the file specified.');
+    assert.strictEqual(error.errno, 2);
   }
 }));


### PR DESCRIPTION
The test `test/parallel/test-debug-process.js` fails on non-English Windows systems due to a locale-dependent error message string.

The test asserts that a call to `process._debugProcess()` on a terminated process throws an error with the message `'The system cannot find the file specified.'`. While this holds true on an English Windows system, the test fails on systems with a different display language.

The underlying `WinapiErrnoException` function correctly retrieves the localized error message from the OS. For example, on a Korean system, the message is "지정된 파일을 찾을 수 없습니다.". This mismatch causes an `AssertionError`.

This behavior can be verified directly in PowerShell:

### On Windows with English (US) display language
```powershell
PS> (New-Object System.ComponentModel.Win32Exception 2).Message 
The system cannot find the file specified.
```
### On Windows with Korean display language
```powershell
PS> (New-Object System.ComponentModel.Win32Exception 2).Message 
지정된 파일을 찾을 수 없습니다.
```
To make the test robust and environment-agnostic, this commit changes the assertion to check the language-independent `error.errno` property, which is consistently `2` for this type of error, instead of the localized `error.message`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
