### PR TITLE
tools: fix for code scanning alert no. 470: Incomplete multi-character sanitization

### DIFF
--- a/tools/doc/json.mjs
+++ b/tools/doc/json.mjs
@@ -371,6 +371,15 @@ const typeExpr = /^\{([^}]+)\}\s*/;
 const leadingHyphen = /^-\s*/;
 const defaultExpr = /\s*\*\*Default:\*\*\s*([^]+)$/i;
 
+function replaceAllHtmlComments(str) {
+  let prev;
+  do {
+    prev = str;
+    str = str.replace(/<!--.*?-->/sg, '');
+  } while (str !== prev);
+  return str;
+}
+
 function parseListItem(item, file) {
   const current = {};
 
@@ -378,7 +387,7 @@ function parseListItem(item, file) {
     .map((node) => (
       file.value.slice(node.position.start.offset, node.position.end.offset)),
     )
-    .join('').replace(/\s+/g, ' ').replace(/<!--.*?-->/sg, '');
+    .join('').replace(/\s+/g, ' ').replaceAllHtmlComments('');
   let text = current.textRaw;
 
   if (!text) {


### PR DESCRIPTION
Potential fix for [https://github.com/nodejs/node/security/code-scanning/470](https://github.com/nodejs/node/security/code-scanning/470)

The best way to fix this problem is to ensure that all instances of HTML comments are removed, even if they overlap or are consecutive. This can be achieved by repeatedly applying the `.replace()` operation until no more matches are found, as described in the background. Specifically, in the code on line 381, instead of a single `.replace(/<!--.*?-->/sg, '')`, we should use a loop that continues to apply the replacement until the string no longer changes. This fix should be applied only to the sanitization of `current.textRaw` in the `parseListItem` function in tools/doc/json.mjs. No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
