### PR TITLE
assert: cap input size in myersDiff to avoid Int32Array overflow

### DIFF
--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -6,6 +6,12 @@ const {
   StringPrototypeEndsWith,
 } = primordials;
 
+const {
+  codes: {
+    ERR_OUT_OF_RANGE,
+  },
+} = require('internal/errors');
+
 const colors = require('internal/util/colors');
 
 const kNopLinesToCollapse = 5;
@@ -29,7 +35,15 @@ function myersDiff(actual, expected, checkCommaDisparity = false) {
   const actualLength = actual.length;
   const expectedLength = expected.length;
   const max = actualLength + expectedLength;
-  // TODO(BridgeAR): Cap the input in case the values go beyond the limit of 2^31 - 1.
+
+  if (max > 0x7FFFFFFF) {
+    throw new ERR_OUT_OF_RANGE(
+      'myersDiff input size',
+      '< 2^31 - 1',
+      max,
+    );
+  }
+
   const v = new Int32Array(2 * max + 1);
   const trace = [];
 

--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -39,7 +39,7 @@ function myersDiff(actual, expected, checkCommaDisparity = false) {
   if (max > 0x7FFFFFFF) {
     throw new ERR_OUT_OF_RANGE(
       'myersDiff input size',
-      '< 2^31 - 1',
+      '< 2^31',
       max,
     );
   }

--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -36,7 +36,7 @@ function myersDiff(actual, expected, checkCommaDisparity = false) {
   const expectedLength = expected.length;
   const max = actualLength + expectedLength;
 
-  if (max > 0x7FFFFFFF) {
+  if (max > 2 ** 31 - 1) {
     throw new ERR_OUT_OF_RANGE(
       'myersDiff input size',
       '< 2^31',

--- a/test/parallel/test-assert-myers-diff.js
+++ b/test/parallel/test-assert-myers-diff.js
@@ -1,0 +1,25 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const { myersDiff } = require('internal/assert/myers_diff');
+
+{
+  const arr1 = { length: 2 ** 31 - 1 };
+  const arr2 = { length: 2 };
+  const max = arr1.length + arr2.length;
+  assert.throws(
+    () => {
+      myersDiff(arr1, arr2);
+    },
+    common.expectsError({
+      code: 'ERR_OUT_OF_RANGE',
+      name: 'RangeError',
+      message: 'The value of "myersDiff input size" ' +
+                'is out of range. It must be < 2^31. ' +
+                `Received ${max}`
+    })
+  );
+}


### PR DESCRIPTION
The current implementation of `myersDiff` may attempt to allocate an
`Int32Array` larger than the supported limit when the input size
exceeds 2^31 - 1. This can lead to an out-of-range runtime failure.

This patch adds a maximum input size check and throws
`ERR_OUT_OF_RANGE` if the limit is exceeded.

It also resolves the TODO left in `internal/assert/myers_diff.js`.

/cc @BridgeAR
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
