### PR TITLE
process: wrap ENOENT from process.cwd() with ERR_SYSTEM_ERROR

### DIFF
--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -35,15 +35,15 @@ const {
   validateString,
   validateUint32,
 } = require('internal/validators');
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+    ERR_SYSTEM_ERROR,
+    ERR_UNKNOWN_CREDENTIAL,
+  },
+} = require('internal/errors');
 
 function wrapPosixCredentialSetters(credentials) {
-  const {
-    codes: {
-      ERR_INVALID_ARG_TYPE,
-      ERR_UNKNOWN_CREDENTIAL,
-    },
-  } = require('internal/errors');
-
   const {
     initgroups: _initgroups,
     setgroups: _setgroups,
@@ -138,7 +138,24 @@ function wrappedUmask(mask) {
 }
 
 function wrappedCwd() {
-  if (cachedCwd === '')
-    cachedCwd = rawMethods.cwd();
+  if (cachedCwd === '') {
+    try {
+      cachedCwd = rawMethods.cwd();
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        const context = {
+          code: 'ENOENT',
+          syscall: 'process.cwd',
+          message:
+            'The current working directory does not exist. It may have been deleted or unmounted.',
+        };
+        const wrapped = new ERR_SYSTEM_ERROR(context);
+        // Preserve the original error for debugging.
+        wrapped.cause = err;
+        throw wrapped;
+      }
+      throw err;
+    }
+  }
   return cachedCwd;
 }


### PR DESCRIPTION
Catch ENOENT from rawMethods.cwd() and rethrow as ERR_SYSTEM_ERROR with context { syscall: 'process.cwd', code: 'ENOENT' }, preserving the original error in cause. This surfaces a clearer, actionable message when the current working directory has been deleted or unmounted and improves the stack (process.cwd instead of wrappedCwd).

Fixes: https://github.com/nodejs/node/issues/57045
