### PR TITLE
doc: replace `integer` with `number`

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -126,7 +126,7 @@ professionalism across all documents.
 * Clearly describe parameters and return values, including types and defaults.
   * Example:
     ```markdown
-    * `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
+    * `byteOffset` {number} Index of first byte to expose. **Default:** `0`.
     ```
 
 ***
@@ -187,7 +187,7 @@ professionalism across all documents.
   ```
   Example:
   ```markdown
-  * `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
+  * `byteOffset` {number} Index of first byte to expose. **Default:** `0`.
   ```
 * **Returns:**
   ```markdown

--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -683,7 +683,7 @@ changes:
                  zero-filled buffer.
 -->
 
-* `size` {integer} The desired length of the new `Buffer`.
+* `size` {number} The desired length of the new `Buffer`.
 * `fill` {string|Buffer|Uint8Array|integer} A value to pre-fill the new `Buffer`
   with. **Default:** `0`.
 * `encoding` {string} If `fill` is a string, this is its encoding.
@@ -782,7 +782,7 @@ changes:
     description: Passing a negative `size` will now throw an error.
 -->
 
-* `size` {integer} The desired length of the new `Buffer`.
+* `size` {number} The desired length of the new `Buffer`.
 * Returns: {Buffer}
 
 Allocates a new `Buffer` of `size` bytes. If `size` is larger than
@@ -853,7 +853,7 @@ changes:
                  for invalid input arguments.
 -->
 
-* `size` {integer} The desired length of the new `Buffer`.
+* `size` {number} The desired length of the new `Buffer`.
 * Returns: {Buffer}
 
 Allocates a new `Buffer` of `size` bytes. If `size` is larger than
@@ -937,7 +937,7 @@ changes:
   value to calculate the length of.
 * `encoding` {string} If `string` is a string, this is its encoding.
   **Default:** `'utf8'`.
-* Returns: {integer} The number of bytes contained within `string`.
+* Returns: {number} The number of bytes contained within `string`.
 
 Returns the byte length of a string when encoded using `encoding`.
 This is not the same as [`String.prototype.length`][], which does not account
@@ -983,7 +983,7 @@ changes:
 
 * `buf1` {Buffer|Uint8Array}
 * `buf2` {Buffer|Uint8Array}
-* Returns: {integer} Either `-1`, `0`, or `1`, depending on the result of the
+* Returns: {number} Either `-1`, `0`, or `1`, depending on the result of the
   comparison. See [`buf.compare()`][] for details.
 
 Compares `buf1` to `buf2`, typically for the purpose of sorting arrays of
@@ -1026,7 +1026,7 @@ changes:
 
 * `list` {Buffer\[] | Uint8Array\[]} List of `Buffer` or {Uint8Array}
   instances to concatenate.
-* `totalLength` {integer} Total length of the `Buffer` instances in `list`
+* `totalLength` {number} Total length of the `Buffer` instances in `list`
   when concatenated.
 * Returns: {Buffer}
 
@@ -1098,8 +1098,8 @@ added:
 -->
 
 * `view` {TypedArray} The {TypedArray} to copy.
-* `offset` {integer} The starting offset within `view`. **Default:** `0`.
-* `length` {integer} The number of elements from `view` to copy.
+* `offset` {number} The starting offset within `view`. **Default:** `0`.
+* `length` {number} The number of elements from `view` to copy.
   **Default:** `view.length - offset`.
 * Returns: {Buffer}
 
@@ -1161,8 +1161,8 @@ added: v5.10.0
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An {ArrayBuffer},
   {SharedArrayBuffer}, for example the `.buffer` property of a
   {TypedArray}.
-* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
-* `length` {integer} Number of bytes to expose.
+* `byteOffset` {number} Index of first byte to expose. **Default:** `0`.
+* `length` {number} Number of bytes to expose.
   **Default:** `arrayBuffer.byteLength - byteOffset`.
 * Returns: {Buffer}
 
@@ -1320,7 +1320,7 @@ added: v8.2.0
 
 * `object` {Object} An object supporting `Symbol.toPrimitive` or `valueOf()`.
 * `offsetOrEncoding` {integer|string} A byte-offset or encoding.
-* `length` {integer} A length.
+* `length` {number} A length.
 * Returns: {Buffer}
 
 For objects whose `valueOf()` function returns a value not strictly equal to
@@ -1500,14 +1500,14 @@ console.log(Buffer.isEncoding(''));
 added: v0.11.3
 -->
 
-* Type: {integer} **Default:** `8192`
+* Type: {number} **Default:** `8192`
 
 This is the size (in bytes) of pre-allocated internal `Buffer` instances used
 for pooling. This value may be modified.
 
 ### `buf[index]`
 
-* `index` {integer}
+* `index` {number}
 
 The index operator `[index]` can be used to get and set the octet at position
 `index` in `buf`. The values refer to individual bytes, so the legal value
@@ -1585,7 +1585,7 @@ console.log(buffer.buffer === arrayBuffer);
 
 ### `buf.byteOffset`
 
-* Type: {integer} The `byteOffset` of the `Buffer`'s underlying `ArrayBuffer` object.
+* Type: {number} The `byteOffset` of the `Buffer`'s underlying `ArrayBuffer` object.
 
 When setting `byteOffset` in `Buffer.from(ArrayBuffer, byteOffset, length)`,
 or sometimes when allocating a `Buffer` smaller than `Buffer.poolSize`, the
@@ -1637,15 +1637,15 @@ changes:
 
 * `target` {Buffer|Uint8Array} A `Buffer` or {Uint8Array} with which to
   compare `buf`.
-* `targetStart` {integer} The offset within `target` at which to begin
+* `targetStart` {number} The offset within `target` at which to begin
   comparison. **Default:** `0`.
-* `targetEnd` {integer} The offset within `target` at which to end comparison
+* `targetEnd` {number} The offset within `target` at which to end comparison
   (not inclusive). **Default:** `target.length`.
-* `sourceStart` {integer} The offset within `buf` at which to begin comparison.
+* `sourceStart` {number} The offset within `buf` at which to begin comparison.
   **Default:** `0`.
-* `sourceEnd` {integer} The offset within `buf` at which to end comparison
+* `sourceEnd` {number} The offset within `buf` at which to end comparison
   (not inclusive). **Default:** [`buf.length`][].
-* Returns: {integer}
+* Returns: {number}
 
 Compares `buf` with `target` and returns a number indicating whether `buf`
 comes before, after, or is the same as `target` in sort order.
@@ -1741,13 +1741,13 @@ added: v0.1.90
 -->
 
 * `target` {Buffer|Uint8Array} A `Buffer` or {Uint8Array} to copy into.
-* `targetStart` {integer} The offset within `target` at which to begin
+* `targetStart` {number} The offset within `target` at which to begin
   writing. **Default:** `0`.
-* `sourceStart` {integer} The offset within `buf` from which to begin copying.
+* `sourceStart` {number} The offset within `buf` from which to begin copying.
   **Default:** `0`.
-* `sourceEnd` {integer} The offset within `buf` at which to stop copying (not
+* `sourceEnd` {number} The offset within `buf` at which to stop copying (not
   inclusive). **Default:** [`buf.length`][].
-* Returns: {integer} The number of bytes copied.
+* Returns: {number} The number of bytes copied.
 
 Copies data from a region of `buf` to a region in `target`, even if the `target`
 memory region overlaps with `buf`.
@@ -1955,9 +1955,9 @@ changes:
 
 * `value` {string|Buffer|Uint8Array|integer} The value with which to fill `buf`.
   Empty value (string, Uint8Array, Buffer) is coerced to `0`.
-* `offset` {integer} Number of bytes to skip before starting to fill `buf`.
+* `offset` {number} Number of bytes to skip before starting to fill `buf`.
   **Default:** `0`.
-* `end` {integer} Where to stop filling `buf` (not inclusive). **Default:**
+* `end` {number} Where to stop filling `buf` (not inclusive). **Default:**
   [`buf.length`][].
 * `encoding` {string} The encoding for `value` if `value` is a string.
   **Default:** `'utf8'`.
@@ -2061,7 +2061,7 @@ added: v5.3.0
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. If negative, then
+* `byteOffset` {number} Where to begin searching in `buf`. If negative, then
   offset is calculated from the end of `buf`. **Default:** `0`.
 * `encoding` {string} If `value` is a string, this is its encoding.
   **Default:** `'utf8'`.
@@ -2128,12 +2128,12 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. If negative, then
+* `byteOffset` {number} Where to begin searching in `buf`. If negative, then
   offset is calculated from the end of `buf`. **Default:** `0`.
 * `encoding` {string} If `value` is a string, this is the encoding used to
   determine the binary representation of the string that will be searched for in
   `buf`. **Default:** `'utf8'`.
-* Returns: {integer} The index of the first occurrence of `value` in `buf`, or
+* Returns: {number} The index of the first occurrence of `value` in `buf`, or
   `-1` if `buf` does not contain `value`.
 
 If `value` is:
@@ -2300,13 +2300,13 @@ changes:
 -->
 
 * `value` {string|Buffer|Uint8Array|integer} What to search for.
-* `byteOffset` {integer} Where to begin searching in `buf`. If negative, then
+* `byteOffset` {number} Where to begin searching in `buf`. If negative, then
   offset is calculated from the end of `buf`. **Default:**
   `buf.length - 1`.
 * `encoding` {string} If `value` is a string, this is the encoding used to
   determine the binary representation of the string that will be searched for in
   `buf`. **Default:** `'utf8'`.
-* Returns: {integer} The index of the last occurrence of `value` in `buf`, or
+* Returns: {number} The index of the last occurrence of `value` in `buf`, or
   `-1` if `buf` does not contain `value`.
 
 Identical to [`buf.indexOf()`][], except the last occurrence of `value` is found
@@ -2426,7 +2426,7 @@ If `value` is an empty string or empty `Buffer`, `byteOffset` will be returned.
 added: v0.1.90
 -->
 
-* Type: {integer}
+* Type: {number}
 
 Returns the number of bytes in `buf`.
 
@@ -2480,7 +2480,7 @@ added:
  - v10.20.0
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
@@ -2497,7 +2497,7 @@ added:
  - v10.20.0
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
@@ -2521,7 +2521,7 @@ changes:
     description: This function is also available as `buf.readBigUint64BE()`.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
@@ -2562,7 +2562,7 @@ changes:
     description: This function is also available as `buf.readBigUint64LE()`.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {bigint}
 
@@ -2600,7 +2600,7 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {number}
 
@@ -2635,7 +2635,7 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 8`. **Default:** `0`.
 * Returns: {number}
 
@@ -2674,7 +2674,7 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
 * Returns: {number}
 
@@ -2709,7 +2709,7 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
 * Returns: {number}
 
@@ -2748,9 +2748,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 1`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads a signed 8-bit integer from `buf` at the specified `offset`.
 
@@ -2793,9 +2793,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads a signed, big-endian 16-bit integer from `buf` at the specified `offset`.
 
@@ -2830,9 +2830,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads a signed, little-endian 16-bit integer from `buf` at the specified
 `offset`.
@@ -2872,9 +2872,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads a signed, big-endian 32-bit integer from `buf` at the specified `offset`.
 
@@ -2909,9 +2909,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads a signed, little-endian 32-bit integer from `buf` at the specified
 `offset`.
@@ -2951,11 +2951,11 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to read. Must satisfy
+* `byteLength` {number} Number of bytes to read. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as a big-endian, two's complement signed value
@@ -2998,11 +2998,11 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to read. Must satisfy
+* `byteLength` {number} Number of bytes to read. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as a little-endian, two's complement signed value
@@ -3042,9 +3042,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 1`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads an unsigned 8-bit integer from `buf` at the specified `offset`.
 
@@ -3092,9 +3092,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads an unsigned, big-endian 16-bit integer from `buf` at the specified
 `offset`.
@@ -3139,9 +3139,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads an unsigned, little-endian 16-bit integer from `buf` at the specified
 `offset`.
@@ -3190,9 +3190,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads an unsigned, big-endian 32-bit integer from `buf` at the specified
 `offset`.
@@ -3233,9 +3233,9 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads an unsigned, little-endian 32-bit integer from `buf` at the specified
 `offset`.
@@ -3280,11 +3280,11 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to read. Must satisfy
+* `byteLength` {number} Number of bytes to read. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as an unsigned big-endian integer supporting
@@ -3330,11 +3330,11 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `offset` {integer} Number of bytes to skip before starting to read. Must
+* `offset` {number} Number of bytes to skip before starting to read. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to read. Must satisfy
+* `byteLength` {number} Number of bytes to read. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer}
+* Returns: {number}
 
 Reads `byteLength` number of bytes from `buf` at the specified `offset`
 and interprets the result as an unsigned, little-endian integer supporting
@@ -3366,8 +3366,8 @@ console.log(buf.readUIntLE(0, 6).toString(16));
 added: v3.0.0
 -->
 
-* `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
-* `end` {integer} Where the new `Buffer` will end (not inclusive).
+* `start` {number} Where the new `Buffer` will start. **Default:** `0`.
+* `end` {number} Where the new `Buffer` will end (not inclusive).
   **Default:** [`buf.length`][].
 * Returns: {Buffer}
 
@@ -3491,8 +3491,8 @@ changes:
                  calculations with them.
 -->
 
-* `start` {integer} Where the new `Buffer` will start. **Default:** `0`.
-* `end` {integer} Where the new `Buffer` will end (not inclusive).
+* `start` {number} Where the new `Buffer` will start. **Default:** `0`.
+* `end` {number} Where the new `Buffer` will end (not inclusive).
   **Default:** [`buf.length`][].
 * Returns: {Buffer}
 
@@ -3774,8 +3774,8 @@ added: v0.1.90
 -->
 
 * `encoding` {string} The character encoding to use. **Default:** `'utf8'`.
-* `start` {integer} The byte offset to start decoding at. **Default:** `0`.
-* `end` {integer} The byte offset to stop decoding at (not inclusive).
+* `start` {number} The byte offset to start decoding at. **Default:** `0`.
+* `end` {number} The byte offset to stop decoding at (not inclusive).
   **Default:** [`buf.length`][].
 * Returns: {string}
 
@@ -3912,12 +3912,12 @@ added: v0.1.90
 -->
 
 * `string` {string} String to write to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write `string`.
+* `offset` {number} Number of bytes to skip before starting to write `string`.
   **Default:** `0`.
-* `length` {integer} Maximum number of bytes to write (written bytes will not
+* `length` {number} Maximum number of bytes to write (written bytes will not
   exceed `buf.length - offset`). **Default:** `buf.length - offset`.
 * `encoding` {string} The character encoding of `string`. **Default:** `'utf8'`.
-* Returns: {integer} Number of bytes written.
+* Returns: {number} Number of bytes written.
 
 Writes `string` to `buf` at `offset` according to the character encoding in
 `encoding`. The `length` parameter is the number of bytes to write. If `buf` did
@@ -3969,9 +3969,9 @@ added:
 -->
 
 * `value` {bigint} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian.
 
@@ -4008,9 +4008,9 @@ added:
 -->
 
 * `value` {bigint} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian.
 
@@ -4053,9 +4053,9 @@ changes:
 -->
 
 * `value` {bigint} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian.
 
@@ -4098,9 +4098,9 @@ changes:
 -->
 
 * `value` {bigint} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy: `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian
 
@@ -4140,9 +4140,9 @@ changes:
 -->
 
 * `value` {number} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian. The `value`
 must be a JavaScript number. Behavior is undefined when `value` is anything
@@ -4182,9 +4182,9 @@ changes:
 -->
 
 * `value` {number} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 8`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian. The `value`
 must be a JavaScript number. Behavior is undefined when `value` is anything
@@ -4224,9 +4224,9 @@ changes:
 -->
 
 * `value` {number} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian. Behavior is
 undefined when `value` is anything other than a JavaScript number.
@@ -4265,9 +4265,9 @@ changes:
 -->
 
 * `value` {number} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian. Behavior is
 undefined when `value` is anything other than a JavaScript number.
@@ -4305,10 +4305,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 1`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset`. `value` must be a valid
 signed 8-bit integer. Behavior is undefined when `value` is anything other than
@@ -4351,10 +4351,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian.  The `value`
 must be a valid signed 16-bit integer. Behavior is undefined when `value` is
@@ -4395,10 +4395,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian.  The `value`
 must be a valid signed 16-bit integer. Behavior is undefined when `value` is
@@ -4439,10 +4439,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian. The `value`
 must be a valid signed 32-bit integer. Behavior is undefined when `value` is
@@ -4483,10 +4483,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian. The `value`
 must be a valid signed 32-bit integer. Behavior is undefined when `value` is
@@ -4527,12 +4527,12 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to write. Must satisfy
+* `byteLength` {number} Number of bytes to write. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`
 as big-endian. Supports up to 48 bits of accuracy. Behavior is undefined when
@@ -4571,12 +4571,12 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to write. Must satisfy
+* `byteLength` {number} Number of bytes to write. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`
 as little-endian. Supports up to 48 bits of accuracy. Behavior is undefined
@@ -4620,10 +4620,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 1`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset`. `value` must be a
 valid unsigned 8-bit integer. Behavior is undefined when `value` is anything
@@ -4675,10 +4675,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian. The `value`
 must be a valid unsigned 16-bit integer. Behavior is undefined when `value`
@@ -4726,10 +4726,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 2`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian. The `value`
 must be a valid unsigned 16-bit integer. Behavior is undefined when `value` is
@@ -4777,10 +4777,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as big-endian. The `value`
 must be a valid unsigned 32-bit integer. Behavior is undefined when `value`
@@ -4826,10 +4826,10 @@ changes:
                  to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - 4`. **Default:** `0`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `value` to `buf` at the specified `offset` as little-endian. The `value`
 must be a valid unsigned 32-bit integer. Behavior is undefined when `value` is
@@ -4875,12 +4875,12 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to write. Must satisfy
+* `byteLength` {number} Number of bytes to write. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`
 as big-endian. Supports up to 48 bits of accuracy. Behavior is undefined
@@ -4926,12 +4926,12 @@ changes:
                  and `byteLength` to `uint32` anymore.
 -->
 
-* `value` {integer} Number to be written to `buf`.
-* `offset` {integer} Number of bytes to skip before starting to write. Must
+* `value` {number} Number to be written to `buf`.
+* `offset` {number} Number of bytes to skip before starting to write. Must
   satisfy `0 <= offset <= buf.length - byteLength`.
-* `byteLength` {integer} Number of bytes to write. Must satisfy
+* `byteLength` {number} Number of bytes to write. Must satisfy
   `0 < byteLength <= 6`.
-* Returns: {integer} `offset` plus the number of bytes written.
+* Returns: {number} `offset` plus the number of bytes written.
 
 Writes `byteLength` bytes of `value` to `buf` at the specified `offset`
 as little-endian. Supports up to 48 bits of accuracy. Behavior is undefined
@@ -5011,8 +5011,8 @@ changes:
 
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An {ArrayBuffer},
   {SharedArrayBuffer} or the `.buffer` property of a {TypedArray}.
-* `byteOffset` {integer} Index of first byte to expose. **Default:** `0`.
-* `length` {integer} Number of bytes to expose.
+* `byteOffset` {number} Index of first byte to expose. **Default:** `0`.
+* `length` {number} Number of bytes to expose.
   **Default:** `arrayBuffer.byteLength - byteOffset`.
 
 See
@@ -5066,7 +5066,7 @@ changes:
 > Stability: 0 - Deprecated: Use [`Buffer.alloc()`][] instead (also see
 > [`Buffer.allocUnsafe()`][]).
 
-* `size` {integer} The desired length of the new `Buffer`.
+* `size` {number} The desired length of the new `Buffer`.
 
 See [`Buffer.alloc()`][] and [`Buffer.allocUnsafe()`][]. This variant of the
 constructor is equivalent to [`Buffer.alloc()`][].
@@ -5251,7 +5251,7 @@ Throws if the `input` is a detached array buffer.
 added: v0.5.4
 -->
 
-* Type: {integer} **Default:** `50`
+* Type: {number} **Default:** `50`
 
 Returns the maximum number of bytes that will be returned when
 `buf.inspect()` is called. This can be overridden by user modules. See
@@ -5263,7 +5263,7 @@ Returns the maximum number of bytes that will be returned when
 added: v3.0.0
 -->
 
-* Type: {integer} The largest size allowed for a single `Buffer` instance.
+* Type: {number} The largest size allowed for a single `Buffer` instance.
 
 An alias for [`buffer.constants.MAX_LENGTH`][].
 
@@ -5273,7 +5273,7 @@ An alias for [`buffer.constants.MAX_LENGTH`][].
 added: v3.0.0
 -->
 
-* Type: {integer} The largest length allowed for a single `string` instance.
+* Type: {number} The largest length allowed for a single `string` instance.
 
 An alias for [`buffer.constants.MAX_STRING_LENGTH`][].
 
@@ -5367,7 +5367,7 @@ changes:
       2<sup>32</sup> - 1 on 64-bit architectures.
 -->
 
-* Type: {integer} The largest size allowed for a single `Buffer` instance.
+* Type: {number} The largest size allowed for a single `Buffer` instance.
 
 On 32-bit architectures, this value currently is 2<sup>30</sup> - 1 (about 1
 GiB).
@@ -5384,7 +5384,7 @@ This value is also available as [`buffer.kMaxLength`][].
 added: v8.2.0
 -->
 
-* Type: {integer} The largest length allowed for a single `string` instance.
+* Type: {number} The largest length allowed for a single `string` instance.
 
 Represents the largest `length` that a `string` primitive can have, counted
 in UTF-16 code units.

--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1662,7 +1662,7 @@ within the child process to close the IPC channel as well.
 
 ### `subprocess.exitCode`
 
-* Type: {integer}
+* Type: {number}
 
 The `subprocess.exitCode` property indicates the exit code of the child process.
 If the child process is still running, the field will be `null`.

--- a/doc/api/cluster.md
+++ b/doc/api/cluster.md
@@ -477,7 +477,7 @@ worker.kill();
 added: v0.8.0
 -->
 
-* Type: {integer}
+* Type: {number}
 
 Each new worker is given its own unique id, this id is stored in the
 `id`.

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2321,8 +2321,8 @@ changes:
 
 * `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
   * `dsaEncoding` {string}
-  * `padding` {integer}
-  * `saltLength` {integer}
+  * `padding` {number}
+  * `saltLength` {number}
 * `outputEncoding` {string} The [encoding][] of the return value.
 * Returns: {Buffer | string}
 
@@ -2339,7 +2339,7 @@ object, the following additional properties can be passed:
   format of the generated signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
-* `padding` {integer} Optional padding value for RSA, one of the following:
+* `padding` {number} Optional padding value for RSA, one of the following:
 
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
@@ -2348,7 +2348,7 @@ object, the following additional properties can be passed:
   used to sign the message as specified in section 3.1 of [RFC 4055][], unless
   an MGF1 hash function has been specified as part of the key in compliance with
   section 3.3 of [RFC 4055][].
-* `saltLength` {integer} Salt length for when padding is
+* `saltLength` {number} Salt length for when padding is
   `RSA_PKCS1_PSS_PADDING`. The special value
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
@@ -2451,8 +2451,8 @@ changes:
 
 * `object` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
   * `dsaEncoding` {string}
-  * `padding` {integer}
-  * `saltLength` {integer}
+  * `padding` {number}
+  * `saltLength` {number}
 * `signature` {string|ArrayBuffer|Buffer|TypedArray|DataView}
 * `signatureEncoding` {string} The [encoding][] of the `signature` string.
 * Returns: {boolean} `true` or `false` depending on the validity of the
@@ -2470,7 +2470,7 @@ object, the following additional properties can be passed:
   format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
-* `padding` {integer} Optional padding value for RSA, one of the following:
+* `padding` {number} Optional padding value for RSA, one of the following:
 
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
@@ -2479,7 +2479,7 @@ object, the following additional properties can be passed:
   used to verify the message as specified in section 3.1 of [RFC 4055][], unless
   an MGF1 hash function has been specified as part of the key in compliance with
   section 3.3 of [RFC 4055][].
-* `saltLength` {integer} Salt length for when padding is
+* `saltLength` {number} Salt length for when padding is
   `RSA_PKCS1_PSS_PADDING`. The special value
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_AUTO` (default) causes it to be
@@ -5109,8 +5109,8 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `min` {integer} Start of random range (inclusive). **Default:** `0`.
-* `max` {integer} End of random range (exclusive).
+* `min` {number} Start of random range (inclusive). **Default:** `0`.
+* `max` {number} End of random range (exclusive).
 * `callback` {Function} `function(err, n) {}`.
 
 Return a random integer `n` such that `min <= n < max`.  This
@@ -5484,14 +5484,14 @@ additional properties can be passed:
   format of the generated signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
-* `padding` {integer} Optional padding value for RSA, one of the following:
+* `padding` {number} Optional padding value for RSA, one of the following:
 
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
 
   `RSA_PKCS1_PSS_PADDING` will use MGF1 with the same hash function
   used to sign the message as specified in section 3.1 of [RFC 4055][].
-* `saltLength` {integer} Salt length for when padding is
+* `saltLength` {number} Salt length for when padding is
   `RSA_PKCS1_PSS_PADDING`. The special value
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
@@ -5606,14 +5606,14 @@ additional properties can be passed:
   format of the signature. It can be one of the following:
   * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
   * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
-* `padding` {integer} Optional padding value for RSA, one of the following:
+* `padding` {number} Optional padding value for RSA, one of the following:
 
   * `crypto.constants.RSA_PKCS1_PADDING` (default)
   * `crypto.constants.RSA_PKCS1_PSS_PADDING`
 
   `RSA_PKCS1_PSS_PADDING` will use MGF1 with the same hash function
   used to sign the message as specified in section 3.1 of [RFC 4055][].
-* `saltLength` {integer} Salt length for when padding is
+* `saltLength` {number} Salt length for when padding is
   `RSA_PKCS1_PSS_PADDING`. The special value
   `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
   size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the

--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -238,7 +238,7 @@ changes:
                  function to the method call.
 -->
 
-* `port` {integer}
+* `port` {number}
 * `address` {string}
 * `callback` {Function} with no parameters. Called when binding is complete.
 
@@ -314,10 +314,10 @@ added: v0.11.14
 -->
 
 * `options` {Object} Required. Supports the following properties:
-  * `port` {integer}
+  * `port` {number}
   * `address` {string}
   * `exclusive` {boolean}
-  * `fd` {integer}
+  * `fd` {number}
 * `callback` {Function}
 
 For UDP sockets, causes the `dgram.Socket` to listen for datagram
@@ -395,7 +395,7 @@ socket has closed.
 added: v12.0.0
 -->
 
-* `port` {integer}
+* `port` {number}
 * `address` {string}
 * `callback` {Function} Called when the connection is completed or on error.
 
@@ -564,9 +564,9 @@ changes:
 -->
 
 * `msg` {Buffer|TypedArray|DataView|string|Array} Message to be sent.
-* `offset` {integer} Offset in the buffer where the message starts.
-* `length` {integer} Number of bytes in the message.
-* `port` {integer} Destination port.
+* `offset` {number} Offset in the buffer where the message starts.
+* `length` {number} Number of bytes in the message.
+* `port` {number} Destination port.
 * `address` {string} Destination host name or IP address.
 * `callback` {Function} Called when the message has been sent.
 
@@ -837,7 +837,7 @@ This method throws `EBADF` if called on an unbound socket.
 added: v0.3.8
 -->
 
-* `ttl` {integer}
+* `ttl` {number}
 
 Sets the `IP_MULTICAST_TTL` socket option. While TTL generally stands for
 "Time to Live", in this context it specifies the number of IP hops that a
@@ -855,7 +855,7 @@ This method throws `EBADF` if called on an unbound socket.
 added: v8.7.0
 -->
 
-* `size` {integer}
+* `size` {number}
 
 Sets the `SO_RCVBUF` socket option. Sets the maximum socket receive buffer
 in bytes.
@@ -868,7 +868,7 @@ This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 added: v8.7.0
 -->
 
-* `size` {integer}
+* `size` {number}
 
 Sets the `SO_SNDBUF` socket option. Sets the maximum socket send buffer
 in bytes.
@@ -881,7 +881,7 @@ This method throws [`ERR_SOCKET_BUFFER_SIZE`][] if called on an unbound socket.
 added: v0.1.101
 -->
 
-* `ttl` {integer}
+* `ttl` {number}
 
 Sets the `IP_TTL` socket option. While TTL generally stands for "Time to Live",
 in this context it specifies the number of IP hops that a packet is allowed to

--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -153,11 +153,11 @@ changes:
 Create a new resolver.
 
 * `options` {Object}
-  * `timeout` {integer} Query timeout in milliseconds, or `-1` to use the
+  * `timeout` {number} Query timeout in milliseconds, or `-1` to use the
     default timeout.
-  * `tries` {integer} The number of tries the resolver will try contacting
+  * `tries` {number} The number of tries the resolver will try contacting
     each name server before giving up. **Default:** `4`
-  * `maxTimeout` {integer} The max retry timeout, in milliseconds.
+  * `maxTimeout` {number} The max retry timeout, in milliseconds.
     **Default:** `0`, disabled.
 
 ### `resolver.cancel()`
@@ -277,7 +277,7 @@ changes:
 * `callback` {Function}
   * `err` {Error}
   * `address` {string} A string representation of an IPv4 or IPv6 address.
-  * `family` {integer} `4` or `6`, denoting the family of `address`, or `0` if
+  * `family` {number} `4` or `6`, denoting the family of `address`, or `0` if
     the address is not an IPv4 or IPv6 address. `0` is a likely indicator of a
     bug in the name resolution service used by the operating system.
 
@@ -1099,7 +1099,7 @@ changes:
 
 * `hostname` {string}
 * `options` {integer | Object}
-  * `family` {integer} The record family. Must be `4`, `6`, or `0`. The value
+  * `family` {number} The record family. Must be `4`, `6`, or `0`. The value
     `0` indicates that either an IPv4 or IPv6 address is returned. If the
     value `0` is used with `{ all: true }` (see below), either one of or both
     IPv4 and IPv6 addresses are returned, depending on the system's DNS

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -642,7 +642,7 @@ console.log(myEE.eventNames());
 added: v1.0.0
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns the current max listener value for the `EventEmitter` which is either
 set by [`emitter.setMaxListeners(n)`][] or defaults to
@@ -662,7 +662,7 @@ changes:
 
 * `eventName` {string|symbol} The name of the event being listened for
 * `listener` {Function} The event handler function
-* Returns: {integer}
+* Returns: {number}
 
 Returns the number of listeners listening for the event named `eventName`.
 If `listener` is provided, it will return how many times the listener is found
@@ -1012,7 +1012,7 @@ Returns a reference to the `EventEmitter`, so that calls can be chained.
 added: v0.3.5
 -->
 
-* `n` {integer}
+* `n` {number}
 * Returns: {EventEmitter}
 
 By default `EventEmitter`s will print a warning if more than `10` listeners are
@@ -1682,11 +1682,11 @@ changes:
 * `options` {Object}
   * `signal` {AbortSignal} Can be used to cancel awaiting events.
   * `close` {string\[]} Names of events that will end the iteration.
-  * `highWaterMark` {integer} **Default:** `Number.MAX_SAFE_INTEGER`
+  * `highWaterMark` {number} **Default:** `Number.MAX_SAFE_INTEGER`
     The high watermark. The emitter is paused every time the size of events
     being buffered is higher than it. Supported only on emitters implementing
     `pause()` and `resume()` methods.
-  * `lowWaterMark` {integer} **Default:** `1`
+  * `lowWaterMark` {number} **Default:** `1`
     The low watermark. The emitter is resumed every time the size of events
     being buffered is lower than it. Supported only on emitters implementing
     `pause()` and `resume()` methods.

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -214,7 +214,7 @@ to with [`fsPromises.open()`][]. Therefore, this is equivalent to
 added: v10.0.0
 -->
 
-* `mode` {integer} the file mode bit mask.
+* `mode` {number} the file mode bit mask.
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Modifies the permissions on the file. See chmod(2).
@@ -225,8 +225,8 @@ Modifies the permissions on the file. See chmod(2).
 added: v10.0.0
 -->
 
-* `uid` {integer} The file's new owner's user id.
-* `gid` {integer} The file's new group's group id.
+* `uid` {number} The file's new owner's user id.
+* `gid` {number} The file's new group's group id.
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Changes the ownership of the file. A wrapper for chown(2).
@@ -263,9 +263,9 @@ added: v16.11.0
   * `encoding` {string} **Default:** `null`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
-  * `start` {integer}
-  * `end` {integer} **Default:** `Infinity`
-  * `highWaterMark` {integer} **Default:** `64 * 1024`
+  * `start` {number}
+  * `end` {number} **Default:** `Infinity`
+  * `highWaterMark` {number} **Default:** `64 * 1024`
   * `signal` {AbortSignal|undefined} **Default:** `undefined`
 * Returns: {fs.ReadStream}
 
@@ -334,7 +334,7 @@ changes:
   * `encoding` {string} **Default:** `'utf8'`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
-  * `start` {integer}
+  * `start` {number}
   * `highWaterMark` {number} **Default:** `16384`
   * `flush` {boolean} If `true`, the underlying file descriptor is flushed
     prior to closing it. **Default:** `false`.
@@ -389,9 +389,9 @@ changes:
 
 * `buffer` {Buffer|TypedArray|DataView} A buffer that will be filled with the
   file data read.
-* `offset` {integer} The location in the buffer at which to start filling.
+* `offset` {number} The location in the buffer at which to start filling.
   **Default:** `0`
-* `length` {integer} The number of bytes to read. **Default:**
+* `length` {number} The number of bytes to read. **Default:**
   `buffer.byteLength - offset`
 * `position` {integer|bigint|null} The location where to begin reading data
   from the file. If `null` or `-1`, data will be read from the current file
@@ -399,7 +399,7 @@ changes:
   integer, the current file position will remain unchanged.
   **Default:**: `null`
 * Returns: {Promise} Fulfills upon success with an object with two properties:
-  * `bytesRead` {integer} The number of bytes read
+  * `bytesRead` {number} The number of bytes read
   * `buffer` {Buffer|TypedArray|DataView} A reference to the passed in `buffer`
     argument.
 
@@ -423,9 +423,9 @@ changes:
 * `options` {Object}
   * `buffer` {Buffer|TypedArray|DataView} A buffer that will be filled with the
     file data read. **Default:** `Buffer.alloc(16384)`
-  * `offset` {integer} The location in the buffer at which to start filling.
+  * `offset` {number} The location in the buffer at which to start filling.
     **Default:** `0`
-  * `length` {integer} The number of bytes to read. **Default:**
+  * `length` {number} The number of bytes to read. **Default:**
     `buffer.byteLength - offset`
   * `position` {integer|bigint|null} The location where to begin reading data
     from the file. If `null` or `-1`, data will be read from the current file
@@ -433,7 +433,7 @@ changes:
     integer, the current file position will remain unchanged.
     **Default:**: `null`
 * Returns: {Promise} Fulfills upon success with an object with two properties:
-  * `bytesRead` {integer} The number of bytes read
+  * `bytesRead` {number} The number of bytes read
   * `buffer` {Buffer|TypedArray|DataView} A reference to the passed in `buffer`
     argument.
 
@@ -457,9 +457,9 @@ changes:
 * `buffer` {Buffer|TypedArray|DataView} A buffer that will be filled with the
   file data read.
 * `options` {Object}
-  * `offset` {integer} The location in the buffer at which to start filling.
+  * `offset` {number} The location in the buffer at which to start filling.
     **Default:** `0`
-  * `length` {integer} The number of bytes to read. **Default:**
+  * `length` {number} The number of bytes to read. **Default:**
     `buffer.byteLength - offset`
   * `position` {integer|bigint|null} The location where to begin reading data
     from the file. If `null` or `-1`, data will be read from the current file
@@ -467,7 +467,7 @@ changes:
     integer, the current file position will remain unchanged.
     **Default:**: `null`
 * Returns: {Promise} Fulfills upon success with an object with two properties:
-  * `bytesRead` {integer} The number of bytes read
+  * `bytesRead` {number} The number of bytes read
   * `buffer` {Buffer|TypedArray|DataView} A reference to the passed in `buffer`
     argument.
 
@@ -576,9 +576,9 @@ added: v18.11.0
   * `encoding` {string} **Default:** `null`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
-  * `start` {integer}
-  * `end` {integer} **Default:** `Infinity`
-  * `highWaterMark` {integer} **Default:** `64 * 1024`
+  * `start` {number}
+  * `end` {number} **Default:** `Infinity`
+  * `highWaterMark` {number} **Default:** `64 * 1024`
 * Returns: {readline.InterfaceConstructor}
 
 Convenience method to create a `readline` interface and stream over the file.
@@ -619,7 +619,7 @@ added:
   the data should be read from. If `position` is not a `number`, the data will
   be read from the current position. **Default:** `null`
 * Returns: {Promise} Fulfills upon success an object containing two properties:
-  * `bytesRead` {integer} the number of bytes read
+  * `bytesRead` {number} the number of bytes read
   * `buffers` {Buffer\[]|TypedArray\[]|DataView\[]} property containing
     a reference to the `buffers` input.
 
@@ -659,7 +659,7 @@ Refer to the POSIX fsync(2) documentation for more detail.
 added: v10.0.0
 -->
 
-* `len` {integer} **Default:** `0`
+* `len` {number} **Default:** `0`
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Truncates the file.
@@ -711,9 +711,9 @@ changes:
 -->
 
 * `buffer` {Buffer|TypedArray|DataView}
-* `offset` {integer} The start position from within `buffer` where the data
+* `offset` {number} The start position from within `buffer` where the data
   to write begins.
-* `length` {integer} The number of bytes from `buffer` to write. **Default:**
+* `length` {number} The number of bytes from `buffer` to write. **Default:**
   `buffer.byteLength - offset`
 * `position` {integer|null} The offset from the beginning of the file where the
   data from `buffer` should be written. If `position` is not a `number`,
@@ -725,7 +725,7 @@ Write `buffer` to the file.
 
 The promise is fulfilled with an object containing two properties:
 
-* `bytesWritten` {integer} the number of bytes written
+* `bytesWritten` {number} the number of bytes written
 * `buffer` {Buffer|TypedArray|DataView} a reference to the
   `buffer` written.
 
@@ -747,8 +747,8 @@ added:
 
 * `buffer` {Buffer|TypedArray|DataView}
 * `options` {Object}
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|null} **Default:** `null`
 * Returns: {Promise}
 
@@ -782,7 +782,7 @@ rejected with an error.
 
 The promise is fulfilled with an object containing two properties:
 
-* `bytesWritten` {integer} the number of bytes written
+* `bytesWritten` {number} the number of bytes written
 * `buffer` {string} a reference to the `string` written.
 
 It is unsafe to use `filehandle.write()` multiple times on the same file
@@ -848,7 +848,7 @@ Write an array of {ArrayBufferView}s to the file.
 
 The promise is fulfilled with an object containing a two properties:
 
-* `bytesWritten` {integer} the number of bytes written
+* `bytesWritten` {number} the number of bytes written
 * `buffers` {Buffer\[]|TypedArray\[]|DataView\[]} a reference to the `buffers`
   input.
 
@@ -881,7 +881,7 @@ added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
-* `mode` {integer} **Default:** `fs.constants.F_OK`
+* `mode` {number} **Default:** `fs.constants.F_OK`
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Tests a user's permissions for the file or directory specified by `path`.
@@ -930,7 +930,7 @@ changes:
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'a'`.
   * `flush` {boolean} If `true`, the underlying file descriptor is flushed
     prior to closing it. **Default:** `false`.
@@ -966,8 +966,8 @@ added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer}
-* `gid` {integer}
+* `uid` {number}
+* `gid` {number}
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Changes the ownership of a file.
@@ -985,7 +985,7 @@ changes:
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `mode` {integer} Optional modifiers that specify the behavior of the copy
+* `mode` {number} Optional modifiers that specify the behavior of the copy
   operation. It is possible to create a mask consisting of the bitwise OR of
   two or more values (e.g.
   `fs.constants.COPYFILE_EXCL | fs.constants.COPYFILE_FICLONE`)
@@ -1066,7 +1066,7 @@ changes:
     operation will ignore errors if you set this to false and the destination
     exists. Use the `errorOnExist` option to change this behavior.
     **Default:** `true`.
-  * `mode` {integer} modifiers for copy operation. **Default:** `0`.
+  * `mode` {number} modifiers for copy operation. **Default:** `0`.
     See `mode` flag of [`fsPromises.copyFile()`][].
   * `preserveTimestamps` {boolean} When `true` timestamps from `src` will
     be preserved. **Default:** `false`.
@@ -1142,7 +1142,7 @@ deprecated: v10.0.0
 > Stability: 0 - Deprecated
 
 * `path` {string|Buffer|URL}
-* `mode` {integer}
+* `mode` {number}
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Changes the permissions on a symbolic link.
@@ -1160,8 +1160,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer}
-* `gid` {integer}
+* `uid` {number}
+* `gid` {number}
 * Returns: {Promise}  Fulfills with `undefined` upon success.
 
 Changes the ownership on a symbolic link.
@@ -1685,14 +1685,14 @@ added: v14.14.0
 * `options` {Object}
   * `force` {boolean} When `true`, exceptions will be ignored if `path` does
     not exist. **Default:** `false`.
-  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  * `maxRetries` {number} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
     `EPERM` error is encountered, Node.js will retry the operation with a linear
     backoff wait of `retryDelay` milliseconds longer on each try. This option
     represents the number of retries. This option is ignored if the `recursive`
     option is not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
     recursive mode operations are retried on failure. **Default:** `false`.
-  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  * `retryDelay` {number} The amount of time in milliseconds to wait between
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.
 * Returns: {Promise} Fulfills with `undefined` upon success.
@@ -1767,7 +1767,7 @@ added: v10.0.0
 -->
 
 * `path` {string|Buffer|URL}
-* `len` {integer} **Default:** `0`
+* `len` {number} **Default:** `0`
 * Returns: {Promise} Fulfills with `undefined` upon success.
 
 Truncates (shortens or extends the length) of the content at `path` to `len`
@@ -1895,7 +1895,7 @@ changes:
 * `data` {string|Buffer|TypedArray|DataView|AsyncIterable|Iterable|Stream}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
   * `flush` {boolean} If all data is successfully written to the file, and
     `flush` is `true`, `filehandle.sync()` is used to flush the data.
@@ -2007,7 +2007,7 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `mode` {integer} **Default:** `fs.constants.F_OK`
+* `mode` {number} **Default:** `fs.constants.F_OK`
 * `callback` {Function}
   * `err` {Error}
 
@@ -2207,7 +2207,7 @@ changes:
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'a'`.
   * `flush` {boolean} If `true`, the underlying file descriptor is flushed
     prior to closing it. **Default:** `false`.
@@ -2383,8 +2383,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer}
-* `gid` {integer}
+* `uid` {number}
+* `gid` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -2418,7 +2418,7 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -2448,7 +2448,7 @@ changes:
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `mode` {integer} modifiers for copy operation. **Default:** `0`.
+* `mode` {number} modifiers for copy operation. **Default:** `0`.
 * `callback` {Function}
   * `err` {Error}
 
@@ -2532,7 +2532,7 @@ changes:
     operation will ignore errors if you set this to false and the destination
     exists. Use the `errorOnExist` option to change this behavior.
     **Default:** `true`.
-  * `mode` {integer} modifiers for copy operation. **Default:** `0`.
+  * `mode` {number} modifiers for copy operation. **Default:** `0`.
     See `mode` flag of [`fs.copyFile()`][].
   * `preserveTimestamps` {boolean} When `true` timestamps from `src` will
     be preserved. **Default:** `false`.
@@ -2601,12 +2601,12 @@ changes:
     `'r'`.
   * `encoding` {string} **Default:** `null`
   * `fd` {integer|FileHandle} **Default:** `null`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
-  * `start` {integer}
-  * `end` {integer} **Default:** `Infinity`
-  * `highWaterMark` {integer} **Default:** `64 * 1024`
+  * `start` {number}
+  * `end` {number} **Default:** `Infinity`
+  * `highWaterMark` {number} **Default:** `64 * 1024`
   * `fs` {Object|null} **Default:** `null`
   * `signal` {AbortSignal|null} **Default:** `null`
 * Returns: {fs.ReadStream}
@@ -2730,10 +2730,10 @@ changes:
     `'w'`.
   * `encoding` {string} **Default:** `'utf8'`
   * `fd` {integer|FileHandle} **Default:** `null`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `autoClose` {boolean} **Default:** `true`
   * `emitClose` {boolean} **Default:** `true`
-  * `start` {integer}
+  * `start` {number}
   * `fs` {Object|null} **Default:** `null`
   * `signal` {AbortSignal|null} **Default:** `null`
   * `highWaterMark` {number} **Default:** `16384`
@@ -2945,7 +2945,7 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `mode` {string|integer}
 * `callback` {Function}
   * `err` {Error}
@@ -2975,9 +2975,9 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
-* `uid` {integer}
-* `gid` {integer}
+* `fd` {number}
+* `uid` {number}
+* `gid` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3006,7 +3006,7 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3039,7 +3039,7 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     {fs.Stats} object should be `bigint`. **Default:** `false`.
@@ -3071,7 +3071,7 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3100,8 +3100,8 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
-* `len` {integer} **Default:** `0`
+* `fd` {number}
+* `len` {number} **Default:** `0`
 * `callback` {Function}
   * `err` {Error}
 
@@ -3169,7 +3169,7 @@ changes:
                  time specifiers.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `atime` {number|string|Date}
 * `mtime` {number|string|Date}
 * `callback` {Function}
@@ -3263,7 +3263,7 @@ changes:
 > Stability: 0 - Deprecated
 
 * `path` {string|Buffer|URL}
-* `mode` {integer}
+* `mode` {number}
 * `callback` {Function}
   * `err` {Error|AggregateError}
 
@@ -3299,8 +3299,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer}
-* `gid` {integer}
+* `uid` {number}
+* `gid` {number}
 * `callback` {Function}
   * `err` {Error}
 
@@ -3620,7 +3620,7 @@ changes:
 * `mode` {string|integer} **Default:** `0o666` (readable and writable)
 * `callback` {Function}
   * `err` {Error}
-  * `fd` {integer}
+  * `fd` {number}
 
 Asynchronous file open. See the POSIX open(2) documentation for more details.
 
@@ -3744,18 +3744,18 @@ changes:
     description: The `length` parameter can now be `0`.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView} The buffer that the data will be
   written to.
-* `offset` {integer} The position in `buffer` to write the data to.
-* `length` {integer} The number of bytes to read.
+* `offset` {number} The position in `buffer` to write the data to.
+* `length` {number} The number of bytes to read.
 * `position` {integer|bigint|null} Specifies where to begin reading from in the
   file. If `position` is `null` or `-1 `, data will be read from the current
   file position, and the file position will be updated. If `position` is
   a non-negative integer, the file position will be unchanged.
 * `callback` {Function}
   * `err` {Error}
-  * `bytesRead` {integer}
+  * `bytesRead` {number}
   * `buffer` {Buffer}
 
 Read data from the file specified by `fd`.
@@ -3814,15 +3814,15 @@ changes:
                  to make buffer, offset, length, and position optional.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `options` {Object}
   * `buffer` {Buffer|TypedArray|DataView} **Default:** `Buffer.alloc(16384)`
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|bigint|null} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesRead` {integer}
+  * `bytesRead` {number}
   * `buffer` {Buffer}
 
 Similar to the [`fs.read()`][] function, this version takes an optional
@@ -3837,16 +3837,16 @@ added:
   - v16.17.0
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView} The buffer that the data will be
   written to.
 * `options` {Object}
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|bigint} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesRead` {integer}
+  * `bytesRead` {number}
   * `buffer` {Buffer}
 
 Similar to the [`fs.read()`][] function, this version takes an optional
@@ -4114,12 +4114,12 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffers` {ArrayBufferView\[]}
 * `position` {integer|null} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesRead` {integer}
+  * `bytesRead` {number}
   * `buffers` {ArrayBufferView\[]}
 
 Read from a file specified by `fd` and write to an array of `ArrayBufferView`s
@@ -4377,14 +4377,14 @@ changes:
 * `options` {Object}
   * `force` {boolean} When `true`, exceptions will be ignored if `path` does
     not exist. **Default:** `false`.
-  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  * `maxRetries` {number} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
     `EPERM` error is encountered, Node.js will retry the operation with a linear
     backoff wait of `retryDelay` milliseconds longer on each try. This option
     represents the number of retries. This option is ignored if the `recursive`
     option is not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive removal. In
     recursive mode operations are retried on failure. **Default:** `false`.
-  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  * `retryDelay` {number} The amount of time in milliseconds to wait between
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.
 * `callback` {Function}
@@ -4621,7 +4621,7 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `len` {integer} **Default:** `0`
+* `len` {number} **Default:** `0`
 * `callback` {Function}
   * `err` {Error|AggregateError}
 
@@ -4917,7 +4917,7 @@ changes:
 * `options` {Object}
   * `bigint` {boolean} **Default:** `false`
   * `persistent` {boolean} **Default:** `true`
-  * `interval` {integer} **Default:** `5007`
+  * `interval` {number} **Default:** `5007`
 * `listener` {Function}
   * `current` {fs.Stats}
   * `previous` {fs.Stats}
@@ -5004,14 +5004,14 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
-* `offset` {integer} **Default:** `0`
-* `length` {integer} **Default:** `buffer.byteLength - offset`
+* `offset` {number} **Default:** `0`
+* `length` {number} **Default:** `buffer.byteLength - offset`
 * `position` {integer|null} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesWritten` {integer}
+  * `bytesWritten` {number}
   * `buffer` {Buffer|TypedArray|DataView}
 
 Write `buffer` to the file specified by `fd`.
@@ -5045,15 +5045,15 @@ added:
   - v16.17.0
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
 * `options` {Object}
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|null} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesWritten` {integer}
+  * `bytesWritten` {number}
   * `buffer` {Buffer|TypedArray|DataView}
 
 Write `buffer` to the file specified by `fd`.
@@ -5096,13 +5096,13 @@ changes:
                  it will emit a deprecation warning with id DEP0013.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `string` {string}
 * `position` {integer|null} **Default:** `null`
 * `encoding` {string} **Default:** `'utf8'`
 * `callback` {Function}
   * `err` {Error}
-  * `written` {integer}
+  * `written` {number}
   * `string` {string}
 
 Write `string` to the file specified by `fd`. If `string` is not a string,
@@ -5199,7 +5199,7 @@ changes:
 * `data` {string|Buffer|TypedArray|DataView}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
   * `flush` {boolean} If all data is successfully written to the file, and
     `flush` is `true`, `fs.fsync()` is used to flush the data.
@@ -5309,12 +5309,12 @@ changes:
                  `ERR_INVALID_CALLBACK`.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffers` {ArrayBufferView\[]}
 * `position` {integer|null} **Default:** `null`
 * `callback` {Function}
   * `err` {Error}
-  * `bytesWritten` {integer}
+  * `bytesWritten` {number}
   * `buffers` {ArrayBufferView\[]}
 
 Write an array of `ArrayBufferView`s to the file specified by `fd` using
@@ -5354,7 +5354,7 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `mode` {integer} **Default:** `fs.constants.F_OK`
+* `mode` {number} **Default:** `fs.constants.F_OK`
 
 Synchronously tests a user's permissions for the file or directory specified
 by `path`. The `mode` argument is an optional integer that specifies the
@@ -5400,7 +5400,7 @@ changes:
 * `data` {string|Buffer}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'a'`.
   * `flush` {boolean} If `true`, the underlying file descriptor is flushed
     prior to closing it. **Default:** `false`.
@@ -5481,8 +5481,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer}
-* `gid` {integer}
+* `uid` {number}
+* `gid` {number}
 
 Synchronously changes owner and group of a file. Returns `undefined`.
 This is the synchronous version of [`fs.chown()`][].
@@ -5495,7 +5495,7 @@ See the POSIX chown(2) documentation for more detail.
 added: v0.1.21
 -->
 
-* `fd` {integer}
+* `fd` {number}
 
 Closes the file descriptor. Returns `undefined`.
 
@@ -5517,7 +5517,7 @@ changes:
 
 * `src` {string|Buffer|URL} source filename to copy
 * `dest` {string|Buffer|URL} destination filename of the copy operation
-* `mode` {integer} modifiers for copy operation. **Default:** `0`.
+* `mode` {number} modifiers for copy operation. **Default:** `0`.
 
 Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists. Returns `undefined`. Node.js makes no guarantees about the
@@ -5588,7 +5588,7 @@ changes:
     operation will ignore errors if you set this to false and the destination
     exists. Use the `errorOnExist` option to change this behavior.
     **Default:** `true`.
-  * `mode` {integer} modifiers for copy operation. **Default:** `0`.
+  * `mode` {number} modifiers for copy operation. **Default:** `0`.
     See `mode` flag of [`fs.copyFileSync()`][].
   * `preserveTimestamps` {boolean} When `true` timestamps from `src` will
     be preserved. **Default:** `false`.
@@ -5638,7 +5638,7 @@ if (existsSync('/etc/passwd'))
 added: v0.4.7
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `mode` {string|integer}
 
 Sets the permissions on the file. Returns `undefined`.
@@ -5651,9 +5651,9 @@ See the POSIX fchmod(2) documentation for more detail.
 added: v0.4.7
 -->
 
-* `fd` {integer}
-* `uid` {integer} The file's new owner's user id.
-* `gid` {integer} The file's new group's group id.
+* `fd` {number}
+* `uid` {number} The file's new owner's user id.
+* `gid` {number} The file's new group's group id.
 
 Sets the owner of the file. Returns `undefined`.
 
@@ -5665,7 +5665,7 @@ See the POSIX fchown(2) documentation for more detail.
 added: v0.1.96
 -->
 
-* `fd` {integer}
+* `fd` {number}
 
 Forces all currently queued I/O operations associated with the file to the
 operating system's synchronized I/O completion state. Refer to the POSIX
@@ -5682,7 +5682,7 @@ changes:
                  the numeric values returned should be bigint.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `options` {Object}
   * `bigint` {boolean} Whether the numeric values in the returned
     {fs.Stats} object should be `bigint`. **Default:** `false`.
@@ -5698,7 +5698,7 @@ See the POSIX fstat(2) documentation for more detail.
 added: v0.1.96
 -->
 
-* `fd` {integer}
+* `fd` {number}
 
 Request that all data for the open file descriptor is flushed to the storage
 device. The specific implementation is operating system and device specific.
@@ -5710,8 +5710,8 @@ Refer to the POSIX fsync(2) documentation for more detail. Returns `undefined`.
 added: v0.8.6
 -->
 
-* `fd` {integer}
-* `len` {integer} **Default:** `0`
+* `fd` {number}
+* `len` {number} **Default:** `0`
 
 Truncates the file descriptor. Returns `undefined`.
 
@@ -5729,7 +5729,7 @@ changes:
                  time specifiers.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `atime` {number|string|Date}
 * `mtime` {number|string|Date}
 
@@ -5791,7 +5791,7 @@ deprecated: v0.4.7
 > Stability: 0 - Deprecated
 
 * `path` {string|Buffer|URL}
-* `mode` {integer}
+* `mode` {number}
 
 Changes the permissions on a symbolic link. Returns `undefined`.
 
@@ -5811,8 +5811,8 @@ changes:
 -->
 
 * `path` {string|Buffer|URL}
-* `uid` {integer} The file's new owner's user id.
-* `gid` {integer} The file's new group's group id.
+* `uid` {number} The file's new owner's user id.
+* `gid` {number} The file's new group's group id.
 
 Set the owner for the path. Returns `undefined`.
 
@@ -6161,10 +6161,10 @@ changes:
     description: The `length` parameter can now be `0`.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
-* `offset` {integer}
-* `length` {integer}
+* `offset` {number}
+* `length` {number}
 * `position` {integer|bigint|null} **Default:** `null`
 * Returns: {number}
 
@@ -6188,11 +6188,11 @@ changes:
                  to make offset, length, and position optional.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
 * `options` {Object}
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|bigint|null} **Default:** `null`
 * Returns: {number}
 
@@ -6212,7 +6212,7 @@ added:
  - v12.17.0
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffers` {ArrayBufferView\[]}
 * `position` {integer|null} **Default:** `null`
 * Returns: {number} The number of bytes read.
@@ -6369,14 +6369,14 @@ changes:
 * `options` {Object}
   * `force` {boolean} When `true`, exceptions will be ignored if `path` does
     not exist. **Default:** `false`.
-  * `maxRetries` {integer} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+  * `maxRetries` {number} If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
     `EPERM` error is encountered, Node.js will retry the operation with a linear
     backoff wait of `retryDelay` milliseconds longer on each try. This option
     represents the number of retries. This option is ignored if the `recursive`
     option is not `true`. **Default:** `0`.
   * `recursive` {boolean} If `true`, perform a recursive directory removal. In
     recursive mode operations are retried on failure. **Default:** `false`.
-  * `retryDelay` {integer} The amount of time in milliseconds to wait between
+  * `retryDelay` {number} The amount of time in milliseconds to wait between
     retries. This option is ignored if the `recursive` option is not `true`.
     **Default:** `100`.
 
@@ -6465,7 +6465,7 @@ added: v0.8.6
 -->
 
 * `path` {string|Buffer|URL}
-* `len` {integer} **Default:** `0`
+* `len` {number} **Default:** `0`
 
 Truncates the file. Returns `undefined`. A file descriptor can also be
 passed as the first argument. In this case, `fs.ftruncateSync()` is called.
@@ -6557,7 +6557,7 @@ changes:
 * `data` {string|Buffer|TypedArray|DataView}
 * `options` {Object|string}
   * `encoding` {string|null} **Default:** `'utf8'`
-  * `mode` {integer} **Default:** `0o666`
+  * `mode` {number} **Default:** `0o666`
   * `flag` {string} See [support of file system `flags`][]. **Default:** `'w'`.
   * `flush` {boolean} If all data is successfully written to the file, and
     `flush` is `true`, `fs.fsyncSync()` is used to flush the data.
@@ -6590,10 +6590,10 @@ changes:
     description: The `offset` and `length` parameters are optional now.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
-* `offset` {integer} **Default:** `0`
-* `length` {integer} **Default:** `buffer.byteLength - offset`
+* `offset` {number} **Default:** `0`
+* `length` {number} **Default:** `buffer.byteLength - offset`
 * `position` {integer|null} **Default:** `null`
 * Returns: {number} The number of bytes written.
 
@@ -6608,11 +6608,11 @@ added:
   - v16.17.0
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffer` {Buffer|TypedArray|DataView}
 * `options` {Object}
-  * `offset` {integer} **Default:** `0`
-  * `length` {integer} **Default:** `buffer.byteLength - offset`
+  * `offset` {number} **Default:** `0`
+  * `length` {number} **Default:** `buffer.byteLength - offset`
   * `position` {integer|null} **Default:** `null`
 * Returns: {number} The number of bytes written.
 
@@ -6633,7 +6633,7 @@ changes:
     description: The `position` parameter is optional now.
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `string` {string}
 * `position` {integer|null} **Default:** `null`
 * `encoding` {string} **Default:** `'utf8'`
@@ -6648,7 +6648,7 @@ this API: [`fs.write(fd, string...)`][].
 added: v12.9.0
 -->
 
-* `fd` {integer}
+* `fd` {number}
 * `buffers` {ArrayBufferView\[]}
 * `position` {integer|null} **Default:** `null`
 * Returns: {number} The number of bytes written.
@@ -7144,7 +7144,7 @@ Emitted when the {fs.ReadStream}'s underlying file descriptor has been closed.
 added: v0.1.93
 -->
 
-* `fd` {integer} Integer file descriptor used by the {fs.ReadStream}.
+* `fd` {number} Integer file descriptor used by the {fs.ReadStream}.
 
 Emitted when the {fs.ReadStream}'s file descriptor has been opened.
 
@@ -7915,7 +7915,7 @@ Emitted when the {fs.WriteStream}'s underlying file descriptor has been closed.
 added: v0.1.93
 -->
 
-* `fd` {integer} Integer file descriptor used by the {fs.WriteStream}.
+* `fd` {number} Integer file descriptor used by the {fs.WriteStream}.
 
 Emitted when the {fs.WriteStream}'s file is opened.
 

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -339,7 +339,7 @@ changes:
   * `port` {number} Port of remote server
   * `localAddress` {string} Local interface to bind for network connections
     when issuing the request
-  * `family` {integer} Must be 4 or 6 if this doesn't equal `undefined`.
+  * `family` {number} Must be 4 or 6 if this doesn't equal `undefined`.
 * Returns: {string}
 
 Get a unique name for a set of request options, to determine whether a
@@ -638,9 +638,9 @@ added: v10.0.0
 
 * `info` {Object}
   * `httpVersion` {string}
-  * `httpVersionMajor` {integer}
-  * `httpVersionMinor` {integer}
-  * `statusCode` {integer}
+  * `httpVersionMajor` {number}
+  * `httpVersionMinor` {number}
+  * `statusCode` {number}
   * `statusMessage` {string}
   * `headers` {Object}
   * `rawHeaders` {string\[]}

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -274,9 +274,9 @@ an `Http2Session`.
 added: v8.4.0
 -->
 
-* `type` {integer} The frame type.
-* `code` {integer} The error code.
-* `id` {integer} The stream id (or `0` if the frame isn't associated with a
+* `type` {number} The frame type.
+* `code` {number} The error code.
+* `id` {number} The stream id (or `0` if the frame isn't associated with a
   stream).
 
 The `'frameError'` event is emitted when an error occurs while attempting to
@@ -786,7 +786,7 @@ changes:
   right away if the session is already connected.
   * `err` {Error|null}
   * `settings` {HTTP/2 Settings Object} The updated `settings` object.
-  * `duration` {integer}
+  * `duration` {number}
 
 Updates the current local settings for this `Http2Session` and sends a new
 `SETTINGS` frame to the connected HTTP/2 peer.
@@ -1296,9 +1296,9 @@ an `Http2Stream`.
 added: v8.4.0
 -->
 
-* `type` {integer} The frame type.
-* `code` {integer} The error code.
-* `id` {integer} The stream id (or `0` if the frame isn't associated with a
+* `type` {number} The frame type.
+* `code` {number} The error code.
+* `id` {number} The stream id (or `0` if the frame isn't associated with a
   stream).
 
 The `'frameError'` event is emitted when an error occurs while attempting to
@@ -2879,10 +2879,10 @@ changes:
     streams for the remote peer as if a `SETTINGS` frame had been received. Will
     be overridden if the remote peer sets its own value for
     `maxConcurrentStreams`. **Default:** `100`.
-  * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
+  * `maxSessionInvalidFrames` {number} Sets the maximum number of invalid
     frames that will be tolerated before the session is closed.
     **Default:** `1000`.
-  * `maxSessionRejectedStreams` {integer} Sets the maximum number of rejected
+  * `maxSessionRejectedStreams` {number} Sets the maximum number of rejected
     upon creation streams that will be tolerated before the session is closed.
     Each rejection is associated with an `NGHTTP2_ENHANCE_YOUR_CALM`
     error that should tell the peer to not open any more streams, continuing
@@ -3065,10 +3065,10 @@ changes:
     streams for the remote peer as if a `SETTINGS` frame had been received. Will
     be overridden if the remote peer sets its own value for
     `maxConcurrentStreams`. **Default:** `100`.
-  * `maxSessionInvalidFrames` {integer} Sets the maximum number of invalid
+  * `maxSessionInvalidFrames` {number} Sets the maximum number of invalid
     frames that will be tolerated before the session is closed.
     **Default:** `1000`.
-  * `maxSessionRejectedStreams` {integer} Sets the maximum number of rejected
+  * `maxSessionRejectedStreams` {number} Sets the maximum number of rejected
     upon creation streams that will be tolerated before the session is closed.
     Each rejection is associated with an `NGHTTP2_ENHANCE_YOUR_CALM`
     error that should tell the peer to not open any more streams, continuing

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -483,7 +483,7 @@ added: v22.8.0
 * `cacheDir` {string|undefined} Optional path to specify the directory where the compile cache
   will be stored/retrieved.
 * Returns: {Object}
-  * `status` {integer} One of the [`module.constants.compileCacheStatus`][]
+  * `status` {number} One of the [`module.constants.compileCacheStatus`][]
   * `message` {string|undefined} If Node.js cannot enable the compile cache, this contains
     the error message. Only set if `status` is `module.constants.compileCacheStatus.FAILED`.
   * `directory` {string|undefined} If the compile cache is enabled, this contains the directory

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -669,7 +669,7 @@ changes:
                  connections. Previously, it was interpreted as `Infinity`.
 -->
 
-* Type: {integer}
+* Type: {number}
 
 When the number of connections reaches the `server.maxConnections` threshold:
 
@@ -986,7 +986,7 @@ deprecated:
 
 > Stability: 0 - Deprecated: Use [`writable.writableLength`][] instead.
 
-* Type: {integer}
+* Type: {number}
 
 This property shows the number of characters buffered for writing. The buffer
 may contain strings whose length after encoding is not yet known. So this number
@@ -1009,7 +1009,7 @@ Users who experience large or growing `bufferSize` should attempt to
 added: v0.5.3
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The amount of received bytes.
 
@@ -1019,7 +1019,7 @@ The amount of received bytes.
 added: v0.5.3
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The amount of bytes sent.
 
@@ -1254,7 +1254,7 @@ connects on `'192.168.1.1'`, the value of `socket.localAddress` would be
 added: v0.9.6
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The numeric representation of the local port. For example, `80` or `21`.
 
@@ -1332,7 +1332,7 @@ the socket is destroyed (for example, if the client disconnected).
 added: v0.5.10
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The numeric representation of the remote port. For example, `80` or `21`. Value may be `undefined` if
 the socket is destroyed (for example, if the client disconnected).
@@ -1927,7 +1927,7 @@ added: v0.3.0
 -->
 
 * `input` {string}
-* Returns: {integer}
+* Returns: {number}
 
 Returns `6` if `input` is an IPv6 address. Returns `4` if `input` is an IPv4
 address in [dot-decimal notation][] with no leading zeroes. Otherwise, returns

--- a/doc/api/os.md
+++ b/doc/api/os.md
@@ -38,7 +38,7 @@ added:
   - v18.14.0
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns an estimate of the default amount of parallelism a program should use.
 Always returns a value greater than zero.
@@ -186,7 +186,7 @@ Possible values are `'BE'` for big endian and `'LE'` for little endian.
 added: v0.3.3
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns the amount of free system memory in bytes as an integer.
 
@@ -196,9 +196,9 @@ Returns the amount of free system memory in bytes as an integer.
 added: v10.10.0
 -->
 
-* `pid` {integer} The process ID to retrieve scheduling priority for.
+* `pid` {number} The process ID to retrieve scheduling priority for.
   **Default:** `0`.
-* Returns: {integer}
+* Returns: {number}
 
 Returns the scheduling priority for the process specified by `pid`. If `pid` is
 not provided or is `0`, the priority of the current process is returned.
@@ -381,9 +381,9 @@ On POSIX systems, the operating system release is determined by calling
 added: v10.10.0
 -->
 
-* `pid` {integer} The process ID to set scheduling priority for.
+* `pid` {number} The process ID to set scheduling priority for.
   **Default:** `0`.
-* `priority` {integer} The scheduling priority to assign to the process.
+* `priority` {number} The scheduling priority to assign to the process.
 
 Attempts to set the scheduling priority for the process specified by `pid`. If
 `pid` is not provided or is `0`, the process ID of the current process is used.
@@ -434,7 +434,7 @@ unless it's explicitly overridden by the users.
 added: v0.3.3
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns the total amount of system memory in bytes as an integer.
 
@@ -463,7 +463,7 @@ changes:
                  component on Windows.
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns the system uptime in number of seconds.
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -96,7 +96,7 @@ the IPC channel is closed.
 added: v0.1.7
 -->
 
-* `code` {integer}
+* `code` {number}
 
 The `'exit'` event is emitted when the Node.js process is about to exit as a
 result of either:
@@ -1099,8 +1099,8 @@ added: v6.1.0
 * `previousValue` {Object} A previous return value from calling
   `process.cpuUsage()`
 * Returns: {Object}
-  * `user` {integer}
-  * `system` {integer}
+  * `user` {number}
+  * `system` {number}
 
 The `process.cpuUsage()` method returns the user and system CPU time usage of
 the current process, in an object with properties `user` and `system`, whose
@@ -2453,7 +2453,7 @@ Android).
 added: v0.1.28
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 The `process.getuid()` method returns the numeric user identity of the process.
 (See getuid(2).)
@@ -2751,11 +2751,11 @@ changes:
 -->
 
 * Returns: {Object}
-  * `rss` {integer}
-  * `heapTotal` {integer}
-  * `heapUsed` {integer}
-  * `external` {integer}
-  * `arrayBuffers` {integer}
+  * `rss` {number}
+  * `heapTotal` {number}
+  * `heapUsed` {number}
+  * `external` {number}
+  * `arrayBuffers` {number}
 
 Returns an object describing the memory usage of the Node.js process measured in
 bytes.
@@ -2822,7 +2822,7 @@ added:
   - v14.18.0
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 The `process.memoryUsage.rss()` method returns an integer representing the
 Resident Set Size (RSS) in bytes.
@@ -3153,7 +3153,7 @@ process.permission.has('fs.read');
 added: v0.1.15
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The `process.pid` property returns the PID of the process.
 
@@ -3215,7 +3215,7 @@ added:
   - v6.13.0
 -->
 
-* Type: {integer}
+* Type: {number}
 
 The `process.ppid` property returns the PID of the parent of the
 current process.
@@ -3637,42 +3637,42 @@ added: v12.6.0
 * Returns: {Object} the resource usage for the current process. All of these
   values come from the `uv_getrusage` call which returns
   a [`uv_rusage_t` struct][uv_rusage_t].
-  * `userCPUTime` {integer} maps to `ru_utime` computed in microseconds.
+  * `userCPUTime` {number} maps to `ru_utime` computed in microseconds.
     It is the same value as [`process.cpuUsage().user`][process.cpuUsage].
-  * `systemCPUTime` {integer} maps to `ru_stime` computed in microseconds.
+  * `systemCPUTime` {number} maps to `ru_stime` computed in microseconds.
     It is the same value as [`process.cpuUsage().system`][process.cpuUsage].
-  * `maxRSS` {integer} maps to `ru_maxrss` which is the maximum resident set
+  * `maxRSS` {number} maps to `ru_maxrss` which is the maximum resident set
     size used in kilobytes.
-  * `sharedMemorySize` {integer} maps to `ru_ixrss` but is not supported by
+  * `sharedMemorySize` {number} maps to `ru_ixrss` but is not supported by
     any platform.
-  * `unsharedDataSize` {integer} maps to `ru_idrss` but is not supported by
+  * `unsharedDataSize` {number} maps to `ru_idrss` but is not supported by
     any platform.
-  * `unsharedStackSize` {integer} maps to `ru_isrss` but is not supported by
+  * `unsharedStackSize` {number} maps to `ru_isrss` but is not supported by
     any platform.
-  * `minorPageFault` {integer} maps to `ru_minflt` which is the number of
+  * `minorPageFault` {number} maps to `ru_minflt` which is the number of
     minor page faults for the process, see
     [this article for more details][wikipedia_minor_fault].
-  * `majorPageFault` {integer} maps to `ru_majflt` which is the number of
+  * `majorPageFault` {number} maps to `ru_majflt` which is the number of
     major page faults for the process, see
     [this article for more details][wikipedia_major_fault]. This field is not
     supported on Windows.
-  * `swappedOut` {integer} maps to `ru_nswap` but is not supported by any
+  * `swappedOut` {number} maps to `ru_nswap` but is not supported by any
     platform.
-  * `fsRead` {integer} maps to `ru_inblock` which is the number of times the
+  * `fsRead` {number} maps to `ru_inblock` which is the number of times the
     file system had to perform input.
-  * `fsWrite` {integer} maps to `ru_oublock` which is the number of times the
+  * `fsWrite` {number} maps to `ru_oublock` which is the number of times the
     file system had to perform output.
-  * `ipcSent` {integer} maps to `ru_msgsnd` but is not supported by any
+  * `ipcSent` {number} maps to `ru_msgsnd` but is not supported by any
     platform.
-  * `ipcReceived` {integer} maps to `ru_msgrcv` but is not supported by any
+  * `ipcReceived` {number} maps to `ru_msgrcv` but is not supported by any
     platform.
-  * `signalsCount` {integer} maps to `ru_nsignals` but is not supported by any
+  * `signalsCount` {number} maps to `ru_nsignals` but is not supported by any
     platform.
-  * `voluntaryContextSwitches` {integer} maps to `ru_nvcsw` which is the
+  * `voluntaryContextSwitches` {number} maps to `ru_nvcsw` which is the
     number of times a CPU context switch resulted due to a process voluntarily
     giving up the processor before its time slice was completed (usually to
     await availability of a resource). This field is not supported on Windows.
-  * `involuntaryContextSwitches` {integer} maps to `ru_nivcsw` which is the
+  * `involuntaryContextSwitches` {number} maps to `ru_nivcsw` which is the
     number of times a CPU context switch resulted due to a higher priority
     process becoming runnable or because the current process exceeded its
     time slice. This field is not supported on Windows.
@@ -4215,8 +4215,8 @@ added: v23.9.0
 * `previousValue` {Object} A previous return value from calling
   `process.threadCpuUsage()`
 * Returns: {Object}
-  * `user` {integer}
-  * `system` {integer}
+  * `user` {number}
+  * `system` {number}
 
 The `process.threadCpuUsage()` method returns the user and system CPU time usage of
 the current worker thread, in an object with properties `user` and `system`, whose

--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -592,7 +592,7 @@ added: v17.0.0
 added: v17.0.0
 -->
 
-* `dir` {integer}
+* `dir` {number}
   * `-1`: to the left from cursor
   * `1`: to the right from cursor
   * `0`: the entire line
@@ -635,8 +635,8 @@ The `rl.commit()` method sends all the pending actions to the associated
 added: v17.0.0
 -->
 
-* `x` {integer}
-* `y` {integer}
+* `x` {number}
+* `y` {number}
 * Returns: this
 
 The `rl.cursorTo()` method adds to the internal list of pending action an action
@@ -650,8 +650,8 @@ was passed to the constructor.
 added: v17.0.0
 -->
 
-* `dx` {integer}
-* `dy` {integer}
+* `dx` {number}
+* `dy` {number}
 * Returns: this
 
 The `rl.moveCursor()` method adds to the internal list of pending action an
@@ -710,7 +710,7 @@ added: v17.0.0
     can both form a complete key sequence using the input read so far and can
     take additional input to complete a longer key sequence).
     **Default:** `500`.
-  * `tabSize` {integer} The number of spaces a tab is equal to (minimum 1).
+  * `tabSize` {number} The number of spaces a tab is equal to (minimum 1).
     **Default:** `8`.
   * `signal` {AbortSignal} Allows closing the interface using an AbortSignal.
 * Returns: {readlinePromises.Interface}
@@ -975,7 +975,7 @@ changes:
     can both form a complete key sequence using the input read so far and can
     take additional input to complete a longer key sequence).
     **Default:** `500`.
-  * `tabSize` {integer} The number of spaces a tab is equal to (minimum 1).
+  * `tabSize` {number} The number of spaces a tab is equal to (minimum 1).
     **Default:** `8`.
   * `signal` {AbortSignal} Allows closing the interface using an AbortSignal.
     Aborting the signal will internally call `close` on the interface.

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -909,7 +909,7 @@ added:
  - v12.16.0
 -->
 
-* Type: {integer}
+* Type: {number}
 
 Number of times [`writable.uncork()`][stream-uncork] needs to be
 called in order to fully uncork the stream.
@@ -3536,7 +3536,7 @@ added:
 -->
 
 * `objectMode` {boolean}
-* Returns: {integer}
+* Returns: {number}
 
 Returns the default highWaterMark used by streams.
 Defaults to `65536` (64 KiB), or `16` for `objectMode`.
@@ -3550,7 +3550,7 @@ added:
 -->
 
 * `objectMode` {boolean}
-* `value` {integer} highWaterMark value
+* `value` {number} highWaterMark value
 
 Sets the default highWaterMark used by streams.
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1932,7 +1932,7 @@ added:
   - v18.13.0
 -->
 
-* Returns: {integer} The number of times that this mock has been invoked.
+* Returns: {number} The number of times that this mock has been invoked.
 
 This function returns the number of times that this mock has been invoked. This
 function is more efficient than checking `ctx.calls.length` because `ctx.calls`
@@ -1987,7 +1987,7 @@ added:
 
 * `implementation` {Function|AsyncFunction} The function to be used as the
   mock's implementation for the invocation number specified by `onCall`.
-* `onCall` {integer} The invocation number that will use `implementation`. If
+* `onCall` {number} The invocation number that will use `implementation`. If
   the specified invocation has already occurred then an exception is thrown.
   **Default:** The number of the next invocation.
 
@@ -2090,7 +2090,7 @@ the mocked property. Each entry in the array is an object with the following pro
 
 ### `ctx.accessCount()`
 
-* Returns: {integer} The number of times that the property was accessed (read or written).
+* Returns: {number} The number of times that the property was accessed (read or written).
 
 This function returns the number of times that the property was accessed.
 This function is more efficient than checking `ctx.accesses.length` because
@@ -2106,7 +2106,7 @@ This function is used to change the value returned by the mocked property getter
 
 * `value` {any} The value to be used as the mock's
   implementation for the invocation number specified by `onAccess`.
-* `onAccess` {integer} The invocation number that will use `value`. If
+* `onAccess` {number} The invocation number that will use `value`. If
   the specified invocation has already occurred then an exception is thrown.
   **Default:** The number of the next invocation.
 
@@ -2177,7 +2177,7 @@ added:
   behavior of `original`. **Default:** The function specified by `original`.
 * `options` {Object} Optional configuration options for the mock function. The
   following properties are supported:
-  * `times` {integer} The number of times that the mock will use the behavior of
+  * `times` {number} The number of times that the mock will use the behavior of
     `implementation`. Once the mock function has been called `times` times, it
     will automatically restore the behavior of `original`. This value must be an
     integer greater than zero. **Default:** `Infinity`.
@@ -2245,7 +2245,7 @@ added:
     This option cannot be used with the `setter` option. **Default:** false.
   * `setter` {boolean} If `true`, `object[methodName]` is treated as a setter.
     This option cannot be used with the `getter` option. **Default:** false.
-  * `times` {integer} The number of times that the mock will use the behavior of
+  * `times` {number} The number of times that the mock will use the behavior of
     `implementation`. Once the mocked method has been called `times` times, it
     will automatically restore the original behavior. This value must be an
     integer greater than zero. **Default:** `Infinity`.

--- a/doc/api/timers.md
+++ b/doc/api/timers.md
@@ -162,7 +162,7 @@ added:
   - v12.19.0
 -->
 
-* Returns: {integer} a number that can be used to reference this `timeout`
+* Returns: {number} a number that can be used to reference this `timeout`
 
 Coerce a `Timeout` to a primitive. The primitive can be used to
 clear the `Timeout`. The primitive can only be used in the

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1474,7 +1474,7 @@ Returns the string representation of the local IP address.
 added: v0.11.4
 -->
 
-* Type: {integer}
+* Type: {number}
 
 Returns the numeric representation of the local port.
 
@@ -1505,7 +1505,7 @@ Returns the string representation of the remote IP family. `'IPv4'` or `'IPv6'`.
 added: v0.11.4
 -->
 
-* Type: {integer}
+* Type: {number}
 
 Returns the numeric representation of the remote port. For example, `443`.
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -267,7 +267,7 @@ added:
  - v10.16.0
 -->
 
-* `count` {integer} The number of colors that are requested (minimum 2).
+* `count` {number} The number of colors that are requested (minimum 2).
   **Default:** 16.
 * `env` {Object} An object containing the environment variables to check. This
   enables simulating the usage of a specific terminal. **Default:**

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -938,14 +938,14 @@ changes:
     **Default:** `true`.
   * `showProxy` {boolean} If `true`, `Proxy` inspection includes
     the [`target` and `handler`][] objects. **Default:** `false`.
-  * `maxArrayLength` {integer} Specifies the maximum number of `Array`,
+  * `maxArrayLength` {number} Specifies the maximum number of `Array`,
     {TypedArray}, {Map}, {WeakMap}, and {WeakSet} elements to include when formatting.
     Set to `null` or `Infinity` to show all elements. Set to `0` or
     negative to show no elements. **Default:** `100`.
-  * `maxStringLength` {integer} Specifies the maximum number of characters to
+  * `maxStringLength` {number} Specifies the maximum number of characters to
     include when formatting. Set to `null` or `Infinity` to show all elements.
     Set to `0` or negative to show no characters. **Default:** `10000`.
-  * `breakLength` {integer} The length at which input values are split across
+  * `breakLength` {number} The length at which input values are split across
     multiple lines. Set to `Infinity` to format the input as a single line
     (in combination with `compact` set to `true` or any number >= `1`).
     **Default:** `80`.

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -17,7 +17,7 @@ const v8 = require('node:v8');
 added: v8.0.0
 -->
 
-* Returns: {integer}
+* Returns: {number}
 
 Returns an integer representing a version tag derived from the V8 version,
 command-line flags, and detected CPU features. This is useful for determining
@@ -588,7 +588,7 @@ changes:
    description: Marking the API stable.
 -->
 
-* `limit` {integer}
+* `limit` {number}
 
 The API is a no-op if `--heapsnapshot-near-heap-limit` is already set from the
 command line or the API is called more than once. `limit` must be a positive
@@ -661,7 +661,7 @@ if a previous write has failed.
 
 #### `serializer.transferArrayBuffer(id, arrayBuffer)`
 
-* `id` {integer} A 32-bit unsigned integer.
+* `id` {number} A 32-bit unsigned integer.
 * `arrayBuffer` {ArrayBuffer} An `ArrayBuffer` instance.
 
 Marks an `ArrayBuffer` as having its contents transferred out of band.
@@ -670,15 +670,15 @@ Pass the corresponding `ArrayBuffer` in the deserializing context to
 
 #### `serializer.writeUint32(value)`
 
-* `value` {integer}
+* `value` {number}
 
 Write a raw 32-bit unsigned integer.
 For use inside of a custom [`serializer._writeHostObject()`][].
 
 #### `serializer.writeUint64(hi, lo)`
 
-* `hi` {integer}
-* `lo` {integer}
+* `hi` {number}
+* `lo` {number}
 
 Write a raw 64-bit unsigned integer, split into high and low 32-bit parts.
 For use inside of a custom [`serializer._writeHostObject()`][].
@@ -766,7 +766,7 @@ Deserializes a JavaScript value from the buffer and returns it.
 
 #### `deserializer.transferArrayBuffer(id, arrayBuffer)`
 
-* `id` {integer} A 32-bit unsigned integer.
+* `id` {number} A 32-bit unsigned integer.
 * `arrayBuffer` {ArrayBuffer|SharedArrayBuffer} An `ArrayBuffer` instance.
 
 Marks an `ArrayBuffer` as having its contents transferred out of band.
@@ -776,7 +776,7 @@ Pass the corresponding `ArrayBuffer` in the serializing context to
 
 #### `deserializer.getWireFormatVersion()`
 
-* Returns: {integer}
+* Returns: {number}
 
 Reads the underlying wire format version. Likely mostly to be useful to
 legacy code reading old wire format versions. May not be called before
@@ -784,7 +784,7 @@ legacy code reading old wire format versions. May not be called before
 
 #### `deserializer.readUint32()`
 
-* Returns: {integer}
+* Returns: {number}
 
 Read a raw 32-bit unsigned integer and return it.
 For use inside of a custom [`deserializer._readHostObject()`][].
@@ -806,7 +806,7 @@ For use inside of a custom [`deserializer._readHostObject()`][].
 
 #### `deserializer.readRawBytes(length)`
 
-* `length` {integer}
+* `length` {number}
 * Returns: {Buffer}
 
 Read raw bytes from the deserializer's internal buffer. The `length` parameter

--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -183,7 +183,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -252,7 +252,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -330,7 +330,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -592,7 +592,7 @@ in the ECMAScript specification.
 ### `module.evaluate([options])`
 
 * `options` {Object}
-  * `timeout` {integer} Specifies the number of milliseconds to evaluate
+  * `timeout` {number} Specifies the number of milliseconds to evaluate
     before terminating execution. If execution is interrupted, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -768,9 +768,9 @@ changes:
     `vm.createContext()` method, to compile and evaluate this `Module` in.
     If no context is specified, the module is evaluated in the current
     execution context.
-  * `lineOffset` {integer} Specifies the line number offset that is displayed
+  * `lineOffset` {number} Specifies the line number offset that is displayed
     in stack traces produced by this `Module`. **Default:** `0`.
-  * `columnOffset` {integer} Specifies the first-line column number offset that
+  * `columnOffset` {number} Specifies the first-line column number offset that
     is displayed in stack traces produced by this `Module`. **Default:** `0`.
   * `initializeImportMeta` {Function} Called during evaluation of this `Module`
     to initialize the `import.meta`.
@@ -1398,7 +1398,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -1487,7 +1487,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`
@@ -1595,7 +1595,7 @@ changes:
   * `displayErrors` {boolean} When `true`, if an [`Error`][] occurs
     while compiling the `code`, the line of code causing the error is attached
     to the stack trace. **Default:** `true`.
-  * `timeout` {integer} Specifies the number of milliseconds to execute `code`
+  * `timeout` {number} Specifies the number of milliseconds to execute `code`
     before terminating execution. If execution is terminated, an [`Error`][]
     will be thrown. This value must be a strictly positive integer.
   * `breakOnSigint` {boolean} If `true`, receiving `SIGINT`

--- a/doc/api/wasi.md
+++ b/doc/api/wasi.md
@@ -173,11 +173,11 @@ changes:
     specified rather than terminating the process. Setting this option to
     `false` will cause the Node.js process to exit with the specified
     exit code instead.  **Default:** `true`.
-  * `stdin` {integer} The file descriptor used as standard input in the
+  * `stdin` {number} The file descriptor used as standard input in the
     WebAssembly application. **Default:** `0`.
-  * `stdout` {integer} The file descriptor used as standard output in the
+  * `stdout` {number} The file descriptor used as standard output in the
     WebAssembly application. **Default:** `1`.
-  * `stderr` {integer} The file descriptor used as standard error in the
+  * `stderr` {number} The file descriptor used as standard error in the
     WebAssembly application. **Default:** `2`.
   * `version` {string} The version of WASI requested. Currently the only
     supported versions are `unstable` and `preview1`. This option is

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -715,7 +715,7 @@ instances spawned from the current context.
 added: v10.5.0
 -->
 
-* Type: {integer}
+* Type: {number}
 
 An integer identifier for the current thread. On the corresponding worker object
 (if there is any), it is available as [`worker.threadId`][].
@@ -1726,7 +1726,7 @@ exception. In that case, the worker is terminated.
 added: v10.5.0
 -->
 
-* `exitCode` {integer}
+* `exitCode` {number}
 
 The `'exit'` event is emitted once the worker has stopped. If the worker
 exited by calling [`process.exit()`][], the `exitCode` parameter is the
@@ -2020,7 +2020,7 @@ Returns a Promise for the exit code that is fulfilled when the
 added: v10.5.0
 -->
 
-* Type: {integer}
+* Type: {number}
 
 An integer identifier for the referenced thread. Inside the worker thread,
 it is available as [`require('node:worker_threads').threadId`][].

--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -794,17 +794,17 @@ Each zlib-based class takes an `options` object. No options are required.
 Some options are only relevant when compressing and are
 ignored by the decompression classes.
 
-* `flush` {integer} **Default:** `zlib.constants.Z_NO_FLUSH`
-* `finishFlush` {integer} **Default:** `zlib.constants.Z_FINISH`
-* `chunkSize` {integer} **Default:** `16 * 1024`
-* `windowBits` {integer}
-* `level` {integer} (compression only)
-* `memLevel` {integer} (compression only)
-* `strategy` {integer} (compression only)
+* `flush` {number} **Default:** `zlib.constants.Z_NO_FLUSH`
+* `finishFlush` {number} **Default:** `zlib.constants.Z_FINISH`
+* `chunkSize` {number} **Default:** `16 * 1024`
+* `windowBits` {number}
+* `level` {number} (compression only)
+* `memLevel` {number} (compression only)
+* `strategy` {number} (compression only)
 * `dictionary` {Buffer|TypedArray|DataView|ArrayBuffer} (deflate/inflate only,
   empty dictionary by default)
 * `info` {boolean} (If `true`, returns an object with `buffer` and `engine`.)
-* `maxOutputLength` {integer} Limits output size when using
+* `maxOutputLength` {number} Limits output size when using
   [convenience methods][]. **Default:** [`buffer.kMaxLength`][]
 
 See the [`deflateInit2` and `inflateInit2`][] documentation for more
@@ -826,11 +826,11 @@ changes:
 
 Each Brotli-based class takes an `options` object. All options are optional.
 
-* `flush` {integer} **Default:** `zlib.constants.BROTLI_OPERATION_PROCESS`
-* `finishFlush` {integer} **Default:** `zlib.constants.BROTLI_OPERATION_FINISH`
-* `chunkSize` {integer} **Default:** `16 * 1024`
+* `flush` {number} **Default:** `zlib.constants.BROTLI_OPERATION_PROCESS`
+* `finishFlush` {number} **Default:** `zlib.constants.BROTLI_OPERATION_FINISH`
+* `chunkSize` {number} **Default:** `16 * 1024`
 * `params` {Object} Key-value object containing indexed [Brotli parameters][].
-* `maxOutputLength` {integer} Limits output size when using
+* `maxOutputLength` {number} Limits output size when using
   [convenience methods][]. **Default:** [`buffer.kMaxLength`][]
 * `info` {boolean} If `true`, returns an object with `buffer` and `engine`. **Default:** `false`
 
@@ -1030,8 +1030,8 @@ writes and will only produce output when data is being read from the stream.
 added: v0.11.4
 -->
 
-* `level` {integer}
-* `strategy` {integer}
+* `level` {number}
+* `strategy` {number}
 * `callback` {Function}
 
 This function is only available for zlib-based streams, i.e. not Brotli.
@@ -1062,11 +1062,11 @@ added:
 
 Each Zstd-based class takes an `options` object. All options are optional.
 
-* `flush` {integer} **Default:** `zlib.constants.ZSTD_e_continue`
-* `finishFlush` {integer} **Default:** `zlib.constants.ZSTD_e_end`
-* `chunkSize` {integer} **Default:** `16 * 1024`
+* `flush` {number} **Default:** `zlib.constants.ZSTD_e_continue`
+* `finishFlush` {number} **Default:** `zlib.constants.ZSTD_e_end`
+* `chunkSize` {number} **Default:** `16 * 1024`
 * `params` {Object} Key-value object containing indexed [Zstd parameters][].
-* `maxOutputLength` {integer} Limits output size when using
+* `maxOutputLength` {number} Limits output size when using
   [convenience methods][]. **Default:** [`buffer.kMaxLength`][]
 * `info` {boolean} If `true`, returns an object with `buffer` and `engine`. **Default:** `false`
 * `dictionary` {Buffer} Optional dictionary used to
@@ -1127,9 +1127,9 @@ added:
 
 * `data` {string|Buffer|TypedArray|DataView} When `data` is a string,
   it will be encoded as UTF-8 before being used for computation.
-* `value` {integer} An optional starting value. It must be a 32-bit unsigned
+* `value` {number} An optional starting value. It must be a 32-bit unsigned
   integer. **Default:** `0`
-* Returns: {integer} A 32-bit unsigned integer containing the checksum.
+* Returns: {number} A 32-bit unsigned integer containing the checksum.
 
 Computes a 32-bit [Cyclic Redundancy Check][] checksum of `data`. If
 `value` is specified, it is used as the starting value of the checksum,

--- a/lib/internal/readline/promises.js
+++ b/lib/internal/readline/promises.js
@@ -37,8 +37,8 @@ class Readline {
 
   /**
    * Moves the cursor to the x and y coordinate on the given stream.
-   * @param {integer} x
-   * @param {integer} [y]
+   * @param {number} x
+   * @param {number} [y]
    * @returns {Readline} this
    */
   cursorTo(x, y = undefined) {
@@ -54,8 +54,8 @@ class Readline {
 
   /**
    * Moves the cursor relative to its current location.
-   * @param {integer} dx
-   * @param {integer} dy
+   * @param {number} dx
+   * @param {number} dy
    * @returns {Readline} this
    */
   moveCursor(dx, dy) {


### PR DESCRIPTION
The `integer` type is an alias of `number` in our documentation, and isn't a valid JavaScript type. So, as to minimize confusion, the correct type (`number`) should be used instead.