### PR TITLE
cherry-pick V8 Linux s390x fixes for clang

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.19',
+    'v8_embedder_string': '-node.20',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.18',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/heap/base/asm/s390/push_registers_asm.cc
+++ b/deps/v8/src/heap/base/asm/s390/push_registers_asm.cc
@@ -21,17 +21,17 @@ asm(".text                                              \n"
     "PushAllRegistersAndIterateStack:                   \n"
     // Push all callee-saved registers.
     // r6-r13, r14 and sp(r15)
-    "  stmg %r6, %sp, 48(%sp)                           \n"
+    "  stmg %r6, %r15, 48(%r15)                         \n"
     // Allocate frame.
-    "  lay %sp, -160(%sp)                               \n"
+    "  lay %r15, -160(%r15)                             \n"
     // Pass 1st parameter (r2) unchanged (Stack*).
     // Pass 2nd parameter (r3) unchanged (StackVisitor*).
     // Save 3rd parameter (r4; IterateStackCallback).
     "  lgr %r5, %r4                                     \n"
     // Pass sp as 3rd parameter. 160+48 to point
     // to callee saved region stored above.
-    "  lay %r4, 208(%sp)                                \n"
+    "  lay %r4, 208(%r15)                               \n"
     // Call the callback.
     "  basr %r14, %r5                                   \n"
-    "  lmg %r14,%sp, 272(%sp)                           \n"
+    "  lmg %r14,%r15, 272(%r15)                         \n"
     "  br %r14                                          \n");


### PR DESCRIPTION
Cherry-pick these two upstream V8 fixes for Linux s390x when building with clang (thanks @miladfarca for the list):
- https://chromium-review.googlesource.com/c/v8/v8/+/6597365
- https://chromium-review.googlesource.com/c/v8/v8/+/6603554

Refs: https://github.com/nodejs/build/issues/4091
Refs: https://github.com/nodejs/build/pull/4123#issuecomment-3191660063

---

Without these patches, building with clang fails:
```
15:19:17 <inline asm>:7:13: error: invalid register
15:19:17     7 |   stmg %r6, %sp, 48(%sp)                           
15:19:17       |             ^
15:19:17 <inline asm>:8:7: error: invalid register
15:19:17     8 |   lay %sp, -160(%sp)                               
15:19:17       |       ^
15:19:17 <inline asm>:10:16: error: invalid register
15:19:17    10 |   lay %r4, 208(%sp)                                
15:19:17       |                ^
15:19:17 <inline asm>:12:12: error: invalid register
15:19:17    12 |   lmg %r14,%sp, 272(%sp)                           
15:19:17       |            ^
```

and [passes](https://ci.nodejs.org/job/richardlau-node-test-commit-linuxone/34/) with this PR.