### PR TITLE
process: fix default `env` for `process.execve`

### DIFF
--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -301,22 +301,20 @@ function wrapProcessMethods(binding) {
     }
 
     const envArray = [];
-    if (env !== undefined) {
-      validateObject(env, 'env');
+    validateObject(env, 'env');
 
-      for (const { 0: key, 1: value } of ObjectEntries(env)) {
-        if (
-          typeof key !== 'string' ||
-          typeof value !== 'string' ||
-          StringPrototypeIncludes(key, '\u0000') ||
-          StringPrototypeIncludes(value, '\u0000')
-        ) {
-          throw new ERR_INVALID_ARG_VALUE(
-            'env', env, 'must be an object with string keys and values without null bytes',
-          );
-        } else {
-          ArrayPrototypePush(envArray, `${key}=${value}`);
-        }
+    for (const { 0: key, 1: value } of ObjectEntries(env)) {
+      if (
+        typeof key !== 'string' ||
+        typeof value !== 'string' ||
+        StringPrototypeIncludes(key, '\u0000') ||
+        StringPrototypeIncludes(value, '\u0000')
+      ) {
+        throw new ERR_INVALID_ARG_VALUE(
+          'env', env, 'must be an object with string keys and values without null bytes',
+        );
+      } else {
+        ArrayPrototypePush(envArray, `${key}=${value}`);
       }
     }
 


### PR DESCRIPTION
The `env` parameter for `process.execve` is documented to default to `process.env`.

Refs: https://github.com/nodejs/build/pull/4156#issuecomment-3335650165

---

`process.execve` is documented to take an optional `env` parameter that is supposed to default to `process.env`: https://github.com/nodejs/node/blob/2e5c8dff9cb1208fa97465ae0fc63abf2213e9e5/doc/api/process.md?plain=1#L1694-L1708

When we attempted to build a `sharedlibs_*` CI with clang we found that `parallel/test-process-execve-no-args`  fails because `process.execve` is not passing on `process.env` to the new process. We didn't notice before when using gcc because on Ubuntu (and other Debian-derived Linux distributions) gcc by default links with `--as-needed` but clang (and gcc on other Linux distributions) does not.

No new test is added, this will unblock the work being done in https://github.com/nodejs/build/pull/4156 and once that is complete regressions will be caught there by the existing  `parallel/test-process-execve-no-args`.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
