### PR TITLE
doc: improve code snippet alternative of url.parse() using WHATWG URL

### DIFF
--- a/doc/api/url.md
+++ b/doc/api/url.md
@@ -1853,7 +1853,7 @@ input. CVEs are not issued for `url.parse()` vulnerabilities. Use the
 function getURL(req) {
   const proto = req.headers['x-forwarded-proto'] || 'https';
   const host = req.headers['x-forwarded-host'] || req.headers.host || 'example.com';
-  return new URL(req.url || '/', `${proto}://${host}`);
+  return new URL(`${proto}://${host}${req.url || '/'}`);
 }
 ```
 
@@ -1863,7 +1863,7 @@ use the example below:
 
 ```js
 function getURL(req) {
-  return new URL(req.url || '/', 'https://example.com');
+  return new URL(`https://example.com${req.url || '/'}`);
 }
 ```
 


### PR DESCRIPTION
This is a follow up to a comment https://github.com/nodejs/node/pull/59736#discussion_r2383025362 that pointed out the existing code snippet is not safe since the `req.url` can start with a double slash which would cause the hostname to be replaced.