### PR TITLE
tools: fix `tools/make-v8.sh` for clang

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -21,16 +21,17 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
     TARGET_ARCH="ppc64"
   fi
   # Propagate ccache to gn.
+  # shellcheck disable=SC2154
   case "$CXX" in
     *ccache*) CC_WRAPPER="cc_wrapper=\"ccache\"" ;;
     *) ;;
   esac
 
+  # shellcheck disable=SC2154
   case "$CXX" in
     *clang*) GN_COMPILER_OPTS="is_clang=true clang_base_path=\"/usr\" clang_use_chrome_plugins=false treat_warnings_as_errors=false use_custom_libcxx=false" ;;
     *) GN_COMPILER_OPTS="treat_warnings_as_errors=false use_custom_libcxx=false" ;;
   esac
-  export PKG_CONFIG_PATH=$BUILD_TOOLS/pkg-config
   gn gen -v "out.gn/$BUILD_ARCH_TYPE" --args="$GN_COMPILER_OPTS is_component_build=false is_debug=false v8_target_cpu=\"$TARGET_ARCH\" target_cpu=\"$TARGET_ARCH\" v8_enable_backtrace=true $CC_WRAPPER"
   ninja -v -C "out.gn/$BUILD_ARCH_TYPE" "${JOBS_ARG}" d8 cctest inspector-test
 else


### PR DESCRIPTION
Update `tools/make-v8.sh` so that it can work with either `gcc` or `clang`.

Adds:
- clang settings when CC/CXX environment variables set to clang/clang++.
- Turns off warnings as errors.

Removes:
- goma settings.
- Machine specific settings (moved to Jenkins job configuration).

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/5541431

---

cc @nodejs/v8-update This is mostly prep -- we can't actually build with clang on ppc64le or s390x until we update V8 as we need patches to V8's `build` DEP that are only in versions later than what is currently on `main`. I've been testing the clang path with a combination of the changes here and https://github.com/nodejs/node/pull/59805.

@targos FYI I don't mind if this lands separately or is rolled into a V8 update PR such as https://github.com/nodejs/node/pull/59805.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
