### PR TITLE
[v24.x] lib: do not modify prototype deprecated asyncResource (encore)

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -262,10 +262,10 @@ class AsyncResource {
         enumerable: true,
         get: deprecate(function() {
           return self;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false),
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false, false),
         set: deprecate(function(val) {
           self = val;
-        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false),
+        }, 'The asyncResource property on bound functions is deprecated', 'DEP0172', false, false),
       },
     });
     return bound;


### PR DESCRIPTION
Previous attempt has missed one argument (`useEmitSync`), therefore it effectively did not work as intended.

This change sets `useEmitSync` to `false` which is equivalent to previous behaviour of `undefined` and sets `modifyPrototype` to `false` as expected.

Refs: #58218
Refs: #59195
