### PR TITLE
doc: provide alternative to `url.parse()` using WHATWG URL

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1847,7 +1847,15 @@ A `URIError` is thrown if the `auth` property is present but cannot be decoded.
 strings. It is prone to security issues such as [host name spoofing][]
 and incorrect handling of usernames and passwords. Do not use with untrusted
 input. CVEs are not issued for `url.parse()` vulnerabilities. Use the
-[WHATWG URL][] API instead.
+[WHATWG URL][] API instead, for example:
+
+```js
+function getURL(req) {
+  const proto = req.headers['x-forwarded-proto'] || 'https';
+  const host = req.headers['x-forwarded-host'] || req.headers.host || 'example.com';
+  return new URL(req.url || '/', `${proto}://${host}`);
+}
+```
 
 ### `url.resolve(from, to)`
 


### PR DESCRIPTION
After 5 years, I keep coming back to this same solution so it would help others to document it:

- Related to https://github.com/nodejs/web-server-frameworks/issues/71#issuecomment-702903372