### PR TITLE
zlib: implement fast path for crc32

### DIFF
--- a/benchmark/zlib/crc32.js
+++ b/benchmark/zlib/crc32.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const common = require('../common.js');
+const { crc32 } = require('zlib');
+
+// Benchmark crc32 on Buffer and String inputs across sizes.
+// Iteration count is scaled inversely with input length to keep runtime sane.
+// Example:
+//   node benchmark/zlib/crc32.js type=buffer len=4096 n=4000000
+//   ./out/Release/node benchmark/zlib/crc32.js --test
+
+const bench = common.createBenchmark(main, {
+  type: ['buffer', 'string'],
+  len: [32, 256, 4096, 65536],
+  n: [4e6],
+});
+
+function makeBuffer(size) {
+  const buf = Buffer.allocUnsafe(size);
+  for (let i = 0; i < size; i++) buf[i] = (i * 1103515245 + 12345) & 0xff;
+  return buf;
+}
+
+function makeAsciiString(size) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+  let out = '';
+  for (let i = 0, j = 0; i < size; i++, j = (j + 7) % chars.length) out += chars[j];
+  return out;
+}
+
+function main({ type, len, n }) {
+  // Scale iterations so that total processed bytes roughly constant around n*4096 bytes.
+  const scale = 4096 / len;
+  const iters = Math.max(1, Math.floor(n * scale));
+
+  const data = type === 'buffer' ? makeBuffer(len) : makeAsciiString(len);
+
+  let acc = 0;
+  for (let i = 0; i < Math.min(iters, 10000); i++) acc ^= crc32(data, 0);
+
+  bench.start();
+  let sum = 0;
+  for (let i = 0; i < iters; i++) sum ^= crc32(data, 0);
+  bench.end(iters);
+
+  if (sum === acc - 1) process.stderr.write('');
+}

--- a/test/sequential/test-zlib-crc32-fast-api.js
+++ b/test/sequential/test-zlib-crc32-fast-api.js
@@ -1,0 +1,26 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+{
+  function testFastPath() {
+    const expected = 0xd87f7e0c; // zlib.crc32('test', 0)
+    assert.strictEqual(zlib.crc32('test', 0), expected);
+    return expected;
+  }
+
+  eval('%PrepareFunctionForOptimization(zlib.crc32)');
+  testFastPath();
+  eval('%OptimizeFunctionOnNextCall(zlib.crc32)');
+  testFastPath();
+  testFastPath();
+
+  if (common.isDebug) {
+    const { internalBinding } = require('internal/test/binding');
+    const { getV8FastApiCallCount } = internalBinding('debug');
+    assert.strictEqual(getV8FastApiCallCount('zlib.crc32'), 2);
+  }
+}


### PR DESCRIPTION
Full benchmarks:

```sh
node % node benchmark/zlib/crc32.js
zlib/crc32.js n=4000000 len=32 type="buffer": 37,396,444.66876052
zlib/crc32.js n=4000000 len=256 type="buffer": 34,468,122.98396251
zlib/crc32.js n=4000000 len=4096 type="buffer": 4,642,218.20245069
zlib/crc32.js n=4000000 len=65536 type="buffer": 414,698.94918172585
zlib/crc32.js n=4000000 len=32 type="string": 27,544,938.95769763
zlib/crc32.js n=4000000 len=256 type="string": 13,360,556.974013995
zlib/crc32.js n=4000000 len=4096 type="string": 3,598,194.020364296
zlib/crc32.js n=4000000 len=65536 type="string": 247,640.72679581624
node % ./node benchmark/zlib/crc32.js
zlib/crc32.js n=4000000 len=32 type="buffer": 47,694,181.36925779
zlib/crc32.js n=4000000 len=256 type="buffer": 41,584,645.71789544
zlib/crc32.js n=4000000 len=4096 type="buffer": 6,730,071.896634588
zlib/crc32.js n=4000000 len=65536 type="buffer": 418,870.8874470888
zlib/crc32.js n=4000000 len=32 type="string": 34,844,878.72618591
zlib/crc32.js n=4000000 len=256 type="string": 24,282,737.956485238
zlib/crc32.js n=4000000 len=4096 type="string": 2,102,476.0393039584
zlib/crc32.js n=4000000 len=65536 type="string": 139,447.8455126307
```