### PR TITLE
sqlite: fix crash session extension callbacks with workers

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1748,8 +1748,9 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
         // The filterCallback should be updated to avoid the check and
         // propagate the error correctly.
         Local<Value> argv[] = {String::NewFromUtf8(env->isolate(),
-                                                   item.c_str(),
-                                                   NewStringType::kNormal)
+                                                   item.data(),
+                                                   NewStringType::kNormal,
+                                                   static_cast<int>(item.size()))
                                    .ToLocalChecked()};
         Local<Value> result =
             filterFunc->Call(env->context(), Null(env->isolate()), 1, argv)

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1648,7 +1648,7 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
 }
 
 struct ConflictCallbackContext {
-  std::function<bool(std::string)> filterCallback;
+  std::function<bool(std::string_view)> filterCallback;
   std::function<int(int)> conflictCallback;
 };
 

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1647,26 +1647,28 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
   job->ScheduleBackup();
 }
 
+struct ConflictCallbackContext {
+  std::function<bool(std::string)> filterCallback;
+  std::function<int(int)> conflictCallback;
+};
+
 // the reason for using static functions here is that SQLite needs a
 // function pointer
-static std::function<int(int)> conflictCallback;
 
 static int xConflict(void* pCtx, int eConflict, sqlite3_changeset_iter* pIter) {
-  if (!conflictCallback) return SQLITE_CHANGESET_ABORT;
-  return conflictCallback(eConflict);
+  auto ctx = static_cast<ConflictCallbackContext*>(pCtx);
+  if (!ctx->conflictCallback) return SQLITE_CHANGESET_ABORT;
+  return ctx->conflictCallback(eConflict);
 }
 
-static std::function<bool(std::string)> filterCallback;
-
 static int xFilter(void* pCtx, const char* zTab) {
-  if (!filterCallback) return 1;
-
-  return filterCallback(zTab) ? 1 : 0;
+  auto ctx = static_cast<ConflictCallbackContext*>(pCtx);
+  if (!ctx->filterCallback) return 1;
+  return ctx->filterCallback(zTab) ? 1 : 0;
 }
 
 void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
-  conflictCallback = nullptr;
-  filterCallback = nullptr;
+  ConflictCallbackContext context;
 
   DatabaseSync* db;
   ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
@@ -1702,7 +1704,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
         return;
       }
       Local<Function> conflictFunc = conflictValue.As<Function>();
-      conflictCallback = [env, conflictFunc](int conflictType) -> int {
+      context.conflictCallback = [env, conflictFunc](int conflictType) -> int {
         Local<Value> argv[] = {Integer::New(env->isolate(), conflictType)};
         TryCatch try_catch(env->isolate());
         Local<Value> result =
@@ -1740,7 +1742,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
 
       Local<Function> filterFunc = filterValue.As<Function>();
 
-      filterCallback = [env, filterFunc](std::string item) -> bool {
+      context.filterCallback = [env, filterFunc](std::string item) -> bool {
         // TODO(@jasnell): The use of ToLocalChecked here means that if
         // the filter function throws an error the process will crash.
         // The filterCallback should be updated to avoid the check and
@@ -1764,7 +1766,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
       const_cast<void*>(static_cast<const void*>(buf.data())),
       xFilter,
       xConflict,
-      nullptr);
+      static_cast<void*>(&context));
   if (r == SQLITE_OK) {
     args.GetReturnValue().Set(true);
     return;

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1742,7 +1742,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
 
       Local<Function> filterFunc = filterValue.As<Function>();
 
-      context.filterCallback = [env, filterFunc](std::string item) -> bool {
+      context.filterCallback = [env, filterFunc](std::string_view item) -> bool {
         // TODO(@jasnell): The use of ToLocalChecked here means that if
         // the filter function throws an error the process will crash.
         // The filterCallback should be updated to avoid the check and

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1742,16 +1742,18 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
 
       Local<Function> filterFunc = filterValue.As<Function>();
 
-      context.filterCallback = [env, filterFunc](std::string_view item) -> bool {
+      context.filterCallback = [env,
+                                filterFunc](std::string_view item) -> bool {
         // TODO(@jasnell): The use of ToLocalChecked here means that if
         // the filter function throws an error the process will crash.
         // The filterCallback should be updated to avoid the check and
         // propagate the error correctly.
-        Local<Value> argv[] = {String::NewFromUtf8(env->isolate(),
-                                                   item.data(),
-                                                   NewStringType::kNormal,
-                                                   static_cast<int>(item.size()))
-                                   .ToLocalChecked()};
+        Local<Value> argv[] = {
+            String::NewFromUtf8(env->isolate(),
+                                item.data(),
+                                NewStringType::kNormal,
+                                static_cast<int>(item.size()))
+                .ToLocalChecked()};
         Local<Value> result =
             filterFunc->Call(env->context(), Null(env->isolate()), 1, argv)
                 .ToLocalChecked();

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -1,18 +1,10 @@
 'use strict';
 const { spawnPromisified, skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync, constants } = require('node:sqlite');
 const { suite, test } = require('node:test');
 const { pathToFileURL } = require('node:url');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
+const { nextDb } = require('../sqlite/next-db.js');
 
 suite('accessing the node:sqlite module', () => {
   test('cannot be accessed without the node: scheme', (t) => {

--- a/test/sqlite/next-db.js
+++ b/test/sqlite/next-db.js
@@ -1,0 +1,14 @@
+'use strict';
+require('../../common');
+const tmpdir = require('../common/tmpdir');
+const { join } = require('node:path');
+
+let cnt = 0;
+
+tmpdir.refresh();
+
+function nextDb() {
+  return join(tmpdir.path, `database-${cnt++}.db`);
+}
+
+module.exports = { nextDb };

--- a/test/sqlite/next-db.js
+++ b/test/sqlite/next-db.js
@@ -1,5 +1,5 @@
 'use strict';
-require('../../common');
+require('../common');
 const tmpdir = require('../common/tmpdir');
 const { join } = require('node:path');
 

--- a/test/sqlite/worker.js
+++ b/test/sqlite/worker.js
@@ -1,7 +1,7 @@
 // This worker is used for one of the tests in test-sqlite-session.js
 
 'use strict';
-require('../../common');
+require('../common');
 const { parentPort, workerData } = require('worker_threads');
 const { DatabaseSync, constants } = require('node:sqlite');
 const { changeset, mode, dbPath } = workerData;

--- a/test/sqlite/worker.js
+++ b/test/sqlite/worker.js
@@ -1,0 +1,24 @@
+// This worker is used for one of the tests in test-sqlite-session.js
+
+'use strict';
+require('../../common');
+const { parentPort, workerData } = require('worker_threads');
+const { DatabaseSync, constants } = require('node:sqlite');
+const { changeset, mode, dbPath } = workerData;
+
+const db = new DatabaseSync(dbPath);
+
+const options = {};
+if (mode !== constants.SQLITE_CHANGESET_ABORT && mode !== constants.SQLITE_CHANGESET_OMIT) {
+  throw new Error('Unexpected value for mode');
+}
+options.onConflict = () => mode;
+
+try {
+  const result = db.applyChangeset(changeset, options);
+  parentPort.postMessage({ mode, result, error: null });
+} catch (error) {
+  parentPort.postMessage({ mode, result: null, errorMessage: error.message, errcode: error.errcode });
+} finally {
+  db.close();  // Just to make sure it is closed ASAP
+}


### PR DESCRIPTION
This PR fixes the problem that static std::function variables are used to store callbacks. This causes problems when SQLite is used (also) used from a worker and can result in a crash.

This PR stack allocates the callbacks and passes it along to `sqlite3changeset_apply` via the context argument.

It also adds a regression test which crashes out before this change.

Lastly some functionality that is uses in `test/parallel/test-sqlite.js` is now also needed in `test/parallel/test-sqlite-session.js` so I factored that out to a different file.