### PR TITLE
buffer: fix error codes

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -595,8 +595,6 @@ Buffer.concat = function concat(list, length) {
   for (let i = 0; i < list.length; i++) {
     const buf = list[i];
     if (!isUint8Array(buf)) {
-      // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
-      // Instead, find the proper error code for this.
       throw new ERR_INVALID_ARG_TYPE(
         `list[${i}]`, ['Buffer', 'Uint8Array'], list[i]);
     }
@@ -1303,8 +1301,7 @@ function atob(input) {
         'The string to be decoded is not correctly encoded.',
         'InvalidCharacterError');
     case -3: // Possible overflow
-      // TODO(@anonrig): Throw correct error in here.
-      throw lazyDOMException('The input causes overflow.', 'InvalidCharacterError');
+      throw lazyDOMException('The input causes overflow.', 'InvalidStateError');
     default:
       return result;
   }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fix incorrect error codes in buffer.js
- In Buffer.concat(), replaced `ERR_INVALID_ARG_TYPE` with `ERR_INVALID_ARG_VALUE` because the error is thrown when the top-level argument is valid, but one of its elements is not. 
- In the atob() implementation, replaced the DOMException thrown for case -3 (overflow) from `InvalidCharacterError` to `InvalidStateError`. 
- Updated tests in tools/paralle/test-buffer-concat.js.