### PR TITLE
assert: resolve TODO and rename function

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -83,7 +83,7 @@ function lazyLoadComparison() {
 // AssertionError's when particular conditions are not met. The
 // assert module must conform to the following interface.
 
-const assert = module.exports = ok;
+module.exports = assert;
 
 const NO_EXCEPTION_SENTINEL = {};
 
@@ -186,8 +186,8 @@ assert.AssertionError = AssertionError;
  * @param {...any} args
  * @returns {void}
  */
-function ok(...args) {
-  innerOk(ok, args.length, ...args);
+function assert(...args) {
+  innerOk(assert, args.length, ...args);
 }
 
 /**
@@ -890,10 +890,8 @@ function strict(...args) {
   innerOk(strict, args.length, ...args);
 }
 
-// TODO(aduh95): take `ok` from `Assert.prototype` instead of a self-ref in a next major.
-assert.ok = assert;
 ArrayPrototypeForEach([
-  'fail', 'equal', 'notEqual', 'deepEqual', 'notDeepEqual',
+  'ok', 'fail', 'equal', 'notEqual', 'deepEqual', 'notDeepEqual',
   'deepStrictEqual', 'notDeepStrictEqual', 'strictEqual',
   'notStrictEqual', 'partialDeepStrictEqual', 'match', 'doesNotMatch',
   'throws', 'rejects', 'doesNotThrow', 'doesNotReject', 'ifError',

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -58,7 +58,7 @@ assert.strictEqual(
       code: 'ENOENT',
       name: 'Error',
       message: /^ENOENT: no such file or directory, access/,
-      stack: /at async ok\.rejects/
+      stack: /at async assert\.rejects/
     }
   ).then(common.mustCall());
 


### PR DESCRIPTION
Two small changes that should be rather safe, but it's probably a better idea not to backport to avoid breaking anyone (not sure if it qualifies as semver-major):

- remove self-ref `assert.ok.ok.ok…`, I doubt anyone is using it.
- `require('node:assert').name` is now `assert` instead of `ok` – for the sake of having clearer stack traces.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
