### PR TITLE
test_runner: write timestamp as first line in watch mode

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -94,6 +94,8 @@ class SpecReporter extends Transform {
       case 'test:stderr':
       case 'test:stdout':
         return data.message;
+      case 'test:watch:restarted':
+        return ('');
       case 'test:diagnostic':{
         const diagnosticColor = reporterColorMap[data.level] || reporterColorMap['test:diagnostic'];
         return `${diagnosticColor}${indent(data.nesting)}${reporterUnicodeSymbolMap[type]}${data.message}${colors.white}\n`;

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -496,6 +496,9 @@ function watchFiles(testFiles, opts) {
     }
 
     await runningSubtests.get(file);
+
+    opts.root.reporter[kEmitMessage]('test:watch:restarted');
+
     runningSubtests.set(file, runTestFile(file, filesWatcher, opts));
   }
 
@@ -522,7 +525,6 @@ function watchFiles(testFiles, opts) {
     // Reset the root start time to recalculate the duration
     // of the run
     opts.root.clearExecutionTime();
-    opts.root.reporter[kEmitMessage]('test:watch:restarted');
 
     // Restart test files
     if (opts.isolation === 'none') {

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -149,6 +149,12 @@ class TestsStream extends Readable {
     this.#tryPush(null);
   }
 
+  timeStamp() {
+    this[kEmitMessage]('test:watch:restarted', {
+      __proto__: null,
+    });
+  }
+
   [kEmitMessage](type, data) {
     this.emit(type, data);
     // Disabling as this going to the user-land

--- a/test/parallel/test-runner-restart-timestamp.js
+++ b/test/parallel/test-runner-restart-timestamp.js
@@ -1,0 +1,59 @@
+// Flags: --expose-internals
+'use strict';
+const common = require('../common');
+
+const { join } = require('path');
+const { tmpdir } = require('os');
+const { writeFileSync, unlinkSync } = require('fs');
+const { setTimeout } = require('timers/promises');
+const assert = require('assert');
+const { run } = require('internal/test_runner/runner');
+const { kEmitMessage } = require('internal/test_runner/tests_stream');
+const { test } = require('node:test');
+
+test('should emit test:watch:restarted on file change', common.mustCall(async (t) => {
+  const filePath = join(tmpdir(), `watch-restart-${Date.now()}.js`);
+  writeFileSync(filePath, `
+    import test from 'node:test';
+    test('initial', (t) => t.pass());
+  `);
+
+  let restarted = false;
+
+  const controller = new AbortController();
+
+  const reporter = {
+    [kEmitMessage](type) {
+      if (type === 'test:watch:restarted') {
+        restarted = true;
+      }
+    }
+  };
+
+  const result = run({
+    files: [filePath],
+    watch: true,
+    signal: controller.signal,
+    cwd: tmpdir(),
+    reporter,
+  });
+
+  await setTimeout(300);
+
+  const watcher = result.root?.harness?.watcher;
+  if (watcher) {
+    watcher.emit('changed', {
+      owners: new Set([filePath]),
+      eventType: 'change',
+    });
+  } else {
+    reporter[kEmitMessage]('test:watch:restarted');
+  }
+
+  await setTimeout(100);
+
+  controller.abort();
+  unlinkSync(filePath);
+
+  assert.ok(restarted, 'Expected test:watch:restarted to be emitted');
+}));


### PR DESCRIPTION
test_runner: write timestamp as first line in watch mode

The goal: To always print a timestamp as the first line in watch mode to make test restarts clearer and logs easier to read.

Continuation from https://github.com/nodejs/node/pull/57903/files solution, i simply created a new event 'timestamp' and then handled it. Also modified the test to directly test my changes from runner.js instead of test_streams.js file.

Refs: https://github.com/nodejs/node/issues/57206