### PR TITLE
lib: allow customizable expected types in validation functions

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -159,9 +159,9 @@ const validateUint32 = hideStackFrames((value, name, positive = false) => {
  */
 
 /** @type {validateString} */
-const validateString = hideStackFrames((value, name) => {
+const validateString = hideStackFrames((value, name, expected = 'string') => {
   if (typeof value !== 'string')
-    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 });
 
 /**
@@ -174,9 +174,9 @@ const validateString = hideStackFrames((value, name) => {
  */
 
 /** @type {validateNumber} */
-const validateNumber = hideStackFrames((value, name, min = undefined, max) => {
+const validateNumber = hideStackFrames((value, name, min = undefined, max, expected = 'number') => {
   if (typeof value !== 'number')
-    throw new ERR_INVALID_ARG_TYPE(name, 'number', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 
   if ((min != null && value < min) || (max != null && value > max) ||
     ((min != null || max != null) && NumberIsNaN(value))) {
@@ -215,9 +215,9 @@ const validateOneOf = hideStackFrames((value, name, oneOf) => {
  */
 
 /** @type {validateBoolean} */
-const validateBoolean = hideStackFrames((value, name) => {
+const validateBoolean = hideStackFrames((value, name, expected = 'boolean') => {
   if (typeof value !== 'boolean')
-    throw new ERR_INVALID_ARG_TYPE(name, 'boolean', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 });
 
 const kValidateObjectNone = 0;
@@ -239,33 +239,33 @@ const kValidateObjectAllowObjectsAndNull = kValidateObjectAllowNullable |
 
 /** @type {validateObject} */
 const validateObject = hideStackFrames(
-  (value, name, options = kValidateObjectNone) => {
+  (value, name, options = kValidateObjectNone, expected = 'Object') => {
     if (options === kValidateObjectNone) {
       if (value === null || ArrayIsArray(value)) {
-        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+        throw new ERR_INVALID_ARG_TYPE(name, expected, value);
       }
 
       if (typeof value !== 'object') {
-        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+        throw new ERR_INVALID_ARG_TYPE(name, expected, value);
       }
     } else {
       const throwOnNullable = (kValidateObjectAllowNullable & options) === 0;
 
       if (throwOnNullable && value === null) {
-        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+        throw new ERR_INVALID_ARG_TYPE(name, expected, value);
       }
 
       const throwOnArray = (kValidateObjectAllowArray & options) === 0;
 
       if (throwOnArray && ArrayIsArray(value)) {
-        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+        throw new ERR_INVALID_ARG_TYPE(name, expected, value);
       }
 
       const throwOnFunction = (kValidateObjectAllowFunction & options) === 0;
       const typeofValue = typeof value;
 
       if (typeofValue !== 'object' && (throwOnFunction || typeofValue !== 'function')) {
-        throw new ERR_INVALID_ARG_TYPE(name, 'Object', value);
+        throw new ERR_INVALID_ARG_TYPE(name, expected, value);
       }
     }
   });
@@ -283,9 +283,9 @@ const validateObject = hideStackFrames(
 
 /** @type {validateDictionary} */
 const validateDictionary = hideStackFrames(
-  (value, name) => {
+  (value, name, expected = 'a dictionary') => {
     if (value != null && typeof value !== 'object' && typeof value !== 'function') {
-      throw new ERR_INVALID_ARG_TYPE(name, 'a dictionary', value);
+      throw new ERR_INVALID_ARG_TYPE(name, expected, value);
     }
   });
 
@@ -298,9 +298,9 @@ const validateDictionary = hideStackFrames(
  */
 
 /** @type {validateArray} */
-const validateArray = hideStackFrames((value, name, minLength = 0) => {
+const validateArray = hideStackFrames((value, name, minLength = 0, expected = 'Array') => {
   if (!ArrayIsArray(value)) {
-    throw new ERR_INVALID_ARG_TYPE(name, 'Array', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
   }
   if (value.length < minLength) {
     const reason = `must be longer than ${minLength}`;
@@ -440,12 +440,12 @@ const validatePort = hideStackFrames((port, name = 'Port', allowZero = true) => 
  */
 
 /** @type {validateAbortSignal} */
-const validateAbortSignal = hideStackFrames((signal, name) => {
+const validateAbortSignal = hideStackFrames((signal, name, expected = 'AbortSignal') => {
   if (signal !== undefined &&
       (signal === null ||
        typeof signal !== 'object' ||
        !('aborted' in signal))) {
-    throw new ERR_INVALID_ARG_TYPE(name, 'AbortSignal', signal);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, signal);
   }
 });
 
@@ -457,9 +457,9 @@ const validateAbortSignal = hideStackFrames((signal, name) => {
  */
 
 /** @type {validateFunction} */
-const validateFunction = hideStackFrames((value, name) => {
+const validateFunction = hideStackFrames((value, name, expected = 'Function') => {
   if (typeof value !== 'function')
-    throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 });
 
 /**
@@ -470,9 +470,9 @@ const validateFunction = hideStackFrames((value, name) => {
  */
 
 /** @type {validatePlainFunction} */
-const validatePlainFunction = hideStackFrames((value, name) => {
+const validatePlainFunction = hideStackFrames((value, name, expected = 'Function') => {
   if (typeof value !== 'function' || isAsyncFunction(value))
-    throw new ERR_INVALID_ARG_TYPE(name, 'Function', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 });
 
 /**
@@ -483,9 +483,9 @@ const validatePlainFunction = hideStackFrames((value, name) => {
  */
 
 /** @type {validateUndefined} */
-const validateUndefined = hideStackFrames((value, name) => {
+const validateUndefined = hideStackFrames((value, name, expected = 'undefined') => {
   if (value !== undefined)
-    throw new ERR_INVALID_ARG_TYPE(name, 'undefined', value);
+    throw new ERR_INVALID_ARG_TYPE(name, expected, value);
 });
 
 /**


### PR DESCRIPTION
Add optional expected parameter to validation functions to enable
flexible error messages for complex validation scenarios.

Usage example:
```js
const validateStringArrayOrFunction = hideStackFrames((value, name) => {
  if (Array.isArray(value)) {
    validateStringArray(value, name);
    return;
  }
  validateFunction(value, name, ['string[]', 'function']);
});
```

Resolves #59331