### PR TITLE
crypto: refactor subtle methods to use synchronous import

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -363,7 +363,7 @@ async function deriveKey(
   }
 
   return ReflectApply(
-    importKey,
+    importKeySync,
     this,
     ['raw-secret', bits, derivedKeyAlgorithm, extractable, keyUsages],
   );
@@ -708,40 +708,7 @@ function aliasKeyFormat(format) {
   }
 }
 
-async function importKey(
-  format,
-  keyData,
-  algorithm,
-  extractable,
-  keyUsages) {
-  if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
-
-  webidl ??= require('internal/crypto/webidl');
-  const prefix = "Failed to execute 'importKey' on 'SubtleCrypto'";
-  webidl.requiredArguments(arguments.length, 4, { prefix });
-  format = webidl.converters.KeyFormat(format, {
-    prefix,
-    context: '1st argument',
-  });
-  const type = format === 'jwk' ? 'JsonWebKey' : 'BufferSource';
-  keyData = webidl.converters[type](keyData, {
-    prefix,
-    context: '2nd argument',
-  });
-  algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
-    prefix,
-    context: '3rd argument',
-  });
-  extractable = webidl.converters.boolean(extractable, {
-    prefix,
-    context: '4th argument',
-  });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
-    prefix,
-    context: '5th argument',
-  });
-
-  algorithm = normalizeAlgorithm(algorithm, 'importKey');
+function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
   let result;
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
@@ -853,6 +820,48 @@ async function importKey(
   return result;
 }
 
+async function importKey(
+  format,
+  keyData,
+  algorithm,
+  extractable,
+  keyUsages) {
+  if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
+
+  webidl ??= require('internal/crypto/webidl');
+  const prefix = "Failed to execute 'importKey' on 'SubtleCrypto'";
+  webidl.requiredArguments(arguments.length, 4, { prefix });
+  format = webidl.converters.KeyFormat(format, {
+    prefix,
+    context: '1st argument',
+  });
+  const type = format === 'jwk' ? 'JsonWebKey' : 'BufferSource';
+  keyData = webidl.converters[type](keyData, {
+    prefix,
+    context: '2nd argument',
+  });
+  algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
+    prefix,
+    context: '3rd argument',
+  });
+  extractable = webidl.converters.boolean(extractable, {
+    prefix,
+    context: '4th argument',
+  });
+  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+    prefix,
+    context: '5th argument',
+  });
+
+  algorithm = normalizeAlgorithm(algorithm, 'importKey');
+
+  return ReflectApply(
+    importKeySync,
+    this,
+    [format, keyData, algorithm, extractable, keyUsages],
+  );
+}
+
 // subtle.wrapKey() is essentially a subtle.exportKey() followed
 // by a subtle.encrypt().
 async function wrapKey(format, key, wrappingKey, algorithm) {
@@ -959,6 +968,8 @@ async function unwrapKey(
     unwrapAlgo = normalizeAlgorithm(unwrapAlgo, 'decrypt');
   }
 
+  unwrappedKeyAlgo = normalizeAlgorithm(unwrappedKeyAlgo, 'importKey');
+
   let keyData = await cipherOrWrap(
     kWebCryptoCipherDecrypt,
     unwrapAlgo,
@@ -979,7 +990,7 @@ async function unwrapKey(
   }
 
   return ReflectApply(
-    importKey,
+    importKeySync,
     this,
     [format, keyData, unwrappedKeyAlgo, extractable, keyUsages],
   );
@@ -1287,8 +1298,8 @@ async function encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKe
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  const sharedKey = await ReflectApply(
-    importKey,
+  const sharedKey = ReflectApply(
+    importKeySync,
     this,
     ['raw-secret', encapsulateBits.sharedKey, normalizedSharedKeyAlgorithm, extractable, usages],
   );
@@ -1408,7 +1419,7 @@ async function decapsulateKey(
   }
 
   return ReflectApply(
-    importKey,
+    importKeySync,
     this,
     ['raw-secret', decapsulatedBits, normalizedSharedKeyAlgorithm, extractable, usages],
   );


### PR DESCRIPTION
Refs: #59699

This changes encapsulateKey, decapsulateKey, deriveKey, and unwrapKey to not use the whole SubtleCrypto.prototype.importKey machinery but instead just its synchronous internal bits.