### PR TITLE
src: remove unused variables from report

### DIFF
--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -757,7 +757,6 @@ static void PrintSystemInformation(JSONWriter* writer) {
 
   writer->json_objectstart("userLimits");
   struct rlimit limit;
-  std::string soft, hard;
 
   for (size_t i = 0; i < arraysize(rlimit_strings); i++) {
     if (getrlimit(rlimit_strings[i].id, &limit) == 0) {
@@ -793,8 +792,6 @@ static void PrintLoadedLibraries(JSONWriter* writer) {
 
 // Obtain and report the node and subcomponent version strings.
 static void PrintComponentVersions(JSONWriter* writer) {
-  std::stringstream buf;
-
   writer->json_objectstart("componentVersions");
 
   for (const auto& version : per_process::metadata.versions.pairs()) {


### PR DESCRIPTION
This PR removes unused variables in `node_report.cc` detected by clang-tidy(`bugprone-unused-local-non-trivial-variable`).