### PR TITLE
test: fix `test-setproctitle` status when `ps` is not available

### DIFF
--- a/test/parallel/test-setproctitle.js
+++ b/test/parallel/test-setproctitle.js
@@ -4,7 +4,7 @@ const common = require('../common');
 const { isMainThread } = require('worker_threads');
 
 // FIXME add sunos support
-if (common.isSunOS || common.isIBMi) {
+if (common.isSunOS || common.isIBMi || common.isWindows) {
   common.skip(`Unsupported platform [${process.platform}]`);
 }
 
@@ -25,15 +25,10 @@ assert.notStrictEqual(process.title, title);
 process.title = title;
 assert.strictEqual(process.title, title);
 
-// Test setting the title but do not try to run `ps` on Windows.
-if (common.isWindows) {
-  common.skip('Windows does not have "ps" utility');
-}
-
 try {
   execSync('command -v ps');
 } catch (err) {
-  if (err.status === 1) {
+  if (err.status === 1 || err.status === 127) {
     common.skip('The "ps" utility is not available');
   }
   throw err;
@@ -53,5 +48,5 @@ exec(cmd, common.mustSucceed((stdout, stderr) => {
     title += ` (${path.basename(process.execPath)})`;
 
   // Omitting trailing whitespace and \n
-  assert.strictEqual(stdout.replace(/\s+$/, '').endsWith(title), true);
+  assert.ok(stdout.trimEnd().endsWith(title));
 }));


### PR DESCRIPTION
The exit code on Ubuntu is 127, the test is only checking for exit code 1.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
