### PR TITLE
[v20.x backport]deps: V8: cherry-pick 6b1b9bca2a8

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.30',
+    'v8_embedder_string': '-node.31',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/codegen/loong64/macro-assembler-loong64.cc
+++ b/deps/v8/src/codegen/loong64/macro-assembler-loong64.cc
@@ -1256,21 +1256,24 @@ void MacroAssembler::li(Register rd, Operand j, LiFlags mode) {
 }
 
 void MacroAssembler::MultiPush(RegList regs) {
-  int16_t stack_offset = 0;
+  int16_t num_to_push = regs.Count();
+  int16_t stack_offset = num_to_push * kSystemPointerSize;
 
+  Sub_d(sp, sp, Operand(stack_offset));
   for (int16_t i = kNumRegisters - 1; i >= 0; i--) {
     if ((regs.bits() & (1 << i)) != 0) {
       stack_offset -= kSystemPointerSize;
       St_d(ToRegister(i), MemOperand(sp, stack_offset));
     }
   }
-  addi_d(sp, sp, stack_offset);
 }
 
 void MacroAssembler::MultiPush(RegList regs1, RegList regs2) {
   DCHECK((regs1 & regs2).is_empty());
-  int16_t stack_offset = 0;
+  int16_t num_to_push = regs1.Count() + regs2.Count();
+  int16_t stack_offset = num_to_push * kSystemPointerSize;
 
+  Sub_d(sp, sp, Operand(stack_offset));
   for (int16_t i = kNumRegisters - 1; i >= 0; i--) {
     if ((regs1.bits() & (1 << i)) != 0) {
       stack_offset -= kSystemPointerSize;
@@ -1283,15 +1286,16 @@ void MacroAssembler::MultiPush(RegList regs1, RegList regs2) {
       St_d(ToRegister(i), MemOperand(sp, stack_offset));
     }
   }
-  addi_d(sp, sp, stack_offset);
 }
 
 void MacroAssembler::MultiPush(RegList regs1, RegList regs2, RegList regs3) {
   DCHECK((regs1 & regs2).is_empty());
   DCHECK((regs1 & regs3).is_empty());
   DCHECK((regs2 & regs3).is_empty());
-  int16_t stack_offset = 0;
+  int16_t num_to_push = regs1.Count() + regs2.Count() + regs3.Count();
+  int16_t stack_offset = num_to_push * kSystemPointerSize;
 
+  Sub_d(sp, sp, Operand(stack_offset));
   for (int16_t i = kNumRegisters - 1; i >= 0; i--) {
     if ((regs1.bits() & (1 << i)) != 0) {
       stack_offset -= kSystemPointerSize;
@@ -1310,7 +1314,6 @@ void MacroAssembler::MultiPush(RegList regs1, RegList regs2, RegList regs3) {
       St_d(ToRegister(i), MemOperand(sp, stack_offset));
     }
   }
-  addi_d(sp, sp, stack_offset);
 }
 
 void MacroAssembler::MultiPop(RegList regs) {
@@ -3563,9 +3566,8 @@ void MacroAssembler::EnterFrame(StackFrame::Type type) {
 
 void MacroAssembler::LeaveFrame(StackFrame::Type type) {
   ASM_CODE_COMMENT(this);
-  addi_d(sp, fp, 2 * kSystemPointerSize);
-  Ld_d(ra, MemOperand(fp, 1 * kSystemPointerSize));
-  Ld_d(fp, MemOperand(fp, 0 * kSystemPointerSize));
+  Move(sp, fp);
+  Pop(ra, fp);
 }
 
 void MacroAssembler::EnterExitFrame(int stack_space,


### PR DESCRIPTION
Backports https://github.com/nodejs/node/pull/59283 to v20.x.

Fix node-20.19.0 cpu-prof test failures can be seen in Debian CI:
https://buildd.debian.org/status/fetch.php?pkg=nodejs&arch=loong64&ver=20.19.0%2Bdfsg-2&stamp=1743722073&raw=0

CC: @marco-ippolito @aduh95 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
