### PR TITLE
test: skip tests that cause timeouts on IBM i

### DIFF
--- a/test/client-proxy/client-proxy.status
+++ b/test/client-proxy/client-proxy.status
@@ -5,3 +5,11 @@ prefix client-proxy
 # sample-test                        : PASS,FLAKY
 
 [true] # This section applies to all platforms
+
+
+[$system==ibmi]
+# https://github.com/nodejs/node/issues/58582
+test-http-proxy-fetch: SKIP
+test-https-proxy-fetch: SKIP
+test-use-env-proxy-cli-http: SKIP
+test-use-env-proxy-cli-https: SKIP

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -134,15 +134,16 @@ test-tls-write-error: PASS, FLAKY
 # https://github.com/nodejs/node/issues/48047
 test-http-pipeline-flood: SKIP
 # https://github.com/nodejs/node/issues/58582
-test-http-proxy-fetch: SKIP
-test-https-proxy-fetch: SKIP
 test-inspector-network-fetch:  SKIP
 test-inspector-network-content-type: SKIP
 test-fetch:  SKIP
 test-without-async-context-frame: SKIP
 test-process-cpuUsage: PASS, FLAKY
 test-web-locks: SKIP
-
+test-http2-allow-http1-upgrade-ws: SKIP
+test-inspector-network-websocket: SKIP
+test-tls-set-default-ca-certificates-append-fetch: SKIP
+test-tls-set-default-ca-certificates-reset-fetch: SKIP
 
 [$asan==on]
 # https://github.com/nodejs/node/issues/39655


### PR DESCRIPTION
Similar to the tests timeouts that were skipped
in #59014, we also want to skip the
following test cases on IBMi-

Tests previously skipped and moved
from parallel to client-proxy:
- client-proxy.test-http-proxy-fetch
- client-proxy.test-https-proxy-fetch


Similar to https://github.com/nodejs/node/pull/59014#issuecomment-3057162303
We have decided to skip these tests
until the underlying issue is resolved.

The tests being skipped are:
- client-proxy.test-use-env-proxy-cli-http
- client-proxy.test-use-env-proxy-cli-https
- parallel.test-http2-allow-http1-upgrade-ws
- parallel.test-inspector-network-websocket
- parallel.test-tls-set-default-ca-certificates-append-fetch
- parallel.test-tls-set-default-ca-certificates-reset-fetch
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->