### PR TITLE
deps: V8: cherry-pick f93055fbd5aa

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/keys.cc
+++ b/deps/v8/src/objects/keys.cc
@@ -464,12 +464,42 @@ MaybeHandle<FixedArray> FastKeyAccumulator::GetKeys(
       return keys;
     }
     if (isolate_->has_exception()) return MaybeHandle<FixedArray>();
+  } else if (filter_ == SKIP_STRINGS && !MayHaveSymbols()) {
+    return isolate_->factory()->empty_fixed_array();
   }
 
   if (try_prototype_info_cache_) {
     return GetKeysWithPrototypeInfoCache(keys_conversion);
   }
   return GetKeysSlow(keys_conversion);
+}
+
+bool FastKeyAccumulator::MayHaveSymbols() {
+  bool own_only = has_empty_prototype_ || mode_ == KeyCollectionMode::kOwnOnly;
+  Tagged<Map> map = receiver_->map();
+  if (!own_only || IsCustomElementsReceiverMap(map)) {
+    return true;
+  }
+
+  // From this point on we are certain to only collect own keys.
+  DCHECK(IsJSObject(*receiver_));
+
+  if (map->is_dictionary_map()) {
+    // TODO(olivf): Keep a bit in the dictionary to remember if we have any
+    // symbols.
+    return true;
+  }
+  int num = map->NumberOfOwnDescriptors();
+  if (num == 0) {
+    return false;
+  }
+  int enum_length = receiver_->map()->EnumLength();
+  if (enum_length != kInvalidEnumCacheSentinel) {
+    return enum_length != num;
+  }
+  // TODO(olivf): Keep a bit in the descriptor to remember if we have any
+  // symbols.
+  return true;
 }
 
 MaybeHandle<FixedArray> FastKeyAccumulator::GetKeysFast(

--- a/deps/v8/src/objects/keys.h
+++ b/deps/v8/src/objects/keys.h
@@ -197,6 +197,7 @@ class FastKeyAccumulator {
   bool is_receiver_simple_enum() { return is_receiver_simple_enum_; }
   bool has_empty_prototype() { return has_empty_prototype_; }
   bool may_have_elements() { return may_have_elements_; }
+  bool MayHaveSymbols();
 
   MaybeHandle<FixedArray> GetKeys(
       GetKeysConversion convert = GetKeysConversion::kKeepNumbers);


### PR DESCRIPTION
Original commit message:

    [runtime] Fastcase for empty getOwnPropertySymbols()

    Since symbols are not enumerable we can rule them out in case all
    properties are in the enum cache.

    Bug: 447154198
    Change-Id: Ib2d58b67e5058d98323fcebaef3daba88c6304b5
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6983286
    Commit-Queue: Olivier Flückiger <olivf@chromium.org>
    Reviewed-by: Toon Verwaest <verwaest@chromium.org>
    Auto-Submit: Olivier Flückiger <olivf@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#102878}

Refs: https://github.com/v8/v8/commit/f93055fbd5aa266d64500ae7b1ad899e8be23cd5

This makes `util.inspect` and `util.isDeepStrictEqual` (including all APIs that are based on the same) significantly faster in case the objects do not contain any symbols.