### PR TITLE
repl: do not cause side effects in tab completion

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1754,10 +1754,25 @@ function findExpressionCompleteTarget(code) {
     return findExpressionCompleteTarget(argumentCode);
   }
 
+  // Walk the AST for the current block of code, and check whether it contains any
+  // statement or expression type that would potentially have side effects if evaluated.
+  let isAllowed = true;
+  const disallow = () => isAllowed = false;
+  acornWalk.simple(lastBodyStatement, {
+    ForInStatement: disallow,
+    ForOfStatement: disallow,
+    CallExpression: disallow,
+    AssignmentExpression: disallow,
+    UpdateExpression: disallow,
+  });
+  if (!isAllowed) {
+    return null;
+  }
+
   // If any of the above early returns haven't activated then it means that
   // the potential complete target is the full code (e.g. the code represents
   // a simple partial identifier, a member expression, etc...)
-  return code;
+  return code.slice(lastBodyStatement.start, lastBodyStatement.end);
 }
 
 /**

--- a/test/parallel/test-repl-completion-on-getters-disabled.js
+++ b/test/parallel/test-repl-completion-on-getters-disabled.js
@@ -61,10 +61,6 @@ describe('REPL completion in relation of getters', () => {
     test(`completions are generated for properties that don't trigger getters`, () => {
       runCompletionTests(
         `
-        function getFooKey() {
-          return "foo";
-        }
-
         const fooKey = "foo";
 
         const keys = {
@@ -90,7 +86,6 @@ describe('REPL completion in relation of getters', () => {
           ["objWithGetters[keys['foo key']].b", ["objWithGetters[keys['foo key']].bar"]],
           ['objWithGetters[fooKey].b', ['objWithGetters[fooKey].bar']],
           ["objWithGetters['f' + 'oo'].b", ["objWithGetters['f' + 'oo'].bar"]],
-          ['objWithGetters[getFooKey()].b', ['objWithGetters[getFooKey()].bar']],
         ]);
     });
 

--- a/test/parallel/test-repl-tab-complete-getter-error.js
+++ b/test/parallel/test-repl-tab-complete-getter-error.js
@@ -27,7 +27,6 @@ async function runTest() {
 
   await new Promise((resolve, reject) => {
     replServer.eval(`
-     const getNameText = () => "name";
      const foo = { get name() { throw new Error(); } };
      `, replServer.context, '', (err) => {
       if (err) {
@@ -38,7 +37,7 @@ async function runTest() {
     });
   });
 
-  ['foo.name.', 'foo["name"].', 'foo[getNameText()].'].forEach((test) => {
+  ['foo.name.', 'foo["name"].'].forEach((test) => {
     replServer.complete(
       test,
       common.mustCall((error, data) => {

--- a/test/parallel/test-repl-tab-complete-nosideeffects.js
+++ b/test/parallel/test-repl-tab-complete-nosideeffects.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const common = require('../common');
+const ArrayStream = require('../common/arraystream');
+const { describe, it } = require('node:test');
+const assert = require('assert');
+
+const repl = require('repl');
+
+function prepareREPL() {
+  const input = new ArrayStream();
+  const replServer = repl.start({
+    prompt: '',
+    input,
+    output: process.stdout,
+    allowBlockingCompletions: true,
+  });
+
+  // Some errors are passed to the domain, but do not callback
+  replServer._domain.on('error', assert.ifError);
+
+  return { replServer, input };
+}
+
+function getNoResultsFunction() {
+  return common.mustSucceed((data) => {
+    assert.deepStrictEqual(data[0], []);
+  });
+}
+
+describe('REPL tab completion without side effects', () => {
+  const setup = [
+    'globalThis.counter = 0;',
+    'function incCounter() { return counter++; }',
+    'const arr = [{ bar: "baz" }];',
+  ];
+  // None of these expressions should affect the value of `counter`
+  for (const code of [
+    'incCounter().',
+    'a=(counter+=1).foo.',
+    'a=(counter++).foo.',
+    'for((counter)of[1])foo.',
+    'for((counter)in{1:1})foo.',
+    'arr[incCounter()].b',
+  ]) {
+    it(`does not evaluate with side effects (${code})`, async () => {
+      const { replServer, input } = prepareREPL();
+      input.run(setup);
+
+      replServer.complete(code, getNoResultsFunction());
+
+      assert.strictEqual(replServer.context.counter, 0);
+      replServer.close();
+    });
+  }
+});


### PR DESCRIPTION
A number of recent changes to the REPL tab completion logic have introduced the ability for completion to cause side effects, specifically, calling arbitrary functions or variable assignments/updates.

This was first introduced in 07220230d9 and the problem exacerbated in 8ba66c5e7b367. Our team noticed this because our tests started failing when attempting to update to Node.js 20.19.5.

Some recent commits, such as 1093f38c437 or 69453378fc44af, have messages or PR descriptions that imply the intention to avoid side effects, which I can can generally be agreed upon is in line with the expectations that a user has of autocomplete functionality.
However, some of the tests introduced in those commts specifically verify that side effects *can* happen under specific circunmstances. I am assuming here that this is unintentional, and the corresponding tests have been removed/replaced in this commit.

Fixes: https://github.com/nodejs/node/issues/58903
Fixes: https://github.com/nodejs/node/issues/59731
Refs: https://github.com/nodejs/node/pull/58709
Refs: https://github.com/nodejs/node/pull/58775
Refs: https://github.com/nodejs/node/pull/57909
Refs: https://github.com/nodejs/node/pull/58891

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
