### PR TITLE
benchmark: calibrate length of util.diff

### DIFF
--- a/benchmark/util/diff.js
+++ b/benchmark/util/diff.js
@@ -5,7 +5,7 @@ const common = require('../common');
 
 const bench = common.createBenchmark(main, {
   n: [1e3],
-  length: [1e3, 2e3],
+  length: [500, 1000],
   scenario: ['identical', 'small-diff', 'medium-diff', 'large-diff'],
 });
 


### PR DESCRIPTION
**benchmark: calibrate length of util.diff**
```
500 + 1000 already covers the curve. 2000 doesn’t add new qualitative insight — it just extends the same curve further down (another ~3–4× slowdown).

According to https://github.com/nodejs/performance/issues/186 this benchmark takes one minute to conclude a single run. This should fix it.
```