### PR TITLE
benchmark: sqlite prevent create both tables on prepare select

### DIFF
--- a/benchmark/sqlite/sqlite-prepare-select-all.js
+++ b/benchmark/sqlite/sqlite-prepare-select-all.js
@@ -26,25 +26,33 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const db = new sqlite.DatabaseSync(':memory:');
 
-  db.exec('CREATE TABLE foo (text_column TEXT, integer_column INTEGER, real_column REAL, blob_column BLOB)');
-  const fooInsertStatement = db.prepare(
-    'INSERT INTO foo (text_column, integer_column, real_column, blob_column) VALUES (?, ?, ?, ?)',
-  );
-
-  for (let i = 0; i < conf.tableSeedSize; i++) {
-    fooInsertStatement.run(
-      crypto.randomUUID(),
-      Math.floor(Math.random() * 100),
-      Math.random(),
-      Buffer.from('example blob data'),
+  // Create only the necessary table for the benchmark type.
+  // If the statement includes 'foo_large', create the foo_large table; otherwise, create the foo table.
+  if (conf.statement.includes('foo_large')) {
+    db.exec('CREATE TABLE foo_large (text_8kb_column TEXT)');
+    const fooLargeInsertStatement = db.prepare(
+      'INSERT INTO foo_large (text_8kb_column) VALUES (?)',
     );
-  }
+    const largeText = 'a'.repeat(8 * 1024);
+    for (let i = 0; i < conf.tableSeedSize; i++) {
+      fooLargeInsertStatement.run(largeText);
+    }
+  } else {
+    db.exec(
+      'CREATE TABLE foo (text_column TEXT, integer_column INTEGER, real_column REAL, blob_column BLOB)',
+    );
+    const fooInsertStatement = db.prepare(
+      'INSERT INTO foo (text_column, integer_column, real_column, blob_column) VALUES (?, ?, ?, ?)',
+    );
 
-  db.exec('CREATE TABLE foo_large (text_8kb_column TEXT)');
-  const fooLargeInsertStatement = db.prepare('INSERT INTO foo_large (text_8kb_column) VALUES (?)');
-  const largeText = 'a'.repeat(8 * 1024);
-  for (let i = 0; i < conf.tableSeedSize; i++) {
-    fooLargeInsertStatement.run(largeText);
+    for (let i = 0; i < conf.tableSeedSize; i++) {
+      fooInsertStatement.run(
+        crypto.randomUUID(),
+        Math.floor(Math.random() * 100),
+        Math.random(),
+        Buffer.from('example blob data'),
+      );
+    }
   }
 
   let i;
@@ -53,8 +61,7 @@ function main(conf) {
   const stmt = db.prepare(conf.statement);
 
   bench.start();
-  for (i = 0; i < conf.n; i += 1)
-    deadCodeElimination = stmt.all();
+  for (i = 0; i < conf.n; i += 1) deadCodeElimination = stmt.all();
   bench.end(conf.n);
 
   assert.ok(deadCodeElimination !== undefined);

--- a/benchmark/sqlite/sqlite-prepare-select-get.js
+++ b/benchmark/sqlite/sqlite-prepare-select-get.js
@@ -20,25 +20,33 @@ const bench = common.createBenchmark(main, {
 function main(conf) {
   const db = new sqlite.DatabaseSync(':memory:');
 
-  db.exec('CREATE TABLE foo (text_column TEXT, integer_column INTEGER, real_column REAL, blob_column BLOB)');
-  const fooInsertStatement = db.prepare(
-    'INSERT INTO foo (text_column, integer_column, real_column, blob_column) VALUES (?, ?, ?, ?)',
-  );
-
-  for (let i = 0; i < conf.tableSeedSize; i++) {
-    fooInsertStatement.run(
-      crypto.randomUUID(),
-      Math.floor(Math.random() * 100),
-      Math.random(),
-      Buffer.from('example blob data'),
+  // Create only the necessary table for the benchmark type.
+  // If the statement includes 'foo_large', create the foo_large table; otherwise, create the foo table.
+  if (conf.statement.includes('foo_large')) {
+    db.exec('CREATE TABLE foo_large (text_8kb_column TEXT)');
+    const fooLargeInsertStatement = db.prepare(
+      'INSERT INTO foo_large (text_8kb_column) VALUES (?)',
     );
-  }
+    const largeText = 'a'.repeat(8 * 1024);
+    for (let i = 0; i < conf.tableSeedSize; i++) {
+      fooLargeInsertStatement.run(largeText);
+    }
+  } else {
+    db.exec(
+      'CREATE TABLE foo (text_column TEXT, integer_column INTEGER, real_column REAL, blob_column BLOB)',
+    );
+    const fooInsertStatement = db.prepare(
+      'INSERT INTO foo (text_column, integer_column, real_column, blob_column) VALUES (?, ?, ?, ?)',
+    );
 
-  db.exec('CREATE TABLE foo_large (text_8kb_column TEXT)');
-  const fooLargeInsertStatement = db.prepare('INSERT INTO foo_large (text_8kb_column) VALUES (?)');
-  const largeText = 'a'.repeat(8 * 1024);
-  for (let i = 0; i < conf.tableSeedSize; i++) {
-    fooLargeInsertStatement.run(largeText);
+    for (let i = 0; i < conf.tableSeedSize; i++) {
+      fooInsertStatement.run(
+        crypto.randomUUID(),
+        Math.floor(Math.random() * 100),
+        Math.random(),
+        Buffer.from('example blob data'),
+      );
+    }
   }
 
   let i;
@@ -47,8 +55,7 @@ function main(conf) {
   const stmt = db.prepare(conf.statement);
 
   bench.start();
-  for (i = 0; i < conf.n; i += 1)
-    deadCodeElimination = stmt.get();
+  for (i = 0; i < conf.n; i += 1) deadCodeElimination = stmt.get();
   bench.end(conf.n);
 
   assert.ok(deadCodeElimination !== undefined);


### PR DESCRIPTION
At the beginning of the two benchmarks `sqlite-prepare-select-all.js` and `sqlite-prepare-select-get.js`, two tables (`foo` and `foo_large`) were created. This PR introduces a conditional to create only the required table for each benchmark, reducing execution time.

|bench| before | after |
|-------|------| ------|
| sqlite-prepare-select-all.js | 4m48.002s | 4m1.381s |
| sqlite-prepare-select-get.js | 0m37.168s |  0m17.383s |