### PR TITLE
lib: refactor to avoid calling destructured required methods

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -66,6 +66,18 @@ const {
 } = require('internal/crypto/random');
 
 let webidl;
+let rsa;
+let cfrg;
+let ec;
+let mac;
+let aes;
+let c20p;
+let mlDsa;
+let mlKem;
+let dh;
+let hkdf;
+let pbkdf2;
+let argon2;
 
 async function digest(algorithm, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
@@ -122,34 +134,38 @@ async function generateKey(
       // Fall through
     case 'RSA-PSS':
       // Fall through
-    case 'RSA-OAEP':
+    case 'RSA-OAEP': {
       resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/rsa')
-        .rsaKeyGenerate(algorithm, extractable, keyUsages);
+      rsa ??= require('internal/crypto/rsa');
+      result = await rsa.rsaKeyGenerate(algorithm, extractable, keyUsages);
       break;
+    }
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
     case 'X25519':
       // Fall through
-    case 'X448':
+    case 'X448': {
       resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/cfrg')
-        .cfrgGenerateKey(algorithm, extractable, keyUsages);
+      cfrg ??= require('internal/crypto/cfrg');
+      result = await cfrg.cfrgGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     case 'ECDSA':
       // Fall through
-    case 'ECDH':
+    case 'ECDH': {
       resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ec')
-        .ecGenerateKey(algorithm, extractable, keyUsages);
+      ec ??= require('internal/crypto/ec');
+      result = await ec.ecGenerateKey(algorithm, extractable, keyUsages);
       break;
-    case 'HMAC':
+    }
+    case 'HMAC': {
       resultType = 'CryptoKey';
-      result = await require('internal/crypto/mac')
-        .hmacGenerateKey(algorithm, extractable, keyUsages);
+      mac ??= require('internal/crypto/mac');
+      result = await mac.hmacGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -158,41 +174,46 @@ async function generateKey(
       // Fall through
     case 'AES-OCB':
       // Fall through
-    case 'AES-KW':
+    case 'AES-KW': {
       resultType = 'CryptoKey';
-      result = await require('internal/crypto/aes')
-        .aesGenerateKey(algorithm, extractable, keyUsages);
+      aes ??= require('internal/crypto/aes');
+      result = await aes.aesGenerateKey(algorithm, extractable, keyUsages);
       break;
-    case 'ChaCha20-Poly1305':
+    }
+    case 'ChaCha20-Poly1305': {
       resultType = 'CryptoKey';
-      result = await require('internal/crypto/chacha20_poly1305')
-        .c20pGenerateKey(algorithm, extractable, keyUsages);
+      c20p ??= require('internal/crypto/chacha20_poly1305');
+      result = await c20p.c20pGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
+    case 'ML-DSA-87': {
       resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ml_dsa')
-        .mlDsaGenerateKey(algorithm, extractable, keyUsages);
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      result = await mlDsa.mlDsaGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
-    case 'ML-KEM-1024':
+    case 'ML-KEM-1024': {
       resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ml_kem')
-        .mlKemGenerateKey(algorithm, extractable, keyUsages);
+      mlKem ??= require('internal/crypto/ml_kem');
+      result = await mlKem.mlKemGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     case 'KMAC128':
       // Fall through
-    case 'KMAC256':
+    case 'KMAC256': {
       resultType = 'CryptoKey';
-      result = await require('internal/crypto/mac')
-        .kmacGenerateKey(algorithm, extractable, keyUsages);
+      mac ??= require('internal/crypto/mac');
+      result = await mac.kmacGenerateKey(algorithm, extractable, keyUsages);
       break;
+    }
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
@@ -245,22 +266,26 @@ async function deriveBits(algorithm, baseKey, length = null) {
       // Fall through
     case 'X448':
       // Fall through
-    case 'ECDH':
-      return await require('internal/crypto/diffiehellman')
-        .ecdhDeriveBits(algorithm, baseKey, length);
-    case 'HKDF':
-      return await require('internal/crypto/hkdf')
-        .hkdfDeriveBits(algorithm, baseKey, length);
-    case 'PBKDF2':
-      return await require('internal/crypto/pbkdf2')
-        .pbkdf2DeriveBits(algorithm, baseKey, length);
+    case 'ECDH': {
+      dh ??= require('internal/crypto/diffiehellman');
+      return await dh.ecdhDeriveBits(algorithm, baseKey, length);
+    }
+    case 'HKDF': {
+      hkdf ??= require('internal/crypto/hkdf');
+      return await hkdf.hkdfDeriveBits(algorithm, baseKey, length);
+    }
+    case 'PBKDF2': {
+      pbkdf2 ??= require('internal/crypto/pbkdf2');
+      return await pbkdf2.pbkdf2DeriveBits(algorithm, baseKey, length);
+    }
     case 'Argon2d':
       // Fall through
     case 'Argon2i':
       // Fall through
-    case 'Argon2id':
-      return await require('internal/crypto/argon2')
-        .argon2DeriveBits(algorithm, baseKey, length);
+    case 'Argon2id': {
+      argon2 ??= require('internal/crypto/argon2');
+      return await argon2.argon2DeriveBits(algorithm, baseKey, length);
+    }
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
@@ -353,26 +378,30 @@ async function deriveKey(
       // Fall through
     case 'X448':
       // Fall through
-    case 'ECDH':
-      bits = await require('internal/crypto/diffiehellman')
-        .ecdhDeriveBits(algorithm, baseKey, length);
+    case 'ECDH': {
+      dh ??= require('internal/crypto/diffiehellman');
+      bits = await dh.ecdhDeriveBits(algorithm, baseKey, length);
       break;
-    case 'HKDF':
-      bits = await require('internal/crypto/hkdf')
-        .hkdfDeriveBits(algorithm, baseKey, length);
+    }
+    case 'HKDF': {
+      hkdf ??= require('internal/crypto/hkdf');
+      bits = await hkdf.hkdfDeriveBits(algorithm, baseKey, length);
       break;
-    case 'PBKDF2':
-      bits = await require('internal/crypto/pbkdf2')
-        .pbkdf2DeriveBits(algorithm, baseKey, length);
+    }
+    case 'PBKDF2': {
+      pbkdf2 ??= require('internal/crypto/pbkdf2');
+      bits = await pbkdf2.pbkdf2DeriveBits(algorithm, baseKey, length);
       break;
+    }
     case 'Argon2d':
       // Fall through
     case 'Argon2i':
       // Fall through
-    case 'Argon2id':
-      bits = await require('internal/crypto/argon2')
-        .argon2DeriveBits(algorithm, baseKey, length);
+    case 'Argon2id': {
+      argon2 ??= require('internal/crypto/argon2');
+      bits = await argon2.argon2DeriveBits(algorithm, baseKey, length);
       break;
+    }
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
@@ -390,39 +419,44 @@ async function exportKeySpki(key) {
       // Fall through
     case 'RSA-PSS':
       // Fall through
-    case 'RSA-OAEP':
-      return await require('internal/crypto/rsa')
-        .rsaExportKey(key, kWebCryptoKeyFormatSPKI);
+    case 'RSA-OAEP': {
+      rsa ??= require('internal/crypto/rsa');
+      return await rsa.rsaExportKey(key, kWebCryptoKeyFormatSPKI);
+    }
     case 'ECDSA':
       // Fall through
-    case 'ECDH':
-      return await require('internal/crypto/ec')
-        .ecExportKey(key, kWebCryptoKeyFormatSPKI);
+    case 'ECDH': {
+      ec ??= require('internal/crypto/ec');
+      return await ec.ecExportKey(key, kWebCryptoKeyFormatSPKI);
+    }
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
     case 'X25519':
       // Fall through
-    case 'X448':
-      return await require('internal/crypto/cfrg')
-        .cfrgExportKey(key, kWebCryptoKeyFormatSPKI);
+    case 'X448': {
+      cfrg ??= require('internal/crypto/cfrg');
+      return await cfrg.cfrgExportKey(key, kWebCryptoKeyFormatSPKI);
+    }
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
+    case 'ML-DSA-87': {
       // Note: mlDsaExportKey does not return a Promise.
-      return require('internal/crypto/ml_dsa')
-        .mlDsaExportKey(key, kWebCryptoKeyFormatSPKI);
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      return mlDsa.mlDsaExportKey(key, kWebCryptoKeyFormatSPKI);
+    }
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
-    case 'ML-KEM-1024':
+    case 'ML-KEM-1024': {
       // Note: mlKemExportKey does not return a Promise.
-      return require('internal/crypto/ml_kem')
-        .mlKemExportKey(key, kWebCryptoKeyFormatSPKI);
+      mlKem ??= require('internal/crypto/ml_kem');
+      return mlKem.mlKemExportKey(key, kWebCryptoKeyFormatSPKI);
+    }
     default:
       return undefined;
   }
@@ -434,39 +468,44 @@ async function exportKeyPkcs8(key) {
       // Fall through
     case 'RSA-PSS':
       // Fall through
-    case 'RSA-OAEP':
-      return await require('internal/crypto/rsa')
-        .rsaExportKey(key, kWebCryptoKeyFormatPKCS8);
+    case 'RSA-OAEP': {
+      rsa ??= require('internal/crypto/rsa');
+      return await rsa.rsaExportKey(key, kWebCryptoKeyFormatPKCS8);
+    }
     case 'ECDSA':
       // Fall through
-    case 'ECDH':
-      return await require('internal/crypto/ec')
-        .ecExportKey(key, kWebCryptoKeyFormatPKCS8);
+    case 'ECDH': {
+      ec ??= require('internal/crypto/ec');
+      return await ec.ecExportKey(key, kWebCryptoKeyFormatPKCS8);
+    }
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
     case 'X25519':
       // Fall through
-    case 'X448':
-      return await require('internal/crypto/cfrg')
-        .cfrgExportKey(key, kWebCryptoKeyFormatPKCS8);
+    case 'X448': {
+      cfrg ??= require('internal/crypto/cfrg');
+      return await cfrg.cfrgExportKey(key, kWebCryptoKeyFormatPKCS8);
+    }
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
+    case 'ML-DSA-87': {
       // Note: mlDsaExportKey does not return a Promise.
-      return require('internal/crypto/ml_dsa')
-        .mlDsaExportKey(key, kWebCryptoKeyFormatPKCS8);
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      return mlDsa.mlDsaExportKey(key, kWebCryptoKeyFormatPKCS8);
+    }
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
-    case 'ML-KEM-1024':
+    case 'ML-KEM-1024': {
       // Note: mlKemExportKey does not return a Promise.
-      return require('internal/crypto/ml_kem')
-        .mlKemExportKey(key, kWebCryptoKeyFormatPKCS8);
+      mlKem ??= require('internal/crypto/ml_kem');
+      return mlKem.mlKemExportKey(key, kWebCryptoKeyFormatPKCS8);
+    }
     default:
       return undefined;
   }
@@ -476,18 +515,20 @@ async function exportKeyRawPublic(key, format) {
   switch (key[kAlgorithm].name) {
     case 'ECDSA':
       // Fall through
-    case 'ECDH':
-      return await require('internal/crypto/ec')
-        .ecExportKey(key, kWebCryptoKeyFormatRaw);
+    case 'ECDH': {
+      ec ??= require('internal/crypto/ec');
+      return await ec.ecExportKey(key, kWebCryptoKeyFormatRaw);
+    }
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
     case 'X25519':
       // Fall through
-    case 'X448':
-      return await require('internal/crypto/cfrg')
-        .cfrgExportKey(key, kWebCryptoKeyFormatRaw);
+    case 'X448': {
+      cfrg ??= require('internal/crypto/cfrg');
+      return await cfrg.cfrgExportKey(key, kWebCryptoKeyFormatRaw);
+    }
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
@@ -498,8 +539,8 @@ async function exportKeyRawPublic(key, format) {
         return undefined;
       }
       // Note: mlDsaExportKey does not return a Promise.
-      return require('internal/crypto/ml_dsa')
-        .mlDsaExportKey(key, kWebCryptoKeyFormatRaw);
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      return mlDsa.mlDsaExportKey(key, kWebCryptoKeyFormatRaw);
     }
     case 'ML-KEM-512':
       // Fall through
@@ -511,8 +552,8 @@ async function exportKeyRawPublic(key, format) {
         return undefined;
       }
       // Note: mlKemExportKey does not return a Promise.
-      return require('internal/crypto/ml_kem')
-        .mlKemExportKey(key, kWebCryptoKeyFormatRaw);
+      mlKem ??= require('internal/crypto/ml_kem');
+      return mlKem.mlKemExportKey(key, kWebCryptoKeyFormatRaw);
     }
     default:
       return undefined;
@@ -525,18 +566,20 @@ async function exportKeyRawSeed(key) {
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
+    case 'ML-DSA-87': {
       // Note: mlDsaExportKey does not return a Promise.
-      return require('internal/crypto/ml_dsa')
-        .mlDsaExportKey(key, kWebCryptoKeyFormatRaw);
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      return mlDsa.mlDsaExportKey(key, kWebCryptoKeyFormatRaw);
+    }
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
-    case 'ML-KEM-1024':
+    case 'ML-KEM-1024': {
       // Note: mlKemExportKey does not return a Promise.
-      return require('internal/crypto/ml_kem')
-        .mlKemExportKey(key, kWebCryptoKeyFormatRaw);
+      mlKem ??= require('internal/crypto/ml_kem');
+      return mlKem.mlKemExportKey(key, kWebCryptoKeyFormatRaw);
+    }
     default:
       return undefined;
   }
@@ -624,10 +667,11 @@ async function exportKeyJWK(key) {
       // Fall through
     case 'AES-OCB':
       // Fall through
-    case 'AES-KW':
-      parameters.alg = require('internal/crypto/aes')
-        .getAlgorithmName(key[kAlgorithm].name, key[kAlgorithm].length);
+    case 'AES-KW': {
+      aes ??= ('internal/crypto/aes');
+      parameters.alg = aes.getAlgorithmName(key[kAlgorithm].name, key[kAlgorithm].length);
       break;
+    }
     case 'ChaCha20-Poly1305':
       parameters.alg = 'C20P';
       break;
@@ -749,37 +793,41 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'RSA-PSS':
       // Fall through
-    case 'RSA-OAEP':
+    case 'RSA-OAEP': {
       format = aliasKeyFormat(format);
-      result = require('internal/crypto/rsa')
-        .rsaImportKey(format, keyData, algorithm, extractable, keyUsages);
+      rsa ??= require('internal/crypto/rsa');
+      result = rsa.rsaImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
     case 'ECDSA':
       // Fall through
-    case 'ECDH':
+    case 'ECDH': {
       format = aliasKeyFormat(format);
-      result = require('internal/crypto/ec')
-        .ecImportKey(format, keyData, algorithm, extractable, keyUsages);
+      ec ??= require('internal/crypto/ec');
+      result = ec.ecImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
     case 'X25519':
       // Fall through
-    case 'X448':
+    case 'X448': {
       format = aliasKeyFormat(format);
-      result = require('internal/crypto/cfrg')
-        .cfrgImportKey(format, keyData, algorithm, extractable, keyUsages);
+      cfrg ??= require('internal/crypto/cfrg');
+      result = cfrg.cfrgImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
     case 'HMAC':
       // Fall through
     case 'KMAC128':
       // Fall through
-    case 'KMAC256':
-      result = require('internal/crypto/mac')
-        .macImportKey(format, keyData, algorithm, extractable, keyUsages);
+    case 'KMAC256': {
+      mac ??= require('internal/crypto/mac');
+      result = mac.macImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -788,14 +836,16 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'AES-KW':
       // Fall through
-    case 'AES-OCB':
-      result = require('internal/crypto/aes')
-        .aesImportKey(algorithm, format, keyData, extractable, keyUsages);
+    case 'AES-OCB': {
+      aes ??= require('internal/crypto/aes');
+      result = aes.aesImportKey(algorithm, format, keyData, extractable, keyUsages);
       break;
-    case 'ChaCha20-Poly1305':
-      result = require('internal/crypto/chacha20_poly1305')
-        .c20pImportKey(algorithm, format, keyData, extractable, keyUsages);
+    }
+    case 'ChaCha20-Poly1305': {
+      c20p ??= require('internal/crypto/chacha20_poly1305');
+      result = c20p.c20pImportKey(algorithm, format, keyData, extractable, keyUsages);
       break;
+    }
     case 'HKDF':
       // Fall through
     case 'PBKDF2':
@@ -825,18 +875,20 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
-      result = require('internal/crypto/ml_dsa')
-        .mlDsaImportKey(format, keyData, algorithm, extractable, keyUsages);
+    case 'ML-DSA-87': {
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      result = mlDsa.mlDsaImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
-    case 'ML-KEM-1024':
-      result = require('internal/crypto/ml_kem')
-        .mlKemImportKey(format, keyData, algorithm, extractable, keyUsages);
+    case 'ML-KEM-1024': {
+      mlKem ??= require('internal/crypto/ml_kem');
+      result = mlKem.mlKemImportKey(format, keyData, algorithm, extractable, keyUsages);
       break;
+    }
   }
 
   if (!result) {
@@ -1047,33 +1099,38 @@ async function signVerify(algorithm, key, data, signature) {
   switch (algorithm.name) {
     case 'RSA-PSS':
       // Fall through
-    case 'RSASSA-PKCS1-v1_5':
-      return await require('internal/crypto/rsa')
-        .rsaSignVerify(key, data, algorithm, signature);
-    case 'ECDSA':
-      return await require('internal/crypto/ec')
-        .ecdsaSignVerify(key, data, algorithm, signature);
+    case 'RSASSA-PKCS1-v1_5': {
+      rsa ??= require('internal/crypto/rsa');
+      return await rsa.rsaSignVerify(key, data, algorithm, signature);
+    }
+    case 'ECDSA': {
+      ec ??= require('internal/crypto/ec');
+      return await ec.ecdsaSignVerify(key, data, algorithm, signature);
+    }
     case 'Ed25519':
       // Fall through
-    case 'Ed448':
-      // Fall through
-      return await require('internal/crypto/cfrg')
-        .eddsaSignVerify(key, data, algorithm, signature);
-    case 'HMAC':
-      return await require('internal/crypto/mac')
-        .hmacSignVerify(key, data, algorithm, signature);
+    case 'Ed448': {
+      cfrg ??= require('internal/crypto/cfrg');
+      return await cfrg.eddsaSignVerify(key, data, algorithm, signature);
+    }
+    case 'HMAC': {
+      mac ??= require('internal/crypto/mac');
+      return await mac.hmacSignVerify(key, data, algorithm, signature);
+    }
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
-    case 'ML-DSA-87':
-      return await require('internal/crypto/ml_dsa')
-        .mlDsaSignVerify(key, data, algorithm, signature);
+    case 'ML-DSA-87': {
+      mlDsa ??= require('internal/crypto/ml_dsa');
+      return await mlDsa.mlDsaSignVerify(key, data, algorithm, signature);
+    }
     case 'KMAC128':
       // Fall through
-    case 'KMAC256':
-      return await require('internal/crypto/mac')
-        .kmacSignVerify(key, data, algorithm, signature);
+    case 'KMAC256': {
+      mac ??= require('internal/crypto/mac');
+      return await mac.kmacSignVerify(key, data, algorithm, signature);
+    }
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
@@ -1145,25 +1202,28 @@ async function cipherOrWrap(mode, algorithm, key, data, op) {
   validateMaxBufferLength(data, 'data');
 
   switch (algorithm.name) {
-    case 'RSA-OAEP':
-      return await require('internal/crypto/rsa')
-        .rsaCipher(mode, key, data, algorithm);
+    case 'RSA-OAEP': {
+      rsa ??= require('internal/crypto/rsa');
+      return await rsa.rsaCipher(mode, key, data, algorithm);
+    }
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
       // Fall through
     case 'AES-GCM':
       // Fall through
-    case 'AES-OCB':
-      return await require('internal/crypto/aes')
-        .aesCipher(mode, key, data, algorithm);
-    case 'ChaCha20-Poly1305':
-      return await require('internal/crypto/chacha20_poly1305')
-        .c20pCipher(mode, key, data, algorithm);
+    case 'AES-OCB': {
+      aes ??= require('internal/crypto/aes');
+      return await aes.aesCipher(mode, key, data, algorithm);
+    }
+    case 'ChaCha20-Poly1305': {
+      c20p ??= require('internal/crypto/chacha20_poly1305');
+      return await c20p.c20pCipher(mode, key, data, algorithm);
+    }
     case 'AES-KW':
       if (op === 'wrapKey' || op === 'unwrapKey') {
-        return await require('internal/crypto/aes')
-          .aesCipher(mode, key, data, algorithm);
+        aes ??= require('internal/crypto/aes');
+        return await aes.aesCipher(mode, key, data, algorithm);
       }
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
@@ -1286,9 +1346,10 @@ async function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
   switch (encapsulationKey[kAlgorithm].name) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
-    case 'ML-KEM-1024':
-      return await require('internal/crypto/ml_kem')
-        .mlKemEncapsulate(encapsulationKey);
+    case 'ML-KEM-1024': {
+      mlKem ??= require('internal/crypto/ml_kem');
+      return await mlKem.mlKemEncapsulate(encapsulationKey);
+    }
   }
 
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
@@ -1341,10 +1402,11 @@ async function encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKe
   switch (encapsulationKey[kAlgorithm].name) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
-    case 'ML-KEM-1024':
-      encapsulateBits = await require('internal/crypto/ml_kem')
-        .mlKemEncapsulate(encapsulationKey);
+    case 'ML-KEM-1024': {
+      mlKem ??= require('internal/crypto/ml_kem');
+      encapsulateBits = await mlKem.mlKemEncapsulate(encapsulationKey);
       break;
+    }
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
@@ -1400,9 +1462,10 @@ async function decapsulateBits(decapsulationAlgorithm, decapsulationKey, ciphert
   switch (decapsulationKey[kAlgorithm].name) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
-    case 'ML-KEM-1024':
-      return await require('internal/crypto/ml_kem')
-        .mlKemDecapsulate(decapsulationKey, ciphertext);
+    case 'ML-KEM-1024': {
+      mlKem ??= require('internal/crypto/ml_kem');
+      return await mlKem.mlKemDecapsulate(decapsulationKey, ciphertext);
+    }
   }
 
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
@@ -1461,10 +1524,11 @@ async function decapsulateKey(
   switch (decapsulationKey[kAlgorithm].name) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
-    case 'ML-KEM-1024':
-      decapsulatedBits = await require('internal/crypto/ml_kem')
-        .mlKemDecapsulate(decapsulationKey, ciphertext);
+    case 'ML-KEM-1024': {
+      mlKem ??= require('internal/crypto/ml_kem');
+      decapsulatedBits = await mlKem.mlKemDecapsulate(decapsulationKey, ciphertext);
       break;
+    }
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
@@ -1671,7 +1735,8 @@ function check(op, alg, length) {
     case 'deriveBits': {
       if (normalizedAlgorithm.name === 'HKDF') {
         try {
-          require('internal/crypto/hkdf').validateHkdfDeriveBitsLength(length);
+          hkdf ??= require('internal/crypto/hkdf');
+          hkdf.validateHkdfDeriveBitsLength(length);
         } catch {
           return false;
         }
@@ -1679,7 +1744,8 @@ function check(op, alg, length) {
 
       if (normalizedAlgorithm.name === 'PBKDF2') {
         try {
-          require('internal/crypto/pbkdf2').validatePbkdf2DeriveBitsLength(length);
+          pbkdf2 ??= require('internal/crypto/pbkdf2');
+          pbkdf2.validatePbkdf2DeriveBitsLength(length);
         } catch {
           return false;
         }
@@ -1687,7 +1753,8 @@ function check(op, alg, length) {
 
       if (StringPrototypeStartsWith(normalizedAlgorithm.name, 'Argon2')) {
         try {
-          require('internal/crypto/argon2').validateArgon2DeriveBitsLength(length);
+          argon2 ??= require('internal/crypto/argon2');
+          argon2.validateArgon2DeriveBitsLength(length);
         } catch {
           return false;
         }


### PR DESCRIPTION
Followup to https://github.com/nodejs/node/pull/59841#pullrequestreview-3206953119

I don't know if this is any better or not though. At least i feel it's better to not rely on require()s cache all the time?

WDYT?