### PR TITLE
esm: fix missed renaming in ModuleJob.runSync

### DIFF
--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -335,7 +335,7 @@ class ModuleJob extends ModuleJobBase {
       const parentFilename = urlToFilename(parent?.filename);
       this.module.hasAsyncGraph ??= this.module.isGraphAsync();
 
-      if (this.module.async && !getOptionValue('--experimental-print-required-tla')) {
+      if (this.module.hasAsyncGraph && !getOptionValue('--experimental-print-required-tla')) {
         throw new ERR_REQUIRE_ASYNC_MODULE(filename, parentFilename);
       }
       if (status === kInstantiated) {

--- a/test/es-module/test-import-require-tla-twice.js
+++ b/test/es-module/test-import-require-tla-twice.js
@@ -1,0 +1,21 @@
+'use strict';
+// This tests that in the require() in imported CJS can retry loading an ESM with TLA
+// twice and get the correct error both times.
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+
+spawnSyncAndAssert(
+  process.execPath,
+  ['--import', fixtures.fileURL('es-modules', 'import-require-tla-twice', 'hook.js'),
+   fixtures.path('es-modules', 'import-require-tla-twice', 'require-tla.js'),
+  ],
+  {
+    stdout(output) {
+      const matches = output.matchAll(/e\.code === ERR_REQUIRE_ASYNC_MODULE true/g);
+      assert.strictEqual([...matches].length, 2);
+    }
+  }
+);

--- a/test/fixtures/es-modules/import-require-tla-twice/hook.js
+++ b/test/fixtures/es-modules/import-require-tla-twice/hook.js
@@ -1,0 +1,6 @@
+const { registerHooks } = require('module');
+registerHooks({
+  load(url, context, nextLoad) {
+    return nextLoad(url, context);
+  }
+});

--- a/test/fixtures/es-modules/import-require-tla-twice/require-tla.js
+++ b/test/fixtures/es-modules/import-require-tla-twice/require-tla.js
@@ -1,0 +1,11 @@
+try {
+  require('./tla.mjs');
+} catch (e) {
+  console.log('e.code === ERR_REQUIRE_ASYNC_MODULE', e.code === 'ERR_REQUIRE_ASYNC_MODULE');
+}
+
+try {
+  require('./tla.mjs');
+} catch (e) {
+  console.log('e.code === ERR_REQUIRE_ASYNC_MODULE', e.code === 'ERR_REQUIRE_ASYNC_MODULE');
+}

--- a/test/fixtures/es-modules/import-require-tla-twice/tla.mjs
+++ b/test/fixtures/es-modules/import-require-tla-twice/tla.mjs
@@ -1,0 +1,1 @@
+await Promise.resolve('1');


### PR DESCRIPTION
https://redirect.github.com/nodejs/node/pull/59675 missed a case when renaming .async to .hasAsyncGraph. This fixes that and add a test that would previously crash with the missed rename.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
