### PR TITLE
util: inspect objects with throwing Symbol.toStringTag

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1186,7 +1186,14 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
     protoProps = undefined;
   }
 
-  let tag = value[SymbolToStringTag];
+  let tag = '';
+
+  try {
+    tag = value[SymbolToStringTag];
+  } catch {
+    // Ignore error.
+  }
+
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (typeof tag !== 'string' ||

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1646,7 +1646,7 @@ util.inspect(process);
     }
   }
 
-  assert.throws(() => util.inspect(new ThrowingClass()), /toStringTag error/);
+  assert.strictEqual(util.inspect(new ThrowingClass()), 'ThrowingClass {}');
 
   const y = {
     get [Symbol.toStringTag]() {
@@ -1655,7 +1655,11 @@ util.inspect(process);
   };
   const x = { y };
   y.x = x;
-  assert.throws(() => util.inspect(x), /TypeError: Converting circular structure to JSON/);
+
+  assert.strictEqual(
+    util.inspect(x),
+    '<ref *1> {\n  y: { x: [Circular *1], Symbol(Symbol.toStringTag): [Getter] }\n}'
+  );
 
   class NotStringClass {
     get [Symbol.toStringTag]() {


### PR DESCRIPTION
`util.inspect()` should handle all kinds of input, even if it is not well defined. Throwing is something that is meant to be worked around in all known cases. This fixes issues inspecting objects where accessing the Symbol.toStringTag would cause an error. The symbol is just ignored in that case.

Refs: https://github.com/nodejs/node/issues/55539
Refs: https://github.com/nodejs/node/pull/55544