### PR TITLE
benchmark: update num to n in dgram offset-length

### DIFF
--- a/benchmark/dgram/offset-length.js
+++ b/benchmark/dgram/offset-length.js
@@ -9,7 +9,7 @@ const PORT = common.PORT;
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
 const bench = common.createBenchmark(main, {
-  len: [1, 64, 256, 1024],
+  len: [1, 512, 1024],
   n: [100],
   type: ['send', 'recv'],
   dur: [5],


### PR DESCRIPTION
Replace the `num` config with `n` to be compatible with the `n` CLI argument.

> According to https://github.com/nodejs/performance/issues/186 this benchmark was taking 40 seconds for a single run.

Since this benchmark doesn’t take too long to run (about 40s), I didn’t change the config.

I ran the benchmarks for comparison, but I’m not sure if using len as [1, 512, 1024] would provide better coverage than [1, 64, 256, 1024]. What do you guys think?

If that makes sense to you, let me know, and I can update it to `[1, 512, 1024]`. 
This change reduces the execution time from 40s to 30s.

Here’s the output for both configs:

len: **[1, 64, 256, 1024]**
```
dgram/offset-length.js dur=5 type="send" n=100 len=1: 0.00029774464483540395
dgram/offset-length.js dur=5 type="recv" n=100 len=1: 0.00008736534416572343
dgram/offset-length.js dur=5 type="send" n=100 len=64: 0.01820060746926647
dgram/offset-length.js dur=5 type="recv" n=100 len=64: 0.005719775647413869
dgram/offset-length.js dur=5 type="send" n=100 len=256: 0.07849402316926338
dgram/offset-length.js dur=5 type="recv" n=100 len=256: 0.02109259972351112
dgram/offset-length.js dur=5 type="send" n=100 len=1024: 0.3289801256746718
dgram/offset-length.js dur=5 type="recv" n=100 len=1024: 0.09215122503886834

real    0m40.983s
user    0m21.080s
sys     0m17.143s
```

len: **[1,512,1024]**
```
dgram/offset-length.js dur=5 type="send" n=100 len=1: 0.0003172381715335142
dgram/offset-length.js dur=5 type="recv" n=100 len=1: 0.00010832342823154378
dgram/offset-length.js dur=5 type="send" n=100 len=512: 0.1707906782931467
dgram/offset-length.js dur=5 type="recv" n=100 len=512: 0.05277125834012046
dgram/offset-length.js dur=5 type="send" n=100 len=1024: 0.3028087268917686
dgram/offset-length.js dur=5 type="recv" n=100 len=1024: 0.08280481519975962

real    0m30.869s
user    0m15.585s
sys     0m13.336s
```

**Benchmark Machine Specifications:**
```
---------------------------------
Uptime     : 3 days, 15 hours, 36 minutes
Processor  : Intel(R) Xeon(R) CPU E5-2690 v2 @ 3.00GHz
CPU cores  : 4 @ 2999.998 MHz
AES-NI     : ✔ Enabled
VM-x/AMD-V : ✔ Enabled
RAM        : 11.4 GiB
Swap       : 0.0 KiB
Disk       : 500.0 GiB
Distro     : CentOS Stream 9
Kernel     : 5.14.0-295.el9.x86_64
VM Type    : KVM
```