### PR TITLE
src: optimize usage of memory api

### DIFF
--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -135,9 +135,13 @@ void PerIsolateOptions::HandleMaxOldSpaceSizePercentage(
   // Use uint64_t for the result to prevent data loss on 32-bit systems.
   uint64_t available_memory =
       (constrained_memory > 0 && constrained_memory != UINT64_MAX)
-          ? constrained_memory
+          ? std::min(total_memory, constrained_memory)
           : total_memory;
 
+  if (available_memory == 0) {
+    errors->push_back("the available memory can not be calculated");
+    return;
+  }
   // Convert to MB and calculate the percentage
   uint64_t memory_mb = available_memory / (1024 * 1024);
   uint64_t calculated_mb = static_cast<size_t>(memory_mb * percentage / 100.0);

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -649,9 +649,7 @@ static void PrintResourceUsage(JSONWriter* writer) {
   }
 
   uint64_t constrained_memory = uv_get_constrained_memory();
-  if (constrained_memory) {
-    writer->json_keyvalue("constrained_memory", constrained_memory);
-  }
+  writer->json_keyvalue("constrained_memory", constrained_memory);
 
   uint64_t available_memory = uv_get_available_memory();
   writer->json_keyvalue("available_memory", available_memory);


### PR DESCRIPTION
1. `constrained_memory` maybe greater than `uv_get_total_memory` so we should take the minimum value. 
And `uv_get_total_memory` maybe 0.

2. We should always report constrained memory in the report even though it is zero.

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
