### PR TITLE
tools: add sccache to `test-internet` workflow

### DIFF
--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -34,8 +34,8 @@ env:
   PYTHON_VERSION: '3.12'
   FLAKY_TESTS: keep_retrying
   CLANG_VERSION: '19'
-  CC: clang-19
-  CXX: clang++-19
+  CC: sccache clang-19
+  CXX: sccache clang++-19
   SCCACHE_GHA_ENABLED: 'true'
 
 permissions:

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -36,6 +36,7 @@ env:
   CLANG_VERSION: '19'
   CC: clang-19
   CXX: clang++-19
+  SCCACHE_GHA_ENABLED: 'true'
 
 permissions:
   contents: read

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -56,6 +56,10 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up sccache
+        uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
+        with:
+          version: v0.10.0
       - name: Environment Information
         run: npx envinfo
       - name: Build


### PR DESCRIPTION
Building `node` takes forever on that job, adding cache should speed it up.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
