### PR TITLE
test: skip more sea tests on Linux ppc64le

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -63,6 +63,9 @@ test-single-executable-application-disable-experimental-sea-warning: SKIP
 test-single-executable-application-empty: SKIP
 test-single-executable-application-exec-argv: SKIP
 test-single-executable-application-exec-argv-empty: SKIP
+test-single-executable-application-exec-argv-extension-cli: SKIP
+test-single-executable-application-exec-argv-extension-env: SKIP
+test-single-executable-application-exec-argv-extension-none: SKIP
 test-single-executable-application-inspect-in-sea-flags: SKIP
 test-single-executable-application-inspect: SKIP
 test-single-executable-application-snapshot: SKIP


### PR DESCRIPTION
Theses tests are failing when compiled with clang. Skip for now to avoid breaking the CI when we switch over to building with clang.

Refs: https://github.com/nodejs/node/issues/59561

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
