### PR TITLE
Fix handling of HTTP upgrades with bodies

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -34,6 +34,7 @@ const {
   SymbolFor,
 } = primordials;
 
+const { Duplex } = require('stream');
 const net = require('net');
 const EE = require('events');
 const assert = require('internal/assert');
@@ -43,6 +44,7 @@ const {
   continueExpression,
   chunkExpression,
   kIncomingMessage,
+  kSocket,
   HTTPParser,
   isLenient,
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
@@ -106,6 +108,7 @@ const onResponseFinishChannel = dc.channel('http.server.response.finish');
 
 const kServerResponse = Symbol('ServerResponse');
 const kServerResponseStatistics = Symbol('ServerResponseStatistics');
+const kUpgradeStream = Symbol('UpgradeStream');
 
 const kOptimizeEmptyRequests = Symbol('OptimizeEmptyRequestsOption');
 
@@ -953,6 +956,77 @@ function socketOnError(e) {
   }
 }
 
+class UpgradeStream extends Duplex {
+  constructor(socket, req) {
+    super({
+      allowHalfOpen: socket.allowHalfOpen,
+    });
+
+    this[kSocket] = socket;
+    this[kIncomingMessage] = req;
+
+    // Proxy error, end & closure events immediately.
+    socket.on('error', (err) => this.destroy(err));
+
+    socket.on('close', () => this.destroy());
+    this.on('close', () => socket.destroy());
+
+    socket.on('end', () => {
+      this.push(null);
+
+      // Match the socket behaviour, where 'end' will fire despite no 'data'
+      // listeners if a socket with no pending data ends:
+      if (this.readableLength === 0) {
+        this.resume();
+      }
+    });
+
+    // Other events (most notably, reading) all only
+    // activate after requestBodyCompleted is called.
+  }
+
+  requestBodyCompleted(upgradeHead) {
+    this[kIncomingMessage] = null;
+
+    // When the request body is completed, we begin streaming all the
+    // post-body data for the upgraded protocol:
+    if (upgradeHead?.length > 0) {
+      if (!this.push(upgradeHead)) {
+        this[kSocket].pause();
+      }
+    }
+
+    this[kSocket].on('data', (data) => {
+      if (!this.push(data)) {
+        this[kSocket].pause();
+      }
+    });
+  }
+
+  _read(size) {
+    // Reading the upgrade stream starts the request stream flowing. It's
+    // important that this happens, even if there are no listeners, or it
+    // would be impossible to read this without explicitly reading all the
+    // request body first, which is backward incompatible & awkward.
+    this[kIncomingMessage]?.resume();
+
+    this[kSocket].resume();
+  }
+
+  _final(callback) {
+    this[kSocket].end(callback);
+  }
+
+  _write(chunk, encoding, callback) {
+    this[kSocket].write(chunk, encoding, callback);
+  }
+
+  _destroy(err, callback) {
+    this[kSocket].destroy(err);
+    callback(err);
+  }
+}
+
 function onParserExecuteCommon(server, socket, parser, state, ret, d) {
   if (ret instanceof Error) {
     prepareError(ret, parser, d);
@@ -962,28 +1036,56 @@ function onParserExecuteCommon(server, socket, parser, state, ret, d) {
     // Upgrade or CONNECT
     const req = parser.incoming;
     debug('SERVER upgrade or connect', req.method);
-
-    d ||= parser.getCurrentBuffer();
-
-    socket.removeListener('data', state.onData);
-    socket.removeListener('end', state.onEnd);
-    socket.removeListener('close', state.onClose);
-    socket.removeListener('drain', state.onDrain);
-    socket.removeListener('error', socketOnError);
-    socket.removeListener('timeout', socketOnTimeout);
-    unconsume(parser, socket);
-    parser.finish();
-    freeParser(parser, req, socket);
-    parser = null;
-
     const eventName = req.method === 'CONNECT' ? 'connect' : 'upgrade';
+
+    let upgradeStream;
+    if (req.complete) {
+      d ||= parser.getCurrentBuffer();
+
+      socket.removeListener('data', state.onData);
+      socket.removeListener('end', state.onEnd);
+      socket.removeListener('close', state.onClose);
+      socket.removeListener('drain', state.onDrain);
+      socket.removeListener('error', socketOnError);
+      socket.removeListener('timeout', socketOnTimeout);
+
+      unconsume(parser, socket);
+      parser.finish();
+      freeParser(parser, req, socket);
+      parser = null;
+
+      // If the request is complete (no body, or all body read upfront) then
+      // we just emit the socket directly as the upgrade stream.
+      upgradeStream = socket;
+    } else {
+      // If the body hasn't been fully parsed yet, we emit immediately but
+      // we add a wrapper around the socket to not expose incoming data
+      // until the request body has finished.
+
+      if (socket[kUpgradeStream]) {
+        // We've already emitted the incomplete upgrade - nothing do to
+        // until actual body parsing completion.
+        return;
+      }
+
+      d ||= Buffer.alloc(0);
+
+      upgradeStream = new UpgradeStream(socket, req);
+      socket[kUpgradeStream] = upgradeStream;
+    }
+
     if (server.listenerCount(eventName) > 0) {
       debug('SERVER have listener for %s', eventName);
+
       const bodyHead = d.slice(ret, d.length);
 
-      socket.readableFlowing = null;
-
-      server.emit(eventName, req, socket, bodyHead);
+      if (req.complete && socket[kUpgradeStream]) {
+        // Previously emitted, now completed - just activate the stream
+        socket[kUpgradeStream].requestBodyCompleted(bodyHead);
+      } else {
+        socket.readableFlowing = null;
+        server.emit(eventName, req, upgradeStream, bodyHead);
+      }
     } else {
       // Got upgrade or CONNECT method, but have no handler.
       socket.destroy();
@@ -1089,8 +1191,9 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   if (req.upgrade) {
     req.upgrade = req.method === 'CONNECT' ||
                   !!server.shouldUpgradeCallback(req);
-    if (req.upgrade)
-      return 2;
+    if (req.upgrade) {
+      return 0;
+    }
   }
 
   state.incoming.push(req);

--- a/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
+++ b/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
@@ -1,0 +1,89 @@
+import * as common from '../common/index.mjs';
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+
+const EXPECTED_BODY_LENGTH = 12;
+
+const upgradeReceivedResolvers = Promise.withResolvers();
+
+const server = http.createServer();
+server.on('request', common.mustNotCall());
+server.on('upgrade', function(req, socket, upgradeHead) {
+  upgradeReceivedResolvers.resolve();
+
+  // Confirm the upgrade:
+  socket.write('HTTP/1.1 101 Switching Protocols\r\n' +
+              'Upgrade: custom-protocol\r\n' +
+              'Connection: Upgrade\r\n' +
+              '\r\n');
+
+  // Read and validate the request body:
+  let reqBodyLength = 0;
+  req.on('data', (chunk) => { reqBodyLength += chunk.length; });
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(reqBodyLength, EXPECTED_BODY_LENGTH);
+
+    assert.deepStrictEqual(req.trailers, { 'extra-data': 'abc' });
+
+    // Defer upgrade stream read slightly to make sure it doesn't start
+    // streaming along with the request body, until we actually read it:
+    setTimeout(common.mustCall(() => {
+      let socketData = upgradeHead;
+
+      socket.on('data', (d) => {
+        socketData = Buffer.concat([socketData, d]);
+      });
+
+      socket.on('end', common.mustCall(() => {
+        assert.strictEqual(socketData.toString(), 'upgrade head\npost-upgrade message');
+        socket.end();
+      }));
+    }), 10);
+  }));
+});
+
+await new Promise((resolve) => server.listen(0, () => resolve()));
+
+const conn = net.createConnection(server.address().port);
+conn.setEncoding('utf8');
+
+await new Promise((resolve) => conn.on('connect', resolve));
+
+// Write request headers, body & upgrade head all together
+conn.write(
+  'POST / HTTP/1.1\r\n' +
+  'host: localhost\r\n' +
+  'Upgrade: custom-protocol\r\n' +
+  'Connection: Upgrade\r\n' +
+  'transfer-encoding: chunked\r\n' +
+  'trailer: extra-data\r\n' +
+  '\r\n'
+);
+
+// Make sure the server has processed the above & fired 'upgrade', before the body
+// data starts streaming:
+await upgradeReceivedResolvers.promise;
+
+// Write the body, and include a chunk extension and a trailer header to check
+// that upgrade handling doesn't skip or confuse anything with request parsing:
+conn.write(
+  // 12 byte body sent immediately, with (ignored) chunk extension.
+  'C;chunk-hash=abc\r\nrequest body\r\n' +
+  '0\r\n' +
+  // Request trailer:
+  'extra-data: abc\r\n' +
+  '\r\n' +
+  'upgrade head'
+);
+
+const response = await new Promise((resolve) => conn.once('data', resolve));
+assert.ok(response.startsWith('HTTP/1.1 101 Switching Protocols\r\n'));
+
+// Send more data after connection is confirmed:
+conn.write('\npost-upgrade message');
+conn.end();
+
+await new Promise((resolve) => conn.on('end', resolve));
+
+server.close();

--- a/test/parallel/test-http-upgrade-server-with-body-error.mjs
+++ b/test/parallel/test-http-upgrade-server-with-body-error.mjs
@@ -1,0 +1,46 @@
+import * as common from '../common/index.mjs';
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+
+const upgradeReceivedResolvers = Promise.withResolvers();
+
+const server = http.createServer();
+server.on('request', common.mustNotCall());
+server.on('upgrade', function(req, socket, upgradeHead) {
+  upgradeReceivedResolvers.resolve();
+
+  // As soon as the body starts arriving, simulate an error
+  req.on('data', () => {
+    req.socket.destroy(new Error('simulated body error'));
+  });
+});
+
+await new Promise((resolve) => server.listen(0, () => resolve()));
+
+const conn = net.createConnection(server.address().port);
+conn.setEncoding('utf8');
+
+await new Promise((resolve) => conn.on('connect', resolve));
+
+// Write request headers, leave the body pending:
+conn.write(
+  'POST / HTTP/1.1\r\n' +
+  'host: localhost\r\n' +
+  'Upgrade: custom-protocol\r\n' +
+  'Connection: Upgrade\r\n' +
+  'transfer-encoding: chunked\r\n' +
+  '\r\n'
+);
+
+// Make sure the server has processed the above & fired 'upgrade' before the body
+// data starts streaming:
+await upgradeReceivedResolvers.promise;
+
+conn.write('5\r\nhello\r\n');
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'simulated body error');
+  conn.destroy();
+  server.close();
+}));

--- a/test/parallel/test-http-upgrade-server-with-body.mjs
+++ b/test/parallel/test-http-upgrade-server-with-body.mjs
@@ -1,0 +1,69 @@
+import * as common from '../common/index.mjs';
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+
+const EXPECTED_BODY_LENGTH = 12;
+
+const server = http.createServer();
+server.on('request', common.mustNotCall());
+server.on('upgrade', function(req, socket, upgradeHead) {
+  // Confirm the upgrade:
+  socket.write('HTTP/1.1 101 Switching Protocols\r\n' +
+              'Upgrade: custom-protocol\r\n' +
+              'Connection: Upgrade\r\n' +
+              '\r\n');
+
+  // Read and validate the request body:
+  let reqBodyLength = 0;
+  req.on('data', (chunk) => { reqBodyLength += chunk.length; });
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(reqBodyLength, EXPECTED_BODY_LENGTH);
+
+    // Defer upgrade stream read slightly to make sure it doesn't start
+    // streaming along with the request body, until we actually read it:
+    setTimeout(common.mustCall(() => {
+      let socketData = upgradeHead;
+
+      socket.on('data', (d) => {
+        socketData = Buffer.concat([socketData, d]);
+      });
+
+      socket.on('end', common.mustCall(() => {
+        assert.strictEqual(socketData.toString(), 'upgrade head\npost-upgrade message');
+        socket.end();
+      }));
+    }), 10);
+  }));
+});
+
+await new Promise((resolve) => server.listen(0, () => resolve()));
+
+const conn = net.createConnection(server.address().port);
+conn.setEncoding('utf8');
+
+await new Promise((resolve) => conn.on('connect', resolve));
+
+// Write request headers, body & upgrade head all together:
+conn.write(
+  'POST / HTTP/1.1\r\n' +
+  'host: localhost\r\n' +
+  'Upgrade: custom-protocol\r\n' +
+  'Connection: Upgrade\r\n' +
+  'transfer-encoding: chunked\r\n' +
+  '\r\n' +
+  'C\r\nrequest body\r\n' + // 12 byte body sent immediately
+  '0\r\n\r\n' +
+  'upgrade head'
+);
+
+const response = await new Promise((resolve) => conn.once('data', resolve));
+assert.ok(response.startsWith('HTTP/1.1 101 Switching Protocols\r\n'));
+
+// Send more data after connection is confirmed:
+conn.write('\npost-upgrade message');
+conn.end();
+
+await new Promise((resolve) => conn.on('end', resolve));
+
+server.close();

--- a/test/parallel/test-http-upgrade-server-with-large-body-unread.mjs
+++ b/test/parallel/test-http-upgrade-server-with-large-body-unread.mjs
@@ -1,0 +1,89 @@
+import * as common from '../common/index.mjs';
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+
+const upgradeReceivedResolvers = Promise.withResolvers();
+
+const server = http.createServer();
+server.on('request', common.mustNotCall());
+server.on('upgrade', function(req, socket, upgradeHead) {
+  upgradeReceivedResolvers.resolve();
+
+  // Confirm the upgrade:
+  socket.write('HTTP/1.1 101 Switching Protocols\r\n' +
+              'Upgrade: custom-protocol\r\n' +
+              'Connection: Upgrade\r\n' +
+              '\r\n');
+
+  // There's a large body stream in req, but we don't read it here, and we check
+  // that despite this we do still get the upgrade stream that follows it:
+
+  // Head should never be available, because body is still streaming:
+  assert.strictEqual(upgradeHead.length, 0);
+
+  // Defer upgrade stream read, to make sure socket is correctly paused
+  // until we read it
+  setTimeout(() => {
+    let socketData = Buffer.alloc(0);
+
+    // Collect the raw upgrade stream and check we do eventually get the
+    // complete stream:
+    socket.on('data', (d) => {
+      socketData = Buffer.concat([socketData, d]);
+    });
+
+    socket.on('end', common.mustCall(() => {
+      assert.strictEqual(socketData.toString(), 'upgrade head\npost-upgrade message');
+      socket.end();
+    }));
+  }, 10);
+});
+
+await new Promise((resolve) => server.listen(0, () => resolve()));
+
+const conn = net.createConnection(server.address().port);
+conn.setEncoding('utf8');
+
+await new Promise((resolve) => conn.on('connect', resolve));
+
+// Write request headers, leave the body pending:
+conn.write(
+  'POST / HTTP/1.1\r\n' +
+  'host: localhost\r\n' +
+  'Upgrade: custom-protocol\r\n' +
+  'Connection: Upgrade\r\n' +
+  'transfer-encoding: chunked\r\n' +
+  '\r\n'
+);
+
+// Make sure the server has processed the above & fired 'upgrade' before the body
+// data starts streaming:
+await upgradeReceivedResolvers.promise;
+
+// Write a 200KB body in small chunks:
+for (let i = 0; i < 20_000; i++) {
+  conn.write('5\r\nhello\r\n'); // 10 byte chunk = 5 byte body
+}
+
+// Wait briefly, to encourage (though we can't guarantee) the server to have to
+// correctly process the final chunk in one go
+await new Promise((resolve) => setTimeout(resolve, 10));
+
+// Final chunk + end-body + 'upgrade head' upgrade stream:
+conn.write(
+  '3\r\nbye\r\n' +
+  '0\r\n\r\n' +
+  'upgrade head'
+);
+
+const response = await new Promise((resolve) => conn.once('data', resolve));
+assert.ok(response.startsWith('HTTP/1.1 101 Switching Protocols\r\n'));
+
+// Send more data after connection is confirmed:
+conn.write('\npost-upgrade message');
+conn.end();
+
+await new Promise((resolve) => conn.on('end', resolve));
+
+server.close();

--- a/test/parallel/test-http-upgrade-server-with-large-body.mjs
+++ b/test/parallel/test-http-upgrade-server-with-large-body.mjs
@@ -1,0 +1,95 @@
+import * as common from '../common/index.mjs';
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+
+const upgradeReceivedResolvers = Promise.withResolvers();
+const mainBodyReceivedResolvers = Promise.withResolvers();
+
+const EXPECTED_BODY_LENGTH = 100_003;
+
+const server = http.createServer();
+server.on('request', common.mustNotCall());
+server.on('upgrade', function(req, socket, upgradeHead) {
+  upgradeReceivedResolvers.resolve();
+
+  // Confirm the upgrade:
+  socket.write('HTTP/1.1 101 Switching Protocols\r\n' +
+              'Upgrade: custom-protocol\r\n' +
+              'Connection: Upgrade\r\n' +
+              '\r\n');
+
+  // Read and check the full body is eventually received:
+  let reqBodyLength = 0;
+  req.on('data', (chunk) => {
+    reqBodyLength += chunk.length;
+    if (reqBodyLength >= 100_000) mainBodyReceivedResolvers.resolve();
+  });
+  req.on('end', common.mustCall(() => {
+    assert.strictEqual(reqBodyLength, EXPECTED_BODY_LENGTH);
+  }));
+
+  // Head should never be available, because body is still streaming:
+  assert.strictEqual(upgradeHead.length, 0);
+
+  let socketData = Buffer.alloc(0);
+
+  // Start streaming the raw upgrade stream immediately as well, and check we do
+  // eventually get the complete stream:
+  socket.on('data', (d) => {
+    socketData = Buffer.concat([socketData, d]);
+  });
+
+  socket.on('end', common.mustCall(() => {
+    assert.strictEqual(socketData.toString(), 'upgrade head\npost-upgrade message');
+    socket.end();
+  }));
+});
+
+await new Promise((resolve) => server.listen(0, () => resolve()));
+
+const conn = net.createConnection(server.address().port);
+conn.setEncoding('utf8');
+
+await new Promise((resolve) => conn.on('connect', resolve));
+
+// Write request headers, leave the body pending:
+conn.write(
+  'POST / HTTP/1.1\r\n' +
+  'host: localhost\r\n' +
+  'Upgrade: custom-protocol\r\n' +
+  'Connection: Upgrade\r\n' +
+  'transfer-encoding: chunked\r\n' +
+  '\r\n'
+);
+
+// Make sure the server has processed the above & fired 'upgrade' before the body
+// data starts streaming:
+await upgradeReceivedResolvers.promise;
+
+// Write a 200KB body in small chunks:
+for (let i = 0; i < 20_000; i++) {
+  conn.write('5\r\nhello\r\n'); // 10 byte chunk = 5 byte body
+}
+
+// Wait until all that has been processed, to strongly encourage (though we can't guarantee)
+// the next chunk to arrive in one go, and have to be processed & correctly split
+await mainBodyReceivedResolvers.promise;
+
+// Final chunk + end-body + 'upgrade head' upgrade stream:
+conn.write(
+  '3\r\nbye\r\n' +
+  '0\r\n\r\n' +
+  'upgrade head'
+);
+
+const response = await new Promise((resolve) => conn.once('data', resolve));
+assert.ok(response.startsWith('HTTP/1.1 101 Switching Protocols\r\n'));
+
+// Send more data after connection is confirmed:
+conn.write('\npost-upgrade message');
+conn.end();
+
+await new Promise((resolve) => conn.on('end', resolve));
+
+server.close();


### PR DESCRIPTION
Fixes #58394

Previously, when processing and accepting a Upgrade request, we ignored all indicators of a body in the request (content-length or transfer-encoding headers) and treated any information following the headers as part of the upgraded stream itself.

This was not correct. An HTTP request to upgrade _can_ have a body, and it will always indicate this with standard headers to do so. If the request had a valid HTTP body, you shouldn't treat it as part of the new protocol stream you've upgraded to.

With this change, we now fully process the requests bodies separately instead, allowing us to automatically handle correct parsing of the body like any other HTTP request.

Fixing this is a matter of persuading llhttp to parse the body like normal. The llhttp return values for on_headers_complete (i.e. this `parserOnIncoming` function) are ([docs](https://github.com/nodejs/llhttp?tab=readme-ov-file#api)):

* 0: Proceed normally.
* 1: Assume that request/response has no body, and proceed to parsing the next message.
* 2: Assume absence of body (as above) and make llhttp_execute() return HPE_PAUSED_UPGRADE.

The current Node code for this basically assumes that `2` is required for to finish parsing an accepted upgrade or CONNECT, but as far as I can tell (based on [this](https://github.com/nodejs/llhttp/blob/66b05c169e8f0824a6c3415cc459446a69000e88/src/llhttp/http.ts#L1147-L1154)) that's not true. In this case, the upgrade flag is already set (that's `req.upgrade` here) and that's what controls whether the upgrade happens after the message is completed ([here](https://github.com/nodejs/llhttp/blob/66b05c169e8f0824a6c3415cc459446a69000e88/src/native/http.c#L29-L50)). Setting `2` would set the upgrade flag to true (but it's already true) and set SKIPBODY to true (which is what we're trying to fix here, and isn't required because [this condition](https://github.com/nodejs/llhttp/blob/66b05c169e8f0824a6c3415cc459446a69000e88/src/native/http.c#L43-L44) skips the body for CONNECT or no-body-headers-present for upgrades anyway).

This is a breaking change if you are currently accepting HTTP Upgrade requests with request bodies successfully, or if you use socket-specific fields & methods on the upgraded stream argument.

In the former case, before now you will have received the request body and then the upgraded data on the same stream without any distinction or HTTP parsing applied. Now, you will need to separately read the request body from the request (the 1st argument) and the upgraded data from the upgrade stream (the 2nd argument). If you're not interested in request bodies, you can continue to just read from the upgrade stream directly.

In the latter case, if you want to access the raw socket, you should do so via request.socket, instead of expecting the 2nd argument to be a socket.

---

Separately, it's debatable whether we should also actually support bodies on CONNECT requests. Even with this change, we currently don't. That would require a small change to llhttp. The latest HTTP RFCs [say](https://www.rfc-editor.org/rfc/rfc9112#section-6):

> Request message framing is independent of method semantics

but [also](https://www.rfc-editor.org/rfc/rfc9110#section-9.3.6) 

> A CONNECT request message does not have content. The interpretation of data sent after the header section of the CONNECT request message is specific to the version of HTTP in use.

so to my mind it's somewhat unspecified (as opposed to Upgrade requests, where this isn't ambiguous at all imo). Opinions welcome on whether to modify llhttp to support that.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
