### PR TITLE
dgram: restore buffer optimization in fixBufferList

### DIFF
--- a/benchmark/dgram/send-types.js
+++ b/benchmark/dgram/send-types.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const common = require('../common.js');
+const dgram = require('dgram');
+const { Buffer } = require('buffer');
+
+const bench = common.createBenchmark(main, {
+  type: ['string', 'buffer', 'mixed', 'typedarray'],
+  chunks: [1, 4, 8, 16],
+  len: [64, 512, 1024],
+  n: [1000],
+});
+
+function main({ type, chunks, len, n }) {
+  const socket = dgram.createSocket('udp4');
+
+  let testData;
+  switch (type) {
+    case 'string':
+      testData = Array(chunks).fill('a'.repeat(len));
+      break;
+    case 'buffer':
+      testData = Array(chunks).fill(Buffer.alloc(len, 'a'));
+      break;
+    case 'mixed':
+      testData = [];
+      for (let i = 0; i < chunks; i++) {
+        if (i % 2 === 0) {
+          testData.push(Buffer.alloc(len, 'a'));
+        } else {
+          testData.push('a'.repeat(len));
+        }
+      }
+      break;
+    case 'typedarray':
+      testData = Array(chunks).fill(new Uint8Array(len).fill(97));
+      break;
+  }
+
+  bench.start();
+
+  for (let i = 0; i < n; i++) {
+    socket.send(testData, 12345, 'localhost', (err) => {
+      if (err && err.code !== 'ENOTCONN' && err.code !== 'ECONNREFUSED') {
+        throw err;
+      }
+    });
+  }
+
+  bench.end(n);
+  socket.close();
+}

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -549,6 +549,8 @@ function fixBufferList(list) {
     const buf = list[i];
     if (typeof buf === 'string')
       newlist[i] = Buffer.from(buf);
+    else if (Buffer.isBuffer(buf))
+      newlist[i] = buf;
     else if (!isArrayBufferView(buf))
       return null;
     else


### PR DESCRIPTION
Restore the Buffer.isBuffer() check to avoid unnecessary Buffer.from() calls when the input is already a Buffer. 
This improves performance buffer-heavy UDP operations.

Includes benchmark test for fixBufferList function to verify the performance improvements across different 
data types and chunk sizes.