### PR TITLE
util: add skipPrototype option to deep equality checks

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -232,7 +232,7 @@ The `Assert` class allows creating independent assertion instances with custom o
 <!-- YAML
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/59762
     description: Added `skipPrototypeComparison` option.
 -->
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -272,9 +272,17 @@ strictEqual({ a: 1 }, { b: { c: 1 } });
 The `skipPrototypeComparison` option affects all deep equality methods:
 
 ```js
-function Foo(a) { this.a = a; }
+class Foo {
+  constructor(a) {
+    this.a = a;
+  }
+}
 
-function Bar(a) { this.a = a; }
+class Bar {
+  constructor(a) {
+    this.a = a;
+  }
+}
 
 const foo = new Foo(1);
 const bar = new Bar(1);

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -233,7 +233,7 @@ The `Assert` class allows creating independent assertion instances with custom o
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/59762
-    description: Added `skipPrototypeComparison` option.
+    description: Added `skipPrototype` option.
 -->
 
 * `options` {Object}
@@ -241,7 +241,7 @@ changes:
     Accepted values: `'simple'`, `'full'`.
   * `strict` {boolean} If set to `true`, non-strict methods behave like their
     corresponding strict methods. Defaults to `true`.
-  * `skipPrototypeComparison` {boolean} If set to `true`, skips prototype and constructor
+  * `skipPrototype` {boolean} If set to `true`, skips prototype and constructor
     comparison in deep equality checks. Defaults to `false`.
 
 Creates a new assertion instance. The `diff` option controls the verbosity of diffs in assertion error messages.
@@ -255,7 +255,7 @@ assertInstance.deepStrictEqual({ a: 1 }, { a: 2 });
 
 **Important**: When destructuring assertion methods from an `Assert` instance,
 the methods lose their connection to the instance's configuration options (such
-as `diff`, `strict`, and `skipPrototypeComparison` settings).
+as `diff`, `strict`, and `skipPrototype` settings).
 The destructured methods will fall back to default behavior instead.
 
 ```js
@@ -269,7 +269,7 @@ const { strictEqual } = myAssert;
 strictEqual({ a: 1 }, { b: { c: 1 } });
 ```
 
-The `skipPrototypeComparison` option affects all deep equality methods:
+The `skipPrototype` option affects all deep equality methods:
 
 ```js
 class Foo {
@@ -292,7 +292,7 @@ const assert1 = new Assert();
 assert1.deepStrictEqual(foo, bar); // AssertionError
 
 // Skip prototype comparison - passes if properties are equal
-const assert2 = new Assert({ skipPrototypeComparison: true });
+const assert2 = new Assert({ skipPrototype: true });
 assert2.deepStrictEqual(foo, bar); // OK
 ```
 

--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -229,11 +229,20 @@ The `Assert` class allows creating independent assertion instances with custom o
 
 ### `new assert.Assert([options])`
 
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Added `skipPrototypeComparison` option.
+-->
+
 * `options` {Object}
   * `diff` {string} If set to `'full'`, shows the full diff in assertion errors. Defaults to `'simple'`.
     Accepted values: `'simple'`, `'full'`.
   * `strict` {boolean} If set to `true`, non-strict methods behave like their
     corresponding strict methods. Defaults to `true`.
+  * `skipPrototypeComparison` {boolean} If set to `true`, skips prototype and constructor
+    comparison in deep equality checks. Defaults to `false`.
 
 Creates a new assertion instance. The `diff` option controls the verbosity of diffs in assertion error messages.
 
@@ -245,7 +254,8 @@ assertInstance.deepStrictEqual({ a: 1 }, { a: 2 });
 ```
 
 **Important**: When destructuring assertion methods from an `Assert` instance,
-the methods lose their connection to the instance's configuration options (such as `diff` and `strict` settings).
+the methods lose their connection to the instance's configuration options (such
+as `diff`, `strict`, and `skipPrototypeComparison` settings).
 The destructured methods will fall back to default behavior instead.
 
 ```js
@@ -257,6 +267,25 @@ myAssert.strictEqual({ a: 1 }, { b: { c: 1 } });
 // This loses the 'full' diff setting - falls back to default 'simple' diff
 const { strictEqual } = myAssert;
 strictEqual({ a: 1 }, { b: { c: 1 } });
+```
+
+The `skipPrototypeComparison` option affects all deep equality methods:
+
+```js
+function Foo(a) { this.a = a; }
+
+function Bar(a) { this.a = a; }
+
+const foo = new Foo(1);
+const bar = new Bar(1);
+
+// Default behavior - fails due to different constructors
+const assert1 = new Assert();
+assert1.deepStrictEqual(foo, bar); // AssertionError
+
+// Skip prototype comparison - passes if properties are equal
+const assert2 = new Assert({ skipPrototypeComparison: true });
+assert2.deepStrictEqual(foo, bar); // OK
 ```
 
 When destructured, methods lose access to the instance's `this` context and revert to default assertion behavior

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1581,9 +1581,17 @@ enumerable properties are deeply strictly equal.
 ```js
 const util = require('node:util');
 
-function Foo(a) { this.a = a; }
+class Foo {
+  constructor(a) {
+    this.a = a;
+  }
+}
 
-function Bar(a) { this.a = a; }
+class Bar {
+  constructor(a) {
+    this.a = a;
+  }
+}
 
 const foo = new Foo(1);
 const bar = new Bar(1);

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1565,16 +1565,15 @@ changes:
 
 * `val1` {any}
 * `val2` {any}
-* `options` {Object}
-  * `skipPrototypeComparison` {boolean} If `true`, prototype and constructor
-    comparison is skipped during deep strict equality check. **Default:** `false`.
+* `skipPrototypeComparison` {boolean} If `true`, prototype and constructor
+  comparison is skipped during deep strict equality check. **Default:** `false`.
 * Returns: {boolean}
 
 Returns `true` if there is deep strict equality between `val1` and `val2`.
 Otherwise, returns `false`.
 
 By default, deep strict equality includes comparison of object prototypes and
-constructors. When `options.skipPrototypeComparison` is `true`, objects with
+constructors. When `skipPrototypeComparison` is `true`, objects with
 different prototypes or constructors can still be considered equal if their
 enumerable properties are deeply strictly equal.
 
@@ -1600,7 +1599,7 @@ const bar = new Bar(1);
 console.log(util.isDeepStrictEqual(foo, bar));
 // false
 
-console.log(util.isDeepStrictEqual(foo, bar, { skipPrototypeComparison: true }));
+console.log(util.isDeepStrictEqual(foo, bar, true));
 // true
 ```
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1559,7 +1559,7 @@ console.log(arr); // logs the full array
 added: v9.0.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/00000
+    pr-url: https://github.com/nodejs/node/pull/59762
     description: Added `options` parameter to allow skipping prototype comparison.
 -->
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1565,7 +1565,7 @@ changes:
 
 * `val1` {any}
 * `val2` {any}
-* `skipPrototypeComparison` {boolean} If `true`, prototype and constructor
+* `skipPrototype` {boolean} If `true`, prototype and constructor
   comparison is skipped during deep strict equality check. **Default:** `false`.
 * Returns: {boolean}
 
@@ -1573,7 +1573,7 @@ Returns `true` if there is deep strict equality between `val1` and `val2`.
 Otherwise, returns `false`.
 
 By default, deep strict equality includes comparison of object prototypes and
-constructors. When `skipPrototypeComparison` is `true`, objects with
+constructors. When `skipPrototype` is `true`, objects with
 different prototypes or constructors can still be considered equal if their
 enumerable properties are deeply strictly equal.
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1553,18 +1553,48 @@ inspect.defaultOptions.maxArrayLength = null;
 console.log(arr); // logs the full array
 ```
 
-## `util.isDeepStrictEqual(val1, val2)`
+## `util.isDeepStrictEqual(val1, val2[, options])`
 
 <!-- YAML
 added: v9.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/00000
+    description: Added `options` parameter to allow skipping prototype comparison.
 -->
 
 * `val1` {any}
 * `val2` {any}
+* `options` {Object}
+  * `skipPrototypeComparison` {boolean} If `true`, prototype and constructor
+    comparison is skipped during deep strict equality check. **Default:** `false`.
 * Returns: {boolean}
 
 Returns `true` if there is deep strict equality between `val1` and `val2`.
 Otherwise, returns `false`.
+
+By default, deep strict equality includes comparison of object prototypes and
+constructors. When `options.skipPrototypeComparison` is `true`, objects with
+different prototypes or constructors can still be considered equal if their
+enumerable properties are deeply strictly equal.
+
+```js
+const util = require('node:util');
+
+function Foo(a) { this.a = a; }
+
+function Bar(a) { this.a = a; }
+
+const foo = new Foo(1);
+const bar = new Bar(1);
+
+// Different constructors, same properties
+console.log(util.isDeepStrictEqual(foo, bar));
+// false
+
+console.log(util.isDeepStrictEqual(foo, bar, { skipPrototypeComparison: true }));
+// true
+```
 
 See [`assert.deepStrictEqual()`][] for more information about deep strict
 equality.

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -313,10 +313,7 @@ Assert.prototype.deepStrictEqual = function deepStrictEqual(actual, expected, me
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected, {
-    __proto__: null,
-    skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison,
-  })) {
+  if (!isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototypeComparison)) {
     innerFail({
       actual,
       expected,
@@ -342,10 +339,7 @@ function notDeepStrictEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (isDeepStrictEqual(actual, expected, {
-    __proto__: null,
-    skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison,
-  })) {
+  if (isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototypeComparison)) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -339,7 +339,7 @@ function notDeepStrictEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (isDeepStrictEqual(actual, expected)) {
+  if (isDeepStrictEqual(actual, expected, { skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -93,6 +93,8 @@ const NO_EXCEPTION_SENTINEL = {};
  * @property {'full'|'simple'} [diff='simple'] - If set to 'full', shows the full diff in assertion errors.
  * @property {boolean} [strict=true] - If set to true, non-strict methods behave like their corresponding
  *   strict methods.
+ * @property {boolean} [skipPrototypeComparison=false] - If set to true, skips comparing prototypes
+ *   in deep equality checks.
  */
 
 /**
@@ -105,7 +107,7 @@ function Assert(options) {
     throw new ERR_CONSTRUCT_CALL_REQUIRED('Assert');
   }
 
-  options = ObjectAssign({ __proto__: null, strict: true }, options);
+  options = ObjectAssign({ __proto__: null, strict: true, skipPrototypeComparison: false }, options);
 
   const allowedDiffs = ['simple', 'full'];
   if (options.diff !== undefined) {
@@ -311,7 +313,7 @@ Assert.prototype.deepStrictEqual = function deepStrictEqual(actual, expected, me
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected)) {
+  if (!isDeepStrictEqual(actual, expected, { skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -339,7 +339,7 @@ function notDeepStrictEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (isDeepStrictEqual(actual, expected, { skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
+  if (isDeepStrictEqual(actual, expected, { __proto__: null, skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -313,7 +313,10 @@ Assert.prototype.deepStrictEqual = function deepStrictEqual(actual, expected, me
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected, { __proto__: null, skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
+  if (!isDeepStrictEqual(actual, expected, {
+    __proto__: null,
+    skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison,
+  })) {
     innerFail({
       actual,
       expected,
@@ -339,7 +342,10 @@ function notDeepStrictEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (isDeepStrictEqual(actual, expected, { __proto__: null, skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
+  if (isDeepStrictEqual(actual, expected, {
+    __proto__: null,
+    skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison,
+  })) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -93,7 +93,7 @@ const NO_EXCEPTION_SENTINEL = {};
  * @property {'full'|'simple'} [diff='simple'] - If set to 'full', shows the full diff in assertion errors.
  * @property {boolean} [strict=true] - If set to true, non-strict methods behave like their corresponding
  *   strict methods.
- * @property {boolean} [skipPrototypeComparison=false] - If set to true, skips comparing prototypes
+ * @property {boolean} [skipPrototype=false] - If set to true, skips comparing prototypes
  *   in deep equality checks.
  */
 
@@ -107,7 +107,7 @@ function Assert(options) {
     throw new ERR_CONSTRUCT_CALL_REQUIRED('Assert');
   }
 
-  options = ObjectAssign({ __proto__: null, strict: true, skipPrototypeComparison: false }, options);
+  options = ObjectAssign({ __proto__: null, strict: true, skipPrototype: false }, options);
 
   const allowedDiffs = ['simple', 'full'];
   if (options.diff !== undefined) {
@@ -313,7 +313,7 @@ Assert.prototype.deepStrictEqual = function deepStrictEqual(actual, expected, me
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototypeComparison)) {
+  if (!isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototype)) {
     innerFail({
       actual,
       expected,
@@ -339,7 +339,7 @@ function notDeepStrictEqual(actual, expected, message) {
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototypeComparison)) {
+  if (isDeepStrictEqual(actual, expected, this?.[kOptions]?.skipPrototype)) {
     innerFail({
       actual,
       expected,

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -313,7 +313,7 @@ Assert.prototype.deepStrictEqual = function deepStrictEqual(actual, expected, me
     throw new ERR_MISSING_ARGS('actual', 'expected');
   }
   if (isDeepEqual === undefined) lazyLoadComparison();
-  if (!isDeepStrictEqual(actual, expected, { skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
+  if (!isDeepStrictEqual(actual, expected, { __proto__: null, skipPrototypeComparison: this?.[kOptions]?.skipPrototypeComparison })) {
     innerFail({
       actual,
       expected,

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -1028,8 +1028,8 @@ module.exports = {
   isDeepEqual(val1, val2) {
     return detectCycles(val1, val2, kLoose);
   },
-  isDeepStrictEqual(val1, val2, skipPrototypeComparison) {
-    if (skipPrototypeComparison) {
+  isDeepStrictEqual(val1, val2, skipPrototype) {
+    if (skipPrototype) {
       return detectCycles(val1, val2, kStrictWithoutPrototypes);
     }
     return detectCycles(val1, val2, kStrict);

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -459,7 +459,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
       }
     } else if (keys2.length !== (keys1 = ObjectKeys(val1)).length) {
       return false;
-    } else if (mode >= kStrict) {
+    } else if (mode === kStrict || mode === kStrictWithoutPrototypes) {
       const symbolKeysA = getOwnSymbols(val1);
       if (symbolKeysA.length !== 0) {
         let count = 0;

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -127,9 +127,10 @@ const {
   getOwnNonIndexProperties,
 } = internalBinding('util');
 
-const kStrict = 1;
+const kStrict = 2;
+const kStrictWithoutPrototypes = 3;
 const kLoose = 0;
-const kPartial = 2;
+const kPartial = 1;
 
 const kNoIterator = 0;
 const kIsArray = 1;
@@ -458,7 +459,7 @@ function keyCheck(val1, val2, mode, memos, iterationType, keys2) {
       }
     } else if (keys2.length !== (keys1 = ObjectKeys(val1)).length) {
       return false;
-    } else if (mode === kStrict) {
+    } else if (mode >= kStrict) {
       const symbolKeysA = getOwnSymbols(val1);
       if (symbolKeysA.length !== 0) {
         let count = 0;
@@ -1027,7 +1028,10 @@ module.exports = {
   isDeepEqual(val1, val2) {
     return detectCycles(val1, val2, kLoose);
   },
-  isDeepStrictEqual(val1, val2) {
+  isDeepStrictEqual(val1, val2, options) {
+    if (options?.skipPrototypeComparison) {
+      return detectCycles(val1, val2, kStrictWithoutPrototypes);
+    }
     return detectCycles(val1, val2, kStrict);
   },
   isPartialStrictEqual(val1, val2) {

--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -1028,8 +1028,8 @@ module.exports = {
   isDeepEqual(val1, val2) {
     return detectCycles(val1, val2, kLoose);
   },
-  isDeepStrictEqual(val1, val2, options) {
-    if (options?.skipPrototypeComparison) {
+  isDeepStrictEqual(val1, val2, skipPrototypeComparison) {
+    if (skipPrototypeComparison) {
       return detectCycles(val1, val2, kStrictWithoutPrototypes);
     }
     return detectCycles(val1, val2, kStrict);

--- a/lib/util.js
+++ b/lib/util.js
@@ -487,11 +487,11 @@ module.exports = {
   isArray: deprecate(ArrayIsArray,
                      'The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.',
                      'DEP0044'),
-  isDeepStrictEqual(a, b, options) {
+  isDeepStrictEqual(a, b, skipPrototypeComparison) {
     if (internalDeepEqual === undefined) {
       internalDeepEqual = require('internal/util/comparisons').isDeepStrictEqual;
     }
-    return internalDeepEqual(a, b, options);
+    return internalDeepEqual(a, b, skipPrototypeComparison);
   },
   promisify,
   stripVTControlCharacters,

--- a/lib/util.js
+++ b/lib/util.js
@@ -487,11 +487,11 @@ module.exports = {
   isArray: deprecate(ArrayIsArray,
                      'The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.',
                      'DEP0044'),
-  isDeepStrictEqual(a, b, skipPrototypeComparison) {
+  isDeepStrictEqual(a, b, skipPrototype) {
     if (internalDeepEqual === undefined) {
       internalDeepEqual = require('internal/util/comparisons').isDeepStrictEqual;
     }
-    return internalDeepEqual(a, b, skipPrototypeComparison);
+    return internalDeepEqual(a, b, skipPrototype);
   },
   promisify,
   stripVTControlCharacters,

--- a/lib/util.js
+++ b/lib/util.js
@@ -488,9 +488,6 @@ module.exports = {
                      'The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.',
                      'DEP0044'),
   isDeepStrictEqual(a, b, options) {
-    if (options !== undefined) {
-      return require('internal/util/comparisons').isDeepStrictEqual(a, b, options);
-    }
     if (internalDeepEqual === undefined) {
       internalDeepEqual = require('internal/util/comparisons').isDeepStrictEqual;
     }

--- a/lib/util.js
+++ b/lib/util.js
@@ -487,12 +487,14 @@ module.exports = {
   isArray: deprecate(ArrayIsArray,
                      'The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.',
                      'DEP0044'),
-  isDeepStrictEqual(a, b) {
-    if (internalDeepEqual === undefined) {
-      internalDeepEqual = require('internal/util/comparisons')
-        .isDeepStrictEqual;
+  isDeepStrictEqual(a, b, options) {
+    if (options !== undefined) {
+      return require('internal/util/comparisons').isDeepStrictEqual(a, b, options);
     }
-    return internalDeepEqual(a, b);
+    if (internalDeepEqual === undefined) {
+      internalDeepEqual = require('internal/util/comparisons').isDeepStrictEqual;
+    }
+    return internalDeepEqual(a, b, options);
   },
   promisify,
   stripVTControlCharacters,

--- a/test/parallel/test-assert-class.js
+++ b/test/parallel/test-assert-class.js
@@ -479,7 +479,7 @@ test('Assert class non strict with simple diff', () => {
   }
 });
 
-// Shared setup for skipPrototypeComparison tests
+// Shared setup for skipPrototype tests
 {
   const message = 'Expected values to be strictly deep-equal:\n' +
   '+ actual - expected\n' +
@@ -507,8 +507,8 @@ test('Assert class non strict with simple diff', () => {
   const modern = new Modern(42);
   const legacy = new Legacy(42);
 
-  test('Assert class strict with skipPrototypeComparison', () => {
-    const assertInstance = new Assert({ skipPrototypeComparison: true });
+  test('Assert class strict with skipPrototype', () => {
+    const assertInstance = new Assert({ skipPrototype: true });
 
     assert.throws(
       () => assertInstance.deepEqual([1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 9, 7]),
@@ -535,8 +535,8 @@ test('Assert class non strict with simple diff', () => {
     assertInstance.deepStrictEqual(arr, buf);
   });
 
-  test('Assert class non strict with skipPrototypeComparison', () => {
-    const assertInstance = new Assert({ strict: false, skipPrototypeComparison: true });
+  test('Assert class non strict with skipPrototype', () => {
+    const assertInstance = new Assert({ strict: false, skipPrototype: true });
 
     assert.throws(
       () => assertInstance.deepStrictEqual([1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 9, 7]),
@@ -547,8 +547,8 @@ test('Assert class non strict with simple diff', () => {
     assertInstance.deepStrictEqual(modern, legacy);
   });
 
-  test('Assert class skipPrototypeComparison with complex objects', () => {
-    const assertInstance = new Assert({ skipPrototypeComparison: true });
+  test('Assert class skipPrototype with complex objects', () => {
+    const assertInstance = new Assert({ skipPrototype: true });
 
     function ComplexAwesomeClass(name, age) {
       this.name = name;
@@ -582,8 +582,8 @@ test('Assert class non strict with simple diff', () => {
     );
   });
 
-  test('Assert class skipPrototypeComparison with arrays and special objects', () => {
-    const assertInstance = new Assert({ skipPrototypeComparison: true });
+  test('Assert class skipPrototype with arrays and special objects', () => {
+    const assertInstance = new Assert({ skipPrototype: true });
 
     const arr1 = [1, 2, 3];
     const arr2 = new Array(1, 2, 3);
@@ -604,8 +604,8 @@ test('Assert class non strict with simple diff', () => {
     );
   });
 
-  test('Assert class skipPrototypeComparison with notDeepStrictEqual', () => {
-    const assertInstance = new Assert({ skipPrototypeComparison: true });
+  test('Assert class skipPrototype with notDeepStrictEqual', () => {
+    const assertInstance = new Assert({ skipPrototype: true });
 
     assert.throws(
       () => assertInstance.notDeepStrictEqual(cool, awesome),
@@ -615,12 +615,12 @@ test('Assert class non strict with simple diff', () => {
     const notAwesome = new AwesomeClass('Not so awesome');
     assertInstance.notDeepStrictEqual(cool, notAwesome);
 
-    const defaultAssertInstance = new Assert({ skipPrototypeComparison: false });
+    const defaultAssertInstance = new Assert({ skipPrototype: false });
     defaultAssertInstance.notDeepStrictEqual(cool, awesome);
   });
 
-  test('Assert class skipPrototypeComparison with mixed types', () => {
-    const assertInstance = new Assert({ skipPrototypeComparison: true });
+  test('Assert class skipPrototype with mixed types', () => {
+    const assertInstance = new Assert({ skipPrototype: true });
 
     const obj1 = { value: 42, nested: { prop: 'test' } };
 

--- a/test/parallel/test-assert-class.js
+++ b/test/parallel/test-assert-class.js
@@ -478,3 +478,46 @@ test('Assert class non strict with simple diff', () => {
     );
   }
 });
+
+// Shared setup for skipPrototypeComparison tests
+{
+  const message = 'Expected values to be strictly deep-equal:\n' +
+  '+ actual - expected\n' +
+  '\n' +
+  '  [\n' +
+  '    1,\n' +
+  '    2,\n' +
+  '    3,\n' +
+  '    4,\n' +
+  '    5,\n' +
+  '+   6,\n' +
+  '-   9,\n' +
+  '    7\n' +
+  '  ]\n';
+
+  function CoolClass(name) { this.name = name; }
+
+  function AwesomeClass(name) { this.name = name; }
+  const person = new CoolClass('Assert is inspiring');
+  const user = new AwesomeClass('Assert is inspiring');
+
+  test('Assert class strict with skipPrototypeComparison', () => {
+    const assertInstance = new Assert({ skipPrototypeComparison: true });
+
+    assert.throws(
+      () => assertInstance.deepEqual([1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 9, 7]),
+      { message }
+    );
+    assertInstance.deepEqual(person, user);
+  });
+
+  test('Assert class non strict with skipPrototypeComparison', () => {
+    const assertInstance = new Assert({ strict: false, skipPrototypeComparison: true });
+
+    assert.throws(
+      () => assertInstance.deepStrictEqual([1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 9, 7]),
+      { message }
+    );
+    assertInstance.deepStrictEqual(person, user);
+  });
+}

--- a/test/parallel/test-util-isDeepStrictEqual.js
+++ b/test/parallel/test-util-isDeepStrictEqual.js
@@ -94,9 +94,9 @@ function notUtilIsDeepStrict(a, b) {
   utilIsDeepStrict(a, b);
 }
 
-// Handle `skipPrototypeComparison` for isDeepStrictEqual
+// Handle `skipPrototype` for isDeepStrictEqual
 {
-  test('util.isDeepStrictEqual with skipPrototypeComparison', () => {
+  test('util.isDeepStrictEqual with skipPrototype', () => {
     function ClassA(value) { this.value = value; }
 
     function ClassB(value) { this.value = value; }
@@ -123,7 +123,7 @@ function notUtilIsDeepStrict(a, b) {
     assert.strictEqual(util.isDeepStrictEqual(uint8Array, buffer, true), true);
   });
 
-  test('util.isDeepStrictEqual skipPrototypeComparison with complex scenarios', () => {
+  test('util.isDeepStrictEqual skipPrototype with complex scenarios', () => {
     class Parent { constructor(x) { this.x = x; } }
     class Child extends Parent { constructor(x, y) { super(x); this.y = y; } }
 

--- a/test/parallel/test-util-isDeepStrictEqual.js
+++ b/test/parallel/test-util-isDeepStrictEqual.js
@@ -94,9 +94,9 @@ function notUtilIsDeepStrict(a, b) {
   utilIsDeepStrict(a, b);
 }
 
-// Handle `skipPrototypeComparison` option for isDeepStrictEqual
+// Handle `skipPrototypeComparison` for isDeepStrictEqual
 {
-  test('util.isDeepStrictEqual with skipPrototypeComparison option', () => {
+  test('util.isDeepStrictEqual with skipPrototypeComparison', () => {
     function ClassA(value) { this.value = value; }
 
     function ClassB(value) { this.value = value; }
@@ -105,22 +105,22 @@ function notUtilIsDeepStrict(a, b) {
     const objB = new ClassB(42);
 
     assert.strictEqual(util.isDeepStrictEqual(objA, objB), false);
-    assert.strictEqual(util.isDeepStrictEqual(objA, objB, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(objA, objB, true), true);
 
     const objC = new ClassB(99);
-    assert.strictEqual(util.isDeepStrictEqual(objA, objC, { skipPrototypeComparison: true }), false);
+    assert.strictEqual(util.isDeepStrictEqual(objA, objC, true), false);
 
     const nestedA = { obj: new ClassA('test'), num: 123 };
     const nestedB = { obj: new ClassB('test'), num: 123 };
 
     assert.strictEqual(util.isDeepStrictEqual(nestedA, nestedB), false);
-    assert.strictEqual(util.isDeepStrictEqual(nestedA, nestedB, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(nestedA, nestedB, true), true);
 
     const uint8Array = new Uint8Array([1, 2, 3]);
     const buffer = Buffer.from([1, 2, 3]);
 
     assert.strictEqual(util.isDeepStrictEqual(uint8Array, buffer), false);
-    assert.strictEqual(util.isDeepStrictEqual(uint8Array, buffer, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(uint8Array, buffer, true), true);
   });
 
   test('util.isDeepStrictEqual skipPrototypeComparison with complex scenarios', () => {
@@ -135,24 +135,23 @@ function notUtilIsDeepStrict(a, b) {
     const legacyParent = new LegacyParent(1);
 
     assert.strictEqual(util.isDeepStrictEqual(modernParent, legacyParent), false);
-    assert.strictEqual(util.isDeepStrictEqual(modernParent, legacyParent, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(modernParent, legacyParent, true), true);
 
     const modern = new Child(1, 2);
     const legacy = new LegacyChild(1, 2);
 
     assert.strictEqual(util.isDeepStrictEqual(modern, legacy), false);
-    assert.strictEqual(util.isDeepStrictEqual(modern, legacy, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(modern, legacy, true), true);
 
     const literal = { name: 'test', values: [1, 2, 3] };
     function Constructor(name, values) { this.name = name; this.values = values; }
     const constructed = new Constructor('test', [1, 2, 3]);
 
     assert.strictEqual(util.isDeepStrictEqual(literal, constructed), false);
-    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, { skipPrototypeComparison: true }), true);
+    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, true), true);
 
-    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, {}), false);
-    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, { skipPrototypeComparison: false }), false);
-    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, { skipPrototypeComparison: null }), false);
-    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, { skipPrototypeComparison: undefined }), false);
+    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, false), false);
+    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, null), false);
+    assert.strictEqual(util.isDeepStrictEqual(literal, constructed, undefined), false);
   });
 }


### PR DESCRIPTION
Adds a new `skipPrototype ` option to `util.isDeepStrictEqual()` and `assert.deepStrictEqual()` methods that allows skipping prototype and constructor comparison during deep strict equality checks.

cc @BridgeAR 