### PR TITLE
doc: fix `CHANGELOG.md` version listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,41 @@ release.
 </tr>
 <tr>
   <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V24.md#24.4.1">24.4.1</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.4.0">24.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.3.0">24.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.2.0">24.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.1.0">24.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.2">24.0.2</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.1">24.0.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V24.md#24.0.0">24.0.0</a><br/>
+  </td>
+  <td valign="top">
+<b><a href="doc/changelogs/CHANGELOG_V22.md#22.17.1">22.17.1</a></b><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.17.0">22.17.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.16.0">22.16.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.15.1">22.15.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.15.0">22.15.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.14.0">22.14.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.13.1">22.13.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.13.0">22.13.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.12.0">22.12.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.11.0">22.11.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.10.0">22.10.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.9.0">22.9.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.8.0">22.8.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.7.0">22.7.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.6.0">22.6.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.5.1">22.5.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.5.0">22.5.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.4.1">22.4.1</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.4.0">22.4.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.3.0">22.3.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.2.0">22.2.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.1.0">22.1.0</a><br/>
+<a href="doc/changelogs/CHANGELOG_V22.md#22.0.0">22.0.0</a><br/>
+  </td>
+  <td valign="top">
 <b><a href="doc/changelogs/CHANGELOG_V20.md#20.19.4">20.19.4</a></b><br/>
 <a href="doc/changelogs/CHANGELOG_V20.md#20.19.3">20.19.3</a><br/>
 <a href="doc/changelogs/CHANGELOG_V20.md#20.19.2">20.19.2</a><br/>


### PR DESCRIPTION
As I was trying to promote 22.18.0 and 24.5.0, I realized that https://github.com/nodejs/node/commit/76c969c45420d150a8f9b7c153964d871f89877d and https://github.com/nodejs/node/commit/86dd22533beec5480e7d18d483603b2ef29d8e73 wrongfully removed v22.x and v24.x release list.
Requesting fast-track so I can promote the releases today.
 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
