### PR TITLE
src,permission: add --allow-inspector ability

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -275,6 +275,36 @@ When passing a single flag with a comma a warning will be displayed.
 
 Examples can be found in the [File System Permissions][] documentation.
 
+### `--allow-inspector`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+When using the [Permission Model][], the process will not be able to connect
+through inspector protocol.
+
+Attempts to do so will throw an `ERR_ACCESS_DENIED` unless the
+user explicitly passes the `--allow-inspector` flag when starting Node.js.
+
+Example:
+
+```js
+const { Session } = require('node:inspector/promises');
+
+const session = new Session();
+session.connect();
+```
+
+```console
+$ node --permission index.js
+Error: connect ERR_ACCESS_DENIED Access to this API has been restricted. Use --allow-inspector to manage permissions.
+  code: 'ERR_ACCESS_DENIED',
+}
+```
+
 ### `--allow-net`
 
 <!-- YAML
@@ -3415,6 +3445,7 @@ one is included in the list below.
 * `--allow-child-process`
 * `--allow-fs-read`
 * `--allow-fs-write`
+* `--allow-inspector`
 * `--allow-net`
 * `--allow-wasi`
 * `--allow-worker`

--- a/doc/node-config-schema.json
+++ b/doc/node-config-schema.json
@@ -45,6 +45,9 @@
             }
           ]
         },
+        "allow-inspector": {
+          "type": "boolean"
+        },
         "allow-net": {
           "type": "boolean"
         },

--- a/doc/node.1
+++ b/doc/node.1
@@ -85,6 +85,9 @@ Allow using native addons when using the permission model.
 .It Fl -allow-child-process
 Allow spawning process when using the permission model.
 .
+.It Fl -allow-inspector
+Allow inspector access when using the permission model.
+.
 .It Fl -allow-net
 Allow network access when using the permission model.
 .

--- a/lib/internal/process/permission.js
+++ b/lib/internal/process/permission.js
@@ -40,6 +40,7 @@ module.exports = ObjectFreeze({
       '--allow-addons',
       '--allow-child-process',
       '--allow-net',
+      '--allow-inspector',
       '--allow-wasi',
       '--allow-worker',
     ];

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -580,6 +580,7 @@ function initializePermission() {
     const warnFlags = [
       '--allow-addons',
       '--allow-child-process',
+      '--allow-inspector',
       '--allow-wasi',
       '--allow-worker',
     ];

--- a/src/env.cc
+++ b/src/env.cc
@@ -911,8 +911,10 @@ Environment::Environment(IsolateData* isolate_data,
       options_->allow_native_addons = false;
       permission()->Apply(this, {"*"}, permission::PermissionScope::kAddon);
     }
-    flags_ = flags_ | EnvironmentFlags::kNoCreateInspector;
-    permission()->Apply(this, {"*"}, permission::PermissionScope::kInspector);
+    if (!options_->allow_inspector) {
+      flags_ = flags_ | EnvironmentFlags::kNoCreateInspector;
+      permission()->Apply(this, {"*"}, permission::PermissionScope::kInspector);
+    }
     if (!options_->allow_child_process) {
       permission()->Apply(
           this, {"*"}, permission::PermissionScope::kChildProcess);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -606,6 +606,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             "allow use of child process when any permissions are set",
             &EnvironmentOptions::allow_child_process,
             kAllowedInEnvvar);
+  AddOption("--allow-inspector",
+            "allow use of inspector when any permissions are set",
+            &EnvironmentOptions::allow_inspector,
+            kAllowedInEnvvar);
   AddOption("--allow-net",
             "allow use of network when any permissions are set",
             &EnvironmentOptions::allow_net,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -140,6 +140,7 @@ class EnvironmentOptions : public Options {
   std::vector<std::string> allow_fs_read;
   std::vector<std::string> allow_fs_write;
   bool allow_addons = false;
+  bool allow_inspector = false;
   bool allow_child_process = false;
   bool allow_net = false;
   bool allow_wasi = false;

--- a/src/permission/permission_base.h
+++ b/src/permission/permission_base.h
@@ -27,7 +27,8 @@ namespace permission {
 #define WORKER_THREADS_PERMISSIONS(V)                                          \
   V(WorkerThreads, "worker", PermissionsRoot, "--allow-worker")
 
-#define INSPECTOR_PERMISSIONS(V) V(Inspector, "inspector", PermissionsRoot, "")
+#define INSPECTOR_PERMISSIONS(V)                                               \
+  V(Inspector, "inspector", PermissionsRoot, "--allow-inspector")
 
 #define NET_PERMISSIONS(V) V(Net, "net", PermissionsRoot, "--allow-net")
 

--- a/test/common/index.js
+++ b/test/common/index.js
@@ -364,6 +364,9 @@ if (hasCrypto) {
   knownGlobals.add(globalThis.SubtleCrypto);
 }
 
+const { Worker } = require('node:worker_threads');
+knownGlobals.add(Worker);
+
 function allowGlobals(...allowlist) {
   for (const val of allowlist) {
     knownGlobals.add(val);

--- a/test/parallel/test-permission-allow-inspector.js
+++ b/test/parallel/test-permission-allow-inspector.js
@@ -1,0 +1,53 @@
+// Flags: --permission --allow-fs-read=* --allow-inspector
+'use strict';
+
+const common = require('../common');
+
+const { Session } = require('node:inspector/promises');
+const assert = require('node:assert');
+
+const session = new Session();
+session.connect();
+
+// Guarantee WorkerImpl doesn't gets bypassed
+(async () => {
+  await session.post('Debugger.enable');
+  await session.post('Runtime.enable');
+
+  globalThis.Worker = require('node:worker_threads').Worker;
+
+  const { result: { objectId } } = await session.post('Runtime.evaluate', { expression: 'Worker' });
+  const { internalProperties } = await session.post('Runtime.getProperties', { objectId: objectId });
+  const {
+    value: {
+      value: { scriptId }
+    }
+  } = internalProperties.filter((prop) => prop.name === '[[FunctionLocation]]')[0];
+  const { scriptSource } = await session.post('Debugger.getScriptSource', { scriptId });
+
+  const lineNumber = scriptSource.substring(0, scriptSource.indexOf('new WorkerImpl')).split('\n').length;
+
+  // Attempt to bypass it based on https://hackerone.com/reports/1962701
+  await session.post('Debugger.setBreakpointByUrl', {
+    lineNumber: lineNumber,
+    url: 'node:internal/worker',
+    columnNumber: 0,
+    condition: '((isInternal = true),false)'
+  });
+
+  assert.throws(() => {
+    // eslint-disable-next-line no-undef
+    new Worker(`
+      const child_process = require("node:child_process");
+      console.log(child_process.execSync("ls -l").toString());
+
+      console.log(require("fs").readFileSync("/etc/passwd").toString())
+    `, {
+      eval: true,
+    });
+  }, {
+    message: 'Access to this API has been restricted. Use --allow-worker to manage permissions.',
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'WorkerThreads'
+  });
+})().then(common.mustCall());

--- a/test/parallel/test-permission-inspector.js
+++ b/test/parallel/test-permission-inspector.js
@@ -22,7 +22,7 @@ if (!common.hasCrypto)
     const session = new Session();
     session.connect();
   }, common.expectsError({
-    message: 'Access to this API has been restricted. ',
+    message: 'Access to this API has been restricted. Use --allow-inspector to manage permissions.',
     code: 'ERR_ACCESS_DENIED',
     permission: 'Inspector',
   }));

--- a/test/parallel/test-permission-warning-flags.js
+++ b/test/parallel/test-permission-warning-flags.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const warnFlags = [
   '--allow-addons',
   '--allow-child-process',
+  '--allow-inspector',
   '--allow-wasi',
   '--allow-worker',
 ];


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/48534

Remaining questions:

* How should it behave when connecting through a Websocket? Should the net permissions deny this access?
* Is there another way of bypassing other features by enabling this?

The test case I included makes sure we won't reintroduce https://github.com/nodejs/node/commit/3df13d5a79134330fd784365b7c0eb895fd5c3d3

cc: @nodejs/security-wg 