### PR TITLE
src: replace Environment::GetCurrent with args.GetIsolate

### DIFF
--- a/src/uv.cc
+++ b/src/uv.cc
@@ -68,7 +68,9 @@ void GetErrMessage(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ErrName(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  Environment* env = Environment::GetCurrent(context);
   if (env->options()->pending_deprecation && env->EmitErrNameWarning()) {
     if (ProcessEmitDeprecationWarning(
         env,
@@ -82,13 +84,12 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
   CHECK_LT(err, 0);
   char name[50];
   uv_err_name_r(err, name, sizeof(name));
-  args.GetReturnValue().Set(OneByteString(env->isolate(), name));
+  args.GetReturnValue().Set(OneByteString(isolate, name));
 }
 
 void GetErrMap(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
-  Local<Context> context = env->context();
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   // This can't return a SafeMap, because the uv binding can be referenced
   // by user code by using `process.binding('uv').getErrorMap()`:


### PR DESCRIPTION
Refactor code in `node_util.cc` and `uv.cc` to remove unnecessary calls to `Environment::GetCurrent(args)`. Instead, use `args.GetIsolate()` and `isolate->GetCurrentContext()` where applicable to reduce extra lookups and improve readability.

No functional change.