### PR TITLE
typings: remove unused imports

### DIFF
--- a/typings/internalBinding/zlib.d.ts
+++ b/typings/internalBinding/zlib.d.ts
@@ -1,5 +1,3 @@
-import { TypedArray } from '../globals';
-
 declare namespace InternalZlibBinding {
   class ZlibBase {
     // These attributes are not used by the C++ binding, but declared on JS side.


### PR DESCRIPTION
The error is caused by the `typings/globals.d.ts` file declaring TypedArray as a global type. 

The line `import { TypedArray } from '../globals';` was added unnecessarily, which is causing the error.

To fix this, I will remove the import line from the `typings/internalBinding/zlib.d.ts` file.

<img width="328" height="24" alt="image" src="https://github.com/user-attachments/assets/498679cd-ba68-42be-aeeb-219fdbb179ad" />
