### PR TITLE
doc: `createSQLTagStore` -> `createTagStore`

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -436,7 +436,7 @@ added: v22.5.0
 Compiles a SQL statement into a [prepared statement][]. This method is a wrapper
 around [`sqlite3_prepare_v2()`][].
 
-### `database.createSQLTagStore([maxSize])`
+### `database.createTagStore([maxSize])`
 
 <!-- YAML
 added: v24.9.0
@@ -460,7 +460,7 @@ avoid the overhead of repeatedly parsing and preparing the same SQL statements.
 import { DatabaseSync } from 'node:sqlite';
 
 const db = new DatabaseSync(':memory:');
-const sql = db.createSQLTagStore();
+const sql = db.createTagStore();
 
 db.exec('CREATE TABLE users (id INT, name TEXT)');
 
@@ -635,14 +635,14 @@ added: v24.9.0
 This class represents a single LRU (Least Recently Used) cache for storing
 prepared statements.
 
-Instances of this class are created via the database.createSQLTagStore() method,
+Instances of this class are created via the database.createTagStore() method,
 not by using a constructor. The store caches prepared statements based on the
 provided SQL query string. When the same query is seen again, the store
 retrieves the cached statement and safely applies the new values through
 parameter binding, thereby preventing attacks like SQL injection.
 
 The cache has a maxSize that defaults to 1000 statements, but a custom size can
-be provided (e.g., database.createSQLTagStore(100)). All APIs exposed by this
+be provided (e.g., database.createTagStore(100)). All APIs exposed by this
 class execute synchronously.
 
 ### `sqlTagStore.all(sqlTemplate[, ...values])`


### PR DESCRIPTION
cc @0hmx to confirm that this is correct.

#58748 added a new method, `createTagStore`, but it's improperly documented as `createSQLTagStore`

Ref: https://discord.com/channels/425824580918181889/425824580918181891/1425966053242048584