### PR TITLE
stream: use new AsyncResource instead of bind

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -45,7 +45,7 @@ const {
 } = require('internal/streams/utils');
 
 // Lazy load
-let AsyncLocalStorage;
+let AsyncResource;
 let addAbortListener;
 
 function isRequest(stream) {
@@ -53,6 +53,14 @@ function isRequest(stream) {
 }
 
 const nop = () => {};
+
+function bindAsyncResource(fn, type) {
+  AsyncResource ??= require('async_hooks').AsyncResource;
+  const resource = new AsyncResource(type);
+  return function (...args) {
+    return resource.runInAsyncScope(fn, this, ...args);
+  }
+}
 
 function eos(stream, options, callback) {
   if (arguments.length === 2) {
@@ -66,8 +74,9 @@ function eos(stream, options, callback) {
   validateFunction(callback, 'callback');
   validateAbortSignal(options.signal, 'options.signal');
 
-  AsyncLocalStorage ??= require('async_hooks').AsyncLocalStorage;
-  callback = once(AsyncLocalStorage.bind(callback));
+  // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
+  // is a bottleneck here.
+  callback = once(bindAsyncResource(callback, 'STREAM_END_OF_STREAM'));
 
   if (isReadableStream(stream) || isWritableStream(stream)) {
     return eosWeb(stream, options, callback);

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -57,9 +57,9 @@ const nop = () => {};
 function bindAsyncResource(fn, type) {
   AsyncResource ??= require('async_hooks').AsyncResource;
   const resource = new AsyncResource(type);
-  return function (...args) {
+  return function(...args) {
     return resource.runInAsyncScope(fn, this, ...args);
-  }
+  };
 }
 
 function eos(stream, options, callback) {


### PR DESCRIPTION
The bind method uses ObjectDefineProperty that shows up in flamegraphs. This changes it to avoid the utility.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
