### PR TITLE
test: skip tests failing when run under root

### DIFF
--- a/test/parallel/test-fs-mkdtempDisposableSync.js
+++ b/test/parallel/test-fs-mkdtempDisposableSync.js
@@ -68,7 +68,7 @@ if (isMainThread) {
 
 // Errors from cleanup are thrown
 // It is difficult to arrange for rmdir to fail on windows
-if (!common.isWindows) {
+if (!common.isWindows && process.getuid() !== 0) {
   const base = fs.mkdtempDisposableSync(tmpdir.resolve('foo.'));
 
   // On Unix we can prevent removal by making the parent directory read-only

--- a/test/parallel/test-fs-promises-mkdtempDisposable.js
+++ b/test/parallel/test-fs-promises-mkdtempDisposable.js
@@ -68,7 +68,7 @@ async function chdirDoesNotAffectRemoval() {
 
 async function errorsAreReThrown() {
   // It is difficult to arrange for rmdir to fail on windows
-  if (common.isWindows) return;
+  if (common.isWindows || process.getuid() === 0) return;
   const base = await fsPromises.mkdtempDisposable(tmpdir.resolve('foo.'));
 
   // On Unix we can prevent removal by making the parent directory read-only


### PR DESCRIPTION
Removing read-only directory doesn't fail for root.