### PR TITLE
src: avoid unnecessary string -> `char*` -> string round trips

### DIFF
--- a/src/inspector/protocol_helper.h
+++ b/src/inspector/protocol_helper.h
@@ -19,7 +19,7 @@ inline std::unique_ptr<v8_inspector::StringBuffer> ToInspectorString(
 inline protocol::String ToProtocolString(v8::Isolate* isolate,
                                          v8::Local<v8::Value> value) {
   Utf8Value buffer(isolate, value);
-  return *buffer;
+  return buffer.ToString();
 }
 
 }  // namespace node::inspector

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -442,11 +442,9 @@ void Blob::StoreDataObject(const FunctionCallbackInfo<Value>& args) {
   Utf8Value type(isolate, args[3]);
 
   binding_data->store_data_object(
-      std::string(*key, key.length()),
+      key.ToString(),
       BlobBindingData::StoredDataObject(
-        BaseObjectPtr<Blob>(blob),
-        length,
-        std::string(*type, type.length())));
+          BaseObjectPtr<Blob>(blob), length, type.ToString()));
 }
 
 // Note: applying the V8 Fast API to the following function does not produce
@@ -486,7 +484,7 @@ void Blob::GetDataObject(const FunctionCallbackInfo<Value>& args) {
   Utf8Value key(isolate, args[0]);
 
   BlobBindingData::StoredDataObject stored =
-      binding_data->get_data_object(std::string(*key, key.length()));
+      binding_data->get_data_object(key.ToString());
   if (stored.blob) {
     Local<Value> type;
     if (!String::NewFromUtf8(isolate,

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -284,10 +284,10 @@ ContextifyContext* ContextifyContext::New(Local<Context> v8_context,
                               options->allow_code_gen_wasm);
 
   Utf8Value name_val(env->isolate(), options->name);
-  ContextInfo info(*name_val);
+  ContextInfo info(name_val.ToString());
   if (!options->origin.IsEmpty()) {
     Utf8Value origin_val(env->isolate(), options->origin);
-    info.origin = *origin_val;
+    info.origin = origin_val.ToString();
   }
 
   ContextifyContext* result;

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -276,12 +276,12 @@ inline void THROW_ERR_REQUIRE_ASYNC_MODULE(
   if (!parent_filename.IsEmpty() && parent_filename->IsString()) {
     Utf8Value utf8(env->isolate(), parent_filename);
     message += "\n  From ";
-    message += utf8.out();
+    message += utf8.ToStringView();
   }
   if (!filename.IsEmpty() && filename->IsString()) {
     Utf8Value utf8(env->isolate(), filename);
     message += "\n  Requiring ";
-    message += +utf8.out();
+    message += utf8.ToStringView();
   }
   THROW_ERR_REQUIRE_ASYNC_MODULE(env, message.c_str());
 }

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1368,7 +1368,7 @@ std::unique_ptr<TransferData> JSTransferable::TransferOrClone() const {
   }
   Utf8Value deserialize_info_str(env()->isolate(), deserialize_info);
   if (*deserialize_info_str == nullptr) return {};
-  return std::make_unique<Data>(*deserialize_info_str,
+  return std::make_unique<Data>(deserialize_info_str.ToString(),
                                 Global<Value>(env()->isolate(), data));
 }
 

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -39,7 +39,7 @@ bool SetOption(Environment* env,
   if (!object->Get(env->context(), name).ToLocal(&value)) return false;
   if (!value->IsUndefined()) {
     Utf8Value utf8(env->isolate(), value);
-    options->*member = *utf8;
+    options->*member = utf8.ToString();
   }
   return true;
 }


### PR DESCRIPTION
In these places we can just generate `std::string` directly, so there's no need to convert to an intermediate C string.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
