### PR TITLE
deps: V8: cherry-pick 1e190bbb0396

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/common/segmented-table.h
+++ b/deps/v8/src/common/segmented-table.h
@@ -41,16 +41,14 @@ class V8_EXPORT_PRIVATE SegmentedTable {
   static constexpr bool kUseContiguousMemory = true;
   static constexpr size_t kReservationSize = size;
   static constexpr size_t kMaxCapacity = kReservationSize / kEntrySize;
-#if defined(V8_TARGET_OS_WIN) || defined(V8_HOST_ARCH_PPC64)
+#if defined(V8_TARGET_OS_WIN)
   // On windows the allocation granularity is 64KB and thus we cannot make a
   // segment smaller than that.
-  // PPC64 can utilize a 64KB page size.
   static constexpr bool kUseSegmentPool = false;
-  static constexpr size_t kSegmentSize = 64 * KB;
 #else
-  static constexpr bool kUseSegmentPool = true;
-  static constexpr size_t kSegmentSize = 16 * KB;
+  static constexpr bool kUseSegmentPool = kMinimumOSPageSize <= 16 * KB;
 #endif
+  static constexpr size_t kSegmentSize = kUseSegmentPool ? 16 * KB : 64 * KB;
 #else
   // On 32 bit, segments are individually mapped.
   static constexpr bool kUseContiguousMemory = false;


### PR DESCRIPTION
Original commit message:

    [segmented-table] Disable segments pool if pages can be too large

    The segments pool can only be used if we have 16Kb allocation
    granularity. On OSs where the page size can be configured larger we have
    to disable it, since it is currently not runtime configurabe.

    Fixed: 425634685
    Change-Id: If77e46b034fc2e324d7eabf19eff54958ea6f7cb
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6973467
    Reviewed-by: Dominik Inführ <dinfuehr@chromium.org>
    Auto-Submit: Olivier Flückiger <olivf@chromium.org>
    Commit-Queue: Olivier Flückiger <olivf@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#102700}

Refs: https://github.com/v8/v8/commit/1e190bbb0396f7228797bf9b74cf689e83c5354e
Fixes: https://github.com/nodejs/build/issues/4172

---

The Linux arm64 builds on the release CI have been [failing](https://github.com/nodejs/build/issues/4172) since the V8 14.1 update. If unaddressed this will block Node.js 25.0.0 as [Linux on arm64 is a Tier 1 supported platform](https://github.com/nodejs/node/blob/75a6fff6befa00dd4338bca5dd260a7478989965/BUILDING.md?plain=1#L112).

 After a long investigation, I have identified https://issues.chromium.org/issues/425634685 as likely to be the issue we are hitting and this PR cherry-picks the fix from https://github.com/v8/v8/commit/1e190bbb0396f7228797bf9b74cf689e83c5354e. 

~I haven't been able to confirm that this actually fixes the builds on the release CI,~ but there is enough circumstantial evidence to point to the reference upstream V8 issues and fix.
**_Update_** Confirmed that his cherry-pick [fixes the build](https://github.com/nodejs/build/issues/4172#issuecomment-3392520621) on the release machine.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
