### PR TITLE
doc: clarify release candidate stability index

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -41,9 +41,9 @@ The stability indexes are as follows:
 >   minimum viability.
 > * 1.2 - Release candidate. Experimental features at this stage are hopefully
 >   ready to become stable. No further breaking changes are anticipated but may
->   still occur in response to user feedback. We encourage user testing and
->   feedback so that we can know that this feature is ready to be marked as
->   stable.
+>   still occur in response to user feedback or the features' underlying
+>   specification development. We encourage user testing and feedback so that
+>   we can know that this feature is ready to be marked as stable.
 >
 > Experimental features leave the experimental status typically either by
 > graduating to stable, or are removed without a deprecation cycle.


### PR DESCRIPTION
This PR updates the Experimental `1.2 - Release candidate` stability index to indicate that changes may occur not only because of user feedback but also, in some cases, due to the underlying specification late development changes.

I wish to be able to mark upcoming Web Cryptography additions 1.1 - Active development with runtime experimental warning but when the dust around the WICG spec settles I wish to remove the experimental warning and mark them as 1.2 - Release candidate.

However, given past experience it may take a long time before the features get merged into the main Web Cryptography spec and in those cases I wish to reserve the option to reflect last minute changes to the spec in the implementation.

cc @nodejs/tsc 