### PR TITLE
tools: run CI with shared libs on GHA

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -140,6 +140,22 @@ jobs:
           NODE=$(command -v node) make lint-md
         env:
           NODE_RELEASED_VERSIONS: ${{ steps.get-released-versions.outputs.NODE_RELEASED_VERSIONS }}
+  lint-nix:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: '*.nix'
+          sparse-checkout-cone-mode: false
+      - uses: cachix/install-nix-action@7be5dee1421f63d07e71ce6e0a9f8a4b07c2a487  # v31.6.1
+      - name: Lint Nix files
+        run: nix-shell -I nixpkgs=./tools/nix/pkgs.nix -p 'nixfmt-tree' --run 'treefmt --quiet --fail-on-change'
+      - if: ${{ failure() }}
+        name: Show diff
+        run: git --no-pager diff
+
   lint-py:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - .mailmap
       - README.md
+      - '*.nix'
       - .github/**
       - '!.github/workflows/test-linux.yml'
     types: [opened, synchronize, reopened, ready_for_review]
@@ -17,6 +18,7 @@ on:
     paths-ignore:
       - .mailmap
       - README.md
+      - '*.nix'
       - .github/**
       - '!.github/workflows/test-linux.yml'
 

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - .mailmap
       - '**.md'
+      - '*.nix'
       - AUTHORS
       - doc/**
       - .github/**
@@ -19,6 +20,7 @@ on:
     paths-ignore:
       - .mailmap
       - '**.md'
+      - '*.nix'
       - AUTHORS
       - doc/**
       - .github/**

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -1,0 +1,83 @@
+name: Test Shared librairies
+
+on:
+  pull_request:
+    paths-ignore:
+      - .mailmap
+      - '**.md'
+      - AUTHORS
+      - doc/**
+      - .github/**
+      - '!.github/workflows/test-shared.yml'
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+      - canary
+      - v[0-9]+.x-staging
+      - v[0-9]+.x
+    paths-ignore:
+      - .mailmap
+      - '**.md'
+      - AUTHORS
+      - doc/**
+      - .github/**
+      - '!.github/workflows/test-shared.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FLAKY_TESTS: keep_retrying
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+          - runner: macos-13
+            system: x86_64-darwin
+          - runner: macos-latest
+            system: aarch64-darwin
+    name: '${{ matrix.system }}: with shared libraries'
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: cachix/install-nix-action@7be5dee1421f63d07e71ce6e0a9f8a4b07c2a487  # v31.6.1
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Configure sccache
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            core.exportVariable('SCCACHE_GHA_VERSION', 'on');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', 'on');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Build Node.js and run tests
+        run: |
+          nix-shell \
+            -I nixpkgs=./tools/nix/pkgs.nix \
+            --pure --keep FLAKY_TESTS \
+            --keep SCCACHE_GHA_VERSION --keep ACTIONS_CACHE_SERVICE_V2 --keep ACTIONS_RESULTS_URL --keep ACTIONS_RUNTIME_TOKEN \
+            --arg loadJSBuiltinsDynamically false \
+            --arg ccache '(import <nixpkgs> {}).sccache' \
+            --arg devTools '[]' \
+            --arg benchmarkTools '[]' \
+            --run '
+                make run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9 --skip-tests=$CI_SKIP_TESTS"
+            '

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -29,6 +29,7 @@ on:
           - llhttp
           - minimatch
           - nbytes
+          - nixpkgs-unstable
           - nghttp2
           - nghttp3
           - ngtcp2
@@ -181,6 +182,14 @@ jobs:
               cat temp-output
               tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
               rm temp-output
+          - id: nixpkgs-unstable
+            subsystem: tools
+            label: tools
+            run: |
+              ./tools/dep_updaters/update-nixpkgs-pin.sh > temp-output
+              cat temp-output
+              tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+              rm temp-output
           - id: nghttp2
             subsystem: deps
             label: dependencies
@@ -281,6 +290,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
+      - name: Set up Nix
+        if: matrix.id == 'nixpkgs-unstable' && (github.event_name == 'schedule' || inputs.id == 'all' || inputs.id == matrix.id)
+        uses: cachix/install-nix-action@7be5dee1421f63d07e71ce6e0a9f8a4b07c2a487  # v31.6.1
       - run: ${{ matrix.run }}
         if: github.event_name == 'schedule' || inputs.id == 'all' || inputs.id == matrix.id
         env:

--- a/doc/contributing/writing-and-running-benchmarks.md
+++ b/doc/contributing/writing-and-running-benchmarks.md
@@ -26,6 +26,10 @@ Basic Unix tools are required for some benchmarks.
 [Git for Windows][git-for-windows] includes Git Bash and the necessary tools,
 which need to be included in the global Windows `PATH`.
 
+If you are using Nix, all the required tools are already listed in the
+`benchmarkTools` argument of the `shell.nix` file, so you can skip those
+prerequesites.
+
 ### HTTP benchmark requirements
 
 Most of the HTTP benchmarks require a benchmarker to be installed. This can be

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,120 @@
+{
+  pkgs ? import "${./tools/nix/pkgs.nix}" { },
+  loadJSBuiltinsDynamically ? true, # Load `lib/**.js` from disk instead of embedding
+  ncu-path ? null, # Provide this if you want to use a local version of NCU
+  icu ? pkgs.icu,
+  sharedLibDeps ? {
+    inherit (pkgs)
+      ada
+      brotli
+      c-ares
+      libuv
+      nghttp2
+      nghttp3
+      ngtcp2
+      openssl
+      simdjson
+      simdutf
+      sqlite
+      uvwasi
+      zlib
+      zstd
+      ;
+    http-parser = pkgs.llhttp;
+  },
+  ccache ? pkgs.ccache,
+  ninja ? pkgs.ninja,
+  devTools ? [
+    pkgs.curl
+    pkgs.gh
+    pkgs.git
+    pkgs.jq
+    pkgs.shellcheck
+  ]
+  ++ (
+    if (ncu-path == null) then
+      [ pkgs.node-core-utils ]
+    else
+      [
+        (pkgs.writeShellScriptBin "git-node" "exec \"${ncu-path}/bin/git-node.js\" \"$@\"")
+        (pkgs.writeShellScriptBin "ncu-ci" "exec \"${ncu-path}/bin/ncu-ci.js\" \"$@\"")
+        (pkgs.writeShellScriptBin "ncu-config" "exec \"${ncu-path}/bin/ncu-config.js\" \"$@\"")
+      ]
+  ),
+  benchmarkTools ? [
+    pkgs.R
+    pkgs.rPackages.ggplot2
+    pkgs.rPackages.plyr
+    pkgs.wrk
+  ],
+  extraConfigFlags ? [
+    "--without-npm"
+    "--debug-node"
+  ],
+}:
+
+let
+  useSharedICU = if builtins.isString icu then icu == "system" else icu != null;
+  useSharedAda = builtins.hasAttr "ada" sharedLibDeps;
+  useSharedOpenSSL = builtins.hasAttr "openssl" sharedLibDeps;
+in
+pkgs.mkShell {
+  inherit (pkgs.nodejs_latest) nativeBuildInputs;
+
+  buildInputs = builtins.attrValues sharedLibDeps ++ pkgs.lib.optionals useSharedICU [ icu ];
+
+  packages = [
+    ccache
+  ]
+  ++ devTools
+  ++ benchmarkTools;
+
+  shellHook =
+    if (ccache != null) then
+      ''
+        export CC="${pkgs.lib.getExe ccache} $CC"
+        export CXX="${pkgs.lib.getExe ccache} $CXX"
+      ''
+    else
+      "";
+
+  BUILD_WITH = if (ninja != null) then "ninja" else "make";
+  NINJA = if (ninja != null) then "${pkgs.lib.getExe ninja}" else "";
+  CI_SKIP_TESTS = pkgs.lib.concatStringsSep "," (
+    [ ]
+    ++ pkgs.lib.optionals useSharedAda [
+      # Different versions of Ada affect the WPT tests
+      "test-url"
+    ]
+    ++ pkgs.lib.optionals useSharedOpenSSL [
+      # Path to the openssl.cnf is different from the expected one
+      "test-strace-openat-openssl"
+    ]
+  );
+  CONFIG_FLAGS = builtins.toString (
+    [
+      (
+        if icu == null then
+          "--without-intl"
+        else
+          "--with-intl=${if useSharedICU then "system" else icu}-icu"
+      )
+    ]
+    ++ extraConfigFlags
+    ++ pkgs.lib.optionals (ninja != null) [
+      "--ninja"
+    ]
+    ++ pkgs.lib.optionals loadJSBuiltinsDynamically [
+      "--node-builtin-modules-path=${builtins.toString ./.}"
+    ]
+    ++ pkgs.lib.concatMap (name: [
+      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}"
+      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}-libpath=${
+        pkgs.lib.getLib sharedLibDeps.${name}
+      }/lib"
+      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}-include=${
+        pkgs.lib.getInclude sharedLibDeps.${name}
+      }/include"
+    ]) (builtins.attrNames sharedLibDeps)
+  );
+}

--- a/tools/dep_updaters/update-nixpkgs-pin.sh
+++ b/tools/dep_updaters/update-nixpkgs-pin.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -ex
+# Shell script to update Nixpkgs pin in the source tree to the most recent
+# version on the unstable channel.
+
+BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+NIXPKGS_PIN_FILE="$BASE_DIR/tools/nix/pkgs.nix"
+
+NIXPKGS_REPO=$(grep 'repo =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
+CURRENT_VERSION_SHA1=$(grep 'rev =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
+CURRENT_VERSION=$(echo "$CURRENT_VERSION_SHA1" | head -c 7)
+
+NEW_UPSTREAM_SHA1=$(git ls-remote "$NIXPKGS_REPO.git" nixpkgs-unstable | awk '{print $1}')
+NEW_VERSION=$(echo "$NEW_UPSTREAM_SHA1" | head -c 7)
+
+
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
+compare_dependency_version "nixpkgs-unstable" "$NEW_VERSION" "$CURRENT_VERSION"
+
+CURRENT_TARBALL_HASH=$(grep 'sha256 =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
+NEW_TARBALL_HASH=$(nix-prefetch-url --unpack "$NIXPKGS_REPO/archive/$NEW_UPSTREAM_SHA1.tar.gz")
+
+TMP_FILE=$(mktemp)
+sed "s/$CURRENT_VERSION_SHA1/$NEW_UPSTREAM_SHA1/;s/$CURRENT_TARBALL_HASH/$NEW_TARBALL_HASH/" "$NIXPKGS_PIN_FILE" > "$TMP_FILE"
+mv "$TMP_FILE" "$NIXPKGS_PIN_FILE"
+
+cat -<<EOF
+All done!
+
+Please git add and commit the new version:
+
+$ git add $NIXPKGS_PIN_FILE
+$ git commit -m 'tools: bump nixpkgs-unstable pin to $NEW_VERSION'
+EOF
+
+# The last line of the script should always print the new version,
+# as we need to add it to $GITHUB_ENV variable.
+echo "NEW_VERSION=$NEW_VERSION"

--- a/tools/nix/pkgs.nix
+++ b/tools/nix/pkgs.nix
@@ -1,0 +1,10 @@
+arg:
+let
+  repo = "https://github.com/NixOS/nixpkgs";
+  rev = "ca77296380960cd497a765102eeb1356eb80fed0";
+  nixpkgs = import (builtins.fetchTarball {
+    url = "${repo}/archive/${rev}.tar.gz";
+    sha256 = "1airrw6l87iyny1a3mb29l28na4s4llifprlgpll2na461jd40iy";
+  }) arg;
+in
+nixpkgs


### PR DESCRIPTION
And introduce a `nix.shell` file which IMO can greatly improve the onboarding of new devs: if installing Nix is an option for them, they don't need to figure out which tools and lib to install and pollute their $PATH with those, they can simply let Nix create a sandboxed environment that's guaranteed to compile `node` (at least on the platforms we can test, i.e. Linux and macOS, and likely on all platforms compatible with Nix).

Regarding the maintenance burden of adding this, I have to maintain it whether this PR lands or not, and so far (I've been using this locally for the past 6 months) it's not been a lot of work, so I'd be happy to take care of it.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
