### PR TITLE
msi: fix WiX warnings

### DIFF
--- a/tools/msvs/msi/nodemsi/nodemsi.wixproj
+++ b/tools/msvs/msi/nodemsi/nodemsi.wixproj
@@ -1,5 +1,5 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.1">
-  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.0-rc.1" />
+<Project>
+  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.6" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
@@ -36,20 +36,24 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.1" />
-    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.0-rc.1" />
-    <PackageReference Include="WixToolset.Heat" Version="4.0.0-rc.1" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.6" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.6" />
+    <PackageReference Include="WixToolset.Heat" Version="4.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../custom_actions/custom_actions.vcxproj" />
   </ItemGroup>
-  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.0-rc.1" />
+  <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.6" />
   <Target Name="BeforeBuild">
     <HeatDirectory ToolPath="$(WixToolPath)" Directory="..\..\..\..\Release\node-v$(FullVersion)-win-$(Platform)\node_modules\npm" PreprocessorVariable="var.NpmSourceDir" DirectoryRefId="NodeModulesFolder" ComponentGroupName="NpmSourceFiles" GenerateGuidsNow="true" SuppressFragments="false" OutputFile="..\..\..\..\npm.wxs">
     </HeatDirectory>
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>move "$(TargetDir)en-us\$(TargetFileName)" "$(TargetPath)"
-    move "$(TargetDir)en-us\$(TargetPdbFileName)" "$(TargetPdbPath)"</PostBuildEvent>
-  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <Move SourceFiles="$(OutputPath)en-us\$(OutputName).msi"
+          DestinationFiles="$(OutputPath)$(OutputName).msi"
+          Condition="Exists('$(OutputPath)en-us\$(OutputName).msi')" />
+    <Move SourceFiles="$(OutputPath)en-us\$(OutputName).wixpdb"
+          DestinationFiles="$(OutputPath)$(OutputName).wixpdb"
+          Condition="Exists('$(OutputPath)en-us\$(OutputName).wixpdb')" />
+  </Target>
 </Project>


### PR DESCRIPTION
This PR fixes WiX warnings noticed during the CI builds while creating the installer. Thanks to @targos for pointing me to them.  Two main issues were:
- Using a release candidate version - I've now updated to the latest WiX v4 version (4.0.6)
- Having a double import of the WiX toolset - I've removed one of them

The only warning left is this one:

```log
C:\workspace\node-compile-windows\node\tools\msvs\msi\nodemsi\product.wxs(26): warning WIX1076: ICE61: This product should remove only older versions of itself. The Maximum version is not less than the current product. (25.0.0 25.0.0) [C:\workspace\node-compile-windows\node\tools\msvs\msi\nodemsi\nodemsi.wixproj]
```

In my opinion, this should stay, as that allows us to install the same version builds over each other. This is useful for development and testing builds, and it has no effect on official releases. I can probably add something in the configuration to suppress it for cleaner logs..

Here is the [CI run](https://ci.nodejs.org/job/node-test-commit-windows-fanned/73560/) building it. A flaky test failed there, but the compilation passed.

Fixes: https://github.com/nodejs/build/issues/4130