### PR TITLE
test: skip quic tests that IBM i does not support

### DIFF
--- a/test/parallel/test-quic-test-client.mjs
+++ b/test/parallel/test-quic-test-client.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-quic
-import { hasQuic, isAIX, isWindows, skip } from '../common/index.mjs';
+import { hasQuic, isAIX, isIBMi, isWindows, skip } from '../common/index.mjs';
 import { rejects } from 'node:assert';
 
 if (!hasQuic) {
@@ -9,6 +9,11 @@ if (isAIX) {
   // AIX does not support some of the networking features used in the ngtcp2
   // example server and client.
   skip('QUIC third-party tests are disabled on AIX');
+}
+if (isIBMi) {
+  // IBM i does not support some of the networking features used in the ngtcp2
+  // example server and client.
+  skip('QUIC third-party tests are disabled on IBM i');
 }
 if (isWindows) {
   // Windows does not support the [Li/U]nix specific headers and system calls

--- a/test/parallel/test-quic-test-server.mjs
+++ b/test/parallel/test-quic-test-server.mjs
@@ -1,5 +1,5 @@
 // Flags: --experimental-quic
-import { hasQuic, isAIX, isWindows, skip } from '../common/index.mjs';
+import { hasQuic, isAIX, isIBMi, isWindows, skip } from '../common/index.mjs';
 
 if (!hasQuic) {
   skip('QUIC support is not enabled');
@@ -8,6 +8,11 @@ if (isAIX) {
   // AIX does not support some of the networking features used in the ngtcp2
   // example server and client.
   skip('QUIC third-party tests are disabled on AIX');
+}
+if (isIBMi) {
+  // IBM i does not support some of the networking features used in the ngtcp2
+  // example server and client.
+  skip('QUIC third-party tests are disabled on IBM i');
 }
 if (isWindows) {
   // Windows does not support the [Li/U]nix specific headers and system calls


### PR DESCRIPTION
Similar to AIX, IBM i does not support certain
network flags and we also skip the following
tests like on AIX

- parallel.test-quic-test-client.mjs
- parallel.test-quic-test-server.mjs

Refer:  https://github.com/nodejs/node/pull/60073

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
