### PR TITLE
util: remove outdated TODO comment

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -182,7 +182,7 @@ function deprecate(fn, msg, code, useEmitSync, modifyPrototype = true) {
   );
 
   function deprecated(...args) {
-    if (!getOptionValue('--no-deprecation') && !process.noDeprecation) {
+    if (!process.noDeprecation) {
       emitDeprecationWarning();
     }
     if (new.target) {

--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -182,8 +182,7 @@ function deprecate(fn, msg, code, useEmitSync, modifyPrototype = true) {
   );
 
   function deprecated(...args) {
-    // TODO(joyeecheung): use getOptionValue('--no-deprecation') instead.
-    if (!process.noDeprecation) {
+    if (!getOptionValue('--no-deprecation') && !process.noDeprecation) {
       emitDeprecationWarning();
     }
     if (new.target) {


### PR DESCRIPTION
Update `deprecated()` in `lib/internal/util.js` to check
`getOptionValue('--no-deprecation')` in addition to `process.noDeprecation`.

No test added yet. Suggested tests:
1. Warning suppressed when `process.noDeprecation` is true.
2. Warning suppressed when `--no-deprecation` CLI flag is set.
3. Warning emitted when neither flag is set.

Feedback on how to best add these tests is welcome.

> TODO (joyeecheung): use getOptionValue('--no-deprecation') instead.
Would appreciate a review whenever you have time. Thanks!  
/cc @joyeecheung

->

This PR only removes the TODO comment in lib/internal/util.js
that suggested replacing process.noDeprecation with
getOptionValue('--no-deprecation').  

As noted in review, changing the behavior could break more than expected,  
so we keep the current logic as-is and just clean up the comment.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
