### PR TITLE
doc: remove optional title prefixes

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -1494,7 +1494,7 @@ console.log(Buffer.isEncoding(''));
 // Prints: false
 ```
 
-### Class property: `Buffer.poolSize`
+### `Buffer.poolSize`
 
 <!-- YAML
 added: v0.11.3

--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -1651,7 +1651,7 @@ A MIME string is a structured string containing multiple meaningful
 components. When parsed, a `MIMEType` object is returned containing
 properties for each of these components.
 
-### Constructor: `new MIMEType(input)`
+### `new MIMEType(input)`
 
 * `input` {string} The input MIME to parse
 
@@ -1843,7 +1843,7 @@ added:
 The `MIMEParams` API provides read and write access to the parameters of a
 `MIMEType`.
 
-### Constructor: `new MIMEParams()`
+### `new MIMEParams()`
 
 Creates a new `MIMEParams` object by with empty parameters
 


### PR DESCRIPTION
Ref: https://github.com/nodejs/doc-kit/issues/378
Companion: https://github.com/nodejs/doc-kit/pull/449

Removes 3 outlier titles, so that stricter RegExps can be used in doc-kit.