### PR TITLE
test_runner: make signal handling configurable

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1502,6 +1502,8 @@ changes:
   * `functionCoverage` {number} Require a minimum percent of covered functions. If code
     coverage does not reach the threshold specified, the process will exit with code `1`.
     **Default:** `0`.
+  * `hookSignal` {boolean} Configures the test runner to handle termination signals like `SIGINT` and  `SIGTERM`.
+    **Default:** `true`.
 * Returns: {TestsStream}
 
 **Note:** `shard` is used to horizontally parallelize test running across

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -297,7 +297,7 @@ function setupProcessState(root, globalOptions) {
   process.on('uncaughtException', exceptionHandler);
   process.on('unhandledRejection', rejectionHandler);
   process.on('beforeExit', exitHandler);
-  if (globalOptions.isTestRunner || globalOptions.hookSignal) {
+  if (globalOptions.isTestRunner || globalOptions.hookSignal === true) {
     process.on('SIGINT', terminationHandler);
     process.on('SIGTERM', terminationHandler);
   }

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -297,7 +297,7 @@ function setupProcessState(root, globalOptions) {
   process.on('uncaughtException', exceptionHandler);
   process.on('unhandledRejection', rejectionHandler);
   process.on('beforeExit', exitHandler);
-  if (globalOptions.isTestRunner || globalOptions.hookSignal === true) {
+  if (globalOptions.isTestRunner && globalOptions.hookSignal !== true) {
     process.on('SIGINT', terminationHandler);
     process.on('SIGTERM', terminationHandler);
   }

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -297,8 +297,7 @@ function setupProcessState(root, globalOptions) {
   process.on('uncaughtException', exceptionHandler);
   process.on('unhandledRejection', rejectionHandler);
   process.on('beforeExit', exitHandler);
-  // TODO(MoLow): Make it configurable to hook when isTestRunner === false.
-  if (globalOptions.isTestRunner) {
+  if (globalOptions.isTestRunner || globalOptions.hookSignal) {
     process.on('SIGINT', terminationHandler);
     process.on('SIGTERM', terminationHandler);
   }

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -593,7 +593,7 @@ function run(options = kEmptyObject) {
     argv = [],
     cwd = process.cwd(),
     rerunFailuresFilePath,
-    hookSignal = false,
+    hookSignal = true,
   } = options;
 
   if (files != null) {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -708,6 +708,7 @@ function run(options = kEmptyObject) {
     // behavior has relied on it, so removing it must be done in a semver major.
     ...parseCommandLine(),
     setup,  // This line can be removed when parseCommandLine() is removed here.
+    hookSignal,
     coverage,
     coverageExcludeGlobs,
     coverageIncludeGlobs,

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -593,6 +593,7 @@ function run(options = kEmptyObject) {
     argv = [],
     cwd = process.cwd(),
     rerunFailuresFilePath,
+    hookSignal = false,
   } = options;
 
   if (files != null) {

--- a/test/parallel/test-runner-exit-code.js
+++ b/test/parallel/test-runner-exit-code.js
@@ -25,7 +25,7 @@ async function runAndKill(file) {
   assert.strictEqual(code, 1);
 }
 
-async function spawnAndKillProgrammatic(childArgs, { code: expectedCode, signal: expectedSignal }) {
+async function spawnAndKill(childArgs, { code: expectedCode, signal: expectedSignal }) {
   if (common.isWindows) {
     common.printSkipMessage('signals are not supported on windows');
     return;
@@ -88,11 +88,11 @@ if (process.argv[2] === 'child') {
   runAndKill(fixtures.path('test-runner', 'never_ending_async.js')).then(common.mustCall());
 
   (async () => {
-    await spawnAndKillProgrammatic(
+    await spawnAndKill(
       [__filename, 'child', 'run-signal-false'],
       { signal: 'SIGINT', code: null },
     );
-    await spawnAndKillProgrammatic(
+    await spawnAndKill(
       [__filename, 'child', 'run-signal-true'],
       { signal: null, code: 0 },
     );

--- a/test/parallel/test-runner-exit-code.js
+++ b/test/parallel/test-runner-exit-code.js
@@ -52,7 +52,7 @@ if (process.argv[2] === 'child') {
     run({ files: [fixtures.path('test-runner', 'never_ending_async.js')] });
     console.log('child started');    
   } else if (process.argv[3] === 'run-signal-true') {
-    run({ files: [fixtures.path('test-runner', 'never_ending_async.js')], signal: true });
+    run({ files: [fixtures.path('test-runner', 'never_ending_async.js')], hookSignal: true });
     console.log('child started');    
   } else assert.fail('unreachable');
 } else {
@@ -94,7 +94,7 @@ if (process.argv[2] === 'child') {
     );
     await spawnAndKillProgrammatic(
       [__filename, 'child', 'run-signal-true'],
-      { signal: null, code: 1 },
+      { signal: null, code: 0 },
     );
   })().then(common.mustCall());
 }

--- a/test/parallel/test-runner-exit-code.js
+++ b/test/parallel/test-runner-exit-code.js
@@ -50,10 +50,10 @@ if (process.argv[2] === 'child') {
     });
   } else if (process.argv[3] === 'run-signal-false') {
     run({ files: [fixtures.path('test-runner', 'never_ending_async.js')] });
-    console.log('child started');    
+    console.log('child started');
   } else if (process.argv[3] === 'run-signal-true') {
     run({ files: [fixtures.path('test-runner', 'never_ending_async.js')], hookSignal: true });
-    console.log('child started');    
+    console.log('child started');
   } else assert.fail('unreachable');
 } else {
   let child = spawnSync(process.execPath, [__filename, 'child', 'pass']);


### PR DESCRIPTION
This PR resolves a TODO in the test runner to allow signal handling to be enabled.

## Purpose

The test runner's signal handlers are only attached when it is invoked via the `--test` CLI flag (isTestRunner === true). This
  prevents users from opting into the same behavior in scenarios where `isTestRunner === false`, such as when calling the run() API from a JS file. In these cases, a `SIGINT` signal would terminate the process abruptly without proper test reporting.

Therefore this PR introduces a new `hookSignal` option to the run() function, allowing developers to enable signal handling for these scenarios.

I would appreciate your feedback😄

## Related Issues
 - PR #46707 : TODO comment added

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->