### PR TITLE
test_runner: isSkipped in JUnit reporter

### DIFF
--- a/lib/internal/test_runner/reporter/junit.js
+++ b/lib/internal/test_runner/reporter/junit.js
@@ -58,7 +58,7 @@ function isFailure(node) {
 }
 
 function isSkipped(node) {
-  return (node?.children && ArrayPrototypeSome(node.children, (c) => c.tag === 'skipped')) || node?.attrs?.failures;
+  return (node?.children && ArrayPrototypeSome(node.children, (c) => c.tag === 'skipped')) || node?.attrs?.skipped;
 }
 
 module.exports = async function* junitReporter(source) {

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -191,4 +191,17 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.match(fileConent, /ℹ skipped 0/);
     assert.match(fileConent, /ℹ todo 0/);
   });
+
+  it('should correctly report pass/fail for junit reporter using reporters.js', async () => {
+    const file = tmpdir.resolve(`${tmpFiles++}.xml`);
+    const child = spawnSync(process.execPath,
+                            ['--test', '--test-reporter', 'junit', '--test-reporter-destination', file, testFile]);
+    assert.strictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.stdout.toString(), '');
+    const fileContents = fs.readFileSync(file, 'utf8');
+    assert.match(fileContents, /<testsuite .*name="nested".*tests="2".*failures="1".*skipped="0".*>/);
+    assert.match(fileContents, /<testcase .*name="failing".*>\s*<failure .*type="testCodeFailure".*message="error".*>/);
+    assert.match(fileContents, /<testcase .*name="ok".*classname="test".*\/>/);
+    assert.match(fileContents, /<testcase .*name="top level".*classname="test".*\/>/);
+  });
 });


### PR DESCRIPTION
I reopene this new PR because of wrong rebase. (closed #59317)

The isSkipped function in the JUnit reporter was incorrectly checking for node?.attrs.failures instead of node?.attrs.skipped.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
