### PR TITLE
src: remove `AnalyzeTemporaryDtors` option from .clang-tidy

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -22,7 +22,6 @@ Checks:          '-*,
                  readability-delete-null-pointer, '
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            nodejs/cpp
 CheckOptions:


### PR DESCRIPTION
This PR removes `AnalyzeTemporaryDtors` option from .clang-tidy. This option was removed in [Clang-Tidy 18](https://releases.llvm.org/18.1.1/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy).