### PR TITLE
test_runner: simplify logic, nix dead reporter code

### DIFF
--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -53,7 +53,7 @@ class SpecReporter extends Transform {
     }
 
     this.#failedTests = []; // Clean up the failed tests
-    return ArrayPrototypeJoin(results, '\n'); ;
+    return ArrayPrototypeJoin(results, '\n');
   }
   #handleTestReportEvent(type, data) {
     const subtest = ArrayPrototypeShift(this.#stack); // This is the matching `test:start` event
@@ -71,13 +71,8 @@ class SpecReporter extends Transform {
       ArrayPrototypeUnshift(this.#reported, msg);
       prefix += `${indent(msg.nesting)}${reporterUnicodeSymbolMap['arrow:right']}${msg.name}\n`;
     }
-    let hasChildren = false;
-    if (this.#reported[0] && this.#reported[0].nesting === data.nesting && this.#reported[0].name === data.name) {
-      ArrayPrototypeShift(this.#reported);
-      hasChildren = true;
-    }
     const indentation = indent(data.nesting);
-    return `${formatTestReport(type, data, prefix, indentation, hasChildren, false)}\n`;
+    return `${formatTestReport(type, data, false, prefix, indentation)}\n`;
   }
   #handleEvent({ type, data }) {
     switch (type) {

--- a/lib/internal/test_runner/reporter/utils.js
+++ b/lib/internal/test_runner/reporter/utils.js
@@ -67,7 +67,7 @@ function formatError(error, indent) {
   return `\n${indent}  ${message}\n`;
 }
 
-function formatTestReport(type, data, prefix = '', indent = '', hasChildren = false, showErrorDetails = true) {
+function formatTestReport(type, data, showErrorDetails = true, prefix = '', indent = '') {
   let color = reporterColorMap[type] ?? colors.white;
   let symbol = reporterUnicodeSymbolMap[type] ?? ' ';
   const { skip, todo } = data;


### PR DESCRIPTION
While trying to understand the underlying logic of the built-in test reporters, necessary because documentation of the semantics of  TestsStream is minimal, I was thoroughly confused by this code in `formatTestReport`:

```
const error = showErrorDetails ? formatError(data.details?.error, indent) : '';
const err = hasChildren ?
  (!error || data.details?.error?.failureType === 'subtestsFailed' ? '' : `\n${error}`) :
  error;
```

...and not just because of the obfuscation. It made sense that if `data.details?.error?.failureType === 'subtestsFailed'`, the error should not be reported against the parent test, and even that this condition is only tested if `hasChildren` is true. But all callers that do pass in `hasChildren` (which otherwise defaults to false) also pass in  `showErrorDetails: false`, so that part of the convoluted nested ternary never even fires.

Ok, I thought, maybe `formatTestReport` represents an API the current built-in reporters do not use fully. But that seems a little odd because it is *internal*. So I reduced it to its essence, *as currently used*. I did it in four steps because I'm old and need to break things down more than you young'uns might need. Each step is a commit, with explanation in the commit message, with each commit passing all tests.

The upshot is the above gets reduced to

```
const err = showErrorDetails && data.details?.error ? 
  formatError(data.details.error, indent) : '';
```

along with an easier to understand formatTestReport function signature and removal of more dead code in the spec reporter.