### PR TITLE
http: use cached '1.1' http version string

### DIFF
--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -93,9 +93,9 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   const incoming = parser.incoming = new ParserIncomingMessage(socket);
   incoming.httpVersionMajor = versionMajor;
   incoming.httpVersionMinor = versionMinor;
-  incoming.httpVersion = versionMajor === 1 && versionMinor === 1
-    ? HTTP_VERSION_1_1
-    : `${versionMajor}.${versionMinor}`;
+  incoming.httpVersion = versionMajor === 1 && versionMinor === 1 ?
+    HTTP_VERSION_1_1 :
+    `${versionMajor}.${versionMinor}`;
   incoming.joinDuplicateHeaders = socket?.server?.joinDuplicateHeaders ||
                                   parser.joinDuplicateHeaders;
   incoming.url = url;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -64,6 +64,8 @@ function parserOnHeaders(headers, url) {
   this._url += url;
 }
 
+const HTTP_VERSION_1_1 = '1.1';
+
 // `headers` and `url` are set only if .onHeaders() has not been called for
 // this request.
 // `url` is not set for response parsers but that's not applicable here since
@@ -91,7 +93,9 @@ function parserOnHeadersComplete(versionMajor, versionMinor, headers, method,
   const incoming = parser.incoming = new ParserIncomingMessage(socket);
   incoming.httpVersionMajor = versionMajor;
   incoming.httpVersionMinor = versionMinor;
-  incoming.httpVersion = `${versionMajor}.${versionMinor}`;
+  incoming.httpVersion = versionMajor === 1 && versionMinor === 1
+    ? HTTP_VERSION_1_1
+    : `${versionMajor}.${versionMinor}`;
   incoming.joinDuplicateHeaders = socket?.server?.joinDuplicateHeaders ||
                                   parser.joinDuplicateHeaders;
   incoming.url = url;


### PR DESCRIPTION
Avoid some common string allocation

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
