### PR TITLE
Make test-worker-message-port-infinite-message-loop.js fail when the `port1.on('message'` callback isn't called

### DIFF
--- a/test/parallel/test-worker-message-port-infinite-message-loop.js
+++ b/test/parallel/test-worker-message-port-infinite-message-loop.js
@@ -27,3 +27,14 @@ port2.postMessage(0);
 // This is part of the test -- the event loop should be available and not stall
 // out due to the recursive .postMessage() calls.
 setTimeout(common.mustCall(), 0);
+
+// Assert that the 'message' handler was actually called.
+//
+// We do not want to assert a specific call count, so common.mustCall cannot be
+// used in the port1.on('message' callback directly.
+process.once(
+  'beforeExit',
+  common.mustCall(() => {
+    assert(count > 0, 'count should be greater than 0');
+  })
+);


### PR DESCRIPTION
The test `test-worker-message-port-infinite-message-loop.js` currently passes if the MessagePort does not emit any messages. 

If the message port does not emit a `"message"` event then the infinite message loop would never occur, therefore it's probably not the intent of the test.

Context: this test was incorrectly passing in Bun when we currently do not start the MessagePort until the `start` method is called. This test continues to pass in Node and now correctly fails in Bun (we will fix this later).