### PR TITLE
repl: handle screen refresh for multiline input

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -364,6 +364,11 @@ class Interface extends InterfaceConstructor {
     return Infinity;
   }
 
+  get rows() {
+    if (this.output?.rows) return this.output.rows;
+    return Infinity;
+  }
+
   /**
    * Sets the prompt written to the output.
    * @param {string} prompt
@@ -496,6 +501,7 @@ class Interface extends InterfaceConstructor {
     const dispPos = this[kGetDisplayPos](line);
     const lineCols = dispPos.cols;
     const lineRows = dispPos.rows;
+    const terminalRows = this.rows;
 
     // cursor position
     const cursorPos = this.getCursorPos();
@@ -513,11 +519,32 @@ class Interface extends InterfaceConstructor {
 
     if (this[kIsMultiline]) {
       const lines = StringPrototypeSplit(this.line, '\n');
-      // Write first line with normal prompt
-      this[kWriteToOutput](this[kPrompt] + lines[0]);
+      // Normal case - display line from the first row to the last
+      let startLine = 0;
+      let endLine = lineRows;
 
+      const exceedsTerminal = lineRows >= terminalRows && terminalRows !== Infinity;
+      if (exceedsTerminal) {
+        const topOfVisibleData = lineRows - terminalRows;
+        // The cursor starts from the last row. If it is within the
+        // visible data segment, show the last part of the multiline data
+        if (cursorPos.rows > topOfVisibleData) {
+          startLine = topOfVisibleData;
+        } else {
+          // Cursor has traveled through the visible rows
+          // Start displaying the data that the cursor is on
+          // up until the terminal size allows
+          startLine = cursorPos.rows;
+          endLine = cursorPos.rows + terminalRows - 1;
+        }
+      }
+      // If the first row is visible, show the normal prompt
+      if (startLine === 0) {
+        this[kWriteToOutput](this[kPrompt] + lines[0]);
+        startLine++;
+      }
       // For continuation lines, add the "|" prefix
-      for (let i = 1; i < lines.length; i++) {
+      for (let i = startLine; i <= endLine; i++) {
         this[kWriteToOutput](`\n${kMultilinePrompt.description}` + lines[i]);
       }
     } else {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/59938

Fixes an issue where when navigating a multiline input which exceeds terminal height, pressing UP arrow would not update the visible data when the cursor reaches the top.

## Demo 
Before | After
-------|-------
![before](https://github.com/user-attachments/assets/81d12705-9e74-4b21-9756-d34360c6a715) |![after](https://github.com/user-attachments/assets/b10ea8b6-19e4-4e2e-8269-e1cd8087f5c7)


## Tests
**_In Progress_**. I am still figuring out how to test the REPL screen rendering in response to cursor movements.




<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
