### PR TITLE
http: improve performance of shouldUseProxy

### DIFF
--- a/benchmark/http/proxy-should-use-proxy.js
+++ b/benchmark/http/proxy-should-use-proxy.js
@@ -8,6 +8,7 @@ const bench = common.createBenchmark(main, {
   hostname: [
     '127.0.0.1',
     'localhost',
+    'localhost:123',
     'www.example.com',
     'example.com',
     'myexample.com',
@@ -16,6 +17,8 @@ const bench = common.createBenchmark(main, {
     '',
     '*',
     '126.255.255.1-127.0.0.255',
+    'localhost',
+    'localhost:123',
     '127.0.0.1',
     'example.com',
     '.example.com',

--- a/benchmark/http/proxy-should-use-proxy.js
+++ b/benchmark/http/proxy-should-use-proxy.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+// Benchmark configuration
+const bench = common.createBenchmark(main, {
+  hostname: [
+    '127.0.0.1',
+    'localhost',
+    'www.example.com',
+    'example.com',
+    'myexample.com',
+  ],
+  no_proxy: [
+    '',
+    '*',
+    '126.255.255.1-127.0.0.255',
+    '127.0.0.1',
+    'example.com',
+    '.example.com',
+    '*.example.com',
+  ],
+  n: [1e6],
+}, {
+  flags: ['--expose-internals'],
+});
+
+function main({ hostname, no_proxy, n }) {
+  const { parseProxyConfigFromEnv } = require('internal/http');
+
+  const protocol = 'https:';
+  const env = {
+    no_proxy,
+    https_proxy: `https://www.example.proxy`,
+  };
+  const proxyConfig = parseProxyConfigFromEnv(env, protocol);
+
+  // Warm up.
+  const length = 1024;
+  const array = [];
+  for (let i = 0; i < length; ++i) {
+    array.push(proxyConfig.shouldUseProxy(hostname));
+  }
+
+  // // Benchmark
+  bench.start();
+
+  for (let i = 0; i < n; ++i) {
+    const index = i % length;
+    array[index] = proxyConfig.shouldUseProxy(hostname);
+  }
+
+  bench.end(n);
+
+  // Verify the entries to prevent dead code elimination from making
+  // the benchmark invalid.
+  for (let i = 0; i < length; ++i) {
+    assert.strictEqual(typeof array[i], 'boolean');
+  }
+}

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -58,12 +58,21 @@ function traceEnd(...args) {
 }
 
 function ipToInt(ip) {
-  const octets = ip.split('.');
   let result = 0;
-  for (let i = 0; i < octets.length; i++) {
-    result = (result << 8) + NumberParseInt(octets[i]);
+  let multiplier = 1;
+  let octetShift = 0;
+  let code = 0;
+
+  for (let i = ip.length - 1; i >= 0; --i) {
+    code = ip.charCodeAt(i);
+    if (code !== 46) {
+      result += ((code - 48) * multiplier) << octetShift;
+      multiplier *= 10;
+    } else {
+      octetShift += 8;
+      multiplier = 1;
+    }
   }
-  // Force unsigned 32-bit result
   return result >>> 0;
 }
 
@@ -96,6 +105,19 @@ function ipToInt(ip) {
 // TLS handshake with the proxy server. Same goes to the HTTPS request tunnel establishment.
 
 /**
+ * @callback ProxyBypassMatchFn
+ * @param {string} host - Host to match against the bypass list.
+ * @param {string} [hostWithPort] - Host with port to match against the bypass list.
+ * @returns {boolean} - True if the host should be bypassed, false otherwise.
+ */
+
+/**
+ * @typedef {object} ProxyConnectionOptions
+ * @property {string} host - Hostname of the proxy server.
+ * @property {number} port - Port of the proxy server.
+ */
+
+/**
  * Represents the proxy configuration for an agent. The built-in http and https agent
  * implementation have one of this when they are configured to use a proxy.
  * @property {string} href - Full URL of the proxy server.
@@ -105,9 +127,28 @@ function ipToInt(ip) {
  * @property {string} protocol - Protocol of the proxy server, e.g. 'http:' or 'https:'.
  * @property {string|undefined} auth - proxy-authorization header value, if username or password is provided.
  * @property {Array<string>} bypassList - List of hosts to bypass the proxy.
- * @property {object} proxyConnectionOptions - Options for connecting to the proxy server.
+ * @property {ProxyConnectionOptions} proxyConnectionOptions - Options for connecting to the proxy server.
  */
 class ProxyConfig {
+  /** @type {Array<string>} */
+  #bypassList = [];
+  /** @type {Array<ProxyBypassMatchFn>} */
+  #bypassMatchFns = [];
+
+  /** @type {ProxyConnectionOptions} */
+  get proxyConnectionOptions() {
+    return {
+      host: this.hostname,
+      port: this.port,
+    };
+  }
+
+  /**
+   * @param {string} proxyUrl - The URL of the proxy server, e.g. 'http://localhost:8080'.
+   * @param {boolean} [keepAlive] - Whether to keep the connection alive.
+   *   This is not used in the current implementation but can be used in the future.
+   * @param {string} [noProxyList] - Comma-separated list of hosts to bypass the proxy.
+   */
   constructor(proxyUrl, keepAlive, noProxyList) {
     const { host, hostname, port, protocol, username, password } = new URL(proxyUrl);
     this.href = proxyUrl; // Full URL of the proxy server.
@@ -121,59 +162,94 @@ class ProxyConfig {
       const auth = `${decodeURIComponent(username)}:${decodeURIComponent(password)}`;
       this.auth = `Basic ${Buffer.from(auth).toString('base64')}`;
     }
+
     if (noProxyList) {
-      this.bypassList = noProxyList.split(',').map((entry) => entry.trim().toLowerCase());
-    } else {
-      this.bypassList = []; // No bypass list provided.
+      this.#bypassList = noProxyList
+        .split(',')
+        .map((entry) => entry.trim().toLowerCase());
     }
-    this.proxyConnectionOptions = {
-      host: this.hostname,
-      port: this.port,
-    };
+
+    if (this.#bypassList.length === 0) {
+      this.shouldUseProxy = () => true; // No bypass list, always use the proxy.
+    } else if (this.#bypassList.includes('*')) {
+      this.shouldUseProxy = () => false; // '*' in the bypass list means to bypass all hosts.
+    } else {
+      this.#buildBypassMatchFns();
+      // Use the bypass match functions to determine if the proxy should be used.
+      this.shouldUseProxy = this.#match.bind(this);
+    }
+  }
+
+  #buildBypassMatchFns(bypassList = this.#bypassList) {
+    this.#bypassMatchFns = [];
+
+    for (const entry of this.#bypassList) {
+      if (
+        // Handle wildcard entries like *.example.com
+        entry.startsWith('*.') ||
+        // Follow curl's behavior: strip leading dot before matching suffixes.
+        entry.startsWith('.')
+      ) {
+        const suffix = entry.split('');
+        suffix.shift(); // Remove the leading dot or asterisk.
+        const suffixLength = suffix.length;
+        if (suffixLength === 0) {
+          // If the suffix is empty, it means to match all hosts.
+          this.#bypassMatchFns.push(() => true);
+          continue;
+        }
+        this.#bypassMatchFns.push((host) => {
+          const hostLength = host.length;
+          const offset = hostLength - suffixLength;
+          if (offset < 0) return false; // Host is shorter than the suffix.
+          for (let i = 0; i < suffixLength; i++) {
+            if (host[offset + i] !== suffix[i]) {
+              return false;
+            }
+          }
+          return true;
+        });
+        continue;
+      }
+
+      // Handle IP ranges (simple format like 192.168.1.0-192.168.1.255)
+      // TODO(joyeecheung): support IPv6.
+      const { 0: startIP, 1: endIP } = entry.split('-').map((ip) => ip.trim());
+      if (entry.includes('-') && startIP && endIP && isIPv4(startIP) && isIPv4(endIP)) {
+        const startInt = ipToInt(startIP);
+        const endInt = ipToInt(endIP);
+        this.#bypassMatchFns.push((host) => {
+          if (isIPv4(host)) {
+            const hostInt = ipToInt(host);
+            return hostInt >= startInt && hostInt <= endInt;
+          }
+          return false;
+        });
+        continue;
+      }
+
+      // Handle simple host or IP entries
+      this.#bypassMatchFns.push((host, hostWithPort) => {
+        return (host === entry || hostWithPort === entry);
+      });
+    }
+  }
+
+  get bypassList() {
+    // Return a copy of the bypass list to prevent external modification.
+    return [...this.#bypassList];
   }
 
   // See: https://about.gitlab.com/blog/we-need-to-talk-no-proxy
   // TODO(joyeecheung): share code with undici.
-  shouldUseProxy(hostname, port) {
-    const bypassList = this.bypassList;
-    if (this.bypassList.length === 0) {
-      return true; // No bypass list, always use the proxy.
-    }
-
+  #match(hostname, port) {
     const host = hostname.toLowerCase();
     const hostWithPort = port ? `${host}:${port}` : host;
 
-    for (let i = 0; i < bypassList.length; i++) {
-      const entry = bypassList[i];
-
-      if (entry === '*') return false;  // * bypasses all hosts.
-      if (entry === host || entry === hostWithPort) return false;  // Matching host and host:port
-
-      // Follow curl's behavior: strip leading dot before matching suffixes.
-      if (entry.startsWith('.')) {
-        const suffix = entry.substring(1);
-        if (host.endsWith(suffix)) return false;
+    for (const bypassMatchFn of this.#bypassMatchFns) {
+      if (bypassMatchFn(host, hostWithPort)) {
+        return false; // If any bypass function matches, do not use the proxy.
       }
-
-      // Handle wildcards like *.example.com
-      if (entry.startsWith('*.') && host.endsWith(entry.substring(1))) return false;
-
-      // Handle IP ranges (simple format like 192.168.1.0-192.168.1.255)
-      // TODO(joyeecheung): support IPv6.
-      if (entry.includes('-') && isIPv4(host)) {
-        let { 0: startIP, 1: endIP } = entry.split('-');
-        startIP = startIP.trim();
-        endIP = endIP.trim();
-        if (startIP && endIP && isIPv4(startIP) && isIPv4(endIP)) {
-          const hostInt = ipToInt(host);
-          const startInt = ipToInt(startIP);
-          const endInt = ipToInt(endIP);
-          if (hostInt >= startInt && hostInt <= endInt) return false;
-        }
-      }
-
-      // It might be useful to support CIDR notation, but it's not so widely supported
-      // in other tools as a de-facto standard to follow, so we don't implement it for now.
     }
 
     return true; // If no matches found, use the proxy.

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -176,7 +176,7 @@ class ProxyConfig {
     } else {
       this.#buildBypassMatchFns();
       // Use the bypass match functions to determine if the proxy should be used.
-      this.shouldUseProxy = this.#match.bind(this);
+      this.shouldUseProxy = this.#match;
     }
   }
 
@@ -199,8 +199,7 @@ class ProxyConfig {
           continue;
         }
         this.#bypassMatchFns.push((host) => {
-          const hostLength = host.length;
-          const offset = hostLength - suffixLength;
+          const offset = host.length - suffixLength;
           if (offset < 0) return false; // Host is shorter than the suffix.
           for (let i = 0; i < suffixLength; i++) {
             if (host[offset + i] !== suffix[i]) {
@@ -246,8 +245,8 @@ class ProxyConfig {
     const host = hostname.toLowerCase();
     const hostWithPort = port ? `${host}:${port}` : host;
 
-    for (const bypassMatchFn of this.#bypassMatchFns) {
-      if (bypassMatchFn(host, hostWithPort)) {
+    for (let i = 0; i < this.#bypassMatchFns.length; i++) {
+      if (this.#bypassMatchFns[i](host, hostWithPort)) {
         return false; // If any bypass function matches, do not use the proxy.
       }
     }


### PR DESCRIPTION
\*wroom* \*wroom*

This PR improves the performance of shouldUseProxy. 

Actually started 2 days ago with improving the perf of ipToInt... 

Benchmarks on my machine:

<details>
before:

```sh
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="127.0.0.1": 152,298,960.42252606
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="127.0.0.1": 109,371,173.71784446
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="127.0.0.1": 629,054.1395199846
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="127.0.0.1": 23,596,691.205888372
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="127.0.0.1": 21,604,331.149891604
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="127.0.0.1": 16,123,322.001540164
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="127.0.0.1": 17,621,371.114304848
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="localhost": 161,158,328.71077526
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="localhost": 110,128,653.39418161
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="localhost": 15,375,318.52086422
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="localhost": 18,567,246.19312502
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="localhost": 24,235,890.246413812
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="localhost": 17,635,878.40280526
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="localhost": 17,837,685.127969157
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="www.example.com": 159,578,253.82453224
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="www.example.com": 104,244,926.37337217
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="www.example.com": 9,661,511.364715049
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="www.example.com": 12,343,979.353065126
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="www.example.com": 11,798,926.93479099
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="www.example.com": 8,826,112.633218365
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="www.example.com": 7,564,523.5133493
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="example.com": 158,343,624.34938583
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="example.com": 103,525,477.30938941
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="example.com": 15,688,007.450171985
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="example.com": 23,058,490.65161519
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="example.com": 26,354,197.248516392
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="example.com": 13,011,310.511034966
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="example.com": 15,525,732.107746532
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="myexample.com": 164,711,350.76978672
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="myexample.com": 106,214,797.76065217
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="myexample.com": 9,192,458.176383602
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="myexample.com": 12,657,966.677396402
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="myexample.com": 12,283,053.183298787
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="myexample.com": 7,655,382.777904308
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="myexample.com": 9,110,204.836031983
```


after:

```sh
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="127.0.0.1": 295,829,017.92753434
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="127.0.0.1": 274,345,562.37822485
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="127.0.0.1": 10,364,300.176334057
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="127.0.0.1": 25,335,366.78365188
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="127.0.0.1": 36,742,652.18604451
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="127.0.0.1": 38,972,973.29529
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="127.0.0.1": 34,475,165.76263014
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="localhost": 303,066,671.03082675
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="localhost": 290,866,275.393353
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="localhost": 21,210,277.974691644
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="localhost": 27,279,087.267927937
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="localhost": 37,369,598.7850396
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="localhost": 38,129,886.178095475
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="localhost": 39,684,624.70012313
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="www.example.com": 284,585,619.1487418
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="www.example.com": 300,751,789.24758214
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="www.example.com": 11,227,351.6249346
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="www.example.com": 13,975,908.915200153
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="www.example.com": 14,612,559.456860516
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="www.example.com": 9,358,467.76951655
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="www.example.com": 7,851,985.981221269
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="example.com": 292,501,575.8522399
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="example.com": 258,859,331.17996883
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="example.com": 21,097,655.7529689
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="example.com": 32,412,925.107667632
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="example.com": 24,466,027.7216731
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="example.com": 13,245,926.46698768
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="example.com": 38,109,891.1669161
http/proxy-should-use-proxy.js n=1000000 no_proxy="" hostname="myexample.com": 208,814,694.70769596
http/proxy-should-use-proxy.js n=1000000 no_proxy="*" hostname="myexample.com": 302,527,648.75813913
http/proxy-should-use-proxy.js n=1000000 no_proxy="126.255.255.1-127.0.0.255" hostname="myexample.com": 11,585,614.499313131
http/proxy-should-use-proxy.js n=1000000 no_proxy="127.0.0.1" hostname="myexample.com": 15,337,032.830145737
http/proxy-should-use-proxy.js n=1000000 no_proxy="example.com" hostname="myexample.com": 14,267,590.980183072
http/proxy-should-use-proxy.js n=1000000 no_proxy=".example.com" hostname="myexample.com": 8,919,752.421567837
http/proxy-should-use-proxy.js n=1000000 no_proxy="*.example.com" hostname="myexample.com": 14,072,507.751840893
```

</details>
