### PR TITLE
src: enable libm trig functions in V8

### DIFF
--- a/benchmark/util/trig.js
+++ b/benchmark/util/trig.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { createBenchmark } = require('../common.js');
+const bench = createBenchmark(main, {
+  n: 1_000_000,
+});
+
+function main({ n }) {
+  bench.start();
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const result = Math.sin(Math.PI * i) * Math.cos(Math.PI * i);
+    sum += result;  // eslint-disable-line no-unused-vars
+  }
+  bench.end(n);
+}

--- a/common.gypi
+++ b/common.gypi
@@ -77,6 +77,8 @@
 
     'v8_win64_unwinding_info': 1,
 
+    'v8_use_libm_trig_functions': 1,
+
     # Variables controlling external defines exposed in public headers.
     'v8_enable_map_packing%': 0,
     'v8_enable_pointer_compression_shared_cage%': 0,

--- a/test/parallel/test-trig.js
+++ b/test/parallel/test-trig.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const { strictEqual } = require('assert');
+
+// Test to verify that the trig functions work as expected with the
+// v8_use_libm_trig_functions flag enabled.
+let sum = 0;
+for (let i = 0; i < 1_000_000; i++) {
+  const result = Math.sin(Math.PI * i) * Math.cos(Math.PI * i);
+  sum += result;
+};
+
+strictEqual(sum, -0.00006123284579142155);


### PR DESCRIPTION
Should provide better performance on some platforms.

```
                       confidence improvement accuracy (*)   (**)  (***)
util/trig.js n=1000000        ***     37.41 %       ±2.11% ±2.81% ±3.67%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 1 comparisons, you can thus
expect the following amount of false-positive results:
  0.05 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.01 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

Context: @t3dotgg put together some benchmarks that show the trig functions running in node.js aren't as fast as they could be. We did some digging and think this may help. https://github.com/t3dotgg/cf-vs-vercel-bench/blob/main/vanilla-bench/vercel-edition/api/

~~There's a possibility this won't work on all platforms/archs so running some tests in CI to verify first.~~ Appears to be fine in CI!

/cc @nodejs/v8 