### PR TITLE
doc: rename x509.extKeyUsage to x509.keyUsage

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2681,16 +2681,6 @@ added: v15.6.0
 Checks whether the public key for this certificate is consistent with
 the given private key.
 
-### `x509.extKeyUsage`
-
-<!-- YAML
-added: v15.6.0
--->
-
-* Type: {string\[]}
-
-An array detailing the key extended usages for this certificate.
-
 ### `x509.fingerprint`
 
 <!-- YAML
@@ -2781,6 +2771,16 @@ added: v15.9.0
 
 The issuer certificate or `undefined` if the issuer certificate is not
 available.
+
+### `x509.keyUsage`
+
+<!-- YAML
+added: v15.6.0
+-->
+
+* Type: {string\[]}
+
+An array detailing the key extended usages for this certificate.
 
 ### `x509.publicKey`
 


### PR DESCRIPTION
This partially reverts #50603. It keeps the description but reverts to use the actual property name. #50603 should not have landed.