### PR TITLE
sqlite: add sqlite-type symbol for DatabaseSync

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2758,6 +2758,12 @@ static void Initialize(Local<Object> target,
                           db_tmpl,
                           FIXED_ONE_BYTE_STRING(isolate, "isTransaction"),
                           DatabaseSync::IsTransactionGetter);
+  Local<String> sqlite_type_key = FIXED_ONE_BYTE_STRING(isolate, "sqlite-type");
+  Local<v8::Symbol> sqlite_type_symbol =
+      v8::Symbol::For(isolate, sqlite_type_key);
+  Local<String> database_sync_string = FIXED_ONE_BYTE_STRING(isolate, "node:sqlite");
+  db_tmpl->InstanceTemplate()->Set(sqlite_type_symbol, database_sync_string);
+
   SetConstructorFunction(context, target, "DatabaseSync", db_tmpl);
   SetConstructorFunction(context,
                          target,

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -281,6 +281,15 @@ suite('DatabaseSync() constructor', () => {
       { changes: 1, lastInsertRowid: 1 },
     );
   });
+
+  test('has sqlite-type symbol property', (t) => {
+    const dbPath = nextDb();
+    const db = new DatabaseSync(dbPath);
+    t.after(() => { db.close(); });
+
+    const sqliteTypeSymbol = Symbol.for('sqlite-type');
+    t.assert.strictEqual(db[sqliteTypeSymbol], 'node:sqlite');
+  });
 });
 
 suite('DatabaseSync.prototype.open()', () => {


### PR DESCRIPTION
Nowadays, there are tons of database packages, like sqlite3, sqlite, better-sqlite, bun:sqlite... Checking the difference from them is pretty hard.
instanceof is not good, since the developer will still need to import the module, which is costly.
 I think we should provide a symbol to distinguish different SQLite classes, at least nodejs could make the first step