### PR TITLE
test: deflake sequential/test-tls-session-timeout

### DIFF
--- a/test/parallel/test-tls-session-timeout-errors.js
+++ b/test/parallel/test-tls-session-timeout-errors.js
@@ -1,0 +1,36 @@
+'use strict';
+// This tests validation of sessionTimeout option in TLS server.
+const common = require('../common');
+
+if (!common.hasCrypto) {
+  common.skip('missing crypto');
+}
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+const key = fixtures.readKey('rsa_private.pem');
+const cert = fixtures.readKey('rsa_cert.crt');
+
+// Node.js should not allow setting negative timeouts since new versions of
+// OpenSSL do not handle those as users might expect
+
+for (const sessionTimeout of [-1, -100, -(2 ** 31)]) {
+  assert.throws(() => {
+    tls.createServer({
+      key: key,
+      cert: cert,
+      ca: [cert],
+      sessionTimeout,
+      maxVersion: 'TLSv1.2',
+    });
+  }, {
+    code: 'ERR_OUT_OF_RANGE',
+    message: 'The value of "options.sessionTimeout" is out of range. It ' +
+              `must be >= 0 && <= ${2 ** 31 - 1}. Received ${sessionTimeout}`,
+  });
+}


### PR DESCRIPTION
This patch:

- Splits the validation tests into a separate file and keep the
  test focus on functional test of the sessionTimeout option.
- Increase the testing timeout to 5 seconds in case it takes too
  long for the first connection to complete and the session is
  already expired when the second connection is started.
- Use a specific `sessionIdContext` to ensure stable session ID.
- Fix the s_client arguments by specifying CA file and server name.
- Do not use the serialized session ticket for the first connection.
  That was genearted years ago and may not work in different OpenSSL
  versions. Let the first fresh connection generate the ticket.
- Use random port instead of the common port.
- Add a timeout before the second connection to ensure session ticket
  is properly written.
- Log information to faciliate debugging.

Fixes: https://github.com/nodejs/node/issues/26839

---

<del>I have no idea if this actually fixes the test because I can't reproduce it locally. I just noticed that it's missing the `-reconnect` option which is theoratically necessary if you actually want session reuse and I figured adding it back might do something. This test has been failing pretty badly (failing 28 PRs out of the last 100 CI runs! https://github.com/nodejs/reliability/issues/1282) so any attempt seems useful  ¯\\_(ツ)_/¯. Another idea is probably adding a setTimeout after the first connection. </del>


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
