### PR TITLE
http, benchmark: remove CRLF variables

### DIFF
--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -16,7 +16,6 @@ function main({ len, n }) {
   const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
   const kOnBody = HTTPParser.kOnBody | 0;
   const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
-  const CRLF = '\r\n';
 
   function processHeader(header, n) {
     const parser = newParser(REQUEST);
@@ -43,12 +42,12 @@ function main({ len, n }) {
     return parser;
   }
 
-  let header = `GET /hello HTTP/1.1${CRLF}Content-Type: text/plain${CRLF}`;
+  let header = `GET /hello HTTP/1.1\r\nContent-Type: text/plain\r\n`;
 
   for (let i = 0; i < len; i++) {
-    header += `X-Filler${i}: ${Math.random().toString(36).substring(2)}${CRLF}`;
+    header += `X-Filler${i}: ${Math.random().toString(36).substring(2)}\r\n`;
   }
-  header += CRLF;
+  header += '\r\n';
 
   processHeader(Buffer.from(header), n);
 }

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -262,6 +262,7 @@ module.exports = {
   _checkIsHttpToken: checkIsHttpToken,
   chunkExpression: /(?:^|\W)chunked(?:$|\W)/i,
   continueExpression: /(?:^|\W)100-continue(?:$|\W)/i,
+  CRLF: '\r\n', // TODO: Deprecate this.
   freeParser,
   methods,
   parsers,

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -262,7 +262,6 @@ module.exports = {
   _checkIsHttpToken: checkIsHttpToken,
   chunkExpression: /(?:^|\W)chunked(?:$|\W)/i,
   continueExpression: /(?:^|\W)100-continue(?:$|\W)/i,
-  CRLF: '\r\n', // TODO: Deprecate this.
   freeParser,
   methods,
   parsers,

--- a/test/parallel/test-http-header-overflow.js
+++ b/test/parallel/test-http-header-overflow.js
@@ -4,14 +4,13 @@ const assert = require('assert');
 const { createServer, maxHeaderSize } = require('http');
 const { createConnection } = require('net');
 
-const CRLF = '\r\n';
 const DUMMY_HEADER_NAME = 'Cookie: ';
 const DUMMY_HEADER_VALUE = 'a'.repeat(
   // Plus one is to make it 1 byte too big
   maxHeaderSize - DUMMY_HEADER_NAME.length + 1
 );
 const PAYLOAD_GET = 'GET /blah HTTP/1.1';
-const PAYLOAD = PAYLOAD_GET + CRLF + DUMMY_HEADER_NAME + DUMMY_HEADER_VALUE;
+const PAYLOAD = PAYLOAD_GET + '\r\n' + DUMMY_HEADER_NAME + DUMMY_HEADER_VALUE;
 
 const server = createServer();
 

--- a/test/parallel/test-http-upgrade-client2.js
+++ b/test/parallel/test-http-upgrade-client2.js
@@ -23,13 +23,11 @@
 const common = require('../common');
 const http = require('http');
 
-const CRLF = '\r\n';
-
 const server = http.createServer();
 server.on('upgrade', function(req, socket) {
-  socket.write(`HTTP/1.1 101 Ok${CRLF}` +
-               `Connection: Upgrade${CRLF}` +
-               `Upgrade: Test${CRLF}${CRLF}` +
+  socket.write(`HTTP/1.1 101 Ok\r\n` +
+               `Connection: Upgrade\r\n` +
+               `Upgrade: Test\r\n\r\n` +
                'head');
   socket.on('end', function() {
     socket.end();

--- a/test/parallel/test-https-foafssl.js
+++ b/test/parallel/test-https-foafssl.js
@@ -47,7 +47,6 @@ const webIdUrl = 'URI:http://example.com/#me';
 const modulus = fixtures.readKey('rsa_cert_foafssl_b.modulus', 'ascii').replace(/\n/g, '');
 const exponent = fixtures.readKey('rsa_cert_foafssl_b.exponent', 'ascii').replace(/\n/g, '');
 
-const CRLF = '\r\n';
 const body = 'hello world\n';
 let cert;
 
@@ -76,7 +75,7 @@ server.listen(0, function() {
   client.stdout.on('data', function(data) {
     console.log('response received');
     const message = data.toString();
-    const contents = message.split(CRLF + CRLF).pop();
+    const contents = message.split('\r\n\r\n').pop();
     assert.strictEqual(body, contents);
     server.close((e) => {
       assert.ifError(e);


### PR DESCRIPTION
This PR replaces remaining usages of the `CRLF` variable with the string literal`\r\n`  and removes the`CRLF`  export from `_http_common.js`.

### Background

In [#40101](https://github.com/nodejs/node/pull/40101), it was discussed that using the string literal `\r\n` is clearer and more explicit than using a `CRLF` variable. Based on this consensus, this PR replaces all remaining usages of the `CRLF` variable with the `\r\n` literal.

### About removing the export

Previously, there was a TODO comment not to remove the `CRLF` export from `_http_common.js` because the module was considered "semi-public" and should not have breaking changes without proper deprecation ([discussion](https://github.com/nodejs/node/pull/40101#discussion_r708599721)).

However, as of [#59293](https://github.com/nodejs/node/pull/59293), the `_http_common.js` module (along with other `node:_http_*` modules) is now officially deprecated and considered internal-only:

Given this, I considered it appropriate to remove the `CRLF` export.