### PR TITLE
doc,crypto: reorder ML-KEM in the asymmetric key types table

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -87,9 +87,9 @@ The following table lists the asymmetric key types recognized by the [`KeyObject
 | `'ml-dsa-44'`[^openssl35]          | ML-DSA-44          | 2.16.840.1.101.3.4.3.17 |
 | `'ml-dsa-65'`[^openssl35]          | ML-DSA-65          | 2.16.840.1.101.3.4.3.18 |
 | `'ml-dsa-87'`[^openssl35]          | ML-DSA-87          | 2.16.840.1.101.3.4.3.19 |
-| `'ml-kem-1024'`[^openssl35]        | ML-KEM-1024        | 2.16.840.1.101.3.4.4.3  |
 | `'ml-kem-512'`[^openssl35]         | ML-KEM-512         | 2.16.840.1.101.3.4.4.1  |
 | `'ml-kem-768'`[^openssl35]         | ML-KEM-768         | 2.16.840.1.101.3.4.4.2  |
+| `'ml-kem-1024'`[^openssl35]        | ML-KEM-1024        | 2.16.840.1.101.3.4.4.3  |
 | `'rsa-pss'`                        | RSA PSS            | 1.2.840.113549.1.1.10   |
 | `'rsa'`                            | RSA                | 1.2.840.113549.1.1.1    |
 | `'slh-dsa-sha2-128f'`[^openssl35]  | SLH-DSA-SHA2-128f  | 2.16.840.1.101.3.4.3.21 |


### PR DESCRIPTION
Order ML-KEM by security strength not by alphabetical order.