### PR TITLE
test: add missing hasPostData in test-inspector-emit-protocol-event

### DIFF
--- a/test/parallel/test-inspector-emit-protocol-event.js
+++ b/test/parallel/test-inspector-emit-protocol-event.js
@@ -27,6 +27,7 @@ const EXPECTED_EVENTS = {
           url: 'https://nodejs.org/en',
           method: 'GET',
           headers: {},
+          hasPostData: false,
         },
         timestamp: 1000,
         wallTime: 1000,


### PR DESCRIPTION
I fixed it because running it directly would result in the following error.
``` sh
shimaryuuheinoMac-mini:node shimaryuuhei$ node test/parallel/test-inspector-emit-protocol-event.js
NOTE: The test started as a child_process using these flags: [ '--inspect=0', '--experimental-network-inspection' ] Use NODE_SKIP_FLAG_CHECK to run the test with the original flags.
Debugger listening on ws://127.0.0.1:59541/ef451551-fb37-4406-b739-65ddcf43c6e9
For help, see: https://nodejs.org/en/docs/inspector
(node:62077) [ERR_ASSERTION] AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  {
    request: {
+     hasPostData: false,
      headers: {},
      method: 'GET',
      url: 'https://nodejs.org/en'
    },
    requestId: 'request-id-1',

(Use `node --trace-warnings ...` to show where the warning was created)
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
