### PR TITLE
lib: adding `--watch-pattern` to support watching files/dirs with glob

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3233,6 +3233,22 @@ This option is only supported on macOS and Windows.
 An `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` exception will be thrown
 when the option is used on a platform that does not support it.
 
+### `--watch-pattern`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+This is similar to `--watch-path` option, which starts Node.js in
+watch mode and is used to specify which paths to watch using globs.
+Additionally, this option supports watching files and directories.
+
+```bash
+node --watch-pattern=./**/*.js index.js
+```
+
 ### `--watch-preserve-output`
 
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -649,6 +649,9 @@ By default, watch mode will watch the entry point and any required or imported m
 .It Fl -watch-path
 Starts Node.js in watch mode and specifies what paths to watch. When in watch mode, changes in the watched paths cause the Node.js process to restart.
 
+.It Fl -watch-pattern
+Starts Node.js in watch mode and can include glob patterns when specifying what paths to watch. When in watch mode, changes in the watched paths cause the Node.js process to restart.
+
 This will turn off watching of required or imported modules, even when used in combination with --watch.
 .
 .It Fl -watch-kill-signal

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -783,5 +783,4 @@ module.exports = {
   __proto__: null,
   Glob,
   matchGlobPattern,
-  createMatcher,
 };

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -783,4 +783,5 @@ module.exports = {
   __proto__: null,
   Glob,
   matchGlobPattern,
+  createMatcher,
 };

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -1,10 +1,7 @@
 'use strict';
 const {
-  ArrayPrototypeConcat,
-  ArrayPrototypeFlatMap,
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
-  ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -1,5 +1,6 @@
 'use strict';
 const {
+  ArrayPrototypeFlatMap,
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
   ArrayPrototypeMap,
@@ -27,14 +28,29 @@ const { inspect } = require('util');
 const { setTimeout, clearTimeout } = require('timers');
 const { resolve } = require('path');
 const { once } = require('events');
+const { createMatcher } = require('internal/fs/glob');
+const { globSync } = require('fs');
 
 prepareMainThreadExecution(false, false);
 markBootstrapComplete();
 
+function hasGlobPattern(path) {
+  return createMatcher(path).hasMagic();
+}
+
+function handleWatchedPath(path) {
+  if (hasGlobPattern(path)) {
+    const matchedFilesFromGlob = globSync(path);
+    const resolvedMatchedFiles = ArrayPrototypeMap(matchedFilesFromGlob, (path) => resolve(path));
+    return resolvedMatchedFiles;
+  }
+  return resolve(path);
+}
+
 const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
-const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
+const kWatchedPaths = ArrayPrototypeFlatMap(getOptionValue('--watch-path'), (path) => handleWatchedPath(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -48,7 +48,7 @@ function handleWatchedPath(path) {
 }
 
 const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
-const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
+const kShouldFilterModules = getOptionValue('--watch-pattern').length === 0;
 const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
 const kWatchedPaths = ArrayPrototypeFlatMap(getOptionValue('--watch-path'), (path) => handleWatchedPath(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');

--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -1,5 +1,6 @@
 'use strict';
 const {
+  ArrayPrototypeConcat,
   ArrayPrototypeFlatMap,
   ArrayPrototypeForEach,
   ArrayPrototypeJoin,
@@ -28,29 +29,43 @@ const { inspect } = require('util');
 const { setTimeout, clearTimeout } = require('timers');
 const { resolve } = require('path');
 const { once } = require('events');
-const { createMatcher } = require('internal/fs/glob');
 const { globSync } = require('fs');
 
 prepareMainThreadExecution(false, false);
 markBootstrapComplete();
 
-function hasGlobPattern(path) {
-  return createMatcher(path).hasMagic();
+const kWatchPath = getOptionValue('--watch-path');
+const kWatchPattern = getOptionValue('--watch-pattern');
+
+function isOptionNotGiven(option) {
+  return option.length === 0;
 }
 
-function handleWatchedPath(path) {
-  if (hasGlobPattern(path)) {
-    const matchedFilesFromGlob = globSync(path);
-    const resolvedMatchedFiles = ArrayPrototypeMap(matchedFilesFromGlob, (path) => resolve(path));
-    return resolvedMatchedFiles;
+function isOptionGiven(option) {
+  return option.length > 0;
+}
+
+function handleWatchedPaths() {
+  const watchedPaths = [];
+  if (isOptionGiven(kWatchPath)) {
+    ArrayPrototypeForEach(kWatchPath, (path) => {
+      ArrayPrototypePush(watchedPaths, resolve(path));
+    });
   }
-  return resolve(path);
+  if (isOptionGiven(kWatchPattern)) {
+    ArrayPrototypeForEach(kWatchPattern, (path) => {
+      const matchedPaths = globSync(path);
+      ArrayPrototypeForEach(matchedPaths, (matchedPathFromGlobPattern) =>
+        ArrayPrototypePush(watchedPaths, resolve(matchedPathFromGlobPattern)));
+    });
+  }
+  return watchedPaths;
 }
 
 const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
-const kShouldFilterModules = getOptionValue('--watch-pattern').length === 0;
+const kShouldFilterModules = isOptionNotGiven(kWatchPath) && isOptionNotGiven(kWatchPattern);
 const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
-const kWatchedPaths = ArrayPrototypeFlatMap(getOptionValue('--watch-path'), (path) => handleWatchedPath(path));
+const kWatchedPaths = handleWatchedPaths();
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
@@ -68,6 +83,12 @@ for (let i = 0; i < process.execArgv.length; i++) {
       // If `--watch` doesn't include `=` and the next
       // argument is not a flag then it is interpreted as
       // the watch argument, so we need to skip that as well
+      i++;
+    }
+    continue;
+  }
+  if (StringPrototypeStartsWith(arg, '--watch-pattern')) {
+    if (arg['--watch-pattern'.length] !== '=') {
       i++;
     }
     continue;

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -1006,6 +1006,9 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "path to watch",
             &EnvironmentOptions::watch_mode_paths,
             kAllowedInEnvvar);
+  AddOption("--watch-pattern",
+            "paths to watch (can include a glob pattern)",
+            &EnvironmentOptions::watch_mode_paths_with_glob_patterns);
   AddOption("--watch-kill-signal",
             "kill signal to send to the process on watch mode restarts"
             "(default: SIGTERM)",
@@ -1016,6 +1019,7 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::watch_mode_preserve_output,
             kAllowedInEnvvar);
   Implies("--watch-path", "--watch");
+  Implies("--watch-pattern", "--watch");
   AddOption("--check",
             "syntax check script without executing",
             &EnvironmentOptions::syntax_check_only);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -234,6 +234,7 @@ class EnvironmentOptions : public Options {
   bool watch_mode_preserve_output = false;
   std::string watch_mode_kill_signal = "SIGTERM";
   std::vector<std::string> watch_mode_paths;
+  std::vector<std::string> watch_mode_paths_with_glob_patterns;
 
   bool syntax_check_only = false;
   bool has_eval_string = false;

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -814,7 +814,7 @@ process.on('message', (message) => {
     ]);
   });
 
-  it('should watch files from a given glob pattern --watch-path=./**/*.js', async () => {
+  it('should watch files from a given glob pattern --watch-pattern=./**/*.js', async () => {
 
     const tmpDirForGlobTest = tmpdir.resolve('glob-test-dir');
     mkdirSync(tmpDirForGlobTest);
@@ -835,7 +835,7 @@ process.on('message', (message) => {
 
     const mainJsFile = createTmpFile('console.log(\'running\')', '.js', tmpDirForGlobTest);
 
-    const args = ['--watch-path', globPattern, mainJsFile];
+    const args = ['--watch-pattern', globPattern, mainJsFile];
     const watchedFiles = [tmpJsFile1, tmpJsFile2, tmpJsFile3, tmpJsFile4, tmpJsFile5];
 
     const { stderr, stdout } = await runWriteSucceed({


### PR DESCRIPTION
Closes #45182 

This adds the `--watch-pattern` cli option to Node.js, which allows to watch files and directories with the use of globs. This PR is a non-breaking change opposed to `--watch-path` option supporting globs since there could be instances where some glob characters are used (e.g., `file[1].js`) which could be treated as a glob and may cause breakage on existing scripts.