### PR TITLE
src: fix usage of deprecated V8 API

### DIFF
--- a/src/async_context_frame.cc
+++ b/src/async_context_frame.cc
@@ -34,7 +34,7 @@ Scope::~Scope() {
 }
 
 Local<Value> current(Isolate* isolate) {
-  return isolate->GetContinuationPreservedEmbedderData();
+  return isolate->GetContinuationPreservedEmbedderDataV2().As<Value>();
 }
 
 void set(Isolate* isolate, Local<Value> value) {
@@ -43,7 +43,7 @@ void set(Isolate* isolate, Local<Value> value) {
     return;
   }
 
-  isolate->SetContinuationPreservedEmbedderData(value);
+  isolate->SetContinuationPreservedEmbedderDataV2(value);
 }
 
 // NOTE: It's generally recommended to use async_context_frame::Scope


### PR DESCRIPTION
Namely `GetContinuationPreservedEmbedderData` and
`SetContinuationPreservedEmbedderData` for their "V2" variants.

Refs: https://github.com/v8/v8/commit/da41db36ec78d7c1f37fc7d0c7a7c580fda970fe

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
