### PR TITLE
[v20.x] tools: accept choco nasm installation

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install deps
-        run: choco install nasm
+        run: choco install nasm -y
       - name: Environment Information
         run: npx envinfo
       - name: Build


### PR DESCRIPTION
The windows coverage job is broken https://github.com/nodejs/node/actions/runs/17322284652/job/49178186430?pr=59653

this should fix it