### PR TITLE
src: include what we use in node_sqlite

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1,18 +1,39 @@
 #include "node_sqlite.h"
-#include <path.h>
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <string_view>
+
+#include "ada.h"
 #include "base_object-inl.h"
-#include "debug_utils-inl.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node.h"
+#include "node_binding.h"
 #include "node_errors.h"
-#include "node_mem-inl.h"
-#include "node_url.h"
+#include "node_internals.h"
+#include "path.h"
+#include "permission/permission.h"
+#include "permission/permission_base.h"
 #include "sqlite3.h"
 #include "threadpoolwork-inl.h"
 #include "util-inl.h"
-
-#include <cinttypes>
+#include "v8-array-buffer.h"
+#include "v8-container.h"
+#include "v8-context.h"
+#include "v8-exception.h"
+#include "v8-function-callback.h"
+#include "v8-function.h"
+#include "v8-isolate.h"
+#include "v8-maybe.h"
+#include "v8-memory-span.h"
+#include "v8-object.h"
+#include "v8-promise.h"
+#include "v8-typed-array.h"
 
 namespace node {
 namespace sqlite {
@@ -218,8 +239,6 @@ void JSValueToSQLiteResult(Isolate* isolate,
         -1);
   }
 }
-
-class DatabaseSync;
 
 inline void THROW_ERR_SQLITE_ERROR(Isolate* isolate, DatabaseSync* db) {
   if (db->ShouldIgnoreSQLiteError()) {

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -3,15 +3,33 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "base_object.h"
-#include "node_mem.h"
-#include "sqlite3.h"
-#include "util.h"
-
 #include <map>
+#include <optional>
+#include <set>
+#include <string>
 #include <unordered_set>
+#include <utility>
+
+#include "base_object.h"
+#include "memory_tracker.h"
+#include "sqlite3.h"
+#include "v8-local-handle.h"
+#include "v8-persistent-handle.h"
+#include "v8-primitive.h"
+#include "v8-template.h"
+#include "v8-value.h"
+
+namespace v8 {
+class Function;
+template <typename T>
+class FunctionCallbackInfo;
+class Object;
+}  // namespace v8
 
 namespace node {
+
+class Environment;
+
 namespace sqlite {
 
 class DatabaseOpenConfiguration {


### PR DESCRIPTION
I'm playing with https://include-what-you-use.org/

With the changes here, it still suggests me to do the following, but it doesn't seem right to me (and to the C++ linter):

```
(../../src/node_sqlite.h has correct #includes/fwd-decls)

../../src/node_sqlite.cc should add these lines:
#include <_inttypes.h>                   // for PRId64
#include <_string.h>                     // for memcpy
#include <__hash_table>                  // for operator!=
#include "env.h"                         // for Environment
#include "util.h"                        // for Utf8Value, FIXED_ONE_BYTE_ST...
```

/cc @nodejs/cpp-reviewers 