### PR TITLE
sqlite: statement.setReadNullAsUndefined()

### DIFF
--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -338,6 +338,7 @@
   V(read_host_object_string, "_readHostObject")                                \
   V(readable_string, "readable")                                               \
   V(read_bigints_string, "readBigInts")                                        \
+  V(read_null_as_undefined_string, "readNullAsUndefined")                      \
   V(reason_string, "reason")                                                   \
   V(refresh_string, "refresh")                                                 \
   V(regexp_string, "regexp")                                                   \

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -43,9 +43,13 @@ class DatabaseOpenConfiguration {
 
   inline bool get_use_big_ints() const { return use_big_ints_; }
 
-  inline void set_use_null_as_undefined(bool flag) { use_null_as_undefined_ = flag; }
+  inline void set_use_null_as_undefined(bool flag) {
+    use_null_as_undefined_ = flag;
+  }
 
-  inline bool get_use_null_as_undefined() const { return use_null_as_undefined_; }
+  inline bool get_use_null_as_undefined() const {
+    return use_null_as_undefined_;
+  }
 
   inline void set_return_arrays(bool flag) { return_arrays_ = flag; }
 
@@ -115,8 +119,12 @@ class DatabaseSync : public BaseObject {
   void FinalizeBackups();
   void UntrackStatement(StatementSync* statement);
   bool IsOpen();
-  bool use_big_ints() const { return open_config_.get_use_big_ints(); }
-  bool use_null_as_undefined() const { return open_config_.get_use_null_as_undefined(); }
+  bool use_big_ints() const {
+    return open_config_.get_use_big_ints();
+  }
+  bool use_null_as_undefined() const {
+    return open_config_.get_use_null_as_undefined();
+  }
   bool return_arrays() const { return open_config_.get_return_arrays(); }
   bool allow_bare_named_params() const {
     return open_config_.get_allow_bare_named_params();
@@ -179,7 +187,8 @@ class StatementSync : public BaseObject {
   static void SetAllowUnknownNamedParameters(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReadBigInts(const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void SetReadNullAsUndefined(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetReadNullAsUndefined(
+    const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReturnArrays(const v8::FunctionCallbackInfo<v8::Value>& args);
   void Finalize();
   bool IsFinalized();

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -43,6 +43,10 @@ class DatabaseOpenConfiguration {
 
   inline bool get_use_big_ints() const { return use_big_ints_; }
 
+  inline void set_use_null_as_undefined(bool flag) { use_null_as_undefined_ = flag; }
+
+  inline bool get_use_null_as_undefined() const { return use_null_as_undefined_; }
+
   inline void set_return_arrays(bool flag) { return_arrays_ = flag; }
 
   inline bool get_return_arrays() const { return return_arrays_; }
@@ -112,6 +116,7 @@ class DatabaseSync : public BaseObject {
   void UntrackStatement(StatementSync* statement);
   bool IsOpen();
   bool use_big_ints() const { return open_config_.get_use_big_ints(); }
+  bool use_null_as_undefined() const { return open_config_.get_use_null_as_undefined(); }
   bool return_arrays() const { return open_config_.get_return_arrays(); }
   bool allow_bare_named_params() const {
     return open_config_.get_allow_bare_named_params();
@@ -256,7 +261,9 @@ class UserDefinedFunction {
   UserDefinedFunction(Environment* env,
                       v8::Local<v8::Function> fn,
                       DatabaseSync* db,
-                      bool use_bigint_args);
+                      bool use_bigint_args,
+                      bool use_null_as_undefined_args
+                    );
   ~UserDefinedFunction();
   static void xFunc(sqlite3_context* ctx, int argc, sqlite3_value** argv);
   static void xDestroy(void* self);
@@ -266,6 +273,7 @@ class UserDefinedFunction {
   v8::Global<v8::Function> fn_;
   DatabaseSync* db_;
   bool use_bigint_args_;
+  bool use_null_as_undefined_args_;
 };
 
 }  // namespace sqlite

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -70,6 +70,7 @@ class DatabaseOpenConfiguration {
   bool enable_dqs_ = false;
   int timeout_ = 0;
   bool use_big_ints_ = false;
+  bool use_null_as_undefined_ = false;
   bool return_arrays_ = false;
   bool allow_bare_named_params_ = true;
   bool allow_unknown_named_params_ = false;
@@ -173,6 +174,7 @@ class StatementSync : public BaseObject {
   static void SetAllowUnknownNamedParameters(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReadBigInts(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetReadNullAsUndefined(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReturnArrays(const v8::FunctionCallbackInfo<v8::Value>& args);
   void Finalize();
   bool IsFinalized();
@@ -186,6 +188,7 @@ class StatementSync : public BaseObject {
   sqlite3_stmt* statement_;
   bool return_arrays_ = false;
   bool use_big_ints_;
+  bool use_null_as_undefined_ = false;
   bool allow_bare_named_params_;
   bool allow_unknown_named_params_;
   std::optional<std::map<std::string, std::string>> bare_named_params_;

--- a/test/parallel/test-sqlite-aggregate-function.mjs
+++ b/test/parallel/test-sqlite-aggregate-function.mjs
@@ -43,6 +43,15 @@ describe('DatabaseSync.prototype.aggregate()', () => {
       });
     });
 
+    test('throws if options.readNullAsUndefined is provided but is not a boolean', (t) => {
+      t.assert.throws(() => {
+        new DatabaseSync('foo', { readNullAsUndefined: 42 });
+      }, {
+        code: 'ERR_INVALID_ARG_TYPE',
+        message: 'The "options.readNullAsUndefined" argument must be a boolean.',
+      })
+    })
+
     test('throws if options.varargs is not a boolean', (t) => {
       t.assert.throws(() => {
         db.aggregate('sum', {

--- a/test/parallel/test-sqlite-aggregate-function.mjs
+++ b/test/parallel/test-sqlite-aggregate-function.mjs
@@ -49,8 +49,8 @@ describe('DatabaseSync.prototype.aggregate()', () => {
       }, {
         code: 'ERR_INVALID_ARG_TYPE',
         message: 'The "options.readNullAsUndefined" argument must be a boolean.',
-      })
-    })
+      });
+    });
 
     test('throws if options.varargs is not a boolean', (t) => {
       t.assert.throws(() => {

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -211,24 +211,24 @@ suite('DatabaseSync() constructor', () => {
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       message: 'The "options.readNullAsUndefined" argument must be a boolean.',
-    })
+    });
   });
 
   test('SQL null can be read as undefined', (t) => {
-    const db = new DatabaseSync(nextDb(), { readNullAsUndefined: true});
+    const db = new DatabaseSync(nextDb(), { readNullAsUndefined: true });
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(is_null TEXT DEFAULT NULL) STRICT;
       INSERT INTO data(is_null) VALUES(NULL);
-    `)
+    `);
     t.assert.strictEqual(setup, undefined);
 
     const query = db.prepare('SELECT is_null FROM DATA');
-    t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_null: null});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null });
     t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
-    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined });
     t.assert.strictEqual(query.setReadNullAsUndefined(false), undefined);
-    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null });
   });
 
   test('throws if options.returnArrays is provided but is not a boolean', (t) => {

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -282,16 +282,16 @@ suite('StatementSync.prototype.setReadNullAsUndefined', () => {
     const setup = db.exec(`
       CREATE TABLE data(is_null TEXT DEFAULT NULL) STRICT;
       INSERT INTO data(is_null) VALUES(NULL);
-    `)
+    `);
     t.assert.strictEqual(setup, undefined);
 
     const query = db.prepare('SELECT is_null FROM DATA');
-    t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_null: null});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null });
     t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
-    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined });
     t.assert.strictEqual(query.setReadNullAsUndefined(false), undefined);
-    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null});
-  })
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null });
+  });
 
   test('does not affect non-null values', (t) => {
     const db = new DatabaseSync(nextDb());
@@ -299,22 +299,21 @@ suite('StatementSync.prototype.setReadNullAsUndefined', () => {
     const setup = db.exec(`
       CREATE TABLE data(is_not_null TEXT) STRICT;
       INSERT INTO data(is_not_null) VALUES('This is not null');
-    `)
+    `);
     t.assert.strictEqual(setup, undefined);
 
     const query = db.prepare('SELECT is_not_null FROM DATA');
-    t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_not_null: 'This is not null'});
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_not_null: 'This is not null' });
     t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
-    console.log(query.get())
-    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_not_null: 'This is not null'});
-  })
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_not_null: 'This is not null' });
+  });
   test('throws when input is not a boolean', (t) => {
     const db = new DatabaseSync(nextDb());
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(is_not_null TEXT) STRICT;
       INSERT INTO data(is_not_null) VALUES('This is not null');
-    `)
+    `);
     t.assert.strictEqual(setup, undefined);
 
     const stmt = db.prepare('SELECT is_not_null FROM data');

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -288,7 +288,6 @@ suite('StatementSync.prototype.setReadNullAsUndefined', () => {
     const query = db.prepare('SELECT is_null FROM DATA');
     t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_null: null});
     t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
-    console.log(query.get()); 
     t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined});
     t.assert.strictEqual(query.setReadNullAsUndefined(false), undefined);
     t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null});
@@ -306,6 +305,7 @@ suite('StatementSync.prototype.setReadNullAsUndefined', () => {
     const query = db.prepare('SELECT is_not_null FROM DATA');
     t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_not_null: 'This is not null'});
     t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
+    console.log(query.get())
     t.assert.deepStrictEqual(query.get(), { __proto__: null, is_not_null: 'This is not null'});
   })
   test('throws when input is not a boolean', (t) => {
@@ -379,8 +379,7 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
 
   test('BigInt is required for reading large integers', (t) => {
     const db = new DatabaseSync(nextDb());
-    t.after(() => { db.close(); });
-    const bad = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
+    t.after(() => { db.close(); }); const bad = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
     t.assert.throws(() => {
       bad.get();
     }, {

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -275,6 +275,58 @@ suite('StatementSync.prototype.expandedSQL', () => {
   });
 });
 
+suite('StatementSync.prototype.setReadNullAsUndefined', () => {
+  test('Null can be read as undefined', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    const setup = db.exec(`
+      CREATE TABLE data(is_null TEXT DEFAULT NULL) STRICT;
+      INSERT INTO data(is_null) VALUES(NULL);
+    `)
+    t.assert.strictEqual(setup, undefined);
+
+    const query = db.prepare('SELECT is_null FROM DATA');
+    t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_null: null});
+    t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
+    console.log(query.get()); 
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: undefined});
+    t.assert.strictEqual(query.setReadNullAsUndefined(false), undefined);
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_null: null});
+  })
+
+  test('does not affect non-null values', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    const setup = db.exec(`
+      CREATE TABLE data(is_not_null TEXT) STRICT;
+      INSERT INTO data(is_not_null) VALUES('This is not null');
+    `)
+    t.assert.strictEqual(setup, undefined);
+
+    const query = db.prepare('SELECT is_not_null FROM DATA');
+    t.assert.deepStrictEqual(query.get(),{ __proto__: null, is_not_null: 'This is not null'});
+    t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, is_not_null: 'This is not null'});
+  })
+  test('throws when input is not a boolean', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    const setup = db.exec(`
+      CREATE TABLE data(is_not_null TEXT) STRICT;
+      INSERT INTO data(is_not_null) VALUES('This is not null');
+    `)
+    t.assert.strictEqual(setup, undefined);
+
+    const stmt = db.prepare('SELECT is_not_null FROM data');
+    t.assert.throws(() => {
+      stmt.setReadNullAsUndefined();
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "readNullAsUndefined" argument must be a boolean/,
+    });
+  });
+});
+
 suite('StatementSync.prototype.setReadBigInts()', () => {
   test('BigInts support can be toggled', (t) => {
     const db = new DatabaseSync(nextDb());


### PR DESCRIPTION
This change is in reference to this feature request: https://github.com/nodejs/node/issues/59457.

It adds setReadNullAsUndefined(boolean) so StatementSync in src/node_sqlite.cc and src/node_sqlite.h. All SQL null types will be converted to JavaScript undefined. This is particularly useful for accommodating the null/undefined JavaScript quirk.

A test for setReadNullAsUndefined is written into test-sqlite-statement-sync.js. 