### PR TITLE
util: improve styleText performance

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -123,7 +123,6 @@ function styleText(format, text, { validateStream = true, stream = process.stdou
   validateString(text, 'text');
   validateBoolean(validateStream, 'options.validateStream');
 
-  let skipColorize;
   if (validateStream) {
     if (
       !isReadableStream(stream) &&
@@ -134,8 +133,12 @@ function styleText(format, text, { validateStream = true, stream = process.stdou
     }
 
     // If the stream is falsy or should not be colorized, set skipColorize to true
-    skipColorize = !lazyUtilColors().shouldColorize(stream);
+    const skipColorize = !lazyUtilColors().shouldColorize(stream);
+    if (skipColorize) {
+      return text;
+    }
   }
+
 
   // If the format is not an array, convert it to an array
   const formatArray = ArrayIsArray(format) ? format : [format];
@@ -148,12 +151,7 @@ function styleText(format, text, { validateStream = true, stream = process.stdou
     if (formatCodes == null) {
       validateOneOf(key, 'format', ObjectKeys(inspect.colors));
     }
-    if (skipColorize) continue;
     ArrayPrototypePush(codes, formatCodes);
-  }
-
-  if (skipColorize) {
-    return text;
   }
 
   // Build opening codes

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -5,6 +5,8 @@ const assert = require('node:assert');
 const util = require('node:util');
 const { WriteStream } = require('node:tty');
 
+process.env.FORCE_COLOR = '1';
+
 const styled = '\u001b[31mtest\u001b[39m';
 const noChange = 'test';
 
@@ -35,6 +37,14 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
 });
+
+assert.throws(() => {
+  util.styleText(['invalid'], 'text');
+}, {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+process.env.FORCE_COLOR = '0';
 
 assert.strictEqual(
   util.styleText('red', 'test', { validateStream: false }),
@@ -133,12 +143,6 @@ assert.strictEqual(
 );
 
 assert.throws(() => {
-  util.styleText(['invalid'], 'text');
-}, {
-  code: 'ERR_INVALID_ARG_VALUE',
-});
-
-assert.throws(() => {
   util.styleText('red', 'text', { stream: {} });
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
@@ -153,6 +157,8 @@ assert.strictEqual(
 );
 
 assert.strictEqual(util.styleText('none', 'test'), 'test');
+
+delete process.env.FORCE_COLOR;
 
 const fd = common.getTTYfd();
 if (fd !== -1) {


### PR DESCRIPTION
The validation for when to colorize or not was happening in a loop. Instead, it is now done once up front instead.