### PR TITLE
tools: fix dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
-      cooldown:
-        - semver-major-days: 5
-        - semver-minor-days: 5
-        - semver-patch-days: 5
+    cooldown:
+      - default-days: 5
 
     commit-message:
       prefix: meta
@@ -19,10 +17,8 @@ updates:
     directory: /tools/eslint
     schedule:
       interval: monthly
-      cooldown:
-        - semver-major-days: 5
-        - semver-minor-days: 5
-        - semver-patch-days: 5
+    cooldown:
+      - default-days: 5
     commit-message:
       prefix: tools
     open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
@@ -36,10 +32,8 @@ updates:
     directory: /tools/lint-md
     schedule:
       interval: monthly
-      cooldown:
-        - semver-major-days: 5
-        - semver-minor-days: 5
-        - semver-patch-days: 5
+    cooldown:
+      - default-days: 5
     commit-message:
       prefix: tools
     open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
@@ -53,10 +47,8 @@ updates:
     directory: /tools/doc
     schedule:
       interval: weekly
-      cooldown:
-        - semver-major-days: 5
-        - semver-minor-days: 5
-        - semver-patch-days: 5
+    cooldown:
+      - default-days: 5
     commit-message:
       prefix: tools
     open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}


### PR DESCRIPTION
Fixes the error reported in https://github.com/nodejs/node/pull/59883/checks?check_run_id=51966742676.

Also, switch to using `default-days`, following the DRY principle.

Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
