### PR TITLE
doc: update deprecation guide for `util.is**()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -1194,7 +1194,7 @@ changes:
 Type: End-of-Life
 
 The `util.isNullOrUndefined()` API has been removed. Please use
-`arg == null` instead.
+`arg === null || arg === undefined` instead.
 
 ### DEP0052: `util.isNumber()`
 


### PR DESCRIPTION
## Description 

use modern alternative per @ljharb comment on https://github.com/nodejs/userland-migrations/pull/119.

