### PR TITLE
sea: implement execArgvExtension

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -180,6 +180,7 @@ The configuration currently reads the following top-level fields:
   "useSnapshot": false,  // Default: false
   "useCodeCache": true, // Default: false
   "execArgv": ["--no-warnings", "--max-old-space-size=4096"], // Optional
+  "execArgvExtension": "env", // Default: "env", options: "none", "env", "cli"
   "assets": {  // Optional
     "a.dat": "/path/to/a.dat",
     "b.txt": "/path/to/b.txt"
@@ -312,6 +313,42 @@ similar to what would happen if the application is started with:
 
 ```console
 node --no-warnings --max-old-space-size=2048 /path/to/bundled/script.js user-arg1 user-arg2
+```
+
+### Execution argument extension
+
+The `execArgvExtension` field controls how additional execution arguments can be
+provided beyond those specified in the `execArgv` field. It accepts one of three string values:
+
+* `"none"`: No extension is allowed. Only the arguments specified in `execArgv` will be used,
+  and the `NODE_OPTIONS` environment variable will be ignored.
+* `"env"`: _(Default)_ The `NODE_OPTIONS` environment variable can extend the execution arguments.
+  This is the default behavior to maintain backward compatibility.
+* `"cli"`: The executable can be launched with `--node-options="--flag1 --flag2"`, and those flags
+  will be parsed as execution arguments for Node.js instead of being passed to the user script.
+  This allows using arguments that are not supported by the `NODE_OPTIONS` environment variable.
+
+For example, with `"execArgvExtension": "cli"`:
+
+```json
+{
+  "main": "/path/to/bundled/script.js",
+  "output": "/path/to/write/the/generated/blob.blob",
+  "execArgv": ["--no-warnings"],
+  "execArgvExtension": "cli"
+}
+```
+
+The executable can be launched as:
+
+```console
+./my-sea --node-options="--trace-exit" user-arg1 user-arg2
+```
+
+This would be equivalent to running:
+
+```console
+node --no-warnings --trace-exit /path/to/bundled/script.js user-arg1 user-arg2
 ```
 
 ## In the injected main script

--- a/src/node.cc
+++ b/src/node.cc
@@ -940,7 +940,17 @@ static ExitCode InitializeNodeWithArgsInternal(
   }
 
 #if !defined(NODE_WITHOUT_NODE_OPTIONS)
-  if (!(flags & ProcessInitializationFlags::kDisableNodeOptionsEnv)) {
+  bool should_parse_node_options =
+      !(flags & ProcessInitializationFlags::kDisableNodeOptionsEnv);
+#ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
+  if (sea::IsSingleExecutable()) {
+    sea::SeaResource sea_resource = sea::FindSingleExecutableResource();
+    if (sea_resource.exec_argv_extension != sea::SeaExecArgvExtension::kEnv) {
+      should_parse_node_options = false;
+    }
+  }
+#endif
+  if (should_parse_node_options) {
     // NODE_OPTIONS environment variable is preferred over the file one.
     if (credentials::SafeGetenv("NODE_OPTIONS", &node_options) ||
         !node_options.empty()) {

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -31,8 +31,15 @@ enum class SeaFlags : uint32_t {
   kIncludeExecArgv = 1 << 4,
 };
 
+enum class SeaExecArgvExtension : uint8_t {
+  kNone = 0,
+  kEnv = 1,
+  kCli = 2,
+};
+
 struct SeaResource {
   SeaFlags flags = SeaFlags::kDefault;
+  SeaExecArgvExtension exec_argv_extension = SeaExecArgvExtension::kEnv;
   std::string_view code_path;
   std::string_view main_code_or_snapshot;
   std::optional<std::string_view> code_cache;
@@ -42,7 +49,8 @@ struct SeaResource {
   bool use_snapshot() const;
   bool use_code_cache() const;
 
-  static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags);
+  static constexpr size_t kHeaderSize =
+      sizeof(kMagic) + sizeof(SeaFlags) + sizeof(SeaExecArgvExtension);
 };
 
 bool IsSingleExecutable();

--- a/test/fixtures/sea-exec-argv-extension-cli.js
+++ b/test/fixtures/sea-exec-argv-extension-cli.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+console.log('process.argv:', JSON.stringify(process.argv));
+console.log('process.execArgv:', JSON.stringify(process.execArgv));
+
+// Should have execArgv from SEA config + CLI --node-options
+assert.deepStrictEqual(process.execArgv, ['--no-warnings', '--max-old-space-size=1024']);
+
+assert.deepStrictEqual(process.argv.slice(2), [
+  'user-arg1',
+  'user-arg2'
+]);
+
+console.log('execArgvExtension cli test passed');

--- a/test/fixtures/sea-exec-argv-extension-env.js
+++ b/test/fixtures/sea-exec-argv-extension-env.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+
+process.emitWarning('This warning should not be shown in the output', 'TestWarning');
+
+console.log('process.argv:', JSON.stringify(process.argv));
+console.log('process.execArgv:', JSON.stringify(process.execArgv));
+
+// Should have execArgv from SEA config.
+// Note that flags from NODE_OPTIONS are not included in process.execArgv no matter it's
+// an SEA or not, but we can test whether it works by checking that the warning emitted
+// above was silenced.
+assert.deepStrictEqual(process.execArgv, ['--no-warnings']);
+
+assert.deepStrictEqual(process.argv.slice(2), [
+  'user-arg1', 
+  'user-arg2'
+]);
+
+console.log('execArgvExtension env test passed');

--- a/test/fixtures/sea-exec-argv-extension-none.js
+++ b/test/fixtures/sea-exec-argv-extension-none.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+
+console.log('process.argv:', JSON.stringify(process.argv));
+console.log('process.execArgv:', JSON.stringify(process.execArgv));
+
+// Should only have execArgv from SEA config, no NODE_OPTIONS
+assert.deepStrictEqual(process.execArgv, ['--no-warnings']);
+
+assert.deepStrictEqual(process.argv.slice(2), [
+  'user-arg1',
+  'user-arg2'
+]);
+
+console.log('execArgvExtension none test passed');

--- a/test/sequential/test-single-executable-application-exec-argv-extension-cli.js
+++ b/test/sequential/test-single-executable-application-exec-argv-extension-cli.js
@@ -1,0 +1,63 @@
+'use strict';
+
+require('../common');
+
+const {
+  generateSEA,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the execArgvExtension "cli" mode in single executable applications.
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+tmpdir.refresh();
+
+// Copy test fixture to working directory
+copyFileSync(fixtures.path('sea-exec-argv-extension-cli.js'), tmpdir.resolve('sea.js'));
+
+writeFileSync(configFile, `
+{
+  "main": "sea.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "execArgv": ["--no-warnings"],
+  "execArgvExtension": "cli"
+}
+`);
+
+spawnSyncAndExitWithoutError(
+  process.execPath,
+  ['--experimental-sea-config', 'sea-config.json'],
+  { cwd: tmpdir.path });
+
+assert(existsSync(seaPrepBlob));
+
+generateSEA(outputFile, process.execPath, seaPrepBlob);
+
+// Test that --node-options works with execArgvExtension: "cli"
+spawnSyncAndAssert(
+  outputFile,
+  ['--node-options=--max-old-space-size=1024', 'user-arg1', 'user-arg2'],
+  {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--max-old-space-size=2048', // Should be ignored
+      COMMON_DIRECTORY: join(__dirname, '..', 'common'),
+      NODE_DEBUG_NATIVE: 'SEA',
+    }
+  },
+  {
+    stdout: /execArgvExtension cli test passed/
+  });

--- a/test/sequential/test-single-executable-application-exec-argv-extension-env.js
+++ b/test/sequential/test-single-executable-application-exec-argv-extension-env.js
@@ -1,0 +1,68 @@
+'use strict';
+
+require('../common');
+
+const {
+  generateSEA,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the execArgvExtension "env" mode (default) in single executable applications.
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+tmpdir.refresh();
+
+// Copy test fixture to working directory
+copyFileSync(fixtures.path('sea-exec-argv-extension-env.js'), tmpdir.resolve('sea.js'));
+
+writeFileSync(configFile, `
+{
+  "main": "sea.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "execArgv": ["--no-warnings"],
+  "execArgvExtension": "env"
+}
+`);
+
+spawnSyncAndExitWithoutError(
+  process.execPath,
+  ['--experimental-sea-config', 'sea-config.json'],
+  { cwd: tmpdir.path });
+
+assert(existsSync(seaPrepBlob));
+
+generateSEA(outputFile, process.execPath, seaPrepBlob);
+
+// Test that NODE_OPTIONS works with execArgvExtension: "env" (default behavior)
+spawnSyncAndAssert(
+  outputFile,
+  ['user-arg1', 'user-arg2'],
+  {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--max-old-space-size=512',
+      COMMON_DIRECTORY: join(__dirname, '..', 'common'),
+      NODE_DEBUG_NATIVE: 'SEA',
+    }
+  },
+  {
+    stdout: /execArgvExtension env test passed/,
+    stderr(output) {
+      assert.doesNotMatch(output, /This warning should not be shown in the output/);
+      return true;
+    },
+    trim: true
+  });

--- a/test/sequential/test-single-executable-application-exec-argv-extension-none.js
+++ b/test/sequential/test-single-executable-application-exec-argv-extension-none.js
@@ -1,0 +1,63 @@
+'use strict';
+
+require('../common');
+
+const {
+  generateSEA,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the execArgvExtension "none" mode in single executable applications.
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+tmpdir.refresh();
+
+// Copy test fixture to working directory
+copyFileSync(fixtures.path('sea-exec-argv-extension-none.js'), tmpdir.resolve('sea.js'));
+
+writeFileSync(configFile, `
+{
+  "main": "sea.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "execArgv": ["--no-warnings"],
+  "execArgvExtension": "none"
+}
+`);
+
+spawnSyncAndExitWithoutError(
+  process.execPath,
+  ['--experimental-sea-config', 'sea-config.json'],
+  { cwd: tmpdir.path });
+
+assert(existsSync(seaPrepBlob));
+
+generateSEA(outputFile, process.execPath, seaPrepBlob);
+
+// Test that NODE_OPTIONS is ignored with execArgvExtension: "none"
+spawnSyncAndAssert(
+  outputFile,
+  ['user-arg1', 'user-arg2'],
+  {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--max-old-space-size=2048',
+      COMMON_DIRECTORY: join(__dirname, '..', 'common'),
+      NODE_DEBUG_NATIVE: 'SEA',
+    }
+  },
+  {
+    stdout: /execArgvExtension none test passed/
+  });


### PR DESCRIPTION
This implements the execArgvExtension configuration field for SEA, which takes one of three string values to specify whether and how execution arguments can be extended for the SEA at run time:

* `"none"`: No extension is allowed. Only the arguments specified in `execArgv` will be used, and the `NODE_OPTIONS` environment variable will be ignored.
* `"env"`: _(Default)_ The `NODE_OPTIONS` environment variable can extend the execution arguments. This is the default behavior to maintain backward compatibility.
* `"cli"`: The executable can be launched with `--node-options="--flag1 --flag2"`, and those flags will be parsed as execution arguments for Node.js instead of being passed to the user script. This allows using arguments that are not supported by the `NODE_OPTIONS` environment variable.

Refs: https://github.com/nodejs/node/issues/51688
Fixes: https://github.com/nodejs/node/issues/55573
Fixes: https://github.com/nodejs/single-executable/issues/100

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
