### PR TITLE
win,tools: Add description to signature

### DIFF
--- a/tools/sign.bat
+++ b/tools/sign.bat
@@ -20,7 +20,7 @@ if "%AZURE_SIGN_METADATA_PATH%"=="" (
 )
 
 
-signtool sign /tr "http://timestamp.acs.microsoft.com" /td sha256 /fd sha256 /v /dlib %AZURE_SIGN_DLIB_PATH% /dmdf %AZURE_SIGN_METADATA_PATH% %1
+signtool sign /d "Node.js" /tr "http://timestamp.acs.microsoft.com" /td sha256 /fd sha256 /v /dlib %AZURE_SIGN_DLIB_PATH% /dmdf %AZURE_SIGN_METADATA_PATH% %1
 if not ERRORLEVEL 1 (
     echo Successfully signed %1 using signtool
     exit /b 0


### PR DESCRIPTION
When signing files for Windows, add "Node.js" as the description.

This should cause the string highlighted in the UAC elevation prompt screenshot below to be replaced with the string specified as the description.

<img width="344" height="293" alt="image" src="https://github.com/user-attachments/assets/dd91c155-004f-479b-972a-b9006852aab2" />
