### PR TITLE
lib: use slice to compact Readable buffer in streams

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -23,6 +23,7 @@
 
 const {
   ArrayPrototypeIndexOf,
+  ArrayPrototypeSlice,
   NumberIsInteger,
   NumberIsNaN,
   NumberParseInt,
@@ -1673,7 +1674,7 @@ function fromList(n, state) {
     state.buffer.length = 0;
     state.bufferIndex = 0;
   } else if (idx > 1024) {
-    state.buffer.splice(0, idx);
+    state.buffer = ArrayPrototypeSlice(state.buffer, idx);
     state.bufferIndex = 0;
   } else {
     state.bufferIndex = idx;


### PR DESCRIPTION
Replace `splice(0, idx)` with
`state.buffer = ArrayPrototypeSlice(state.buffer, idx)` when compacting the Readable buffer.

Rationale:
- avoids O(N) left-shift and extra return array from `splice`
- reduces CPU/GC churn on large buffers
- aligns with similar optimization in Writable https://github.com/nodejs/node/pull/59406

Benchmark (local):
```
                                      confidence improvement accuracy (*)   (**)  (***)
streams/readable-bigread.js n=1000           *      0.77 %       ±0.73% ±0.97% ±1.26%
```