### PR TITLE
test: fix hidden error in test-http-server-stale-close.js

### DIFF
--- a/test/parallel/test-http-server-stale-close.js
+++ b/test/parallel/test-http-server-stale-close.js
@@ -31,7 +31,7 @@ if (process.env.NODE_TEST_FORK_PORT) {
     method: 'POST',
     host: '127.0.0.1',
     port: +process.env.NODE_TEST_FORK_PORT,
-  }, process.exit);
+  }, () => process.exit(0));
   req.write('BAM');
   req.end();
 } else {


### PR DESCRIPTION
before:

```
❯ node test/parallel/test-http-server-stale-close.js
node:internal/errors:540
      throw error;
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received an instance of IncomingMessage
    at process.set [as exitCode] (node:internal/bootstrap/node:119:9)
    at ClientRequest.exit (node:internal/process/per_thread:231:24)
    at Object.onceWrapper (node:events:622:26)
    at ClientRequest.emit (node:events:507:28)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:716:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:117:17)
    at Socket.socketOnData (node:_http_client:558:22)
    at Socket.emit (node:events:507:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3) {
  code: 'ERR_INVALID_ARG_TYPE'
}

Node.js v24.3.0

❯ echo $?
0
```

after:

```
❯ node test/parallel/test-http-server-stale-close.js
```
