### PR TITLE
repl: fix REPL completion under unary expressions

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1744,6 +1744,16 @@ function findExpressionCompleteTarget(code) {
     return findExpressionCompleteTarget(lastDeclarationInitCode);
   }
 
+  // If the last statement is an expression statement with a unary operator (delete, typeof, etc.)
+  // we want to extract the argument for completion (e.g. for `delete obj.prop` we want `obj.prop`)
+  if (lastBodyStatement.type === 'ExpressionStatement' &&
+      lastBodyStatement.expression.type === 'UnaryExpression' &&
+      lastBodyStatement.expression.argument) {
+    const argument = lastBodyStatement.expression.argument;
+    const argumentCode = code.slice(argument.start, argument.end);
+    return findExpressionCompleteTarget(argumentCode);
+  }
+
   // If any of the above early returns haven't activated then it means that
   // the potential complete target is the full code (e.g. the code represents
   // a simple partial identifier, a member expression, etc...)

--- a/test/parallel/test-repl-tab-complete-unary-expressions.js
+++ b/test/parallel/test-repl-tab-complete-unary-expressions.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const repl = require('repl');
+const { describe, it } = require('node:test');
+
+// This test verifies that tab completion works correctly with unary expressions
+// like delete, typeof, void, etc. This is a regression test for the issue where
+// typing "delete globalThis._" and then backspacing and typing "globalThis"
+// would cause "globalThis is not defined" error.
+
+describe('REPL tab completion with unary expressions', () => {
+  it('should handle delete operator correctly', (t, done) => {
+    const r = repl.start({
+      prompt: '',
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    // Test delete with member expression
+    r.complete(
+      'delete globalThis._',
+      common.mustSucceed((completions) => {
+        assert.strictEqual(completions[1], 'globalThis._');
+
+        // Test delete with identifier
+        r.complete(
+          'delete globalThis',
+          common.mustSucceed((completions) => {
+            assert.strictEqual(completions[1], 'globalThis');
+            r.close();
+            done();
+          })
+        );
+      })
+    );
+  });
+
+  it('should handle typeof operator correctly', (t, done) => {
+    const r = repl.start({
+      prompt: '',
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    r.complete(
+      'typeof globalThis',
+      common.mustSucceed((completions) => {
+        assert.strictEqual(completions[1], 'globalThis');
+        r.close();
+        done();
+      })
+    );
+  });
+
+  it('should handle void operator correctly', (t, done) => {
+    const r = repl.start({
+      prompt: '',
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    r.complete(
+      'void globalThis',
+      common.mustSucceed((completions) => {
+        assert.strictEqual(completions[1], 'globalThis');
+        r.close();
+        done();
+      })
+    );
+  });
+
+  it('should handle other unary operators correctly', (t, done) => {
+    const r = repl.start({
+      prompt: '',
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    const unaryOperators = [
+      '!globalThis',
+      '+globalThis',
+      '-globalThis',
+      '~globalThis',
+    ];
+
+    let testIndex = 0;
+
+    function testNext() {
+      if (testIndex >= unaryOperators.length) {
+        r.close();
+        done();
+        return;
+      }
+
+      const testCase = unaryOperators[testIndex++];
+      r.complete(
+        testCase,
+        common.mustSucceed((completions) => {
+          assert.strictEqual(completions[1], 'globalThis');
+          testNext();
+        })
+      );
+    }
+
+    testNext();
+  });
+
+  it('should still evaluate globalThis correctly after unary expression completion', (t, done) => {
+    const r = repl.start({
+      prompt: '',
+      input: process.stdin,
+      output: process.stdout,
+      terminal: false,
+    });
+
+    // First trigger completion with delete
+    r.complete(
+      'delete globalThis._',
+      common.mustSucceed(() => {
+        // Then evaluate globalThis
+        r.eval(
+          'globalThis',
+          r.context,
+          'test.js',
+          common.mustSucceed((result) => {
+            assert.strictEqual(typeof result, 'object');
+            assert.ok(result !== null);
+            r.close();
+            done();
+          })
+        );
+      })
+    );
+  });
+});


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fix REPL completion when the input is a unary expression (delete/typeof/void/!/+/-/~) by targeting the operand rather than the whole unary expression.

Fixes: #59735