### PR TITLE
lib: optimize FixedQueue by reusing one segment

### DIFF
--- a/benchmark/util/fixed-queue-oscillate.js
+++ b/benchmark/util/fixed-queue-oscillate.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const common = require('../common');
+
+// Oscillates the FixedQueue between N and N+1 segments repeatedly to
+// exercise the spare-segment reuse path: push k items to force a new segment,
+// then shift k items to empty one segment; repeat.
+const bench = common.createBenchmark(main, {
+  cycles: [5e3],
+}, { flags: ['--expose-internals'] });
+
+function main({ cycles }) {
+  const FixedQueue = require('internal/fixed_queue');
+  const q = new FixedQueue();
+  // Derive the internal segment size (kSize) from the current head.
+  const k = q.head.list.length;
+
+  bench.start();
+  for (let c = 0; c < cycles; c++) {
+    // Grow to N+1 by pushing k items: k-1 fills the current segment,
+    // the k-th push creates/uses the next segment.
+    for (let i = 0; i < k; i++) q.push(i);
+    // Shrink back to N by shifting k items: empties one segment and advances.
+    for (let i = 0; i < k; i++) q.shift();
+  }
+  // Report total operations (push + shift) to normalize throughput.
+  bench.end(cycles * 2 * k);
+}

--- a/benchmark/util/fixed-queue.js
+++ b/benchmark/util/fixed-queue.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../common');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+}, { flags: ['--expose-internals'] });
+
+function main({ n }) {
+  const FixedQueue = require('internal/fixed_queue');
+  const queue = new FixedQueue();
+  bench.start();
+  for (let i = 0; i < n; i++)
+    queue.push(i);
+  for (let i = 0; i < n; i++)
+    queue.shift();
+  bench.end(n);
+}

--- a/lib/internal/fixed_queue.js
+++ b/lib/internal/fixed_queue.js
@@ -65,6 +65,16 @@ class FixedCircularBuffer {
     this.next = null;
   }
 
+  /**
+   * Resets the buffer for reuse without reallocating the backing array.
+   * Assumes all used slots have been set back to `undefined` by shift().
+   */
+  reset() {
+    this.bottom = 0;
+    this.top = 0;
+    this.next = null;
+  }
+
   isEmpty() {
     return this.top === this.bottom;
   }
@@ -74,16 +84,18 @@ class FixedCircularBuffer {
   }
 
   push(data) {
-    this.list[this.top] = data;
-    this.top = (this.top + 1) & kMask;
+    const top = this.top;
+    this.list[top] = data;
+    this.top = (top + 1) & kMask;
   }
 
   shift() {
-    const nextItem = this.list[this.bottom];
+    const bottom = this.bottom;
+    const nextItem = this.list[bottom];
     if (nextItem === undefined)
       return null;
-    this.list[this.bottom] = undefined;
-    this.bottom = (this.bottom + 1) & kMask;
+    this.list[bottom] = undefined;
+    this.bottom = (bottom + 1) & kMask;
     return nextItem;
   }
 }
@@ -91,6 +103,7 @@ class FixedCircularBuffer {
 module.exports = class FixedQueue {
   constructor() {
     this.head = this.tail = new FixedCircularBuffer();
+    this._spare = null;
   }
 
   isEmpty() {
@@ -98,12 +111,21 @@ module.exports = class FixedQueue {
   }
 
   push(data) {
-    if (this.head.isFull()) {
-      // Head is full: Creates a new queue, sets the old queue's `.next` to it,
-      // and sets it as the new main queue.
-      this.head = this.head.next = new FixedCircularBuffer();
+    let head = this.head;
+    if (head.isFull()) {
+      // Head is full: reuse the spare buffer if available.
+      // Otherwise create a new one. Link it and advance head.
+      let nextBuf = this._spare;
+      if (nextBuf !== null) {
+        this._spare = null;
+        nextBuf.reset();
+      } else {
+        nextBuf = new FixedCircularBuffer();
+      }
+      head = head.next = nextBuf;
+      this.head = head;
     }
-    this.head.push(data);
+    head.push(data);
   }
 
   shift() {
@@ -112,7 +134,9 @@ module.exports = class FixedQueue {
     if (tail.isEmpty() && tail.next !== null) {
       // If there is another queue, it forms the new tail.
       this.tail = tail.next;
-      tail.next = null;
+      // Place the emptied buffer into the spare slot for potential reuse.
+      tail.reset();
+      this._spare = tail; // Overwrite any existing spare
     }
     return next;
   }


### PR DESCRIPTION
Benchmarks:

main:

```sh
node % ./node benchmark/run.js --filter fixed-queue util

util/fixed-queue-oscillate.js
util/fixed-queue-oscillate.js cycles=5000: 240,760,722.06068513
util/fixed-queue.js
util/fixed-queue.js n=100000: 30,605,608.47775355
```

branch:

```sh
node % ./node benchmark/run.js --filter fixed-queue util
util/fixed-queue-oscillate.js
util/fixed-queue-oscillate.js cycles=5000: 283,339,287.4243814
util/fixed-queue.js
util/fixed-queue.js n=100000: 32,606,927.0808029
```

When the head segment fills, we reuse a single “spare” `FixedCircularBuffer` if available; when a segment becomes empty, we reset it and stash it as the spare. This cuts allocations/GC especially when the queue oscillates between N and N+1 segments, which is more likely to be the case in real life scenarios where Events/Promises are emitted/created and consumed in bursts.

We only call reset() when reusing a spare (not for a freshly allocated buffer).

And finally, there is no behavior change: we have the same data structure (linked fixed-size circular buffers), same invariants (one-slot-wasted), same FIFO semantics and API. Capacity per segment stays `kSize - 1`, so overall capacity is unchanged.