### PR TITLE
doc: mark `path.matchesGlob` as stable

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -291,7 +291,7 @@ added:
   - v20.17.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/TODO
+    pr-url: https://github.com/nodejs/node/pull/59572
     description: Marking the API stable.
 -->
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -289,9 +289,11 @@ path.format({
 added:
   - v22.5.0
   - v20.17.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/TODO
+    description: Marking the API stable.
 -->
-
-> Stability: 1 - Experimental
 
 * `path` {string} The path to glob-match against.
 * `pattern` {string} The glob to check the path against.


### PR DESCRIPTION
All other glob features were marked stable in https://github.com/nodejs/node/pull/57513, and this function stopped emitting experimental warnings in https://github.com/nodejs/node/pull/58236.

However, `path.matchesGlob` was never explicitly marked stable.