### PR TITLE
benchmark: calibrate config array-vs-concat

### DIFF
--- a/benchmark/dgram/array-vs-concat.js
+++ b/benchmark/dgram/array-vs-concat.js
@@ -5,7 +5,7 @@ const common = require('../common.js');
 const dgram = require('dgram');
 const PORT = common.PORT;
 
-// `n` is the n of send requests to queue up each time.
+// `n` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
 const bench = common.createBenchmark(main, {


### PR DESCRIPTION
**benchmark: calibrate config array-vs-concat**

```
According to https://github.com/nodejs/performance/issues/186 this benchmark was taking 160 seconds for a single run.

Based on research in a dedicated machine, the results don't have variation based on the configs, so we don't need to bench all variations.
```

Results:

```
dgram/array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=64: 0.09442034752744355
dgram/array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=64: 0.09636922038589629
dgram/array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=64: 0.09402284494321313
dgram/array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=64: 0.092408799678465
dgram/array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=64: 0.09222950646717998
dgram/array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=64: 0.08934529765769729
dgram/array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=64: 0.08979177917590465
dgram/array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=64: 0.08130694986285242
dgram/array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=256: 0.37584647545465855
dgram/array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=256: 0.38207436031246833
dgram/array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=256: 0.37082519387552987
dgram/array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=256: 0.3702416015668334
dgram/array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=256: 0.3653237893192474
dgram/array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=256: 0.3549820227541549
dgram/array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=256: 0.3537396970973691
dgram/array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=256: 0.32694135931247525
dgram/array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=512: 0.7363157665277977
dgram/array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=512: 0.7555213939125762
dgram/array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=512: 0.7324405324870785
dgram/array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=512: 0.7379061609627977
dgram/array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=512: 0.7139355247925053
dgram/array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=512: 0.7128036051681932
dgram/array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=512: 0.7083613555122222
dgram/array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=512: 0.6565216506050623
dgram/array-vs-concat.js dur=5 type="concat" chunks=1 num=100 len=1024: 1.437767402690974
dgram/array-vs-concat.js dur=5 type="multi" chunks=1 num=100 len=1024: 1.5118896462637457
dgram/array-vs-concat.js dur=5 type="concat" chunks=2 num=100 len=1024: 1.4227555808033046
dgram/array-vs-concat.js dur=5 type="multi" chunks=2 num=100 len=1024: 1.4492008406803956
dgram/array-vs-concat.js dur=5 type="concat" chunks=4 num=100 len=1024: 1.390010171228112
dgram/array-vs-concat.js dur=5 type="multi" chunks=4 num=100 len=1024: 1.394034732287971
dgram/array-vs-concat.js dur=5 type="concat" chunks=8 num=100 len=1024: 1.3295181181371518
dgram/array-vs-concat.js dur=5 type="multi" chunks=8 num=100 len=1024: 1.2851256771264528
```

As you can see, the results are basically the first result * len.