### PR TITLE
src: fix broken fast callback signatures

### DIFF
--- a/src/histogram.h
+++ b/src/histogram.h
@@ -101,22 +101,14 @@ class HistogramImpl {
   static void GetPercentilesBigInt(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void FastReset(v8::Local<v8::Value> unused,
-                        v8::Local<v8::Value> receiver);
-  static double FastGetCount(v8::Local<v8::Value> unused,
-                             v8::Local<v8::Value> receiver);
-  static double FastGetMin(v8::Local<v8::Value> unused,
-                           v8::Local<v8::Value> receiver);
-  static double FastGetMax(v8::Local<v8::Value> unused,
-                           v8::Local<v8::Value> receiver);
-  static double FastGetMean(v8::Local<v8::Value> unused,
-                            v8::Local<v8::Value> receiver);
-  static double FastGetExceeds(v8::Local<v8::Value> unused,
-                               v8::Local<v8::Value> receiver);
-  static double FastGetStddev(v8::Local<v8::Value> unused,
-                              v8::Local<v8::Value> receiver);
-  static double FastGetPercentile(v8::Local<v8::Value> unused,
-                                  v8::Local<v8::Value> receiver,
+  static void FastReset(v8::Local<v8::Value> receiver);
+  static double FastGetCount(v8::Local<v8::Value> receiver);
+  static double FastGetMin(v8::Local<v8::Value> receiver);
+  static double FastGetMax(v8::Local<v8::Value> receiver);
+  static double FastGetMean(v8::Local<v8::Value> receiver);
+  static double FastGetExceeds(v8::Local<v8::Value> receiver);
+  static double FastGetStddev(v8::Local<v8::Value> receiver);
+  static double FastGetPercentile(v8::Local<v8::Value> receiver,
                                   const double percentile);
 
   static void AddMethods(v8::Isolate* isolate,
@@ -165,13 +157,8 @@ class HistogramBase final : public BaseObject, public HistogramImpl {
   static void RecordDelta(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Add(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void FastRecord(
-      v8::Local<v8::Value> unused,
-      v8::Local<v8::Value> receiver,
-      const int64_t value,
-      v8::FastApiCallbackOptions& options);  // NOLINT(runtime/references)
-  static void FastRecordDelta(v8::Local<v8::Value> unused,
-                              v8::Local<v8::Value> receiver);
+  static void FastRecord(v8::Local<v8::Value> receiver, const int64_t value);
+  static void FastRecordDelta(v8::Local<v8::Value> receiver);
 
   HistogramBase(
       Environment* env,
@@ -243,11 +230,8 @@ class IntervalHistogram final : public HandleWrap, public HistogramImpl {
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void FastStart(v8::Local<v8::Value> unused,
-                        v8::Local<v8::Value> receiver,
-                        bool reset);
-  static void FastStop(v8::Local<v8::Value> unused,
-                       v8::Local<v8::Value> receiver);
+  static void FastStart(v8::Local<v8::Value> receiver, bool reset);
+  static void FastStop(v8::Local<v8::Value> receiver);
 
   BaseObject::TransferMode GetTransferMode() const override {
     return TransferMode::kCloneable;

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "node_debug.h"
 #include "node_snapshotable.h"
 #include "v8-fast-api-calls.h"
 #include "v8.h"
@@ -72,23 +73,23 @@ class BindingData : public SnapshotableObject {
   SET_SELF_SIZE(BindingData)
 
   static BindingData* FromV8Value(v8::Local<v8::Value> receiver);
-  static void NumberImpl(BindingData* receiver);
+  static void HrtimeImpl(BindingData* receiver);
 
-  static void FastNumber(v8::Local<v8::Value> unused,
-                         v8::Local<v8::Value> receiver) {
-    NumberImpl(FromV8Value(receiver));
+  static void FastHrtime(v8::Local<v8::Value> receiver) {
+    TRACK_V8_FAST_API_CALL("process.hrtime");
+    HrtimeImpl(FromV8Value(receiver));
   }
 
-  static void SlowNumber(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SlowHrtime(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-  static void BigIntImpl(BindingData* receiver);
+  static void HrtimeBigIntImpl(BindingData* receiver);
 
-  static void FastBigInt(v8::Local<v8::Value> unused,
-                         v8::Local<v8::Value> receiver) {
-    BigIntImpl(FromV8Value(receiver));
+  static void FastHrtimeBigInt(v8::Local<v8::Value> receiver) {
+    TRACK_V8_FAST_API_CALL("process.hrtimeBigInt");
+    HrtimeBigIntImpl(FromV8Value(receiver));
   }
 
-  static void SlowBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SlowHrtimeBigInt(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void LoadEnvFile(const v8::FunctionCallbackInfo<v8::Value>& args);
 
@@ -101,8 +102,8 @@ class BindingData : public SnapshotableObject {
   // These need to be static so that we have their addresses available to
   // register as external references in the snapshot at environment creation
   // time.
-  static v8::CFunction fast_number_;
-  static v8::CFunction fast_bigint_;
+  static v8::CFunction fast_hrtime_;
+  static v8::CFunction fast_hrtime_bigint_;
 };
 
 }  // namespace process

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -266,7 +266,6 @@ inline void EinvalError() {}
 
 template <typename FT, FT F, typename R, typename... Args>
 R WASI::WasiFunction<FT, F, R, Args...>::FastCallback(
-    Local<Object> unused,
     Local<Object> receiver,
     Args... args,
     // NOLINTNEXTLINE(runtime/references) This is V8 api.

--- a/src/node_wasi.h
+++ b/src/node_wasi.h
@@ -160,8 +160,7 @@ class WASI : public BaseObject,
                             v8::Local<v8::FunctionTemplate>);
 
    private:
-    static R FastCallback(v8::Local<v8::Object> unused,
-                          v8::Local<v8::Object> receiver,
+    static R FastCallback(v8::Local<v8::Object> receiver,
                           Args...,
                           v8::FastApiCallbackOptions&);
 

--- a/src/timers.cc
+++ b/src/timers.cc
@@ -53,9 +53,8 @@ void BindingData::SlowScheduleTimer(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
-void BindingData::FastScheduleTimer(Local<Object> unused,
-                                    Local<Object> receiver,
-                                    int64_t duration) {
+void BindingData::FastScheduleTimer(Local<Object> receiver, int64_t duration) {
+  TRACK_V8_FAST_API_CALL("timers.scheduleTimer");
   ScheduleTimerImpl(FromJSObject<BindingData>(receiver), duration);
 }
 
@@ -69,9 +68,8 @@ void BindingData::SlowToggleTimerRef(
                      args[0]->IsTrue());
 }
 
-void BindingData::FastToggleTimerRef(Local<Object> unused,
-                                     Local<Object> receiver,
-                                     bool ref) {
+void BindingData::FastToggleTimerRef(Local<Object> receiver, bool ref) {
+  TRACK_V8_FAST_API_CALL("timers.toggleTimerRef");
   ToggleTimerRefImpl(FromJSObject<BindingData>(receiver), ref);
 }
 
@@ -85,9 +83,8 @@ void BindingData::SlowToggleImmediateRef(
                          args[0]->IsTrue());
 }
 
-void BindingData::FastToggleImmediateRef(Local<Object> unused,
-                                         Local<Object> receiver,
-                                         bool ref) {
+void BindingData::FastToggleImmediateRef(Local<Object> receiver, bool ref) {
+  TRACK_V8_FAST_API_CALL("timers.toggleImmediateRef");
   ToggleImmediateRefImpl(FromJSObject<BindingData>(receiver), ref);
 }
 

--- a/src/timers.h
+++ b/src/timers.h
@@ -31,23 +31,18 @@ class BindingData : public SnapshotableObject {
 
   static void SlowScheduleTimer(
       const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FastScheduleTimer(v8::Local<v8::Object> unused,
-                                v8::Local<v8::Object> receiver,
+  static void FastScheduleTimer(v8::Local<v8::Object> receiver,
                                 int64_t duration);
   static void ScheduleTimerImpl(BindingData* data, int64_t duration);
 
   static void SlowToggleTimerRef(
       const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FastToggleTimerRef(v8::Local<v8::Object> unused,
-                                 v8::Local<v8::Object> receiver,
-                                 bool ref);
+  static void FastToggleTimerRef(v8::Local<v8::Object> receiver, bool ref);
   static void ToggleTimerRefImpl(BindingData* data, bool ref);
 
   static void SlowToggleImmediateRef(
       const v8::FunctionCallbackInfo<v8::Value>& args);
-  static void FastToggleImmediateRef(v8::Local<v8::Object> unused,
-                                     v8::Local<v8::Object> receiver,
-                                     bool ref);
+  static void FastToggleImmediateRef(v8::Local<v8::Object> receiver, bool ref);
   static void ToggleImmediateRefImpl(BindingData* data, bool ref);
 
   static void CreatePerIsolateProperties(IsolateData* isolate_data,

--- a/test/parallel/test-perf-hooks-histogram-fast-calls.js
+++ b/test/parallel/test-perf-hooks-histogram-fast-calls.js
@@ -1,0 +1,35 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
+
+const histogram = require('perf_hooks').createHistogram();
+
+function testFastMethods() {
+  histogram.record(1);
+  histogram.recordDelta();
+  histogram.percentile(50);
+  histogram.reset();
+}
+
+eval('%PrepareFunctionForOptimization(histogram.record)');
+eval('%PrepareFunctionForOptimization(histogram.recordDelta)');
+eval('%PrepareFunctionForOptimization(histogram.percentile)');
+eval('%PrepareFunctionForOptimization(histogram.reset)');
+testFastMethods();
+eval('%OptimizeFunctionOnNextCall(histogram.record)');
+eval('%OptimizeFunctionOnNextCall(histogram.recordDelta)');
+eval('%OptimizeFunctionOnNextCall(histogram.percentile)');
+eval('%OptimizeFunctionOnNextCall(histogram.reset)');
+testFastMethods();
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('histogram.record'), 1);
+  assert.strictEqual(getV8FastApiCallCount('histogram.recordDelta'), 1);
+  assert.strictEqual(getV8FastApiCallCount('histogram.percentile'), 1);
+  assert.strictEqual(getV8FastApiCallCount('histogram.reset'), 1);
+}

--- a/test/parallel/test-perf-hooks-histogram.js
+++ b/test/parallel/test-perf-hooks-histogram.js
@@ -41,8 +41,10 @@ const { inspect } = require('util');
       code: 'ERR_INVALID_ARG_TYPE'
     });
   });
-  throws(() => h.record(0, Number.MAX_SAFE_INTEGER + 1), {
-    code: 'ERR_OUT_OF_RANGE'
+  [0, Number.MAX_SAFE_INTEGER + 1].forEach((i) => {
+    throws(() => h.record(i), {
+      code: 'ERR_OUT_OF_RANGE'
+    });
   });
 
   strictEqual(h.min, 1);

--- a/test/parallel/test-process-hrtime-bigint.js
+++ b/test/parallel/test-process-hrtime-bigint.js
@@ -1,9 +1,12 @@
+// Flags: --allow-natives-syntax --expose-internals --no-warnings
 'use strict';
 
 // Tests that process.hrtime.bigint() works.
 
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
 
 const start = process.hrtime.bigint();
 assert.strictEqual(typeof start, 'bigint');
@@ -12,3 +15,13 @@ const end = process.hrtime.bigint();
 assert.strictEqual(typeof end, 'bigint');
 
 assert(end - start >= 0n);
+
+eval('%PrepareFunctionForOptimization(process.hrtime.bigint)');
+assert(process.hrtime.bigint());
+eval('%OptimizeFunctionOnNextCall(process.hrtime.bigint)');
+assert(process.hrtime.bigint());
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('process.hrtimeBigInt'), 1);
+}

--- a/test/parallel/test-process-hrtime.js
+++ b/test/parallel/test-process-hrtime.js
@@ -19,9 +19,12 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --allow-natives-syntax --expose-internals --no-warnings
 'use strict';
-require('../common');
+const common = require('../common');
 const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
 
 // The default behavior, return an Array "tuple" of numbers
 const tuple = process.hrtime();
@@ -72,3 +75,13 @@ function validateTuple(tuple) {
 
 const diff = process.hrtime([0, 1e9 - 1]);
 assert(diff[1] >= 0); // https://github.com/nodejs/node/issues/4751
+
+eval('%PrepareFunctionForOptimization(process.hrtime)');
+assert(process.hrtime());
+eval('%OptimizeFunctionOnNextCall(process.hrtime)');
+assert(process.hrtime());
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('process.hrtime'), 1);
+}

--- a/test/parallel/test-timers-fast-calls.js
+++ b/test/parallel/test-timers-fast-calls.js
@@ -1,0 +1,28 @@
+// Flags: --allow-natives-syntax --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
+const binding = internalBinding('timers');
+
+function testFastCalls() {
+  binding.scheduleTimer(1);
+  binding.toggleTimerRef(true);
+  binding.toggleTimerRef(false);
+  binding.toggleImmediateRef(true);
+  binding.toggleImmediateRef(false);
+}
+
+eval('%PrepareFunctionForOptimization(testFastCalls)');
+testFastCalls();
+eval('%OptimizeFunctionOnNextCall(testFastCalls)');
+testFastCalls();
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('timers.scheduleTimer'), 1);
+  assert.strictEqual(getV8FastApiCallCount('timers.toggleTimerRef'), 2);
+  assert.strictEqual(getV8FastApiCallCount('timers.toggleImmediateRef'), 2);
+}


### PR DESCRIPTION
Re-submitting #59055 for visibility, as the last PR went six weeks without any reviews.

----

Since #54408, the various fast callbacks that were edited by that PR have broken signatures and have not been invoked. (The changed signatures would only have been valid if the receiver were prepended to the function arguments wherever those bindings were called from JS, which isn't the case.)

There was no debug tracking of these callbacks, so this went unnoticed at the time.

This change fixes the broken signatures and adds debug testing to validate the fast paths.

This effectively reverts the remaining source changes from #54408 that were not already covered by #58054.