### PR TITLE
src: remove unnecessary `Environment::GetCurrent()` calls

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1678,7 +1678,6 @@ Maybe<int> ReverseTraits::Parse(QueryReverseWrap* wrap,
 namespace {
 template <class Wrap>
 static void Query(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   ChannelWrap* channel;
   ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
 
@@ -1690,7 +1689,7 @@ static void Query(const FunctionCallbackInfo<Value>& args) {
   Local<String> string = args[1].As<String>();
   auto wrap = std::make_unique<Wrap>(channel, req_wrap_obj);
 
-  node::Utf8Value utf8name(env->isolate(), string);
+  node::Utf8Value utf8name(args.GetIsolate(), string);
   auto plain_name = utf8name.ToStringView();
   std::string name = ada::idna::to_ascii(plain_name);
   channel->ModifyActivityQueryCount(1);
@@ -1704,7 +1703,6 @@ static void Query(const FunctionCallbackInfo<Value>& args) {
 
   args.GetReturnValue().Set(err);
 }
-
 
 void AfterGetAddrInfo(uv_getaddrinfo_t* req, int status, struct addrinfo* res) {
   auto cleanup = OnScopeLeave([&]() { uv_freeaddrinfo(res); });

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -805,12 +805,11 @@ void KeyObjectHandle::InitECRaw(const FunctionCallbackInfo<Value>& args) {
 }
 
 void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
   ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsString());
-  Utf8Value name(env->isolate(), args[0]);
+  Utf8Value name(args.GetIsolate(), args[0]);
 
   ArrayBufferOrViewContents<unsigned char> key_data(args[1]);
   KeyType type = FromV8Value<KeyType>(args[2]);
@@ -850,12 +849,11 @@ void KeyObjectHandle::InitEDRaw(const FunctionCallbackInfo<Value>& args) {
 
 #if OPENSSL_WITH_PQC
 void KeyObjectHandle::InitPqcRaw(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   KeyObjectHandle* key;
   ASSIGN_OR_RETURN_UNWRAP(&key, args.This());
 
   CHECK(args[0]->IsString());
-  Utf8Value name(env->isolate(), args[0]);
+  Utf8Value name(args.GetIsolate(), args[0]);
 
   ArrayBufferOrViewContents<unsigned char> key_data(args[1]);
   KeyType type = FromV8Value<KeyType>(args[2]);

--- a/src/crypto/crypto_tls.cc
+++ b/src/crypto/crypto_tls.cc
@@ -1357,8 +1357,6 @@ void TLSWrap::EnableALPNCb(const FunctionCallbackInfo<Value>& args) {
 }
 
 void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   TLSWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
@@ -1368,15 +1366,13 @@ void TLSWrap::GetServername(const FunctionCallbackInfo<Value>& args) {
   if (servername.has_value()) {
     auto& sn = servername.value();
     args.GetReturnValue().Set(
-        OneByteString(env->isolate(), sn.data(), sn.length()));
+        OneByteString(args.GetIsolate(), sn.data(), sn.length()));
   } else {
     args.GetReturnValue().Set(false);
   }
 }
 
 void TLSWrap::SetServername(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   TLSWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(&wrap, args.This());
 
@@ -1387,7 +1383,7 @@ void TLSWrap::SetServername(const FunctionCallbackInfo<Value>& args) {
 
   CHECK(wrap->ssl_);
 
-  Utf8Value servername(env->isolate(), args[0].As<String>());
+  Utf8Value servername(args.GetIsolate(), args[0].As<String>());
   SSL_set_tlsext_host_name(wrap->ssl_.get(), *servername);
 }
 
@@ -2095,11 +2091,10 @@ void TLSWrap::GetEphemeralKeyInfo(const FunctionCallbackInfo<Value>& args) {
 }
 
 void TLSWrap::GetProtocol(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   TLSWrap* w;
   ASSIGN_OR_RETURN_UNWRAP(&w, args.This());
   args.GetReturnValue().Set(
-      OneByteString(env->isolate(), SSL_get_version(w->ssl_.get())));
+      OneByteString(args.GetIsolate(), SSL_get_version(w->ssl_.get())));
 }
 
 void TLSWrap::GetALPNNegotiatedProto(const FunctionCallbackInfo<Value>& args) {

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -714,9 +714,8 @@ void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
 }
 
 void SecureHeapUsed(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   args.GetReturnValue().Set(
-      BigInt::New(env->isolate(), DataPointer::GetSecureHeapUsed()));
+      BigInt::New(args.GetIsolate(), DataPointer::GetSecureHeapUsed()));
 }
 }  // namespace
 

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -115,8 +115,7 @@ void BindingData::EncodeInto(const FunctionCallbackInfo<Value>& args) {
 // Encode a single string to a UTF-8 Uint8Array (not Buffer).
 // Used in TextEncoder.prototype.encode.
 void BindingData::EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
   CHECK_GE(args.Length(), 1);
   CHECK(args[0]->IsString());
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -455,10 +455,9 @@ void HistogramImpl::GetCount(const FunctionCallbackInfo<Value>& args) {
 }
 
 void HistogramImpl::GetCountBigInt(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(
-      BigInt::NewFromUnsigned(env->isolate(), (*histogram)->Count()));
+      BigInt::NewFromUnsigned(args.GetIsolate(), (*histogram)->Count()));
 }
 
 void HistogramImpl::GetMin(const FunctionCallbackInfo<Value>& args) {
@@ -468,9 +467,9 @@ void HistogramImpl::GetMin(const FunctionCallbackInfo<Value>& args) {
 }
 
 void HistogramImpl::GetMinBigInt(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
-  args.GetReturnValue().Set(BigInt::New(env->isolate(), (*histogram)->Min()));
+  args.GetReturnValue().Set(
+      BigInt::New(args.GetIsolate(), (*histogram)->Min()));
 }
 
 void HistogramImpl::GetMax(const FunctionCallbackInfo<Value>& args) {
@@ -480,9 +479,9 @@ void HistogramImpl::GetMax(const FunctionCallbackInfo<Value>& args) {
 }
 
 void HistogramImpl::GetMaxBigInt(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
-  args.GetReturnValue().Set(BigInt::New(env->isolate(), (*histogram)->Max()));
+  args.GetReturnValue().Set(
+      BigInt::New(args.GetIsolate(), (*histogram)->Max()));
 }
 
 void HistogramImpl::GetMean(const FunctionCallbackInfo<Value>& args) {
@@ -497,10 +496,9 @@ void HistogramImpl::GetExceeds(const FunctionCallbackInfo<Value>& args) {
 }
 
 void HistogramImpl::GetExceedsBigInt(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   args.GetReturnValue().Set(
-      BigInt::New(env->isolate(), (*histogram)->Exceeds()));
+      BigInt::New(args.GetIsolate(), (*histogram)->Exceeds()));
 }
 
 void HistogramImpl::GetStddev(const FunctionCallbackInfo<Value>& args) {
@@ -518,12 +516,11 @@ void HistogramImpl::GetPercentile(const FunctionCallbackInfo<Value>& args) {
 
 void HistogramImpl::GetPercentileBigInt(
     const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   CHECK(args[0]->IsNumber());
   double percentile = args[0].As<Number>()->Value();
   int64_t value = (*histogram)->Percentile(percentile);
-  args.GetReturnValue().Set(BigInt::New(env->isolate(), value));
+  args.GetReturnValue().Set(BigInt::New(args.GetIsolate(), value));
 }
 
 void HistogramImpl::GetPercentiles(const FunctionCallbackInfo<Value>& args) {

--- a/src/inspector_js_api.cc
+++ b/src/inspector_js_api.cc
@@ -128,14 +128,13 @@ class JSBindingsConnection : public BaseObject {
   }
 
   static void Dispatch(const FunctionCallbackInfo<Value>& info) {
-    Environment* env = Environment::GetCurrent(info);
     JSBindingsConnection* session;
     ASSIGN_OR_RETURN_UNWRAP(&session, info.This());
     CHECK(info[0]->IsString());
 
     if (session->session_) {
       session->session_->Dispatch(
-          ToInspectorString(env->isolate(), info[0])->string());
+          ToInspectorString(info.GetIsolate(), info[0])->string());
     }
   }
 

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -47,7 +47,6 @@ namespace {
 void Concat(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
-  Environment* env = Environment::GetCurrent(context);
 
   CHECK(args[0]->IsArray());
   Local<Array> array = args[0].As<Array>();
@@ -84,7 +83,7 @@ void Concat(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::shared_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-      env->isolate(), total, BackingStoreInitializationMode::kUninitialized);
+      isolate, total, BackingStoreInitializationMode::kUninitialized);
   uint8_t* ptr = static_cast<uint8_t*>(store->Data());
   for (size_t n = 0; n < views.size(); n++) {
     uint8_t* from =
@@ -93,7 +92,7 @@ void Concat(const FunctionCallbackInfo<Value>& args) {
     ptr += views[n].length;
   }
 
-  args.GetReturnValue().Set(ArrayBuffer::New(env->isolate(), std::move(store)));
+  args.GetReturnValue().Set(ArrayBuffer::New(isolate, std::move(store)));
 }
 
 void BlobFromFilePath(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -327,10 +327,10 @@ void Transcode(const FunctionCallbackInfo<Value>&args) {
 }
 
 void ICUErrorName(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsInt32());
   UErrorCode status = static_cast<UErrorCode>(args[0].As<Int32>()->Value());
-  args.GetReturnValue().Set(OneByteString(env->isolate(), u_errorName(status)));
+  args.GetReturnValue().Set(
+      OneByteString(args.GetIsolate(), u_errorName(status)));
 }
 
 }  // anonymous namespace
@@ -372,10 +372,8 @@ size_t Converter::max_char_size() const {
 }
 
 void ConverterObject::Has(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-
   CHECK_GE(args.Length(), 1);
-  Utf8Value label(env->isolate(), args[0]);
+  Utf8Value label(args.GetIsolate(), args[0]);
 
   UErrorCode status = U_ZERO_ERROR;
   ConverterPointer conv(ucnv_open(*label, &status));
@@ -645,13 +643,12 @@ static int GetColumnWidth(UChar32 codepoint,
 
 // Returns the column width for the given String.
 static void GetStringWidth(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsString());
 
   bool ambiguous_as_full_width = args[1]->IsTrue();
   bool expand_emoji_sequence = !args[2]->IsBoolean() || args[2]->IsTrue();
 
-  TwoByteValue value(env->isolate(), args[0]);
+  TwoByteValue value(args.GetIsolate(), args[0]);
   // reinterpret_cast is required by windows to compile
   UChar* str = reinterpret_cast<UChar*>(*value);
   static_assert(sizeof(*str) == sizeof(**value),

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -107,8 +107,7 @@ static void GetOSInformation(const FunctionCallbackInfo<Value>& args) {
 }
 
 static void GetCPUInfo(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
 
   uv_cpu_info_t* cpu_infos;
   int count;

--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -82,8 +82,7 @@ static void GetCompact(const FunctionCallbackInfo<Value>& info) {
 
 static void SetCompact(const FunctionCallbackInfo<Value>& info) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
-  Environment* env = Environment::GetCurrent(info);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = info.GetIsolate();
   bool compact = info[0]->ToBoolean(isolate)->Value();
   per_process::cli_options->report_compact = compact;
 }
@@ -122,9 +121,8 @@ static void GetDirectory(const FunctionCallbackInfo<Value>& info) {
 
 static void SetDirectory(const FunctionCallbackInfo<Value>& info) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
-  Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsString());
-  Utf8Value dir(env->isolate(), info[0].As<String>());
+  Utf8Value dir(info.GetIsolate(), info[0].As<String>());
   per_process::cli_options->report_directory = *dir;
 }
 
@@ -140,9 +138,8 @@ static void GetFilename(const FunctionCallbackInfo<Value>& info) {
 
 static void SetFilename(const FunctionCallbackInfo<Value>& info) {
   Mutex::ScopedLock lock(per_process::cli_options_mutex);
-  Environment* env = Environment::GetCurrent(info);
   CHECK(info[0]->IsString());
-  Utf8Value name(env->isolate(), info[0].As<String>());
+  Utf8Value name(info.GetIsolate(), info[0].As<String>());
   per_process::cli_options->report_filename = *name;
 }
 

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1768,15 +1768,14 @@ void DatabaseSync::EnableLoadExtension(
     const FunctionCallbackInfo<Value>& args) {
   DatabaseSync* db;
   ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
-  Environment* env = Environment::GetCurrent(args);
+  auto isolate = args.GetIsolate();
   if (!args[0]->IsBoolean()) {
-    THROW_ERR_INVALID_ARG_TYPE(env->isolate(),
+    THROW_ERR_INVALID_ARG_TYPE(isolate,
                                "The \"allow\" argument must be a boolean.");
     return;
   }
 
   const int enable = args[0].As<Boolean>()->Value();
-  auto isolate = env->isolate();
 
   if (db->allow_load_extension_ == false && enable == true) {
     THROW_ERR_INVALID_STATE(

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -129,8 +129,7 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
 namespace task_queue {
 
 static void EnqueueMicrotask(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
 
   CHECK(args[0]->IsFunction());
 

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -399,9 +399,7 @@ static void DefineLazyProperties(const FunctionCallbackInfo<Value>& args) {
   // enumerable: Whether the property should be enumerable.
   CHECK(args.Length() == 3 || args[3]->IsBoolean());
 
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-  auto context = isolate->GetCurrentContext();
+  auto context = args.GetIsolate()->GetCurrentContext();
 
   auto target = args[0].As<Object>();
   Local<Value> id = args[1];

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -183,10 +183,8 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
 }
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Local<Integer> result =
-      Integer::NewFromUnsigned(env->isolate(),
-                               ScriptCompiler::CachedDataVersionTag());
+  Local<Integer> result = Integer::NewFromUnsigned(
+      args.GetIsolate(), ScriptCompiler::CachedDataVersionTag());
   args.GetReturnValue().Set(result);
 }
 

--- a/src/node_wasm_web_api.cc
+++ b/src/node_wasm_web_api.cc
@@ -86,7 +86,7 @@ void WasmStreamingObject::SetURL(const FunctionCallbackInfo<Value>& args) {
 
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsString());
-  Utf8Value url(Environment::GetCurrent(args)->isolate(), args[0]);
+  Utf8Value url(args.GetIsolate(), args[0]);
   obj->streaming_->SetUrl(url.out(), url.length());
 }
 

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -60,12 +60,11 @@ using v8::String;
 using v8::Value;
 
 void GetErrMessage(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
   int err = args[0].As<v8::Int32>()->Value();
   CHECK_LT(err, 0);
   char message[50];
   uv_strerror_r(err, message, sizeof(message));
-  args.GetReturnValue().Set(OneByteString(env->isolate(), message));
+  args.GetReturnValue().Set(OneByteString(args.GetIsolate(), message));
 }
 
 void ErrName(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
This PR refactors several call sites that only needed a `v8::Isolate*` but first fetched an `Environment*` via `Environment::GetCurrent(info)` and then called `env->isolate()`. These occurrences are simplified to use `info.GetIsolate()` directly, as follows:

```patch
-  Environment* env = Environment::GetCurrent(info);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = info.GetIsolate();
```

`Environment::GetCurrent(const FunctionCallbackInfo<Value>& info)` is defined as:
```c++
inline Environment* Environment::GetCurrent(
    const v8::FunctionCallbackInfo<v8::Value>& info) {
  return GetCurrent(info.GetIsolate()->GetCurrentContext());
}
```
