### PR TITLE
test: ensure that the message event is fired

### DIFF
--- a/test/parallel/test-worker-message-port-infinite-message-loop.js
+++ b/test/parallel/test-worker-message-port-infinite-message-loop.js
@@ -11,7 +11,7 @@ const { MessageChannel } = require('worker_threads');
 
 const { port1, port2 } = new MessageChannel();
 let count = 0;
-port1.on('message', () => {
+port1.on('message', common.mustCallAtLeast(() => {
   if (count === 0) {
     setTimeout(common.mustCall(() => {
       port1.close();
@@ -20,7 +20,7 @@ port1.on('message', () => {
 
   port2.postMessage(0);
   assert(count++ < 10000, `hit ${count} loop iterations`);
-});
+}, 1));
 
 port2.postMessage(0);
 


### PR DESCRIPTION
Use `common.mustCallAtLeast()` to verify that the `'message'` event is fired.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
