### PR TITLE
src: improve performance of dotenv ToObject

### DIFF
--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -215,6 +215,7 @@ describe('.env supports edge cases', () => {
     ].join('\n'));
 
     assert.deepStrictEqual(result, {
+      __proto__: null,
       baz: 'whatever',
       VALID_AFTER_INVALID: 'test',
       ANOTHER_VALID: 'value',
@@ -236,6 +237,7 @@ describe('.env supports edge cases', () => {
     ].join('\n'));
 
     assert.deepStrictEqual(result, {
+      __proto__: null,
       KEY_WITH_SPACES_BEFORE: 'value_with_spaces_before_and_after',
       KEY_WITH_TABS_BEFORE: 'value_with_tabs_before_and_after',
       KEY_WITH_SPACES_AND_TABS: 'value_with_spaces_and_tabs',
@@ -255,6 +257,7 @@ describe('.env supports edge cases', () => {
     ].join('\n'));
 
     assert.deepStrictEqual(result, {
+      __proto__: null,
       KEY_WITH_COMMENT_IN_VALUE: 'value # this is a comment',
     });
   });

--- a/test/parallel/test-util-parse-env.js
+++ b/test/parallel/test-util-parse-env.js
@@ -10,7 +10,8 @@ const fs = require('node:fs');
   const validEnvFilePath = fixtures.path('dotenv/valid.env');
   const validContent = fs.readFileSync(validEnvFilePath, 'utf8');
 
-  assert.deepStrictEqual(util.parseEnv(validContent), {
+  const checkObj = {
+    __proto__: null,
     A: 'B=C',
     B: 'C=D',
     AFTER_LINE: 'after_line',
@@ -56,11 +57,14 @@ const fs = require('node:fs');
     SPACED_KEY: 'parsed',
     SPACE_BEFORE_DOUBLE_QUOTES: 'space before double quotes',
     TRIM_SPACE_FROM_UNQUOTED: 'some spaced out string',
-  });
+  };
+
+  assert.deepStrictEqual(util.parseEnv(validContent), checkObj);
 }
 
-assert.deepStrictEqual(util.parseEnv(''), {});
-assert.deepStrictEqual(util.parseEnv('FOO=bar\nFOO=baz\n'), { FOO: 'baz' });
+assert.deepStrictEqual(util.parseEnv(''), { __proto__: null });
+assert.deepStrictEqual(util.parseEnv('FOO=bar\nFOO=baz\n'),
+                       { __proto__: null, FOO: 'baz' });
 
 // Test for invalid input.
 assert.throws(() => {


### PR DESCRIPTION
Improves the performance of the dotenv parser ToObject method. Also, switch to a null prototype object to avoid potential prototype pollution issues.

```
util/parse-env.js n=30000 *** 57.69 %  ±1.37% ±1.83% ±2.40%
```

semver-major because of the switch to the null prototype.