### PR TITLE
doc: update "Type stripping in dependencies" section

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -206,8 +206,8 @@ are enabled by default.
 ### Type stripping in dependencies
 
 To discourage package authors from publishing packages written in TypeScript,
-Node.js will by default refuse to handle TypeScript files inside folders under
-a `node_modules` path.
+Node.js currently refuses to handle TypeScript files inside folders under a
+`node_modules` path.
 
 ### Paths aliases
 

--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -206,8 +206,8 @@ are enabled by default.
 ### Type stripping in dependencies
 
 To discourage package authors from publishing packages written in TypeScript,
-Node.js currently refuses to handle TypeScript files inside folders under a
-`node_modules` path.
+Node.js refuses to handle TypeScript files inside folders under a `node_modules`
+path.
 
 ### Paths aliases
 


### PR DESCRIPTION
The docs state, "To discourage package authors from publishing packages written in TypeScript, Node.js will _by default_ refuse to handle TypeScript files inside folders under a `node_modules` path" (emphasis added). This suggests that there's a way to override that default. However, as far as I can tell, there is not.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
