### PR TITLE
http2: report sent headers object in client stream dcs

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -760,7 +760,7 @@ const deprecateWeight = deprecateProperty('weight',
 // When a ClientHttp2Session is first created, the socket may not yet be
 // connected. If request() is called during this time, the actual request
 // will be deferred until the socket is ready to go.
-function requestOnConnect(headersList, headersParam, options) {
+function requestOnConnect(headersList, options) {
   const session = this[kSession];
 
   // At this point, the stream should have already been destroyed during
@@ -824,7 +824,7 @@ function requestOnConnect(headersList, headersParam, options) {
   if (onClientStreamStartChannel.hasSubscribers) {
     onClientStreamStartChannel.publish({
       stream: this,
-      headers: headersParam,
+      headers: this.sentHeaders,
     });
   }
 }
@@ -1888,7 +1888,7 @@ class ClientHttp2Session extends Http2Session {
       }
     }
 
-    const onConnect = reqAsync.bind(requestOnConnect.bind(stream, headersList, headersParam, options));
+    const onConnect = reqAsync.bind(requestOnConnect.bind(stream, headersList, options));
     if (this.connecting) {
       if (this[kPendingRequestCalls] !== null) {
         this[kPendingRequestCalls].push(onConnect);
@@ -1906,7 +1906,7 @@ class ClientHttp2Session extends Http2Session {
     if (onClientStreamCreatedChannel.hasSubscribers) {
       onClientStreamCreatedChannel.publish({
         stream,
-        headers: headersParam,
+        headers: stream.sentHeaders,
       });
     }
 

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-created.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-created.js
@@ -18,6 +18,9 @@ const { Duplex } = require('stream');
 
 const clientHttp2StreamCreationCount = 2;
 
+let countdown;
+let port;
+
 dc.subscribe('http2.client.stream.created', common.mustCall(({ stream, headers }) => {
   // Since ClientHttp2Stream is not exported from any module, this just checks
   // if the stream is an instance of Duplex and the constructor name is
@@ -25,6 +28,28 @@ dc.subscribe('http2.client.stream.created', common.mustCall(({ stream, headers }
   assert.ok(stream instanceof Duplex);
   assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
   assert.ok(headers && !Array.isArray(headers) && typeof headers === 'object');
+  if (countdown.remaining === clientHttp2StreamCreationCount) {
+    // The request stream headers.
+    assert.deepStrictEqual(headers, {
+      '__proto__': null,
+      ':method': 'GET',
+      ':authority': `localhost:${port}`,
+      ':scheme': 'http',
+      ':path': '/',
+      'requestHeader': 'requestValue',
+    });
+  } else {
+    // The push stream headers.
+    assert.deepStrictEqual(headers, {
+      '__proto__': null,
+      ':method': 'GET',
+      ':authority': `localhost:${port}`,
+      ':scheme': 'http',
+      ':path': '/',
+      [http2.sensitiveHeaders]: [],
+      'pushheader': 'pushValue',
+    });
+  }
 }, clientHttp2StreamCreationCount));
 
 const server = http2.createServer();
@@ -32,22 +57,22 @@ server.on('stream', common.mustCall((stream) => {
   stream.respond();
   stream.end();
 
-  stream.pushStream({}, common.mustSucceed((pushStream) => {
+  stream.pushStream({ 'pushHeader': 'pushValue' }, common.mustSucceed((pushStream) => {
     pushStream.respond();
     pushStream.end();
   }, 1));
 }, 1));
 
 server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
+  port = server.address().port;
   const client = http2.connect(`http://localhost:${port}`);
 
-  const countdown = new Countdown(clientHttp2StreamCreationCount, () => {
+  countdown = new Countdown(clientHttp2StreamCreationCount, () => {
     client.close();
     server.close();
   });
 
-  const stream = client.request({});
+  const stream = client.request(['requestHeader', 'requestValue']);
   stream.on('response', common.mustCall(() => {
     countdown.dec();
   }));


### PR DESCRIPTION
This change improves diagnosis by reporting the headers object that is actually sent rather than the original input headers in the following diagnostics channels:
- 'http2.client.stream.created'
- 'http2.client.stream.start'

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
