### PR TITLE
events: repurpose `events.listenerCount()` to accept EventTargets

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -786,6 +786,9 @@ The [`domain`][] module is deprecated and should not be used.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60214
+    description: Deprecation revoked.
   - version:
     - v6.12.0
     - v4.8.6
@@ -796,10 +799,12 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Revoked
 
-The [`events.listenerCount(emitter, eventName)`][] API is
-deprecated. Please use [`emitter.listenerCount(eventName)`][] instead.
+The [`events.listenerCount(emitter, eventName)`][] API was deprecated, as it
+provided identical fuctionality to [`emitter.listenerCount(eventName)`][]. The
+deprecation was revoked because this function has been repurposed to also
+accept {EventTarget} arguments.
 
 ### DEP0034: `fs.exists(path, callback)`
 
@@ -4398,7 +4403,7 @@ import { opendir } from 'node:fs/promises';
 [`domain`]: domain.md
 [`ecdh.setPublicKey()`]: crypto.md#ecdhsetpublickeypublickey-encoding
 [`emitter.listenerCount(eventName)`]: events.md#emitterlistenercounteventname-listener
-[`events.listenerCount(emitter, eventName)`]: events.md#eventslistenercountemitter-eventname
+[`events.listenerCount(emitter, eventName)`]: events.md#eventslistenercountemitterortarget-eventname
 [`fs.Dir`]: fs.md#class-fsdir
 [`fs.FileHandle`]: fs.md#class-filehandle
 [`fs.access()`]: fs.md#fsaccesspath-mode-callback

--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1622,39 +1622,66 @@ changes:
 
 See how to write a custom [rejection handler][rejection].
 
-## `events.listenerCount(emitter, eventName)`
+## `events.listenerCount(emitterOrTarget, eventName)`
 
 <!-- YAML
 added: v0.9.12
-deprecated: v3.2.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60214
+    description: Now accepts EventTarget arguments.
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60214
+    description: Deprecation revoked.
+  - version: v3.2.0
+    pr-url: https://github.com/nodejs/node/pull/2349
+    description: Documentation-only deprecation.
 -->
 
-> Stability: 0 - Deprecated: Use [`emitter.listenerCount()`][] instead.
+* `emitterOrTarget` {EventEmitter|EventTarget}
+* `eventName` {string|symbol}
+* Returns: {integer}
 
-* `emitter` {EventEmitter} The emitter to query
-* `eventName` {string|symbol} The event name
+Returns the number of registered listeners for the event named `eventName`.
 
-A class method that returns the number of listeners for the given `eventName`
-registered on the given `emitter`.
+For `EventEmitter`s this behaves exactly the same as calling `.listenerCount`
+on the emitter.
+
+For `EventTarget`s this is the only way to obtain the listener count. This can
+be useful for debugging and diagnostic purposes.
 
 ```mjs
 import { EventEmitter, listenerCount } from 'node:events';
 
-const myEmitter = new EventEmitter();
-myEmitter.on('event', () => {});
-myEmitter.on('event', () => {});
-console.log(listenerCount(myEmitter, 'event'));
-// Prints: 2
+{
+  const ee = new EventEmitter();
+  ee.on('event', () => {});
+  ee.on('event', () => {});
+  console.log(listenerCount(ee, 'event')); // 2
+}
+{
+  const et = new EventTarget();
+  et.addEventListener('event', () => {});
+  et.addEventListener('event', () => {});
+  console.log(listenerCount(et, 'event')); // 2
+}
 ```
 
 ```cjs
 const { EventEmitter, listenerCount } = require('node:events');
 
-const myEmitter = new EventEmitter();
-myEmitter.on('event', () => {});
-myEmitter.on('event', () => {});
-console.log(listenerCount(myEmitter, 'event'));
-// Prints: 2
+{
+  const ee = new EventEmitter();
+  ee.on('event', () => {});
+  ee.on('event', () => {});
+  console.log(listenerCount(ee, 'event')); // 2
+}
+{
+  const et = new EventTarget();
+  et.addEventListener('event', () => {});
+  et.addEventListener('event', () => {});
+  console.log(listenerCount(et, 'event')); // 2
+}
 ```
 
 ## `events.on(emitter, eventName[, options])`
@@ -2648,7 +2675,6 @@ to the `EventTarget`.
 [`Event` Web API]: https://dom.spec.whatwg.org/#event
 [`domain`]: domain.md
 [`e.stopImmediatePropagation()`]: #eventstopimmediatepropagation
-[`emitter.listenerCount()`]: #emitterlistenercounteventname-listener
 [`emitter.removeListener()`]: #emitterremovelistenereventname-listener
 [`emitter.setMaxListeners(n)`]: #emittersetmaxlistenersn
 [`event.defaultPrevented`]: #eventdefaultprevented

--- a/lib/events.js
+++ b/lib/events.js
@@ -33,7 +33,6 @@ const {
   Error,
   ErrorCaptureStackTrace,
   FunctionPrototypeBind,
-  FunctionPrototypeCall,
   NumberMAX_SAFE_INTEGER,
   ObjectDefineProperties,
   ObjectDefineProperty,
@@ -215,6 +214,7 @@ module.exports.once = once;
 module.exports.on = on;
 module.exports.getEventListeners = getEventListeners;
 module.exports.getMaxListeners = getMaxListeners;
+module.exports.listenerCount = listenerCount;
 // Backwards-compat with node 0.10.x
 EventEmitter.EventEmitter = EventEmitter;
 
@@ -814,30 +814,13 @@ EventEmitter.prototype.rawListeners = function rawListeners(type) {
 };
 
 /**
- * Returns the number of listeners listening to the event name
- * specified as `type`.
- * @deprecated since v3.2.0
- * @param {EventEmitter} emitter
- * @param {string | symbol} type
- * @returns {number}
- */
-EventEmitter.listenerCount = function(emitter, type) {
-  if (typeof emitter.listenerCount === 'function') {
-    return emitter.listenerCount(type);
-  }
-  return FunctionPrototypeCall(listenerCount, emitter, type);
-};
-
-EventEmitter.prototype.listenerCount = listenerCount;
-
-/**
  * Returns the number of listeners listening to event name
  * specified as `type`.
  * @param {string | symbol} type
- * @param {Function} listener
+ * @param {Function} [listener]
  * @returns {number}
  */
-function listenerCount(type, listener) {
+EventEmitter.prototype.listenerCount = function listenerCount(type, listener) {
   const events = this._events;
 
   if (events !== undefined) {
@@ -867,7 +850,7 @@ function listenerCount(type, listener) {
   }
 
   return 0;
-}
+};
 
 /**
  * Returns an array listing the events for which
@@ -944,6 +927,25 @@ function getMaxListeners(emitterOrTarget) {
     return emitterOrTarget[kMaxEventTargetListeners];
   }
 
+  throw new ERR_INVALID_ARG_TYPE('emitter',
+                                 ['EventEmitter', 'EventTarget'],
+                                 emitterOrTarget);
+}
+
+/**
+ * Returns the number of registered listeners for `type`.
+ * @param {EventEmitter | EventTarget} emitterOrTarget
+ * @param {string | symbol} type
+ * @returns {number}
+ */
+function listenerCount(emitterOrTarget, type) {
+  if (typeof emitterOrTarget.listenerCount === 'function') {
+    return emitterOrTarget.listenerCount(type);
+  }
+  const { isEventTarget, kEvents } = require('internal/event_target');
+  if (isEventTarget(emitterOrTarget)) {
+    return emitterOrTarget[kEvents].get(type)?.size ?? 0;
+  }
   throw new ERR_INVALID_ARG_TYPE('emitter',
                                  ['EventEmitter', 'EventTarget'],
                                  emitterOrTarget);

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -59,7 +59,8 @@ Stream.prototype.pipe = function(dest, options) {
   // Don't leave dangling pipes when there are errors.
   function onerror(er) {
     cleanup();
-    if (EE.listenerCount(this, 'error') === 0) {
+    // If we removed the last error handler, trigger an unhandled error event.
+    if (this.listenerCount?.('error') === 0) {
       this.emit('error', er);
     }
   }

--- a/test/parallel/test-aborted-util.js
+++ b/test/parallel/test-aborted-util.js
@@ -4,7 +4,7 @@
 const common = require('../common');
 const { aborted } = require('util');
 const assert = require('assert');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const { inspect } = require('util');
 
 const {
@@ -17,7 +17,7 @@ test('Aborted works when provided a resource', async () => {
   ac.abort();
   await promise;
   assert.strictEqual(ac.signal.aborted, true);
-  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(ac.signal, 'abort'), 0);
 });
 
 test('Aborted with gc cleanup', async () => {
@@ -31,7 +31,7 @@ test('Aborted with gc cleanup', async () => {
     globalThis.gc();
     ac.abort();
     assert.strictEqual(ac.signal.aborted, true);
-    assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(ac.signal, 'abort'), 0);
     resolve();
   }));
 

--- a/test/parallel/test-child-process-execfile.js
+++ b/test/parallel/test-child-process-execfile.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const { execFile, execFileSync } = require('child_process');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const { getSystemErrorName } = require('util');
 const fixtures = require('../common/fixtures');
 const os = require('os');
@@ -106,7 +106,7 @@ common.expectWarning(
   const { signal } = ac;
 
   const callback = common.mustCall((err) => {
-    assert.strictEqual(getEventListeners(ac.signal).length, 0);
+    assert.strictEqual(listenerCount(ac.signal, 'abort'), 0);
     assert.strictEqual(err, null);
   });
   execFile(process.execPath, [fixture, 0], { signal }, callback);

--- a/test/parallel/test-child-process-fork-timeout-kill-signal.js
+++ b/test/parallel/test-child-process-fork-timeout-kill-signal.js
@@ -4,7 +4,7 @@ const { mustCall } = require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const { fork } = require('child_process');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 
 {
   // Verify default signal
@@ -43,8 +43,8 @@ const { getEventListeners } = require('events');
     timeout: 6,
     signal,
   });
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+  assert.strictEqual(listenerCount(signal, 'abort'), 1);
   cp.on('exit', mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }));
 }

--- a/test/parallel/test-child-process-spawn-timeout-kill-signal.js
+++ b/test/parallel/test-child-process-spawn-timeout-kill-signal.js
@@ -4,7 +4,7 @@ const { mustCall } = require('../common');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
 const { spawn } = require('child_process');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 
 const aliveForeverFile = 'child-process-stay-alive-forever.js';
 {
@@ -43,8 +43,8 @@ const aliveForeverFile = 'child-process-stay-alive-forever.js';
     timeout: 6,
     signal,
   });
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+  assert.strictEqual(listenerCount(signal, 'abort'), 1);
   cp.on('exit', mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }));
 }

--- a/test/parallel/test-events-once.js
+++ b/test/parallel/test-events-once.js
@@ -2,7 +2,7 @@
 // Flags: --no-warnings
 
 const common = require('../common');
-const { once, EventEmitter, getEventListeners } = require('events');
+const { once, EventEmitter, listenerCount } = require('events');
 const assert = require('assert');
 
 async function onceAnEvent() {
@@ -72,7 +72,7 @@ async function catchesErrorsWithAbortSignal() {
   try {
     const promise = once(ee, 'myevent', { signal });
     assert.strictEqual(ee.listenerCount('error'), 1);
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
 
     await promise;
   } catch (e) {
@@ -81,7 +81,7 @@ async function catchesErrorsWithAbortSignal() {
   assert.strictEqual(err, expected);
   assert.strictEqual(ee.listenerCount('error'), 0);
   assert.strictEqual(ee.listenerCount('myevent'), 0);
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(signal, 'abort'), 0);
 }
 
 async function stopListeningAfterCatchingError() {
@@ -191,9 +191,9 @@ async function abortSignalAfterEvent() {
     ac.abort();
   });
   const promise = once(ee, 'foo', { signal: ac.signal });
-  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
+  assert.strictEqual(listenerCount(ac.signal, 'abort'), 1);
   await promise;
-  assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(ac.signal, 'abort'), 0);
 }
 
 async function abortSignalRemoveListener() {

--- a/test/parallel/test-eventtarget.js
+++ b/test/parallel/test-eventtarget.js
@@ -9,7 +9,7 @@ const {
 
 const assert = require('assert');
 
-const { once } = require('events');
+const { listenerCount, once } = require('events');
 
 const { inspect } = require('util');
 const { setTimeout: delay } = require('timers/promises');
@@ -141,10 +141,13 @@ let asyncTest = Promise.resolve();
 
   eventTarget.addEventListener('foo', ev1);
   eventTarget.addEventListener('foo', ev2, { once: true });
+  assert.strictEqual(listenerCount(eventTarget, 'foo'), 2);
   assert.ok(eventTarget.dispatchEvent(new Event('foo')));
+  assert.strictEqual(listenerCount(eventTarget, 'foo'), 1);
   eventTarget.dispatchEvent(new Event('foo'));
 
   eventTarget.removeEventListener('foo', ev1);
+  assert.strictEqual(listenerCount(eventTarget, 'foo'), 0);
   eventTarget.dispatchEvent(new Event('foo'));
 }
 {

--- a/test/parallel/test-http-agent-abort-controller.js
+++ b/test/parallel/test-http-agent-abort-controller.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const http = require('http');
 const Agent = http.Agent;
-const { getEventListeners, once } = require('events');
+const { listenerCount, once } = require('events');
 const agent = new Agent();
 const server = http.createServer();
 
@@ -20,7 +20,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const connection = agent.createConnection({ ...options, signal });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     const [err] = await once(connection, 'error');
     assert.strictEqual(err?.name, 'AbortError');
@@ -44,7 +44,7 @@ server.listen(0, common.mustCall(async () => {
       agent: agent,
       signal,
     });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     const [err] = await once(request, 'error');
     assert.strictEqual(err?.name, 'AbortError');
@@ -60,7 +60,7 @@ server.listen(0, common.mustCall(async () => {
       agent: agent,
       signal,
     });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     const [err] = await once(request, 'error');
     assert.strictEqual(err?.name, 'AbortError');
   }

--- a/test/parallel/test-http-client-abort-destroy.js
+++ b/test/parallel/test-http-client-abort-destroy.js
@@ -2,7 +2,7 @@
 const common = require('../common');
 const http = require('http');
 const assert = require('assert');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 
 {
   // abort
@@ -85,7 +85,7 @@ const { getEventListeners } = require('events');
       assert.strictEqual(err.name, 'AbortError');
       server.close();
     }));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     assert.strictEqual(req.aborted, false);
     assert.strictEqual(req.destroyed, false);
     controller.abort();
@@ -113,7 +113,7 @@ const { getEventListeners } = require('events');
       server.close();
     }));
 
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     process.nextTick(() => controller.abort());
   }));
 }
@@ -127,7 +127,7 @@ const { getEventListeners } = require('events');
     controller.abort();
     const options = { port: server.address().port, signal };
     const req = http.get(options, common.mustNotCall());
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     req.on('error', common.mustCall((err) => {
       assert.strictEqual(err.code, 'ABORT_ERR');
       assert.strictEqual(err.name, 'AbortError');

--- a/test/parallel/test-http2-client-destroy.js
+++ b/test/parallel/test-http2-client-destroy.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 const h2 = require('http2');
 const { kSocket } = require('internal/http2/util');
 const Countdown = require('../common/countdown');
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 {
   const server = h2.createServer();
   server.listen(0, common.mustCall(() => {
@@ -179,11 +179,11 @@ const { getEventListeners } = require('events');
     client.on('close', common.mustCall());
 
     const { signal } = controller;
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
 
     client.on('error', common.mustCall(() => {
       // After underlying stream dies, signal listener detached
-      assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+      assert.strictEqual(listenerCount(signal, 'abort'), 0);
     }));
 
     const req = client.request({}, { signal });
@@ -197,7 +197,7 @@ const { getEventListeners } = require('events');
     assert.strictEqual(req.aborted, false);
     assert.strictEqual(req.destroyed, false);
     // Signal listener attached
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
 
     controller.abort();
 
@@ -218,16 +218,16 @@ const { getEventListeners } = require('events');
     const { signal } = controller;
     controller.abort();
 
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
 
     client.on('error', common.mustCall(() => {
       // After underlying stream dies, signal listener detached
-      assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+      assert.strictEqual(listenerCount(signal, 'abort'), 0);
     }));
 
     const req = client.request({}, { signal });
     // Signal already aborted, so no event listener attached.
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
 
     assert.strictEqual(req.aborted, false);
     // Destroyed on same tick as request made
@@ -256,7 +256,7 @@ const { getEventListeners } = require('events');
         signal,
       });
       client.on('close', common.mustCall());
-      assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+      assert.strictEqual(listenerCount(signal, 'abort'), 1);
 
       client.on('error', common.mustCall(common.mustCall((err) => {
         assert.strictEqual(err.code, 'ABORT_ERR');
@@ -264,7 +264,7 @@ const { getEventListeners } = require('events');
       })));
 
       const req = client.request({}, {});
-      assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+      assert.strictEqual(listenerCount(signal, 'abort'), 1);
 
       req.on('error', common.mustCall((err) => {
         assert.strictEqual(err.code, 'ERR_HTTP2_STREAM_CANCEL');
@@ -277,7 +277,7 @@ const { getEventListeners } = require('events');
       assert.strictEqual(req.aborted, false);
       assert.strictEqual(req.destroyed, false);
       // Signal listener attached
-      assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+      assert.strictEqual(listenerCount(signal, 'abort'), 1);
 
       controller.abort();
     }));
@@ -305,7 +305,7 @@ const { getEventListeners } = require('events');
 
     const { signal } = controller;
     const req = client.request({}, { signal });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     req.on('error', common.mustCall((err) => {
       assert.strictEqual(err.code, 'ABORT_ERR');
       assert.strictEqual(err.name, 'AbortError');

--- a/test/parallel/test-https-abortcontroller.js
+++ b/test/parallel/test-https-abortcontroller.js
@@ -7,7 +7,7 @@ if (!common.hasCrypto)
 const fixtures = require('../common/fixtures');
 const https = require('https');
 const assert = require('assert');
-const { once, getEventListeners } = require('events');
+const { once, listenerCount } = require('events');
 
 const options = {
   key: fixtures.readKey('agent1-key.pem'),
@@ -30,7 +30,7 @@ const options = {
       rejectUnauthorized: false,
       signal: ac.signal,
     });
-    assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(ac.signal, 'abort'), 1);
     process.nextTick(() => ac.abort());
     const [ err ] = await once(req, 'error');
     assert.strictEqual(err.name, 'AbortError');
@@ -57,7 +57,7 @@ const options = {
       rejectUnauthorized: false,
       signal,
     });
-    assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(ac.signal, 'abort'), 1);
     ac.abort();
     const [ err ] = await once(req, 'error');
     assert.strictEqual(err.name, 'AbortError');
@@ -85,7 +85,7 @@ const options = {
       rejectUnauthorized: false,
       signal,
     });
-    assert.strictEqual(getEventListeners(ac.signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(ac.signal, 'abort'), 0);
     const [ err ] = await once(req, 'error');
     assert.strictEqual(err.name, 'AbortError');
     assert.strictEqual(err.code, 'ABORT_ERR');

--- a/test/parallel/test-https-agent-abort-controller.js
+++ b/test/parallel/test-https-agent-abort-controller.js
@@ -9,7 +9,7 @@ const { once } = require('events');
 const Agent = https.Agent;
 const fixtures = require('../common/fixtures');
 
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const agent = new Agent();
 
 const options = {
@@ -33,7 +33,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const connection = agent.createConnection({ ...options, signal });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     const [err] = await once(connection, 'error');
     assert.strictEqual(err.name, 'AbortError');
@@ -58,7 +58,7 @@ server.listen(0, common.mustCall(async () => {
       agent: agent,
       signal,
     });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     const [err] = await once(request, 'error');
     assert.strictEqual(err.name, 'AbortError');
@@ -74,7 +74,7 @@ server.listen(0, common.mustCall(async () => {
       agent: agent,
       signal,
     });
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     const [err] = await once(request, 'error');
     assert.strictEqual(err.name, 'AbortError');
   }

--- a/test/parallel/test-net-connect-abort-controller.js
+++ b/test/parallel/test-net-connect-abort-controller.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const net = require('net');
 const assert = require('assert');
 const server = net.createServer();
-const { getEventListeners, once } = require('events');
+const { listenerCount, once } = require('events');
 
 const liveConnections = new Set();
 
@@ -31,7 +31,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const socket = net.connect(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     await assertAbort(socket, 'postAbort');
   }
@@ -41,7 +41,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     ac.abort();
     const socket = net.connect(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     await assertAbort(socket, 'preAbort');
   }
 
@@ -50,7 +50,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     setImmediate(() => ac.abort());
     const socket = net.connect(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     await assertAbort(socket, 'tickAbort');
   }
 
@@ -59,7 +59,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     ac.abort();
     const socket = new net.Socket(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     await assertAbort(socket, 'testConstructor');
   }
 
@@ -67,7 +67,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const socket = new net.Socket(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     await assertAbort(socket, 'testConstructorPost');
   }
@@ -76,7 +76,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const socket = new net.Socket(socketOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     setImmediate(() => ac.abort());
     await assertAbort(socket, 'testConstructorPostTick');
   }

--- a/test/parallel/test-readline-interface.js
+++ b/test/parallel/test-readline-interface.js
@@ -34,7 +34,7 @@ const {
   getStringWidth,
   stripVTControlCharacters
 } = require('internal/util/inspect');
-const { EventEmitter, getEventListeners } = require('events');
+const { EventEmitter, listenerCount } = require('events');
 const { Writable, Readable } = require('stream');
 
 class FakeInput extends EventEmitter {
@@ -1438,7 +1438,7 @@ for (let i = 0; i < 12; i++) {
     signal,
   });
   rl.on('close', common.mustCall());
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(signal, 'abort'), 0);
 }
 
 {
@@ -1450,10 +1450,10 @@ for (let i = 0; i < 12; i++) {
     output: fi,
     signal,
   });
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+  assert.strictEqual(listenerCount(signal, 'abort'), 1);
   rl.on('close', common.mustCall());
   ac.abort();
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(signal, 'abort'), 0);
 }
 
 {
@@ -1465,9 +1465,9 @@ for (let i = 0; i < 12; i++) {
     output: fi,
     signal,
   });
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+  assert.strictEqual(listenerCount(signal, 'abort'), 1);
   rl.close();
-  assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+  assert.strictEqual(listenerCount(signal, 'abort'), 0);
 }
 
 {

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -4,7 +4,7 @@ process.env.NODE_TEST_KNOWN_GLOBALS = 0;
 const common = require('../common');
 
 const assert = require('node:assert');
-const { getEventListeners } = require('node:events');
+const { listenerCount } = require('node:events');
 const { it, mock, describe } = require('node:test');
 const nodeTimers = require('node:timers');
 const nodeTimersPromises = require('node:timers/promises');
@@ -444,8 +444,6 @@ describe('Mock Timers Test Suite', () => {
     });
 
     describe('timers/promises', () => {
-      const hasAbortListener = (signal) => !!getEventListeners(signal, 'abort').length;
-
       describe('setTimeout Suite', () => {
         it('should advance in time and trigger timers when calling the .tick function multiple times', async (t) => {
           t.mock.timers.enable({ apis: ['setTimeout'] });
@@ -548,11 +546,11 @@ describe('Mock Timers Test Suite', () => {
             signal: controller.signal,
           });
 
-          assert(hasAbortListener(controller.signal));
+          assert.strictEqual(listenerCount(controller.signal, 'abort'), 1);
 
           t.mock.timers.tick(500);
           await p;
-          assert(!hasAbortListener(controller.signal));
+          assert.strictEqual(listenerCount(controller.signal, 'abort'), 0);
         });
 
         it('should reject given an an invalid signal instance', async (t) => {
@@ -780,9 +778,9 @@ describe('Mock Timers Test Suite', () => {
           t.mock.timers.tick();
 
           await first;
-          assert(hasAbortListener(abortController.signal));
+          assert.strictEqual(listenerCount(abortController.signal, 'abort'), 1);
           await intervalIterator.return();
-          assert(!hasAbortListener(abortController.signal));
+          assert.strictEqual(listenerCount(abortController.signal, 'abort'), 0);
         });
 
         it('should abort operation given an abort controller signal on a real use case', async (t) => {

--- a/test/parallel/test-timers-immediate-promisified.js
+++ b/test/parallel/test-timers-immediate-promisified.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const timers = require('timers');
 const { promisify } = require('util');
 
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -56,7 +56,7 @@ assert.strictEqual(setPromiseImmediate, timerPromises.setImmediate);
   const signal = new NodeEventTarget();
   signal.aborted = false;
   setPromiseImmediate(0, { signal }).finally(common.mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }));
 }
 

--- a/test/parallel/test-timers-interval-promisified.js
+++ b/test/parallel/test-timers-interval-promisified.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const timers = require('timers');
 const { promisify } = require('util');
 
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -118,10 +118,10 @@ const { setInterval } = timerPromises;
   signal.aborted = false;
   const iterator = setInterval(1, undefined, { signal });
   iterator.next().then(common.mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     iterator.return();
   })).finally(common.mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }));
 }
 
@@ -135,7 +135,7 @@ const { setInterval } = timerPromises;
     // eslint-disable-next-line no-unused-vars
     for await (const _ of iterator) {
       if (i === 0) {
-        assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+        assert.strictEqual(listenerCount(signal, 'abort'), 1);
       }
       i++;
       if (i === 2) {
@@ -143,7 +143,7 @@ const { setInterval } = timerPromises;
       }
     }
     assert.strictEqual(i, 2);
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }
 
   tryBreak().then(common.mustCall());

--- a/test/parallel/test-timers-timeout-promisified.js
+++ b/test/parallel/test-timers-timeout-promisified.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const timers = require('timers');
 const { promisify } = require('util');
 
-const { getEventListeners } = require('events');
+const { listenerCount } = require('events');
 const { NodeEventTarget } = require('internal/event_target');
 
 const timerPromises = require('timers/promises');
@@ -56,7 +56,7 @@ assert.strictEqual(setPromiseTimeout, timerPromises.setTimeout);
   const signal = new NodeEventTarget();
   signal.aborted = false;
   setPromiseTimeout(0, null, { signal }).finally(common.mustCall(() => {
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
   }));
 }
 

--- a/test/parallel/test-tls-connect-abort-controller.js
+++ b/test/parallel/test-tls-connect-abort-controller.js
@@ -6,7 +6,7 @@ if (!common.hasCrypto)
 const tls = require('tls');
 const assert = require('assert');
 const fixtures = require('../common/fixtures');
-const { getEventListeners, once } = require('events');
+const { listenerCount, once } = require('events');
 
 const serverOptions = {
   key: fixtures.readKey('agent1-key.pem'),
@@ -33,7 +33,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const socket = tls.connect(connectOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     await assertAbort(socket, 'postAbort');
   }
@@ -43,7 +43,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     ac.abort();
     const socket = tls.connect(connectOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     await assertAbort(socket, 'preAbort');
   }
 
@@ -52,7 +52,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     const socket = tls.connect(connectOptions(signal));
     setImmediate(() => ac.abort());
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     await assertAbort(socket, 'tickAbort');
   }
 
@@ -61,7 +61,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     ac.abort();
     const socket = new tls.TLSSocket(undefined, connectOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 0);
+    assert.strictEqual(listenerCount(signal, 'abort'), 0);
     await assertAbort(socket, 'testConstructor');
   }
 
@@ -69,7 +69,7 @@ server.listen(0, common.mustCall(async () => {
     const ac = new AbortController();
     const { signal } = ac;
     const socket = new tls.TLSSocket(undefined, connectOptions(signal));
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     ac.abort();
     await assertAbort(socket, 'testConstructorPost');
   }
@@ -79,7 +79,7 @@ server.listen(0, common.mustCall(async () => {
     const { signal } = ac;
     const socket = new tls.TLSSocket(undefined, connectOptions(signal));
     setImmediate(() => ac.abort());
-    assert.strictEqual(getEventListeners(signal, 'abort').length, 1);
+    assert.strictEqual(listenerCount(signal, 'abort'), 1);
     await assertAbort(socket, 'testConstructorPostTick');
   }
 


### PR DESCRIPTION
Resolves #60212.

Makes `events.listenerCount()` agnostic over both EventEmitters and EventTargets.

For EventTargets, this is faster than the `events.getEventListeners(...).length` pattern currently in use within the test suite, as it doesn't need to traverse the linked list.

Note that this now validates the emitter argument, whereas the previous version did not (it just returned 0 if the target wasn't an EventEmitter). Dealer's choice as to whether or not this constitutes a minor or major change.