### PR TITLE
http: don't set keepAliveTimeoutBuffer twice.

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -25,7 +25,6 @@ const {
   ArrayIsArray,
   Error,
   MathMin,
-  NumberIsFinite,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ReflectApply,
@@ -556,12 +555,6 @@ function Server(options, requestListener) {
 
   storeHTTPOptions.call(this, options);
 
-  // Optional buffer added to the keep-alive timeout when setting socket timeouts.
-  // Helps reduce ECONNRESET errors from clients by extending the internal timeout.
-  // Default is 1000ms if not specified.
-  const buf = options.keepAliveTimeoutBuffer;
-  this.keepAliveTimeoutBuffer =
-  (typeof buf === 'number' && NumberIsFinite(buf) && buf >= 0) ? buf : 1000;
   net.Server.call(
     this,
     { allowHalfOpen: true, noDelay: options.noDelay ?? true,
@@ -1031,6 +1024,9 @@ function resOnFinish(req, res, socket, state, server) {
       // Extend the internal timeout by the configured buffer to reduce
       // the likelihood of ECONNRESET errors.
       // This allows fine-tuning beyond the advertised keepAliveTimeout.
+      validateInteger(server.keepAliveTimeoutBuffer, 'keepAliveTimeoutBuffer', 0);
+      validateInteger(server.keepAliveTimeout, 'keepAliveTimeout', 0);
+
       socket.setTimeout(server.keepAliveTimeout + server.keepAliveTimeoutBuffer);
       state.keepAliveTimeoutSet = true;
     }


### PR DESCRIPTION
It's already set once through storeHTTPOptions

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
