### PR TITLE
src: add NODE_OPTIONS_STANDALONE

### DIFF
--- a/argparse.cc
+++ b/argparse.cc
@@ -1,0 +1,108 @@
+#include "src/node_options.h"
+#include "src/util.h"
+
+#include <iostream>
+#include <ranges>
+#include <string>
+#include <vector>
+
+extern "C" {
+
+uint64_t uv_get_total_memory() {
+  return 0;
+}
+
+uint64_t uv_get_constrained_memory() {
+  return 0;
+}
+};
+
+namespace node {
+
+void Assert(const AssertionInfo& info) {
+  fprintf(stderr,
+          "\n"
+          "  #  %s at %s\n"
+          "  #  Assertion failed: %s\n\n",
+          info.function ? info.function : "(unknown function)",
+          info.file_line ? info.file_line : "(unknown source location)",
+          info.message);
+
+  fflush(stderr);
+
+  abort();
+}
+
+}  // namespace node
+
+int main(int argc, char** argv) {
+  std::vector<std::string> args(argv, argv + argc);
+  std::vector<std::string> exec_args;
+  std::vector<std::string> errors;
+
+  node::PerProcessOptions cli_options;
+
+  cli_options.cmdline = args;
+
+  if (const char* result = std::getenv("NODE_OPTIONS")) {
+    std::string node_options(result);
+
+    std::vector<std::string> env_argv =
+        node::ParseNodeOptionsEnvVar(node_options, &errors);
+    for (auto error : errors) {
+      std::cout << "error: " << error << std::endl;
+    }
+    if (!errors.empty()) return 1;
+
+    env_argv.insert(env_argv.begin(), args.at(0));
+
+    {
+      std::vector<std::string> v8_args;
+      node::options_parser::Parse(&env_argv,
+                                  nullptr,
+                                  &v8_args,
+                                  &cli_options,
+                                  node::OptionEnvvarSettings::kAllowedInEnvvar,
+                                  &errors);
+
+      for (auto arg : v8_args | std::views::drop(1)) {
+        std::cout << "v8_arg: " << arg << std::endl;
+      }
+    }
+  }
+
+  node::HandleEnvOptions(cli_options.per_isolate->per_env,
+                         [](const char* name) {
+                           const char* value = std::getenv(name);
+                           if (value != nullptr) {
+                             return std::string(value);
+                           }
+                           return std::string("");
+                         });
+
+  {
+    std::vector<std::string> v8_args;
+    node::options_parser::Parse(&args,
+                                &exec_args,
+                                &v8_args,
+                                &cli_options,
+                                node::OptionEnvvarSettings::kDisallowedInEnvvar,
+                                &errors);
+
+    for (auto arg : v8_args | std::views::drop(1)) {
+      std::cout << "v8_arg: " << arg << std::endl;
+    }
+  }
+
+  for (auto arg : args) {
+    std::cout << "arg: " << arg << std::endl;
+  }
+
+  for (auto arg : exec_args) {
+    std::cout << "exec_arg: " << arg << std::endl;
+  }
+
+  for (auto error : errors) {
+    std::cout << "error: " << error << std::endl;
+  }
+}

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -389,7 +389,6 @@ namespace options_parser {
 
 HostPort SplitHostPort(const std::string& arg,
                        std::vector<std::string>* errors);
-void GetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
 std::string GetBashCompletion();
 
 enum OptionType {
@@ -638,6 +637,7 @@ class OptionsParser {
   template <typename OtherOptions>
   friend class OptionsParser;
 
+#ifndef NODE_OPTIONS_STANDALONE
   friend void GetCLIOptionsValues(
       const v8::FunctionCallbackInfo<v8::Value>& args);
   friend void GetCLIOptionsInfo(
@@ -652,6 +652,7 @@ class OptionsParser {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   friend void GetOptionsAsFlags(
       const v8::FunctionCallbackInfo<v8::Value>& args);
+#endif  // NODE_OPTIONS_STANDALONE
 };
 
 using StringVector = std::vector<std::string>;
@@ -663,6 +664,7 @@ void Parse(
 
 }  // namespace options_parser
 
+#ifndef NODE_OPTIONS_STANDALONE
 namespace per_process {
 
 extern Mutex cli_options_mutex;
@@ -671,6 +673,7 @@ extern NODE_EXTERN_PRIVATE std::shared_ptr<PerProcessOptions> cli_options;
 }  // namespace per_process
 
 void HandleEnvOptions(std::shared_ptr<EnvironmentOptions> env_options);
+#endif  // NODE_OPTIONS_STANDALONE
 void HandleEnvOptions(std::shared_ptr<EnvironmentOptions> env_options,
                       std::function<std::string(const char*)> opt_getter);
 


### PR DESCRIPTION
I'd like to, in deno, parse command line arguments the exact same way that node does. It seems to me that the best way to achieve this is to simply use the same code. In order to do this as non-invasively as possible, I tried to just insert a few targeted `NODE_OPTIONS_STANDALONE` checks. I verified this using the below command, but ideally I'd like to add a test to the CI that this actually compiles (and maybe even run the resulting binary?)

```
clang++ -DNODE_WANT_INTERNALS=1 -DNODE_OPTIONS_STANDALONE=1 -std=c++20 -Ideps/v8/include -Isrc src/node_options.cc argparse.cc -o argparse
```

So if y'all would be interested in accepting this PR, I'd appreciate some pointers on the best way to make `argparse.cc` be a test.