### PR TITLE
Revert "lib: optimize writable stream buffer clearing"

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -784,7 +784,7 @@ function clearBuffer(stream, state) {
     if (i === buffered.length) {
       resetBuffer(state);
     } else if (i > 256) {
-      state[kBufferedValue] = ArrayPrototypeSlice(buffered, i);
+      buffered.splice(0, i);
       state.bufferedIndex = 0;
     } else {
       state.bufferedIndex = i;


### PR DESCRIPTION
The changes in #59406 were intended to improve performance, but subsequent CI benchmarks showed inconsistent results, including some performance regressions. The observed improvements were not statistically significant due to a high margin of error.

The performance issues and related discussion can be found in the comments of nodejs/node#59676.
