### PR TITLE
http: unbreak keepAliveTimeoutBuffer

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -1027,11 +1027,16 @@ function resOnFinish(req, res, socket, state, server) {
       socket.end();
     }
   } else if (state.outgoing.length === 0) {
-    if (server.keepAliveTimeout && typeof socket.setTimeout === 'function') {
+    const keepAliveTimeout = NumberIsFinite(server.keepAliveTimeout) && server.keepAliveTimeout >= 0 ?
+      server.keepAliveTimeout : 0;
+    const keepAliveTimeoutBuffer = NumberIsFinite(server.keepAliveTimeoutBuffer) && server.keepAliveTimeoutBuffer >= 0 ?
+      server.keepAliveTimeoutBuffer : 1e3;
+
+    if (keepAliveTimeout && typeof socket.setTimeout === 'function') {
       // Extend the internal timeout by the configured buffer to reduce
       // the likelihood of ECONNRESET errors.
       // This allows fine-tuning beyond the advertised keepAliveTimeout.
-      socket.setTimeout(server.keepAliveTimeout + server.keepAliveTimeoutBuffer);
+      socket.setTimeout(keepAliveTimeout + keepAliveTimeoutBuffer);
       state.keepAliveTimeoutSet = true;
     }
   } else {


### PR DESCRIPTION
If keepAliveTimeoutBuffer is set to undefined (for whatever reason) or if not set at all we will throw.

This adds a guard.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
