### PR TITLE
src: remove useless dereferencing in `THROW_...`

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -1460,7 +1460,7 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
       method = TLS_client_method();
     } else {
       THROW_ERR_TLS_INVALID_PROTOCOL_METHOD(
-          env, "Unknown method: %s", *sslmethod);
+          env, "Unknown method: %s", sslmethod);
       return;
     }
   }

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -506,7 +506,7 @@ Maybe<void> HashTraits::AdditionalConfig(
   Utf8Value digest(env->isolate(), args[offset]);
   params->digest = ncrypto::getDigestByName(*digest);
   if (params->digest == nullptr) [[unlikely]] {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
     return Nothing<void>();
   }
 

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -57,7 +57,7 @@ Maybe<void> HKDFTraits::AdditionalConfig(
   Utf8Value hash(env->isolate(), args[offset]);
   params->digest = Digest::FromName(*hash);
   if (!params->digest) [[unlikely]] {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *hash);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", hash);
     return Nothing<void>();
   }
 

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -197,7 +197,7 @@ Maybe<void> HmacTraits::AdditionalConfig(
   Utf8Value digest(env->isolate(), args[offset + 1]);
   params->digest = Digest::FromName(*digest);
   if (!params->digest) [[unlikely]] {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
     return Nothing<void>();
   }
 

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -103,7 +103,7 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
   Utf8Value name(args.GetIsolate(), args[offset + 4]);
   params->digest = Digest::FromName(*name);
   if (!params->digest) [[unlikely]] {
-    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *name);
+    THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", name);
     return Nothing<void>();
   }
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -143,7 +143,7 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
       Utf8Value digest(env->isolate(), args[*offset]);
       params->params.md = Digest::FromName(*digest);
       if (!params->params.md) {
-        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
         return Nothing<void>();
       }
     }
@@ -153,8 +153,7 @@ Maybe<void> RsaKeyGenTraits::AdditionalConfig(
       Utf8Value digest(env->isolate(), args[*offset + 1]);
       params->params.mgf1_md = Digest::FromName(*digest);
       if (!params->params.mgf1_md) {
-        THROW_ERR_CRYPTO_INVALID_DIGEST(
-            env, "Invalid MGF1 digest: %s", *digest);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid MGF1 digest: %s", digest);
         return Nothing<void>();
       }
     }
@@ -279,7 +278,7 @@ Maybe<void> RSACipherTraits::AdditionalConfig(
       Utf8Value digest(env->isolate(), args[offset + 1]);
       params->digest = Digest::FromName(*digest);
       if (!params->digest) {
-        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
+        THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
         return Nothing<void>();
       }
 

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -627,7 +627,7 @@ Maybe<void> SignTraits::AdditionalConfig(
     Utf8Value digest(env->isolate(), args[offset + 6]);
     params->digest = Digest::FromName(*digest);
     if (!params->digest) [[unlikely]] {
-      THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", *digest);
+      THROW_ERR_CRYPTO_INVALID_DIGEST(env, "Invalid digest: %s", digest);
       return Nothing<void>();
     }
   }

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -487,9 +487,9 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
       dlib->Close();
 #ifdef _WIN32
       // Windows needs to add the filename into the error message
-      errmsg += *filename;
+      errmsg += filename.ToStringView();
 #endif  // _WIN32
-      THROW_ERR_DLOPEN_FAILED(env, "%s", errmsg.c_str());
+      THROW_ERR_DLOPEN_FAILED(env, "%s", errmsg);
       return false;
     }
 
@@ -520,7 +520,7 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
         if (mp == nullptr || mp->nm_context_register_func == nullptr) {
           dlib->Close();
           THROW_ERR_DLOPEN_FAILED(
-              env, "Module did not self-register: '%s'.", *filename);
+              env, "Module did not self-register: '%s'.", filename);
           return false;
         }
       }
@@ -649,7 +649,7 @@ void GetInternalBinding(const FunctionCallbackInfo<Value>& args) {
     exports = InitInternalBinding(realm, mod);
     realm->internal_bindings.insert(mod);
   } else {
-    return THROW_ERR_INVALID_MODULE(isolate, "No such binding: %s", *module_v);
+    return THROW_ERR_INVALID_MODULE(isolate, "No such binding: %s", module_v);
   }
 
   args.GetReturnValue().Set(exports);
@@ -680,7 +680,7 @@ void GetLinkedBinding(const FunctionCallbackInfo<Value>& args) {
 
   if (mod == nullptr) {
     return THROW_ERR_INVALID_MODULE(
-        env, "No such binding was linked: %s", *module_name_v);
+        env, "No such binding was linked: %s", module_name_v);
   }
 
   Local<Object> module = Object::New(env->isolate());

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -613,7 +613,7 @@ static void LoadEnvFile(const v8::FunctionCallbackInfo<v8::Value>& args) {
     }
     case dotenv.ParseResult::InvalidContent: {
       THROW_ERR_INVALID_ARG_TYPE(
-          env, "Contents of '%s' should be a valid string.", path.c_str());
+          env, "Contents of '%s' should be a valid string.", path);
       break;
     }
     case dotenv.ParseResult::FileError: {

--- a/src/node_report.cc
+++ b/src/node_report.cc
@@ -501,7 +501,7 @@ static void PrintJavaScriptStack(JSONWriter* writer,
     const int column = frame->GetColumn();
 
     std::string stack_line = SPrintF(
-        "at %s (%s:%d:%d)", *function_name, *script_name, line_number, column);
+        "at %s (%s:%d:%d)", function_name, script_name, line_number, column);
     writer->json_element(stack_line);
   }
   writer->json_arrayend();

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1963,7 +1963,7 @@ bool StatementSync::BindParams(const FunctionCallbackInfo<Value>& args) {
             continue;
           } else {
             THROW_ERR_INVALID_STATE(
-                env(), "Unknown named parameter '%s'", *utf8_key);
+                env(), "Unknown named parameter '%s'", utf8_key);
             return false;
           }
         }

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -68,14 +68,14 @@ bool SetOption(Environment* env,
     if (!value->IsUint32()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be an uint32", *nameStr);
+          env, "The %s option must be an uint32", nameStr);
       return false;
     }
     v8::Local<v8::Uint32> num;
     if (!value->ToUint32(env->context()).ToLocal(&num)) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be an uint32", *nameStr);
+          env, "The %s option must be an uint32", nameStr);
       return false;
     }
     options->*member = num->Value();
@@ -95,7 +95,7 @@ bool SetOption(Environment* env,
     if (!value->IsBigInt() && !value->IsNumber()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "option %s must be a bigint or number", *nameStr);
+          env, "option %s must be a bigint or number", nameStr);
       return false;
     }
     DCHECK_IMPLIES(!value->IsBigInt(), value->IsNumber());
@@ -106,14 +106,14 @@ bool SetOption(Environment* env,
       val = value.As<v8::BigInt>()->Uint64Value(&lossless);
       if (!lossless) {
         Utf8Value label(env->isolate(), name);
-        THROW_ERR_INVALID_ARG_VALUE(env, "option %s is out of range", *label);
+        THROW_ERR_INVALID_ARG_VALUE(env, "option %s is out of range", label);
         return false;
       }
     } else {
       double dbl = value.As<v8::Number>()->Value();
       if (dbl < 0) {
         Utf8Value label(env->isolate(), name);
-        THROW_ERR_INVALID_ARG_VALUE(env, "option %s is out of range", *label);
+        THROW_ERR_INVALID_ARG_VALUE(env, "option %s is out of range", label);
         return false;
       }
       val = static_cast<uint64_t>(dbl);

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -104,7 +104,7 @@ bool SetOption(Environment* env,
     if (!value->ToNumber(env->context()).ToLocal(&num)) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be a number", *nameStr);
+          env, "The %s option must be a number", nameStr);
       return false;
     }
     options->*member = num->Value();
@@ -124,7 +124,7 @@ bool SetOption(Environment* env,
     if (!value->IsUint32()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be an uint8", *nameStr);
+          env, "The %s option must be an uint8", nameStr);
       return false;
     }
     Local<Uint32> num;
@@ -132,7 +132,7 @@ bool SetOption(Environment* env,
         num->Value() > std::numeric_limits<uint8_t>::max()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be an uint8", *nameStr);
+          env, "The %s option must be an uint8", nameStr);
       return false;
     }
     options->*member = num->Value();
@@ -151,7 +151,7 @@ bool SetOption(Environment* env,
     if (!value->IsArrayBufferView()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
-          env, "The %s option must be an ArrayBufferView", *nameStr);
+          env, "The %s option must be an ArrayBufferView", nameStr);
       return false;
     }
     Store store;
@@ -163,7 +163,7 @@ bool SetOption(Environment* env,
       THROW_ERR_INVALID_ARG_VALUE(
           env,
           "The %s option must be an ArrayBufferView of length %d",
-          *nameStr,
+          nameStr,
           TokenSecret::QUIC_TOKENSECRET_LEN);
       return false;
     }

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -128,7 +128,7 @@ bool SetOption(Environment* env,
         } else {
           Utf8Value namestr(env->isolate(), name);
           THROW_ERR_INVALID_ARG_TYPE(
-              env, "%s value must be a key object", *namestr);
+              env, "%s value must be a key object", namestr);
           return false;
         }
       } else if constexpr (std::is_same<T, Store>::value) {
@@ -163,7 +163,7 @@ bool SetOption(Environment* env,
       } else {
         Utf8Value namestr(env->isolate(), name);
         THROW_ERR_INVALID_ARG_TYPE(
-            env, "%s value must be a key object", *namestr);
+            env, "%s value must be a key object", namestr);
         return false;
       }
     } else if constexpr (std::is_same<T, Store>::value) {


### PR DESCRIPTION
Our `THROW_...` helpers can handle strings or string views just fine, all this does is add an extra `strlen()` call that can and should be avoided.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
