### PR TITLE
node-api: make napi_delete_reference use node_api_basic_env

### DIFF
--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -364,7 +364,7 @@ napi_create_reference(napi_env env,
 
 // Deletes a reference. The referenced value is released, and may
 // be GC'd unless there are other references to it.
-NAPI_EXTERN napi_status NAPI_CDECL napi_delete_reference(napi_env env,
+NAPI_EXTERN napi_status NAPI_CDECL napi_delete_reference(node_api_basic_env env,
                                                          napi_ref ref);
 
 // Increments the reference count, optionally returning the resulting count.

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -2773,7 +2773,11 @@ napi_status NAPI_CDECL napi_create_reference(napi_env env,
 // there are other references to it.
 // For a napi_reference returned from `napi_wrap`, this must be called in the
 // finalizer.
-napi_status NAPI_CDECL napi_delete_reference(napi_env env, napi_ref ref) {
+// Deletes a reference. The referenced value is released, and may be GC'd unless
+// there are other references to it.
+// For a napi_reference returned from `napi_wrap`, this must be called in the
+// finalizer.
+napi_status NAPI_CDECL napi_delete_reference(node_api_basic_env env, napi_ref ref) {
   // Omit NAPI_PREAMBLE and GET_RETURN_STATUS because V8 calls here cannot throw
   // JS exceptions.
   CHECK_ENV(env);

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -171,7 +171,7 @@ napi_value InitializeLocalNapiRefBinding(napi_env env, napi_value exports) {
   napi_ref ref{};
   if (node_api_version == NAPI_VERSION_EXPERIMENTAL) {
     CHECK_EQ(napi_create_reference(env, key, 1, &ref), napi_ok);
-    CHECK_EQ(napi_delete_reference(env, ref), napi_ok);
+    CHECK_EQ(napi_delete_reference(static_cast<node_api_basic_env>(env), ref), napi_ok);
   } else {
     CHECK_EQ(napi_create_reference(env, key, 1, &ref), napi_invalid_arg);
   }

--- a/test/js-native-api/6_object_wrap/myobject.cc
+++ b/test/js-native-api/6_object_wrap/myobject.cc
@@ -11,7 +11,7 @@ MyObject::MyObject(double value)
     : value_(value), env_(nullptr), wrapper_(nullptr) {}
 
 MyObject::~MyObject() {
-  napi_delete_reference(env_, wrapper_);
+  napi_delete_reference(static_cast<node_api_basic_env>(env_), wrapper_);
 }
 
 void MyObject::Destructor(node_api_basic_env env,
@@ -215,7 +215,7 @@ napi_value ObjectWrapDanglingReferenceTest(napi_env env,
 
   if (out == nullptr) {
     // If the napi_ref has been invalidated, delete it.
-    NODE_API_CALL(env, napi_delete_reference(env, dangling_ref));
+  NODE_API_CALL(env, napi_delete_reference(static_cast<node_api_basic_env>(env), dangling_ref));
     NODE_API_CALL(env, napi_get_boolean(env, true, &ret));
   } else {
     // The dangling napi_ref is still valid.

--- a/test/js-native-api/6_object_wrap/nested_wrap.cc
+++ b/test/js-native-api/6_object_wrap/nested_wrap.cc
@@ -8,10 +8,10 @@ static int finalization_count = 0;
 NestedWrap::NestedWrap() {}
 
 NestedWrap::~NestedWrap() {
-  napi_delete_reference(env_, wrapper_);
+  napi_delete_reference(static_cast<node_api_basic_env>(env_), wrapper_);
 
   // Delete the nested reference as well.
-  napi_delete_reference(env_, nested_);
+  napi_delete_reference(static_cast<node_api_basic_env>(env_), nested_);
 }
 
 void NestedWrap::Destructor(node_api_basic_env env,

--- a/test/js-native-api/7_factory_wrap/myobject.cc
+++ b/test/js-native-api/7_factory_wrap/myobject.cc
@@ -5,7 +5,7 @@ static int finalize_count = 0;
 
 MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
 
-MyObject::~MyObject() { napi_delete_reference(env_, wrapper_); }
+MyObject::~MyObject() { napi_delete_reference(static_cast<node_api_basic_env>(env_), wrapper_); }
 
 void MyObject::Destructor(napi_env env,
                           void* nativeObject,

--- a/test/js-native-api/8_passing_wrapped/myobject.cc
+++ b/test/js-native-api/8_passing_wrapped/myobject.cc
@@ -7,7 +7,7 @@ MyObject::MyObject() : env_(nullptr), wrapper_(nullptr) {}
 
 MyObject::~MyObject() {
   finalize_count++;
-  napi_delete_reference(env_, wrapper_);
+  napi_delete_reference(static_cast<node_api_basic_env>(env_), wrapper_);
 }
 
 void MyObject::Destructor(

--- a/test/node-api/test_uv_loop/test_uv_loop.cc
+++ b/test/node-api/test_uv_loop/test_uv_loop.cc
@@ -65,7 +65,7 @@ napi_value SetImmediateBinding(napi_env env, napi_callback_info info) {
     NODE_API_CALL(env, napi_open_handle_scope(env, &scope));
     NODE_API_CALL(env, napi_get_undefined(env, &undefined));
     NODE_API_CALL(env, napi_get_reference_value(env, cbref, &callback));
-    NODE_API_CALL(env, napi_delete_reference(env, cbref));
+  NODE_API_CALL(env, napi_delete_reference(static_cast<node_api_basic_env>(env), cbref));
     NODE_API_CALL(env,
         napi_call_function(env, undefined, callback, 0, nullptr, nullptr));
     NODE_API_CALL(env, napi_close_handle_scope(env, scope));


### PR DESCRIPTION
This PR updates the signature of `napi_delete_reference` to accept a `node_api_basic_env` instead of a `napi_env`, as discussed in nodejs/node#59583. This change reflects that `napi_delete_reference` does not require the environment to be in a non-GC state and aligns the API with its intended usage.

- Updates the function signature in both the implementation and header files.
- Refactors all internal and test usages to pass a `node_api_basic_env` as the first argument.

Refs: #59583

##### Checklist
- [x] PR description includes references to the issue
- [x] Function signature and all usages updated
- [x] Tests updated to match new signature

/cc @nodejs/node-api