### PR TITLE
test: add missing r.close() calls in REPL multiline tests

### DIFF
--- a/test/parallel/test-repl-multiline-navigation.js
+++ b/test/parallel/test-repl-multiline-navigation.js
@@ -81,6 +81,8 @@ tmpdir.refresh();
 
     r.input.run([{ name: 'down' }]);
     assert.strictEqual(r.cursor, 27);
+
+    r.close();
   });
 
   repl.createInternalRepl(
@@ -142,6 +144,8 @@ tmpdir.refresh();
 
     r.input.run([{ name: 'down' }]);
     assert.strictEqual(r.cursor, 55);
+
+    r.close();
   });
 
   repl.createInternalRepl(
@@ -185,6 +189,8 @@ tmpdir.refresh();
     r.input.run([{ name: 'up' }]);
     // Check that the line is properly displayed
     assert.strictEqual(r.line, 'let lineWithMistake = `I have some\nproblem with my syntax`');
+
+    r.close();
   });
 
   repl.createInternalRepl(
@@ -232,6 +238,8 @@ tmpdir.refresh();
     '  123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123,\n' +
     '  123\n' +
     ']\n'), true);
+
+    r.close();
   });
 
   repl.createInternalRepl(


### PR DESCRIPTION
  ## Summary
  - Adds missing `r.close()` calls to 4 test cases in `test/parallel/test-repl-multiline-navigation.js`
  - Prevents resource leaks by properly cleaning up REPL instances after each test
  - Ensures test isolation and improves reliability in CI environments

<img width="1457" height="279" alt="image" src="https://github.com/user-attachments/assets/51d456fa-d0a6-4244-804f-40698a8ab63c" />

<img width="535" height="87" alt="image" src="https://github.com/user-attachments/assets/079ed258-5880-4e79-a518-69893d94635e" />

  ## Test plan
  - [x] Run the modified test file: `./node test/parallel/test-repl-multiline-navigation.js`
  - [x] Verify all tests pass without resource warnings
  - [x] Run full REPL test suite: `tools/test.py repl`
  - [x] Check for any memory leak indicators in test output