### PR TITLE
test_runner: make it compatible with fake timers

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -149,7 +149,7 @@ function stopTest(timeout, signal) {
 
     disposeFunction = () => {
       abortListener[SymbolDispose]();
-      timer[SymbolDispose]();
+      clearTimeout(timer);
     };
   }
 


### PR DESCRIPTION
If `setTimeout` is monkey-patched, it might be missing the symbol. Moreover, we plan to remove it in the future anyway in https://github.com/nodejs/node/issues/58689.