### PR TITLE
lib: remove redundant destroyHook checks

### DIFF
--- a/lib/internal/async_hooks.js
+++ b/lib/internal/async_hooks.js
@@ -532,7 +532,7 @@ function emitAfterScript(asyncId) {
 
 function emitDestroyScript(asyncId) {
   // Return early if there are no destroy callbacks, or invalid asyncId.
-  if (!hasHooks(kDestroy) || asyncId <= 0)
+  if (!hasHooks(kDestroy) || !(asyncId > 0))
     return;
   async_wrap.queueDestroyAsyncId(asyncId);
 }

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -27,7 +27,6 @@ const {
   getDefaultTriggerAsyncId,
   newAsyncId,
   initHooksExist,
-  destroyHooksExist,
   emitInit,
   emitBefore,
   emitAfter,

--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -94,8 +94,7 @@ function processTicksAndRejections() {
           }
         }
       } finally {
-        if (destroyHooksExist())
-          emitDestroy(asyncId);
+        emitDestroy(asyncId);
       }
 
       emitAfter(asyncId);

--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -92,7 +92,6 @@ const {
   getDefaultTriggerAsyncId,
   newAsyncId,
   initHooksExist,
-  destroyHooksExist,
   // The needed emit*() functions.
   emitInit,
   emitBefore,
@@ -508,8 +507,7 @@ function getTimerCallbacks(runNextTicks) {
       } finally {
         immediate._onImmediate = null;
 
-        if (destroyHooksExist())
-          emitDestroy(asyncId);
+        emitDestroy(asyncId);
 
         outstandingQueue.head = immediate = immediate._idleNext;
       }
@@ -585,8 +583,7 @@ function getTimerCallbacks(runNextTicks) {
           if (timer[kRefed])
             timeoutInfo[0]--;
 
-          if (destroyHooksExist())
-            emitDestroy(asyncId);
+          emitDestroy(asyncId);
         }
         continue;
       }
@@ -621,8 +618,7 @@ function getTimerCallbacks(runNextTicks) {
           if (timer[kRefed])
             timeoutInfo[0]--;
 
-          if (destroyHooksExist())
-            emitDestroy(asyncId);
+          emitDestroy(asyncId);
         }
       }
 

--- a/lib/timers.js
+++ b/lib/timers.js
@@ -63,7 +63,6 @@ let timersPromises;
 let timers;
 
 const {
-  destroyHooksExist,
   // The needed emit*() functions.
   emitDestroy,
 } = require('internal/async_hooks');
@@ -78,9 +77,7 @@ function unenroll(item) {
   if (item[kHasPrimitive])
     delete knownTimersById[item[async_id_symbol]];
 
-  // Fewer checks may be possible, but these cover everything.
-  if (destroyHooksExist() && item[async_id_symbol] !== undefined)
-    emitDestroy(item[async_id_symbol]);
+  emitDestroy(item[async_id_symbol]);
 
   L.remove(item);
 
@@ -239,9 +236,7 @@ function clearImmediate(immediate) {
   }
   immediate[kRefed] = null;
 
-  if (destroyHooksExist() && immediate[async_id_symbol] !== undefined) {
-    emitDestroy(immediate[async_id_symbol]);
-  }
+  emitDestroy(immediate[async_id_symbol]);
 
   immediate._onImmediate = null;
 

--- a/test/fixtures/errors/async_error_nexttick_main.snapshot
+++ b/test/fixtures/errors/async_error_nexttick_main.snapshot
@@ -1,7 +1,7 @@
 Error: test
     at one (*fixtures*async-error.js:4:9)
     at two (*fixtures*async-error.js:17:9)
-    at process.processTicksAndRejections (node:internal*process*task_queues:104:5)
+    at process.processTicksAndRejections (node:internal*process*task_queues:103:5)
     at async three (*fixtures*async-error.js:20:3)
     at async four (*fixtures*async-error.js:24:3)
     at async main (*async_error_nexttick_main.js:7:5)

--- a/test/fixtures/errors/async_error_nexttick_main.snapshot
+++ b/test/fixtures/errors/async_error_nexttick_main.snapshot
@@ -1,7 +1,7 @@
 Error: test
     at one (*fixtures*async-error.js:4:9)
     at two (*fixtures*async-error.js:17:9)
-    at process.processTicksAndRejections (node:internal*process*task_queues:105:5)
+    at process.processTicksAndRejections (node:internal*process*task_queues:104:5)
     at async three (*fixtures*async-error.js:20:3)
     at async four (*fixtures*async-error.js:24:3)
     at async main (*async_error_nexttick_main.js:7:5)


### PR DESCRIPTION
> // Fewer checks may be possible, but these cover everything.

`emitDestroy` already checks these now:

https://github.com/nodejs/node/blob/6f941fcfba50fe7c3a342ed2066770aecaaa9b5a/lib/internal/async_hooks.js#L533-L538

We are essentially checking the same condition twice

Also the invalid id check didn't cover `undefined`. I don't know if it was intentional, but in any case, since https://github.com/nodejs/node/pull/56966, which removed `enroll`, I'm not sure if we can have an undefined `asyncId` anyway