### PR TITLE
http: improve performance of header processessing

### DIFF
--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -29,11 +29,11 @@ const {
 
 const { Readable, finished } = require('stream');
 const {
+  getHeaderFieldLowercase,
   getHeaderType,
   ARRAY_HTTP_HEADER,
   DUPLICATE_ALLOWED_HTTP_HEADER,
   HTTP_HEADER_JOIN_SEMI,
-  getHeaderFieldLowercase,
 } = require('internal/http');
 
 const kHeaders = Symbol('kHeaders');
@@ -314,7 +314,7 @@ function _addHeaderLine(field, value, dest) {
 
 IncomingMessage.prototype._addHeaderLineDistinct = _addHeaderLineDistinct;
 function _addHeaderLineDistinct(field, value, dest) {
-  field = field.toLowerCase();
+  field = getHeaderFieldLowercase(field);
   if (!dest[field]) {
     dest[field] = [value];
   } else {

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -28,6 +28,13 @@ const {
 } = primordials;
 
 const { Readable, finished } = require('stream');
+const {
+  getHeaderType,
+  ARRAY_HTTP_HEADER,
+  DUPLICATE_ALLOWED_HTTP_HEADER,
+  HTTP_HEADER_JOIN_SEMI,
+  getHeaderFieldLowercase,
+} = require('internal/http');
 
 const kHeaders = Symbol('kHeaders');
 const kHeadersDistinct = Symbol('kHeadersDistinct');
@@ -262,113 +269,6 @@ function _addHeaderLines(headers, n) {
   }
 }
 
-
-// This function is used to help avoid the lowercasing of a field name if it
-// matches a 'traditional cased' version of a field name. It then returns the
-// lowercased name to both avoid calling toLowerCase() a second time and to
-// indicate whether the field was a 'no duplicates' field. If a field is not a
-// 'no duplicates' field, a `0` byte is prepended as a flag. The one exception
-// to this is the Set-Cookie header which is indicated by a `1` byte flag, since
-// it is an 'array' field and thus is treated differently in _addHeaderLines().
-// TODO: perhaps http_parser could be returning both raw and lowercased versions
-// of known header names to avoid us having to call toLowerCase() for those
-// headers.
-function matchKnownFields(field, lowercased) {
-  switch (field.length) {
-    case 3:
-      if (field === 'Age' || field === 'age') return 'age';
-      break;
-    case 4:
-      if (field === 'Host' || field === 'host') return 'host';
-      if (field === 'From' || field === 'from') return 'from';
-      if (field === 'ETag' || field === 'etag') return 'etag';
-      if (field === 'Date' || field === 'date') return '\u0000date';
-      if (field === 'Vary' || field === 'vary') return '\u0000vary';
-      break;
-    case 6:
-      if (field === 'Server' || field === 'server') return 'server';
-      if (field === 'Cookie' || field === 'cookie') return '\u0002cookie';
-      if (field === 'Origin' || field === 'origin') return '\u0000origin';
-      if (field === 'Expect' || field === 'expect') return '\u0000expect';
-      if (field === 'Accept' || field === 'accept') return '\u0000accept';
-      break;
-    case 7:
-      if (field === 'Referer' || field === 'referer') return 'referer';
-      if (field === 'Expires' || field === 'expires') return 'expires';
-      if (field === 'Upgrade' || field === 'upgrade') return '\u0000upgrade';
-      break;
-    case 8:
-      if (field === 'Location' || field === 'location')
-        return 'location';
-      if (field === 'If-Match' || field === 'if-match')
-        return '\u0000if-match';
-      break;
-    case 10:
-      if (field === 'User-Agent' || field === 'user-agent')
-        return 'user-agent';
-      if (field === 'Set-Cookie' || field === 'set-cookie')
-        return '\u0001';
-      if (field === 'Connection' || field === 'connection')
-        return '\u0000connection';
-      break;
-    case 11:
-      if (field === 'Retry-After' || field === 'retry-after')
-        return 'retry-after';
-      break;
-    case 12:
-      if (field === 'Content-Type' || field === 'content-type')
-        return 'content-type';
-      if (field === 'Max-Forwards' || field === 'max-forwards')
-        return 'max-forwards';
-      break;
-    case 13:
-      if (field === 'Authorization' || field === 'authorization')
-        return 'authorization';
-      if (field === 'Last-Modified' || field === 'last-modified')
-        return 'last-modified';
-      if (field === 'Cache-Control' || field === 'cache-control')
-        return '\u0000cache-control';
-      if (field === 'If-None-Match' || field === 'if-none-match')
-        return '\u0000if-none-match';
-      break;
-    case 14:
-      if (field === 'Content-Length' || field === 'content-length')
-        return 'content-length';
-      break;
-    case 15:
-      if (field === 'Accept-Encoding' || field === 'accept-encoding')
-        return '\u0000accept-encoding';
-      if (field === 'Accept-Language' || field === 'accept-language')
-        return '\u0000accept-language';
-      if (field === 'X-Forwarded-For' || field === 'x-forwarded-for')
-        return '\u0000x-forwarded-for';
-      break;
-    case 16:
-      if (field === 'Content-Encoding' || field === 'content-encoding')
-        return '\u0000content-encoding';
-      if (field === 'X-Forwarded-Host' || field === 'x-forwarded-host')
-        return '\u0000x-forwarded-host';
-      break;
-    case 17:
-      if (field === 'If-Modified-Since' || field === 'if-modified-since')
-        return 'if-modified-since';
-      if (field === 'Transfer-Encoding' || field === 'transfer-encoding')
-        return '\u0000transfer-encoding';
-      if (field === 'X-Forwarded-Proto' || field === 'x-forwarded-proto')
-        return '\u0000x-forwarded-proto';
-      break;
-    case 19:
-      if (field === 'Proxy-Authorization' || field === 'proxy-authorization')
-        return 'proxy-authorization';
-      if (field === 'If-Unmodified-Since' || field === 'if-unmodified-since')
-        return 'if-unmodified-since';
-      break;
-  }
-  if (lowercased) {
-    return '\u0000' + field;
-  }
-  return matchKnownFields(field.toLowerCase(), true);
-}
 // Add the given (field, value) pair to the message
 //
 // Per RFC2616, section 4.2 it is acceptable to join multiple instances of the
@@ -380,17 +280,16 @@ function matchKnownFields(field, lowercased) {
 // 'x-') are always joined.
 IncomingMessage.prototype._addHeaderLine = _addHeaderLine;
 function _addHeaderLine(field, value, dest) {
-  field = matchKnownFields(field);
-  const flag = field.charCodeAt(0);
-  if (flag === 0 || flag === 2) {
-    field = field.slice(1);
+  field = getHeaderFieldLowercase(field);
+  const type = getHeaderType(field);
+  if (type & DUPLICATE_ALLOWED_HTTP_HEADER) {
     // Make a delimited list
     if (typeof dest[field] === 'string') {
-      dest[field] += (flag === 0 ? ', ' : '; ') + value;
+      dest[field] += (type & HTTP_HEADER_JOIN_SEMI ? '; ' : ', ') + value;
     } else {
       dest[field] = value;
     }
-  } else if (flag === 1) {
+  } else if (type === ARRAY_HTTP_HEADER) {
     // Array header -- only Set-Cookie at the moment
     if (dest['set-cookie'] !== undefined) {
       dest['set-cookie'].push(value);

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -38,7 +38,7 @@ const { getDefaultHighWaterMark } = require('internal/streams/state');
 const assert = require('internal/assert');
 const EE = require('events');
 const Stream = require('stream');
-const { kOutHeaders, utcDate, kNeedDrain } = require('internal/http');
+const { kOutHeaders, utcDate, kNeedDrain, getHeaderFieldLowercase } = require('internal/http');
 const { Buffer } = require('buffer');
 const {
   _checkIsHttpToken: checkIsHttpToken,
@@ -552,7 +552,7 @@ function processHeader(self, state, key, value, validate) {
   if (ArrayIsArray(value)) {
     if (
       (value.length < 2 || !isCookieField(key)) &&
-      (!self[kUniqueHeaders] || !self[kUniqueHeaders].has(key.toLowerCase()))
+      (!self[kUniqueHeaders] || !self[kUniqueHeaders].has(getHeaderFieldLowercase(key)))
     ) {
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
@@ -575,7 +575,7 @@ function storeHeader(self, state, key, value, validate) {
 function matchHeader(self, state, field, value) {
   if (field.length < 4 || field.length > 17)
     return;
-  field = field.toLowerCase();
+  field = getHeaderFieldLowercase(field);
   switch (field) {
     case 'connection':
       state.connection = true;
@@ -631,7 +631,7 @@ function parseUniqueHeadersOption(headers) {
   const unique = new SafeSet();
   const l = headers.length;
   for (let i = 0; i < l; i++) {
-    unique.add(headers[i].toLowerCase());
+    unique.add(getHeaderFieldLowercase(headers[i]));
   }
 
   return unique;
@@ -648,7 +648,7 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
   if (headers === null)
     this[kOutHeaders] = headers = { __proto__: null };
 
-  headers[name.toLowerCase()] = [name, value];
+  headers[getHeaderFieldLowercase(name)] = [name, value];
   return this;
 };
 
@@ -700,7 +700,7 @@ OutgoingMessage.prototype.appendHeader = function appendHeader(name, value) {
   validateHeaderName(name);
   validateHeaderValue(name, value);
 
-  const field = name.toLowerCase();
+  const field = getHeaderFieldLowercase(name);
   const headers = this[kOutHeaders];
   if (headers === null || !headers[field]) {
     return this.setHeader(name, value);
@@ -731,7 +731,7 @@ OutgoingMessage.prototype.getHeader = function getHeader(name) {
   if (headers === null)
     return;
 
-  const entry = headers[name.toLowerCase()];
+  const entry = headers[getHeaderFieldLowercase(name)];
   return entry?.[1];
 };
 
@@ -780,7 +780,7 @@ OutgoingMessage.prototype.getHeaders = function getHeaders() {
 OutgoingMessage.prototype.hasHeader = function hasHeader(name) {
   validateString(name, 'name');
   return this[kOutHeaders] !== null &&
-    !!this[kOutHeaders][name.toLowerCase()];
+    !!this[kOutHeaders][getHeaderFieldLowercase(name)];
 };
 
 
@@ -791,7 +791,7 @@ OutgoingMessage.prototype.removeHeader = function removeHeader(name) {
     throw new ERR_HTTP_HEADERS_SENT('remove');
   }
 
-  const key = name.toLowerCase();
+  const key = getHeaderFieldLowercase(name);
 
   switch (key) {
     case 'connection':
@@ -996,7 +996,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
     const isArrayValue = ArrayIsArray(value);
     if (
       isArrayValue && value.length > 1 &&
-      (!this[kUniqueHeaders] || !this[kUniqueHeaders].has(field.toLowerCase()))
+      (!this[kUniqueHeaders] || !this[kUniqueHeaders].has(getHeaderFieldLowercase(field)))
     ) {
       for (let j = 0, l = value.length; j < l; j++) {
         if (checkInvalidHeaderChar(value[j])) {

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -3,6 +3,7 @@
 const {
   Date,
   NumberParseInt,
+  SafeMap,
   Symbol,
   decodeURIComponent,
 } = primordials;
@@ -238,6 +239,87 @@ function filterEnvForProxies(env) {
   };
 }
 
+/**
+ * @see https://www.iana.org/assignments/http-fields/http-fields.xhtml
+ */
+const IANARegisteredHeaders = [
+  'A-IM', 'Accept', 'Accept-Additions', 'Accept-CH', 'Accept-Charset', 'Accept-Datetime',
+  'Accept-Encoding', 'Accept-Features', 'Accept-Language', 'Accept-Patch', 'Accept-Post', 'Accept-Ranges',
+  'Accept-Signature', 'Access-Control', 'Access-Control-Allow-Credentials', 'Access-Control-Allow-Headers',
+  'Access-Control-Allow-Methods', 'Access-Control-Allow-Origin', 'Access-Control-Expose-Headers',
+  'Access-Control-Max-Age', 'Access-Control-Request-Headers', 'Access-Control-Request-Method',
+  'Activate-Storage-Access', 'Age', 'Allow', 'ALPN', 'Alt-Svc', 'Alt-Used', 'Alternates', 'AMP-Cache-Transform',
+  'Apply-To-Redirect-Ref', 'Authentication-Control', 'Authentication-Info', 'Authorization', 'Available-Dictionary',
+  'C-Ext', 'C-Man', 'C-Opt', 'C-PEP', 'C-PEP-Info', 'Cache-Control', 'Cache-Group-Invalidation', 'Cache-Groups',
+  'Cache-Status', 'Cal-Managed-ID', 'CalDAV-Timezones', 'Capsule-Protocol', 'CDN-Cache-Control', 'CDN-Loop',
+  'Cert-Not-After', 'Cert-Not-Before', 'Clear-Site-Data', 'Client-Cert', 'Client-Cert-Chain', 'Close', 'CMCD-Object',
+  'CMCD-Request', 'CMCD-Session', 'CMCD-Status', 'CMSD-Dynamic', 'CMSD-Static', 'Concealed-Auth-Export',
+  'Configuration-Context', 'Connection', 'Content-Base', 'Content-Digest', 'Content-Disposition', 'Content-Encoding',
+  'Content-ID', 'Content-Language', 'Content-Length', 'Content-Location', 'Content-MD5', 'Content-Range',
+  'Content-Script-Type', 'Content-Security-Policy', 'Content-Security-Policy-Report-Only', 'Content-Style-Type',
+  'Content-Type', 'Content-Version', 'Cookie', 'Cookie2', 'Cross-Origin-Embedder-Policy',
+  'Cross-Origin-Embedder-Policy-Report-Only', 'Cross-Origin-Opener-Policy', 'Cross-Origin-Opener-Policy-Report-Only',
+  'Cross-Origin-Resource-Policy', 'CTA-Common-Access-Token', 'DASL', 'Date', 'DAV', 'Default-Style', 'Delta-Base',
+  'Deprecation', 'Depth', 'Derived-From', 'Destination', 'Detached-JWS', 'Differential-ID', 'Dictionary-ID', 'Digest',
+  'DPoP', 'DPoP-Nonce', 'Early-Data', 'EDIINT-Features', 'ETag', 'Expect', 'Expect-CT', 'Expires', 'Ext', 'Forwarded',
+  'From', 'GetProfile', 'Hobareg', 'Host', 'HTTP2-Settings', 'If', 'If-Match', 'If-Modified-Since', 'If-None-Match',
+  'If-Range', 'If-Schedule-Tag-Match', 'If-Unmodified-Since', 'IM', 'Include-Referred-Token-Binding-ID', 'Isolation',
+  'Keep-Alive', 'Label', 'Last-Event-ID', 'Last-Modified', 'Link', 'Link-Template', 'Location', 'Lock-Token', 'Man',
+  'Max-Forwards', 'Memento-Datetime', 'Meter', 'Method-Check', 'Method-Check-Expires', 'MIME-Version', 'Negotiate',
+  'NEL', 'OData-EntityId', 'OData-Isolation', 'OData-MaxVersion', 'OData-Version', 'Opt', 'Optional-WWW-Authenticate',
+  'Ordering-Type', 'Origin', 'Origin-Agent-Cluster', 'OSCORE', 'OSLC-Core-Version', 'Overwrite', 'P3P', 'PEP',
+  'PEP-Info', 'Permissions-Policy', 'PICS-Label', 'Ping-From', 'Ping-To', 'Position', 'Pragma', 'Prefer',
+  'Preference-Applied', 'Priority', 'ProfileObject', 'Protocol', 'Protocol-Info', 'Protocol-Query',
+  'Protocol-Request', 'Proxy-Authenticate', 'Proxy-Authentication-Info', 'Proxy-Authorization', 'Proxy-Features',
+  'Proxy-Instruction', 'Proxy-Status', 'Public', 'Public-Key-Pins', 'Public-Key-Pins-Report-Only', 'Range',
+  'Redirect-Ref', 'Referer', 'Referer-Root', 'Referrer-Policy', 'Refresh', 'Repeatability-Client-ID',
+  'Repeatability-First-Sent', 'Repeatability-Request-ID', 'Repeatability-Result', 'Replay-Nonce',
+  'Reporting-Endpoints', 'Repr-Digest', 'Retry-After', 'Safe', 'Schedule-Reply', 'Schedule-Tag', 'Sec-Fetch-Dest',
+  'Sec-Fetch-Mode', 'Sec-Fetch-Site', 'Sec-Fetch-Storage-Access', 'Sec-Fetch-User', 'Sec-GPC', 'Sec-Purpose',
+  'Sec-Token-Binding', 'Sec-WebSocket-Accept', 'Sec-WebSocket-Extensions', 'Sec-WebSocket-Key',
+  'Sec-WebSocket-Protocol', 'Sec-WebSocket-Version', 'Security-Scheme', 'Server', 'Server-Timing', 'Set-Cookie',
+  'Set-Cookie2', 'SetProfile', 'Signature', 'Signature-Input', 'SLUG', 'SoapAction', 'Status-URI',
+  'Strict-Transport-Security', 'Sunset', 'Surrogate-Capability', 'Surrogate-Control', 'TCN', 'TE', 'Timeout',
+  'Timing-Allow-Origin', 'Topic', 'Traceparent', 'Tracestate', 'Trailer', 'Transfer-Encoding', 'TTL', 'Upgrade',
+  'Urgency', 'URI', 'Use-As-Dictionary', 'User-Agent', 'Variant-Vary', 'Vary', 'Via', 'Want-Content-Digest',
+  'Want-Digest', 'Want-Repr-Digest', 'Warning', 'WWW-Authenticate', 'X-Content-Type-Options', 'X-Frame-Options',
+];
+
+
+const IANAHTTPHeaders = new SafeMap([
+  ...IANARegisteredHeaders.map((fieldname) => ([fieldname, fieldname.toLowerCase()])),
+  ...IANARegisteredHeaders.map((fieldname) => ([fieldname.toLowerCase(), fieldname.toLowerCase()])),
+]);
+
+const DUPLICATE_ALLOWED_HTTP_HEADER = 0b0001;
+const HTTP_HEADER_JOIN_SEMI = 0b0010;
+const NO_DUPLICATE_ALLOWED_HTTP_HEADER = 0b0100;
+const ARRAY_HTTP_HEADER = 0b1000;
+const DUPLICATE_ALLOWED_HTTP_HEADER_SEMI = DUPLICATE_ALLOWED_HTTP_HEADER | HTTP_HEADER_JOIN_SEMI;
+
+const noDuplicatesAllowedHeaders = [
+  'age', 'host', 'from', 'etag', 'server', 'referer', 'expires',
+  'location', 'user-agent', 'retry-after', 'content-type',
+  'max-forwards', 'authorization', 'last-modified',
+  'content-length', 'if-modified-since', 'proxy-authorization',
+  'if-unmodified-since',
+];
+
+const HeaderTypeMap = new SafeMap(
+  [
+    ...noDuplicatesAllowedHeaders.map((fieldname) => ([fieldname, NO_DUPLICATE_ALLOWED_HTTP_HEADER])),
+    ['set-cookie', ARRAY_HTTP_HEADER],
+    ['cookie', DUPLICATE_ALLOWED_HTTP_HEADER_SEMI],
+  ]);
+
+function getHeaderFieldLowercase(field) {
+  return IANAHTTPHeaders.get(field) ?? field.toLowerCase();
+}
+
+function getHeaderType(header) {
+  return HeaderTypeMap.get(header) || DUPLICATE_ALLOWED_HTTP_HEADER;
+}
+
 module.exports = {
   kOutHeaders: Symbol('kOutHeaders'),
   kNeedDrain: Symbol('kNeedDrain'),
@@ -251,4 +333,11 @@ module.exports = {
   getNextTraceEventId,
   isTraceHTTPEnabled,
   filterEnvForProxies,
+  getHeaderFieldLowercase,
+  getHeaderType,
+  NO_DUPLICATE_ALLOWED_HTTP_HEADER,
+  DUPLICATE_ALLOWED_HTTP_HEADER,
+  ARRAY_HTTP_HEADER,
+  HTTP_HEADER_JOIN_SEMI,
+  DUPLICATE_ALLOWED_HTTP_HEADER_SEMI,
 };


### PR DESCRIPTION
@nodejs/performance

I think this should improve the performance for processing the headers. This is what my local benchmarks show. Maybe we can get some better assessment of the impact by running the benchmarks...

before:
```sh
aras@aras-HP-ZBook-15-G3:~/workspace/node$ ./node benchmark/http/headers.js 
http/headers.js group="fewHeaders" duration=5 len=1 n=10 benchmarker="test-double-http": 37,985
http/headers.js group="fewHeaders" duration=5 len=5 n=10 benchmarker="test-double-http": 40,182
http/headers.js group="mediumHeaders" duration=5 len=1 n=50 benchmarker="test-double-http": 30,288
http/headers.js group="mediumHeaders" duration=5 len=10 n=50 benchmarker="test-double-http": 31,641
http/headers.js group="manyHeaders" duration=5 len=1 n=600 benchmarker="test-double-http": 6,420
http/headers.js group="manyHeaders" duration=5 len=100 n=600 benchmarker="test-double-http": 7,991
```

```sh
aras@aras-HP-ZBook-15-G3:~/workspace/node$ ./node benchmark/http/incoming_headers.js 
http/incoming_headers.js duration=5 w=0 headers=20 connections=50 benchmarker="test-double-http": 38,762
http/incoming_headers.js duration=5 w=6 headers=20 connections=50 benchmarker="test-double-http": 42,223
```

after:

```sh
aras@aras-HP-ZBook-15-G3:~/workspace/node$ ./node benchmark/http/headers.js 
http/headers.js group="fewHeaders" duration=5 len=1 n=10 benchmarker="test-double-http": 40,371
http/headers.js group="fewHeaders" duration=5 len=5 n=10 benchmarker="test-double-http": 41,027
http/headers.js group="mediumHeaders" duration=5 len=1 n=50 benchmarker="test-double-http": 30,142
http/headers.js group="mediumHeaders" duration=5 len=10 n=50 benchmarker="test-double-http": 34,608
http/headers.js group="manyHeaders" duration=5 len=1 n=600 benchmarker="test-double-http": 7,226
http/headers.js group="manyHeaders" duration=5 len=100 n=600 benchmarker="test-double-http": 10,551
```

```sh
aras@aras-HP-ZBook-15-G3:~/workspace/node$ ./node benchmark/http/incoming_headers.js 
http/incoming_headers.js duration=5 w=0 headers=20 connections=50 benchmarker="test-double-http": 43,544
http/incoming_headers.js duration=5 w=6 headers=20 connections=50 benchmarker="test-double-http": 43,428
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
