### PR TITLE
console,util: improve array inspection performance

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2271,11 +2271,12 @@ function formatArray(ctx, value, recurseTimes) {
   const remaining = valLen - len;
   const output = [];
   for (let i = 0; i < len; i++) {
-    // Special handle sparse arrays.
-    if (!ObjectPrototypeHasOwnProperty(value, i)) {
+    const desc = ObjectGetOwnPropertyDescriptor(value, i);
+    if (desc === undefined) {
+      // Special handle sparse arrays.
       return formatSpecialArray(ctx, value, recurseTimes, len, output, i);
     }
-    ArrayPrototypePush(output, formatProperty(ctx, value, recurseTimes, i, kArrayType));
+    ArrayPrototypePush(output, formatProperty(ctx, value, recurseTimes, i, kArrayType, desc));
   }
   if (remaining > 0) {
     ArrayPrototypePush(output, remainingText(remaining));


### PR DESCRIPTION
There is no need to do the own property check, since the descriptor is needed right afterwards anyway.

```
                                                                      confidence improvement accuracy (*)    (**)   (***)
util/inspect-array.js type='denseArray_showHidden' len=100 n=5000            ***      2.61 %       ±1.50%  ±1.99%  ±2.59%
util/inspect-array.js type='denseArray' len=100 n=5000                       ***      3.38 %       ±1.24%  ±1.66%  ±2.16%
util/inspect.js option='colors' method='Array' n=80000                       ***      1.99 %       ±0.49%  ±0.65%  ±0.85%
util/inspect.js option='none' method='Array' n=80000                         ***      5.64 %       ±0.59%  ±0.79%  ±1.02%
util/inspect.js option='showHidden' method='Array' n=80000                   ***      3.81 %       ±0.50%  ±0.67%  ±0.87%
```