### PR TITLE
lib: fix parser for package name

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -1018,7 +1018,9 @@ The resolver can throw the following errors:
 > 5. Otherwise,
 >    1. If _packageSpecifier_ does not contain a _"/"_ separator, then
 >       1. Throw an _Invalid Module Specifier_ error.
->    2. Set _packageName_ to the substring of _packageSpecifier_
+>    2. If _"/"_ separator is the first character of _packageSpecifier_, then
+>       1. Throw an _Invalid Module Specifier_ error.
+>    3. Set _packageName_ to the substring of _packageSpecifier_
 >       until the second _"/"_ separator or the end of the string.
 > 6. If _packageName_ starts with _"."_ or contains _"\\"_ or _"%"_, then
 >    1. Throw an _Invalid Module Specifier_ error.

--- a/lib/internal/modules/package_json_reader.js
+++ b/lib/internal/modules/package_json_reader.js
@@ -203,7 +203,7 @@ function parsePackageName(specifier, base) {
   let isScoped = false;
   if (specifier[0] === '@') {
     isScoped = true;
-    if (separatorIndex === -1 || specifier.length === 0) {
+    if (separatorIndex === -1 || separatorIndex === 1) {
       validPackageName = false;
     } else {
       separatorIndex = StringPrototypeIndexOf(


### PR DESCRIPTION
Fix `parsePackageName` to handle cases where the package name starts with `@` and if there's no character before `/`,which is invalid module specifier `''`.

e.g. import `@/foo` should be invalid.

Fixes: https://github.com/nodejs/node/issues/59359