### PR TITLE
worker: add Notification API

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2045,6 +2045,16 @@ valid.
 The imported module string is an invalid URL, package name, or package subpath
 specifier.
 
+<a id="ERR_INVALID_NOTIFICATION"></a>
+
+### `ERR_INVALID_NOTIFICATION`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+The notification ID is not valid.
+
 <a id="ERR_INVALID_OBJECT_DEFINE_PROPERTY"></a>
 
 ### `ERR_INVALID_OBJECT_DEFINE_PROPERTY`

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2328,6 +2328,19 @@ The references returned by `process.getBuiltinModule(id)` always point to
 the built-in module corresponding to `id` even if users modify
 [`require.cache`][] so that `require(id)` returns something else.
 
+## `process.getNotifications()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {Array<bigint>} A list of notifications registered in the current thread.
+
+Return the list of all notifications registered in the current thread via
+[`process.registerNotification(callback)`](#processregisternotificationcallback).
+
 ## `process.getegid()`
 
 <!-- YAML
@@ -3100,6 +3113,21 @@ the [`'warning'` event][process_warning] and the
 [`emitWarning()` method][process_emit_warning] for more information about this
 flag's behavior.
 
+## `process.notify(id)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `id` {bigint}: The notification ID
+
+Triggers the notification previously registered via [`process.registerNotification(callback)`](#processregisternotificationcallback).
+
+It will throw an error if the notification is not found.  It is safe to invoke a notification
+registered in the same thread.
+
 ## `process.permission`
 
 <!-- YAML
@@ -3252,6 +3280,24 @@ implemented by using `ref()` and `unref()` methods directly on the objects.
 This pattern, however, is being deprecated in favor of the "Refable protocol"
 in order to better support Web Platform API types whose APIs cannot be modified
 to add `ref()` and `unref()` methods but still need to support that behavior.
+
+## `process.registerNotification(callback)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `callback` {Function} A function to execute when the notification is received.
+* Returns: {bigint} The notification ID
+
+Register a callback associated to a notification.
+
+A notification is a number which can be safely transferred and used in other threads to trigger
+the associated callback via [`process.notify(id`)](#processnotifyid).
+
+The notification can be unregistered using [`process.unregisterNotification(id)`](#processunregisternotificationid).
 
 ## `process.release`
 
@@ -4339,6 +4385,21 @@ implemented by using `ref()` and `unref()` methods directly on the objects.
 This pattern, however, is being deprecated in favor of the "Refable protocol"
 in order to better support Web Platform API types whose APIs cannot be modified
 to add `ref()` and `unref()` methods but still need to support that behavior.
+
+## `process.unregisterNotification(id)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* `id` {number}
+
+Unregister a notification previously registered with [`process.registerNotification(callback)`](#processregisternotificationcallback).
+
+It will throw an error if the notification is not found. The notification must be unregistered from the same thread
+that registered it.
 
 ## `process.uptime()`
 

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -180,6 +180,10 @@ const rawMethods = internalBinding('process_methods');
   process.execve = wrapped.execve;
   process.ref = perThreadSetup.ref;
   process.unref = perThreadSetup.unref;
+  process.getNotifications = wrapped.getNotifications;
+  process.registerNotification = wrapped.registerNotification;
+  process.unregisterNotification = wrapped.unregisterNotification;
+  process.notify = wrapped.notify;
 
   let finalizationMod;
   ObjectDefineProperty(process, 'finalization', {

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -11,9 +11,11 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSplice,
+  BigInt,
   BigUint64Array,
   Float64Array,
   FunctionPrototypeCall,
+  NumberIsInteger,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperty,
   ObjectEntries,
@@ -49,6 +51,7 @@ const { emitExperimentalWarning } = require('internal/util');
 const format = require('internal/util/inspect').format;
 const {
   validateArray,
+  validateFunction,
   validateNumber,
   validateObject,
   validateString,
@@ -113,6 +116,10 @@ function wrapProcessMethods(binding) {
     resourceUsage: _resourceUsage,
     loadEnvFile: _loadEnvFile,
     execve: _execve,
+    getNotifications,
+    registerNotification: _registerNotification,
+    sendNotification,
+    unregisterNotification: _unregisterNotification,
   } = binding;
 
   function _rawDebug(...args) {
@@ -365,6 +372,39 @@ function wrapProcessMethods(binding) {
     }
   }
 
+  function notify(id) {
+    if (typeof id !== 'number' && typeof id !== 'bigint') {
+      throw new ERR_INVALID_ARG_TYPE('id', ['number', 'bigint'], id);
+    }
+
+    if (typeof id === 'number' && !NumberIsInteger(id)) {
+      throw new ERR_OUT_OF_RANGE('id', 'an integer', id);
+    } else if (id < 0) {
+      throw new ERR_OUT_OF_RANGE('id', `>= 1`, id);
+    }
+
+    sendNotification(BigInt(id));
+  }
+
+  function registerNotification(listener) {
+    validateFunction(listener, 'listener');
+    return _registerNotification(listener);
+  }
+
+  function unregisterNotification(id) {
+    if (typeof id !== 'number' && typeof id !== 'bigint') {
+      throw new ERR_INVALID_ARG_TYPE('id', ['number', 'bigint'], id);
+    }
+
+    if (typeof id === 'number' && !NumberIsInteger(id)) {
+      throw new ERR_OUT_OF_RANGE('id', 'an integer', id);
+    } else if (id < 0) {
+      throw new ERR_OUT_OF_RANGE('id', `>= 1`, id);
+    }
+
+    _unregisterNotification(BigInt(id));
+  }
+
   return {
     _rawDebug,
     cpuUsage,
@@ -375,6 +415,10 @@ function wrapProcessMethods(binding) {
     exit,
     execve,
     loadEnvFile,
+    getNotifications,
+    notify,
+    registerNotification,
+    unregisterNotification,
   };
 }
 

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -379,7 +379,7 @@ function wrapProcessMethods(binding) {
 
     if (typeof id === 'number' && !NumberIsInteger(id)) {
       throw new ERR_OUT_OF_RANGE('id', 'an integer', id);
-    } else if (id < 0) {
+    } else if (id < 1) {
       throw new ERR_OUT_OF_RANGE('id', `>= 1`, id);
     }
 
@@ -398,7 +398,7 @@ function wrapProcessMethods(binding) {
 
     if (typeof id === 'number' && !NumberIsInteger(id)) {
       throw new ERR_OUT_OF_RANGE('id', 'an integer', id);
-    } else if (id < 0) {
+    } else if (id < 1) {
       throw new ERR_OUT_OF_RANGE('id', `>= 1`, id);
     }
 

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -98,6 +98,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
   V(ERR_INVALID_PACKAGE_CONFIG, Error)                                         \
   V(ERR_INVALID_OBJECT_DEFINE_PROPERTY, TypeError)                             \
   V(ERR_INVALID_MODULE, Error)                                                 \
+  V(ERR_INVALID_NOTIFICATION, Error)                                           \
   V(ERR_INVALID_STATE, Error)                                                  \
   V(ERR_INVALID_THIS, TypeError)                                               \
   V(ERR_INVALID_URL, TypeError)                                                \
@@ -217,6 +218,7 @@ ERRORS_WITH_CODE(V)
   V(ERR_INVALID_ADDRESS, "Invalid socket address")                             \
   V(ERR_INVALID_INVOCATION, "Invalid invocation")                              \
   V(ERR_INVALID_MODULE, "No such module")                                      \
+  V(ERR_INVALID_NOTIFICATION, "Invalid notification")                          \
   V(ERR_INVALID_STATE, "Invalid state")                                        \
   V(ERR_INVALID_THIS, "Value of \"this\" is the wrong type")                   \
   V(ERR_INVALID_URL_SCHEME, "The URL must be of scheme file:")                 \

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -792,6 +792,17 @@ static void CreatePerIsolateProperties(IsolateData* isolate_data,
   SetMethod(isolate, target, "loadEnvFile", LoadEnvFile);
 
   SetMethod(isolate, target, "setEmitWarningSync", SetEmitWarningSync);
+
+  SetMethod(isolate, target, "getNotifications", Environment::GetNotifications);
+  SetMethod(isolate,
+            target,
+            "registerNotification",
+            Environment::RegisterNotification);
+  SetMethod(isolate,
+            target,
+            "unregisterNotification",
+            Environment::UnregisterNotification);
+  SetMethod(isolate, target, "sendNotification", Environment::SendNotification);
 }
 
 static void CreatePerContextProperties(Local<Object> target,
@@ -820,6 +831,11 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(CPUUsage);
   registry->Register(ThreadCPUUsage);
   registry->Register(ResourceUsage);
+
+  registry->Register(Environment::GetNotifications);
+  registry->Register(Environment::RegisterNotification);
+  registry->Register(Environment::UnregisterNotification);
+  registry->Register(Environment::SendNotification);
 
   registry->Register(GetActiveRequests);
   registry->Register(GetActiveHandles);

--- a/test/parallel/test-process-notifications-validation.js
+++ b/test/parallel/test-process-notifications-validation.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { mustCall } = require('../common');
+const { throws } = require('assert');
+const { Worker, parentPort, workerData } = require('worker_threads');
+
+// Generic argument validation
+{
+
+  throws(() => process.registerNotification(), { code: 'ERR_INVALID_ARG_TYPE' });
+  throws(() => process.registerNotification(123), { code: 'ERR_INVALID_ARG_TYPE' });
+
+  throws(() => process.unregisterNotification(), { code: 'ERR_INVALID_ARG_TYPE' });
+  throws(() => process.unregisterNotification('STRING'), { code: 'ERR_INVALID_ARG_TYPE' });
+  throws(() => process.unregisterNotification(123.45), { code: 'ERR_OUT_OF_RANGE' });
+  throws(() => process.unregisterNotification(-123), { code: 'ERR_OUT_OF_RANGE' });
+  throws(() => process.unregisterNotification(123), { code: 'ERR_INVALID_NOTIFICATION' });
+  throws(() => process.unregisterNotification(
+    BigInt(Number.MAX_SAFE_INTEGER + 1000)), { code: 'ERR_INVALID_NOTIFICATION' },
+  );
+
+  throws(() => process.notify(), { code: 'ERR_INVALID_ARG_TYPE' });
+  throws(() => process.notify('STRING'), { code: 'ERR_INVALID_ARG_TYPE' });
+  throws(() => process.notify(123.45), { code: 'ERR_OUT_OF_RANGE' });
+  throws(() => process.notify(-123), { code: 'ERR_OUT_OF_RANGE' });
+  throws(() => process.notify(123), { code: 'ERR_INVALID_NOTIFICATION' });
+  throws(() => process.notify(BigInt(Number.MAX_SAFE_INTEGER + 1000)), { code: 'ERR_INVALID_NOTIFICATION' });
+}
+
+// Unregistering a notification from another thread should not be permitted
+{
+  // The initial thread spawns another thread which registers a notification handler
+  if (!workerData?.registerNotification) {
+    const worker = new Worker(__filename, { workerData: { registerNotification: true } });
+
+    worker.once('message', mustCall((arg) => {
+      throws(() => process.unregisterNotification(arg), { code: 'ERR_INVALID_NOTIFICATION' });
+      worker.terminate();
+    }));
+  } else {
+    const notification = process.registerNotification(() => {});
+    parentPort.postMessage(notification);
+  }
+}

--- a/test/parallel/test-process-notifications-worker.js
+++ b/test/parallel/test-process-notifications-worker.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const { mustCall } = require('../common');
+const { strictEqual } = require('assert');
+const { Worker, workerData, parentPort } = require('worker_threads');
+
+// The initial thread spawns another thread which registers a notification handler
+if (!workerData?.registerNotification) {
+  const worker = new Worker(__filename, { workerData: { registerNotification: true } });
+
+  worker.on('message', mustCall((arg) => {
+    if (typeof arg !== 'string') {
+      process.notify(arg);
+      return;
+    }
+
+    strictEqual(arg, 'invoked');
+    worker.terminate();
+  }, 2));
+} else {
+  const notification = process.registerNotification(() => {
+    parentPort.postMessage('invoked');
+  });
+
+  parentPort.postMessage(notification);
+
+  // Keep the worker alive until the main thread terminates it.
+  setInterval(() => {}, 1000);
+}

--- a/test/parallel/test-process-notifications.js
+++ b/test/parallel/test-process-notifications.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { mustCall, skip, platformTimeout, mustNotCall } = require('../common');
+const Countdown = require('../common/countdown');
+const { deepStrictEqual, strictEqual, throws } = require('assert');
+const { Worker, workerData, isMainThread } = require('worker_threads');
+
+if (!isMainThread && !workerData?.workerNotification) {
+  skip('This test only works on a main thread');
+}
+
+if (isMainThread) {
+  let worker;
+
+  const countdown = new Countdown(3, mustCall(() => worker.terminate()));
+  const ownNotification = process.registerNotification(mustCall());
+  const workerNotification = process.registerNotification(() => countdown.dec());
+  const temporaryNotification = process.registerNotification(mustNotCall());
+
+  // Check ID management
+  strictEqual(ownNotification, 1n);
+  deepStrictEqual(process.getNotifications().sort(), [ownNotification, workerNotification, temporaryNotification]);
+
+  // Immediately self notify
+  process.notify(ownNotification);
+
+  // Self notify in the workerNotification
+  setTimeout(mustCall(() => {
+    process.notify(workerNotification);
+  }), platformTimeout(50));
+
+  // Unregister the temporary notification after some time, this should lead the worker thread to fail
+  setTimeout(mustCall(() => {
+    process.unregisterNotification(temporaryNotification);
+  }), platformTimeout(100));
+
+  worker = new Worker(__filename, { workerData: { workerNotification, temporaryNotification } });
+} else {
+  // Immediately notify the main thread once
+  process.notify(workerData.workerNotification);
+
+  setTimeout(mustCall(() => {
+    // This should fail as the main thread unregistered it
+    throws(() => process.notify(workerData.temporaryNotification), { code: 'ERR_INVALID_NOTIFICATION' });
+
+    // This will cause the main thread to kill this thread
+    process.notify(workerData.workerNotification);
+  }), platformTimeout(200));
+
+  // Keep the worker alive until the main thread terminates it.
+  setInterval(() => {}, 1e6);
+}


### PR DESCRIPTION
This PR adds a new notification API to the `worker` module made of the following methods:

* `registerNotification`
* `sendNotification`
* `unregisterNotification`
* `unregisterNotifications`
* `getNotifications`

The idea behind it is being able to trigger a callback in another module without having to go throughout all workers messaging and event handling.

The API purposely does not allow to attach any data to the notifications. The two threads must use `SharedArrayBuffer`s to share data.

The usecase is threads that must transfer data back and forth the quickest way possible. For instance to simulate a socket via threads.

This is the typical usage:

```
import {
  registerNotification,
  sendNotification,
  unregisterNotification,
  isMainThread,
  workerData,
  Worker
} from 'node:worker_threads`

if (!isMainThread) {
  sendNotification(workerData.notification)
} else {
  // registerNotification returns a bigint, so it's easy to send between threads.
  const notification = registerNotification(() => {
    console.log('INVOKED')
    worker.terminate()
    unregisterNotification(notification)
  })

  new Worker(import.meta.filename, { workerData: { notification }));
}
```