### PR TITLE
src: use cached primordials_string

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -853,8 +853,7 @@ Maybe<void> InitializePrimordials(Local<Context> context,
   if (!GetPerContextExports(context).ToLocal(&exports)) {
     return Nothing<void>();
   }
-  Local<String> primordials_string =
-      FIXED_ONE_BYTE_STRING(isolate, "primordials");
+  Local<String> primordials_string = isolate_data->primordials_string();
   // Ensure that `InitializePrimordials` is called exactly once on a given
   // context.
   CHECK(!exports->Has(context, primordials_string).FromJust());


### PR DESCRIPTION
Use cached `primordials` string from IsolateData and pass isolate_data to GetPerContextExports() to avoid unnecessary string creation and keep the bootstrap path consistent.

No functional change.