### PR TITLE
repl: fix cpu overhead pasting big strings to the REPL

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -658,6 +658,12 @@ class Interface extends InterfaceConstructor {
 
   [kInsertString](c) {
     this[kBeforeEdit](this.line, this.cursor);
+    if (!this.isCompletionEnabled) {
+      this.line += c;
+      this.cursor += c.length;
+      this[kWriteToOutput](c);
+      return;
+    }
     if (this.cursor < this.line.length) {
       const beg = StringPrototypeSlice(this.line, 0, this.cursor);
       const end = StringPrototypeSlice(

--- a/test/parallel/test-repl-paste-big-data.js
+++ b/test/parallel/test-repl-paste-big-data.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const common = require('../common');
+const repl = require('repl');
+const stream = require('stream');
+const assert = require('assert');
+
+// Pasting big input should not cause the process to have a huge CPU usage.
+
+const cpuUsage = process.cpuUsage();
+
+const r = initRepl();
+r.input.emit('data', 'a'.repeat(2e4) + '\n');
+r.input.emit('data', '.exit\n');
+
+r.once('exit', common.mustCall(() => {
+  const diff = process.cpuUsage(cpuUsage);
+  assert.ok(diff.user < 1e6);
+}));
+
+function initRepl() {
+  const input = new stream();
+  input.write = input.pause = input.resume = () => {};
+  input.readable = true;
+
+  const output = new stream();
+  output.write = () => {};
+  output.writable = true;
+
+  return repl.start({
+    input,
+    output,
+    terminal: true,
+    prompt: ''
+  });
+}


### PR DESCRIPTION
Pasting input should not trigger any completions and other calculations. This is now handled by just writing the string to the terminal in case the user is pasting. As soon as pasting is done, the completions will be re-enabled.

Fixes: https://github.com/nodejs/node/issues/40626
Fixes: https://github.com/nodejs/node/issues/43343

The improvement is not linear (former data was always reparsed), so providing a concrete number is not sufficient. On my machine it is 50x faster for `'a'.repeat(5e4)`.

The test case I added has a big time buffer to not be flaky. On some CPUs, it might however still be flaky and I could not think of a better test case that does not cause it to be flaky or have a long runtime.