### PR TITLE
http2: do not crash on mismatched ping buffer length

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1444,9 +1444,9 @@ class Http2Session extends EventEmitter {
     }
     if (payload) {
       validateBuffer(payload, 'payload');
-    }
-    if (payload && payload.length !== 8) {
-      throw new ERR_HTTP2_PING_LENGTH();
+      if (payload.byteLength !== 8) {
+        throw new ERR_HTTP2_PING_LENGTH();
+      }
     }
     validateFunction(callback, 'callback');
 

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -64,11 +64,11 @@ server.listen(0, common.mustCall(() => {
       })));
     }
     {
-      const payload = Buffer.from('abcdefgi');
+      const payload = new Uint16Array([1, 2, 3, 4]);
       assert(client.ping(payload, common.mustCall((err, duration, ret) => {
         assert.strictEqual(err, null);
         assert.strictEqual(typeof duration, 'number');
-        assert.deepStrictEqual(payload, ret);
+        assert.deepStrictEqual(payload.buffer, ret.buffer);
       })));
     }
 
@@ -99,7 +99,8 @@ server.listen(0, common.mustCall(() => {
     {
       const shortPayload = Buffer.from('abcdefg');
       const longPayload = Buffer.from('abcdefghi');
-      [shortPayload, longPayload].forEach((payloadWithInvalidLength) =>
+      const mismatchedPayload = new Uint32Array(8);
+      [shortPayload, longPayload, mismatchedPayload].forEach((payloadWithInvalidLength) =>
         assert.throws(
           () => client.ping(payloadWithInvalidLength),
           {


### PR DESCRIPTION
```js
const session = require('http2').connect('http://localhost/')
session.ping(new Uint32Array(8), console.debug)
```
yields
```
  #  node[1898056]: static void node::http2::Http2Session::Ping(const v8::FunctionCallbackInfo<v8::Value>&) at ../src/node_http2.cc:3227
  #  Assertion failed: (payload.length()) == (8)

IOT instruction (core dumped)
```