### PR TITLE
doc: update OpenSSL default security level to 2 in TLS documentation

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -454,7 +454,7 @@ are not enabled by default since they offer less security.
 The OpenSSL library enforces security levels to control the minimum acceptable
 level of security for cryptographic operations. OpenSSL's security levels range
 from 0 to 5, with each level imposing stricter security requirements. The default
-security level is 1, which is generally suitable for most modern applications.
+security level is 2, which is generally suitable for most modern applications.
 However, some legacy features and protocols, such as TLSv1, require a lower
 security level (`SECLEVEL=0`) to function properly. For more detailed information,
 please refer to the [OpenSSL documentation on security levels][].


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/59715

This pull request updates the Node.js TLS documentation to reflect the change in the default OpenSSL security level from 1 to 2, starting with Node.js 24.5 (OpenSSL 3.2+).

The documentation previously stated the default security level was 1.
The default is now 2, which enforces stricter cryptographic requirements.