### PR TITLE
Test runner/add restart timestamp

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -94,6 +94,8 @@ class SpecReporter extends Transform {
       case 'test:stderr':
       case 'test:stdout':
         return data.message;
+      case 'test:watch:restarted':
+        return ('');
       case 'test:diagnostic':{
         const diagnosticColor = reporterColorMap[data.level] || reporterColorMap['test:diagnostic'];
         return `${diagnosticColor}${indent(data.nesting)}${reporterUnicodeSymbolMap[type]}${data.message}${colors.white}\n`;

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -496,6 +496,12 @@ function watchFiles(testFiles, opts) {
     }
 
     await runningSubtests.get(file);
+
+    // Emit the 'test:restarted' event if a timeStamp reporter is available.
+    if (opts.root?.reporter?.timeStamp) {
+      opts.root.reporter.timeStamp('test:restarted', { __proto__: null, file });
+    }
+
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
 

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -498,7 +498,9 @@ function watchFiles(testFiles, opts) {
     await runningSubtests.get(file);
 
     // Emit the 'test:restarted' event if a timeStamp reporter is available.
-    opts.root.reporter[kEmitMessage]('test:watch:restarted');
+    if (opts.root?.reporter?.timeStamp) {
+      opts.root.reporter.timeStamp('test:restarted', { __proto__: null, file });
+    }
 
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -498,9 +498,7 @@ function watchFiles(testFiles, opts) {
     await runningSubtests.get(file);
 
     // Emit the 'test:restarted' event if a timeStamp reporter is available.
-    if (opts.root?.reporter?.timeStamp) {
-      opts.root.reporter.timeStamp('test:restarted', { __proto__: null, file });
-    }
+    opts.root.reporter[kEmitMessage]('test:watch:restarted');
 
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
@@ -528,7 +526,6 @@ function watchFiles(testFiles, opts) {
     // Reset the root start time to recalculate the duration
     // of the run
     opts.root.clearExecutionTime();
-    opts.root.reporter[kEmitMessage]('test:watch:restarted');
 
     // Restart test files
     if (opts.isolation === 'none') {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -2,6 +2,7 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
+  Date,
   NumberMAX_SAFE_INTEGER,
   Symbol,
 } = primordials;
@@ -147,6 +148,11 @@ class TestsStream extends Readable {
 
   end() {
     this.#tryPush(null);
+  }
+
+  // This event emitter logs a timestamp whenever a test restarts because of changes in any related files.
+  timeStamp(type, data) {
+    process.stdout.write(`\n[${new Date().toLocaleString('en-GB').replace(',', '')}] INFO: Test restarted\n`);
   }
 
   [kEmitMessage](type, data) {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -2,7 +2,6 @@
 const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
-  Date,
   NumberMAX_SAFE_INTEGER,
   Symbol,
 } = primordials;
@@ -151,8 +150,10 @@ class TestsStream extends Readable {
   }
 
   // This event emitter logs a timestamp whenever a test restarts because of changes in any related files.
-  timeStamp(type, data) {
-    process.stdout.write(`\n[${new Date().toLocaleString('en-GB').replace(',', '')}] INFO: Test restarted\n`);
+  timeStamp() {
+    this[kEmitMessage]('test:watch:restarted', {
+      __proto__: null,
+    });
   }
 
   [kEmitMessage](type, data) {

--- a/test/parallel/test-runner-restart-timestamp.js
+++ b/test/parallel/test-runner-restart-timestamp.js
@@ -1,0 +1,31 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { TestsStream } = require('internal/test_runner/tests_stream');
+
+// ✅ Instantiate the TestsStream reporter directly
+const reporter = new TestsStream();
+
+// ✅ Patch to monitor the console output
+let consoleOutput = '';
+const originalWrite = process.stdout.write;
+process.stdout.write = (chunk, ...args) => {
+  consoleOutput += chunk;
+  return originalWrite.call(process.stdout, chunk, ...args);
+};
+
+// ✅ Wrap timeStamp with mustCall (this ensures it is invoked)
+common.mustCall(() => {
+  reporter.timeStamp('test:restarted', { file: 'dummy.js' });
+})();
+
+// ✅ Restore console
+process.stdout.write = originalWrite;
+
+// ✅ Assert output contains the timestamp message
+assert.ok(
+  consoleOutput.includes('INFO: Test restarted'),
+  'Expected timestamp message in console output'
+);


### PR DESCRIPTION
test_runner: write timestamp as first line in watch mode

The goal: To always print a timestamp as the first line in watch mode to make test restarts clearer and logs easier to read.

Continuation from https://github.com/nodejs/node/pull/57903/files solution, i simply created a new event 'timestamp' and then handled it. Also modified the test to directly test my changes from runner.js instead of test_streams.js file.

Refs: https://github.com/nodejs/node/issues/57206