### PR TITLE
doc: lint according to `@node-core/remark-lint`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -2461,11 +2461,13 @@ of Node.js core and was removed.
 <!-- YAML
 changes:
   - version: v11.0.0
-    pr-url:
-      - https://github.com/nodejs/node/pull/22519
-      - https://github.com/nodejs/node/pull/23017
-    description: Documentation-only deprecation
+    pr-url: https://github.com/nodejs/node/pull/22519
+    description: Deprecation revoked.
+                 Status changed to a documentation-only deprecation.
                  with `--pending-deprecation` support.
+  - version: v11.0.0
+    pr-url: https://github.com/nodejs/node/pull/23017
+    description: Runtime deprecation.
 -->
 
 Type: Documentation-only (supports [`--pending-deprecation`][])

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3425,7 +3425,7 @@ changes:
   - version:
      - v11.4.0
      - v10.15.0
-    commit: 186035243fad247e3955f
+    commit: 186035243fad247e3955fa0c202987cae99e82db
     pr-url: https://github.com/nodejs-private/node-private/pull/143
     description: Max header size in `http_parser` was set to 8 KiB.
 -->

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -651,8 +651,6 @@ added:
   - v24.5.0
 -->
 
-> Stability: 1.1 - Active Development
-
 This feature is only available with the `--experimental-inspector-network-resource` flag enabled.
 
 The inspector.NetworkResources.put method is used to provide a response for a loadNetworkResource

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -937,8 +937,6 @@ added:
   - v18.19.0
 -->
 
-> Stability: 1.2 - Release candidate
-
 * `data` {any} The data from `register(loader, import.meta.url, { data })`.
 
 The `initialize` hook is only accepted by [`register`][]. `registerHooks()` does


### PR DESCRIPTION
This PR lints the documentation according to https://www.npmjs.com/package/@node-core/remark-lint, which'll be the linter associated with the new tooling.

The difference which are rectified by this PR:
- The linter requires one PR URL per change
- The linter disallows duplicate stability nodes
- The linter requires full 40-character commits