### PR TITLE
build: fix 'implicit-function-declaration' on OpenHarmony platform

### DIFF
--- a/deps/uvwasi/uvwasi.gyp
+++ b/deps/uvwasi/uvwasi.gyp
@@ -28,7 +28,7 @@
         'include_dirs': ['include']
       },
       'conditions': [
-        [ 'OS=="linux"', {
+        [ 'OS=="linux" or OS=="openharmony"', {
           'defines': [
             '_GNU_SOURCE',
             '_POSIX_C_SOURCE=200112',


### PR DESCRIPTION
When I cross-compile Node.js for the OpenHarmony platform, I must add the parameter `-Wno-error=implicit-function-declaration`.

This is my compile script: https://github.com/hqzing/build-ohos-node/blob/main/build.sh

If I don't add this parameter, I will encounter this error:
```log
../deps/uvwasi/src/uvwasi.c:1444:5: error: call to undeclared function 'seekdir'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1444 |     seekdir(dir->dir, cookie);
      |     ^
../deps/uvwasi/src/uvwasi.c:1459:14: error: call to undeclared function 'telldir'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 1459 |       tell = telldir(dir->dir);
      |              ^
2 errors generated.
make[1]: *** [deps/uvwasi/uvwasi.target.mk:100: /root/build-ohos-node/node-v24.2.0/out/Release/obj.target/uvwasi/deps/uvwasi/src/uvwasi.o] Error 1
make[1]: *** Waiting for unfinished jobs....
```

Now that I have identified the root cause, which is the missing macro definition `_GNU_SOURCE` during the build process, I am proposing this PR to fix the issue and eliminate the dependency on `-Wno-error=implicit-function-declaration` parameter.
