### PR TITLE
src: remove `ToLocalChecked()` from UnionBytes

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -90,7 +90,11 @@ void BuiltinLoader::GetNatives(Local<Name> property,
   auto source = env->builtin_loader()->source_.read();
   for (auto const& x : *source) {
     Local<String> key = OneByteString(isolate, x.first);
-    if (out->Set(context, key, x.second.ToStringChecked(isolate)).IsNothing()) {
+    Local<String> value;
+    if (!x.second.ToString(isolate).ToLocal(&value)) {
+      return;
+    }
+    if (out->Set(context, key, value).IsNothing()) {
       return;
     }
   }
@@ -98,7 +102,11 @@ void BuiltinLoader::GetNatives(Local<Name> property,
 }
 
 Local<String> BuiltinLoader::GetConfigString(Isolate* isolate) {
-  return config_.ToStringChecked(isolate);
+  Local<String> config_str;
+  if (!config_.ToString(isolate).ToLocal(&config_str)) {
+    return {};
+  }
+  return config_str;
 }
 
 BuiltinLoader::BuiltinCategories BuiltinLoader::GetBuiltinCategories() const {
@@ -203,7 +211,7 @@ MaybeLocal<String> BuiltinLoader::LoadBuiltinSource(Isolate* isolate,
     fprintf(stderr, "Cannot find native builtin: \"%s\".\n", id);
     ABORT();
   }
-  return source_it->second.ToStringChecked(isolate);
+  return source_it->second.ToString(isolate);
 #else   // !NODE_BUILTIN_MODULES_PATH
   std::string filename = OnDiskFileName(id);
 

--- a/src/node_union_bytes.h
+++ b/src/node_union_bytes.h
@@ -52,7 +52,7 @@ using StaticExternalTwoByteResource =
 
 // Similar to a v8::String, but it's independent from Isolates
 // and can be materialized in Isolates as external Strings
-// via ToStringChecked.
+// via ToString.
 class UnionBytes {
  public:
   explicit UnionBytes(StaticExternalOneByteResource* one_byte_resource)
@@ -67,7 +67,7 @@ class UnionBytes {
 
   bool is_one_byte() const { return one_byte_resource_ != nullptr; }
 
-  v8::Local<v8::String> ToStringChecked(v8::Isolate* isolate) const;
+  v8::MaybeLocal<v8::String> ToString(v8::Isolate* isolate) const;
 
  private:
   StaticExternalOneByteResource* one_byte_resource_;

--- a/src/util.cc
+++ b/src/util.cc
@@ -32,6 +32,7 @@
 #include "node_snapshot_builder.h"
 #include "node_v8_platform-inl.h"
 #include "string_bytes.h"
+#include "v8-local-handle.h"
 #include "v8-value.h"
 
 #ifdef _WIN32
@@ -91,6 +92,7 @@ using v8::Context;
 using v8::FunctionTemplate;
 using v8::Isolate;
 using v8::Local;
+using v8::MaybeLocal;
 using v8::Object;
 using v8::String;
 using v8::Template;
@@ -725,13 +727,11 @@ void SetConstructorFunction(Isolate* isolate,
   that->Set(name, tmpl);
 }
 
-Local<String> UnionBytes::ToStringChecked(Isolate* isolate) const {
+MaybeLocal<String> UnionBytes::ToString(Isolate* isolate) const {
   if (is_one_byte()) {
-    return String::NewExternalOneByte(isolate, one_byte_resource_)
-        .ToLocalChecked();
+    return String::NewExternalOneByte(isolate, one_byte_resource_);
   } else {
-    return String::NewExternalTwoByte(isolate, two_byte_resource_)
-        .ToLocalChecked();
+    return String::NewExternalTwoByte(isolate, two_byte_resource_);
   }
 }
 


### PR DESCRIPTION
This PR removes `ToLocalChecked()` usage from `UnionBytes` to avoid unexpected crashes.

- Rename `UnionBytes::ToStringChecked()` -> `UnionBytes::ToString()`.
- Change return type to `MaybeLocal`.
- Update call sites to handle empty `MaybeLocal`.