### PR TITLE
process: fix wrong asyncContext under unhandled-rejections=strict

### DIFF
--- a/lib/internal/process/promises.js
+++ b/lib/internal/process/promises.js
@@ -281,7 +281,7 @@ function strictUnhandledRejectionsMode(promise, promiseInfo, promiseAsyncId) {
     reason : new UnhandledPromiseRejection(reason);
   // This destroys the async stack, don't clear it after
   triggerUncaughtException(err, true /* fromPromise */);
-  if (promiseAsyncId === undefined) {
+  if (promiseAsyncId !== undefined) {
     pushAsyncContext(
       promise[kAsyncIdSymbol],
       promise[kTriggerAsyncIdSymbol],

--- a/test/parallel/test-promise-unhandled-error-with-reading-file.js
+++ b/test/parallel/test-promise-unhandled-error-with-reading-file.js
@@ -1,0 +1,29 @@
+// Flags: --unhandled-rejections=strict
+'use strict';
+
+const common = require('../common');
+const fs = require('fs');
+const assert = require('assert');
+
+process.on('unhandledRejection', common.mustNotCall);
+
+process.on('uncaughtException', common.mustCall((err) => {
+  assert.ok(err.message.includes('foo'));
+}));
+
+
+async function readFile() {
+  return fs.promises.readFile(__filename);
+}
+
+async function crash() {
+  throw new Error('foo');
+}
+
+
+async function main() {
+  crash();
+  readFile();
+}
+
+main();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60034

When I looked at the crash point in the issue, I found that asyncId was undefined.
https://github.com/nodejs/node/blob/main/src/api/callback.cc#L185

I suspect that the code may have been mistakenly changed in this PR.
https://github.com/nodejs/node/pull/52108/files#diff-04f0a68c4bc76396de863bbe0982c85d70a5b71432bdc26bc503e3ac317c6f82L263

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
