### PR TITLE
benchmark: calibrate config cluster/echo.js

### DIFF
--- a/benchmark/cluster/echo.js
+++ b/benchmark/cluster/echo.js
@@ -8,7 +8,7 @@ if (cluster.isPrimary) {
     payload: ['string', 'object'],
     sendsPerBroadcast: [1, 10],
     serialization: ['json', 'advanced'],
-    n: [1e5],
+    n: [1e3],
   });
 
   function main({


### PR DESCRIPTION
I ran the calibrate-n script to find the optimal n value for the cluster/echo.js benchmark.
As a result, it was confirmed that with n=1000, the average Coefficient of Variation (CV) is a stable 2.16%, so I am applying this value.

<img width="1534" height="1540" alt="image" src="https://github.com/user-attachments/assets/414b1ba9-b59b-4ed6-8067-166c3a6fe70e" />
