### PR TITLE
src: replace `v.find() == v.end()` with C++20 `contains()`

### DIFF
--- a/src/inspector/io_agent.cc
+++ b/src/inspector/io_agent.cc
@@ -27,7 +27,7 @@ DispatchResponse IoAgent::read(const String& in_handle,
   if (in_offset.has_value()) {
     offset = *in_offset;
     offset_was_specified = true;
-  } else if (offset_map_.find(url) != offset_map_.end()) {
+  } else if (offset_map_.contains(url)) {
     offset = offset_map_[url];
   }
   int size = 1 << 20;

--- a/src/inspector_profiler.h
+++ b/src/inspector_profiler.h
@@ -66,7 +66,7 @@ class V8ProfilerConnection {
   virtual void WriteProfile(simdjson::ondemand::object* result);
 
   bool HasProfileId(uint64_t id) const {
-    return profile_ids_.find(id) != profile_ids_.end();
+    return profile_ids_.contains(id);
   }
 
   void RemoveProfileId(uint64_t id) { profile_ids_.erase(id); }

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -537,11 +537,11 @@ void BlobBindingData::store_data_object(
 }
 
 void BlobBindingData::revoke_data_object(const std::string& uuid) {
-  if (data_objects_.find(uuid) == data_objects_.end()) {
+  if (!data_objects_.contains(uuid)) {
     return;
   }
   data_objects_.erase(uuid);
-  CHECK_EQ(data_objects_.find(uuid), data_objects_.end());
+  CHECK(!data_objects_.contains(uuid));
 }
 
 BlobBindingData::StoredDataObject BlobBindingData::get_data_object(

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -307,7 +307,7 @@ MaybeLocal<Function> BuiltinLoader::LookupAndCompileInternal(
   if (should_eager_compile_) {
     options = ScriptCompiler::kEagerCompile;
   } else if (!to_eager_compile_.empty()) {
-    if (to_eager_compile_.find(id) != to_eager_compile_.end()) {
+    if (to_eager_compile_.contains(id)) {
       options = ScriptCompiler::kEagerCompile;
     }
   }

--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -273,7 +273,7 @@ void MapKVStore::Set(Isolate* isolate, Local<String> key, Local<String> value) {
 
 int32_t MapKVStore::Query(const char* key) const {
   Mutex::ScopedLock lock(mutex_);
-  return map_.find(key) == map_.end() ? -1 : 0;
+  return map_.contains(key) ? 0 : -1;
 }
 
 int32_t MapKVStore::Query(Isolate* isolate, Local<String> key) const {

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1505,7 +1505,7 @@ Maybe<bool> SiblingGroup::Dispatch(
   RwLock::ScopedReadLock lock(group_mutex_);
 
   // The source MessagePortData is not part of this group.
-  if (ports_.find(source) == ports_.end()) {
+  if (!ports_.contains(source)) {
     if (error != nullptr)
       *error = "Source MessagePort is not entangled with this group.";
     return Nothing<bool>();

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -170,7 +170,7 @@ void DecreaseSignalHandlerCount(int signum) {
 
 bool HasSignalJSHandler(int signum) {
   Mutex::ScopedLock lock(handled_signals_mutex);
-  return handled_signals.find(signum) != handled_signals.end();
+  return handled_signals.contains(signum);
 }
 }  // namespace node
 


### PR DESCRIPTION
This PR refactors several `v.find(...) == v.end()` and `v.find(...) != v.end()` to use more expressive and readable C++20 `contains()` method.