### PR TITLE
util: fix numericSeparator with negative fractional numbers

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1684,23 +1684,33 @@ function formatNumber(fn, number, numericSeparator) {
     }
     return fn(`${number}`, 'number');
   }
+
+  const numberString = String(number);
   const integer = MathTrunc(number);
-  const string = String(integer);
+
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(string, 'e')) {
-      return fn(string, 'number');
+    if (!NumberIsFinite(number) || StringPrototypeIncludes(numberString, 'e')) {
+      return fn(numberString, 'number');
     }
-    return fn(`${addNumericSeparator(string)}`, 'number');
+    return fn(`${addNumericSeparator(numberString)}`, 'number');
   }
   if (NumberIsNaN(number)) {
-    return fn(string, 'number');
+    return fn(numberString, 'number');
   }
+
+  // Find decimal point position in original string
+  const decimalIndex = StringPrototypeIndexOf(numberString, '.');
+  if (decimalIndex === -1) {
+    return fn(numberString, 'number');
+  }
+
+  const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
+  const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);
+
   return fn(`${
-    addNumericSeparator(string)
+    addNumericSeparator(integerPart)
   }.${
-    addNumericSeparatorEnd(
-      StringPrototypeSlice(String(number), string.length + 1),
-    )
+    addNumericSeparatorEnd(fractionalPart)
   }`, 'number');
 }
 

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3324,6 +3324,27 @@ assert.strictEqual(
     util.inspect(-123456789.12345678, { numericSeparator: true }),
     '-123_456_789.123_456_78'
   );
+
+  // Regression test for https://github.com/nodejs/node/issues/59376
+  // numericSeparator should work correctly for negative fractional numbers
+  {
+    // Test the exact values from the GitHub issue
+    const values = [0.1234, -0.12, -0.123, -0.1234, -1.234];
+    assert.strictEqual(
+      util.inspect(values, { numericSeparator: true }),
+      '[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]'
+    );
+
+    // Test individual negative fractional numbers between -1 and 0
+    assert.strictEqual(
+      util.inspect(-0.1234, { numericSeparator: true }),
+      '-0.123_4'
+    );
+    assert.strictEqual(
+      util.inspect(-0.12345, { numericSeparator: true }),
+      '-0.123_45'
+    );
+  }
 }
 
 // Regression test for https://github.com/nodejs/node/issues/41244


### PR DESCRIPTION
util: fix numericSeparator for negative fractional numbers

Fixes a bug in util.inspect() where negative fractional numbers between -1 and 0 were incorrectly formatted when using the numericSeparator option.

Changes

- Fix formatNumber function: Use original string representation to preserve negative sign for fractional numbers
- Update test expectations: Correct scientific notation test to not expect numeric separators

Before

util.inspect([-0.12, -0.123], { numericSeparator: true })
// Output: '[ 0..12, 0..12_3 ]'  ❌

After

util.inspect([-0.12, -0.123], { numericSeparator: true })
// Output: '[ -0.12, -0.123 ]'  ✅

Root Cause

The issue was in the formatNumber function where String(Math.trunc(-0.12)) returns "0" instead of "-0", losing the negative sign. The fix uses the original string representation and properly slices integer and fractional parts while preserving the sign.

Testing
<img width="362" height="71" alt="image" src="https://github.com/user-attachments/assets/2ac58bc1-00a2-47ef-880d-8760a0e5d016" />

- ✅ Existing regression test now passes
- ✅ All util.inspect tests pass
- ✅ No breaking changes to existing functionality

Closes #59376