### PR TITLE
timers: use reflect.apply instead of spread

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -501,10 +501,11 @@ function getTimerCallbacks(runNextTicks) {
 
       try {
         const argv = immediate._argv;
-        if (!argv)
+        if (argv === undefined) {
           immediate._onImmediate();
-        else
-          immediate._onImmediate(...argv);
+        } else {
+          ReflectApply(immediate._onImmediate, immediate, argv);
+        }
       } finally {
         immediate._onImmediate = null;
 


### PR DESCRIPTION
Small PR that uses ReflectApply for immediate calls [like timeout calls](https://github.com/gurgunday/node/blob/6ae595303c7cbd38e5287eeef8d525f2ed6e8e27/lib/internal/timers.js#L608-L611), I see **solid** improvement locally but don't know if it will translate on the CI, we can run the benchmark

Benchmarks:

main
```sh
node % ./node benchmark/run.js --filter immediate timers      

timers/immediate.js
timers/immediate.js type="depth" n=5000000: 70,071.0670045977
timers/immediate.js type="depth1" n=5000000: 71,603.17299590204
timers/immediate.js type="breadth" n=5000000: 5,408,702.0356087135
timers/immediate.js type="breadth1" n=5000000: 3,599,842.0372034833
timers/immediate.js type="breadth4" n=5000000: 2,985,861.2007491523
timers/immediate.js type="clear" n=5000000: 29,272,924.559199043

timers/set-immediate-breadth-args.js
timers/set-immediate-breadth-args.js n=5000000: 3,264,368.825960096

timers/set-immediate-breadth.js
timers/set-immediate-breadth.js n=10000000: 4,898,277.771658332

timers/set-immediate-depth-args.js
timers/set-immediate-depth-args.js n=5000000: 70,717.37332918265
```

branch
```sh
node % ./node benchmark/run.js --filter immediate timers

timers/immediate.js
timers/immediate.js type="depth" n=5000000: 75,616.26089957527
timers/immediate.js type="depth1" n=5000000: 72,812.61935540586
timers/immediate.js type="breadth" n=5000000: 6,881,622.561299371
timers/immediate.js type="breadth1" n=5000000: 4,196,294.988597117
timers/immediate.js type="breadth4" n=5000000: 3,206,647.251486441
timers/immediate.js type="clear" n=5000000: 31,875,066.721487317

timers/set-immediate-breadth-args.js
timers/set-immediate-breadth-args.js n=5000000: 3,812,316.9670883627

timers/set-immediate-breadth.js
timers/set-immediate-breadth.js n=10000000: 5,104,154.308605225

timers/set-immediate-depth-args.js
timers/set-immediate-depth-args.js n=5000000: 77,569.67536101848
```