### PR TITLE
src,sqlite: refactor value conversion

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2017,6 +2017,19 @@ MaybeLocal<Name> StatementSync::ColumnNameToName(const int column) {
 
 void StatementSync::MemoryInfo(MemoryTracker* tracker) const {}
 
+std::optional<LocalVector<Value>> ExtractRowValues(Isolate* isolate,
+                                                   int num_cols,
+                                                   StatementSync* stmt) {
+  LocalVector<Value> row_values(isolate);
+  row_values.reserve(num_cols);
+  for (int i = 0; i < num_cols; ++i) {
+    Local<Value> val;
+    if (!stmt->ColumnToValue(i).ToLocal(&val)) return std::nullopt;
+    row_values.emplace_back(val);
+  }
+  return row_values;
+}
+
 void StatementSync::All(const FunctionCallbackInfo<Value>& args) {
   StatementSync* stmt;
   ASSIGN_OR_RETURN_UNWRAP(&stmt, args.This());
@@ -2034,24 +2047,19 @@ void StatementSync::All(const FunctionCallbackInfo<Value>& args) {
   auto reset = OnScopeLeave([&]() { sqlite3_reset(stmt->statement_); });
   int num_cols = sqlite3_column_count(stmt->statement_);
   LocalVector<Value> rows(isolate);
+  LocalVector<Value> row_values(isolate);
+  LocalVector<Name> row_keys(isolate);
 
-  if (stmt->return_arrays_) {
-    while ((r = sqlite3_step(stmt->statement_)) == SQLITE_ROW) {
-      LocalVector<Value> array_values(isolate);
-      array_values.reserve(num_cols);
-      for (int i = 0; i < num_cols; ++i) {
-        Local<Value> val;
-        if (!stmt->ColumnToValue(i).ToLocal(&val)) return;
-        array_values.emplace_back(val);
-      }
+  while ((r = sqlite3_step(stmt->statement_)) == SQLITE_ROW) {
+    auto maybe_row_values = ExtractRowValues(env->isolate(), num_cols, stmt);
+    if (!maybe_row_values.has_value()) return;
+
+    row_values = std::move(maybe_row_values.value());
+    if (stmt->return_arrays_) {
       Local<Array> row_array =
-          Array::New(isolate, array_values.data(), array_values.size());
+          Array::New(isolate, row_values.data(), row_values.size());
       rows.emplace_back(row_array);
-    }
-  } else {
-    LocalVector<Name> row_keys(isolate);
-
-    while ((r = sqlite3_step(stmt->statement_)) == SQLITE_ROW) {
+    } else {
       if (row_keys.size() == 0) {
         row_keys.reserve(num_cols);
         for (int i = 0; i < num_cols; ++i) {
@@ -2059,14 +2067,6 @@ void StatementSync::All(const FunctionCallbackInfo<Value>& args) {
           if (!stmt->ColumnNameToName(i).ToLocal(&key)) return;
           row_keys.emplace_back(key);
         }
-      }
-
-      LocalVector<Value> row_values(isolate);
-      row_values.reserve(num_cols);
-      for (int i = 0; i < num_cols; ++i) {
-        Local<Value> val;
-        if (!stmt->ColumnToValue(i).ToLocal(&val)) return;
-        row_values.emplace_back(val);
       }
 
       DCHECK_EQ(row_keys.size(), row_values.size());
@@ -2546,28 +2546,23 @@ void StatementSyncIterator::Next(const FunctionCallbackInfo<Value>& args) {
 
   int num_cols = sqlite3_column_count(iter->stmt_->statement_);
   Local<Value> row_value;
+  LocalVector<Name> row_keys(isolate);
+  LocalVector<Value> row_values(isolate);
+
+  auto maybe_row_values =
+      ExtractRowValues(isolate, num_cols, iter->stmt_.get());
+  if (!maybe_row_values.has_value()) return;
+
+  row_values = std::move(maybe_row_values.value());
 
   if (iter->stmt_->return_arrays_) {
-    LocalVector<Value> array_values(isolate);
-    array_values.reserve(num_cols);
-    for (int i = 0; i < num_cols; ++i) {
-      Local<Value> val;
-      if (!iter->stmt_->ColumnToValue(i).ToLocal(&val)) return;
-      array_values.emplace_back(val);
-    }
-    row_value = Array::New(isolate, array_values.data(), array_values.size());
+    row_value = Array::New(isolate, row_values.data(), row_values.size());
   } else {
-    LocalVector<Name> row_keys(isolate);
-    LocalVector<Value> row_values(isolate);
     row_keys.reserve(num_cols);
-    row_values.reserve(num_cols);
     for (int i = 0; i < num_cols; ++i) {
       Local<Name> key;
       if (!iter->stmt_->ColumnNameToName(i).ToLocal(&key)) return;
-      Local<Value> val;
-      if (!iter->stmt_->ColumnToValue(i).ToLocal(&val)) return;
       row_keys.emplace_back(key);
-      row_values.emplace_back(val);
     }
 
     DCHECK_EQ(row_keys.size(), row_values.size());

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -174,6 +174,8 @@ class StatementSync : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReadBigInts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReturnArrays(const v8::FunctionCallbackInfo<v8::Value>& args);
+  v8::MaybeLocal<v8::Value> ColumnToValue(const int column);
+  v8::MaybeLocal<v8::Name> ColumnNameToName(const int column);
   void Finalize();
   bool IsFinalized();
 
@@ -191,8 +193,6 @@ class StatementSync : public BaseObject {
   std::optional<std::map<std::string, std::string>> bare_named_params_;
   bool BindParams(const v8::FunctionCallbackInfo<v8::Value>& args);
   bool BindValue(const v8::Local<v8::Value>& value, const int index);
-  v8::MaybeLocal<v8::Value> ColumnToValue(const int column);
-  v8::MaybeLocal<v8::Name> ColumnNameToName(const int column);
 
   friend class StatementSyncIterator;
 };


### PR DESCRIPTION
This PR refactors `SatetmentSync::All` and `StatementSyncIterator::Next` methods to reduce complexity.

This will make it a lot easier to move forward with the implementation of the [async api for node:sqlite](https://github.com/nodejs/node/pull/59109)