### PR TITLE
quic: remove redundant === 0n checks in kFinishClose method

### DIFF
--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -352,7 +352,7 @@ const onSessionHandshakeChannel = dc.channel('quic.session.handshake');
  * @property {bigint|number} [maxConnectionsTotal] The maximum number of total connections
  * @property {bigint|number} [maxStatelessResetsPerHost] The maximum number of stateless resets per host
  * @property {bigint|number} [addressLRUSize] The size of the address LRU cache
- * @property {bigint|number} [maxRetries] The maximum number of retriesw
+ * @property {bigint|number} [maxRetries] The maximum number of retries
  * @property {number} [rxDiagnosticLoss] The receive diagnostic loss probability (range 0.0-1.0)
  * @property {number} [txDiagnosticLoss] The transmit diagnostic loss probability (range 0.0-1.0)
  * @property {number} [udpReceiveBufferSize] The UDP receive buffer size
@@ -507,7 +507,7 @@ setCallbacks({
     if (session.destroyed) {
       stream.destroy();
       return;
-    };
+    }
     session[kNewStream](stream, direction);
   },
 
@@ -1383,29 +1383,21 @@ class QuicSession {
     debug('finishing closing the session with an error', errorType, code, reason);
     // Otherwise, errorType indicates the type of error that occurred, code indicates
     // the specific error, and reason is an optional string describing the error.
+    // Note: code is guaranteed to be non-zero here due to early return above
     switch (errorType) {
       case 0: /* Transport Error */
-        if (code === 0n) {
-          this.destroy();
-        } else {
-          this.destroy(new ERR_QUIC_TRANSPORT_ERROR(code, reason));
-        }
+        this.destroy(new ERR_QUIC_TRANSPORT_ERROR(code, reason));
         break;
       case 1: /* Application Error */
-        if (code === 0n) {
-          this.destroy();
-        } else {
-          this.destroy(new ERR_QUIC_APPLICATION_ERROR(code, reason));
-        }
+        this.destroy(new ERR_QUIC_APPLICATION_ERROR(code, reason));
         break;
       case 2: /* Version Negotiation Error */
         this.destroy(new ERR_QUIC_VERSION_NEGOTIATION_ERROR());
         break;
-      case 3: /* Idle close */ {
+      case 3: /* Idle close */
         // An idle close is not really an error. We can just destroy.
         this.destroy();
         break;
-      }
     }
   }
 


### PR DESCRIPTION
Removed redundant `code === 0n` checks in `[kFinishClose]` method (lib/internal/quic/quic.js:1386-1401). These conditionals were unreachable due to early return, reducing code complexity.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
