### PR TITLE
Update VTune include paths

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -18,7 +18,7 @@
 #include "node_wasm_web_api.h"
 #include "uv.h"
 #ifdef NODE_ENABLE_VTUNE_PROFILING
-#include "../deps/v8/src/third_party/vtune/v8-vtune.h"
+#include "../deps/v8/third_party/vtune/v8-vtune.h"
 #endif
 #if HAVE_INSPECTOR
 #include "inspector/worker_inspector.h"  // ParentInspectorHandle

--- a/src/node.cc
+++ b/src/node.cc
@@ -73,7 +73,7 @@
 #endif
 
 #ifdef NODE_ENABLE_VTUNE_PROFILING
-#include "../deps/v8/src/third_party/vtune/v8-vtune.h"
+#include "../deps/v8/third_party/vtune/v8-vtune.h"
 #endif
 
 #include "large_pages/node_large_page.h"

--- a/tools/v8_gypfiles/v8vtune.gyp
+++ b/tools/v8_gypfiles/v8vtune.gyp
@@ -13,17 +13,14 @@
       'target_name': 'v8_vtune',
       'type': 'static_library',
       'sources': [
-        '<(V8_ROOT)/third_party/ittapi/src/ittnotify/ittnotify_config.h',
-        '<(V8_ROOT)/third_party/ittapi/src/ittnotify/ittnotify_types.h',
         '<(V8_ROOT)/third_party/ittapi/src/ittnotify/jitprofiling.c',
-        '<(V8_ROOT)/third_party/ittapi/include/jitprofiling.h',
-        '<(V8_ROOT)/src/third_party/vtune/v8-vtune.h',
-        '<(V8_ROOT)/src/third_party/vtune/vtune-jit.cc',
-        '<(V8_ROOT)/src/third_party/vtune/vtune-jit.h',
+        '<(V8_ROOT)/third_party/vtune/vtune-jit.cc',
       ],
       'include_dirs': [
         '<(V8_ROOT)/third_party/ittapi/include',
         '<(V8_ROOT)/third_party/ittapi/src/ittnotify',
+        '<(V8_ROOT)/include',
+        '<(V8_ROOT)',
       ],
 
       'direct_dependent_settings': {


### PR DESCRIPTION
Updates VTune include header paths which were changed in v8 https://github.com/v8/v8/commit/846f470ae0b6b334ce3b4e14cca6f7606f6fce42

This fixes the VTune build when built as follows 
```
./configure --enable-vtune-profiling
make
```
and shows the appropriate JIT / Dynamic Code module in VTune.