### PR TITLE
test_runner: do not error when getting `fullName` of root context

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -1502,6 +1502,8 @@ class Suite extends Test {
 }
 
 function getFullName(test) {
+  if (test === test.root) return test.name;
+
   let fullName = test.name;
 
   for (let t = test.parent; t !== t.root; t = t.parent) {

--- a/test/parallel/test-runner-test-fullname.js
+++ b/test/parallel/test-runner-test-fullname.js
@@ -1,7 +1,11 @@
 'use strict';
 require('../common');
 const { strictEqual } = require('node:assert');
-const { suite, test } = require('node:test');
+const { before, suite, test } = require('node:test');
+
+before((t) => {
+  strictEqual(t.fullName, '<root>');
+});
 
 suite('suite', (t) => {
   strictEqual(t.fullName, 'suite');


### PR DESCRIPTION
```js
const { before, test } = require('node:test');

before((t) => t.fullName);
test();
```
yields
```
TypeError: Cannot read properties of null (reading 'root')
    at getFullName (node:internal/test_runner/test:1507:37)
    at get fullName (node:internal/test_runner/test:282:12)
    at TestContext.<anonymous> (...)
```