### PR TITLE
lib: revert to using default derived class constructors

### DIFF
--- a/lib/inspector/promises.js
+++ b/lib/inspector/promises.js
@@ -3,9 +3,7 @@
 const inspector = require('inspector');
 const { promisify } = require('internal/util');
 
-class Session extends inspector.Session {
-  constructor() { super(); } // eslint-disable-line no-useless-constructor
-}
+class Session extends inspector.Session {}
 Session.prototype.post = promisify(inspector.Session.prototype.post);
 
 module.exports = {

--- a/lib/internal/buffer.js
+++ b/lib/internal/buffer.js
@@ -960,14 +960,7 @@ function writeFloatBackwards(val, offset = 0) {
   return offset;
 }
 
-class FastBuffer extends Uint8Array {
-  // Using an explicit constructor here is necessary to avoid relying on
-  // `Array.prototype[Symbol.iterator]`, which can be mutated by users.
-  // eslint-disable-next-line no-useless-constructor
-  constructor(bufferOrLength, byteOffset, length) {
-    super(bufferOrLength, byteOffset, length);
-  }
-}
+class FastBuffer extends Uint8Array {}
 
 function addBufferPrototypeMethods(proto) {
   proto.readBigUInt64LE = readBigUInt64LE;

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -253,11 +253,6 @@ const {
   }
 
   class AsymmetricKeyObject extends KeyObject {
-    // eslint-disable-next-line no-useless-constructor
-    constructor(type, handle) {
-      super(type, handle);
-    }
-
     get asymmetricKeyType() {
       return this[kAsymmetricKeyType] ||= this[kHandle].getAsymmetricKeyType();
     }

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -240,7 +240,6 @@ class Pattern {
 class ResultSet extends SafeSet {
   #root = '.';
   #isExcluded = () => false;
-  constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
 
   setup(root, isExcludedFn) {
     this.#root = root;

--- a/lib/internal/modules/esm/module_map.js
+++ b/lib/internal/modules/esm/module_map.js
@@ -23,8 +23,6 @@ const { validateString } = require('internal/validators');
  * This cache is *not* used when custom loaders are registered.
  */
 class ResolveCache extends SafeMap {
-  constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-
   /**
    * Generates the internal serialized cache key and returns it along the actual cache object.
    *
@@ -93,7 +91,6 @@ class ResolveCache extends SafeMap {
  * Cache the results of the `load` step of the module resolution and loading process.
  */
 class LoadCache extends SafeMap {
-  constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
   get(url, type = kImplicitTypeAttribute) {
     validateString(url, 'url');
     validateString(type, 'type');

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -401,55 +401,36 @@ primordials.makeSafe = makeSafe;
 
 // Subclass the constructors because we need to use their prototype
 // methods later.
-// Defining the `constructor` is necessary here to avoid the default
-// constructor which uses the user-mutable `%ArrayIteratorPrototype%.next`.
 primordials.SafeMap = makeSafe(
   Map,
-  class SafeMap extends Map {
-    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-  },
+  class SafeMap extends Map {},
 );
 primordials.SafeWeakMap = makeSafe(
   WeakMap,
-  class SafeWeakMap extends WeakMap {
-    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-  },
+  class SafeWeakMap extends WeakMap {},
 );
 
 primordials.SafeSet = makeSafe(
   Set,
-  class SafeSet extends Set {
-    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-  },
+  class SafeSet extends Set {},
 );
 primordials.SafeWeakSet = makeSafe(
   WeakSet,
-  class SafeWeakSet extends WeakSet {
-    constructor(i) { super(i); } // eslint-disable-line no-useless-constructor
-  },
+  class SafeWeakSet extends WeakSet {},
 );
 
 primordials.SafeFinalizationRegistry = makeSafe(
   FinalizationRegistry,
-  class SafeFinalizationRegistry extends FinalizationRegistry {
-    // eslint-disable-next-line no-useless-constructor
-    constructor(cleanupCallback) { super(cleanupCallback); }
-  },
+  class SafeFinalizationRegistry extends FinalizationRegistry {},
 );
 primordials.SafeWeakRef = makeSafe(
   WeakRef,
-  class SafeWeakRef extends WeakRef {
-    // eslint-disable-next-line no-useless-constructor
-    constructor(target) { super(target); }
-  },
+  class SafeWeakRef extends WeakRef {},
 );
 
 const SafePromise = makeSafe(
   Promise,
-  class SafePromise extends Promise {
-    // eslint-disable-next-line no-useless-constructor
-    constructor(executor) { super(executor); }
-  },
+  class SafePromise extends Promise {},
 );
 
 /**

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -359,10 +359,6 @@ ObjectSetPrototypeOf(InterfaceConstructor.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(InterfaceConstructor, EventEmitter);
 
 class Interface extends InterfaceConstructor {
-  // eslint-disable-next-line no-useless-constructor
-  constructor(input, output, completer, terminal) {
-    super(input, output, completer, terminal);
-  }
   get columns() {
     if (this.output?.columns) return this.output.columns;
     return Infinity;

--- a/lib/internal/repl/utils.js
+++ b/lib/internal/repl/utils.js
@@ -97,10 +97,6 @@ function isRecoverableError(e, code) {
     .extend(
       (Parser) => {
         return class extends Parser {
-          // eslint-disable-next-line no-useless-constructor
-          constructor(options, input, startPos) {
-            super(options, input, startPos);
-          }
           nextToken() {
             super.nextToken();
             if (this.type === tt.eof)

--- a/lib/readline/promises.js
+++ b/lib/readline/promises.js
@@ -27,10 +27,6 @@ const {
 let addAbortListener;
 
 class Interface extends _Interface {
-  // eslint-disable-next-line no-useless-constructor
-  constructor(input, output, completer, terminal) {
-    super(input, output, completer, terminal);
-  }
   question(query, options = kEmptyObject) {
     return new Promise((resolve, reject) => {
       let cb = resolve;


### PR DESCRIPTION
ES2021 altered the behaviour of default constructors for derived classes, such that constructor calls no longer use array spreading when passing arguments to the parent constructor.

The following used to fail, but passes as of v22.0.0:

```js
Reflect.getPrototypeOf(Array.prototype[Symbol.iterator]()).next = function next() {
  throw new Error('%ArrayIteratorPrototype%.next called!');
}
new class Derived extends Object {} ();
```

Previously, internal derived classes were given manually-defined "pass-through" constructors in order to avoid exposure to prototype pollution. These are no longer required, and can be safely removed.

cc: @aduh95 