### PR TITLE
src: remove temporary string in the parsing of --snapshot-config

### DIFF
--- a/src/node_snapshotable.cc
+++ b/src/node_snapshotable.cc
@@ -935,15 +935,13 @@ std::optional<SnapshotConfig> ReadSnapshotConfig(const char* config_path) {
       return std::nullopt;
     }
     if (key == "builder") {
-      std::string builder_path;
-      if (field.value().get_string().get(builder_path) ||
-          builder_path.empty()) {
+      if (field.value().get_string().get(result.builder_script_path) ||
+          result.builder_script_path.empty()) {
         FPrintF(stderr,
                 "\"builder\" field of %s is not a non-empty string\n",
                 config_path);
         return std::nullopt;
       }
-      result.builder_script_path = builder_path;
     } else if (key == "withoutCodeCache") {
       bool without_code_cache_value = false;
       if (field.value().get_bool().get(without_code_cache_value)) {


### PR DESCRIPTION
This is a very small change following https://github.com/nodejs/node/pull/59473 by @joyeecheung motivated by a remark from @anonrig : it seems that we create a temporary string needlessly.

This PR is not about performance per se, but rather code simplicity. It removes two lines of code.
