### PR TITLE
timers: check for undefined instead of nullish value

### DIFF
--- a/lib/internal/timers.js
+++ b/lib/internal/timers.js
@@ -531,7 +531,7 @@ function getTimerCallbacks(runNextTicks) {
 
     let list;
     let ranAtLeastOneList = false;
-    while ((list = timerListQueue.peek()) != null) {
+    while ((list = timerListQueue.peek()) !== undefined) {
       if (list.expiry > now) {
         nextExpiry = list.expiry;
         return timeoutInfo[0] > 0 ? nextExpiry : -nextExpiry;


### PR DESCRIPTION
Now that the Priority Queue heap is a [PACKED array](https://github.com/nodejs/node/pull/60039), we can safely check if the value is `undefined` instead of nullish here