### PR TITLE
console: allow per-stream `inspectOptions` option

### DIFF
--- a/doc/api/console.md
+++ b/doc/api/console.md
@@ -102,6 +102,9 @@ const { Console } = console;
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60082
+    description: The `inspectOptions` option can be a `Map` from stream to options.
   - version:
      - v14.2.0
      - v12.17.0
@@ -131,8 +134,9 @@ changes:
     and the value returned by `getColorDepth()` on the respective stream. This
     option can not be used, if `inspectOptions.colors` is set as well.
     **Default:** `'auto'`.
-  * `inspectOptions` {Object} Specifies options that are passed along to
-    [`util.inspect()`][].
+  * `inspectOptions` {Object|Map} Specifies options that are passed along to
+    [`util.inspect()`][]. Can be an options object or, if different options
+    for stdout and stderr are desired, a `Map` from stream objects to options.
   * `groupIndentation` {number} Set group indentation.
     **Default:** `2`.
 

--- a/lib/internal/console/constructor.js
+++ b/lib/internal/console/constructor.js
@@ -12,6 +12,8 @@ const {
   Boolean,
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
+  MapPrototypeGet,
+  MapPrototypeValues,
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectKeys,
@@ -139,12 +141,20 @@ function Console(options /* or: stdout, stderr, ignoreErrors = true */) {
   if (inspectOptions !== undefined) {
     validateObject(inspectOptions, 'options.inspectOptions');
 
-    if (inspectOptions.colors !== undefined &&
-        options.colorMode !== undefined) {
-      throw new ERR_INCOMPATIBLE_OPTION_PAIR(
-        'options.inspectOptions.color', 'colorMode');
+    const inspectOptionsMap = isMap(inspectOptions) ?
+      inspectOptions : new SafeMap([
+        [stdout, inspectOptions],
+        [stderr, inspectOptions],
+      ]);
+
+    for (const inspectOptions of MapPrototypeValues(inspectOptionsMap)) {
+      if (inspectOptions.colors !== undefined &&
+          options.colorMode !== undefined) {
+        throw new ERR_INCOMPATIBLE_OPTION_PAIR(
+          'options.inspectOptions.color', 'colorMode');
+      }
     }
-    optionsMap.set(this, inspectOptions);
+    optionsMap.set(this, inspectOptionsMap);
   }
 
   // Bind the prototype functions to this Console instance
@@ -316,7 +326,8 @@ ObjectDefineProperties(Console.prototype, {
         color = lazyUtilColors().shouldColorize(stream);
       }
 
-      const options = optionsMap.get(this);
+      const inspectOptionsMap = optionsMap.get(this);
+      const options = inspectOptionsMap ? MapPrototypeGet(inspectOptionsMap, stream) : undefined;
       if (options) {
         if (options.colors === undefined) {
           options.colors = color;

--- a/test/parallel/test-console-tty-colors-per-stream.js
+++ b/test/parallel/test-console-tty-colors-per-stream.js
@@ -1,0 +1,23 @@
+'use strict';
+require('../common');
+const { Console } = require('console');
+const { PassThrough } = require('stream');
+const { strict: assert } = require('assert');
+
+const stdout = new PassThrough().setEncoding('utf8');
+const stderr = new PassThrough().setEncoding('utf8');
+
+const console = new Console({
+  stdout,
+  stderr,
+  inspectOptions: new Map([
+    [stdout, { colors: true }],
+    [stderr, { colors: false }],
+  ]),
+});
+
+console.log('Hello', 42);
+console.warn('Hello', 42);
+
+assert.strictEqual(stdout.read(), 'Hello \x1B[33m42\x1B[39m\n');
+assert.strictEqual(stderr.read(), 'Hello 42\n');


### PR DESCRIPTION
We (correctly) allow different streams to be specified for `stdout` and `stderr`, so we should also allow different inspect options for these streams.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
