### PR TITLE
vm: hint module identifier in instantiate errors

### DIFF
--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -99,7 +99,6 @@ class ModuleWrap : public BaseObject {
  public:
   enum InternalFields {
     kModuleSlot = BaseObject::kInternalFieldCount,
-    kURLSlot,
     kModuleSourceObjectSlot,
     kSyntheticEvaluationStepsSlot,
     kContextObjectSlot,   // Object whose creation context is the target Context
@@ -215,6 +214,7 @@ class ModuleWrap : public BaseObject {
       v8::Local<v8::FixedArray> import_attributes,
       v8::Local<v8::Module> referrer);
 
+  std::string url_;
   v8::Global<v8::Module> module_;
   ResolveCache resolve_cache_;
   contextify::ContextifyContext* contextify_context_ = nullptr;

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -295,12 +295,11 @@ inline v8::Local<v8::Object> ERR_BUFFER_TOO_LARGE(v8::Isolate* isolate) {
 }
 
 inline void THROW_ERR_SOURCE_PHASE_NOT_DEFINED(v8::Isolate* isolate,
-                                               v8::Local<v8::String> url) {
-  std::string message = std::string(*v8::String::Utf8Value(isolate, url));
+                                               const std::string& url) {
   return THROW_ERR_SOURCE_PHASE_NOT_DEFINED(
       isolate,
-      "Source phase import object is not defined for module %s",
-      message.c_str());
+      "Source phase import object is not defined for module '%s'",
+      url);
 }
 
 inline v8::Local<v8::Object> ERR_STRING_TOO_LONG(v8::Isolate* isolate) {

--- a/test/parallel/test-vm-module-linkmodulerequests.js
+++ b/test/parallel/test-vm-module-linkmodulerequests.js
@@ -65,3 +65,14 @@ test('mismatch linkage', () => {
     code: 'ERR_MODULE_LINK_MISMATCH',
   });
 });
+
+test('instantiate error should hint about module identifier', () => {
+  const foo = new SourceTextModule('import bar from "bar"', { identifier: 'file://foo' });
+  const bar = new SourceTextModule('import "unknown"', { identifier: 'file://bar' });
+
+  foo.linkRequests([bar]);
+  assert.throws(() => foo.instantiate(), {
+    message: `request for 'unknown' can not be resolved on module 'file://bar' that is not linked`,
+    code: 'ERR_VM_MODULE_LINK_FAILURE',
+  });
+});


### PR DESCRIPTION
Improves the error message on `vm.SourceTextModule` link errors.

Fixes: https://github.com/nodejs/node/issues/60157