### PR TITLE
src: remove unused DSAKeyExportJob

### DIFF
--- a/src/crypto/crypto_dsa.cc
+++ b/src/crypto/crypto_dsa.cc
@@ -74,37 +74,6 @@ Maybe<void> DsaKeyGenTraits::AdditionalConfig(
   return JustVoid();
 }
 
-Maybe<void> DSAKeyExportTraits::AdditionalConfig(
-    const FunctionCallbackInfo<Value>& args,
-    unsigned int offset,
-    DSAKeyExportConfig* params) {
-  return JustVoid();
-}
-
-WebCryptoKeyExportStatus DSAKeyExportTraits::DoExport(
-    const KeyObjectData& key_data,
-    WebCryptoKeyFormat format,
-    const DSAKeyExportConfig& params,
-    ByteSource* out) {
-  CHECK_NE(key_data.GetKeyType(), kKeyTypeSecret);
-
-  switch (format) {
-    case kWebCryptoKeyFormatRaw:
-      // Not supported for RSA keys of either type
-      return WebCryptoKeyExportStatus::FAILED;
-    case kWebCryptoKeyFormatPKCS8:
-      if (key_data.GetKeyType() != kKeyTypePrivate)
-        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
-      return PKEY_PKCS8_Export(key_data, out);
-    case kWebCryptoKeyFormatSPKI:
-      if (key_data.GetKeyType() != kKeyTypePublic)
-        return WebCryptoKeyExportStatus::INVALID_KEY_TYPE;
-      return PKEY_SPKI_Export(key_data, out);
-    default:
-      UNREACHABLE();
-  }
-}
-
 bool GetDsaKeyDetail(Environment* env,
                      const KeyObjectData& key,
                      Local<Object> target) {
@@ -132,12 +101,10 @@ bool GetDsaKeyDetail(Environment* env,
 namespace DSAAlg {
 void Initialize(Environment* env, Local<Object> target) {
   DsaKeyPairGenJob::Initialize(env, target);
-  DSAKeyExportJob::Initialize(env, target);
 }
 
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   DsaKeyPairGenJob::RegisterExternalReferences(registry);
-  DSAKeyExportJob::RegisterExternalReferences(registry);
 }
 }  // namespace DSAAlg
 }  // namespace crypto

--- a/src/crypto/crypto_dsa.h
+++ b/src/crypto/crypto_dsa.h
@@ -36,29 +36,6 @@ struct DsaKeyGenTraits final {
 
 using DsaKeyPairGenJob = KeyGenJob<KeyPairGenTraits<DsaKeyGenTraits>>;
 
-struct DSAKeyExportConfig final : public MemoryRetainer {
-  SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(DSAKeyExportConfig)
-  SET_SELF_SIZE(DSAKeyExportConfig)
-};
-
-struct DSAKeyExportTraits final {
-  static constexpr const char* JobName = "DSAKeyExportJob";
-  using AdditionalParameters = DSAKeyExportConfig;
-
-  static v8::Maybe<void> AdditionalConfig(
-      const v8::FunctionCallbackInfo<v8::Value>& args,
-      unsigned int offset,
-      DSAKeyExportConfig* config);
-
-  static WebCryptoKeyExportStatus DoExport(const KeyObjectData& key_data,
-                                           WebCryptoKeyFormat format,
-                                           const DSAKeyExportConfig& params,
-                                           ByteSource* out);
-};
-
-using DSAKeyExportJob = KeyExportJob<DSAKeyExportTraits>;
-
 bool GetDsaKeyDetail(Environment* env,
                      const KeyObjectData& key,
                      v8::Local<v8::Object> target);


### PR DESCRIPTION
Removes the unused `DSAKeyExportJob`, a remnant of Node-only Web Cryptography algorithms.