### PR TITLE
sea: support argv in sea config

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -314,6 +314,8 @@ An alias of [`assert.ok()`][].
 
 ## `assert.deepEqual(actual, expected[, message])`
 
+<!--lint disable nodejs-yaml-comments-->
+
 <!-- YAML
 added: v0.1.21
 changes:

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -29,6 +29,7 @@ enum class SeaFlags : uint32_t {
   kUseCodeCache = 1 << 2,
   kIncludeAssets = 1 << 3,
   kIncludeExecArgv = 1 << 4,
+  kIncludeUserArgv = 1 << 5,
 };
 
 enum class SeaExecArgvExtension : uint8_t {
@@ -45,6 +46,7 @@ struct SeaResource {
   std::optional<std::string_view> code_cache;
   std::unordered_map<std::string_view, std::string_view> assets;
   std::vector<std::string_view> exec_argv;
+  std::vector<std::string_view> user_argv;
 
   bool use_snapshot() const;
   bool use_code_cache() const;

--- a/test/fixtures/sea-argv.js
+++ b/test/fixtures/sea-argv.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+
+process.emitWarning('This warning should not be shown in the output', 'TestWarning');
+
+console.log('process.argv:', JSON.stringify(process.argv));
+
+assert.deepStrictEqual(process.argv.slice(2), [
+  'user-arg1',
+  'user-arg2',
+  'user-arg3'
+]);
+
+console.log('multiple argv test passed');

--- a/test/sequential/test-single-executable-application-argv.js
+++ b/test/sequential/test-single-executable-application-argv.js
@@ -1,0 +1,65 @@
+'use strict';
+
+require('../common');
+
+const {
+  generateSEA,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the argv functionality with multiple arguments in single executable applications.
+
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const { copyFileSync, writeFileSync, existsSync } = require('fs');
+const { spawnSyncAndAssert, spawnSyncAndExitWithoutError } = require('../common/child_process');
+const { join } = require('path');
+const assert = require('assert');
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+tmpdir.refresh();
+
+// Copy test fixture to working directory
+copyFileSync(fixtures.path('sea-argv.js'), tmpdir.resolve('sea.js'));
+
+writeFileSync(configFile, `
+{
+  "main": "sea.js",
+  "output": "sea-prep.blob",
+  "disableExperimentalSEAWarning": true,
+  "argv": ["user-arg1", "user-arg2"]
+}
+`);
+
+spawnSyncAndExitWithoutError(
+  process.execPath,
+  ['--experimental-sea-config', 'sea-config.json'],
+  { cwd: tmpdir.path });
+
+assert(existsSync(seaPrepBlob));
+
+generateSEA(outputFile, process.execPath, seaPrepBlob);
+
+// Test that multiple argv are properly applied
+spawnSyncAndAssert(
+  outputFile,
+  [
+    'user-arg3',
+  ],
+  {
+    env: {
+      ...process.env,
+      NODE_NO_WARNINGS: '0',
+      COMMON_DIRECTORY: join(__dirname, '..', 'common'),
+      NODE_DEBUG_NATIVE: 'SEA',
+    }
+  },
+  {
+    stdout: /multiple argv test passed/,
+    trim: true,
+  });

--- a/test/sequential/test-single-executable-application-snapshot-with-argv.js
+++ b/test/sequential/test-single-executable-application-snapshot-with-argv.js
@@ -1,0 +1,109 @@
+'use strict';
+
+require('../common');
+
+const {
+  generateSEA,
+  skipIfSingleExecutableIsNotSupported,
+} = require('../common/sea');
+
+skipIfSingleExecutableIsNotSupported();
+
+// This tests the snapshot support in single executable applications.
+
+const tmpdir = require('../common/tmpdir');
+const { writeFileSync, existsSync } = require('fs');
+const {
+  spawnSyncAndAssert,
+  spawnSyncAndExit,
+} = require('../common/child_process');
+const assert = require('assert');
+
+const configFile = tmpdir.resolve('sea-config.json');
+const seaPrepBlob = tmpdir.resolve('sea-prep.blob');
+const outputFile = tmpdir.resolve(process.platform === 'win32' ? 'sea.exe' : 'sea');
+
+{
+  tmpdir.refresh();
+
+  writeFileSync(tmpdir.resolve('snapshot.js'), '', 'utf-8');
+  writeFileSync(configFile, `
+  {
+    "main": "snapshot.js",
+    "output": "sea-prep.blob",
+    "useSnapshot": true
+  }
+  `);
+
+  spawnSyncAndExit(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path
+    },
+    {
+      status: 1,
+      signal: null,
+      stderr: /snapshot\.js does not invoke v8\.startupSnapshot\.setDeserializeMainFunction\(\)/
+    });
+}
+
+{
+  tmpdir.refresh();
+  const code = `
+  const {
+    setDeserializeMainFunction,
+  } = require('v8').startupSnapshot;
+  
+  setDeserializeMainFunction(() => {
+    console.log('Hello from snapshot with config argv:', process.argv[2]);
+  });
+  `;
+
+  writeFileSync(tmpdir.resolve('snapshot.js'), code, 'utf-8');
+  writeFileSync(configFile, `
+  {
+    "main": "snapshot.js",
+    "output": "sea-prep.blob",
+    "useSnapshot": true,
+    "argv": ["user-arg"]
+  }
+  `);
+
+  spawnSyncAndAssert(
+    process.execPath,
+    ['--experimental-sea-config', 'sea-config.json'],
+    {
+      cwd: tmpdir.path,
+      env: {
+        NODE_DEBUG_NATIVE: 'SEA',
+        ...process.env,
+      },
+    },
+    {
+      stderr: /Single executable application is an experimental feature/
+    });
+
+  assert(existsSync(seaPrepBlob));
+
+  generateSEA(outputFile, process.execPath, seaPrepBlob);
+
+  spawnSyncAndAssert(
+    outputFile,
+    {
+      env: {
+        NODE_DEBUG_NATIVE: 'SEA,MKSNAPSHOT',
+        ...process.env,
+      }
+    },
+    {
+      trim: true,
+      stdout: 'Hello from snapshot with config argv: user-arg',
+      stderr(output) {
+        assert.doesNotMatch(
+          output,
+          /Single executable application is an experimental feature/);
+      }
+    }
+  );
+}


### PR DESCRIPTION
implement argv config for sea including snapshot

this resolves todo message:
```cc
// TODO(joyeecheung): make the arguments configurable through the JSON
// config or a programmatic API.
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
