### PR TITLE
doc: mark --env-file and --env-file-if-exists as stable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -884,7 +884,7 @@ added: v22.9.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/59925
-    description: The `--env-file-if-exists` flag is now stable.
+    description: The `--env-file-if-exists` flag is no longer experimental.
 -->
 
 Behavior is the same as [`--env-file`][], but an error is not thrown if the file
@@ -897,7 +897,7 @@ added: v20.6.0
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/59925
-    description: The `--env-file` flag is now stable.
+    description: The `--env-file` flag is no longer experimental.
   - version:
     - v21.7.0
     - v20.12.0

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -881,9 +881,11 @@ node --entry-url 'data:text/javascript,console.log("Hello")'
 
 <!-- YAML
 added: v22.9.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59925
+    description: The `--env-file-if-exists` flag is now stable.
 -->
-
-> Stability: 1.1 - Active development
 
 Behavior is the same as [`--env-file`][], but an error is not thrown if the file
 does not exist.
@@ -893,14 +895,15 @@ does not exist.
 <!-- YAML
 added: v20.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59925
+    description: The `--env-file` flag is now stable.
   - version:
     - v21.7.0
     - v20.12.0
     pr-url: https://github.com/nodejs/node/pull/51289
     description: Add support to multi-line values.
 -->
-
-> Stability: 1.1 - Active development
 
 Loads environment variables from a file relative to the current directory,
 making them available to applications on `process.env`. The [environment

--- a/doc/api/environment_variables.md
+++ b/doc/api/environment_variables.md
@@ -18,7 +18,7 @@ For more details refer to the [`process.env` documentation][].
 
 Set of utilities for dealing with additional environment variables defined in `.env` files.
 
-> Stability: 1.1 - Active development
+> Stability: 2 - Stable
 
 <!--introduced_in=v20.12.0-->
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2696,9 +2696,11 @@ debugger. See [Signal Events][].
 added:
   - v21.7.0
   - v20.12.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59925
+    description: This API is no longer experimental.
 -->
-
-> Stability: 1.1 - Active development
 
 * `path` {string | URL | Buffer | undefined}. **Default:** `'./.env'`
 

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -2211,9 +2211,11 @@ $ node negate.js --no-logfile --logfile=test.log --color --no-color
 added:
   - v21.7.0
   - v20.12.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/59925
+    description: This API is no longer experimental.
 -->
-
-> Stability: 1.1 - Active development
 
 * `content` {string}
 


### PR DESCRIPTION
As discussed in https://github.com/nodejs/node/issues/49148#issuecomment-3307288256 the feature should be ready to be marked stable.

The change could probably be picked to v24 and be featured in the change log.

This is my first time contributing to node so let me know if there's any mistakes.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
