### PR TITLE
esm: link modules synchronously when no async loader hooks are used

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -65,6 +65,8 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
   debug = fn;
 });
 
+const { isPromise } = require('internal/util/types');
+
 /**
  * @typedef {import('./hooks.js').HooksProxy} HooksProxy
  * @typedef {import('./module_job.js').ModuleJobBase} ModuleJobBase
@@ -592,15 +594,21 @@ class ModuleLoader {
 
   /**
    * Load a module and translate it into a ModuleWrap for ordinary imported ESM.
-   * This is run asynchronously.
+   * This may be run asynchronously if there are asynchronous module loader hooks registered.
    * @param {string} url URL of the module to be translated.
    * @param {object} loadContext See {@link load}
    * @param {boolean} isMain Whether the module to be translated is the entry point.
-   * @returns {Promise<ModuleWrap>}
+   * @returns {Promise<ModuleWrap>|ModuleWrap}
    */
-  async loadAndTranslate(url, loadContext, isMain) {
-    const { format, source } = await this.load(url, loadContext);
-    return this.#translate(url, format, source, isMain);
+  loadAndTranslate(url, loadContext, isMain) {
+    const maybePromise = this.load(url, loadContext);
+    const afterLoad = ({ format, source }) => {
+      return this.#translate(url, format, source, isMain);
+    };
+    if (isPromise(maybePromise)) {
+      return maybePromise.then(afterLoad);
+    }
+    return afterLoad(maybePromise);
   }
 
   /**

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -37,6 +37,7 @@ const {
   },
 } = internalBinding('util');
 const { decorateErrorStack, kEmptyObject } = require('internal/util');
+const { isPromise } = require('internal/util/types');
 const {
   getSourceMapsSupport,
 } = require('internal/source_map/source_map_cache');
@@ -138,12 +139,11 @@ class ModuleJob extends ModuleJobBase {
     this.#loader = loader;
 
     // Expose the promise to the ModuleWrap directly for linking below.
-    if (isForRequireInImportedCJS) {
-      this.module = moduleOrModulePromise;
-      assert(this.module instanceof ModuleWrap);
-      this.modulePromise = PromiseResolve(this.module);
-    } else {
+    if (isPromise(moduleOrModulePromise)) {
       this.modulePromise = moduleOrModulePromise;
+    } else {
+      this.module = moduleOrModulePromise;
+      this.modulePromise = PromiseResolve(moduleOrModulePromise);
     }
 
     if (this.phase === kEvaluationPhase) {

--- a/test/es-module/test-esm-error-cache.js
+++ b/test/es-module/test-esm-error-cache.js
@@ -19,7 +19,9 @@ let error;
   await assert.rejects(
     () => import(file),
     (e) => {
-      assert.strictEqual(error, e);
+      // The module may be compiled again and a new SyntaxError would be thrown but
+      // with the same content.
+      assert.deepStrictEqual(error, e);
       return true;
     }
   );

--- a/test/es-module/test-esm-import-attributes-errors.js
+++ b/test/es-module/test-esm-import-attributes-errors.js
@@ -28,7 +28,7 @@ async function test() {
 
   await rejects(
     import(jsModuleDataUrl, { with: { type: 'json', other: 'unsupported' } }),
-    { code: 'ERR_IMPORT_ATTRIBUTE_TYPE_INCOMPATIBLE' }
+    { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
   );
 
   await rejects(
@@ -48,7 +48,7 @@ async function test() {
 
   await rejects(
     import(jsonModuleDataUrl, { with: { foo: 'bar' } }),
-    { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' }
+    { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
   );
 
   await rejects(

--- a/test/es-module/test-esm-import-attributes-errors.mjs
+++ b/test/es-module/test-esm-import-attributes-errors.mjs
@@ -23,7 +23,7 @@ await rejects(
 
 await rejects(
   import(jsModuleDataUrl, { with: { type: 'json', other: 'unsupported' } }),
-  { code: 'ERR_IMPORT_ATTRIBUTE_TYPE_INCOMPATIBLE' }
+  { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
 );
 
 await rejects(
@@ -43,7 +43,7 @@ await rejects(
 
 await rejects(
   import(jsonModuleDataUrl, { with: { foo: 'bar' } }),
-  { code: 'ERR_IMPORT_ATTRIBUTE_MISSING' }
+  { code: 'ERR_IMPORT_ATTRIBUTE_UNSUPPORTED' }
 );
 
 await rejects(


### PR DESCRIPTION
### esm: show race error message for inner module job race

The race can not only happen when the ESM is loaded by
the CommonJS loader, but can also happen to inner
module jobs in the dependency graph.

### esm: link modules synchrnously when no async loader hooks are used

When no async loader hooks are registered, perform the linking as
synchronously as possible to reduce the chance of races from the
the shared module loading cache.

Fixes: https://github.com/nodejs/node/issues/59366
Refs: https://github.com/abejfehr/node-22.18-issue-repro

Note that this is still a band-aid and only reduces the chance of races when no async loader hooks are used, to fully eliminate the races we still need https://github.com/nodejs/node/issues/55782

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
