### PR TITLE
repl: add subprompt option to set multiline prompt

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -781,6 +781,7 @@ changes:
     previews or not. **Default:** `true` with the default eval function and
     `false` in case a custom eval function is used. If `terminal` is falsy, then
     there are no previews and the value of `preview` has no effect.
+  * `subprompt` {string} The prompt to display for multiline input. **Default:** `'| '`.
 * Returns: {repl.REPLServer}
 
 The `repl.start()` method creates and starts a [`repl.REPLServer`][] instance.

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -312,6 +312,10 @@ function REPLServer(prompt,
 
   const preview = options.terminal &&
     (options.preview !== undefined ? !!options.preview : !eval_);
+  
+  if (options.subprompt !== undefined && typeof options.subprompt === 'string') {
+    this._subprompt = options.subprompt;
+  }
 
   ObjectDefineProperty(this, 'inputStream', {
     __proto__: null,
@@ -1212,7 +1216,9 @@ REPLServer.prototype.resetContext = function() {
 REPLServer.prototype.displayPrompt = function(preserveCursor) {
   let prompt = this._initialPrompt;
   if (this[kBufferedCommandSymbol].length) {
-    prompt = kMultilinePrompt.description;
+    prompt = this._subprompt !== undefined ?
+      this._subprompt :
+      kMultilinePrompt.description;
   }
 
   // Do not overwrite `_initialPrompt` here

--- a/test/parallel/test-repl-subprompt.js
+++ b/test/parallel/test-repl-subprompt.js
@@ -1,0 +1,77 @@
+'use strict';
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const assert = require('assert');
+const repl = require('repl');
+
+function runTest({ subprompt, expectedSubprompt }) {
+  const inputStream = new ArrayStream();
+  const outputStream = new ArrayStream();
+  let output = '';
+
+  outputStream.write = (data) => { output += data.replace('\r', ''); };
+
+  const r = repl.start({
+    prompt: '> ',
+    input: inputStream,
+    output: outputStream,
+    terminal: true,
+    useColors: false,
+    subprompt,
+  });
+
+  r.on('exit', common.mustCall(() => {
+    const actual = output.split('\n');
+
+    // Validate that the correct subprompt is used for multiline input
+    assert.ok(actual.some((line) => line.includes(expectedSubprompt)),
+              `Expected to find "${expectedSubprompt}" in output`);
+  }));
+
+  // Input multiline code to trigger the subprompt
+  inputStream.run([
+    'const obj = {',
+    '  a: 1,',
+    '  b: 2',
+    '};',
+    'obj',
+  ]);
+
+  r.close();
+}
+
+// Test default subprompt
+runTest({
+  subprompt: undefined,
+  expectedSubprompt: '| ',
+});
+
+// Test custom subprompt
+runTest({
+  subprompt: '... ',
+  expectedSubprompt: '... ',
+});
+
+// Test empty string subprompt
+runTest({
+  subprompt: '',
+  expectedSubprompt: '',
+});
+
+// Test long subprompt
+runTest({
+  subprompt: '  -> ',
+  expectedSubprompt: '  -> ',
+});
+
+// Test non-string subprompt should be ignored
+runTest({
+  subprompt: 123,
+  expectedSubprompt: '| ',
+});
+
+// Test null subprompt should be ignored
+runTest({
+  subprompt: null,
+  expectedSubprompt: '| ',
+}); 


### PR DESCRIPTION
This commit adds a new `subprompt` option to the REPL configuration
that allows users to customize the prompt displayed for multiline
input.

The default remains "| " to maintain backward compatibility.

This new option provides flexibility for different use cases while
preserving the default behavior.

Closes: nodejs/node[#59401](https://github.com/nodejs/node/issues/59401)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
