### PR TITLE
doc: fix missing reference links for server.keepAliveTimeoutBuffer

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1945,7 +1945,7 @@ incoming data, after it has finished writing the last response, before a socket
 will be destroyed.
 
 This timeout value is combined with the
-\[`server.keepAliveTimeoutBuffer`]\[] option to determine the actual socket
+[`server.keepAliveTimeoutBuffer`][] option to determine the actual socket
 timeout, calculated as:
 socketTimeout = keepAliveTimeout + keepAliveTimeoutBuffer
 If the server receives new data before the keep-alive timeout has fired, it
@@ -4453,6 +4453,7 @@ const agent2 = new http.Agent({ proxyEnv: process.env });
 [`response.writeHead()`]: #responsewriteheadstatuscode-statusmessage-headers
 [`server.close()`]: #serverclosecallback
 [`server.headersTimeout`]: #serverheaderstimeout
+[`server.keepAliveTimeoutBuffer`]: #serverkeepalivetimeoutbuffer
 [`server.keepAliveTimeout`]: #serverkeepalivetimeout
 [`server.listen()`]: net.md#serverlisten
 [`server.requestTimeout`]: #serverrequesttimeout


### PR DESCRIPTION
This PR fixes missing or broken Markdown reference links in [http.md#serverkeepalivetimeout](https://github.com/nodejs/node/blob/main/doc/api/http.md#serverkeepalivetimeout)

There was an issue where some Markdown reference links were not rendered correctly in the generated documentation, as shown in the screenshot below:

<img width="762" height="406" alt="image" src="https://github.com/user-attachments/assets/0651f302-5859-475f-9269-d79d2783b4cc" />

