### PR TITLE
lib: handle superscript variants on windows device

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -73,6 +73,8 @@ const WINDOWS_RESERVED_NAMES = [
   'CON', 'PRN', 'AUX', 'NUL',
   'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
   'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+  'COM\xb9', 'COM\xb2', 'COM\xb3',
+  'LPT\xb9', 'LPT\xb2', 'LPT\xb3',
 ];
 
 function isWindowsReservedName(path, colonIndex) {

--- a/test/parallel/test-path-win32-normalize-device-names.js
+++ b/test/parallel/test-path-win32-normalize-device-names.js
@@ -45,10 +45,18 @@ const normalizeDeviceNameTests = [
 
   { input: 'COM1:', expected: '.\\COM1:.' },
   { input: 'COM9:', expected: '.\\COM9:.' },
+  { input: 'COM¹:', expected: '.\\COM¹:.' },
+  { input: 'COM²:', expected: '.\\COM²:.' },
+  { input: 'COM³:', expected: '.\\COM³:.' },
   { input: 'COM1:.\\..\\..\\foo', expected: '.\\COM1:..\\..\\foo' },
+  { input: 'COM¹:.\\..\\..\\foo', expected: '.\\COM¹:..\\..\\foo' },
   { input: 'LPT1:', expected: '.\\LPT1:.' },
+  { input: 'LPT¹:', expected: '.\\LPT¹:.' },
+  { input: 'LPT²:', expected: '.\\LPT²:.' },
+  { input: 'LPT³:', expected: '.\\LPT³:.' },
   { input: 'LPT9:', expected: '.\\LPT9:.' },
   { input: 'LPT1:.\\..\\..\\foo', expected: '.\\LPT1:..\\..\\foo' },
+  { input: 'LPT¹:.\\..\\..\\foo', expected: '.\\LPT¹:..\\..\\foo' },
   { input: 'LpT5:/another/path', expected: '.\\LpT5:another\\path' },
 
   { input: 'C:\\foo', expected: 'C:\\foo' },


### PR DESCRIPTION
Windows recognizes the 8-bit [ISO/IEC 8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) superscript digits ¹, ², and ³ as digits and treats them as valid parts of COM# and LPT# device names, making them reserved in every directory.
