### PR TITLE
test: fix typos in comments and variable names

### DIFF
--- a/test/parallel/test-abortsignal-cloneable.js
+++ b/test/parallel/test-abortsignal-cloneable.js
@@ -35,7 +35,7 @@ test('Can create a transferable abort controller', async () => {
 
   mc.port2.postMessage(ac.signal, [ac.signal]);
 
-  // Can be cloned/transferd multiple times and they all still work
+  // Can be cloned/transferred multiple times and they all still work
   mc.port2.postMessage(ac.signal, [ac.signal]);
 
   // Although we're using transfer semantics, the local AbortSignal

--- a/test/parallel/test-abortsignal-drop-settled-signals.mjs
+++ b/test/parallel/test-abortsignal-drop-settled-signals.mjs
@@ -104,17 +104,17 @@ const limit = 10_000;
 
 describe('when there is a long-lived signal', () => {
   it('drops settled dependant signals', (t, done) => {
-    makeSubsequentCalls(limit, (signal, depandantSignalsKey) => {
+    makeSubsequentCalls(limit, (signal, dependantSignalsKey) => {
       setImmediate(() => {
-        t.assert.strictEqual(signal[depandantSignalsKey].size, 0);
+        t.assert.strictEqual(signal[dependantSignalsKey].size, 0);
         done();
       });
     });
   });
 
   it('keeps all active dependant signals', (t, done) => {
-    makeSubsequentCalls(limit, (signal, depandantSignalsKey) => {
-      t.assert.strictEqual(signal[depandantSignalsKey].size, limit);
+    makeSubsequentCalls(limit, (signal, dependantSignalsKey) => {
+      t.assert.strictEqual(signal[dependantSignalsKey].size, limit);
 
       done();
     }, true);

--- a/test/parallel/test-assert-first-line.js
+++ b/test/parallel/test-assert-first-line.js
@@ -12,7 +12,7 @@ test('Verify that asserting in the very first line produces the expected result'
     () => require(path('assert-first-line')),
     {
       name: 'AssertionError',
-      message: "The expression evaluated to a falsy value:\n\n  ässört.ok('')\n"
+      message: "The expression evaluated to a falsy value:\n\n  assert.ok('')\n"
     }
   );
 


### PR DESCRIPTION
Fix minor typos:
- "transferd" → "transferred"
- "depandant" → "dependant"
- "ässört" → "assert"