### PR TITLE
src: simplify watchdog instantiations via `std::optional`

### DIFF
--- a/src/node_watchdog.h
+++ b/src/node_watchdog.h
@@ -51,6 +51,11 @@ class Watchdog {
   v8::Isolate* isolate() { return isolate_; }
 
  private:
+  Watchdog(const Watchdog&) = delete;
+  Watchdog& operator=(const Watchdog&) = delete;
+  Watchdog(Watchdog&&) = delete;
+  Watchdog& operator=(Watchdog&&) = delete;
+
   static void Run(void* arg);
   static void Timer(uv_timer_t* timer);
 
@@ -77,6 +82,11 @@ class SigintWatchdog : public SigintWatchdogBase {
   SignalPropagation HandleSigint() override;
 
  private:
+  SigintWatchdog(const SigintWatchdog&) = delete;
+  SigintWatchdog& operator=(const SigintWatchdog&) = delete;
+  SigintWatchdog(SigintWatchdog&&) = delete;
+  SigintWatchdog& operator=(SigintWatchdog&&) = delete;
+
   v8::Isolate* isolate_;
   bool* received_signal_;
 };


### PR DESCRIPTION
It's been a bit of a code smell that we create these objects in different conditional branches, effectively forcing ourselves to duplicate logic between those branches.

This code predates `std::optional` being available to us, but now that it is, it's the idiomatic way to resolve this issue.

(This commit also explicitly deletes move and copy members for these classes; these had previously been omitted for brevity, but adding them made me feel more confident that there is no hidden copy operation added through this change.)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
