### PR TITLE
src: remove unnecessary `std::string` error messages

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3260,24 +3260,25 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   if (!error_code) {
     // Check if src and dest are identical.
     if (std::filesystem::equivalent(src_path, dest_path)) {
-      std::string message = "src and dest cannot be the same %s";
-      return THROW_ERR_FS_CP_EINVAL(env, message.c_str(), dest_path_str);
+      static constexpr const char* message =
+          "src and dest cannot be the same %s";
+      return THROW_ERR_FS_CP_EINVAL(env, message, dest_path_str);
     }
 
     const bool dest_is_dir =
         dest_status.type() == std::filesystem::file_type::directory;
     if (src_is_dir && !dest_is_dir) {
-      std::string message =
+      static constexpr const char* message =
           "Cannot overwrite non-directory %s with directory %s";
       return THROW_ERR_FS_CP_DIR_TO_NON_DIR(
-          env, message.c_str(), dest_path_str, src_path_str);
+          env, message, dest_path_str, src_path_str);
     }
 
     if (!src_is_dir && dest_is_dir) {
-      std::string message =
+      static constexpr const char* message =
           "Cannot overwrite directory %s with non-directory %s";
       return THROW_ERR_FS_CP_NON_DIR_TO_DIR(
-          env, message.c_str(), dest_path_str, src_path_str);
+          env, message, dest_path_str, src_path_str);
     }
   }
 
@@ -3286,9 +3287,9 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   }
   // Check if dest_path is a subdirectory of src_path.
   if (src_is_dir && dest_path_str.starts_with(src_path_str)) {
-    std::string message = "Cannot copy %s to a subdirectory of self %s";
-    return THROW_ERR_FS_CP_EINVAL(
-        env, message.c_str(), src_path_str, dest_path_str);
+    static constexpr const char* message =
+        "Cannot copy %s to a subdirectory of self %s";
+    return THROW_ERR_FS_CP_EINVAL(env, message, src_path_str, dest_path_str);
   }
 
   auto dest_parent = dest_path.parent_path();
@@ -3299,9 +3300,9 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
          dest_parent.parent_path() != dest_parent) {
     if (std::filesystem::equivalent(
             src_path, dest_path.parent_path(), error_code)) {
-      std::string message = "Cannot copy %s to a subdirectory of self %s";
-      return THROW_ERR_FS_CP_EINVAL(
-          env, message.c_str(), src_path_str, dest_path_str);
+      static constexpr const char* message =
+          "Cannot copy %s to a subdirectory of self %s";
+      return THROW_ERR_FS_CP_EINVAL(env, message, src_path_str, dest_path_str);
     }
 
     // If equivalent fails, it's highly likely that dest_parent does not exist
@@ -3313,23 +3314,24 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   }
 
   if (src_is_dir && !recursive) {
-    std::string message =
+    static constexpr const char* message =
         "Recursive option not enabled, cannot copy a directory: %s";
-    return THROW_ERR_FS_EISDIR(env, message.c_str(), src_path_str);
+    return THROW_ERR_FS_EISDIR(env, message, src_path_str);
   }
 
   switch (src_status.type()) {
     case std::filesystem::file_type::socket: {
-      std::string message = "Cannot copy a socket file: %s";
-      return THROW_ERR_FS_CP_SOCKET(env, message.c_str(), dest_path_str);
+      static constexpr const char* message = "Cannot copy a socket file: %s";
+      return THROW_ERR_FS_CP_SOCKET(env, message, dest_path_str);
     }
     case std::filesystem::file_type::fifo: {
-      std::string message = "Cannot copy a FIFO pipe: %s";
-      return THROW_ERR_FS_CP_FIFO_PIPE(env, message.c_str(), dest_path_str);
+      static constexpr const char* message = "Cannot copy a FIFO pipe: %s";
+      return THROW_ERR_FS_CP_FIFO_PIPE(env, message, dest_path_str);
     }
     case std::filesystem::file_type::unknown: {
-      std::string message = "Cannot copy an unknown file type: %s";
-      return THROW_ERR_FS_CP_UNKNOWN(env, message.c_str(), dest_path_str);
+      static constexpr const char* message =
+          "Cannot copy an unknown file type: %s";
+      return THROW_ERR_FS_CP_UNKNOWN(env, message, dest_path_str);
     }
     default:
       break;


### PR DESCRIPTION
If we can just use the classic `THROW_...()` methods directly, without needing to allocate an `std::string` for the message/format parameter, let's just do so.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
