### PR TITLE
http,net: optimize repeated property access

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -160,33 +160,36 @@ function Agent(options) {
 
   this.options = { __proto__: null, ...options };
 
-  this.defaultPort = this.options.defaultPort || 80;
-  this.protocol = this.options.protocol || 'http:';
+  // Cache options for better performance
+  const opts = this.options;
 
-  if (this.options.noDelay === undefined)
-    this.options.noDelay = true;
+  this.defaultPort = opts.defaultPort || 80;
+  this.protocol = opts.protocol || 'http:';
+
+  if (opts.noDelay === undefined)
+    opts.noDelay = true;
 
   // Don't confuse net and make it think that we're connecting to a pipe
-  this.options.path = null;
+  opts.path = null;
   this.requests = { __proto__: null };
   this.sockets = { __proto__: null };
   this.freeSockets = { __proto__: null };
-  this.keepAliveMsecs = this.options.keepAliveMsecs || 1000;
-  this.keepAlive = this.options.keepAlive || false;
-  this.maxSockets = this.options.maxSockets || Agent.defaultMaxSockets;
-  this.maxFreeSockets = this.options.maxFreeSockets || 256;
-  this.scheduling = this.options.scheduling || 'lifo';
-  this.maxTotalSockets = this.options.maxTotalSockets;
+  this.keepAliveMsecs = opts.keepAliveMsecs || 1000;
+  this.keepAlive = opts.keepAlive || false;
+  this.maxSockets = opts.maxSockets || Agent.defaultMaxSockets;
+  this.maxFreeSockets = opts.maxFreeSockets || 256;
+  this.scheduling = opts.scheduling || 'lifo';
+  this.maxTotalSockets = opts.maxTotalSockets;
   this.totalSocketCount = 0;
 
   this.agentKeepAliveTimeoutBuffer =
-    typeof this.options.agentKeepAliveTimeoutBuffer === 'number' &&
-    this.options.agentKeepAliveTimeoutBuffer >= 0 &&
-    NumberIsFinite(this.options.agentKeepAliveTimeoutBuffer) ?
-      this.options.agentKeepAliveTimeoutBuffer :
+    typeof opts.agentKeepAliveTimeoutBuffer === 'number' &&
+    opts.agentKeepAliveTimeoutBuffer >= 0 &&
+    NumberIsFinite(opts.agentKeepAliveTimeoutBuffer) ?
+      opts.agentKeepAliveTimeoutBuffer :
       1000;
 
-  const proxyEnv = this.options.proxyEnv;
+  const proxyEnv = opts.proxyEnv;
   if (typeof proxyEnv === 'object' && proxyEnv !== null) {
     this[kProxyConfig] = parseProxyConfigFromEnv(proxyEnv, this.protocol, this.keepAlive);
     debug(`new ${this.protocol} agent with proxy config`, this[kProxyConfig]);

--- a/lib/net.js
+++ b/lib/net.js
@@ -836,9 +836,10 @@ Socket.prototype.setNoDelay = function(enable) {
     return this;
   }
 
-  if (this._handle.setNoDelay && enable !== this[kSetNoDelay]) {
+  const handle = this._handle;
+  if (handle.setNoDelay && enable !== this[kSetNoDelay]) {
     this[kSetNoDelay] = enable;
-    this._handle.setNoDelay(enable);
+    handle.setNoDelay(enable);
   }
 
   return this;
@@ -867,7 +868,8 @@ Socket.prototype.setKeepAlive = function(enable, initialDelayMsecs,
     return this;
   }
 
-  if (!this._handle.setKeepAlive) {
+  const handle = this._handle;
+  if (!handle.setKeepAlive) {
     return this;
   }
 
@@ -883,7 +885,7 @@ Socket.prototype.setKeepAlive = function(enable, initialDelayMsecs,
     this[kSetKeepAliveInitialDelay] = initialDelay;
     this[kSetKeepAliveInterval] = interval;
     this[kSetKeepAliveCount] = count;
-    this._handle.setKeepAlive(enable, initialDelay, interval, count);
+    handle.setKeepAlive(enable, initialDelay, interval, count);
   }
 
   return this;


### PR DESCRIPTION
## Summary
- Cache frequently accessed object properties in local variables to reduce property lookup overhead
- Optimizes HTTP Agent constructor and net.Socket configuration methods

## Details
This PR optimizes repeated property access patterns in network-related modules:

### HTTP Agent Constructor (`lib/_http_agent.js`)
- Caches `this.options` in a local `opts` variable
- Eliminates 14+ repeated property access chains during Agent instantiation
- HTTP Agents are created frequently for HTTP/HTTPS requests

### Socket Configuration Methods (`lib/net.js`)
- `setNoDelay()`: Caches `this._handle` to avoid 2 property lookups
- `setKeepAlive()`: Caches `this._handle` to avoid 2 property lookups  
- These methods are called during socket setup for every TCP connection

## Performance Impact
- Reduces object traversal overhead in hot paths
- Particularly beneficial for applications with high connection volumes
- Follows the same optimization pattern as recent PRs (#59934, #59967)

## Test plan
- [x] Existing HTTP/HTTPS tests pass
- [x] Existing net tests pass
- [x] No functional changes, only performance optimizations
- [x] Manually verified Agent creation and socket configuration work correctly