### PR TITLE
docs: fix parameter name typo in process.unref from maybeUnfefable to maybeRefable

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -4329,7 +4329,7 @@ added:
 
 > Stability: 1 - Experimental
 
-* `maybeUnfefable` {any} An object that may be "unref'd".
+* `maybeRefable` {any} An object that may be "unref'd".
 
 An object is "unrefable" if it implements the Node.js "Refable protocol".
 Specifically, this means that the object implements the `Symbol.for('nodejs.ref')`


### PR DESCRIPTION
This PR fixes a small but important typo in the Node.js documentation for `process.unref(maybeRefable)`.

The parameter was mistakenly documented as `maybeUnfefable`, but the correct name is `maybeRefable`.
This change ensures consistency with the [function signature](https://nodejs.org/api/process.html#processunrefmayberefable) and other documentation sources like [Deno docs](https://docs.deno.com/api/node/process/~/Process.unref).

<img width="652" height="264" alt="스크린샷 2025-09-01 오후 10 34 20" src="https://github.com/user-attachments/assets/88ed2410-0a43-49e5-a314-6f43ffe6374a" />


No code changes are included—only the documentation text was corrected to improve clarity and correctness.