### PR TITLE
doc: add missing Zstd strategy constants

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -750,6 +750,34 @@ The most important options are:
 * `ZSTD_c_compressionLevel`
   * Set compression parameters according to pre-defined cLevel table. Default
     level is ZSTD\_CLEVEL\_DEFAULT==3.
+* `ZSTD_c_strategy`
+  * Select the compression strategy. Default is `ZSTD_lazy2`.
+  * Possible values are listed in the strategy options section below.
+
+#### Strategy options
+
+The following constants can be used as values for the `ZSTD_c_strategy`
+parameter:
+
+* `zlib.constants.ZSTD_fast`
+* `zlib.constants.ZSTD_dfast`
+* `zlib.constants.ZSTD_greedy`
+* `zlib.constants.ZSTD_lazy`
+* `zlib.constants.ZSTD_lazy2`
+* `zlib.constants.ZSTD_btlazy2`
+* `zlib.constants.ZSTD_btopt`
+* `zlib.constants.ZSTD_btultra`
+* `zlib.constants.ZSTD_btultra2`
+
+Example:
+
+```js
+const stream = zlib.createZstdCompress({
+  params: {
+    [zlib.constants.ZSTD_c_strategy]: zlib.constants.ZSTD_btultra,
+  },
+});
+```
 
 #### Pledged Source Size
 

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -751,7 +751,7 @@ The most important options are:
   * Set compression parameters according to pre-defined cLevel table. Default
     level is ZSTD\_CLEVEL\_DEFAULT==3.
 * `ZSTD_c_strategy`
-  * Select the compression strategy. Default is `ZSTD_lazy2`.
+  * Select the compression strategy.
   * Possible values are listed in the strategy options section below.
 
 #### Strategy options


### PR DESCRIPTION
Documents the ZSTD_c_strategy parameter and its possible values (ZSTD_fast … ZSTD_btultra2) that were already exposed in zlib.constants but missing from the API docs and added an example for reference.

Fixes: #59290 