### PR TITLE
fs: fix wrong order of file names in cpSync error message

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3270,7 +3270,7 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
       std::string message =
           "Cannot overwrite non-directory %s with directory %s";
       return THROW_ERR_FS_CP_DIR_TO_NON_DIR(
-          env, message.c_str(), src_path_str, dest_path_str);
+          env, message.c_str(), dest_path_str, src_path_str);
     }
 
     if (!src_is_dir && dest_is_dir) {

--- a/test/parallel/test-fs-cp-sync-copy-directory-to-file-error.mjs
+++ b/test/parallel/test-fs-cp-sync-copy-directory-to-file-error.mjs
@@ -14,11 +14,11 @@ if (isInsideDirWithUnusualChars) {
 tmpdir.refresh();
 
 {
-  const src = nextdir();
+  const src = nextdir('FIRST_DIRECTORY');
   mkdirSync(src, mustNotMutateObjectDeep({ recursive: true }));
   const dest = fixtures.path('copy/kitchen-sink/README.md');
   assert.throws(
     () => cpSync(src, dest),
-    { code: 'ERR_FS_CP_DIR_TO_NON_DIR' }
+    { code: 'ERR_FS_CP_DIR_TO_NON_DIR', message: /non-directory .*README\.md with directory .*FIRST_DIRECTORY/ }
   );
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
