### PR TITLE
tools: avoid parsing test files twice

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -791,8 +791,7 @@ def Execute(args, context, timeout=None, env=None, disable_core_files=False,
   # We append NODE_SKIP_FLAG_CHECK (ref: test/common/index.js)
   # to avoid parsing the test files twice when looking for
   # flags or environment variables defined via // Flags: and // Env:
-  if not "NODE_SKIP_FLAG_CHECK" in env_copy:
-    env_copy["NODE_SKIP_FLAG_CHECK"] = "true"
+  env_copy["NODE_SKIP_FLAG_CHECK"] = "true"
 
   preexec_fn = None
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -788,6 +788,12 @@ def Execute(args, context, timeout=None, env=None, disable_core_files=False,
   for key, value in env.items():
     env_copy[key] = value
 
+  # We append NODE_SKIP_FLAG_CHECK (ref: test/common/index.js)
+  # to avoid parsing the test files twice when looking for
+  # flags or environment variables defined via // Flags: and // Env:
+  if not "NODE_SKIP_FLAG_CHECK" in env_copy:
+    env_copy["NODE_SKIP_FLAG_CHECK"] = "true"
+
   preexec_fn = None
 
   def disableCoreFiles():


### PR DESCRIPTION
I've noticed that we're currently parsing the test files twice:

1. In the Python test runner
2. In `test/common/index.js`

By appending `NODE_SKIP_FLAG_CHECK` directly from the test runner, we can avoid this double check.
I'm opening this PR to evaluate whether the change provides any runtime benefits.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
4. Update documentation if relevant.
5. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
