### PR TITLE
src: use string_view in `WriteReport()`

### DIFF
--- a/src/node_report_module.cc
+++ b/src/node_report_module.cc
@@ -34,18 +34,18 @@ void WriteReport(const FunctionCallbackInfo<Value>& info) {
   Local<Value> error;
 
   CHECK_EQ(info.Length(), 4);
-  String::Utf8Value message(isolate, info[0].As<String>());
-  String::Utf8Value trigger(isolate, info[1].As<String>());
+  Utf8Value message(isolate, info[0].As<String>());
+  Utf8Value trigger(isolate, info[1].As<String>());
 
-  if (info[2]->IsString())
-    filename = *String::Utf8Value(isolate, info[2]);
+  if (info[2]->IsString()) filename = Utf8Value(isolate, info[2]).ToString();
   if (!info[3].IsEmpty())
     error = info[3];
   else
     error = Local<Value>();
 
   // Return value is the report filename
-  filename = TriggerNodeReport(env, *message, *trigger, filename, error);
+  filename = TriggerNodeReport(
+      env, message.ToStringView(), trigger.ToStringView(), filename, error);
   Local<Value> ret;
   if (ToV8Value(env->context(), filename, env->isolate()).ToLocal(&ret)) {
     info.GetReturnValue().Set(ret);


### PR DESCRIPTION
Since 075936b4133e, `TriggerNodeReport()` takes `std::string_view` arguments directly.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
