### PR TITLE
test: use case-insensitive path checking on Windows in fs.cpSync tests

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -26,12 +26,9 @@ test-async-context-frame: PASS, FLAKY
 test-runner-run-watch: PASS, FLAKY
 # https://github.com/nodejs/node/pull/59408#issuecomment-3170650933
 test-fs-cp-sync-error-on-exist: PASS, FLAKY
-test-fs-cp-sync-copy-symlink-not-pointing-to-folder: PASS, FLAKY
 test-fs-cp-sync-symlink-points-to-dest-error: PASS, FLAKY
-test-fs-cp-sync-resolve-relative-symlinks-false: PASS, FLAKY
 test-fs-cp-async-symlink-points-to-dest: PASS, FLAKY
 test-fs-cp-sync-unicode-folder-names: PASS, FLAKY
-test-fs-cp-sync-resolve-relative-symlinks-default: PASS, FLAKY
 
 # https://github.com/nodejs/node/issues/56751
 test-without-async-context-frame: PASS, FLAKY

--- a/test/parallel/test-fs-cp-sync-copy-symlink-not-pointing-to-folder.mjs
+++ b/test/parallel/test-fs-cp-sync-copy-symlink-not-pointing-to-folder.mjs
@@ -1,5 +1,5 @@
 // This tests that cpSync copies link if it does not point to folder in src.
-import { mustNotMutateObjectDeep } from '../common/index.mjs';
+import { mustNotMutateObjectDeep, isWindows } from '../common/index.mjs';
 import { nextdir } from '../common/fs.js';
 import assert from 'node:assert';
 import { cpSync, mkdirSync, symlinkSync, readlinkSync } from 'node:fs';
@@ -16,4 +16,11 @@ mkdirSync(join(dest, 'a'), mustNotMutateObjectDeep({ recursive: true }));
 symlinkSync(dest, join(dest, 'a', 'c'));
 cpSync(src, dest, mustNotMutateObjectDeep({ recursive: true }));
 const link = readlinkSync(join(dest, 'a', 'c'));
-assert.strictEqual(link, src);
+
+if (isWindows) {
+  // On Windows, readlinkSync() may return a path with uppercase drive letter,
+  // but paths are case-insensitive.
+  assert.strictEqual(link.toLowerCase(), src.toLowerCase());
+} else {
+  assert.strictEqual(link, src);
+}

--- a/test/parallel/test-fs-cp-sync-resolve-relative-symlinks-default.mjs
+++ b/test/parallel/test-fs-cp-sync-resolve-relative-symlinks-default.mjs
@@ -1,5 +1,5 @@
 // This tests that cpSync resolves relative symlinks to their absolute path by default.
-import { mustNotMutateObjectDeep } from '../common/index.mjs';
+import { mustNotMutateObjectDeep, isWindows } from '../common/index.mjs';
 import { nextdir } from '../common/fs.js';
 import assert from 'node:assert';
 import { cpSync, mkdirSync, writeFileSync, symlinkSync, readlinkSync } from 'node:fs';
@@ -18,4 +18,11 @@ mkdirSync(dest, mustNotMutateObjectDeep({ recursive: true }));
 
 cpSync(src, dest, mustNotMutateObjectDeep({ recursive: true }));
 const link = readlinkSync(join(dest, 'bar.js'));
-assert.strictEqual(link, join(src, 'foo.js'));
+
+if (isWindows) {
+  // On Windows, readlinkSync() may return a path with uppercase drive letter,
+  // but paths are case-insensitive.
+  assert.strictEqual(link.toLowerCase(), join(src, 'foo.js').toLowerCase());
+} else {
+  assert.strictEqual(link, join(src, 'foo.js'));
+}

--- a/test/parallel/test-fs-cp-sync-resolve-relative-symlinks-false.mjs
+++ b/test/parallel/test-fs-cp-sync-resolve-relative-symlinks-false.mjs
@@ -1,5 +1,5 @@
 // This tests that cpSync resolves relative symlinks when verbatimSymlinks is false.
-import { mustNotMutateObjectDeep } from '../common/index.mjs';
+import { mustNotMutateObjectDeep, isWindows } from '../common/index.mjs';
 import { nextdir } from '../common/fs.js';
 import assert from 'node:assert';
 import { cpSync, mkdirSync, writeFileSync, symlinkSync, readlinkSync } from 'node:fs';
@@ -18,4 +18,11 @@ mkdirSync(dest, mustNotMutateObjectDeep({ recursive: true }));
 
 cpSync(src, dest, mustNotMutateObjectDeep({ recursive: true, verbatimSymlinks: false }));
 const link = readlinkSync(join(dest, 'bar.js'));
-assert.strictEqual(link, join(src, 'foo.js'));
+
+if (isWindows) {
+  // On Windows, readlinkSync() may return a path with uppercase drive letter,
+  // but paths are case-insensitive.
+  assert.strictEqual(link.toLowerCase(), join(src, 'foo.js').toLowerCase());
+} else {
+  assert.strictEqual(link, join(src, 'foo.js'));
+}


### PR DESCRIPTION
In certain machine configurations on Windows, fs.readlinkSync() may return a path with upper case drive letter while the other paths may be constructed from a base path with a lower case drive letter (e.g. from process.cwd()). Checking path mismatch in a case-sensitive manner can lead to failure in some tests, specifically with the Windows machine configurations in the Jenkins CI. Since paths are case-insensitive on Windows anyway, compare them in a case-insensitive manner in the tests.

This reduces the orange-ness of the Windows CI. I discovered it by logging the output in [a test run](https://ci.nodejs.org/job/node-test-binary-windows-js-suites/36242/#showFailuresLink)

```
  process.env.NODE_TEST_DIR: undefined
  tmpdir.path: c:\workspace\node-test-binary-windows-js-suites\node\test\.tmp.337
  dest: c:\workspace\node-test-binary-windows-js-suites\node\test\.tmp.337\copy_%2
  src: c:\workspace\node-test-binary-windows-js-suites\node\test\.tmp.337\copy_%1
  join(dest, "a", "c") c:\workspace\node-test-binary-windows-js-suites\node\test\.tmp.337\copy_%2\a\c
  link: C:\workspace\node-test-binary-windows-js-suites\node\test\.tmp.337\copy_%1
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
