### PR TITLE
test: add new `startNewREPLSever` testing utility

### DIFF
--- a/test/common/repl.js
+++ b/test/common/repl.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const ArrayStream = require('../common/arraystream');
+const repl = require('node:repl');
+const assert = require('node:assert');
+
+function startNewREPLServer(replOpts = {}, testingOpts = {}) {
+  const input = new ArrayStream();
+  const output = new ArrayStream();
+
+  output.accumulator = '';
+  output.write = (data) => (output.accumulator += `${data}`.replaceAll('\r', ''));
+
+  const replServer = repl.start({
+    prompt: '',
+    input,
+    output,
+    terminal: true,
+    allowBlockingCompletions: true,
+    ...replOpts,
+  });
+
+  if (!testingOpts.disableDomainErrorAssert) {
+    // Some errors are passed to the domain, but do not callback
+    replServer._domain.on('error', assert.ifError);
+  }
+
+  return { replServer, input, output };
+}
+
+module.exports = { startNewREPLServer };

--- a/test/parallel/test-repl-autolibs.js
+++ b/test/parallel/test-repl-autolibs.js
@@ -22,12 +22,12 @@
 'use strict';
 const common = require('../common');
 const ArrayStream = require('../common/arraystream');
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('assert');
 const util = require('util');
-const repl = require('repl');
 
 const putIn = new ArrayStream();
-repl.start('', putIn, null, true);
+startNewREPLServer({ input: putIn, output: putIn, useGlobal: true, terminal: false });
 
 test1();
 

--- a/test/parallel/test-repl-completion-on-getters-disabled.js
+++ b/test/parallel/test-repl-completion-on-getters-disabled.js
@@ -4,19 +4,11 @@ const common = require('../common');
 const assert = require('node:assert');
 const { describe, test } = require('node:test');
 
-const ArrayStream = require('../common/arraystream');
-
-const repl = require('node:repl');
+const { startNewREPLServer } = require('../common/repl');
 
 function runCompletionTests(replInit, tests) {
-  const stream = new ArrayStream();
-  const testRepl = repl.start({ stream });
-
-  // Some errors are passed to the domain
-  testRepl._domain.on('error', assert.ifError);
-
-  testRepl.write(replInit);
-  testRepl.write('\n');
+  const { replServer: testRepl, input } = startNewREPLServer();
+  input.run([replInit]);
 
   tests.forEach(([query, expectedCompletions]) => {
     testRepl.complete(query, common.mustCall((error, data) => {

--- a/test/parallel/test-repl-context.js
+++ b/test/parallel/test-repl-context.js
@@ -1,38 +1,28 @@
 'use strict';
 require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
-const repl = require('repl');
 const vm = require('vm');
-
-// Create a dummy stream that does nothing.
-const stream = new ArrayStream();
+const { startNewREPLServer } = require('../common/repl');
 
 // Test context when useGlobal is false.
 {
-  const r = repl.start({
-    input: stream,
-    output: stream,
+  const { replServer, output } = startNewREPLServer({
+    terminal: false,
     useGlobal: false
   });
 
-  let output = '';
-  stream.write = function(d) {
-    output += d;
-  };
-
   // Ensure that the repl context gets its own "console" instance.
-  assert(r.context.console);
+  assert(replServer.context.console);
 
   // Ensure that the repl console instance is not the global one.
-  assert.notStrictEqual(r.context.console, console);
-  assert.notStrictEqual(r.context.Object, Object);
+  assert.notStrictEqual(replServer.context.console, console);
+  assert.notStrictEqual(replServer.context.Object, Object);
 
-  stream.run(['({} instanceof Object)']);
+  replServer.write('({} instanceof Object)\n');
 
-  assert.strictEqual(output, 'true\n> ');
+  assert.strictEqual(output.accumulator, 'true\n');
 
-  const context = r.createContext();
+  const context = replServer.createContext();
   // Ensure that the repl context gets its own "console" instance.
   assert(context.console instanceof require('console').Console);
 
@@ -41,44 +31,46 @@ const stream = new ArrayStream();
 
   // Ensure that the repl console instance is writable.
   context.console = 'foo';
-  r.close();
+  replServer.close();
 }
 
 // Test for context side effects.
 {
-  const server = repl.start({ input: stream, output: stream });
+  const { replServer } = startNewREPLServer({
+    useGlobal: false
+  });
 
-  assert.ok(!server.underscoreAssigned);
-  assert.strictEqual(server.lines.length, 0);
+  assert.ok(!replServer.underscoreAssigned);
+  assert.strictEqual(replServer.lines.length, 0);
 
   // An assignment to '_' in the repl server
-  server.write('_ = 500;\n');
-  assert.ok(server.underscoreAssigned);
-  assert.strictEqual(server.lines.length, 1);
-  assert.strictEqual(server.lines[0], '_ = 500;');
-  assert.strictEqual(server.last, 500);
+  replServer.write('_ = 500;\n');
+  assert.ok(replServer.underscoreAssigned);
+  assert.strictEqual(replServer.lines.length, 1);
+  assert.strictEqual(replServer.lines[0], '_ = 500;');
+  assert.strictEqual(replServer.last, 500);
 
   // Use the server to create a new context
-  const context = server.createContext();
+  const context = replServer.createContext();
 
   // Ensure that creating a new context does not
   // have side effects on the server
-  assert.ok(server.underscoreAssigned);
-  assert.strictEqual(server.lines.length, 1);
-  assert.strictEqual(server.lines[0], '_ = 500;');
-  assert.strictEqual(server.last, 500);
+  assert.ok(replServer.underscoreAssigned);
+  assert.strictEqual(replServer.lines.length, 1);
+  assert.strictEqual(replServer.lines[0], '_ = 500;');
+  assert.strictEqual(replServer.last, 500);
 
   // Reset the server context
-  server.resetContext();
-  assert.ok(!server.underscoreAssigned);
-  assert.strictEqual(server.lines.length, 0);
+  replServer.resetContext();
+  assert.ok(!replServer.underscoreAssigned);
+  assert.strictEqual(replServer.lines.length, 0);
 
   // Ensure that assigning to '_' in the new context
   // does not change the value in our server.
-  assert.ok(!server.underscoreAssigned);
+  assert.ok(!replServer.underscoreAssigned);
   vm.runInContext('_ = 1000;\n', context);
 
-  assert.ok(!server.underscoreAssigned);
-  assert.strictEqual(server.lines.length, 0);
-  server.close();
+  assert.ok(!replServer.underscoreAssigned);
+  assert.strictEqual(replServer.lines.length, 0);
+  replServer.close();
 }

--- a/test/parallel/test-repl-definecommand.js
+++ b/test/parallel/test-repl-definecommand.js
@@ -1,25 +1,20 @@
 'use strict';
 
 require('../common');
+const { startNewREPLServer } = require('../common/repl');
 
 const stream = require('stream');
 const assert = require('assert');
-const repl = require('repl');
 
 let output = '';
-const inputStream = new stream.PassThrough();
 const outputStream = new stream.PassThrough();
 outputStream.on('data', function(d) {
   output += d;
 });
 
-const r = repl.start({
-  input: inputStream,
-  output: outputStream,
-  terminal: true
-});
+const { replServer: replServer, input } = startNewREPLServer({ prompt: '> ', terminal: true, output: outputStream });
 
-r.defineCommand('say1', {
+replServer.defineCommand('say1', {
   help: 'help for say1',
   action: function(thing) {
     output = '';
@@ -28,21 +23,21 @@ r.defineCommand('say1', {
   }
 });
 
-r.defineCommand('say2', function() {
+replServer.defineCommand('say2', function() {
   output = '';
   this.output.write('hello from say2\n');
   this.displayPrompt();
 });
 
-inputStream.write('.help\n');
+input.run(['.help\n']);
 assert.match(output, /\n\.say1 {5}help for say1\n/);
 assert.match(output, /\n\.say2\n/);
-inputStream.write('.say1 node developer\n');
+input.run(['.say1 node developer\n']);
 assert.ok(output.startsWith('hello node developer\n'),
           `say1 output starts incorrectly: "${output}"`);
 assert.ok(output.includes('> '),
           `say1 output does not include prompt: "${output}"`);
-inputStream.write('.say2 node developer\n');
+input.run(['.say2 node developer\n']);
 assert.ok(output.startsWith('hello from say2\n'),
           `say2 output starts incorrectly: "${output}"`);
 assert.ok(output.includes('> '),

--- a/test/parallel/test-repl-domain.js
+++ b/test/parallel/test-repl-domain.js
@@ -21,14 +21,18 @@
 
 'use strict';
 require('../common');
+const { startNewREPLServer } = require('../common/repl');
 const ArrayStream = require('../common/arraystream');
 
-const repl = require('repl');
+const stream = new ArrayStream();
 
-const putIn = new ArrayStream();
-repl.start('', putIn);
+startNewREPLServer({
+  input: stream,
+  output: stream,
+  terminal: false,
+});
 
-putIn.write = function(data) {
+stream.write = function(data) {
   // Don't use assert for this because the domain might catch it, and
   // give a false negative.  Don't throw, just print and exit.
   if (data === 'OK\n') {
@@ -39,7 +43,7 @@ putIn.write = function(data) {
   }
 };
 
-putIn.run([
+stream.run([
   'require("domain").create().on("error", function() { console.log("OK") })' +
   '.run(function() { throw new Error("threw") })',
 ]);

--- a/test/parallel/test-repl-empty.js
+++ b/test/parallel/test-repl-empty.js
@@ -1,27 +1,23 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
-{
-  let evalCalledWithExpectedArgs = false;
+let evalCalledWithExpectedArgs = false;
 
-  const options = {
-    eval: common.mustCall((cmd, context) => {
-      // Assertions here will not cause the test to exit with an error code
-      // so set a boolean that is checked later instead.
-      evalCalledWithExpectedArgs = (cmd === '\n');
-    })
-  };
+const { replServer } = startNewREPLServer({
+  eval: common.mustCall((cmd, context) => {
+    // Assertions here will not cause the test to exit with an error code
+    // so set a boolean that is checked later instead.
+    evalCalledWithExpectedArgs = (cmd === '\n');
+  })
+});
 
-  const r = repl.start(options);
-
-  try {
-    // Empty strings should be sent to the repl's eval function
-    r.write('\n');
-  } finally {
-    r.write('.exit\n');
-  }
-
-  assert(evalCalledWithExpectedArgs);
+try {
+  // Empty strings should be sent to the repl's eval function
+  replServer.write('\n');
+} finally {
+  replServer.write('.exit\n');
 }
+
+assert(evalCalledWithExpectedArgs);

--- a/test/parallel/test-repl-end-emits-exit.js
+++ b/test/parallel/test-repl-end-emits-exit.js
@@ -21,28 +21,20 @@
 
 'use strict';
 require('../common');
-const ArrayStream = require('../common/arraystream');
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('assert');
-const repl = require('repl');
 let terminalExit = 0;
 let regularExit = 0;
 
-// Create a dummy stream that does nothing
-const stream = new ArrayStream();
-
 function testTerminalMode() {
-  const r1 = repl.start({
-    input: stream,
-    output: stream,
-    terminal: true
-  });
+  const { replServer, input } = startNewREPLServer({ terminal: true });
 
   process.nextTick(function() {
     // Manually fire a ^D keypress
-    stream.emit('data', '\u0004');
+    input.emit('data', '\u0004');
   });
 
-  r1.on('exit', function() {
+  replServer.on('exit', function() {
     // Should be fired from the simulated ^D keypress
     terminalExit++;
     testRegularMode();
@@ -50,17 +42,13 @@ function testTerminalMode() {
 }
 
 function testRegularMode() {
-  const r2 = repl.start({
-    input: stream,
-    output: stream,
-    terminal: false
-  });
+  const { replServer, input } = startNewREPLServer({ terminal: true });
 
   process.nextTick(function() {
-    stream.emit('end');
+    input.emit('end');
   });
 
-  r2.on('exit', function() {
+  replServer.on('exit', function() {
     // Should be fired from the simulated 'end' event
     regularExit++;
   });

--- a/test/parallel/test-repl-function-definition-edge-case.js
+++ b/test/parallel/test-repl-function-definition-edge-case.js
@@ -2,36 +2,18 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const repl = require('repl');
-const stream = require('stream');
+const { startNewREPLServer } = require('../common/repl');
 
-const r = initRepl();
+const { replServer } = startNewREPLServer({
+  useColors: false,
+  terminal: false
+});
 
-r.input.emit('data', 'function a() { return 42; } (1)\n');
-r.input.emit('data', 'a\n');
-r.input.emit('data', '.exit\n');
-r.once('exit', common.mustCall());
+replServer.input.emit('data', 'function a() { return 42; } (1)\n');
+replServer.input.emit('data', 'a\n');
+replServer.input.emit('data', '.exit\n');
+replServer.once('exit', common.mustCall());
 
 const expected = '1\n[Function: a]\n';
-const got = r.output.accumulator.join('');
+const got = replServer.output.accumulator;
 assert.strictEqual(got, expected);
-
-function initRepl() {
-  const input = new stream();
-  input.write = input.pause = input.resume = () => {};
-  input.readable = true;
-
-  const output = new stream();
-  output.writable = true;
-  output.accumulator = [];
-
-  output.write = (data) => output.accumulator.push(data);
-
-  return repl.start({
-    input,
-    output,
-    useColors: false,
-    terminal: false,
-    prompt: ''
-  });
-}

--- a/test/parallel/test-repl-let-process.js
+++ b/test/parallel/test-repl-let-process.js
@@ -1,9 +1,7 @@
 'use strict';
 require('../common');
-const ArrayStream = require('../common/arraystream');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 // Regression test for https://github.com/nodejs/node/issues/6802
-const input = new ArrayStream();
-repl.start({ input, output: process.stdout, useGlobal: true });
+const { input } = startNewREPLServer({ useGlobal: true }, { disableDomainErrorAssert: true });
 input.run(['let process']);

--- a/test/parallel/test-repl-load-multiline-no-trailing-newline.js
+++ b/test/parallel/test-repl-load-multiline-no-trailing-newline.js
@@ -1,9 +1,8 @@
 'use strict';
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 if (process.env.TERM === 'dumb') {
   common.skip('skipping - dumb terminal');
@@ -24,21 +23,11 @@ const eat = (food) => '<nom nom nom>';
 undefined
 `;
 
-let accum = '';
+const { replServer, output } = startNewREPLServer();
 
-const inputStream = new ArrayStream();
-const outputStream = new ArrayStream();
-
-outputStream.write = (data) => accum += data.replace('\r', '');
-
-const r = repl.start({
-  prompt: '',
-  input: inputStream,
-  output: outputStream,
-  terminal: true,
-  useColors: false
-});
-
-r.write(`${command}\n`);
-assert.strictEqual(accum.replace(terminalCodeRegex, ''), expected);
-r.close();
+replServer.write(`${command}\n`);
+assert.strictEqual(
+  output.accumulator.replace(terminalCodeRegex, ''),
+  expected
+);
+replServer.close();

--- a/test/parallel/test-repl-load-multiline.js
+++ b/test/parallel/test-repl-load-multiline.js
@@ -1,9 +1,8 @@
 'use strict';
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 if (process.env.TERM === 'dumb') {
   common.skip('skipping - dumb terminal');
@@ -24,21 +23,8 @@ const eat = (food) => '<nom nom nom>';
 undefined
 `;
 
-let accum = '';
+const { replServer, output } = startNewREPLServer();
 
-const inputStream = new ArrayStream();
-const outputStream = new ArrayStream();
-
-outputStream.write = (data) => accum += data.replace('\r', '');
-
-const r = repl.start({
-  prompt: '',
-  input: inputStream,
-  output: outputStream,
-  terminal: true,
-  useColors: false
-});
-
-r.write(`${command}\n`);
-assert.strictEqual(accum.replace(terminalCodeRegex, ''), expected);
-r.close();
+replServer.write(`${command}\n`);
+assert.strictEqual(output.accumulator.replace(terminalCodeRegex, ''), expected);
+replServer.close();

--- a/test/parallel/test-repl-no-terminal.js
+++ b/test/parallel/test-repl-no-terminal.js
@@ -1,11 +1,8 @@
 'use strict';
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
-const stream = new ArrayStream();
-
-const replServer = repl.start({ terminal: false, input: stream, output: stream });
+const { replServer } = startNewREPLServer();
 
 replServer.setupHistory('/nonexistent/file', common.mustSucceed(() => {
   replServer.close();

--- a/test/parallel/test-repl-null-thrown.js
+++ b/test/parallel/test-repl-null-thrown.js
@@ -1,23 +1,13 @@
 'use strict';
 require('../common');
-const repl = require('repl');
 const assert = require('assert');
-const Stream = require('stream');
+const { startNewREPLServer } = require('../common/repl');
 
-const output = new Stream();
-let text = '';
-output.write = output.pause = output.resume = function(buf) {
-  text += buf.toString();
-};
+const { replServer, output } = startNewREPLServer();
 
-const replserver = repl.start({
-  output: output,
-  input: process.stdin
-});
-
-replserver.emit('line', 'process.nextTick(() => { throw null; })');
-replserver.emit('line', '.exit');
+replServer.emit('line', 'process.nextTick(() => { throw null; })');
+replServer.emit('line', '.exit');
 
 setTimeout(() => {
-  assert(text.includes('Uncaught null'));
+  assert(output.accumulator.includes('Uncaught null'));
 }, 0);

--- a/test/parallel/test-repl-paste-big-data.js
+++ b/test/parallel/test-repl-paste-big-data.js
@@ -1,36 +1,18 @@
 'use strict';
 
 const common = require('../common');
-const repl = require('repl');
-const stream = require('stream');
 const assert = require('assert');
+const { startNewREPLServer } = require('../common/repl');
 
 // Pasting big input should not cause the process to have a huge CPU usage.
 
 const cpuUsage = process.cpuUsage();
 
-const r = initRepl();
-r.input.emit('data', 'a'.repeat(2e4) + '\n');
-r.input.emit('data', '.exit\n');
+const { replServer } = startNewREPLServer({}, { disableDomainErrorAssert: true });
+replServer.input.emit('data', 'a'.repeat(2e4) + '\n');
+replServer.input.emit('data', '.exit\n');
 
-r.once('exit', common.mustCall(() => {
+replServer.once('exit', common.mustCall(() => {
   const diff = process.cpuUsage(cpuUsage);
   assert.ok(diff.user < 1e6);
 }));
-
-function initRepl() {
-  const input = new stream();
-  input.write = input.pause = input.resume = () => {};
-  input.readable = true;
-
-  const output = new stream();
-  output.write = () => {};
-  output.writable = true;
-
-  return repl.start({
-    input,
-    output,
-    terminal: true,
-    prompt: ''
-  });
-}

--- a/test/parallel/test-repl-pretty-custom-stack.js
+++ b/test/parallel/test-repl-pretty-custom-stack.js
@@ -1,41 +1,32 @@
 'use strict';
 require('../common');
-const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 const stackRegExp = /(REPL\d+):[0-9]+:[0-9]+/g;
 
 function run({ command, expected }) {
-  let accum = '';
-
-  const inputStream = new ArrayStream();
-  const outputStream = new ArrayStream();
-
-  outputStream.write = (data) => accum += data.replace('\r', '');
-
-  const r = repl.start({
-    prompt: '',
-    input: inputStream,
-    output: outputStream,
+  const { replServer, output } = startNewREPLServer({
     terminal: false,
     useColors: false
+  }, {
+    disableDomainErrorAssert: true,
   });
 
-  r.write(`${command}\n`);
+  replServer.write(`${command}\n`);
   if (typeof expected === 'string') {
     assert.strictEqual(
-      accum.replace(stackRegExp, '$1:*:*'),
+      output.accumulator.replace(stackRegExp, '$1:*:*'),
       expected.replace(stackRegExp, '$1:*:*')
     );
   } else {
     assert.match(
-      accum.replace(stackRegExp, '$1:*:*'),
+      output.accumulator.replace(stackRegExp, '$1:*:*'),
       expected
     );
   }
-  r.close();
+  replServer.close();
 }
 
 const origPrepareStackTrace = Error.prepareStackTrace;

--- a/test/parallel/test-repl-pretty-stack-custom-writer.js
+++ b/test/parallel/test-repl-pretty-stack-custom-writer.js
@@ -1,23 +1,18 @@
 'use strict';
 require('../common');
-const { PassThrough } = require('stream');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
-{
-  const input = new PassThrough();
-  const output = new PassThrough();
+const testingReplPrompt = '_REPL_TESTING_PROMPT_>';
 
-  const r = repl.start({
-    prompt: '',
-    input,
-    output,
-    writer: String,
-    terminal: false,
-    useColors: false
-  });
+const { replServer, output } = startNewREPLServer(
+  { prompt: testingReplPrompt },
+  { disableDomainErrorAssert: true }
+);
 
-  r.write('throw new Error("foo[a]")\n');
-  r.close();
-  assert.strictEqual(output.read().toString(), 'Uncaught Error: foo[a]\n');
-}
+replServer.write('throw new Error("foo[a]")\n');
+
+assert.strictEqual(
+  output.accumulator.split('\n').filter((line) => !line.includes(testingReplPrompt)).join(''),
+  'Uncaught Error: foo[a]'
+);

--- a/test/parallel/test-repl-preview-timeout.js
+++ b/test/parallel/test-repl-preview-timeout.js
@@ -1,27 +1,17 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 common.skipIfInspectorDisabled();
 
-const inputStream = new ArrayStream();
-const outputStream = new ArrayStream();
-repl.start({
-  input: inputStream,
-  output: outputStream,
-  useGlobal: false,
-  terminal: true,
-  useColors: true
-});
+const { output, input } = startNewREPLServer();
 
-let output = '';
-outputStream.write = (chunk) => output += chunk;
+output.accumulator = '';
 
 // Input without '\n' triggering actual run.
-const input = 'while (true) {}';
-inputStream.emit('data', input);
+const inputStr = 'while (true) {}';
+input.emit('data', inputStr);
 // No preview available when timed out.
-assert.strictEqual(output, input);
+assert.strictEqual(output.accumulator, inputStr);

--- a/test/parallel/test-repl-reset-event.js
+++ b/test/parallel/test-repl-reset-event.js
@@ -21,27 +21,19 @@
 
 'use strict';
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
-const repl = require('repl');
 const util = require('util');
+const { startNewREPLServer } = require('../common/repl');
 
 common.allowGlobals(42);
 
-// Create a dummy stream that does nothing
-const dummy = new ArrayStream();
-
 function testReset(cb) {
-  const r = repl.start({
-    input: dummy,
-    output: dummy,
-    useGlobal: false
-  });
-  r.context.foo = 42;
-  r.on('reset', common.mustCall(function(context) {
+  const { replServer } = startNewREPLServer();
+  replServer.context.foo = 42;
+  replServer.on('reset', common.mustCall(function(context) {
     assert(!!context, 'REPL did not emit a context with reset event');
-    assert.strictEqual(context, r.context, 'REPL emitted incorrect context. ' +
-    `context is ${util.inspect(context)}, expected ${util.inspect(r.context)}`);
+    assert.strictEqual(context, replServer.context, 'REPL emitted incorrect context. ' +
+    `context is ${util.inspect(context)}, expected ${util.inspect(replServer.context)}`);
     assert.strictEqual(
       context.foo,
       undefined,
@@ -51,17 +43,13 @@ function testReset(cb) {
     context.foo = 42;
     cb();
   }));
-  r.resetContext();
+  replServer.resetContext();
 }
 
 function testResetGlobal() {
-  const r = repl.start({
-    input: dummy,
-    output: dummy,
-    useGlobal: true
-  });
-  r.context.foo = 42;
-  r.on('reset', common.mustCall(function(context) {
+  const { replServer } = startNewREPLServer({ useGlobal: true });
+  replServer.context.foo = 42;
+  replServer.on('reset', common.mustCall(function(context) {
     assert.strictEqual(
       context.foo,
       42,
@@ -69,7 +57,7 @@ function testResetGlobal() {
       `context.foo is ${context.foo}, expected 42.`
     );
   }));
-  r.resetContext();
+  replServer.resetContext();
 }
 
 testReset(common.mustCall(testResetGlobal));

--- a/test/parallel/test-repl-save-load-editor-mode.js
+++ b/test/parallel/test-repl-save-load-editor-mode.js
@@ -1,30 +1,17 @@
 'use strict';
 
 require('../common');
-const ArrayStream = require('../common/arraystream');
-
 const assert = require('node:assert');
 const fs = require('node:fs');
-const repl = require('node:repl');
 const path = require('node:path');
+const { startNewREPLServer } = require('../common/repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Test for saving a REPL session in editor mode
 
-const input = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output: new ArrayStream(),
-  allowBlockingCompletions: true,
-  terminal: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input } = startNewREPLServer();
 
 input.run(['.editor']);
 

--- a/test/parallel/test-repl-save-load-invalid-save.js
+++ b/test/parallel/test-repl-save-load-invalid-save.js
@@ -1,28 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
 const assert = require('node:assert');
-const repl = require('node:repl');
+const { startNewREPLServer } = require('../common/repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Test for the appropriate handling of cases in which REPL saves fail
 
-const input = new ArrayStream();
-const output = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input, output } = startNewREPLServer({ terminal: false });
 
 // NUL (\0) is disallowed in filenames in UNIX-like operating systems and
 // Windows so we can use that to test failed saves.

--- a/test/parallel/test-repl-save-load-load-dir.js
+++ b/test/parallel/test-repl-save-load-load-dir.js
@@ -1,28 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('node:assert');
-const repl = require('node:repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Tests that an appropriate error is displayed if the user tries to load a directory instead of a file
 
-const input = new ArrayStream();
-const output = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input, output } = startNewREPLServer({ terminal: false });
 
 const dirPath = tmpdir.path;
 

--- a/test/parallel/test-repl-save-load-load-non-existent.js
+++ b/test/parallel/test-repl-save-load-load-non-existent.js
@@ -1,28 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('node:assert');
-const repl = require('node:repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Tests that an appropriate error is displayed if the user tries to load a non existent file
 
-const input = new ArrayStream();
-const output = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input, output } = startNewREPLServer({ terminal: false });
 
 const filePath = tmpdir.resolve('file.does.not.exist');
 

--- a/test/parallel/test-repl-save-load-load-without-name.js
+++ b/test/parallel/test-repl-save-load-load-without-name.js
@@ -1,28 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('node:assert');
-const repl = require('node:repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Tests that an appropriate error is displayed if .load is called without a filename
 
-const input = new ArrayStream();
-const output = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input, output } = startNewREPLServer({ terminal: false });
 
 output.write = common.mustCall(function(data) {
   assert.strictEqual(data, 'The "file" argument must be specified\n');

--- a/test/parallel/test-repl-save-load-save-without-name.js
+++ b/test/parallel/test-repl-save-load-save-without-name.js
@@ -1,28 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('node:assert');
-const repl = require('node:repl');
 
 const tmpdir = require('../common/tmpdir');
 tmpdir.refresh();
 
 // Tests that an appropriate error is displayed if .save is called without a filename
 
-const input = new ArrayStream();
-const output = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input, output } = startNewREPLServer({ terminal: false });
 
 output.write = common.mustCall(function(data) {
   assert.strictEqual(data, 'The "file" argument must be specified\n');

--- a/test/parallel/test-repl-save-load.js
+++ b/test/parallel/test-repl-save-load.js
@@ -22,11 +22,9 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-
+const { startNewREPLServer } = require('../common/repl');
 const assert = require('node:assert');
 const fs = require('node:fs');
-const repl = require('node:repl');
 const path = require('node:path');
 
 const tmpdir = require('../common/tmpdir');
@@ -34,17 +32,7 @@ tmpdir.refresh();
 
 // Tests that a REPL session data can be saved to and loaded from a file
 
-const input = new ArrayStream();
-
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output: new ArrayStream(),
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input } = startNewREPLServer({ terminal: false });
 
 const filePath = path.resolve(tmpdir.path, 'test.save.js');
 

--- a/test/parallel/test-repl-syntax-error-stack.js
+++ b/test/parallel/test-repl-syntax-error-stack.js
@@ -1,32 +1,32 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
+
 let found = false;
 
 process.on('exit', () => {
   assert.strictEqual(found, true);
 });
 
-ArrayStream.prototype.write = function(output) {
+const { input, output } = startNewREPLServer({}, { disableDomainErrorAssert: true });
+
+output.write = (data) => {
   // Matching only on a minimal piece of the stack because the string will vary
   // greatly depending on the JavaScript engine. V8 includes `;` because it
   // displays the line of code (`var foo bar;`) that is causing a problem.
   // ChakraCore does not display the line of code but includes `;` in the phrase
   // `Expected ';' `.
-  if (/;/.test(output))
+  if (/;/.test(data))
     found = true;
 };
 
-const putIn = new ArrayStream();
-repl.start('', putIn);
 let file = fixtures.path('syntax', 'bad_syntax');
 
 if (common.isWindows)
   file = file.replace(/\\/g, '\\\\');
 
-putIn.run(['.clear']);
-putIn.run([`require('${file}');`]);
+input.run(['.clear']);
+input.run([`require('${file}');`]);

--- a/test/parallel/test-repl-tab-complete-buffer.js
+++ b/test/parallel/test-repl-tab-complete-buffer.js
@@ -1,22 +1,11 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const { hijackStderr, restoreStderr } = require('../common/hijackstdio');
 const assert = require('assert');
+const { startNewREPLServer } = require('../common/repl');
 
-const repl = require('repl');
-
-const input = new ArrayStream();
-const replServer = repl.start({
-  prompt: '',
-  input,
-  output: process.stdout,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer, input } = startNewREPLServer();
 
 for (const type of [
   Array,

--- a/test/parallel/test-repl-tab-complete-computed-props.js
+++ b/test/parallel/test-repl-tab-complete-computed-props.js
@@ -1,26 +1,9 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
+const { startNewREPLServer } = require('../common/repl');
 const { describe, it, before, after } = require('node:test');
 const assert = require('assert');
-
-const repl = require('repl');
-
-function prepareREPL() {
-  const input = new ArrayStream();
-  const replServer = repl.start({
-    prompt: '',
-    input,
-    output: process.stdout,
-    allowBlockingCompletions: true,
-  });
-
-  // Some errors are passed to the domain, but do not callback
-  replServer._domain.on('error', assert.ifError);
-
-  return { replServer, input };
-}
 
 function testCompletion(replServer, { input, expectedCompletions }) {
   replServer.complete(
@@ -36,7 +19,7 @@ describe('REPL tab object completion on computed properties', () => {
     let replServer;
 
     before(() => {
-      const { replServer: server, input } = prepareREPL();
+      const { replServer: server, input } = startNewREPLServer();
       replServer = server;
 
       input.run([
@@ -97,7 +80,7 @@ describe('REPL tab object completion on computed properties', () => {
     let replServer;
 
     before(() => {
-      const { replServer: server, input } = prepareREPL();
+      const { replServer: server, input } = startNewREPLServer();
       replServer = server;
 
       input.run([

--- a/test/parallel/test-repl-tab-complete-crash.js
+++ b/test/parallel/test-repl-tab-complete-crash.js
@@ -1,28 +1,21 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
-ArrayStream.prototype.write = () => {};
-
-const putIn = new ArrayStream();
-const testMe = repl.start('', putIn);
+const { replServer, input } = startNewREPLServer({}, { disableDomainErrorAssert: true });
 
 // https://github.com/nodejs/node/issues/3346
 // Tab-completion should be empty
-putIn.run(['.clear']);
-putIn.run(['function () {']);
-testMe.complete('arguments.', common.mustCall((err, completions) => {
+input.run(['.clear', 'function () {']);
+replServer.complete('arguments.', common.mustCall((err, completions) => {
   assert.strictEqual(err, null);
   assert.deepStrictEqual(completions, [[], 'arguments.']);
 }));
 
-putIn.run(['.clear']);
-putIn.run(['function () {']);
-putIn.run(['undef;']);
-testMe.complete('undef.', common.mustCall((err, completions) => {
+input.run(['.clear', 'function () {', 'undef;']);
+replServer.complete('undef.', common.mustCall((err, completions) => {
   assert.strictEqual(err, null);
   assert.deepStrictEqual(completions, [[], 'undef.']);
 }));

--- a/test/parallel/test-repl-tab-complete-custom-completer.js
+++ b/test/parallel/test-repl-tab-complete-custom-completer.js
@@ -1,21 +1,14 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
-
-const repl = require('repl');
-
-const putIn = new ArrayStream();
+const { startNewREPLServer } = require('../common/repl');
 
 // To test custom completer function.
 // Sync mode.
 {
   const customCompletions = 'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' ');
-  const testCustomCompleterSyncMode = repl.start({
-    prompt: '',
-    input: putIn,
-    output: putIn,
+  const { replServer } = startNewREPLServer({
     completer: function completer(line) {
       const hits = customCompletions.filter((c) => c.startsWith(line));
       // Show all completions if none found.
@@ -25,7 +18,7 @@ const putIn = new ArrayStream();
 
   // On empty line should output all the custom completions
   // without complete anything.
-  testCustomCompleterSyncMode.complete('', common.mustCall((error, data) => {
+  replServer.complete('', common.mustCall((error, data) => {
     assert.deepStrictEqual(data, [
       customCompletions,
       '',
@@ -33,7 +26,7 @@ const putIn = new ArrayStream();
   }));
 
   // On `a` should output `aaa aa1 aa2` and complete until `aa`.
-  testCustomCompleterSyncMode.complete('a', common.mustCall((error, data) => {
+  replServer.complete('a', common.mustCall((error, data) => {
     assert.deepStrictEqual(data, [
       'aaa aa1 aa2'.split(' '),
       'a',
@@ -45,10 +38,7 @@ const putIn = new ArrayStream();
 // Async mode.
 {
   const customCompletions = 'aaa aa1 aa2 bbb bb1 bb2 bb3 ccc ddd eee'.split(' ');
-  const testCustomCompleterAsyncMode = repl.start({
-    prompt: '',
-    input: putIn,
-    output: putIn,
+  const { replServer } = startNewREPLServer({
     completer: function completer(line, callback) {
       const hits = customCompletions.filter((c) => c.startsWith(line));
       // Show all completions if none found.
@@ -58,7 +48,7 @@ const putIn = new ArrayStream();
 
   // On empty line should output all the custom completions
   // without complete anything.
-  testCustomCompleterAsyncMode.complete('', common.mustCall((error, data) => {
+  replServer.complete('', common.mustCall((error, data) => {
     assert.deepStrictEqual(data, [
       customCompletions,
       '',
@@ -66,7 +56,7 @@ const putIn = new ArrayStream();
   }));
 
   // On `a` should output `aaa aa1 aa2` and complete until `aa`.
-  testCustomCompleterAsyncMode.complete('a', common.mustCall((error, data) => {
+  replServer.complete('a', common.mustCall((error, data) => {
     assert.deepStrictEqual(data, [
       'aaa aa1 aa2'.split(' '),
       'a',

--- a/test/parallel/test-repl-tab-complete-files.js
+++ b/test/parallel/test-repl-tab-complete-files.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const path = require('path');
+const { startNewREPLServer } = require('../common/repl');
 
 const { isMainThread } = require('worker_threads');
 
@@ -11,17 +11,7 @@ if (!isMainThread) {
   common.skip('process.chdir is not available in Workers');
 }
 
-const repl = require('repl');
-
-const replServer = repl.start({
-  prompt: '',
-  input: new ArrayStream(),
-  output: process.stdout,
-  allowBlockingCompletions: true,
-});
-
-// Some errors are passed to the domain, but do not callback
-replServer._domain.on('error', assert.ifError);
+const { replServer } = startNewREPLServer();
 
 // Tab completion for files/directories
 {

--- a/test/parallel/test-repl-tab-complete-getter-error.js
+++ b/test/parallel/test-repl-tab-complete-getter-error.js
@@ -1,29 +1,15 @@
 'use strict';
 
 const common = require('../common');
-const repl = require('repl');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
+const { startNewREPLServer } = require('../common/repl');
 
 (async function() {
   await runTest();
 })().then(common.mustCall());
 
 async function runTest() {
-  const input = new ArrayStream();
-  const output = new ArrayStream();
-
-  const replServer = repl.start({
-    prompt: '',
-    input,
-    output: output,
-    allowBlockingCompletions: true,
-    terminal: true
-  });
-
-  replServer._domain.on('error', (e) => {
-    assert.fail(`Error in REPL domain: ${e}`);
-  });
+  const { replServer } = startNewREPLServer();
 
   await new Promise((resolve, reject) => {
     replServer.eval(`

--- a/test/parallel/test-repl-tab-complete-import.js
+++ b/test/parallel/test-repl-tab-complete-import.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { builtinModules } = require('module');
@@ -19,20 +18,12 @@ if (!isMainThread) {
 process.chdir(fixtures.fixturesDir);
 
 const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
-const putIn = new ArrayStream();
-const testMe = repl.start({
-  prompt: '',
-  input: putIn,
-  output: process.stdout,
-  allowBlockingCompletions: true
-});
-
-// Some errors are passed to the domain, but do not callback
-testMe._domain.on('error', assert.ifError);
+const { replServer, input } = startNewREPLServer();
 
 // Tab complete provides built in libs for import()
-testMe.complete('import(\'', common.mustSucceed((data) => {
+replServer.complete('import(\'', common.mustSucceed((data) => {
   publicUnprefixedModules.forEach((lib) => {
     assert(
       data[0].includes(lib) && data[0].includes(`node:${lib}`),
@@ -42,14 +33,14 @@ testMe.complete('import(\'', common.mustSucceed((data) => {
   const newModule = 'foobar';
   assert(!builtinModules.includes(newModule));
   repl.builtinModules.push(newModule);
-  testMe.complete('import(\'', common.mustSucceed(([modules]) => {
+  replServer.complete('import(\'', common.mustSucceed(([modules]) => {
     assert.strictEqual(data[0].length + 1, modules.length);
     assert(modules.includes(newModule) &&
       !modules.includes(`node:${newModule}`));
   }));
 }));
 
-testMe.complete("import\t( 'n", common.mustSucceed((data) => {
+replServer.complete("import\t( 'n", common.mustSucceed((data) => {
   assert.strictEqual(data.length, 2);
   assert.strictEqual(data[1], 'n');
   const completions = data[0];
@@ -74,38 +65,37 @@ testMe.complete("import\t( 'n", common.mustSucceed((data) => {
   const expected = ['@nodejsscope', '@nodejsscope/'];
   // Import calls should handle all types of quotation marks.
   for (const quotationMark of ["'", '"', '`']) {
-    putIn.run(['.clear']);
-    testMe.complete('import(`@nodejs', common.mustSucceed((data) => {
+    input.run(['.clear']);
+    replServer.complete('import(`@nodejs', common.mustSucceed((data) => {
       assert.deepStrictEqual(data, [expected, '@nodejs']);
     }));
 
-    putIn.run(['.clear']);
+    input.run(['.clear']);
     // Completions should not be greedy in case the quotation ends.
-    const input = `import(${quotationMark}@nodejsscope${quotationMark}`;
-    testMe.complete(input, common.mustSucceed((data) => {
+    replServer.complete(`import(${quotationMark}@nodejsscope${quotationMark}`, common.mustSucceed((data) => {
       assert.deepStrictEqual(data, [[], undefined]);
     }));
   }
 }
 
 {
-  putIn.run(['.clear']);
+  input.run(['.clear']);
   // Completions should find modules and handle whitespace after the opening
   // bracket.
-  testMe.complete('import \t("no_ind', common.mustSucceed((data) => {
+  replServer.complete('import \t("no_ind', common.mustSucceed((data) => {
     assert.deepStrictEqual(data, [['no_index', 'no_index/'], 'no_ind']);
   }));
 }
 
 // Test tab completion for import() relative to the current directory
 {
-  putIn.run(['.clear']);
+  input.run(['.clear']);
 
   const cwd = process.cwd();
   process.chdir(__dirname);
 
   ['import(\'.', 'import(".'].forEach((input) => {
-    testMe.complete(input, common.mustSucceed((data) => {
+    replServer.complete(input, common.mustSucceed((data) => {
       assert.strictEqual(data.length, 2);
       assert.strictEqual(data[1], '.');
       assert.strictEqual(data[0].length, 2);
@@ -115,14 +105,14 @@ testMe.complete("import\t( 'n", common.mustSucceed((data) => {
   });
 
   ['import(\'..', 'import("..'].forEach((input) => {
-    testMe.complete(input, common.mustSucceed((data) => {
+    replServer.complete(input, common.mustSucceed((data) => {
       assert.deepStrictEqual(data, [['../'], '..']);
     }));
   });
 
   ['./', './test-'].forEach((path) => {
     [`import('${path}`, `import("${path}`].forEach((input) => {
-      testMe.complete(input, common.mustSucceed((data) => {
+      replServer.complete(input, common.mustSucceed((data) => {
         assert.strictEqual(data.length, 2);
         assert.strictEqual(data[1], path);
         assert.ok(data[0].includes('./test-repl-tab-complete.js'));
@@ -132,7 +122,7 @@ testMe.complete("import\t( 'n", common.mustSucceed((data) => {
 
   ['../parallel/', '../parallel/test-'].forEach((path) => {
     [`import('${path}`, `import("${path}`].forEach((input) => {
-      testMe.complete(input, common.mustSucceed((data) => {
+      replServer.complete(input, common.mustSucceed((data) => {
         assert.strictEqual(data.length, 2);
         assert.strictEqual(data[1], path);
         assert.ok(data[0].includes('../parallel/test-repl-tab-complete.js'));
@@ -142,7 +132,7 @@ testMe.complete("import\t( 'n", common.mustSucceed((data) => {
 
   {
     const path = '../fixtures/repl-folder-extensions/f';
-    testMe.complete(`import('${path}`, common.mustSucceed((data) => {
+    replServer.complete(`import('${path}`, common.mustSucceed((data) => {
       assert.strictEqual(data.length, 2);
       assert.strictEqual(data[1], path);
       assert.ok(data[0].includes(

--- a/test/parallel/test-repl-tab-complete-no-warn.js
+++ b/test/parallel/test-repl-tab-complete-no-warn.js
@@ -1,21 +1,17 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 const DEFAULT_MAX_LISTENERS = require('events').defaultMaxListeners;
 
-ArrayStream.prototype.write = () => {};
-
-const putIn = new ArrayStream();
-const testMe = repl.start('', putIn);
+const { replServer, input } = startNewREPLServer();
 
 // https://github.com/nodejs/node/issues/18284
 // Tab-completion should not repeatedly add the
 // `Runtime.executionContextCreated` listener
 process.on('warning', common.mustNotCall());
 
-putIn.run(['async function test() {']);
+input.run(['async function test() {']);
 for (let i = 0; i < DEFAULT_MAX_LISTENERS; i++) {
-  testMe.complete('await Promise.resolve()', () => {});
+  replServer.complete('await Promise.resolve()', () => {});
 }

--- a/test/parallel/test-repl-tab-complete-nosideeffects.js
+++ b/test/parallel/test-repl-tab-complete-nosideeffects.js
@@ -1,26 +1,9 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const { describe, it } = require('node:test');
 const assert = require('assert');
-
-const repl = require('repl');
-
-function prepareREPL() {
-  const input = new ArrayStream();
-  const replServer = repl.start({
-    prompt: '',
-    input,
-    output: process.stdout,
-    allowBlockingCompletions: true,
-  });
-
-  // Some errors are passed to the domain, but do not callback
-  replServer._domain.on('error', assert.ifError);
-
-  return { replServer, input };
-}
+const { startNewREPLServer } = require('../common/repl');
 
 function getNoResultsFunction() {
   return common.mustSucceed((data) => {
@@ -44,7 +27,7 @@ describe('REPL tab completion without side effects', () => {
     'arr[incCounter()].b',
   ]) {
     it(`does not evaluate with side effects (${code})`, async () => {
-      const { replServer, input } = prepareREPL();
+      const { replServer, input } = startNewREPLServer();
       input.run(setup);
 
       replServer.complete(code, getNoResultsFunction());

--- a/test/parallel/test-repl-tab-complete-on-editor-mode.js
+++ b/test/parallel/test-repl-tab-complete-on-editor-mode.js
@@ -2,41 +2,28 @@
 
 const common = require('../common');
 const assert = require('assert');
-const ArrayStream = require('../common/arraystream');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 
 // Tab completion in editor mode
 {
-  const editorStream = new ArrayStream();
-  const editor = repl.start({
-    stream: editorStream,
-    terminal: true,
-    useColors: false
-  });
+  const { replServer, input } = startNewREPLServer();
 
-  editorStream.run(['.clear']);
-  editorStream.run(['.editor']);
+  input.run(['.clear', '.editor']);
 
-  editor.completer('Uin', common.mustCall((_error, data) => {
+  replServer.completer('Uin', common.mustCall((_error, data) => {
     assert.deepStrictEqual(data, [['Uint'], 'Uin']);
   }));
 
-  editorStream.run(['.clear']);
-  editorStream.run(['.editor']);
+  input.run(['.clear', '.editor']);
 
-  editor.completer('var log = console.l', common.mustCall((_error, data) => {
+  replServer.completer('var log = console.l', common.mustCall((_error, data) => {
     assert.deepStrictEqual(data, [['console.log'], 'console.l']);
   }));
 }
 
 // Regression test for https://github.com/nodejs/node/issues/43528
 {
-  const stream = new ArrayStream();
-  const replServer = repl.start({
-    input: stream,
-    output: stream,
-    terminal: true,
-  });
+  const { replServer } = startNewREPLServer();
 
   // Editor mode
   replServer.write('.editor\n');

--- a/test/parallel/test-repl-tab-complete-require.js
+++ b/test/parallel/test-repl-tab-complete-require.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const common = require('../common');
-const ArrayStream = require('../common/arraystream');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const { builtinModules } = require('module');
@@ -19,24 +18,11 @@ if (!isMainThread) {
 process.chdir(fixtures.fixturesDir);
 
 const repl = require('repl');
-
-function prepareREPL() {
-  const replServer = repl.start({
-    prompt: '',
-    input: new ArrayStream(),
-    output: process.stdout,
-    allowBlockingCompletions: true,
-  });
-
-  // Some errors are passed to the domain, but do not callback
-  replServer._domain.on('error', assert.ifError);
-
-  return replServer;
-}
+const { startNewREPLServer } = require('../common/repl');
 
 // Tab completion on require on builtin modules works
 {
-  const replServer = prepareREPL();
+  const { replServer } = startNewREPLServer();
 
   replServer.complete(
     "require('",
@@ -65,7 +51,7 @@ function prepareREPL() {
 
 // Tab completion on require on builtin modules works (with extra spaces and "n" prefix)
 {
-  const replServer = prepareREPL();
+  const { replServer } = startNewREPLServer();
 
   replServer.complete(
     "require\t( 'n",
@@ -98,7 +84,7 @@ function prepareREPL() {
 {
   const expected = ['@nodejsscope', '@nodejsscope/'];
 
-  const replServer = prepareREPL();
+  const { replServer } = startNewREPLServer();
 
   // Require calls should handle all types of quotation marks.
   for (const quotationMark of ["'", '"', '`']) {
@@ -124,7 +110,7 @@ function prepareREPL() {
 
 {
   // Completions should find modules and handle whitespace after the opening bracket.
-  const replServer = prepareREPL();
+  const { replServer } = startNewREPLServer();
 
   replServer.complete(
     'require \t("no_ind',
@@ -137,7 +123,7 @@ function prepareREPL() {
 
 // Test tab completion for require() relative to the current directory
 {
-  const replServer = prepareREPL();
+  const { replServer } = startNewREPLServer();
 
   const cwd = process.cwd();
   process.chdir(__dirname);

--- a/test/parallel/test-repl-tab-complete-unary-expressions.js
+++ b/test/parallel/test-repl-tab-complete-unary-expressions.js
@@ -2,7 +2,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const repl = require('repl');
+const { startNewREPLServer } = require('../common/repl');
 const { describe, it } = require('node:test');
 
 // This test verifies that tab completion works correctly with unary expressions
@@ -12,25 +12,20 @@ const { describe, it } = require('node:test');
 
 describe('REPL tab completion with unary expressions', () => {
   it('should handle delete operator correctly', (t, done) => {
-    const r = repl.start({
-      prompt: '',
-      input: process.stdin,
-      output: process.stdout,
-      terminal: false,
-    });
+    const { replServer } = startNewREPLServer({ terminal: false });
 
     // Test delete with member expression
-    r.complete(
+    replServer.complete(
       'delete globalThis._',
       common.mustSucceed((completions) => {
         assert.strictEqual(completions[1], 'globalThis._');
 
         // Test delete with identifier
-        r.complete(
+        replServer.complete(
           'delete globalThis',
           common.mustSucceed((completions) => {
             assert.strictEqual(completions[1], 'globalThis');
-            r.close();
+            replServer.close();
             done();
           })
         );
@@ -39,48 +34,33 @@ describe('REPL tab completion with unary expressions', () => {
   });
 
   it('should handle typeof operator correctly', (t, done) => {
-    const r = repl.start({
-      prompt: '',
-      input: process.stdin,
-      output: process.stdout,
-      terminal: false,
-    });
+    const { replServer } = startNewREPLServer({ terminal: false });
 
-    r.complete(
+    replServer.complete(
       'typeof globalThis',
       common.mustSucceed((completions) => {
         assert.strictEqual(completions[1], 'globalThis');
-        r.close();
+        replServer.close();
         done();
       })
     );
   });
 
   it('should handle void operator correctly', (t, done) => {
-    const r = repl.start({
-      prompt: '',
-      input: process.stdin,
-      output: process.stdout,
-      terminal: false,
-    });
+    const { replServer } = startNewREPLServer({ terminal: false });
 
-    r.complete(
+    replServer.complete(
       'void globalThis',
       common.mustSucceed((completions) => {
         assert.strictEqual(completions[1], 'globalThis');
-        r.close();
+        replServer.close();
         done();
       })
     );
   });
 
   it('should handle other unary operators correctly', (t, done) => {
-    const r = repl.start({
-      prompt: '',
-      input: process.stdin,
-      output: process.stdout,
-      terminal: false,
-    });
+    const { replServer } = startNewREPLServer({ terminal: false });
 
     const unaryOperators = [
       '!globalThis',
@@ -93,13 +73,13 @@ describe('REPL tab completion with unary expressions', () => {
 
     function testNext() {
       if (testIndex >= unaryOperators.length) {
-        r.close();
+        replServer.close();
         done();
         return;
       }
 
       const testCase = unaryOperators[testIndex++];
-      r.complete(
+      replServer.complete(
         testCase,
         common.mustSucceed((completions) => {
           assert.strictEqual(completions[1], 'globalThis');
@@ -112,26 +92,21 @@ describe('REPL tab completion with unary expressions', () => {
   });
 
   it('should still evaluate globalThis correctly after unary expression completion', (t, done) => {
-    const r = repl.start({
-      prompt: '',
-      input: process.stdin,
-      output: process.stdout,
-      terminal: false,
-    });
+    const { replServer } = startNewREPLServer({ terminal: false });
 
     // First trigger completion with delete
-    r.complete(
+    replServer.complete(
       'delete globalThis._',
       common.mustSucceed(() => {
         // Then evaluate globalThis
-        r.eval(
+        replServer.eval(
           'globalThis',
-          r.context,
+          replServer.context,
           'test.js',
           common.mustSucceed((result) => {
             assert.strictEqual(typeof result, 'object');
             assert.ok(result !== null);
-            r.close();
+            replServer.close();
             done();
           })
         );

--- a/test/parallel/test-repl-uncaught-exception-async.js
+++ b/test/parallel/test-repl-uncaught-exception-async.js
@@ -5,40 +5,37 @@
 // should throw.
 
 require('../common');
-const ArrayStream = require('../common/arraystream');
-const repl = require('repl');
 const assert = require('assert');
+const { startNewREPLServer } = require('../common/repl');
 
-let accum = '';
+const { replServer, output } = startNewREPLServer(
+  {
+    prompt: '',
+    terminal: false,
+    useColors: false,
+    global: false,
+  },
+  {
+    disableDomainErrorAssert: true
+  },
+);
 
-const output = new ArrayStream();
-output.write = (data) => accum += data.replace('\r', '');
-
-const r = repl.start({
-  prompt: '',
-  input: new ArrayStream(),
-  output,
-  terminal: false,
-  useColors: false,
-  global: false
-});
-
-r.write(
+replServer.write(
   'process.nextTick(() => {\n' +
   '  process.on("uncaughtException", () => console.log("Foo"));\n' +
   '  throw new TypeError("foobar");\n' +
   '});\n'
 );
-r.write(
+replServer.write(
   'setTimeout(() => {\n' +
   '  throw new RangeError("abc");\n' +
   '}, 1);console.log()\n'
 );
 
 setTimeout(() => {
-  r.close();
+  replServer.close();
   const len = process.listenerCount('uncaughtException');
   process.removeAllListeners('uncaughtException');
   assert.strictEqual(len, 0);
-  assert.match(accum, /ERR_INVALID_REPL_INPUT.*(?!Type)RangeError: abc/s);
+  assert.match(output.accumulator, /ERR_INVALID_REPL_INPUT.*(?!Type)RangeError: abc/s);
 }, 2);

--- a/test/parallel/test-repl-uncaught-exception-evalcallback.js
+++ b/test/parallel/test-repl-uncaught-exception-evalcallback.js
@@ -1,23 +1,27 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
-const repl = require('repl');
-const { PassThrough } = require('stream');
-const input = new PassThrough();
-const output = new PassThrough();
+const { startNewREPLServer } = require('../common/repl');
 
-const r = repl.start({
-  input, output,
-  eval: common.mustCall((code, context, filename, cb) => {
-    r.setPrompt('prompt! ');
-    cb(new Error('err'));
-  })
-});
+const { replServer, output } = startNewREPLServer(
+  {
+    prompt: '',
+    terminal: false,
+    useColors: false,
+    global: false,
+    eval: common.mustCall((code, context, filename, cb) => {
+      replServer.setPrompt('prompt! ');
+      cb(new Error('err'));
+    })
+  },
+  {
+    disableDomainErrorAssert: true
+  },
+);
 
-input.end('foo\n');
+replServer.write('foo\n');
 
 // The output includes exactly one post-error prompt.
-const out = output.read().toString();
-assert.match(out, /prompt!/);
-assert.doesNotMatch(out, /prompt![\S\s]*prompt!/);
+assert.match(output.accumulator, /prompt!/);
+assert.doesNotMatch(output.accumulator, /prompt![\S\s]*prompt!/);
 output.on('data', common.mustNotCall());


### PR DESCRIPTION
This PR adds a new testing utility called `startNewREPLSever` which simply starts a new repl server that can be used for testing.

The reasoning for proposing this change are to reduce unnecessary code repetition (notice that the PR is net removing more than 450  lines of code[^1]) and to also provide some consistency on how repl server are tested.

[^1]: The output accumulation logic is re-implemented multiple times as well as the error domain on error handler logic.

Currently in tests when a new repl server gets started some input/output streams need to be passed to it, sometimes they are implemented via `new stream.PassThrough()`, some other times (more commonly) via `new ArrayStream()`, sometimes a single stream is passed both as the input and output, sometimes different streams are passed instead.
In most cases (as far as I can tell) there isn't a specific reason as to why an implementation has been chosen or not. `startNewREPLSever` removes this variation by  adopting what looked to me like the most commonly used implementation aspects.

Another nice thing is that `startNewREPLSever`  helps with variable name consistency. Currently when a test repl server is started it is stored in a variable which name can be `r`, `replServer`, `server` or `testMe`. Input streams can be `input`, `putIn` or `inputStream`. Output streams can be `output`, `putIn` or `outputStream`. (I am likely forgetting some variation  too). `startNewREPLSever` consistently refers to these values respectively as `replServer` , `input` and `output`.

___

Please note that my PR is not replacing all repl server starts in tests with `startNewREPLSever`, mainly because sometimes that is not helpful (for example when testing the repl constructor default values) or because it would require some involved refactoring (and I think that this PR is pretty big as it is :sweat_smile:, if this lands I can also see as a followup if `startNewREPLSever` could, be used in a few other tests as well)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
