### PR TITLE
tools: copyedit `build-tarball.yml`

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -52,16 +52,14 @@ jobs:
       - name: Make tarball
         run: |
           export DISTTYPE=nightly
-          export DATESTRING=`date "+%Y-%m-%d"`
+          export DATESTRING=$(date "+%Y-%m-%d")
           export COMMIT=$(git rev-parse --short=10 "$GITHUB_SHA")
-          ./configure && make tar -j8 SKIP_XZ=1
-          mkdir tarballs
-          mv *.tar.gz tarballs
+          ./configure && make tar -j4 SKIP_XZ=1
       - name: Upload tarball artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: tarballs
-          path: tarballs
+          path: '*.tar.gz'
           compression-level: 0
   test-tarball-linux:
     needs: build-tarball
@@ -97,11 +95,10 @@ jobs:
           path: tarballs
       - name: Extract tarball
         run: |
-          tar xzf tarballs/*.tar.gz -C $RUNNER_TEMP
-          echo "TAR_DIR=$RUNNER_TEMP/`basename tarballs/*.tar.gz .tar.gz`" >> $GITHUB_ENV
+          tar xzf tarballs/*.tar.gz -C "$RUNNER_TEMP"
+          echo "TAR_DIR=$RUNNER_TEMP/$(basename tarballs/*.tar.gz .tar.gz)" >> "$GITHUB_ENV"
       - name: Build
-        run: |
-          make -C "$TAR_DIR" build-ci -j4 V=1
+        run: make -C "$TAR_DIR" build-ci -j4 V=1
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           persist-credentials: false
@@ -113,5 +110,4 @@ jobs:
           mv tools/eslint "$TAR_DIR/tools"
           mv tools/eslint-rules "$TAR_DIR/tools"
       - name: Test
-        run: |
-          make -C "$TAR_DIR" run-ci -j4 V=1 TEST_CI_ARGS="-p dots --measure-flakiness 9"
+        run: make -C "$TAR_DIR" run-ci -j4 V=1 TEST_CI_ARGS="-p dots --measure-flakiness 9"


### PR DESCRIPTION
Make shell commands in `build-tarball.yml` meet our shellcheck guidelines:

- Use `$(...)` notation instead of legacy backticks.
- Double quote to prevent globbing and word splitting.

Also, some small changes to make this workflow closer than other workflows we have:

- Use `-j4` instead of `-j8` – GH runners typically do not have 8 cores anyway.
- Single line commands are no longer written as multi-line YAML string.
- Remove unnecessary `tarballs` dir creation.

Refs: https://www.shellcheck.net/wiki/SC2006
Refs: https://www.shellcheck.net/wiki/SC2086

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
