### PR TITLE
tools: fix return value of try_check_compiler

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1113,7 +1113,7 @@ def try_check_compiler(cc, lang):
     proc = subprocess.Popen(shlex.split(cc) + ['-E', '-P', '-x', lang, '-'],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
   except OSError:
-    return (False, False, '', '')
+    return (False, False, '', '', False)
 
   with proc:
     proc.stdin.write(b'__clang__ __GNUC__ __GNUC_MINOR__ __GNUC_PATCHLEVEL__ '


### PR DESCRIPTION
`configure.py` throws an error in `Python 3.12.3`.

```python
Traceback (most recent call last):
  File "/home/ubuntu/node/./configure", line 27, in <module>
    import configure
  File "/home/ubuntu/node/configure.py", line 2328, in <module>
    check_compiler(output)
  File "/home/ubuntu/node/configure.py", line 1297, in check_compiler
    ok, is_clang, clang_version, gcc_version, is_apple = try_check_compiler(CXX, 'c++')
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 5, got 4)
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
