### PR TITLE
src: add validation for CLI options that don't take an argument

### DIFF
--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -268,6 +268,10 @@ inline std::string RequiresArgumentErr(const std::string& arg) {
   return arg + " requires an argument";
 }
 
+inline std::string UnexpectedArgumentErr(const std::string& arg) {
+  return arg + " does not take an argument";
+}
+
 inline std::string NegationImpliesBooleanError(const std::string& arg) {
   return arg + " is an invalid negation because it is not a boolean option";
 }
@@ -475,6 +479,10 @@ void OptionsParser<Options>::Parse(
             value = value.substr(1);  // Treat \- as escaping an -.
         }
       }
+    } else if (info.type == kBoolean && equals_index != std::string::npos) {
+      // Boolean options don't accept arguments
+      errors->push_back(UnexpectedArgumentErr(name));
+      break;
     }
 
     switch (info.type) {

--- a/test/parallel/test-cli-bad-options.js
+++ b/test/parallel/test-cli-bad-options.js
@@ -17,6 +17,8 @@ requiresArgument('--eval');
 missingOption('--allow-fs-read=*', '--permission');
 missingOption('--allow-fs-write=*', '--permission');
 
+forbidsArgument('--check');
+
 function missingOption(option, requiredOption) {
   const r = spawnSync(process.execPath, [option], { encoding: 'utf8' });
   assert.strictEqual(r.status, 1);
@@ -34,5 +36,17 @@ function requiresArgument(option) {
   assert.strictEqual(
     msg,
     `${process.execPath}: ${option} requires an argument`
+  );
+}
+
+function forbidsArgument(option) {
+  const r = spawnSync(process.execPath, [`${option}=invalid`], { encoding: 'utf8' });
+
+  assert.strictEqual(r.status, 9);
+
+  const msg = r.stderr.split(/\r?\n/)[0];
+  assert.strictEqual(
+    msg,
+    `${process.execPath}: ${option} does not take an argument`
   );
 }


### PR DESCRIPTION
Certain command-line options don't take an argument. Among them are `--watch` and `--check`. However, as @dario-piotrowicz points out in #57864, Node's argument parser will silently accept an argument for boolean flags, admitting inputs like `--watch=this-value-should-not-be-here.js`, which creates user confusion.

In this PR,  I worked together with @dario-piotrowicz  to add an error message if an argument is mistakenly provided for boolean flags.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
