### PR TITLE
test: add test for coverage control comments

### DIFF
--- a/test/fixtures/test-runner/coverage/coverage-control-comments.js
+++ b/test/fixtures/test-runner/coverage/coverage-control-comments.js
@@ -1,0 +1,25 @@
+'use strict';
+const { test } = require('node:test');
+
+function coveredFunction() { 
+    return 'This function is covered in coverage';
+}
+
+/* node:coverage ignore next 7 */
+function ignoredFunctionDefinitionWithCount() {
+    const ignoredVar = true;
+    if (ignoredVar) {
+        return 'This line is ignored';
+    }
+    return 'This should not be returned';
+}
+
+/* node:coverage disable */
+function disabledFunction() {
+    return 'This function is entirely disabled in coverage';
+}
+/* node:coverage enable */
+
+test('coverage control comments fixture', () => {
+    coveredFunction();
+});

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -552,21 +552,21 @@ test('correctly prints the coverage report of files contained in parent director
 });
 
 test('should respect /* node:coverage */ comments', skipIfNoInspector, () => {
-  let report = [
-  '# start of coverage report',
-  '# ---------------------------------------------------------------------------------',
-  '# file                             | line % | branch % | funcs % | uncovered lines',
-  '# ---------------------------------------------------------------------------------',
-  '# test                             |        |          |         | ',
-  '#  fixtures                        |        |          |         | ',
-  '#   test-runner                    |        |          |         | ',
-  '#    coverage                      |        |          |         | ',
-  '#     coverage-control-comments.js | 100.00 |   100.00 |  100.00 | ',
-  '# ---------------------------------------------------------------------------------',
-  '# all files                        | 100.00 |   100.00 |  100.00 | ',
-  '# ---------------------------------------------------------------------------------',
-  '# end of coverage report',
-].join('\n');
+  const report = [
+    '# start of coverage report',
+    '# ---------------------------------------------------------------------------------',
+    '# file                             | line % | branch % | funcs % | uncovered lines',
+    '# ---------------------------------------------------------------------------------',
+    '# test                             |        |          |         | ',
+    '#  fixtures                        |        |          |         | ',
+    '#   test-runner                    |        |          |         | ',
+    '#    coverage                      |        |          |         | ',
+    '#     coverage-control-comments.js | 100.00 |   100.00 |  100.00 | ',
+    '# ---------------------------------------------------------------------------------',
+    '# all files                        | 100.00 |   100.00 |  100.00 | ',
+    '# ---------------------------------------------------------------------------------',
+    '# end of coverage report',
+  ].join('\n');
 
   if (common.isWindows) {
     return report.replaceAll('/', '\\');

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -550,3 +550,41 @@ test('correctly prints the coverage report of files contained in parent director
   assert(result.stdout.toString().includes(report));
   assert.strictEqual(result.status, 0);
 });
+
+test('should respect /* node:coverage */ comments', skipIfNoInspector, () => {
+  let report = [
+  '# start of coverage report',
+  '# ---------------------------------------------------------------------------------',
+  '# file                             | line % | branch % | funcs % | uncovered lines',
+  '# ---------------------------------------------------------------------------------',
+  '# test                             |        |          |         | ',
+  '#  fixtures                        |        |          |         | ',
+  '#   test-runner                    |        |          |         | ',
+  '#    coverage                      |        |          |         | ',
+  '#     coverage-control-comments.js | 100.00 |   100.00 |  100.00 | ',
+  '# ---------------------------------------------------------------------------------',
+  '# all files                        | 100.00 |   100.00 |  100.00 | ',
+  '# ---------------------------------------------------------------------------------',
+  '# end of coverage report',
+].join('\n');
+
+  if (common.isWindows) {
+    return report.replaceAll('/', '\\');
+  }
+
+  const fixture = fixtures.path('test-runner', 'coverage', 'coverage-control-comments.js');
+  const args = [
+    '--test',
+    '--experimental-test-coverage',
+    '--test-coverage-exclude=!test/**',
+    '--test-reporter',
+    'tap',
+    fixture,
+  ];
+
+  const result = spawnSync(process.execPath, args);
+
+  assert.strictEqual(result.stderr.toString(), '');
+  assert(result.stdout.toString().includes(report));
+  assert.strictEqual(result.status, 0);
+});


### PR DESCRIPTION
This PR adds a comprehensive test suite for the `node:coverage control comments feature` within the test runner.

I noticed there wasn't a specific test that checked all coverage control comments (ignore next, disable/enable).

Also I have a couple of questions to ensure I'm following the project's guidelines:

1.  I've used the term `control-comments` to describe the /* node:coverage */ comments. Is this the appropriate convention?
2. For this test, I created a new fixture file named `coverage-control-comments.js`. I want to ensure that adding the new fixture is right choice.

I appreciate your feedback😀

refs: [https://nodejs.org/api/test.html#collecting-code-coverage](https://nodejs.org/api/test.html#collecting-code-coverage)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
4. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
