### PR TITLE
http: add IPv6 range support for NO_PROXY environment variable

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -4607,6 +4607,8 @@ The `NO_PROXY` environment variable supports several formats:
 * `*.example.com` - Wildcard domain match
 * `192.168.1.100` - Exact IP address match
 * `192.168.1.1-192.168.1.100` - IP address range
+* `::1` or `[::1]` - Exact IPv6 address match
+* `::1-::100` - IPv6 address range
 * `example.com:8080` - Hostname with specific port
 
 Multiple entries should be separated by commas.

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const {
-  Array,
-  BigInt,
   Date,
   Number,
   NumberParseInt,
@@ -21,6 +19,7 @@ const {
 
 const { URL } = require('internal/url');
 const { Buffer } = require('buffer');
+const { BlockList } = require('internal/blocklist');
 const { isIPv4, isIPv6 } = require('internal/net');
 const { ERR_PROXY_INVALID_CONFIG } = require('internal/errors').codes;
 let utcCache;
@@ -70,35 +69,6 @@ function ipToInt(ip) {
   }
   // Force unsigned 32-bit result
   return result >>> 0;
-}
-
-function ipv6ToBigInt(ip) {
-  const cleanIp = ip.startsWith('[') ? ip.slice(1, -1) : ip;
-
-  const parts = cleanIp.split('::');
-  let left = parts[0];
-  let right = parts[1] || '';
-
-  if (parts.length === 2) {
-    const leftParts = left.split(':').filter((p) => p.length > 0);
-    const rightParts = right.split(':').filter((p) => p.length > 0);
-    const missingParts = 8 - leftParts.length - rightParts.length;
-
-    left = leftParts.join(':');
-    right = Array(missingParts).fill('0').join(':') + (right ? ':' + rightParts.join(':') : '');
-  }
-
-  const fullAddress = (left + (right ? ':' + right : '')).replace(/^:|:$/g, '');
-  const hexParts = fullAddress.split(':');
-
-  let result = BigInt(0);
-  for (const hexVal of hexParts) {
-    if (hexVal) {
-      result = (result << BigInt(16)) + BigInt('0x' + hexVal);
-    }
-  }
-
-  return result;
 }
 
 // There are two factors in play when proxying the request:
@@ -213,11 +183,18 @@ class ProxyConfig {
           const startInt = ipToInt(startIP);
           const endInt = ipToInt(endIP);
           if (hostInt >= startInt && hostInt <= endInt) return false;
-        } else if (startIP && endIP && isIPv6(startIP) && isIPv6(endIP) && isIPv6(host)) {
-          const hostInt = ipv6ToBigInt(host);
-          const startInt = ipv6ToBigInt(startIP);
-          const endInt = ipv6ToBigInt(endIP);
-          if (hostInt >= startInt && hostInt <= endInt) return false;
+        } else {
+          const hostIP = host[0] === '[' && host[host.length - 1] === ']' ?
+            host.slice(1, -1) : host;
+          if (startIP && endIP && isIPv6(startIP) && isIPv6(endIP) && isIPv6(hostIP)) {
+            const blockList = new BlockList();
+            try {
+              blockList.addRange(startIP, endIP, 'ipv6');
+            } catch {
+              continue;
+            }
+            if (blockList.check(hostIP, 'ipv6')) return false;
+          }
         }
       }
 

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -204,17 +204,16 @@ class ProxyConfig {
       if (entry.startsWith('*.') && host.endsWith(entry.substring(1))) return false;
 
       // Handle IP ranges (simple format like 192.168.1.0-192.168.1.255)
-      // TODO(joyeecheung): support IPv6.
       if (entry.includes('-')) {
         let { 0: startIP, 1: endIP } = entry.split('-');
         startIP = startIP.trim();
         endIP = endIP.trim();
-        if (isIPv4(startIP) && isIPv4(endIP) && isIPv4(host)) {
+        if (startIP && endIP && isIPv4(startIP) && isIPv4(endIP) && isIPv4(host)) {
           const hostInt = ipToInt(host);
           const startInt = ipToInt(startIP);
           const endInt = ipToInt(endIP);
           if (hostInt >= startInt && hostInt <= endInt) return false;
-        } else if (isIPv6(startIP) && isIPv6(endIP) && isIPv6(host)) {
+        } else if (startIP && endIP && isIPv6(startIP) && isIPv6(endIP) && isIPv6(host)) {
           const hostInt = ipv6ToBigInt(host);
           const startInt = ipv6ToBigInt(startIP);
           const endInt = ipv6ToBigInt(endIP);

--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  Array,
+  BigInt,
   Date,
   Number,
   NumberParseInt,
@@ -19,7 +21,7 @@ const {
 
 const { URL } = require('internal/url');
 const { Buffer } = require('buffer');
-const { isIPv4 } = require('internal/net');
+const { isIPv4, isIPv6 } = require('internal/net');
 const { ERR_PROXY_INVALID_CONFIG } = require('internal/errors').codes;
 let utcCache;
 
@@ -68,6 +70,35 @@ function ipToInt(ip) {
   }
   // Force unsigned 32-bit result
   return result >>> 0;
+}
+
+function ipv6ToBigInt(ip) {
+  const cleanIp = ip.startsWith('[') ? ip.slice(1, -1) : ip;
+
+  const parts = cleanIp.split('::');
+  let left = parts[0];
+  let right = parts[1] || '';
+
+  if (parts.length === 2) {
+    const leftParts = left.split(':').filter((p) => p.length > 0);
+    const rightParts = right.split(':').filter((p) => p.length > 0);
+    const missingParts = 8 - leftParts.length - rightParts.length;
+
+    left = leftParts.join(':');
+    right = Array(missingParts).fill('0').join(':') + (right ? ':' + rightParts.join(':') : '');
+  }
+
+  const fullAddress = (left + (right ? ':' + right : '')).replace(/^:|:$/g, '');
+  const hexParts = fullAddress.split(':');
+
+  let result = BigInt(0);
+  for (const hexVal of hexParts) {
+    if (hexVal) {
+      result = (result << BigInt(16)) + BigInt('0x' + hexVal);
+    }
+  }
+
+  return result;
 }
 
 // There are two factors in play when proxying the request:
@@ -174,14 +205,19 @@ class ProxyConfig {
 
       // Handle IP ranges (simple format like 192.168.1.0-192.168.1.255)
       // TODO(joyeecheung): support IPv6.
-      if (entry.includes('-') && isIPv4(host)) {
+      if (entry.includes('-')) {
         let { 0: startIP, 1: endIP } = entry.split('-');
         startIP = startIP.trim();
         endIP = endIP.trim();
-        if (startIP && endIP && isIPv4(startIP) && isIPv4(endIP)) {
+        if (isIPv4(startIP) && isIPv4(endIP) && isIPv4(host)) {
           const hostInt = ipToInt(host);
           const startInt = ipToInt(startIP);
           const endInt = ipToInt(endIP);
+          if (hostInt >= startInt && hostInt <= endInt) return false;
+        } else if (isIPv6(startIP) && isIPv6(endIP) && isIPv6(host)) {
+          const hostInt = ipv6ToBigInt(host);
+          const startInt = ipv6ToBigInt(startIP);
+          const endInt = ipv6ToBigInt(endIP);
           if (hostInt >= startInt && hostInt <= endInt) return false;
         }
       }

--- a/test/client-proxy/test-http-proxy-request-no-proxy-ipv6.mjs
+++ b/test/client-proxy/test-http-proxy-request-no-proxy-ipv6.mjs
@@ -1,0 +1,75 @@
+// This tests that NO_PROXY environment variable supports IPv6 ranges.
+
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { once } from 'events';
+import http from 'node:http';
+import { runProxiedRequest } from '../common/proxy-server.js';
+
+// Start a server to process the final request.
+const server = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Hello IPv6\n');
+}, 1));
+server.on('error', common.mustNotCall((err) => { console.error('Server error', err); }));
+server.listen(0, '::1');
+await once(server, 'listening');
+
+// Start a proxy server that should be used.
+const proxy = http.createServer(common.mustCall((req, res) => {
+  res.writeHead(200, { 'Content-Type': 'text/plain' });
+  res.end('Proxied Hello IPv6\n');
+}, 2));
+proxy.listen(0, '::1');
+await once(proxy, 'listening');
+
+// Test NO_PROXY with IPv6 range (::1-::100 includes ::1)
+{
+  const { code, signal, stderr, stdout } = await runProxiedRequest({
+    NODE_USE_ENV_PROXY: 1,
+    REQUEST_URL: `http://[::1]:${server.address().port}/test`,
+    HTTP_PROXY: `http://[::1]:${proxy.address().port}`,
+    NO_PROXY: '::1-::100',
+  });
+  // The request should succeed and bypass proxy
+  assert.match(stdout, /Status Code: 200/);
+  assert.match(stdout, /Hello IPv6/);
+  assert.strictEqual(stderr.trim(), '');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}
+
+// Test another IPv6 address within the range (::50)
+{
+  const { code, signal, stderr, stdout } = await runProxiedRequest({
+    NODE_USE_ENV_PROXY: 1,
+    REQUEST_URL: `http://[::1]:${server.address().port}/test`,
+    HTTP_PROXY: `http://localhost:${proxy.address().port}`,
+    NO_PROXY: '::50-::100',
+  });
+  // The request should succeed and bypass proxy
+  assert.match(stdout, /Status Code: 200/);
+  assert.match(stdout, /Hello IPv6/);
+  assert.strictEqual(stderr.trim(), '');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}
+
+// Test NO_PROXY with an IPv6 address outside the range (::200)
+{
+  const { code, signal, stderr, stdout } = await runProxiedRequest({
+    NODE_USE_ENV_PROXY: 1,
+    REQUEST_URL: `http://[::200]:${server.address().port}/test`,
+    HTTP_PROXY: `http://[::1]:${proxy.address().port}`,
+    NO_PROXY: '::1-::100',
+  });
+  // The request should be proxied
+  assert.match(stdout, /Status Code: 200/);
+  assert.match(stdout, /Proxied Hello IPv6/);
+  assert.strictEqual(stderr.trim(), '');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}
+
+proxy.close();
+server.close();


### PR DESCRIPTION
This PR resolves the `// TODO(joyeecheung): support IPv6.` comment in `internal/http.js` by adding comprehensive support for IPv6 address ranges to the `NO_PROXY` environment variable.

Previously, the `ProxyConfig` class's `shouldUseProxy` method could only handle IPv4 address ranges. With this change, users can now specify IPv6 ranges (e.g., `::1-::100`) to correctly bypass proxies for hosts within those ranges.

The implementation involves:
* A new helper function `ipv6ToBigInt` to convert 128-bit IPv6 addresses into `BigInt`s for reliable numerical comparison.
* Updated `shouldUseProxy` logic to check if a host is within a given IPv6 range.

This update ensures the proxy bypass feature is robust and consistent with both IPv4 and IPv6 network standards.

New test cases have been added to `test/client-proxy/test-http-proxy-request-no-proxy-ipv6.mjs` to verify the new functionality.

Test
* A host within the specified IPv6 range (`::1-::100`) correctly bypasses the proxy.
* A host outside the specified IPv6 range correctly uses the proxy.

This ensures that the new feature works as expected and does not introduce regressions to existing functionality.

/cc @joyeecheung 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
