### PR TITLE
test: fix test when linked with shared libraries

### DIFF
--- a/test/parallel/test-process-execve-no-args.js
+++ b/test/parallel/test-process-execve-no-args.js
@@ -20,6 +20,13 @@ if (!existsSync(executable)) {
   skip(executable + ' binary is not available');
 }
 
-process.execve(executable);
+// The binary may need `LD_LIBRARY_PATH` or equivalent set to run.
+// The assumption here is that if `node` was configured to link to
+// any external libraries then the test binary was as well.
+if (process.config.target_defaults.libraries.length > 0) {
+  process.execve(executable, undefined, process.env);
+} else {
+  process.execve(executable);
+}
 // If process.execve succeeds, this should never be executed.
 fail('process.execve failed');


### PR DESCRIPTION
If the `nop` binary used in `parallel/test-process-execve-no-args` has been linked to external libraries, it may need an environment variable such as `LD_LIBRARY_PATH` to be set to be able to run.

Assume if `node` has been configured to link against any external libraries then `nop` has also been, and in that case pass through the environment variables to the test.

Refs: https://github.com/nodejs/build/pull/4156#issuecomment-3338588007

---

This is a really subtle problem with `parallel/test-process-execve-no-args` that has not been caught until now because we've been running the `sharedlibs_*` CI on Ubuntu with gcc and suddenly came up when we tested switching over to clang. 

With many of the `sharedlibs_*` builds we add libraries onto the command line, e.g. for OpenSSL
```
-L/opt/openssl-3.5.0/lib64 -lcrypto -lssl
```

The `nop` binary used by the test doesn't need any of that, so gcc on Ubuntu (and other Debian-derived Linux distributions) will not link the `nop` binary to those additional libraries[1]. However `gcc` on other Linux distributions, and clang do not do this by default so the `nop` binary will be linked to the additional libraries.  `parallel/test-process-execve-no-args` currently doesn't pass on the environment variables, so if `LD_LIBRARY_PATH` (or equivalent for the platform) needed to be set to find those additional libraries the test would not be able to successfully run `nop`.

For completeness, it's possible to replicate the Ubuntu gcc default behaviour by passing `--as-needed` through to the linker (e.g. `-Wl,--as-needed`) but that's sensitive to the linker being used (e.g. the default linker on AIX/Illumos does not support that flag). In an ideal world we would not be appending the additional libraries onto the command line when linking `nop`, but that would be tricky to do with the way `configure` and `gyp` currently work.

FYI @nodejs/distros 

[1]: https://stackoverflow.com/questions/79405331/why-does-ubuntus-linker-use-as-needed-by-default
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
