### PR TITLE
benchmark: calibrate config v8/serialize.js

### DIFF
--- a/benchmark/v8/serialize.js
+++ b/benchmark/v8/serialize.js
@@ -4,8 +4,8 @@ const common = require('../common.js');
 const v8 = require('v8');
 
 const bench = common.createBenchmark(main, {
-  len: [256, 1024 * 16, 1024 * 512],
-  n: [1e6],
+  len: [256, 1024 * 16],
+  n: [1e5],
 });
 
 function main({ n, len }) {


### PR DESCRIPTION
**benchmark: calibrate config v8/serialize.js**

```
According to recent tests with `calibrate-n` on
a dedicated Hetzner machine (4vCPUs | 16gb) the
The results got stable with n=1e5.

The work on https://github.com/nodejs/performance/issues/186#issue-3326002531 has shown that this benchmark file takes 2-minutes for a single run. This should improve things a bit.
```

---

Possibly, 1e4 is good too, but I got a higher CV% for the (removed) `1024 * 512` on my tests

```
Configuration: {"n":10000,"len":524288}
  CV: 17.20% (lower values mean more stable results)
  Stability: ✗ Unstable
```