### PR TITLE
[v22.x backport] lib: handle windows reserved device names on UNC

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -291,10 +291,16 @@ const win32 = {
                 j++;
               }
               if (j === len || j !== last) {
-                // We matched a UNC root
-                device =
-                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-                rootEnd = j;
+                if (firstPart !== '.' && firstPart !== '?') {
+                  // We matched a UNC root
+                  device =
+                    `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+                  rootEnd = j;
+                } else {
+                  // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                  device = `\\\\${firstPart}`;
+                  rootEnd = 4;
+                }
               }
             }
           }
@@ -404,17 +410,22 @@ const win32 = {
                    !isPathSeparator(StringPrototypeCharCodeAt(path, j))) {
               j++;
             }
-            if (j === len) {
-              // We matched a UNC root only
-              // Return the normalized version of the UNC root since there
-              // is nothing left to process
-              return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
-            }
-            if (j !== last) {
-              // We matched a UNC root with leftovers
-              device =
-                `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
-              rootEnd = j;
+            if (j === len || j !== last) {
+              if (firstPart === '.' || firstPart === '?') {
+                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                device = `\\\\${firstPart}`;
+                rootEnd = 4;
+              } else if (j === len) {
+                // We matched a UNC root only
+                // Return the normalized version of the UNC root since there
+                // is nothing left to process
+                return `\\\\${firstPart}\\${StringPrototypeSlice(path, last)}\\`;
+              } else {
+                // We matched a UNC root with leftovers
+                device =
+                  `\\\\${firstPart}\\${StringPrototypeSlice(path, last, j)}`;
+                rootEnd = j;
+              }
             }
           }
         }

--- a/lib/path.js
+++ b/lib/path.js
@@ -415,6 +415,13 @@ const win32 = {
                 // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
                 device = `\\\\${firstPart}`;
                 rootEnd = 4;
+                const colonIndex = StringPrototypeIndexOf(path, ':');
+                // Special case: handle \\?\COM1: or similar reserved device paths
+                const possibleDevice = StringPrototypeSlice(path, 4, colonIndex + 1);
+                if (isWindowsReservedName(possibleDevice, possibleDevice.length - 1)) {
+                  device = `\\\\?\\${possibleDevice}`;
+                  rootEnd = 4 + possibleDevice.length;
+                }
               } else if (j === len) {
                 // We matched a UNC root only
                 // Return the normalized version of the UNC root since there
@@ -571,6 +578,36 @@ const win32 = {
       // Replace the slashes if needed
       if (slashCount >= 2)
         joined = `\\${StringPrototypeSlice(joined, slashCount)}`;
+    }
+
+    // Skip normalization when reserved device names are present
+    const parts = [];
+    let part = '';
+
+    for (let i = 0; i < joined.length; i++) {
+      if (joined[i] === '\\') {
+        if (part) parts.push(part);
+        part = '';
+        // Skip consecutive backslashes
+        while (i + 1 < joined.length && joined[i + 1] === '\\') i++;
+      } else {
+        part += joined[i];
+      }
+    }
+    // Add the final part if any
+    if (part) parts.push(part);
+
+    // Check if any part has a Windows reserved name
+    if (parts.some((p) => {
+      const colonIndex = StringPrototypeIndexOf(p, ':');
+      return colonIndex !== -1 && isWindowsReservedName(p, colonIndex);
+    })) {
+      // Replace forward slashes with backslashes
+      let result = '';
+      for (let i = 0; i < joined.length; i++) {
+        result += joined[i] === '/' ? '\\' : joined[i];
+      }
+      return result;
     }
 
     return win32.normalize(joined);

--- a/src/path.cc
+++ b/src/path.cc
@@ -170,9 +170,16 @@ std::string PathResolve(Environment* env,
               j++;
             }
             if (j == len || j != last) {
-              // We matched a UNC root
-              device = "\\\\" + firstPart + "\\" + path.substr(last, j - last);
-              rootEnd = j;
+              if (firstPart != "." && firstPart != "?") {
+                // We matched a UNC root
+                device =
+                    "\\\\" + firstPart + "\\" + path.substr(last, j - last);
+                rootEnd = j;
+              } else {
+                // We matched a device root (e.g. \\\\.\\PHYSICALDRIVE0)
+                device = "\\\\" + firstPart;
+                rootEnd = 4;
+              }
             }
           }
         }

--- a/test/cctest/test_path.cc
+++ b/test/cctest/test_path.cc
@@ -39,6 +39,10 @@ TEST_F(PathTest, PathResolve) {
   EXPECT_EQ(
       PathResolve(*env, {"C:\\foo\\tmp.3\\", "..\\tmp.3\\cycles\\root.js"}),
       "C:\\foo\\tmp.3\\cycles\\root.js");
+  EXPECT_EQ(PathResolve(*env, {"\\\\.\\PHYSICALDRIVE0"}),
+            "\\\\.\\PHYSICALDRIVE0");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\PHYSICALDRIVE0"}),
+            "\\\\?\\PHYSICALDRIVE0");
 #else
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "../", "file/"}), "/var/file");
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "/../", "file/"}), "/file");

--- a/test/parallel/test-path-join.js
+++ b/test/parallel/test-path-join.js
@@ -110,6 +110,14 @@ joinTests.push([
       [['c:.', 'file'], 'c:file'],
       [['c:', '/'], 'c:\\'],
       [['c:', 'file'], 'c:\\file'],
+      // UNC path join tests (Windows)
+      [['\\server\\share', 'file.txt'], '\\server\\share\\file.txt'],
+      [['\\server\\share', 'folder', 'another.txt'], '\\server\\share\\folder\\another.txt'],
+      [['\\server\\share', 'COM1:'], '\\server\\share\\COM1:'],
+      [['\\server\\share', 'path', 'LPT1:'], '\\server\\share\\path\\LPT1:'],
+      [['\\fileserver\\public\\uploads', 'CON:..\\..\\..\\private\\db.conf'],
+       '\\fileserver\\public\\uploads\\CON:..\\..\\..\\private\\db.conf'],
+
       // Path traversal in previous versions of Node.js.
       [['./upload', '/../C:/Windows'], '.\\C:\\Windows'],
       [['upload', '../', 'C:foo'], '.\\C:foo'],

--- a/test/parallel/test-path-makelong.js
+++ b/test/parallel/test-path-makelong.js
@@ -79,7 +79,7 @@ assert.strictEqual(path.win32.toNamespacedPath('\\\\foo\\bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
 assert.strictEqual(path.win32.toNamespacedPath('//foo//bar'),
                    '\\\\?\\UNC\\foo\\bar\\');
-assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo\\');
+assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\foo'), '\\\\?\\foo');
 assert.strictEqual(path.win32.toNamespacedPath('\\\\?\\c:\\Windows/System'), '\\\\?\\c:\\Windows\\System');
 assert.strictEqual(path.win32.toNamespacedPath(null), null);
 assert.strictEqual(path.win32.toNamespacedPath(true), true);

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -40,6 +40,8 @@ assert.strictEqual(
   '..\\..\\..\\..\\baz'
 );
 assert.strictEqual(path.win32.normalize('foo/bar\\baz'), 'foo\\bar\\baz');
+assert.strictEqual(path.win32.normalize('\\\\.\\foo'), '\\\\.\\foo');
+assert.strictEqual(path.win32.normalize('\\\\.\\foo\\'), '\\\\.\\foo\\');
 
 // Tests related to CVE-2024-36139. Path traversal should not result in changing
 // the root directory on Windows.
@@ -58,10 +60,10 @@ assert.strictEqual(path.win32.normalize('/test/../??/D:/Test'), '\\??\\D:\\Test'
 assert.strictEqual(path.win32.normalize('/test/../?/D:/Test'), '\\?\\D:\\Test');
 assert.strictEqual(path.win32.normalize('//test/../??/D:/Test'), '\\\\test\\..\\??\\D:\\Test');
 assert.strictEqual(path.win32.normalize('//test/../?/D:/Test'), '\\\\test\\..\\?\\D:\\Test');
-assert.strictEqual(path.win32.normalize('\\\\?\\test/../?/D:/Test'), '\\\\?\\test\\?\\D:\\Test');
-assert.strictEqual(path.win32.normalize('\\\\?\\test/../../?/D:/Test'), '\\\\?\\test\\?\\D:\\Test');
-assert.strictEqual(path.win32.normalize('\\\\.\\test/../?/D:/Test'), '\\\\.\\test\\?\\D:\\Test');
-assert.strictEqual(path.win32.normalize('\\\\.\\test/../../?/D:/Test'), '\\\\.\\test\\?\\D:\\Test');
+assert.strictEqual(path.win32.normalize('\\\\?\\test/../?/D:/Test'), '\\\\?\\?\\D:\\Test');
+assert.strictEqual(path.win32.normalize('\\\\?\\test/../../?/D:/Test'), '\\\\?\\?\\D:\\Test');
+assert.strictEqual(path.win32.normalize('\\\\.\\test/../?/D:/Test'), '\\\\.\\?\\D:\\Test');
+assert.strictEqual(path.win32.normalize('\\\\.\\test/../../?/D:/Test'), '\\\\.\\?\\D:\\Test');
 assert.strictEqual(path.win32.normalize('//server/share/dir/../../../?/D:/file'),
                    '\\\\server\\share\\?\\D:\\file');
 assert.strictEqual(path.win32.normalize('//server/goodshare/../badshare/file'),

--- a/test/parallel/test-path-resolve.js
+++ b/test/parallel/test-path-resolve.js
@@ -35,6 +35,8 @@ const resolveTests = [
      [['c:/', '///some//dir'], 'c:\\some\\dir'],
      [['C:\\foo\\tmp.3\\', '..\\tmp.3\\cycles\\root.js'],
       'C:\\foo\\tmp.3\\cycles\\root.js'],
+     [['\\\\.\\PHYSICALDRIVE0'], '\\\\.\\PHYSICALDRIVE0'],
+     [['\\\\?\\PHYSICALDRIVE0'], '\\\\?\\PHYSICALDRIVE0'],
     ],
   ],
   [ path.posix.resolve,

--- a/test/parallel/test-path-win32-normalize-device-names.js
+++ b/test/parallel/test-path-win32-normalize-device-names.js
@@ -9,6 +9,19 @@ if (!common.isWindows) {
 }
 
 const normalizeDeviceNameTests = [
+  // UNC paths: \\server\share\... is a Windows UNC path, where 'server' is the network server name and 'share'
+  // is the shared folder. These are used for network file access and are subject to reserved device name
+  // checks after the share.
+  { input: '\\\\server\\share\\COM1:', expected: '\\\\server\\share\\COM1:' },
+  { input: '\\\\server\\share\\PRN:', expected: '\\\\server\\share\\PRN:' },
+  { input: '\\\\server\\share\\AUX:', expected: '\\\\server\\share\\AUX:' },
+  { input: '\\\\server\\share\\LPT1:', expected: '\\\\server\\share\\LPT1:' },
+  { input: '\\\\server\\share\\COM1:\\foo\\bar', expected: '\\\\server\\share\\COM1:\\foo\\bar' },
+  { input: '\\\\server\\share\\path\\COM1:', expected: '\\\\server\\share\\path\\COM1:' },
+  { input: '\\\\server\\share\\COM1:..\\..\\..\\..\\Windows', expected: '\\\\server\\share\\Windows' },
+  { input: '\\\\server\\share\\path\\to\\LPT9:..\\..\\..\\..\\..\\..\\..\\..\\..\\file.txt',
+    expected: '\\\\server\\share\\file.txt' },
+
   { input: 'CON', expected: 'CON' },
   { input: 'con', expected: 'con' },
   { input: 'CON:', expected: '.\\CON:.' },
@@ -81,6 +94,8 @@ const normalizeDeviceNameTests = [
   // Test cases from original vulnerability reports or similar scenarios
   { input: 'COM1:.\\..\\..\\foo.js', expected: '.\\COM1:..\\..\\foo.js' },
   { input: 'LPT1:.\\..\\..\\another.txt', expected: '.\\LPT1:..\\..\\another.txt' },
+  // UNC paths
+  { input: '\\\\?\\COM1:.\\..\\..\\foo2.js', expected: '\\\\?\\COM1:\\foo2.js' },
 
   // Paths with device names not at the beginning
   { input: 'C:\\CON', expected: 'C:\\CON' },


### PR DESCRIPTION
This PR backports https://github.com/nodejs/node/pull/59286 and https://github.com/nodejs/node/pull/55623 to v22.x-staging.

I have amended on 4b94984ac531c6c6394f167bf996e8c56c5b419f due to https://github.com/nodejs-private/node-private/pull/555#issuecomment-2601026680