### PR TITLE
lib: fix inspect deduplication logic

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1039,7 +1039,7 @@ function getPrefix(constructor, tag, fallback, size = '') {
     } else {
       const endPos = position + tag.length;
       if (endPos !== constructor.length &&
-        constructor[endPos + 1] === constructor[endPos + 1].toLowerCase()) {
+        constructor[endPos] === constructor[endPos].toLowerCase()) {
         result += `[${tag}] `;
       }
     }

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1507,7 +1507,7 @@ function getClassBase(value, constructor, tag) {
   if (constructor !== 'Function' && constructor !== null) {
     base += ` [${constructor}]`;
   }
-  if (tag !== '' && (constructor === null || !constructor.includes(tag))) {
+  if (tag !== '' && constructor !== tag) {
     base += ` [${tag}]`;
   }
   if (constructor !== null) {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1033,7 +1033,7 @@ function getPrefix(constructor, tag, fallback, size = '') {
 
   let result = `${constructor}${size} `;
   if (tag !== '') {
-    const position =  constructor.indexOf(tag);
+    const position = constructor.indexOf(tag);
     if (position === -1) {
       result += `[${tag}] `;
     } else {

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1902,6 +1902,13 @@ function formatError(err, constructor, tag, ctx, keys) {
   const name = err.name != null ? err.name : 'Error';
   let stack = getStackString(ctx, err);
 
+  if (tag !== '' && constructor !== null &&
+      StringPrototypeIncludes(constructor, 'Error') &&
+      !StringPrototypeIncludes(tag, 'Error') &&
+      StringPrototypeStartsWith(constructor, tag)) {
+    return `[${tag}: ${err.message}]`;
+  }
+
   removeDuplicateErrorKeys(ctx, keys, err, stack);
 
   if ('cause' in err &&

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1031,7 +1031,7 @@ function getPrefix(constructor, tag, fallback, size = '') {
     return `[${fallback}${size}: null prototype] `;
   }
 
-  if (tag !== '' && constructor !== tag) {
+  if (tag !== '' && !constructor.includes(tag)) {
     return `${constructor}${size} [${tag}] `;
   }
   return `${constructor}${size} `;
@@ -1507,7 +1507,7 @@ function getClassBase(value, constructor, tag) {
   if (constructor !== 'Function' && constructor !== null) {
     base += ` [${constructor}]`;
   }
-  if (tag !== '' && constructor !== tag) {
+  if (tag !== '' && (constructor === null || !constructor.includes(tag))) {
     base += ` [${tag}]`;
   }
   if (constructor !== null) {
@@ -1554,7 +1554,7 @@ function getFunctionBase(ctx, value, constructor, tag) {
   if (constructor !== type && constructor !== null) {
     base += ` ${constructor}`;
   }
-  if (tag !== '' && constructor !== tag) {
+  if (tag !== '' && (constructor === null || !constructor.includes(tag))) {
     base += ` [${tag}]`;
   }
   return base;

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1031,10 +1031,20 @@ function getPrefix(constructor, tag, fallback, size = '') {
     return `[${fallback}${size}: null prototype] `;
   }
 
-  if (tag !== '' && !constructor.includes(tag)) {
-    return `${constructor}${size} [${tag}] `;
+  let result = `${constructor}${size} `;
+  if (tag !== '') {
+    const position =  constructor.indexOf(tag);
+    if (position === -1) {
+      result += `[${tag}] `;
+    } else {
+      const endPos = position + tag.length;
+      if (endPos !== constructor.length &&
+        constructor[endPos + 1] === constructor[endPos + 1].toLowerCase()) {
+        result += `[${tag}] `;
+      }
+    }
   }
-  return `${constructor}${size} `;
+  return result;
 }
 
 // Look up the keys of the object.

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1902,13 +1902,6 @@ function formatError(err, constructor, tag, ctx, keys) {
   const name = err.name != null ? err.name : 'Error';
   let stack = getStackString(ctx, err);
 
-  if (tag !== '' && constructor !== null &&
-      StringPrototypeIncludes(constructor, 'Error') &&
-      !StringPrototypeIncludes(tag, 'Error') &&
-      StringPrototypeStartsWith(constructor, tag)) {
-    return `[${tag}: ${err.message}]`;
-  }
-
   removeDuplicateErrorKeys(ctx, keys, err, stack);
 
   if ('cause' in err &&

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1554,7 +1554,7 @@ function getFunctionBase(ctx, value, constructor, tag) {
   if (constructor !== type && constructor !== null) {
     base += ` ${constructor}`;
   }
-  if (tag !== '' && (constructor === null || !constructor.includes(tag))) {
+  if (tag !== '' && constructor !== tag) {
     base += ` [${tag}]`;
   }
   return base;

--- a/test/es-module/test-esm-loader-with-syntax-error.mjs
+++ b/test/es-module/test-esm-loader-with-syntax-error.mjs
@@ -13,7 +13,7 @@ describe('ESM: loader with syntax error', { concurrency: !process.env.TEST_PARAL
       path('print-error-message.js'),
     ]);
 
-    match(stderr, /SyntaxError \[Error\]:/);
+    match(stderr, /SyntaxError/);
     ok(!stderr.includes('Bad command or file name'));
     notStrictEqual(code, 0);
   });

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1415,11 +1415,11 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(new ArraySubclass(1, 2, 3)),
                      'ArraySubclass(3) [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
-                     'SetSubclass(3) [Set] { 1, 2, 3 }');
+                     'SetSubclass(3) { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
-                     "MapSubclass(1) [Map] { 'foo' => 42 }");
+                     "MapSubclass(1) { 'foo' => 42 }");
   assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
-                     'PromiseSubclass [Promise] { <pending> }');
+                     'PromiseSubclass { <pending> }');
   assert.strictEqual(util.inspect(new SymbolNameClass()),
                      'Symbol(name) {}');
   assert.strictEqual(

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1432,12 +1432,7 @@ if (typeof Symbol !== 'undefined') {
   );
 
   class MiddleErrorPart extends Error {}
-  Object.defineProperty(MiddleErrorPart.prototype, Symbol.toStringTag, {
-    value: 'Middle',
-    configurable: true
-  });
-  assert.strictEqual(util.inspect(new MiddleErrorPart('foo')),
-                     '[Middle: foo]');
+  assert(util.inspect(new MiddleErrorPart('foo')).includes('MiddleErrorPart: foo'));
 
   class MapClass extends Map {}
   assert.strictEqual(util.inspect(new MapClass([['key', 'value']])),

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1484,8 +1484,8 @@ if (typeof Symbol !== 'undefined') {
   class ObjectSubclass {}
   class ArraySubclass extends Array {}
   class SetSubclass extends Set {}
-  class MapSubclass extends Map {}
-  class PromiseSubclass extends Promise {}
+  class SubclassMap extends Map {}
+  class APromiseSubclass extends Promise {}
   class SymbolNameClass {
     static name = Symbol('name');
   }
@@ -1498,10 +1498,10 @@ if (typeof Symbol !== 'undefined') {
                      'ArraySubclass(3) [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
                      'SetSubclass(3) { 1, 2, 3 }');
-  assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
-                     "MapSubclass(1) { 'foo' => 42 }");
-  assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
-                     'PromiseSubclass { <pending> }');
+  assert.strictEqual(util.inspect(new SubclassMap([['foo', 42]])),
+                     "SubclassMap(1) { 'foo' => 42 }");
+  assert.strictEqual(util.inspect(new APromiseSubclass(() => {})),
+                     'APromiseSubclass { <pending> }');
   assert.strictEqual(util.inspect(new SymbolNameClass()),
                      'Symbol(name) {}');
   assert.strictEqual(

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -85,6 +85,88 @@ assert.strictEqual(util.inspect(async () => {}), '[AsyncFunction (anonymous)]');
   );
 }
 
+// Null constructor scenarios
+{
+  function fnNull() {}
+  Object.setPrototypeOf(fnNull, null);
+  assert.strictEqual(
+    util.inspect(fnNull),
+    '[Function (null prototype): fnNull]'
+  );
+
+  function fnNullAndStringTag() {}
+  Object.defineProperty(fnNullAndStringTag, Symbol.toStringTag, {
+    value: 'CustomTag',
+    configurable: true
+  });
+  Object.setPrototypeOf(fnNullAndStringTag, null);
+  assert.strictEqual(
+    util.inspect(fnNullAndStringTag),
+    '[Function (null prototype): fnNullAndStringTag] [CustomTag]'
+  );
+
+  function fnAnonymous() {}
+  Object.defineProperty(fnAnonymous, Symbol.toStringTag, {
+    value: 'AnonymousCustom',
+    configurable: true
+  });
+  Object.setPrototypeOf(fnAnonymous, null);
+  assert.strictEqual(
+    util.inspect(fnAnonymous),
+    '[Function (null prototype): fnAnonymous] [AnonymousCustom]'
+  );
+
+  const fnArrow = () => {};
+  Object.setPrototypeOf(fnArrow, null);
+  assert.strictEqual(
+    util.inspect(fnArrow),
+    '[Function (null prototype): fnArrow]'
+  );
+
+  async function fnAsync() {}
+  Object.defineProperty(fnAsync, Symbol.toStringTag, {
+    value: 'AsyncCustom',
+    configurable: true
+  });
+  Object.setPrototypeOf(fnAsync, null);
+  assert.strictEqual(
+    util.inspect(fnAsync),
+    '[AsyncFunction (null prototype): fnAsync] [AsyncCustom]'
+  );
+
+  class TestClass {}
+  Object.defineProperty(TestClass, Symbol.toStringTag, {
+    value: 'ClassTag',
+    configurable: true
+  });
+  Object.setPrototypeOf(TestClass, null);
+  assert.strictEqual(
+    util.inspect(TestClass),
+    '[class TestClass [ClassTag] extends [null prototype]]'
+  );
+
+  function fnMatchConstructor() {}
+  Object.defineProperty(fnMatchConstructor, Symbol.toStringTag, {
+    value: 'Function',
+    configurable: true
+  });
+  assert.strictEqual(
+    util.inspect(fnMatchConstructor),
+    '[Function: fnMatchConstructor]'
+  );
+
+  function fnNullMatchConstructor() {}
+  Object.defineProperty(fnNullMatchConstructor, Symbol.toStringTag, {
+    value: 'Function',
+    configurable: true
+  });
+  Object.setPrototypeOf(fnNullMatchConstructor, null);
+  assert.strictEqual(
+    util.inspect(fnNullMatchConstructor),
+    '[Function (null prototype): fnNullMatchConstructor] [Function]'
+  );
+}
+
 assert.strictEqual(util.inspect(undefined), 'undefined');
 assert.strictEqual(util.inspect(null), 'null');
 assert.strictEqual(util.inspect(/foo(bar\n)?/gi), '/foo(bar\\n)?/gi');

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -85,88 +85,6 @@ assert.strictEqual(util.inspect(async () => {}), '[AsyncFunction (anonymous)]');
   );
 }
 
-// Null constructor scenarios
-{
-  function fnNull() {}
-  Object.setPrototypeOf(fnNull, null);
-  assert.strictEqual(
-    util.inspect(fnNull),
-    '[Function (null prototype): fnNull]'
-  );
-
-  function fnNullAndStringTag() {}
-  Object.defineProperty(fnNullAndStringTag, Symbol.toStringTag, {
-    value: 'CustomTag',
-    configurable: true
-  });
-  Object.setPrototypeOf(fnNullAndStringTag, null);
-  assert.strictEqual(
-    util.inspect(fnNullAndStringTag),
-    '[Function (null prototype): fnNullAndStringTag] [CustomTag]'
-  );
-
-  function fnAnonymous() {}
-  Object.defineProperty(fnAnonymous, Symbol.toStringTag, {
-    value: 'AnonymousCustom',
-    configurable: true
-  });
-  Object.setPrototypeOf(fnAnonymous, null);
-  assert.strictEqual(
-    util.inspect(fnAnonymous),
-    '[Function (null prototype): fnAnonymous] [AnonymousCustom]'
-  );
-
-  const fnArrow = () => {};
-  Object.setPrototypeOf(fnArrow, null);
-  assert.strictEqual(
-    util.inspect(fnArrow),
-    '[Function (null prototype): fnArrow]'
-  );
-
-  async function fnAsync() {}
-  Object.defineProperty(fnAsync, Symbol.toStringTag, {
-    value: 'AsyncCustom',
-    configurable: true
-  });
-  Object.setPrototypeOf(fnAsync, null);
-  assert.strictEqual(
-    util.inspect(fnAsync),
-    '[AsyncFunction (null prototype): fnAsync] [AsyncCustom]'
-  );
-
-  class TestClass {}
-  Object.defineProperty(TestClass, Symbol.toStringTag, {
-    value: 'ClassTag',
-    configurable: true
-  });
-  Object.setPrototypeOf(TestClass, null);
-  assert.strictEqual(
-    util.inspect(TestClass),
-    '[class TestClass [ClassTag] extends [null prototype]]'
-  );
-
-  function fnMatchConstructor() {}
-  Object.defineProperty(fnMatchConstructor, Symbol.toStringTag, {
-    value: 'Function',
-    configurable: true
-  });
-  assert.strictEqual(
-    util.inspect(fnMatchConstructor),
-    '[Function: fnMatchConstructor]'
-  );
-
-  function fnNullMatchConstructor() {}
-  Object.defineProperty(fnNullMatchConstructor, Symbol.toStringTag, {
-    value: 'Function',
-    configurable: true
-  });
-  Object.setPrototypeOf(fnNullMatchConstructor, null);
-  assert.strictEqual(
-    util.inspect(fnNullMatchConstructor),
-    '[Function (null prototype): fnNullMatchConstructor] [Function]'
-  );
-}
-
 assert.strictEqual(util.inspect(undefined), 'undefined');
 assert.strictEqual(util.inspect(null), 'null');
 assert.strictEqual(util.inspect(/foo(bar\n)?/gi), '/foo(bar\\n)?/gi');
@@ -1497,11 +1415,11 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(new ArraySubclass(1, 2, 3)),
                      'ArraySubclass(3) [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
-                     'SetSubclass(3) [Set] { 1, 2, 3 }');
+                     'SetSubclass(3) { 1, 2, 3 }');
   assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
-                     "MapSubclass(1) [Map] { 'foo' => 42 }");
+                     "MapSubclass(1) { 'foo' => 42 }");
   assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
-                     'PromiseSubclass [Promise] { <pending> }');
+                     'PromiseSubclass { <pending> }');
   assert.strictEqual(util.inspect(new SymbolNameClass()),
                      'Symbol(name) {}');
   assert.strictEqual(
@@ -1513,35 +1431,31 @@ if (typeof Symbol !== 'undefined') {
     '[ObjectSubclass: null prototype] { foo: 42 }'
   );
 
-  class CustomClass {}
-  Object.defineProperty(CustomClass.prototype, Symbol.toStringTag, {
-    value: 'Custom',
+  class MiddleErrorPart extends Error {}
+  Object.defineProperty(MiddleErrorPart.prototype, Symbol.toStringTag, {
+    value: 'Middle',
     configurable: true
   });
-  assert.strictEqual(util.inspect(new CustomClass()),
-                     'CustomClass [Custom] {}');
+  assert.strictEqual(util.inspect(new MiddleErrorPart('foo')),
+                     '[Middle: foo]');
 
   class MapClass extends Map {}
-  Object.defineProperty(MapClass.prototype, Symbol.toStringTag, {
-    value: 'Map',
-    configurable: true
-  });
   assert.strictEqual(util.inspect(new MapClass([['key', 'value']])),
-                     "MapClass(1) [Map] { 'key' => 'value' }");
+                     "MapClass(1) { 'key' => 'value' }");
+
+  class AbcMap extends Map {}
+  assert.strictEqual(util.inspect(new AbcMap([['key', 'value']])),
+                     "AbcMap(1) { 'key' => 'value' }");
+
+  class SetAbc extends Set {}
+  assert.strictEqual(util.inspect(new SetAbc([1, 2, 3])),
+                     'SetAbc(3) { 1, 2, 3 }');
 
   class FooSet extends Set {}
-  Object.defineProperty(FooSet.prototype, Symbol.toStringTag, {
-    value: 'Set',
-    configurable: true
-  });
   assert.strictEqual(util.inspect(new FooSet([1, 2, 3])),
                      'FooSet(3) { 1, 2, 3 }');
 
   class Settings extends Set {}
-  Object.defineProperty(Settings.prototype, Symbol.toStringTag, {
-    value: 'Set',
-    configurable: true
-  });
   assert.strictEqual(util.inspect(new Settings([1, 2, 3])),
                      'Settings(3) [Set] { 1, 2, 3 }');
 }

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1484,8 +1484,8 @@ if (typeof Symbol !== 'undefined') {
   class ObjectSubclass {}
   class ArraySubclass extends Array {}
   class SetSubclass extends Set {}
-  class SubclassMap extends Map {}
-  class APromiseSubclass extends Promise {}
+  class MapSubclass extends Map {}
+  class PromiseSubclass extends Promise {}
   class SymbolNameClass {
     static name = Symbol('name');
   }
@@ -1497,11 +1497,11 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(util.inspect(new ArraySubclass(1, 2, 3)),
                      'ArraySubclass(3) [ 1, 2, 3 ]');
   assert.strictEqual(util.inspect(new SetSubclass([1, 2, 3])),
-                     'SetSubclass(3) { 1, 2, 3 }');
-  assert.strictEqual(util.inspect(new SubclassMap([['foo', 42]])),
-                     "SubclassMap(1) { 'foo' => 42 }");
-  assert.strictEqual(util.inspect(new APromiseSubclass(() => {})),
-                     'APromiseSubclass { <pending> }');
+                     'SetSubclass(3) [Set] { 1, 2, 3 }');
+  assert.strictEqual(util.inspect(new MapSubclass([['foo', 42]])),
+                     "MapSubclass(1) [Map] { 'foo' => 42 }");
+  assert.strictEqual(util.inspect(new PromiseSubclass(() => {})),
+                     'PromiseSubclass [Promise] { <pending> }');
   assert.strictEqual(util.inspect(new SymbolNameClass()),
                      'Symbol(name) {}');
   assert.strictEqual(
@@ -1512,6 +1512,38 @@ if (typeof Symbol !== 'undefined') {
     util.inspect(Object.setPrototypeOf(x, null)),
     '[ObjectSubclass: null prototype] { foo: 42 }'
   );
+
+  class CustomClass {}
+  Object.defineProperty(CustomClass.prototype, Symbol.toStringTag, {
+    value: 'Custom',
+    configurable: true
+  });
+  assert.strictEqual(util.inspect(new CustomClass()),
+                     'CustomClass [Custom] {}');
+
+  class MapClass extends Map {}
+  Object.defineProperty(MapClass.prototype, Symbol.toStringTag, {
+    value: 'Map',
+    configurable: true
+  });
+  assert.strictEqual(util.inspect(new MapClass([['key', 'value']])),
+                     "MapClass(1) [Map] { 'key' => 'value' }");
+
+  class FooSet extends Set {}
+  Object.defineProperty(FooSet.prototype, Symbol.toStringTag, {
+    value: 'Set',
+    configurable: true
+  });
+  assert.strictEqual(util.inspect(new FooSet([1, 2, 3])),
+                     'FooSet(3) { 1, 2, 3 }');
+
+  class Settings extends Set {}
+  Object.defineProperty(Settings.prototype, Symbol.toStringTag, {
+    value: 'Set',
+    configurable: true
+  });
+  assert.strictEqual(util.inspect(new Settings([1, 2, 3])),
+                     'Settings(3) [Set] { 1, 2, 3 }');
 }
 
 // Empty and circular before depth.


### PR DESCRIPTION
Fix deduplication logic for `inspect` output when dealing with constructor names that contain custom tags, but checking for tag followed by lowercase characters, e.g: avoiding unnecessary tag `Set` from a constructor extended like `FooSet(3) { 1, 2, 3 }` from a `util.inspect(new FooSet([1, 2, 3]))` but keeping it for `Settings(3) [Set] { 1, 2, 3 }` from a `util.inspect(new Settings([1, 2, 3]))`

cc @BridgeAR 