### PR TITLE
test: lazy-load internalTTy

### DIFF
--- a/test/parallel/test-runner-output.mjs
+++ b/test/parallel/test-runner-output.mjs
@@ -7,17 +7,12 @@ import { hostname } from 'node:os';
 import { chdir, cwd } from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-let internalTTy;
-async function lazyInternalTTy() {
-  internalTTy ??= (await import('internal/tty')).default;
-  return internalTTy;
-}
-
 const skipForceColors =
   process.config.variables.icu_gyp_path !== 'tools/icu/icu-generic.gyp' ||
   process.config.variables.node_shared_openssl;
 
-const canColorize = (await lazyInternalTTy()).getColorDepth() > 2;
+// We're using dynamic import here to not break `NODE_REGENERATE_SNAPSHOTS`.
+const canColorize = (await import('internal/tty')).default.getColorDepth() > 2;
 const skipCoverageColors = !canColorize;
 
 function replaceTestDuration(str) {


### PR DESCRIPTION
The documentation states the following:

```
### `NODE_REGENERATE_SNAPSHOTS`

If set, test snapshots for the current test are regenerated.
For example, `NODE_REGENERATE_SNAPSHOTS=1 out/Release/node test/parallel/test-runner-output.mjs`
will update all the test runner output snapshots.
```

However, due to an internal dependency, the suggested command fails:

![Image](https://github.com/user-attachments/assets/488856ca-f9cf-4179-940a-ec8c8d0c7776)

To avoid this error, I lazy-loaded the internal dependency:

![Image](https://github.com/user-attachments/assets/685da210-7d45-4dd7-a912-fac5a8af2437)
