### PR TITLE
src: enable Uint8Array base64/hex

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -781,6 +781,7 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
   }
 
   v8_args.emplace_back("--js-source-phase-imports");
+  v8_args.emplace_back("--js-base-64");
 
 #ifdef __POSIX__
   // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the

--- a/test/parallel/test-u8-base64.js
+++ b/test/parallel/test-u8-base64.js
@@ -1,0 +1,23 @@
+'use strict';
+
+require('../common');
+
+// Test verifies that the toBase64, fromBase64, toHex, and fromHex methods
+// of Uint8Array are available and work as expected.
+
+const { strictEqual } = require('assert');
+const { Buffer } = require('buffer');
+
+const buf = Buffer.from('hello');
+
+const checkBase64 = buf.toString('base64');
+const checkHex = buf.toString('hex');
+
+const enc = new TextEncoder();
+
+strictEqual(enc.encode('hello').toBase64(), checkBase64);
+strictEqual(enc.encode('hello').toHex(), checkHex);
+
+const dec = new TextDecoder();
+strictEqual(dec.decode(Uint8Array.fromBase64(checkBase64)), 'hello');
+strictEqual(dec.decode(Uint8Array.fromHex(checkHex)), 'hello');


### PR DESCRIPTION
TC-39 advanced the toBase64/toHex/fromBase64/fromHex APIs to stage 4. V8 does not yet have these unflagged by default but the implementation is available with with `--js-base-64` flag and the implementation is stable. This commit enables the flag by default.

No particular rush landing this if folks feel more comfortable waiting.

Refs: https://github.com/nodejs/node/issues/59285

/cc @targos @panva 