### PR TITLE
lib: remove util.getCallSite

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -473,11 +473,6 @@ module.exports = {
   format,
   styleText,
   formatWithOptions,
-  // Deprecated getCallSite.
-  // This API can be removed in next semver-minor release.
-  getCallSite: deprecate(getCallSites,
-                         'The `util.getCallSite` API has been renamed to `util.getCallSites()`.',
-                         'ExperimentalWarning'),
   getCallSites,
   getSystemErrorMap,
   getSystemErrorName,


### PR DESCRIPTION
This API has been replaced by util.getCallSites().

It was previously experimental with a warning about its usage and its removal in a semver-minor PR. Here it is.