### PR TITLE
doc: update BUILDING to reflect Clang 19 changes

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -155,7 +155,7 @@ Depending on the host platform, the selection of toolchains may vary.
 
 | Operating System | Compiler Versions                                              |
 | ---------------- | -------------------------------------------------------------- |
-| Linux            | GCC >= 12.2                                                    |
+| Linux            | GCC >= 12.2 or Clang >= 19.1                                   |
 | Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |
 | macOS            | Xcode >= 16.3 (Apple LLVM >= 19)                               |
 
@@ -163,17 +163,17 @@ Depending on the host platform, the selection of toolchains may vary.
 
 Binaries at <https://nodejs.org/download/release/> are produced on:
 
-| Binary package          | Platform and Toolchain                                    |
-| ----------------------- | --------------------------------------------------------- |
-| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                   |
-| darwin-x64              | macOS 13, Xcode 16 with -mmacosx-version-min=13.5         |
-| darwin-arm64 (and .pkg) | macOS 13 (arm64), Xcode 16 with -mmacosx-version-min=13.5 |
-| linux-arm64             | RHEL 8 with gcc-toolset-12[^6]                            |
-| linux-ppc64le           | RHEL 8 with gcc-toolset-12[^6]                            |
-| linux-s390x             | RHEL 8 with gcc-toolset-12[^6]                            |
-| linux-x64               | RHEL 8 with gcc-toolset-12[^6]                            |
-| win-arm64               | Windows Server 2022 (x64) with Visual Studio 2022         |
-| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022         |
+| Binary package          | Platform and Toolchain                                        |
+| ----------------------- | ------------------------------------------------------------- |
+| aix-ppc64               | AIX 7.2 TL04 on PPC64BE with GCC 12[^5]                       |
+| darwin-x64              | macOS 13, Xcode 16 with -mmacosx-version-min=13.5             |
+| darwin-arm64 (and .pkg) | macOS 13 (arm64), Xcode 16 with -mmacosx-version-min=13.5     |
+| linux-arm64             | RHEL 8 with Clang 19.1 and gcc-toolset-14-libatomic-devel[^6] |
+| linux-ppc64le           | RHEL 8 with Clang 19.1 and gcc-toolset-14-libatomic-devel[^6] |
+| linux-s390x             | RHEL 8 with Clang 19.1 and gcc-toolset-14-libatomic-devel[^6] |
+| linux-x64               | RHEL 8 with Clang 19.1 and gcc-toolset-14-libatomic-devel[^6] |
+| win-arm64               | Windows Server 2022 (x64) with Visual Studio 2022             |
+| win-x64                 | Windows Server 2022 (x64) with Visual Studio 2022             |
 
 <!--lint disable final-definition-->
 
@@ -232,7 +232,7 @@ Consult previous versions of this document for older versions of Node.js:
 
 #### Unix prerequisites
 
-* `gcc` and `g++` >= 12.2 or newer
+* `gcc` and `g++` >= 12.2 or `clang` and `clang++` >= 19.1
 * GNU Make 3.81 or newer
 * [A supported version of Python][Python versions]
   * For test coverage, your Python installation must include pip.


### PR DESCRIPTION
Clang 19.1 is now tested and supported on Linux, and used to
build some releases.

Refs: https://github.com/nodejs/build/issues/4091

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
