### PR TITLE
path: change `win32.join` to use array

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -24,6 +24,7 @@
 const {
   ArrayPrototypeIncludes,
   ArrayPrototypeJoin,
+  ArrayPrototypePush,
   ArrayPrototypeSlice,
   FunctionPrototypeBind,
   StringPrototypeCharCodeAt,
@@ -511,13 +512,13 @@ const win32 = {
       const arg = args[i];
       validateString(arg, 'path');
       if (arg.length > 0) {
-        path.push(arg);
+        ArrayPrototypePush(path, arg);
       }
     }
 
     if (path.length === 0)
       return '.';
-    
+
     const firstPart = path[0];
     let joined = ArrayPrototypeJoin(path, '\\');
 


### PR DESCRIPTION
Change `win32.join` to use `array.join` instead of additional assignment.

benchmark result (local):
```
                                                                                                 confidence improvement accuracy (*)   (**)   (***)
path/join-win32.js n=100000 paths='C:\\foo|bar||baz\\asdf|quux|..'                                      ***      6.08 %       ±2.09% ±2.82%  ±3.73%
```