### PR TITLE
buffer: remove unreachable overflow check in atob

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -110,6 +110,8 @@ const {
   inspect: utilInspect,
 } = require('internal/util/inspect');
 
+const assert = require('internal/assert');
+
 const {
   codes: {
     ERR_BUFFER_OUT_OF_BOUNDS,
@@ -1401,6 +1403,8 @@ function atob(input) {
       throw lazyDOMException(
         'The string to be decoded is not correctly encoded.',
         'InvalidCharacterError');
+    case -3:
+      assert.fail('Unrecognized simdutf error');
     default:
       return result;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -37,6 +37,7 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
+  RangeError,
   RegExpPrototypeSymbolReplace,
   StringPrototypeCharCodeAt,
   StringPrototypeSlice,
@@ -1402,8 +1403,7 @@ function atob(input) {
         'The string to be decoded is not correctly encoded.',
         'InvalidCharacterError');
     case -3: // Possible overflow
-      // TODO(@anonrig): Throw correct error in here.
-      throw lazyDOMException('The input causes overflow.', 'InvalidCharacterError');
+      throw new RangeError('The string to be decoded is too long.');
     default:
       return result;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1401,8 +1401,6 @@ function atob(input) {
       throw lazyDOMException(
         'The string to be decoded is not correctly encoded.',
         'InvalidCharacterError');
-    case -3: // Possible overflow
-      throw new ERR_INVALID_ARG_VALUE('input', result, 'The string to be decoded is too long.');
     default:
       return result;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -37,7 +37,6 @@ const {
   ObjectDefineProperty,
   ObjectPrototypeHasOwnProperty,
   ObjectSetPrototypeOf,
-  RangeError,
   RegExpPrototypeSymbolReplace,
   StringPrototypeCharCodeAt,
   StringPrototypeSlice,
@@ -1403,7 +1402,7 @@ function atob(input) {
         'The string to be decoded is not correctly encoded.',
         'InvalidCharacterError');
     case -3: // Possible overflow
-      throw new RangeError('The string to be decoded is too long.');
+      throw new ERR_INVALID_ARG_VALUE('input', result, 'The string to be decoded is too long.');
     default:
       return result;
   }

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1405,6 +1405,7 @@ function atob(input) {
         'InvalidCharacterError');
     case -3:
       assert.fail('Unrecognized simdutf error');
+      break;
     default:
       return result;
   }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1456,7 +1456,7 @@ static void Btoa(const FunctionCallbackInfo<Value>& args) {
 // In case of error, a negative value is returned:
 // * -1 indicates a single character remained,
 // * -2 indicates an invalid character,
-// * -3 indicates a possible overflow (i.e., more than 2 GB output).
+// * -3 indicates an unrecognized simdutf error.
 static void Atob(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   Environment* env = Environment::GetCurrent(args);
@@ -1501,7 +1501,7 @@ static void Atob(const FunctionCallbackInfo<Value>& args) {
     return args.GetReturnValue().Set(value);
   }
 
-  // Default value is: "possible overflow"
+  // Default value is: "unrecognized simdutf error"
   int32_t error_code = -3;
 
   if (result.error == simdutf::error_code::INVALID_BASE64_CHARACTER) {


### PR DESCRIPTION
This commit resolves a TODO comment in lib/buffer.js by changing the error thrown by atob() during a potential overflow condition.

Modified lib/buffer.js to instantiate and throw new ERR_INVALID_ARG_VALUE('input', result, 'The string to be decoded is too long.'); for the overflow case (result === -3).

This change makes the atob implementation more robust and developer-friendly.
@anonrig

->

The case for a result of -3 was intended to handle a potential
buffer overflow error. However, the underlying C++ implementation using
simdutf::base64_to_binary does not perform bounds-checking and therefore
can never return an OUTPUT_BUFFER_TOO_SMALL error.

This makes the `case -3:` block unreachable code. This commit removes
the dead code for correctness and clarity.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
