### PR TITLE
doc: fix `blob.bytes()` heading level

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -513,7 +513,7 @@ added:
 Returns a promise that fulfills with an {ArrayBuffer} containing a copy of
 the `Blob` data.
 
-#### `blob.bytes()`
+### `blob.bytes()`
 
 <!-- YAML
 added:


### PR DESCRIPTION
The title says it all. The screenshots below show how it is currently being rendered on [nodejs.org/docs](https://nodejs.org/docs/latest-v24.x/api/buffer.html#blobbytes).

<img width="512" height="384" alt="Screenshot From 2025-10-14 15-59-37" src="https://github.com/user-attachments/assets/43760f8e-eca0-4ca3-8079-38530a79cf85" />

<img width="512" height="512" alt="Screenshot From 2025-10-14 15-47-24" src="https://github.com/user-attachments/assets/e90d5db7-f2a0-40dc-b87d-795d204cb955" />
