### PR TITLE
build: fix OpenSSL version detection

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1205,7 +1205,7 @@ def get_gas_version(cc):
   warn(f'Could not recognize `gas`: {gas_ret}')
   return '0.0'
 
-def get_openssl_version():
+def get_openssl_version(o):
   """Parse OpenSSL version from opensslv.h header file.
 
   Returns the version as a number matching OPENSSL_VERSION_NUMBER format:
@@ -1219,6 +1219,9 @@ def get_openssl_version():
       args = ['-I', 'deps/openssl/openssl/include'] + args
     elif options.shared_openssl_includes:
       args = ['-I', options.shared_openssl_includes] + args
+    else:
+      for dir in o['include_dirs']:
+        args = ['-I', dir] + args
 
     proc = subprocess.Popen(
       shlex.split(CC) + args,
@@ -1887,9 +1890,9 @@ def configure_openssl(o):
   if options.quic:
     o['defines'] += ['NODE_OPENSSL_HAS_QUIC']
 
-  o['variables']['openssl_version'] = get_openssl_version()
-
   configure_library('openssl', o)
+
+  o['variables']['openssl_version'] = get_openssl_version(o)
 
 def configure_sqlite(o):
   o['variables']['node_use_sqlite'] = b(not options.without_sqlite)


### PR DESCRIPTION
Fix OpenSSL version detection in `configure.py` when `pkg-config` is used to configure building with a shared OpenSSL library.

Fixes: https://github.com/nodejs/node/pull/59249#discussion_r2249368196

---

cc @jasnell 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
