### PR TITLE
doc: correct orthography `eg.` → `e.g.`

### DIFF
--- a/doc/contributing/investigating-native-memory-leaks.md
+++ b/doc/contributing/investigating-native-memory-leaks.md
@@ -396,7 +396,7 @@ call:
 }
 ```
 
-Create a file (eg. `node-12.14.1.supp`) with the contents of the suppression
+Create a file (e.g. `node-12.14.1.supp`) with the contents of the suppression
 records, and run Valgrind with the suppression file previously created:
 
 ```bash

--- a/tools/msvs/msi/nodemsi/product.wxs
+++ b/tools/msvs/msi/nodemsi/product.wxs
@@ -41,7 +41,7 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR"/>
 
     <!-- WiX 4 QueryWindowsWellKnownSIDs element replaces previously used PropertyRef. -->
-    <!-- It sets all properties with the WIX_ACCOUNT_ prefix eg. WIX_ACCOUNT_USERS, etc. -->
+    <!-- It sets all properties with the WIX_ACCOUNT_ prefix e.g. WIX_ACCOUNT_USERS, etc. -->
     <util:QueryWindowsWellKnownSIDs/>
 
     <Property Id="INSTALLDIR" Secure="yes">


### PR DESCRIPTION
"exempli gratia" is abbreviated "e.g."