### PR TITLE
test: skip sea tests on Linux ppc64le

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -51,3 +51,17 @@ test-tls-psk-client: PASS, FLAKY
 [$arch==arm]
 # https://github.com/nodejs/node/issues/49933
 test-watch-mode-inspect: SKIP
+
+[$system==linux && $arch==ppc64]
+# https://github.com/nodejs/node/issues/59561
+test-single-executable-application: SKIP
+test-single-executable-application-assets: SKIP
+test-single-executable-application-assets-raw: SKIP
+test-single-executable-application-disable-experimental-sea-warning: SKIP
+test-single-executable-application-empty: SKIP
+test-single-executable-application-exec-argv: SKIP
+test-single-executable-application-exec-argv-empty: SKIP
+test-single-executable-application-snapshot: SKIP
+test-single-executable-application-snapshot-and-code-cache: SKIP
+test-single-executable-application-snapshot-worker: SKIP
+test-single-executable-application-use-code-cache: SKIP


### PR DESCRIPTION
Theses tests are failing when compiled with clang. Skip for now to avoid breaking the CI when we switch over to building with clang.

Refs: https://github.com/nodejs/node/issues/59561

