### PR TITLE
lib: add protection in worker_thread.js

### DIFF
--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -92,6 +92,29 @@ if (process.env.NODE_CHANNEL_FD) {
     workerThreadSetup.unavailable('process.disconnect()');
 }
 
+let locked = false;
+let _evalValue = '_evalValue';
+ObjectDefineProperty(process, '_eval', {
+  __proto__: null,
+  configurable: false,
+  enumerable: true,
+  get() {
+    return _evalValue;
+  },
+  set(val) {
+    if (locked) {
+      const {
+        codes: {
+          ERR_INVALID_STATE,
+        },
+      } = require('internal/errors');
+
+      throw new ERR_INVALID_STATE('process._eval cannot be overwritten for now');
+    }
+    _evalValue = val;
+  },
+});
+
 port.on('message', (message) => {
   if (message.type === LOAD_SCRIPT) {
     port.unref();
@@ -162,12 +185,9 @@ port.on('message', (message) => {
         const name = '[worker eval]';
         // This is necessary for CJS module compilation.
         // TODO: pass this with something really internal.
-        ObjectDefineProperty(process, '_eval', {
-          __proto__: null,
-          configurable: true,
-          enumerable: true,
-          value: filename,
-        });
+        process._eval = filename;
+        locked = true;
+
         ArrayPrototypeSplice(process.argv, 1, 0, name);
         const tsEnabled = getOptionValue('--experimental-strip-types');
         const inputType = getOptionValue('--input-type');
@@ -176,6 +196,7 @@ port.on('message', (message) => {
           // This is a special case where we want to parse and eval the
           // TypeScript code as a module
           parseAndEvalModuleTypeScript(filename, false);
+          locked = false;
           break;
         }
 
@@ -192,6 +213,7 @@ port.on('message', (message) => {
         }
 
         evalFunction(name, filename);
+        locked = false;
         break;
       }
 


### PR DESCRIPTION
add getter and setter to protect global object's property _eval

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
