### PR TITLE
src: add name for more threads

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -101,6 +101,7 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
 
   std::unique_ptr<uv_thread_t> Start() {
     auto start_thread = [](void* data) {
+      uv_thread_setname("DelayedTaskSchedulerWorker");
       static_cast<DelayedTaskScheduler*>(data)->Run();
     };
     std::unique_ptr<uv_thread_t> t { new uv_thread_t() };

--- a/src/node_watchdog.cc
+++ b/src/node_watchdog.cc
@@ -80,6 +80,7 @@ Watchdog::~Watchdog() {
 
 
 void Watchdog::Run(void* arg) {
+  uv_thread_setname("Watchdog");
   Watchdog* wd = static_cast<Watchdog*>(arg);
 
   // UV_RUN_DEFAULT the loop will be stopped either by the async or the
@@ -229,9 +230,9 @@ void TraceSigintWatchdog::HandleInterrupt() {
 
 #ifdef __POSIX__
 void* SigintWatchdogHelper::RunSigintWatchdog(void* arg) {
+  uv_thread_setname("SigintWatchdog");
   // Inside the helper thread.
   bool is_stopping;
-
   do {
     uv_sem_wait(&instance.sem_);
     is_stopping = InformWatchdogsAboutSignal();

--- a/src/tracing/agent.cc
+++ b/src/tracing/agent.cc
@@ -94,10 +94,15 @@ void Agent::Start() {
   // This thread should be created *after* async handles are created
   // (within NodeTraceWriter and NodeTraceBuffer constructors).
   // Otherwise the thread could shut down prematurely.
-  CHECK_EQ(0, uv_thread_create(&thread_, [](void* arg) {
-    Agent* agent = static_cast<Agent*>(arg);
-    uv_run(&agent->tracing_loop_, UV_RUN_DEFAULT);
-  }, this));
+  CHECK_EQ(0,
+           uv_thread_create(
+               &thread_,
+               [](void* arg) {
+                 uv_thread_setname("TraceEventWorker");
+                 Agent* agent = static_cast<Agent*>(arg);
+                 uv_run(&agent->tracing_loop_, UV_RUN_DEFAULT);
+               },
+               this));
   started_ = true;
 }
 


### PR DESCRIPTION
```js
const vm = require('vm');
const trace_events = require('trace_events');

trace_events.createTracing({ categories: ['node.perf'] }).enable();

new vm.Script('while(1) {}').runInThisContext({breakOnSigint: true, timeout: 100000});
```
<img width="2298" height="590" alt="5dff6e25-5eda-4c2f-8266-e9e01a97e642" src="https://github.com/user-attachments/assets/89013ff2-404a-4842-a68b-b81fd9cc9a80" />

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
