### PR TITLE
src: add Intel CET properties to large_pages.S

### DIFF
--- a/src/large_pages/node_text_start.S
+++ b/src/large_pages/node_text_start.S
@@ -1,6 +1,27 @@
 #if defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
+// Add .note.gnu.property note for x86_64 to enable Intel CET
+// Based on: https://sourceware.org/annobin/annobin.html/Test-cf-protection.html
+// Refs: https://github.com/nodejs/node/issues/59084
+#if defined(__x86_64__) || defined(_M_X64)
+.section	.note.gnu.property,"a"
+.align 8
+.long	 1f - 0f
+.long	 4f - 1f
+.long	 5
+0:
+.string	 "GNU"
+1:
+.align 8
+.long	 0xc0000002
+.long	 3f - 2f
+2:
+.long	 0x3
+3:
+.align 8
+4:
+#endif
 .text
 .align 0x2000
 .global __node_text_start


### PR DESCRIPTION
Add note indicating support of Intel CET for large_pages.S file based on annocheck guide: https://sourceware.org/annobin/annobin.html/Test-cf-protection.html

This change should serve as preparation for enabling Intel CET feature, as all object have to support it, and linking with assembly file without this note would disable the feature for the final binary.

In this linking step the object **node_text_start.o** is used and without the note inserted by this PR into the source assembly file the feature is disabled for the object and therefore for node binary itself.

`g++ -o /node/out/Release/node -pthread -Wl, -rdynamic **/node/out/Release/obj.target/node_text_start/src/large_pages/node_text_start.o** -Wl,--whole-archive /node/out/Release/obj.target/libnode.a `


The PR adds to the .note.gnu.property the following line which indicates Intel CET is enabled: 
*       Properties: x86 feature: IBT, SHSTK
```
readelf -n node_text_start.o

Displaying notes found in: .note.gnu.property
  Owner                Data size        Description
  GNU                  0x00000010       NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature: IBT, SHSTK
  GNU                  0x00000020       NT_GNU_PROPERTY_TYPE_0
      Properties: x86 ISA used: 
        x86 feature used: x86
```

Refs: https://github.com/nodejs/node/issues/59084

 