### PR TITLE
doc: fix missing links in the `errors` page

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2095,7 +2095,7 @@ urlSearchParams.has.call(buf, 'foo');
 ### `ERR_INVALID_TUPLE`
 
 An element in the `iterable` provided to the [WHATWG][WHATWG URL API]
-[`URLSearchParams` constructor][`new URLSearchParams(iterable)`] did not
+[`URLSearchParams` constructor][] [`new URLSearchParams(iterable)`][] did not
 represent a `[name, value]` tuple – that is, if an element is not iterable, or
 does not consist of exactly two elements.
 
@@ -2127,8 +2127,8 @@ An invalid URI was passed.
 
 ### `ERR_INVALID_URL`
 
-An invalid URL was passed to the [WHATWG][WHATWG URL API] [`URL`
-constructor][`new URL(input)`] or the legacy [`url.parse()`][] to be parsed.
+An invalid URL was passed to the [WHATWG][WHATWG URL API] [`URL` constructor][]
+[`new URL(input)`][] or the legacy [`url.parse()`][] to be parsed.
 The thrown error object typically has an additional property `'input'` that
 contains the URL that failed to parse.
 
@@ -2136,8 +2136,8 @@ contains the URL that failed to parse.
 
 ### `ERR_INVALID_URL_PATTERN`
 
-An invalid URLPattern was passed to the [WHATWG][WHATWG URL API] \[`URLPattern`
-constructor]\[`new URLPattern(input)`] to be parsed.
+An invalid URLPattern was passed to the [WHATWG][WHATWG URL API] [`URLPattern` constructor][]
+[`new URLPattern(input)`][] to be parsed.
 
 <a id="ERR_INVALID_URL_SCHEME"></a>
 
@@ -4321,6 +4321,9 @@ An error occurred trying to allocate memory. This should never happen.
 [`Object.setPrototypeOf`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf
 [`REPL`]: repl.md
 [`ServerResponse`]: http.md#class-httpserverresponse
+[`URLPattern` constructor]: url.md#class-urlpattern
+[`URLSearchParams` constructor]: url.md#class-urlsearchparams
+[`URL` constructor]: url.md#class-url
 [`Writable`]: stream.md#class-streamwritable
 [`child_process`]: child_process.md
 [`cipher.getAuthTag()`]: crypto.md#ciphergetauthtag
@@ -4352,6 +4355,7 @@ An error occurred trying to allocate memory. This should never happen.
 [`net.Socket.write()`]: net.md#socketwritedata-encoding-callback
 [`net`]: net.md
 [`new URL(input)`]: url.md#new-urlinput-base
+[`new URLPattern(input)`]: url.md#new-urlpatternstring-baseurl-options
 [`new URLSearchParams(iterable)`]: url.md#new-urlsearchparamsiterable
 [`package.json`]: packages.md#nodejs-packagejson-field-definitions
 [`postMessage()`]: worker_threads.md#portpostmessagevalue-transferlist


### PR DESCRIPTION
This PR fixes missing or broken Markdown reference links in `errors.md`

<img width="2048" height="215" alt="image" src="https://github.com/user-attachments/assets/42317c96-1a05-4c41-8635-78dafbb795bb" />
<img width="2048" height="380" alt="image" src="https://github.com/user-attachments/assets/6c6d8d0f-6ac5-4d6a-b8a6-160694acbac0" />

ERR_INVALID_TUPLE: `new URLSearchParams(iterable)`
ERR_INVALID_VALUE: `new URL(input)`
ERR_INVALD_URL_PATTERN: `URLPattern` constructor, `new URLPattern(input)`

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
