### PR TITLE
test_runner: set mocktimer's interval undefined when clearInterval called

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -321,6 +321,7 @@ class MockTimers {
     if (timer?.priorityQueuePosition !== undefined) {
       this.#executionQueue.removeAt(timer.priorityQueuePosition);
       timer.priorityQueuePosition = undefined;
+      timer.interval = undefined;
     }
   }
 

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -201,6 +201,27 @@ describe('Mock Timers Test Suite', () => {
         // Should not throw
       });
     });
+
+    it('interval cleared inside callback should only fire once', (t) => {
+      t.mock.timers.enable();
+      const calls = [];
+
+      setInterval(() => {
+        calls.push('foo');
+      }, 10);
+      const timerId = setInterval(() => {
+        calls.push('bar');
+        clearInterval(timerId);
+      }, 10);
+
+      t.mock.timers.tick(10);
+      t.mock.timers.tick(10);
+
+      assert.deepStrictEqual(
+        calls,
+        ['foo', 'bar', 'foo'],
+      );
+    });
   });
 
   describe('globals/timers', () => {


### PR DESCRIPTION
this PR prevents adding timer to execution queue if clearInterval() called.
fixes https://github.com/nodejs/node/issues/59483

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
