### PR TITLE
test: skip test-watch-mode inspect when no inspector

### DIFF
--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -671,7 +671,7 @@ console.log(values.random);
     ]);
   });
 
-  it('should run when `--watch --inspect`', async () => {
+  it('should run when `--watch --inspect`', { skip: !process.features.inspector }, async () => {
     const file = createTmpFile();
     const args = ['--watch', '--inspect', file];
     const { stdout, stderr } = await runWriteSucceed({ file, watchedFile: file, watchFlag: null, args });


### PR DESCRIPTION
The test for watch mode with inspect fails when the inspector is not available (such as when configured with `--without-ssl`). This commit skips the test in such cases.
