### PR TITLE
test: replace manual error checks with assert.ifError/mustSucceed

### DIFF
--- a/test/parallel/test-child-process-send-returns-boolean.js
+++ b/test/parallel/test-child-process-send-returns-boolean.js
@@ -33,19 +33,19 @@ const subScript = fixtures.path('child-process-persistent.js');
 
     // Sending a handle and not giving the tickQueue time to acknowledge should
     // create the internal backlog, but leave it empty.
-    const rv1 = s.send('one', handle, (err) => { if (err) assert.fail(err); });
+    const rv1 = s.send('one', handle, assert.ifError);
     assert.strictEqual(rv1, true);
     // Since the first `send` included a handle (should be unacknowledged),
     // we can safely queue up only one more message.
-    const rv2 = s.send('two', (err) => { if (err) assert.fail(err); });
+    const rv2 = s.send('two', assert.ifError);
     assert.strictEqual(rv2, true);
     // The backlog should now be indicate to backoff.
-    const rv3 = s.send('three', (err) => { if (err) assert.fail(err); });
+    const rv3 = s.send('three', assert.ifError);
     assert.strictEqual(rv3, false);
     const rv4 = s.send('four', (err) => {
-      if (err) assert.fail(err);
+      assert.ifError(err);
       // `send` queue should have been drained.
-      const rv5 = s.send('5', handle, (err) => { if (err) assert.fail(err); });
+      const rv5 = s.send('5', handle, assert.ifError);
       assert.strictEqual(rv5, true);
 
       // End test and cleanup.

--- a/test/parallel/test-dgram-blocklist.js
+++ b/test/parallel/test-dgram-blocklist.js
@@ -41,9 +41,13 @@ const net = require('net');
   receiveSocket.bind(0, common.localhostIPv4, common.mustCall(() => {
     const addressInfo = receiveSocket.address();
     const client = dgram.createSocket('udp4');
-    client.send('hello', addressInfo.port, addressInfo.address, common.mustCall((err) => {
-      assert.ok(!err);
-      client.close();
-    }));
+    client.send(
+      'hello',
+      addressInfo.port,
+      addressInfo.address,
+      common.mustSucceed(() => {
+        client.close();
+      })
+    );
   }));
 }

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -94,9 +94,7 @@ if (common.isLinux || common.isMacOS || common.isWindows) {
     }));
 
     const interval = setInterval(() => {
-      fs.writeFile(path.join(dir, 'foo.txt'), 'foo', common.mustCall((err) => {
-        if (err) assert.fail(err);
-      }));
+      fs.writeFile(path.join(dir, 'foo.txt'), 'foo', common.mustSucceed());
     }, 1);
   }
 


### PR DESCRIPTION
Replace manual error checks (`if (err) assert.fail(err)` and `assert.ok(!err)`) with `assert.ifError()` or `common.mustSucceed()` in a few tests to improve clarity and follow project conventions.

- test/parallel/test-child-process-send-returns-boolean.js
- test/parallel/test-dgram-blocklist.js
- test/parallel/test-fs-watchfile.js

No functional changes to the tests, only improved readability and consistency.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
