### PR TITLE
test: deflake test-http-keep-alive-empty-line

### DIFF
--- a/test/parallel/test-http-keep-alive-empty-line.mjs
+++ b/test/parallel/test-http-keep-alive-empty-line.mjs
@@ -3,6 +3,10 @@ import assert from 'node:assert';
 import { createServer } from 'node:http';
 import { connect } from 'node:net';
 
+// This test ensures that data like an empty line (`\r\n`) recevied by the
+// server after a request, does not reset the keep-alive timeout. See
+// https://github.com/nodejs/node/issues/58140.
+
 const server = createServer({
   connectionsCheckingInterval: 100,
   headersTimeout: 100,
@@ -28,23 +32,24 @@ server.listen(0, () => {
           '\r\n'
     );
 
-    setTimeout(() => {
-      client.write('\r\n');
-    }, 100);
+    let response = '';
+    let responseReceived = false;
 
-    let responseBuffer = '';
-
+    client.setEncoding('utf-8');
     client.on('data', (chunk) => {
-      responseBuffer += chunk.toString();
+      response += chunk;
 
       // Check if we've received the full header (ending with \r\n\r\n)
-      if (responseBuffer.includes('\r\n\r\n')) {
-        const statusLine = responseBuffer.split('\r\n')[0];
+      if (response.includes('\r\n\r\n')) {
+        responseReceived = true;
+        const statusLine = response.split('\r\n')[0];
         const status = statusLine.split(' ')[1];
         assert.strictEqual(status, '404');
-        client.end();
+        client.write('\r\n');
       }
     });
-    client.on('end', common.mustCall());
+    client.on('end', common.mustCall(() => {
+      assert.ok(responseReceived);
+    }));
   });
 });


### PR DESCRIPTION
- Do not call `client.end()` to ensure that the socket is closed by the server.
- Remove the timer and send the empty line when the response is received.

Fixes: https://github.com/nodejs/node/issues/59577

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
