### PR TITLE
src: move shared_ptr objects in KeyObjectData

### DIFF
--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -127,7 +127,7 @@ class KeyObjectData final : public MemoryRetainer {
   KeyObjectData(KeyType type,
                 std::shared_ptr<Mutex> mutex,
                 std::shared_ptr<Data> data)
-      : key_type_(type), mutex_(mutex), data_(data) {}
+      : key_type_(type), mutex_(std::move(mutex)), data_(std::move(data)) {}
 };
 
 class KeyObjectHandle : public BaseObject {


### PR DESCRIPTION
Since copying `shared_ptr` may involve costly atomic operations when copied implicitly, explicitly move both `shared_ptr` objects that are passed to the private `KeyObjectData` constructor.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
