### PR TITLE
crypto: fix subtle.getPublicKey error for secret type key inputs

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -1090,7 +1090,8 @@ async function getPublicKey(key, keyUsages) {
   });
 
   if (key[kKeyType] !== 'private')
-    throw lazyDOMException('key must be a private key', 'InvalidAccessError');
+    throw lazyDOMException('key must be a private key',
+                           key[kKeyType] === 'secret' ? 'NotSupportedError' : 'InvalidAccessError');
 
   const keyObject = createPublicKey(key[kKeyObject]);
 

--- a/test/parallel/test-webcrypto-get-public-key.mjs
+++ b/test/parallel/test-webcrypto-get-public-key.mjs
@@ -41,11 +41,16 @@ for await (const { privateKey } of [
     name: 'SyntaxError',
     message: /Unsupported key usage/
   });
+
+  await assert.rejects(() => subtle.getPublicKey(publicKey, publicKey.usages), {
+    name: 'InvalidAccessError',
+    message: 'key must be a private key'
+  });
 }
 
 const secretKey = await subtle.generateKey(
   { name: 'AES-CBC', length: 128 }, true, ['encrypt', 'decrypt']);
 await assert.rejects(() => subtle.getPublicKey(secretKey, ['encrypt', 'decrypt']), {
-  name: 'InvalidAccessError',
+  name: 'NotSupportedError',
   message: 'key must be a private key'
 });


### PR DESCRIPTION
As per https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey

> 3. If the cryptographic algorithm identified by algorithm does not support deriving a public key from a private key, then return a Promise rejected with a `NotSupportedError`.

Any secret-type key input should give `NotSupportedError`.

> 8. If the `[[type]]` internal slot of key is not "private", then throw an `InvalidAccessError`.

Public-type key input should give `InvalidAccessError`.