### PR TITLE
util: fix debuglog.enabled not being present with callback logger

### DIFF
--- a/lib/internal/util/debuglog.js
+++ b/lib/internal/util/debuglog.js
@@ -94,8 +94,17 @@ function debuglog(set, cb) {
     // Only invokes debuglogImpl() when the debug function is
     // called for the first time.
     debug = debuglogImpl(enabled, set);
-    if (typeof cb === 'function')
+    if (typeof cb === 'function') {
+      ObjectDefineProperty(debug, 'enabled', {
+        __proto__: null,
+        get() {
+          return enabled;
+        },
+        configurable: true,
+        enumerable: true,
+      });
       cb(debug);
+    }
     switch (args.length) {
       case 1: return debug(args[0]);
       case 2: return debug(args[0], args[1]);

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -57,7 +57,7 @@ function parent() {
 
 function test(environ, shouldWrite, section, forceColors = false) {
   let expectErr = '';
-  const expectOut = shouldWrite ? 'enabled\n' : 'disabled\n';
+  const expectOut = shouldWrite ? 'outer enabled\ninner enabled\n' : 'outer disabled\ninner disabled\n';
 
   const spawn = require('child_process').spawn;
   const child = spawn(process.execPath, [__filename, 'child', section], {
@@ -116,11 +116,18 @@ function child(section) {
   Object.defineProperty(process.stderr, 'hasColors', {
     value: tty.WriteStream.prototype.hasColors
   });
+
+  let innerDebug = null;
   // eslint-disable-next-line no-restricted-syntax
   const debug = util.debuglog(section, common.mustCall((cb) => {
     assert.strictEqual(typeof cb, 'function');
+    innerDebug = cb;
   }));
   debug('this', { is: 'a' }, /debugging/);
   debug('num=%d str=%s obj=%j', 1, 'a', { foo: 'bar' });
-  console.log(debug.enabled ? 'enabled' : 'disabled');
+  console.log(debug.enabled ? 'outer enabled' : 'outer disabled');
+  console.log(innerDebug.enabled ? 'inner enabled' : 'inner disabled');
+
+  assert.strictEqual(typeof Object.getOwnPropertyDescriptor(debug, 'enabled').get, 'function');
+  assert.strictEqual(typeof Object.getOwnPropertyDescriptor(innerDebug, 'enabled').get, 'function');
 }


### PR DESCRIPTION
The method returned by the callback is missing the .enabled property. This is added in a consistent way that it also verifies that it's a getter.

Fixes: https://github.com/nodejs/node/issues/56676
