### PR TITLE
benchmark: reduce readfile-permission-enabled config

### DIFF
--- a/benchmark/fs/readfile-permission-enabled.js
+++ b/benchmark/fs/readfile-permission-enabled.js
@@ -12,8 +12,8 @@ const filename = tmpdir.resolve(`.removeme-benchmark-garbage-${process.pid}`);
 
 const bench = common.createBenchmark(main, {
   duration: [5],
-  encoding: ['', 'utf-8'],
-  len: [1024, 16 * 1024 * 1024],
+  encoding: ['utf-8'],
+  len: [1024],
   concurrent: [1, 10],
 }, {
   flags: [


### PR DESCRIPTION
**benchmark: reduce readfile-permission-enabled config**
```
There's no need to test all readfile config as
permission model won't impact based on size.
```
