### PR TITLE
benchmark: reflect current OpenSSL in crypto key benchmarks

### DIFF
--- a/benchmark/crypto/create-keyobject.js
+++ b/benchmark/crypto/create-keyobject.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common.js');
+const { hasOpenSSL } = require('../../test/common/crypto.js');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -21,11 +22,14 @@ const keyFixtures = {
   'ec': readKeyPair('ec_p256_public', 'ec_p256_private'),
   'rsa': readKeyPair('rsa_public_2048', 'rsa_private_2048'),
   'ed25519': readKeyPair('ed25519_public', 'ed25519_private'),
-  'ml-dsa-44': readKeyPair('ml_dsa_44_public', 'ml_dsa_44_private'),
 };
 
+if (hasOpenSSL(3, 5)) {
+  keyFixtures['ml-dsa-44'] = readKeyPair('ml_dsa_44_public', 'ml_dsa_44_private');
+}
+
 const bench = common.createBenchmark(main, {
-  keyType: ['rsa', 'ec', 'ed25519', 'ml-dsa-44'],
+  keyType: Object.keys(keyFixtures),
   keyFormat: ['pkcs8', 'spki', 'der-pkcs8', 'der-spki', 'jwk-public', 'jwk-private'],
   n: [1e3],
 });

--- a/benchmark/crypto/oneshot-sign.js
+++ b/benchmark/crypto/oneshot-sign.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common.js');
+const { hasOpenSSL } = require('../../test/common/crypto.js');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -14,8 +15,11 @@ const keyFixtures = {
   'ec': readKey('ec_p256_private'),
   'rsa': readKey('rsa_private_2048'),
   'ed25519': readKey('ed25519_private'),
-  'ml-dsa-44': readKey('ml_dsa_44_private'),
 };
+
+if (hasOpenSSL(3, 5)) {
+  keyFixtures['ml-dsa-44'] = readKey('ml_dsa_44_private');
+}
 
 const data = crypto.randomBytes(256);
 
@@ -23,7 +27,7 @@ let pems;
 let keyObjects;
 
 const bench = common.createBenchmark(main, {
-  keyType: ['rsa', 'ec', 'ed25519', 'ml-dsa-44'],
+  keyType: Object.keys(keyFixtures),
   mode: ['sync', 'async', 'async-parallel'],
   keyFormat: ['pem', 'der', 'jwk', 'keyObject', 'keyObject.unique'],
   n: [1e3],

--- a/benchmark/crypto/oneshot-verify.js
+++ b/benchmark/crypto/oneshot-verify.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../common.js');
+const { hasOpenSSL } = require('../../test/common/crypto.js');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
@@ -21,8 +22,11 @@ const keyFixtures = {
   'ec': readKeyPair('ec_p256_public', 'ec_p256_private'),
   'rsa': readKeyPair('rsa_public_2048', 'rsa_private_2048'),
   'ed25519': readKeyPair('ed25519_public', 'ed25519_private'),
-  'ml-dsa-44': readKeyPair('ml_dsa_44_public', 'ml_dsa_44_private'),
 };
+
+if (hasOpenSSL(3, 5)) {
+  keyFixtures['ml-dsa-44'] = readKeyPair('ml_dsa_44_public', 'ml_dsa_44_private');
+}
 
 const data = crypto.randomBytes(256);
 
@@ -30,7 +34,7 @@ let pems;
 let keyObjects;
 
 const bench = common.createBenchmark(main, {
-  keyType: ['rsa', 'ec', 'ed25519', 'ml-dsa-44'],
+  keyType: Object.keys(keyFixtures),
   mode: ['sync', 'async', 'async-parallel'],
   keyFormat: ['pem', 'der', 'jwk', 'keyObject', 'keyObject.unique'],
   n: [1e3],


### PR DESCRIPTION
updates the crypto benchmarks so that they can be executed on OpenSSL < 3.5 and don't always run non 3.5 jobs in CI into flake status.