### PR TITLE
tls: use options in getCACertificates() with X509Certificate

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -2374,21 +2374,35 @@ const additionalCerts = ['-----BEGIN CERTIFICATE-----\n...'];
 tls.setDefaultCACertificates([...currentCerts, ...additionalCerts]);
 ```
 
-## `tls.getCACertificates([type])`
+## `tls.getCACertificates([options])`
 
 <!-- YAML
 added:
   - v23.10.0
   - v22.15.0
+changes:
+  - version:
+      - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59349
+    description: Added optional `options.type` parameter to `getCACertificates()`.
 -->
 
-* `type` {string|undefined} The type of CA certificates that will be returned. Valid values
-  are `"default"`, `"system"`, `"bundled"` and `"extra"`.
-  **Default:** `"default"`.
-* Returns: {string\[]} An array of PEM-encoded certificates. The array may contain duplicates
-  if the same certificate is repeatedly stored in multiple sources.
+* `options` {string|Object|undefined}
+  Optional. If a string, it is treated as the `type` of certificates to return.
+  If an object, it may contain:
+  * `type` {string} The type of CA certificates to return. One of `"default"`, `"system"`, `"bundled"`, or `"extra"`.
+    **Default:** `"default"`.
+  * `format` {string} The format of returned certificates. One of `"pem"`, `"der"`, or `"x509"`.
+    **Default:** `"pem"`.
+    * `"pem"` (alias: `"string"`): Returns an array of PEM-encoded certificate strings.
+    * `"der"` (alias: `"buffer"`): Returns an array of certificate data as `Buffer` objects in DER format.
+    * `"x509"`: Returns an array of [`X509Certificate`][x509certificate] instances.
 
-Returns an array containing the CA certificates from various sources, depending on `type`:
+* Returns: {Array}
+  An array of certificate data in the specified format:
+  * PEM strings when `format` is `"pem"` (or `"string"`).
+  * `Buffer` objects containing DER data when `format` is `"der"` (or `"buffer"`).
+  * [`X509Certificate`][x509certificate] instances when `format` is `"x509"`.
 
 * `"default"`: return the CA certificates that will be used by the Node.js TLS clients by default.
   * When [`--use-bundled-ca`][] is enabled (default), or [`--use-openssl-ca`][] is not enabled,
@@ -2397,11 +2411,14 @@ Returns an array containing the CA certificates from various sources, depending 
     trusted store.
   * When [`NODE_EXTRA_CA_CERTS`][] is used, this would also include certificates loaded from the specified
     file.
+
 * `"system"`: return the CA certificates that are loaded from the system's trusted store, according
   to rules set by [`--use-system-ca`][]. This can be used to get the certificates from the system
   when [`--use-system-ca`][] is not enabled.
+
 * `"bundled"`: return the CA certificates from the bundled Mozilla CA store. This would be the same
   as [`tls.rootCertificates`][].
+
 * `"extra"`: return the CA certificates loaded from [`NODE_EXTRA_CA_CERTS`][]. It's an empty array if
   [`NODE_EXTRA_CA_CERTS`][] is not set.
 
@@ -2585,7 +2602,7 @@ added: v0.11.3
 [`tls.connect()`]: #tlsconnectoptions-callback
 [`tls.createSecureContext()`]: #tlscreatesecurecontextoptions
 [`tls.createServer()`]: #tlscreateserveroptions-secureconnectionlistener
-[`tls.getCACertificates()`]: #tlsgetcacertificatestype
+[`tls.getCACertificates()`]: #tlsgetcacertificatesoptions
 [`tls.getCiphers()`]: #tlsgetciphers
 [`tls.rootCertificates`]: #tlsrootcertificates
 [`x509.checkHost()`]: crypto.md#x509checkhostname-options
@@ -2594,3 +2611,4 @@ added: v0.11.3
 [cipher list format]: https://www.openssl.org/docs/man1.1.1/man1/ciphers.html#CIPHER-LIST-FORMAT
 [forward secrecy]: https://en.wikipedia.org/wiki/Perfect_forward_secrecy
 [perfect forward secrecy]: #perfect-forward-secrecy
+[x509certificate]: crypto.md#class-x509certificate

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -70,7 +70,11 @@ const { canonicalizeIP } = internalBinding('cares_wrap');
 const tlsCommon = require('internal/tls/common');
 const tlsWrap = require('internal/tls/wrap');
 const { domainToASCII } = require('internal/url');
-const { validateString } = require('internal/validators');
+const {
+  validateOneOf,
+  validateString,
+} = require('internal/validators');
+const { X509Certificate } = require('crypto');
 
 const {
   namespace: {
@@ -186,8 +190,7 @@ function cacheDefaultCACertificates() {
   return defaultCACertificates;
 }
 
-// TODO(joyeecheung): support X509Certificate output?
-function getCACertificates(type = 'default') {
+function getCACertificatesAsStrings(type = 'default') {
   validateString(type, 'type');
 
   switch (type) {
@@ -203,6 +206,40 @@ function getCACertificates(type = 'default') {
       throw new ERR_INVALID_ARG_VALUE('type', type);
   }
 }
+
+function getCACertificates(options = undefined) {
+  let type = 'default';
+  let format = 'pem';
+
+  if (typeof options === 'object' && options !== null) {
+    ({ type = 'default', format = 'pem' } = options);
+  } else if (typeof options === 'string' || options === undefined) {
+    type = options ?? 'default';
+  } else {
+    throw new ERR_INVALID_ARG_TYPE('options', ['string', 'object'], options);
+  }
+
+  validateString(type, 'type');
+  validateOneOf(format, 'format', ['pem', 'der', 'x509', 'string', 'buffer']);
+
+  const certs = getCACertificatesAsStrings(type);
+
+  if (format === 'pem' || format === 'string') {
+    return certs;
+  }
+
+  if (format === 'x509') {
+    return certs.map((cert) => new X509Certificate(cert));
+  }
+
+  const buffers = certs.map((cert) => {
+    const base64 = cert.replace(/(?:\s|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----)+/g, '');
+    return Buffer.from(base64, 'base64');
+  });
+
+  return buffers;
+}
+
 exports.getCACertificates = getCACertificates;
 
 function setDefaultCACertificates(certs) {

--- a/test/parallel/test-tls-get-ca-certificates-default.js
+++ b/test/parallel/test-tls-get-ca-certificates-default.js
@@ -13,8 +13,5 @@ const { assertIsCAArray } = require('../common/tls');
 const certs = tls.getCACertificates();
 assertIsCAArray(certs);
 
-const certs2 = tls.getCACertificates('default');
-assert.strictEqual(certs, certs2);
-
 // It's cached on subsequent accesses.
 assert.strictEqual(certs, tls.getCACertificates('default'));

--- a/test/parallel/test-tls-get-ca-certificates-x509-option.js
+++ b/test/parallel/test-tls-get-ca-certificates-x509-option.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const { X509Certificate } = require('crypto');
+const tlsCommon = require('../common/tls');
+
+const expectedPems = tls.getCACertificates({ type: 'default', format: 'pem' });
+
+{
+  const certs = tls.getCACertificates({ type: 'default', format: 'x509' });
+  assert.strictEqual(certs.length, expectedPems.length);
+
+  const certsRaw = certs.map((c) => c.raw);
+  tlsCommon.assertEqualCerts(certsRaw, expectedPems);
+
+  for (const cert of certs) {
+    assert.ok(cert instanceof X509Certificate);
+  }
+}
+
+{
+  const certs = tls.getCACertificates({ type: 'default', format: 'buffer' });
+  assert.strictEqual(certs.length, expectedPems.length);
+  tlsCommon.assertEqualCerts(certs, expectedPems);
+
+  for (const cert of certs) {
+    assert.ok(Buffer.isBuffer(cert));
+  }
+}
+
+{
+  const certs = tls.getCACertificates({ type: 'default' });
+  assert.strictEqual(certs.length, expectedPems.length);
+  for (const cert of certs) {
+    assert.strictEqual(typeof cert, 'string');
+    assert.ok(cert.includes('-----BEGIN CERTIFICATE-----'));
+  }
+}
+
+{
+  assert.throws(() => {
+    tls.getCACertificates({ type: 'default', format: 'invalid' });
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: /must be one of/
+  });
+}
+
+{
+  const certs = tls.getCACertificates({ format: 'buffer' });
+  assert.ok(Array.isArray(certs));
+  assert.ok(certs.length > 0);
+  for (const cert of certs) {
+    assert.ok(Buffer.isBuffer(cert));
+  }
+}
+
+{
+  assert.throws(() => {
+    tls.getCACertificates({ type: 'invalid', format: 'buffer' });
+  }, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: /The argument 'type' is invalid/
+  });
+}


### PR DESCRIPTION
This PR implements the TODO(joyeecheung) note to support X509Certificate output in tls.getCACertificates(). It introduces a new format option, enhancing the function's flexibility and aligning its API with Node.js's broader crypto module.

The function's behavior is now extended as follows:
API Enhancement: Adds an optional format parameter to tls.getCACertificates() to specify the output format.

Output Options:
- 'pem' (default): Returns an array of PEM-encoded certificate strings. This is the new default to align with the name used in other Node.js crypto APIs.
- 'der': Returns an array of certificate data as Buffer objects in DER format.
- 'x509': Returns an array of crypto.X509Certificate instances, providing direct access to certificate properties.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
