### PR TITLE
esm: use index-based resolution callbacks

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-script.h
+++ b/deps/v8/include/v8-script.h
@@ -220,6 +220,13 @@ class V8_EXPORT Module : public Data {
       Local<Context> context, Local<String> specifier,
       Local<FixedArray> import_attributes, Local<Module> referrer);
 
+  using ResolveModuleByIndexCallback = MaybeLocal<Module> (*)(
+      Local<Context> context, size_t module_request_index,
+      Local<Module> referrer);
+  using ResolveSourceByIndexCallback = MaybeLocal<Object> (*)(
+      Local<Context> context, size_t module_request_index,
+      Local<Module> referrer);
+
   /**
    * Instantiates the module and its dependencies.
    *
@@ -230,6 +237,16 @@ class V8_EXPORT Module : public Data {
   V8_WARN_UNUSED_RESULT Maybe<bool> InstantiateModule(
       Local<Context> context, ResolveModuleCallback module_callback,
       ResolveSourceCallback source_callback = nullptr);
+
+  /**
+   * Similar to the variant that takes ResolveModuleCallback and
+   * ResolveSourceCallback, but uses the index into the array that is returned
+   * by GetModuleRequests() instead of the specifier and import attributes to
+   * identify the requests.
+   */
+  V8_WARN_UNUSED_RESULT Maybe<bool> InstantiateModule(
+      Local<Context> context, ResolveModuleByIndexCallback module_callback,
+      ResolveSourceByIndexCallback source_callback = nullptr);
 
   /**
    * Evaluates the module and its dependencies.

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -2245,14 +2245,33 @@ int Module::GetIdentityHash() const {
   return self->hash();
 }
 
+Maybe<bool> Module::InstantiateModule(
+    Local<Context> context, ResolveModuleByIndexCallback module_callback,
+    ResolveSourceByIndexCallback source_callback) {
+  auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
+  ENTER_V8(i_isolate, context, Module, InstantiateModule, i::HandleScope);
+
+  i::Module::UserResolveCallbacks callbacks;
+  callbacks.module_callback_by_index = module_callback;
+  callbacks.source_callback_by_index = source_callback;
+  has_exception =
+      !i::Module::Instantiate(i_isolate, Utils::OpenHandle(this), context,
+                              callbacks);
+  RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
+  return Just(true);
+}
+
 Maybe<bool> Module::InstantiateModule(Local<Context> context,
                                       ResolveModuleCallback module_callback,
                                       ResolveSourceCallback source_callback) {
   auto i_isolate = reinterpret_cast<i::Isolate*>(context->GetIsolate());
   ENTER_V8(i_isolate, context, Module, InstantiateModule, i::HandleScope);
+  i::Module::UserResolveCallbacks callbacks;
+  callbacks.module_callback = module_callback;
+  callbacks.source_callback = source_callback;
   has_exception =
       !i::Module::Instantiate(i_isolate, Utils::OpenHandle(this), context,
-                              module_callback, source_callback);
+                              callbacks);
   RETURN_ON_FAILED_EXECUTION_PRIMITIVE(bool);
   return Just(true);
 }

--- a/deps/v8/src/objects/module.cc
+++ b/deps/v8/src/objects/module.cc
@@ -205,14 +205,12 @@ MaybeHandle<Cell> Module::ResolveExport(Isolate* isolate, Handle<Module> module,
 
 bool Module::Instantiate(Isolate* isolate, Handle<Module> module,
                          v8::Local<v8::Context> context,
-                         v8::Module::ResolveModuleCallback module_callback,
-                         v8::Module::ResolveSourceCallback source_callback) {
+                         Module::UserResolveCallbacks callbacks) {
 #ifdef DEBUG
   PrintStatusMessage(*module, "Instantiating module ");
 #endif  // DEBUG
 
-  if (!PrepareInstantiate(isolate, module, context, module_callback,
-                          source_callback)) {
+  if (!PrepareInstantiate(isolate, module, context, callbacks)) {
     ResetGraph(isolate, module);
     DCHECK_EQ(module->status(), kUnlinked);
     return false;
@@ -231,11 +229,9 @@ bool Module::Instantiate(Isolate* isolate, Handle<Module> module,
   return true;
 }
 
-bool Module::PrepareInstantiate(
-    Isolate* isolate, DirectHandle<Module> module,
-    v8::Local<v8::Context> context,
-    v8::Module::ResolveModuleCallback module_callback,
-    v8::Module::ResolveSourceCallback source_callback) {
+bool Module::PrepareInstantiate(Isolate* isolate, DirectHandle<Module> module,
+                                v8::Local<v8::Context> context,
+                                UserResolveCallbacks callbacks) {
   DCHECK_NE(module->status(), kEvaluating);
   DCHECK_NE(module->status(), kLinking);
   if (module->status() >= kPreLinking) return true;
@@ -244,8 +240,7 @@ bool Module::PrepareInstantiate(
 
   if (IsSourceTextModule(*module)) {
     return SourceTextModule::PrepareInstantiate(
-        isolate, Cast<SourceTextModule>(module), context, module_callback,
-        source_callback);
+        isolate, Cast<SourceTextModule>(module), context, callbacks);
   } else {
     return SyntheticModule::PrepareInstantiate(
         isolate, Cast<SyntheticModule>(module), context);

--- a/deps/v8/src/objects/module.h
+++ b/deps/v8/src/objects/module.h
@@ -58,14 +58,21 @@ class Module : public TorqueGeneratedModule<Module, HeapObject> {
   // i.e. has a top-level await.
   V8_WARN_UNUSED_RESULT bool IsGraphAsync(Isolate* isolate) const;
 
+  struct UserResolveCallbacks {
+    v8::Module::ResolveModuleCallback module_callback = nullptr;
+    v8::Module::ResolveSourceCallback source_callback = nullptr;
+    v8::Module::ResolveModuleByIndexCallback module_callback_by_index = nullptr;
+    v8::Module::ResolveSourceByIndexCallback source_callback_by_index = nullptr;
+  };
+
   // Implementation of spec operation ModuleDeclarationInstantiation.
   // Returns false if an exception occurred during instantiation, true
   // otherwise. (In the case where the callback throws an exception, that
   // exception is propagated.)
-  static V8_WARN_UNUSED_RESULT bool Instantiate(
-      Isolate* isolate, Handle<Module> module, v8::Local<v8::Context> context,
-      v8::Module::ResolveModuleCallback module_callback,
-      v8::Module::ResolveSourceCallback source_callback);
+  static V8_WARN_UNUSED_RESULT bool Instantiate(Isolate* isolate,
+                                                Handle<Module> module,
+                                                v8::Local<v8::Context> context,
+                                                UserResolveCallbacks callbacks);
 
   // Implementation of spec operation ModuleEvaluation.
   static V8_WARN_UNUSED_RESULT MaybeDirectHandle<Object> Evaluate(
@@ -100,9 +107,7 @@ class Module : public TorqueGeneratedModule<Module, HeapObject> {
 
   static V8_WARN_UNUSED_RESULT bool PrepareInstantiate(
       Isolate* isolate, DirectHandle<Module> module,
-      v8::Local<v8::Context> context,
-      v8::Module::ResolveModuleCallback module_callback,
-      v8::Module::ResolveSourceCallback source_callback);
+      v8::Local<v8::Context> context, UserResolveCallbacks callbacks);
   static V8_WARN_UNUSED_RESULT bool FinishInstantiate(
       Isolate* isolate, Handle<Module> module,
       ZoneForwardList<Handle<SourceTextModule>>* stack, unsigned* dfs_index,

--- a/deps/v8/src/objects/source-text-module.cc
+++ b/deps/v8/src/objects/source-text-module.cc
@@ -345,10 +345,10 @@ MaybeHandle<Cell> SourceTextModule::ResolveExportUsingStarExports(
 
 bool SourceTextModule::PrepareInstantiate(
     Isolate* isolate, DirectHandle<SourceTextModule> module,
-    v8::Local<v8::Context> context,
-    v8::Module::ResolveModuleCallback module_callback,
-    v8::Module::ResolveSourceCallback source_callback) {
-  DCHECK_NE(module_callback, nullptr);
+    v8::Local<v8::Context> context, Module::UserResolveCallbacks callbacks) {
+  // One of the callbacks must be set, otherwise we cannot resolve.
+  DCHECK_IMPLIES(callbacks.module_callback == nullptr,
+                 callbacks.module_callback_by_index != nullptr);
   // Obtain requested modules.
   DirectHandle<SourceTextModuleInfo> module_info(module->info(), isolate);
   DirectHandle<FixedArray> module_requests(module_info->module_requests(),
@@ -364,11 +364,23 @@ bool SourceTextModule::PrepareInstantiate(
     switch (module_request->phase()) {
       case ModuleImportPhase::kEvaluation: {
         v8::Local<v8::Module> api_requested_module;
-        if (!module_callback(context, v8::Utils::ToLocal(specifier),
-                             v8::Utils::FixedArrayToLocal(import_attributes),
-                             v8::Utils::ToLocal(Cast<Module>(module)))
-                 .ToLocal(&api_requested_module)) {
-          return false;
+        if (callbacks.module_callback != nullptr) {
+          if (!callbacks
+                   .module_callback(
+                       context, v8::Utils::ToLocal(specifier),
+                       v8::Utils::FixedArrayToLocal(import_attributes),
+                       v8::Utils::ToLocal(Cast<Module>(module)))
+                   .ToLocal(&api_requested_module)) {
+            return false;
+          }
+        } else {
+          DCHECK_NOT_NULL(callbacks.module_callback_by_index);
+          if (!callbacks
+                   .module_callback_by_index(
+                       context, i, v8::Utils::ToLocal(Cast<Module>(module)))
+                   .ToLocal(&api_requested_module)) {
+            return false;
+          }
         }
         DirectHandle<Module> requested_module =
             Utils::OpenDirectHandle(*api_requested_module);
@@ -378,11 +390,23 @@ bool SourceTextModule::PrepareInstantiate(
       case ModuleImportPhase::kSource: {
         DCHECK(v8_flags.js_source_phase_imports);
         v8::Local<v8::Object> api_requested_module_source;
-        if (!source_callback(context, v8::Utils::ToLocal(specifier),
-                             v8::Utils::FixedArrayToLocal(import_attributes),
-                             v8::Utils::ToLocal(Cast<Module>(module)))
-                 .ToLocal(&api_requested_module_source)) {
-          return false;
+        if (callbacks.source_callback != nullptr) {
+          if (!callbacks
+                   .source_callback(
+                       context, v8::Utils::ToLocal(specifier),
+                       v8::Utils::FixedArrayToLocal(import_attributes),
+                       v8::Utils::ToLocal(Cast<Module>(module)))
+                   .ToLocal(&api_requested_module_source)) {
+            return false;
+          }
+        } else {
+          DCHECK_NOT_NULL(callbacks.source_callback_by_index);
+          if (!callbacks
+                   .source_callback_by_index(
+                       context, i, v8::Utils::ToLocal(Cast<Module>(module)))
+                   .ToLocal(&api_requested_module_source)) {
+            return false;
+          }
         }
         DirectHandle<JSReceiver> requested_module_source =
             Utils::OpenDirectHandle(*api_requested_module_source);
@@ -404,7 +428,7 @@ bool SourceTextModule::PrepareInstantiate(
     DirectHandle<Module> requested_module(
         Cast<Module>(requested_modules->get(i)), isolate);
     if (!Module::PrepareInstantiate(isolate, requested_module, context,
-                                    module_callback, source_callback)) {
+                                    callbacks)) {
       return false;
     }
   }

--- a/deps/v8/src/objects/source-text-module.h
+++ b/deps/v8/src/objects/source-text-module.h
@@ -172,9 +172,7 @@ class SourceTextModule
 
   static V8_WARN_UNUSED_RESULT bool PrepareInstantiate(
       Isolate* isolate, DirectHandle<SourceTextModule> module,
-      v8::Local<v8::Context> context,
-      v8::Module::ResolveModuleCallback module_callback,
-      v8::Module::ResolveSourceCallback source_callback);
+      v8::Local<v8::Context> context, Module::UserResolveCallbacks callbacks);
   static V8_WARN_UNUSED_RESULT bool FinishInstantiate(
       Isolate* isolate, Handle<SourceTextModule> module,
       ZoneForwardList<Handle<SourceTextModule>>* stack, unsigned* dfs_index,

--- a/deps/v8/test/unittests/objects/modules-unittest.cc
+++ b/deps/v8/test/unittests/objects/modules-unittest.cc
@@ -1259,4 +1259,334 @@ TEST_F(ModuleTest, AsyncEvaluatingInEvaluateEntryPoint) {
   CHECK_EQ(v8::Promise::kFulfilled, promise1->State());
 }
 
+// Test data for index-based module resolution
+static std::vector<v8::Global<Module>> index_modules_global;
+
+MaybeLocal<Module> ResolveByIndexCallback(Local<Context> context,
+                                          size_t module_request_index,
+                                          Local<Module> referrer) {
+  Isolate* isolate = Isolate::GetCurrent();
+  if (module_request_index < index_modules_global.size()) {
+    return index_modules_global[module_request_index].Get(isolate);
+  } else {
+    isolate->ThrowException(
+        String::NewFromUtf8(isolate, "module index out of bounds")
+            .ToLocalChecked());
+    return MaybeLocal<Module>();
+  }
+}
+
+TEST_F(ModuleTest, ModuleInstantiationByIndex) {
+  HandleScope scope(isolate());
+  v8::TryCatch try_catch(isolate());
+
+  // Clear any previous modules
+  for (auto& module : index_modules_global) {
+    module.Reset();
+  }
+  index_modules_global.clear();
+
+  Local<Module> module;
+  {
+    Local<String> source_text = NewString(
+        "import './dep1.js';\n"
+        "export {} from './dep2.js';");
+    ScriptOrigin origin = ModuleOrigin(NewString("main.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    module = ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    CHECK_EQ(Module::kUninstantiated, module->GetStatus());
+
+    Local<FixedArray> module_requests = module->GetModuleRequests();
+    CHECK_EQ(2, module_requests->Length());
+
+    // Verify the requests are in expected order
+    Local<ModuleRequest> module_request_0 =
+        module_requests->Get(context(), 0).As<ModuleRequest>();
+    CHECK(
+        NewString("./dep1.js")->StrictEquals(module_request_0->GetSpecifier()));
+
+    Local<ModuleRequest> module_request_1 =
+        module_requests->Get(context(), 1).As<ModuleRequest>();
+    CHECK(
+        NewString("./dep2.js")->StrictEquals(module_request_1->GetSpecifier()));
+  }
+
+  // Create dependency modules to be resolved by index
+  {
+    Local<String> source_text = NewString("export const x = 42;");
+    ScriptOrigin origin = ModuleOrigin(NewString("dep1.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> dep1 =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), dep1);
+  }
+
+  {
+    Local<String> source_text = NewString("export const y = 24;");
+    ScriptOrigin origin = ModuleOrigin(NewString("dep2.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> dep2 =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), dep2);
+  }
+
+  // Instantiate using index-based callback
+  CHECK(
+      module->InstantiateModule(context(), ResolveByIndexCallback).FromJust());
+  CHECK_EQ(Module::kInstantiated, module->GetStatus());
+
+  // Verify evaluation works
+  MaybeLocal<Value> result = module->Evaluate(context());
+  CHECK_EQ(Module::kEvaluated, module->GetStatus());
+  Local<Promise> promise = Local<Promise>::Cast(result.ToLocalChecked());
+  CHECK_EQ(promise->State(), v8::Promise::kFulfilled);
+
+  CHECK(!try_catch.HasCaught());
+
+  // Clean up
+  for (auto& mod : index_modules_global) {
+    mod.Reset();
+  }
+  index_modules_global.clear();
+}
+
+TEST_F(ModuleTest, ModuleInstantiationByIndexFailure) {
+  HandleScope scope(isolate());
+  v8::TryCatch try_catch(isolate());
+
+  // Clear any previous modules
+  for (auto& module : index_modules_global) {
+    module.Reset();
+  }
+  index_modules_global.clear();
+
+  Local<Module> module;
+  {
+    Local<String> source_text = NewString(
+        "import './dep1.js';\n"
+        "import './dep2.js';\n"
+        "import './dep3.js';");
+    ScriptOrigin origin = ModuleOrigin(NewString("main.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    module = ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    CHECK_EQ(Module::kUninstantiated, module->GetStatus());
+
+    Local<FixedArray> module_requests = module->GetModuleRequests();
+    CHECK_EQ(3, module_requests->Length());
+  }
+
+  // Only provide 2 modules, so index 2 will fail
+  {
+    Local<String> source_text = NewString("export const x = 1;");
+    ScriptOrigin origin = ModuleOrigin(NewString("dep1.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> dep1 =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), dep1);
+  }
+
+  {
+    Local<String> source_text = NewString("export const y = 2;");
+    ScriptOrigin origin = ModuleOrigin(NewString("dep2.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> dep2 =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), dep2);
+  }
+
+  // Instantiation should fail when trying to resolve index 2
+  {
+    v8::TryCatch inner_try_catch(isolate());
+    CHECK(module->InstantiateModule(context(), ResolveByIndexCallback)
+              .IsNothing());
+    CHECK(inner_try_catch.HasCaught());
+    CHECK(inner_try_catch.Exception()->StrictEquals(
+        NewString("module index out of bounds")));
+    CHECK_EQ(Module::kUninstantiated, module->GetStatus());
+  }
+
+  CHECK(!try_catch.HasCaught());
+
+  // Clean up
+  for (auto& mod : index_modules_global) {
+    mod.Reset();
+  }
+  index_modules_global.clear();
+}
+
+TEST_F(ModuleTest, ModuleInstantiationByIndexWithImportAttributes) {
+  bool prev_import_attributes = i::v8_flags.harmony_import_attributes;
+  i::v8_flags.harmony_import_attributes = true;
+  HandleScope scope(isolate());
+  v8::TryCatch try_catch(isolate());
+
+  // Clear any previous modules
+  for (auto& module : index_modules_global) {
+    module.Reset();
+  }
+  index_modules_global.clear();
+
+  Local<Module> module;
+  {
+    Local<String> source_text = NewString(
+        "import './foo.js' with { };\n"
+        "export {} from './bar.js' with { type: 'json' };");
+    ScriptOrigin origin = ModuleOrigin(NewString("main.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    module = ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    CHECK_EQ(Module::kUninstantiated, module->GetStatus());
+
+    Local<FixedArray> module_requests = module->GetModuleRequests();
+    CHECK_EQ(2, module_requests->Length());
+
+    // Verify first request (no attributes)
+    Local<ModuleRequest> module_request_0 =
+        module_requests->Get(context(), 0).As<ModuleRequest>();
+    CHECK(
+        NewString("./foo.js")->StrictEquals(module_request_0->GetSpecifier()));
+    CHECK_EQ(0, module_request_0->GetImportAttributes()->Length());
+
+    // Verify second request (with attributes)
+    Local<ModuleRequest> module_request_1 =
+        module_requests->Get(context(), 1).As<ModuleRequest>();
+    CHECK(
+        NewString("./bar.js")->StrictEquals(module_request_1->GetSpecifier()));
+    Local<FixedArray> import_attributes_1 =
+        module_request_1->GetImportAttributes();
+    CHECK_EQ(3, import_attributes_1->Length());
+    Local<String> attribute_key =
+        import_attributes_1->Get(context(), 0).As<String>();
+    CHECK(NewString("type")->StrictEquals(attribute_key));
+    Local<String> attribute_value =
+        import_attributes_1->Get(context(), 1).As<String>();
+    CHECK(NewString("json")->StrictEquals(attribute_value));
+  }
+
+  // Create dependency modules
+  {
+    Local<String> source_text = NewString("export const foo = 'hello';");
+    ScriptOrigin origin = ModuleOrigin(NewString("foo.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> foo_module =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), foo_module);
+  }
+
+  {
+    Local<String> source_text = NewString("export const bar = 'world';");
+    ScriptOrigin origin = ModuleOrigin(NewString("bar.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    Local<Module> bar_module =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+    index_modules_global.emplace_back(isolate(), bar_module);
+  }
+
+  // Instantiate using index-based callback
+  CHECK(
+      module->InstantiateModule(context(), ResolveByIndexCallback).FromJust());
+  CHECK_EQ(Module::kInstantiated, module->GetStatus());
+
+  // Verify evaluation works
+  MaybeLocal<Value> result = module->Evaluate(context());
+  CHECK_EQ(Module::kEvaluated, module->GetStatus());
+  Local<Promise> promise = Local<Promise>::Cast(result.ToLocalChecked());
+  CHECK_EQ(promise->State(), v8::Promise::kFulfilled);
+
+  CHECK(!try_catch.HasCaught());
+  i::v8_flags.harmony_import_attributes = prev_import_attributes;
+
+  // Clean up
+  for (auto& mod : index_modules_global) {
+    mod.Reset();
+  }
+  index_modules_global.clear();
+}
+
+TEST_F(ModuleTest, ModuleInstantiationByIndexComparedToSpecifier) {
+  HandleScope scope(isolate());
+  v8::TryCatch try_catch(isolate());
+
+  // Test that both methods produce equivalent results
+  Local<Module> module_by_specifier, module_by_index;
+
+  // Create identical modules for both tests
+  Local<String> source_text = NewString(
+      "import './dep1.js';\n"
+      "export const result = 'test';");
+
+  {
+    ScriptOrigin origin = ModuleOrigin(NewString("main1.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    module_by_specifier =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+  }
+
+  {
+    ScriptOrigin origin = ModuleOrigin(NewString("main2.js"), isolate());
+    ScriptCompiler::Source source(source_text, origin);
+    module_by_index =
+        ScriptCompiler::CompileModule(isolate(), &source).ToLocalChecked();
+  }
+
+  // Create dependency for specifier-based resolution
+  {
+    Local<String> dep_source = NewString("export const dep = 'dependency';");
+    ScriptOrigin dep_origin = ModuleOrigin(NewString("dep1.js"), isolate());
+    ScriptCompiler::Source dep_source_obj(dep_source, dep_origin);
+    Local<Module> dep1 =
+        ScriptCompiler::CompileModule(isolate(), &dep_source_obj)
+            .ToLocalChecked();
+    dep1_global.Reset(isolate(), dep1);
+  }
+
+  // Create dependency for index-based resolution
+  {
+    Local<String> dep_source = NewString("export const dep = 'dependency';");
+    ScriptOrigin dep_origin = ModuleOrigin(NewString("dep1.js"), isolate());
+    ScriptCompiler::Source dep_source_obj(dep_source, dep_origin);
+    Local<Module> dep1 =
+        ScriptCompiler::CompileModule(isolate(), &dep_source_obj)
+            .ToLocalChecked();
+
+    // Clear previous modules and add this one
+    for (auto& module : index_modules_global) {
+      module.Reset();
+    }
+    index_modules_global.clear();
+    index_modules_global.emplace_back(isolate(), dep1);
+  }
+
+  // Instantiate both modules
+  CHECK(module_by_specifier->InstantiateModule(context(), ResolveCallback)
+            .FromJust());
+  CHECK(module_by_index->InstantiateModule(context(), ResolveByIndexCallback)
+            .FromJust());
+
+  // Both should be instantiated
+  CHECK_EQ(Module::kInstantiated, module_by_specifier->GetStatus());
+  CHECK_EQ(Module::kInstantiated, module_by_index->GetStatus());
+
+  // Both should evaluate successfully
+  MaybeLocal<Value> result1 = module_by_specifier->Evaluate(context());
+  MaybeLocal<Value> result2 = module_by_index->Evaluate(context());
+
+  CHECK_EQ(Module::kEvaluated, module_by_specifier->GetStatus());
+  CHECK_EQ(Module::kEvaluated, module_by_index->GetStatus());
+
+  Local<Promise> promise1 = Local<Promise>::Cast(result1.ToLocalChecked());
+  Local<Promise> promise2 = Local<Promise>::Cast(result2.ToLocalChecked());
+
+  CHECK_EQ(promise1->State(), v8::Promise::kFulfilled);
+  CHECK_EQ(promise2->State(), v8::Promise::kFulfilled);
+
+  CHECK(!try_catch.HasCaught());
+
+  // Clean up
+  dep1_global.Reset();
+  for (auto& mod : index_modules_global) {
+    mod.Reset();
+  }
+  index_modules_global.clear();
+}
+
 }  // anonymous namespace

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -72,49 +72,6 @@ void ModuleCacheKey::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("import_attributes", import_attributes);
 }
 
-template <int elements_per_attribute>
-ModuleCacheKey ModuleCacheKey::From(Local<Context> context,
-                                    Local<String> specifier,
-                                    Local<FixedArray> import_attributes) {
-  CHECK_EQ(import_attributes->Length() % elements_per_attribute, 0);
-  Isolate* isolate = context->GetIsolate();
-  std::size_t h1 = specifier->GetIdentityHash();
-  size_t num_attributes = import_attributes->Length() / elements_per_attribute;
-  ImportAttributeVector attributes;
-  attributes.reserve(num_attributes);
-
-  std::size_t h2 = 0;
-
-  for (int i = 0; i < import_attributes->Length();
-       i += elements_per_attribute) {
-    DCHECK(DataIsString(import_attributes->Get(context, i)));
-    DCHECK(DataIsString(import_attributes->Get(context, i + 1)));
-
-    Local<String> v8_key = import_attributes->Get(context, i).As<String>();
-    Local<String> v8_value =
-        import_attributes->Get(context, i + 1).As<String>();
-    Utf8Value key_utf8(isolate, v8_key);
-    Utf8Value value_utf8(isolate, v8_value);
-
-    attributes.emplace_back(key_utf8.ToString(), value_utf8.ToString());
-    h2 ^= v8_key->GetIdentityHash();
-    h2 ^= v8_value->GetIdentityHash();
-  }
-
-  // Combine the hashes using a simple XOR and bit shift to reduce
-  // collisions. Note that the hash does not guarantee uniqueness.
-  std::size_t hash = h1 ^ (h2 << 1);
-
-  Utf8Value utf8_specifier(isolate, specifier);
-  return ModuleCacheKey{utf8_specifier.ToString(), attributes, hash};
-}
-
-ModuleCacheKey ModuleCacheKey::From(Local<Context> context,
-                                    Local<ModuleRequest> v8_request) {
-  return From(
-      context, v8_request->GetSpecifier(), v8_request->GetImportAttributes());
-}
-
 ModuleWrap::ModuleWrap(Realm* realm,
                        Local<Object> object,
                        Local<Module> module,
@@ -141,15 +98,6 @@ ModuleWrap::ModuleWrap(Realm* realm,
   }
   MakeWeak();
   module_.SetWeak();
-
-  HandleScope scope(realm->isolate());
-  Local<Context> context = realm->context();
-  Local<FixedArray> requests = module->GetModuleRequests();
-  for (int i = 0; i < requests->Length(); i++) {
-    ModuleCacheKey module_cache_key = ModuleCacheKey::From(
-        context, requests->Get(context, i).As<ModuleRequest>());
-    resolve_cache_[module_cache_key] = i;
-  }
 }
 
 ModuleWrap::~ModuleWrap() {
@@ -991,11 +939,10 @@ void ModuleWrap::GetError(const FunctionCallbackInfo<Value>& args) {
 // static
 MaybeLocal<Module> ModuleWrap::ResolveModuleCallback(
     Local<Context> context,
-    Local<String> specifier,
-    Local<FixedArray> import_attributes,
+    size_t module_request_index,
     Local<Module> referrer) {
   ModuleWrap* resolved_module;
-  if (!ResolveModule(context, specifier, import_attributes, referrer)
+  if (!ResolveModule(context, module_request_index, referrer)
            .To(&resolved_module)) {
     return {};
   }
@@ -1006,11 +953,10 @@ MaybeLocal<Module> ModuleWrap::ResolveModuleCallback(
 // static
 MaybeLocal<Object> ModuleWrap::ResolveSourceCallback(
     Local<Context> context,
-    Local<String> specifier,
-    Local<FixedArray> import_attributes,
+    size_t module_request_index,
     Local<Module> referrer) {
   ModuleWrap* resolved_module;
-  if (!ResolveModule(context, specifier, import_attributes, referrer)
+  if (!ResolveModule(context, module_request_index, referrer)
            .To(&resolved_module)) {
     return {};
   }
@@ -1031,12 +977,22 @@ MaybeLocal<Object> ModuleWrap::ResolveSourceCallback(
   return module_source_object.As<Object>();
 }
 
+static std::string GetSpecifierFromModuleRequest(Local<Context> context,
+                                                 Local<Module> referrer,
+                                                 size_t module_request_index) {
+  Local<ModuleRequest> raw_request =
+      referrer->GetModuleRequests()
+          ->Get(context, static_cast<int>(module_request_index))
+          .As<ModuleRequest>();
+  Local<String> specifier = raw_request->GetSpecifier();
+  Utf8Value specifier_utf8(context->GetIsolate(), specifier);
+  return specifier_utf8.ToString();
+}
+
 // static
-Maybe<ModuleWrap*> ModuleWrap::ResolveModule(
-    Local<Context> context,
-    Local<String> specifier,
-    Local<FixedArray> import_attributes,
-    Local<Module> referrer) {
+Maybe<ModuleWrap*> ModuleWrap::ResolveModule(Local<Context> context,
+                                             size_t module_request_index,
+                                             Local<Module> referrer) {
   Isolate* isolate = context->GetIsolate();
   Environment* env = Environment::GetCurrent(context);
   if (env == nullptr) {
@@ -1046,31 +1002,24 @@ Maybe<ModuleWrap*> ModuleWrap::ResolveModule(
   // Check that the referrer is not yet been instantiated.
   DCHECK(referrer->GetStatus() <= Module::kInstantiated);
 
-  ModuleCacheKey cache_key =
-      ModuleCacheKey::From(context, specifier, import_attributes);
-
   ModuleWrap* dependent = ModuleWrap::GetFromModule(env, referrer);
   if (dependent == nullptr) {
+    std::string specifier =
+        GetSpecifierFromModuleRequest(context, referrer, module_request_index);
     THROW_ERR_VM_MODULE_LINK_FAILURE(
-        env, "request for '%s' is from invalid module", cache_key.specifier);
+        env, "request for '%s' is from invalid module", specifier);
     return Nothing<ModuleWrap*>();
   }
   if (!dependent->IsLinked()) {
+    std::string specifier =
+        GetSpecifierFromModuleRequest(context, referrer, module_request_index);
     THROW_ERR_VM_MODULE_LINK_FAILURE(
-        env,
-        "request for '%s' is from a module not been linked",
-        cache_key.specifier);
+        env, "request for '%s' is from a module not been linked", specifier);
     return Nothing<ModuleWrap*>();
   }
 
-  auto it = dependent->resolve_cache_.find(cache_key);
-  if (it == dependent->resolve_cache_.end()) {
-    THROW_ERR_VM_MODULE_LINK_FAILURE(
-        env, "request for '%s' is not in cache", cache_key.specifier);
-    return Nothing<ModuleWrap*>();
-  }
-
-  ModuleWrap* module_wrap = dependent->GetLinkedRequest(it->second);
+  ModuleWrap* module_wrap =
+      dependent->GetLinkedRequest(static_cast<uint32_t>(module_request_index));
   CHECK_NOT_NULL(module_wrap);
   return Just(module_wrap);
 }

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -90,9 +90,6 @@ struct ModuleCacheKey : public MemoryRetainer {
 };
 
 class ModuleWrap : public BaseObject {
-  using ResolveCache =
-      std::unordered_map<ModuleCacheKey, uint32_t, ModuleCacheKey::Hash>;
-
  public:
   enum InternalFields {
     kModuleSlot = BaseObject::kInternalFieldCount,
@@ -195,26 +192,21 @@ class ModuleWrap : public BaseObject {
 
   static v8::MaybeLocal<v8::Module> ResolveModuleCallback(
       v8::Local<v8::Context> context,
-      v8::Local<v8::String> specifier,
-      v8::Local<v8::FixedArray> import_attributes,
+      size_t module_request_index,
       v8::Local<v8::Module> referrer);
   static v8::MaybeLocal<v8::Object> ResolveSourceCallback(
       v8::Local<v8::Context> context,
-      v8::Local<v8::String> specifier,
-      v8::Local<v8::FixedArray> import_attributes,
+      size_t module_request_index,
       v8::Local<v8::Module> referrer);
   static ModuleWrap* GetFromModule(node::Environment*, v8::Local<v8::Module>);
 
   // This method may throw a JavaScript exception, so the return type is
   // wrapped in a Maybe.
-  static v8::Maybe<ModuleWrap*> ResolveModule(
-      v8::Local<v8::Context> context,
-      v8::Local<v8::String> specifier,
-      v8::Local<v8::FixedArray> import_attributes,
-      v8::Local<v8::Module> referrer);
+  static v8::Maybe<ModuleWrap*> ResolveModule(v8::Local<v8::Context> context,
+                                              size_t module_request_index,
+                                              v8::Local<v8::Module> referrer);
 
   v8::Global<v8::Module> module_;
-  ResolveCache resolve_cache_;
   contextify::ContextifyContext* contextify_context_ = nullptr;
   bool synthetic_ = false;
   bool linked_ = false;


### PR DESCRIPTION
This makes use of a new module resolution V8 API that passes in
an index to the module request array to identify the module
request, which eliminates the need of hashing on the module
request for lookup on our end.

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/6804466

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
