### PR TITLE
sqlite: make `SQLTagStore.prototype.size` a getter

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -1074,13 +1074,17 @@ Executes the given SQL query, which is expected to not return any rows (e.g., IN
 This function is intended to be used as a template literal tag, not to be
 called directly.
 
-### `sqlTagStore.size()`
+### `sqlTagStore.size`
 
 <!-- YAML
 added: v24.9.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60246
+    description: Changed from a method to a getter.
 -->
 
-* Returns: {integer} The number of prepared statements currently in the cache.
+* Type: {integer}
 
 A read-only property that returns the number of prepared statements currently in the cache.
 

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -313,15 +313,14 @@ class SQLTagStore : public BaseObject {
       Environment* env, BaseObjectWeakPtr<DatabaseSync> database, int capacity);
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
-  static void All(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Get(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Iterate(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Run(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Size(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Capacity(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Reset(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void Clear(const v8::FunctionCallbackInfo<v8::Value>& info);
-  static void DatabaseGetter(const v8::FunctionCallbackInfo<v8::Value>& info);
+  static void All(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Get(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Iterate(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Run(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Clear(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void CapacityGetter(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void DatabaseGetter(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SizeGetter(const v8::FunctionCallbackInfo<v8::Value>& args);
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(SQLTagStore)
   SET_SELF_SIZE(SQLTagStore)

--- a/test/parallel/test-sqlite-template-tag.js
+++ b/test/parallel/test-sqlite-template-tag.js
@@ -77,23 +77,23 @@ test('queries with no results', () => {
 
 test('TagStore capacity, size, and clear', () => {
   assert.strictEqual(sql.capacity, 10);
-  assert.strictEqual(sql.size(), 0);
+  assert.strictEqual(sql.size, 0);
 
   assert.strictEqual(sql.run`INSERT INTO foo (text) VALUES (${'one'})`.changes, 1);
-  assert.strictEqual(sql.size(), 1);
+  assert.strictEqual(sql.size, 1);
 
   assert.ok(sql.get`SELECT * FROM foo WHERE text = ${'one'}`);
-  assert.strictEqual(sql.size(), 2);
+  assert.strictEqual(sql.size, 2);
 
   // Using the same template string shouldn't increase the size
   assert.strictEqual(sql.get`SELECT * FROM foo WHERE text = ${'two'}`, undefined);
-  assert.strictEqual(sql.size(), 2);
+  assert.strictEqual(sql.size, 2);
 
   assert.strictEqual(sql.all`SELECT * FROM foo`.length, 1);
-  assert.strictEqual(sql.size(), 3);
+  assert.strictEqual(sql.size, 3);
 
   sql.clear();
-  assert.strictEqual(sql.size(), 0);
+  assert.strictEqual(sql.size, 0);
   assert.strictEqual(sql.capacity, 10);
 });
 


### PR DESCRIPTION
As implemented, `.db` and `.capacity` are getters, and `.size` is a callable method. There's no reason for this inconsistency, so change `.size` to a getter.

Drive-by changes while making alterations to the class template: the `FunctionCallbackInfo` parameter for SQLTagStore member functions was variably labelled `args` or `info`, and wasn't consistent with the header either. Use the canonical `args`.
