### PR TITLE
doc: add path.join and path.normalize clarification

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -179,6 +179,11 @@ then untrusted input must not lead to arbitrary JavaScript code execution.
   See <https://nodejs.org/api/modules.html#all-together>.
 * The `node:wasi` module does not currently provide the comprehensive file
   system security properties provided by some WASI runtimes.
+* The execution path is trusted. Additionally, Node.js path manipulation functions
+  such as `path.join()` and `path.normalize()` trust their input. Reports about issues
+  related to these functions that rely on unsanitized input are not considered vulnerabilities
+  requiring CVEs, as it's the user's responsibility to sanitize path inputs according to
+  their security requirements.
 
 Any unexpected behavior from the data manipulation from Node.js Internal
 functions may be considered a vulnerability if they are exploitable via


### PR DESCRIPTION
We've had inconsistencies in how we handle path manipulation function issues:
- Sometimes we've issued CVEs for path-related issues
- Sometimes we've fixed them without CVEs

This update to SECURITY.md clarifies our position by explicitly stating that:
1. Node.js path manipulation functions trust their input
2. It's the developer's responsibility to sanitize path inputs
3. Issues stemming from unsanitized path inputs don't warrant CVEs

cc: @nodejs/security-wg @nodejs/security-triage @nodejs/tsc 