### PR TITLE
assert: change utils to use index instead of for...of

### DIFF
--- a/lib/internal/assert/utils.js
+++ b/lib/internal/assert/utils.js
@@ -222,7 +222,8 @@ function getErrMessage(message, fn) {
       }
       const frames = StringPrototypeSplit(message, '\n');
       message = ArrayPrototypeShift(frames);
-      for (const frame of frames) {
+      for (let i = 0; i < frames.length; i++) {
+        const frame = frames[i];
         let pos = 0;
         while (pos < column && (frame[pos] === ' ' || frame[pos] === '\t')) {
           pos++;


### PR DESCRIPTION
This PR changes a for...of loop to an index-based for loop in the getErrMessage() function within lib/internal/assert/utils.js.

Refs: https://github.com/nodejs/node/blob/main/doc/contributing/primordials.md#unsafe-array-iteration
