### PR TITLE
build: add the missing macro definitions for OpenHarmony

### DIFF
--- a/deps/ngtcp2/ngtcp2.gyp
+++ b/deps/ngtcp2/ngtcp2.gyp
@@ -123,7 +123,7 @@
             },
           },
         }],
-        ['OS=="linux" or OS=="android"', {
+        ['OS=="linux" or OS=="android" or OS=="openharmony"', {
           'defines': [
             'HAVE_ARPA_INET_H',
             'HAVE_NETINET_IN_H',
@@ -205,7 +205,7 @@
         ['OS!="win"', {
           'defines': ['HAVE_UNISTD_H']
         }],
-        ['OS=="linux" or OS=="android"', {
+        ['OS=="linux" or OS=="android" or OS=="openharmony"', {
           'defines': [
             'HAVE_ARPA_INET_H',
             'HAVE_NETINET_IN_H',


### PR DESCRIPTION
This is the unfinished work of PR https://github.com/nodejs/node/pull/59547. I missed this modification point, and it was my mistake. Now I have rechecked and confirmed that there are no other omissions except for this one.