### PR TITLE
typings: update 'types' binding

### DIFF
--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -14,31 +14,31 @@ namespace node {
 namespace {
 
 #define VALUE_METHOD_MAP(V)                                                    \
-  V(External)                                                                  \
-  V(Date)                                                                      \
   V(ArgumentsObject)                                                           \
+  V(ArrayBuffer)                                                               \
+  V(AsyncFunction)                                                             \
   V(BigIntObject)                                                              \
   V(BooleanObject)                                                             \
-  V(NumberObject)                                                              \
-  V(StringObject)                                                              \
-  V(SymbolObject)                                                              \
-  V(NativeError)                                                               \
-  V(RegExp)                                                                    \
-  V(AsyncFunction)                                                             \
+  V(DataView)                                                                  \
+  V(Date)                                                                      \
+  V(External)                                                                  \
   V(GeneratorFunction)                                                         \
   V(GeneratorObject)                                                           \
-  V(Promise)                                                                   \
   V(Map)                                                                       \
-  V(Set)                                                                       \
   V(MapIterator)                                                               \
-  V(SetIterator)                                                               \
-  V(WeakMap)                                                                   \
-  V(WeakSet)                                                                   \
-  V(ArrayBuffer)                                                               \
-  V(DataView)                                                                  \
-  V(SharedArrayBuffer)                                                         \
+  V(ModuleNamespaceObject)                                                     \
+  V(NativeError)                                                               \
+  V(NumberObject)                                                              \
+  V(Promise)                                                                   \
   V(Proxy)                                                                     \
-  V(ModuleNamespaceObject)
+  V(RegExp)                                                                    \
+  V(Set)                                                                       \
+  V(SetIterator)                                                               \
+  V(SharedArrayBuffer)                                                         \
+  V(StringObject)                                                              \
+  V(SymbolObject)                                                              \
+  V(WeakMap)                                                                   \
+  V(WeakSet)
 
 #define V(type)                                                                \
   static void Is##type(const FunctionCallbackInfo<Value>& args) {              \

--- a/typings/internalBinding/types.d.ts
+++ b/typings/internalBinding/types.d.ts
@@ -1,26 +1,29 @@
 export interface TypesBinding {
-  isAsyncFunction(value: unknown): value is (...args: unknown[]) => Promise<unknown>;
-  isGeneratorFunction(value: unknown): value is GeneratorFunction;
-  isAnyArrayBuffer(value: unknown): value is (ArrayBuffer | SharedArrayBuffer);
+  isArgumentsObject(value: unknown): value is IArguments;
   isArrayBuffer(value: unknown): value is ArrayBuffer;
-  isArgumentsObject(value: unknown): value is ArrayLike<unknown>;
-  isBoxedPrimitive(value: unknown): value is (BigInt | Boolean | Number | String | Symbol);
+  isAsyncFunction(value: unknown): value is (...args: unknown[]) => Promise<unknown>;
+  isBigIntObject: (value: unknown) => value is BigInt;
+  isBooleanObject: (value: unknown) => value is Boolean;
   isDataView(value: unknown): value is DataView;
-  isExternal(value: unknown): value is Object;
+  isDate: (value: unknown) => value is Date;
+  isExternal(value: unknown): value is object;
+  isGeneratorFunction(value: unknown): value is GeneratorFunction;
+  isGeneratorObject(value: unknown): value is Generator;
   isMap(value: unknown): value is Map<unknown, unknown>;
   isMapIterator: (value: unknown) => value is IterableIterator<unknown>;
   isModuleNamespaceObject: (value: unknown) => value is { [Symbol.toStringTag]: 'Module' };
-  isNativeError: (value: unknown) => Error;
+  isNativeError: (value: unknown) => value is Error;
+  isNumberObject: (value: unknown) => value is Number;
   isPromise: (value: unknown) => value is Promise<unknown>;
+  isProxy: (value: unknown) => value is object;
+  isRegExp: (value: unknown) => value is RegExp;
   isSet: (value: unknown) => value is Set<unknown>;
   isSetIterator: (value: unknown) => value is IterableIterator<unknown>;
+  isSharedArrayBuffer: (value: unknown) => value is SharedArrayBuffer;
+  isStringObject: (value: unknown) => value is String;
+  isSymbolObject: (value: unknown) => value is Symbol;
   isWeakMap: (value: unknown) => value is WeakMap<object, unknown>;
   isWeakSet: (value: unknown) => value is WeakSet<object>;
-  isRegExp: (value: unknown) => RegExp;
-  isDate: (value: unknown) => Date;
-  isTypedArray: (value: unknown) => value is TypedArray;
-  isStringObject: (value: unknown) => value is String;
-  isNumberObject: (value: unknown) => value is Number;
-  isBooleanObject: (value: unknown) => value is Boolean,
-  isBigIntObject: (value: unknown) => value is BigInt;
+  isAnyArrayBuffer(value: unknown): value is ArrayBufferLike;
+  isBoxedPrimitive(value: unknown): value is BigInt | Boolean | Number | String | Symbol;
 }


### PR DESCRIPTION
- Add missing methods:
  - isGeneratorObject
  - isProxy
  - isSharedArrayBuffer
  - isSymbolObject
- Remove non-extant methods:
  - isTypedArray
- Fix bad predicates:
  - isDate, isNativeError, isRegExp
    - These were previously declared to return the type itself, not a predicate.
- Improvements to predicate types:
  - isArgumentsObject
    - TypeScript provides `IArguments` to describe the built-in `arguments` object.
  - isExternal
    - In TypeScript, `object` is the non-primitive object type. `Object` resolves to any value that is not `null` or `undefined`.

These definitions remain compatible with TS 3.9+, as before.

Also sorts the macro list in node_types.cc and matches the ordering in types.d.ts to the source, for ease of maintenance.