### PR TITLE
benchmark: calibrate util.*

### DIFF
--- a/benchmark/util/deprecate.js
+++ b/benchmark/util/deprecate.js
@@ -3,16 +3,26 @@
 const common = require('../common');
 const assert = require('assert');
 
-const bench = common.createBenchmark(main, {
-  n: [1e5],
-  modifyPrototype: [1, 0],
-  emitWarningSync: [1, 0],
-}, {
-  flags: ['--expose-internals'],
-});
+const bench = common.createBenchmark(
+  main,
+  {
+    n: [1000],
+    modifyPrototype: [1, 0],
+    emitWarningSync: [1, 0],
+  },
+  {
+    flags: ['--expose-internals'],
+  },
+);
 
 function simpleFunction(x) {
-  return x * 2 + (new Array(1000)).fill(0).map((_, i) => i).reduce((a, b) => a + b, 0);
+  return (
+    x * 2 +
+    new Array(1000)
+      .fill(0)
+      .map((_, i) => i)
+      .reduce((a, b) => a + b, 0)
+  );
 }
 
 function main({ n, modifyPrototype, emitWarningSync }) {

--- a/benchmark/util/format.js
+++ b/benchmark/util/format.js
@@ -13,12 +13,19 @@ const inputs = {
   'no-replace-2': ['foobar', 'yeah', 'mensch', 5],
   'only-objects': [{ msg: 'This is an error' }, { msg: 'This is an error' }],
   'many-%': ['replace%%%%s%%%%many%s%s%s', 'percent'],
-  'object-to-string': ['foo %s bar', { toString() { return 'bla'; } }],
+  'object-to-string': [
+    'foo %s bar',
+    {
+      toString() {
+        return 'bla';
+      },
+    },
+  ],
   'object-%s': ['foo %s bar', { a: true, b: false }],
 };
 
 const bench = common.createBenchmark(main, {
-  n: [1e6],
+  n: [100],
   type: Object.keys(inputs),
 });
 

--- a/benchmark/util/get-callsite.js
+++ b/benchmark/util/get-callsite.js
@@ -5,7 +5,7 @@ const { getCallSites } = require('node:util');
 const assert = require('node:assert');
 
 const bench = common.createBenchmark(main, {
-  n: [1e6],
+  n: [100],
   method: ['ErrorCallSites', 'ErrorCallSitesSerialized', 'CPP'],
 });
 

--- a/benchmark/util/inspect-array.js
+++ b/benchmark/util/inspect-array.js
@@ -4,14 +4,9 @@ const common = require('../common');
 const util = require('util');
 
 const bench = common.createBenchmark(main, {
-  n: [5e3],
+  n: [10],
   len: [1e2, 1e5],
-  type: [
-    'denseArray',
-    'sparseArray',
-    'mixedArray',
-    'denseArray_showHidden',
-  ],
+  type: ['denseArray', 'sparseArray', 'mixedArray', 'denseArray_showHidden'],
 });
 
 function main({ n, len, type }) {
@@ -29,8 +24,7 @@ function main({ n, len, type }) {
     case 'sparseArray':
       break;
     case 'mixedArray':
-      for (let i = 0; i < n; i += 2)
-        arr[i] = i;
+      for (let i = 0; i < n; i += 2) arr[i] = i;
       break;
     default:
       throw new Error(`Unsupported type ${type}`);

--- a/benchmark/util/inspect-proxy.js
+++ b/benchmark/util/inspect-proxy.js
@@ -4,7 +4,7 @@ const util = require('util');
 const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
-  n: [1e5],
+  n: [100],
   showProxy: [0, 1],
   isProxy: [0, 1],
 });

--- a/benchmark/util/inspect.js
+++ b/benchmark/util/inspect.js
@@ -9,7 +9,7 @@ const opts = {
   none: undefined,
 };
 const bench = common.createBenchmark(main, {
-  n: [8e4],
+  n: [1000],
   method: [
     'Object',
     'Object_empty',
@@ -47,18 +47,22 @@ function main({ method, n, option }) {
       benchmark(n, {}, options);
       break;
     case 'Object_deep_ln':
-      if (options)
-        options.depth = Infinity;
-      obj = { first:
-              { second:
-                { third:
-                  { a: 'first',
-                    b: 'second',
-                    c: 'third',
-                    d: 'fourth',
-                    e: 'fifth',
-                    f: 'sixth',
-                    g: 'seventh' } } } };
+      if (options) options.depth = Infinity;
+      obj = {
+        first: {
+          second: {
+            third: {
+              a: 'first',
+              b: 'second',
+              c: 'third',
+              d: 'fourth',
+              e: 'fifth',
+              f: 'sixth',
+              g: 'seventh',
+            },
+          },
+        },
+      };
       benchmark(n, obj, options || { depth: Infinity });
       break;
     case 'String':
@@ -81,14 +85,28 @@ function main({ method, n, option }) {
       benchmark(n, new Error('error'), options);
       break;
     case 'Array':
-      benchmark(n, Array(50).fill().map((_, i) => i), options);
+      benchmark(
+        n,
+        Array(50)
+          .fill()
+          .map((_, i) => i),
+        options,
+      );
       break;
     case 'TypedArray':
-      obj = new Uint8Array(Array(50).fill().map((_, i) => i));
+      obj = new Uint8Array(
+        Array(50)
+          .fill()
+          .map((_, i) => i),
+      );
       benchmark(n, obj, options);
       break;
     case 'TypedArray_extra':
-      obj = new Uint8Array(Array(50).fill().map((_, i) => i));
+      obj = new Uint8Array(
+        Array(50)
+          .fill()
+          .map((_, i) => i),
+      );
       obj.foo = 'bar';
       obj[Symbol('baz')] = 5;
       benchmark(n, obj, options);

--- a/benchmark/util/parse-env.js
+++ b/benchmark/util/parse-env.js
@@ -7,10 +7,13 @@ const util = require('node:util');
 const assert = require('node:assert');
 
 const bench = createBenchmark(main, {
-  n: 3e4,
+  n: 10,
 });
 
-const env = fs.readFileSync(path.resolve(__dirname, '../fixtures/valid.env'), 'utf-8');
+const env = fs.readFileSync(
+  path.resolve(__dirname, '../fixtures/valid.env'),
+  'utf-8',
+);
 
 function main({ n }) {
   let noDead;

--- a/benchmark/util/priority-queue.js
+++ b/benchmark/util/priority-queue.js
@@ -2,17 +2,19 @@
 
 const common = require('../common');
 
-const bench = common.createBenchmark(main, {
-  n: [1e5],
-}, { flags: ['--expose-internals'] });
+const bench = common.createBenchmark(
+  main,
+  {
+    n: [100],
+  },
+  { flags: ['--expose-internals'] },
+);
 
-function main({ n, type }) {
+function main({ n }) {
   const PriorityQueue = require('internal/priority_queue');
   const queue = new PriorityQueue();
   bench.start();
-  for (let i = 0; i < n; i++)
-    queue.insert(Math.random() * 1e7 | 0);
-  for (let i = 0; i < n; i++)
-    queue.shift();
+  for (let i = 0; i < n; i++) queue.insert((Math.random() * 1e7) | 0);
+  for (let i = 0; i < n; i++) queue.shift();
   bench.end(n);
 }

--- a/benchmark/util/splice-one.js
+++ b/benchmark/util/splice-one.js
@@ -2,11 +2,15 @@
 
 const common = require('../common');
 
-const bench = common.createBenchmark(main, {
-  n: [5e6],
-  pos: ['start', 'middle', 'end'],
-  size: [10, 100, 500],
-}, { flags: ['--expose-internals'] });
+const bench = common.createBenchmark(
+  main,
+  {
+    n: [1000],
+    pos: ['start', 'middle', 'end'],
+    size: [10, 100, 500],
+  },
+  { flags: ['--expose-internals'] },
+);
 
 function main({ n, pos, size }) {
   const { spliceOne } = require('internal/util');

--- a/benchmark/util/style-text.js
+++ b/benchmark/util/style-text.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
   messageType: ['string', 'number', 'boolean', 'invalid'],
   format: ['red', 'italic', 'invalid'],
   validateStream: [1, 0],
-  n: [1e3],
+  n: [100],
 });
 
 function main({ messageType, format, validateStream, n }) {

--- a/benchmark/util/text-encoder.js
+++ b/benchmark/util/text-encoder.js
@@ -4,8 +4,8 @@ const common = require('../common.js');
 const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
-  len: [32, 256, 1024, 1024 * 8],
-  n: [1e6],
+  len: [32, 1024, 1024 * 8],
+  n: [1000],
   type: ['one-byte-string', 'two-byte-string', 'ascii'],
   op: ['encode', 'encodeInto'],
 });
@@ -31,8 +31,7 @@ function main({ n, op, len, type }) {
     const expected = encoder.encode(input);
     let result;
     bench.start();
-    for (let i = 0; i < n; i++)
-      result = encoder.encode(input);
+    for (let i = 0; i < n; i++) result = encoder.encode(input);
     bench.end(n);
     assert.deepStrictEqual(result, expected);
   } else {
@@ -41,8 +40,7 @@ function main({ n, op, len, type }) {
     const expectedStats = encoder.encodeInto(input, expected);
     let result;
     bench.start();
-    for (let i = 0; i < n; i++)
-      result = encoder.encodeInto(input, subarray);
+    for (let i = 0; i < n; i++) result = encoder.encodeInto(input, subarray);
     bench.end(n);
     assert.deepStrictEqual(subarray, expected);
     assert.deepStrictEqual(result, expectedStats);

--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -25,14 +25,18 @@ const args = {
   },
 };
 
-const bench = common.createBenchmark(main, {
-  type: Object.keys(args),
-  version: ['native', 'js'],
-  argument: ['true', 'false-primitive', 'false-object'],
-  n: [1e6],
-}, {
-  flags: ['--expose-internals', '--no-warnings'],
-});
+const bench = common.createBenchmark(
+  main,
+  {
+    type: Object.keys(args),
+    version: ['native', 'js'],
+    argument: ['true', 'false-primitive', 'false-object'],
+    n: [1000],
+  },
+  {
+    flags: ['--expose-internals', '--no-warnings'],
+  },
+);
 
 function main({ type, argument, version, n }) {
   const util = common.binding('util');


### PR DESCRIPTION
According to [https://github.com/nodejs/performance/issues/186](https://github.com/nodejs/performance/issues/186)

Update all benchmarks in the util namespace by setting the `n` value to the result from `calibrate-n`.

# Util Calibration Benchmarks

| Util Function | Duration (minutes) | From Value | To Value |
|---------------|-------------------|------------|----------|
| util.text-encoder | 42.00 | 1e6 | 1e3 |
| util.deprecate | 1.00 | 1e5 | 1e3 |
| util.format | 2.00 | 1e6 | 1e2 |
| util.get-callsite | 5.50 | 1e6 | 1e2 |
| util.inspect-array | 1.30 | 5e3 | 10 |
| util.inspect-proxy | 0.47 | 1e5 | 1e2 |
| util.inspect | 5.14 | 8e4 | 1e3 |
| util.parse-env | 0.34 | 3e4 | 10 |
| util.priority-queue | 0.04 | 1e5 | 100 |
| util.splice-one | 2.12 | 5e6 | 1e3 |
| util.style-text | 0.48 | 1e3 | 1e2 |
| util.type-check | 0.28 | 1e6 | 1e3 |
