### PR TITLE
test,crypto: skip unsupported ciphers

### DIFF
--- a/test/parallel/test-crypto-aes-wrap.js
+++ b/test/parallel/test-crypto-aes-wrap.js
@@ -53,6 +53,11 @@ const key3 = Buffer.from('29c9eab5ed5ad44134a1437fe2e673b4d88a5b7c72e68454fea087
     text: '12345678123456781234567812345678123'
   },
 ].forEach(({ algorithm, key, iv, text }) => {
+  if (!crypto.getCiphers().includes(algorithm)) {
+    common.printSkipMessage(`Skipping unsupported ${algorithm} test case`);
+    return;
+  }
+
   const cipher = crypto.createCipheriv(algorithm, key, iv);
   const decipher = crypto.createDecipheriv(algorithm, key, iv);
   const msg = decipher.update(cipher.update(text, 'utf8'), 'buffer', 'utf8');

--- a/test/parallel/test-crypto-authenticated-stream.js
+++ b/test/parallel/test-crypto-authenticated-stream.js
@@ -115,6 +115,11 @@ function fstream(config) {
 fstream.count = 0;
 
 function test(config) {
+  if (!crypto.getCiphers().includes(config.cipher)) {
+    common.printSkipMessage(`unsupported cipher: ${config.cipher}`);
+    return;
+  }
+
   direct(config);
   mstream(config);
   fstream(config);

--- a/test/parallel/test-crypto-default-shake-lengths.js
+++ b/test/parallel/test-crypto-default-shake-lengths.js
@@ -4,6 +4,12 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const crypto = require('crypto');
+if (!crypto.getCiphers().includes('shake128')) {
+  common.printSkipMessage('unsupported shake128 test');
+  return;
+}
+
 const { createHash } = require('crypto');
 
 common.expectWarning({

--- a/test/parallel/test-crypto-default-shake-lengths.js
+++ b/test/parallel/test-crypto-default-shake-lengths.js
@@ -5,7 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const crypto = require('crypto');
-if (!crypto.getCiphers().includes('shake128')) {
+if (!crypto.getHashes().includes('shake128')) {
   common.skip('unsupported shake128 test');
 }
 

--- a/test/parallel/test-crypto-default-shake-lengths.js
+++ b/test/parallel/test-crypto-default-shake-lengths.js
@@ -6,8 +6,7 @@ if (!common.hasCrypto)
 
 const crypto = require('crypto');
 if (!crypto.getCiphers().includes('shake128')) {
-  common.printSkipMessage('unsupported shake128 test');
-  return;
+  common.skip('unsupported shake128 test');
 }
 
 const { createHash } = require('crypto');

--- a/test/parallel/test-crypto-des3-wrap.js
+++ b/test/parallel/test-crypto-des3-wrap.js
@@ -6,6 +6,10 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
+const ciphers = crypto.getCiphers();
+if (!ciphers.includes('des3-wrap'))
+  common.skip('des3-wrap cipher is not available');
+
 // Test case for des-ede3 wrap/unwrap. des3-wrap needs extra 2x blocksize
 // then plaintext to store ciphertext.
 const test = {

--- a/test/parallel/test-crypto-ecb.js
+++ b/test/parallel/test-crypto-ecb.js
@@ -37,6 +37,10 @@ if (hasOpenSSL3) {
     'OpenSSl 3.x');
 }
 
+if (!crypto.getCiphers().includes('BF-ECB')) {
+  common.skip('BF-ECB cipher is not available');
+}
+
 const assert = require('assert');
 
 // Testing whether EVP_CipherInit_ex is functioning correctly.

--- a/test/parallel/test-crypto-padding-aes256.js
+++ b/test/parallel/test-crypto-padding-aes256.js
@@ -27,6 +27,9 @@ if (!common.hasCrypto)
 const assert = require('assert');
 const crypto = require('crypto');
 
+if (!crypto.getCiphers().includes('aes256'))
+  common.skip('aes256 cipher is not available');
+
 const iv = Buffer.from('00000000000000000000000000000000', 'hex');
 const key = Buffer.from('0123456789abcdef0123456789abcdef' +
                         '0123456789abcdef0123456789abcdef', 'hex');


### PR DESCRIPTION
Skip unsupported ciphers in some crypto tests. Improves BoringSSL compatibility.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
