### PR TITLE
This PR updates the documentation for `fs.statfs` to clarify that `bsize` is in bytes.  Fixes #50749

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7672,7 +7672,7 @@ added:
 
 * Type: {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size in bytes.
 
 #### `statfs.ffree`
 


### PR DESCRIPTION
### Summary
This PR updates the documentation for `fs.statfs` to clarify that `bsize` is measured in bytes.

### Description
The current documentation for `fs.statfs` does not explicitly state the unit for `bsize`. This change clarifies that the value returned is in bytes to improve developer clarity and prevent implementation errors.

Fixes: https://github.com/nodejs/node/issues/50749
Fixes: https://github.com/nodejs/node/issues/59407