### PR TITLE
benchmark: calibrate config dgram multi-buffer

### DIFF
--- a/benchmark/dgram/multi-buffer.js
+++ b/benchmark/dgram/multi-buffer.js
@@ -5,18 +5,18 @@ const common = require('../common.js');
 const dgram = require('dgram');
 const PORT = common.PORT;
 
-// `num` is the number of send requests to queue up each time.
+// `n` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
 const bench = common.createBenchmark(main, {
-  len: [64, 256, 1024],
-  num: [100],
-  chunks: [1, 2, 4, 8],
+  len: [64, 512, 1024],
+  n: [100],
+  chunks: [1, 8],
   type: ['send', 'recv'],
   dur: [5],
 });
 
-function main({ dur, len, num, type, chunks }) {
+function main({ dur, len, n, type, chunks }) {
   const chunk = [];
   for (let i = 0; i < chunks; i++) {
     chunk.push(Buffer.allocUnsafe(Math.round(len / chunks)));
@@ -26,11 +26,11 @@ function main({ dur, len, num, type, chunks }) {
   const socket = dgram.createSocket('udp4');
 
   function onsend() {
-    if (sent++ % num === 0) {
+    if (sent++ % n === 0) {
       // The setImmediate() is necessary to have event loop progress on OSes
       // that only perform synchronous I/O on nonblocking UDP sockets.
       setImmediate(() => {
-        for (let i = 0; i < num; i++) {
+        for (let i = 0; i < n; i++) {
           socket.send(chunk, PORT, '127.0.0.1', onsend);
         }
       });


### PR DESCRIPTION
## benchmark: calibrate config dgram multi-buffer

>According to https://github.com/nodejs/performance/issues/186 this benchmark was taking 120 seconds for a single run.

Replaced the `num` config with `n` to be compatible with the `n` CLI argument.

Looking at the outputs:
Chunks 1 and 2 have very similar results, as do 4 and 8. I removed 2 and 4, keeping only `[1, 8]`.
I think `[64, 512, 1024]` covers a sufficient range, making `256` unnecessary.

If you don’t agree with the changes in the configs, let me know, and we can revert them and just proceed with the `num` → `n` change.

**Before:**

```
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=64: 0.02159776900313264
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=64: 0.006370982125852746
dgram/multi-buffer.js dur=5 type="send" chunks=2 num=100 len=64: 0.019968965727621038
dgram/multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=64: 0.0065620125827753895
dgram/multi-buffer.js dur=5 type="send" chunks=4 num=100 len=64: 0.018757382448239258
dgram/multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=64: 0.006038470399058101
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=64: 0.018424407658972627
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=64: 0.006163888777129781
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=256: 0.07851840833396243
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=256: 0.02525007588911196
dgram/multi-buffer.js dur=5 type="send" chunks=2 num=100 len=256: 0.08073162407176149
dgram/multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=256: 0.02644216218504364
dgram/multi-buffer.js dur=5 type="send" chunks=4 num=100 len=256: 0.07463644870359572
dgram/multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=256: 0.023162586909074932
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=256: 0.06731181696255606
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=256: 0.022431238817084607
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=1024: 0.3347208971649177
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=1024: 0.10439931674844129
dgram/multi-buffer.js dur=5 type="send" chunks=2 num=100 len=1024: 0.3101641839458067
dgram/multi-buffer.js dur=5 type="recv" chunks=2 num=100 len=1024: 0.10438314021018165
dgram/multi-buffer.js dur=5 type="send" chunks=4 num=100 len=1024: 0.27517756080719574
dgram/multi-buffer.js dur=5 type="recv" chunks=4 num=100 len=1024: 0.09388188786316794
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=1024: 0.28254754245657304
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=1024: 0.0879612743767823

```

**After**
```
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=64: 0.0167936146345295
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=64: 0.005354682449073383
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=64: 0.015419676735804152
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=64: 0.0050131099437866035
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=512: 0.13095162163779964
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=512: 0.04466295950176055
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=512: 0.11549371186498686
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=512: 0.03911223248945854
dgram/multi-buffer.js dur=5 type="send" chunks=1 num=100 len=1024: 0.26748475704592795
dgram/multi-buffer.js dur=5 type="recv" chunks=1 num=100 len=1024: 0.07819024584576521
dgram/multi-buffer.js dur=5 type="send" chunks=8 num=100 len=1024: 0.24212710888603306
dgram/multi-buffer.js dur=5 type="recv" chunks=8 num=100 len=1024: 0.07220577293082356
```

**Benchmark Machine Specifications:**
```
---------------------------------
Uptime     : 3 days, 15 hours, 36 minutes
Processor  : Intel(R) Xeon(R) CPU E5-2690 v2 @ 3.00GHz
CPU cores  : 4 @ 2999.998 MHz
AES-NI     : ✔ Enabled
VM-x/AMD-V : ✔ Enabled
RAM        : 11.4 GiB
Swap       : 0.0 KiB
Disk       : 500.0 GiB
Distro     : CentOS Stream 9
Kernel     : 5.14.0-295.el9.x86_64
VM Type    : KVM

```