### PR TITLE
doc: add automated migration info to deprecations

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -551,8 +551,7 @@ Type: End-of-Life
 The `os.tmpDir()` API was deprecated in Node.js 7.0.0 and has since been
 removed. Please use [`os.tmpdir()`][] instead.
 
-If you want an automated way to update your code you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/tmpDir-to-tmpdir)):
 ```bash
 npx codemod@latest @nodejs/tmpDir-to-tmpdir
 ```
@@ -634,8 +633,7 @@ Type: End-of-Life
 
 `util.print()` has been removed. Please use [`console.log()`][] instead.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -661,8 +659,7 @@ Type: End-of-Life
 
 `util.puts()` has been removed. Please use [`console.log()`][] instead.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -688,6 +685,7 @@ Type: End-of-Life
 
 `util.debug()` has been removed. Please use [`console.error()`][] instead.
 
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-debug-to-console-error)):
 ```bash
 npx codemod@latest @nodejs/util-debug-to-console-error
 ```
@@ -713,8 +711,7 @@ Type: End-of-Life
 
 `util.error()` has been removed. Please use [`console.error()`][] instead.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -1444,8 +1441,7 @@ By adopting one of these alternatives, you can transition away from `util.log()`
 and choose a logging strategy that aligns with the specific
 requirements and complexity of your application.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-log-to-console-log)):
 ```bash
 npx codemod@latest @nodejs/util-log-to-console-log
 ```
@@ -2788,8 +2784,7 @@ Type: End-of-Life
 
 Use [`module.createRequire()`][] instead.
 
-If you want an automated way to update your code you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/create-require-from-path)):
 ```bash
 npx codemod@latest @nodejs/create-require-from-path
 ```
@@ -2955,8 +2950,7 @@ modules is unsupported.
 It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/process-main-module)):
 ```bash
 npx codemod@latest @nodejs/process-main-module
 ```
@@ -3131,8 +3125,7 @@ Use `fs.rm(path, { recursive: true, force: true })`,
 `fs.rmSync(path, { recursive: true, force: true })` or
 `fs.promises.rm(path, { recursive: true, force: true })` instead.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/rmdir)):
 ```bash
 npx codemod@latest @nodejs/rmdir
 ```
@@ -3738,8 +3731,7 @@ Type: End-of-Life
 `F_OK`, `R_OK`, `W_OK` and `X_OK` getters exposed directly on `node:fs` were
 removed. Get them from `fs.constants` or `fs.promises.constants` instead.
 
-If you want an automated way to update your code you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/fs-access-mode-constants)):
 ```bash
 npx codemod@latest @nodejs/fs-access-mode-constants
 ```
@@ -4089,8 +4081,7 @@ Instantiating classes without the `new` qualifier exported by the `node:http` mo
 It is recommended to use the `new` qualifier instead. This applies to all http classes, such as
 `OutgoingMessage`, `IncomingMessage`, `ServerResponse` and `ClientRequest`.
 
-If you want to update your code automatically you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/http-classes-with-new)):
 ```bash
 npx codemod@latest @nodejs/http-classes-with-new
 ```
@@ -4134,8 +4125,7 @@ Type: Documentation-only
 
 The [`util.types.isNativeError`][] API is deprecated. Please use [`Error.isError`][] instead.
 
-If you want an automated way to update you can use this codemod:
-
+An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/types-is-native-error)):
 ```bash
 npx codemod@latest @nodejs/types-is-native-error
 ```

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -552,6 +552,7 @@ The `os.tmpDir()` API was deprecated in Node.js 7.0.0 and has since been
 removed. Please use [`os.tmpdir()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/tmpDir-to-tmpdir)):
+
 ```bash
 npx codemod@latest @nodejs/tmpDir-to-tmpdir
 ```
@@ -634,6 +635,7 @@ Type: End-of-Life
 `util.print()` has been removed. Please use [`console.log()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
+
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -660,6 +662,7 @@ Type: End-of-Life
 `util.puts()` has been removed. Please use [`console.log()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
+
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -686,6 +689,7 @@ Type: End-of-Life
 `util.debug()` has been removed. Please use [`console.error()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-debug-to-console-error)):
+
 ```bash
 npx codemod@latest @nodejs/util-debug-to-console-error
 ```
@@ -712,6 +716,7 @@ Type: End-of-Life
 `util.error()` has been removed. Please use [`console.error()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-print-to-console-log)):
+
 ```bash
 npx codemod@latest @nodejs/util-print-to-console-log
 ```
@@ -1442,6 +1447,7 @@ and choose a logging strategy that aligns with the specific
 requirements and complexity of your application.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/util-log-to-console-log)):
+
 ```bash
 npx codemod@latest @nodejs/util-log-to-console-log
 ```
@@ -2785,6 +2791,7 @@ Type: End-of-Life
 Use [`module.createRequire()`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/create-require-from-path)):
+
 ```bash
 npx codemod@latest @nodejs/create-require-from-path
 ```
@@ -2951,6 +2958,7 @@ It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/process-main-module)):
+
 ```bash
 npx codemod@latest @nodejs/process-main-module
 ```
@@ -3126,6 +3134,7 @@ Use `fs.rm(path, { recursive: true, force: true })`,
 `fs.promises.rm(path, { recursive: true, force: true })` instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/rmdir)):
+
 ```bash
 npx codemod@latest @nodejs/rmdir
 ```
@@ -3732,6 +3741,7 @@ Type: End-of-Life
 removed. Get them from `fs.constants` or `fs.promises.constants` instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/fs-access-mode-constants)):
+
 ```bash
 npx codemod@latest @nodejs/fs-access-mode-constants
 ```
@@ -4082,6 +4092,7 @@ It is recommended to use the `new` qualifier instead. This applies to all http c
 `OutgoingMessage`, `IncomingMessage`, `ServerResponse` and `ClientRequest`.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/http-classes-with-new)):
+
 ```bash
 npx codemod@latest @nodejs/http-classes-with-new
 ```
@@ -4126,6 +4137,7 @@ Type: Documentation-only
 The [`util.types.isNativeError`][] API is deprecated. Please use [`Error.isError`][] instead.
 
 An automated migration is available ([source](https://github.com/nodejs/userland-migrations/tree/main/recipes/types-is-native-error)):
+
 ```bash
 npx codemod@latest @nodejs/types-is-native-error
 ```

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -551,6 +551,12 @@ Type: End-of-Life
 The `os.tmpDir()` API was deprecated in Node.js 7.0.0 and has since been
 removed. Please use [`os.tmpdir()`][] instead.
 
+If you want an automated way to update your code you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/tmpDir-to-tmpdir
+```
+
 ### DEP0023: `os.getNetworkInterfaces()`
 
 <!-- YAML
@@ -628,6 +634,12 @@ Type: End-of-Life
 
 `util.print()` has been removed. Please use [`console.log()`][] instead.
 
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/util-print-to-console-log
+```
+
 ### DEP0027: `util.puts()`
 
 <!-- YAML
@@ -648,6 +660,12 @@ changes:
 Type: End-of-Life
 
 `util.puts()` has been removed. Please use [`console.log()`][] instead.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/util-print-to-console-log
+```
 
 ### DEP0028: `util.debug()`
 
@@ -670,6 +688,10 @@ Type: End-of-Life
 
 `util.debug()` has been removed. Please use [`console.error()`][] instead.
 
+```bash
+npx codemod@latest @nodejs/util-debug-to-console-error
+```
+
 ### DEP0029: `util.error()`
 
 <!-- YAML
@@ -690,6 +712,12 @@ changes:
 Type: End-of-Life
 
 `util.error()` has been removed. Please use [`console.error()`][] instead.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/util-print-to-console-log
+```
 
 ### DEP0030: `SlowBuffer`
 
@@ -1415,6 +1443,12 @@ consider the following alternatives based on your specific needs:
 By adopting one of these alternatives, you can transition away from `util.log()`
 and choose a logging strategy that aligns with the specific
 requirements and complexity of your application.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/util-log-to-console-log
+```
 
 ### DEP0060: `util._extend()`
 
@@ -2754,6 +2788,12 @@ Type: End-of-Life
 
 Use [`module.createRequire()`][] instead.
 
+If you want an automated way to update your code you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/create-require-from-path
+```
+
 ### DEP0131: Legacy HTTP parser
 
 <!-- YAML
@@ -2914,6 +2954,12 @@ modules is unsupported.
 
 It is deprecated in favor of [`require.main`][], because it serves the same
 purpose and is only available on CommonJS environment.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/process-main-module
+```
 
 ### DEP0139: `process.umask()` with no arguments
 
@@ -3084,6 +3130,12 @@ to support a `recursive` option. That option has been removed.
 Use `fs.rm(path, { recursive: true, force: true })`,
 `fs.rmSync(path, { recursive: true, force: true })` or
 `fs.promises.rm(path, { recursive: true, force: true })` instead.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/rmdir
+```
 
 ### DEP0148: Folder mappings in `"exports"` (trailing `"/"`)
 
@@ -3686,6 +3738,12 @@ Type: End-of-Life
 `F_OK`, `R_OK`, `W_OK` and `X_OK` getters exposed directly on `node:fs` were
 removed. Get them from `fs.constants` or `fs.promises.constants` instead.
 
+If you want an automated way to update your code you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/fs-access-mode-constants
+```
+
 ### DEP0177: `util.types.isWebAssemblyCompiledModule`
 
 <!-- YAML
@@ -4031,6 +4089,12 @@ Instantiating classes without the `new` qualifier exported by the `node:http` mo
 It is recommended to use the `new` qualifier instead. This applies to all http classes, such as
 `OutgoingMessage`, `IncomingMessage`, `ServerResponse` and `ClientRequest`.
 
+If you want to update your code automatically you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/http-classes-with-new
+```
+
 ### DEP0196: Calling `node:child_process` functions with `options.shell` as an empty string
 
 <!-- YAML
@@ -4069,6 +4133,12 @@ changes:
 Type: Documentation-only
 
 The [`util.types.isNativeError`][] API is deprecated. Please use [`Error.isError`][] instead.
+
+If you want an automated way to update you can use this codemod:
+
+```bash
+npx codemod@latest @nodejs/types-is-native-error
+```
 
 ### DEP0198: Creating SHAKE-128 and SHAKE-256 digests without an explicit `options.outputLength`
 


### PR DESCRIPTION
after a meeting with userland migration team we saw that we can include our job on the deprecation page.

BTW Codemod is officially openjs partner https://openjsf.org/blog/codemod-openjs-foundation-partner