### PR TITLE
doc,crypto: add supported asymmetric key types section

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -75,7 +75,7 @@ try {
 
 ## Asymmetric key types
 
-The following table lists the asymmetric key types recognized the [`KeyObject`][] API:
+The following table lists the asymmetric key types recognized by the [`KeyObject`][] API:
 
 | Key Type                    | Description    | OID                     |
 | --------------------------- | -------------- | ----------------------- |


### PR DESCRIPTION
This PR consolidates `node:crypto`'s supported asymmetric key types into their own section.