### PR TITLE
tools: skip test-internet workflow for draft PRs

### DIFF
--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   test-internet:
-    if: (github.repository == 'nodejs/node' || github.event_name != 'schedule') && github.event.pull_request.draft == false
+    if: github.event_name == 'schedule' && github.repository == 'nodejs/node' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0


### PR DESCRIPTION
When this was opened as draft: 
<img width="427" height="43" alt="CleanShot 2025-09-09 at 08 58 45" src="https://github.com/user-attachments/assets/3ea00a71-8b60-4d7d-ad9f-4c0750b5104e" />
