### PR TITLE
deps: V8: cherry-pick 7ef6a001762 fix LoongArch64 architecture build failed

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/loong64/builtins-loong64.cc
+++ b/deps/v8/src/builtins/loong64/builtins-loong64.cc
@@ -328,7 +328,7 @@ static void GetSharedFunctionInfoBytecodeOrBaseline(
     if (v8_flags.debug_code) {
       Label not_baseline;
       __ GetObjectType(data, scratch1, scratch1);
-      __ Branch(&not_baseline, ne, scratch1, Operand(CODETYPE));
+      __ Branch(&not_baseline, ne, scratch1, Operand(CODE_TYPE));
       AssertCodeIsBaseline(masm, data, scratch1);
       __ Branch(is_baseline);
       __ bind(&not_baseline);

--- a/deps/v8/src/codegen/loong64/macro-assembler-loong64.cc
+++ b/deps/v8/src/codegen/loong64/macro-assembler-loong64.cc
@@ -2650,12 +2650,12 @@ int32_t MacroAssembler::GetOffset(Label* L, OffsetSize bits) {
 }
 
 Register MacroAssembler::GetRkAsRegisterHelper(const Operand& rk,
-                                               Register scratch) {
+                                               UseScratchRegisterScope temps) {
   Register r2 = no_reg;
   if (rk.is_reg()) {
     r2 = rk.rm();
   } else {
-    r2 = scratch;
+    r2 = temps.Acquire();
     li(r2, rk);
   }
 
@@ -2667,7 +2667,6 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
                                            bool need_link) {
   UseScratchRegisterScope temps(this);
   BlockTrampolinePoolScope block_trampoline_pool(this);
-  Register scratch = temps.Acquire();
   DCHECK_NE(rj, zero_reg);
 
   // Be careful to always use shifted_branch_offset only just before the
@@ -2703,7 +2702,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
           // We don't want any other register but scratch clobbered.
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           offset = GetOffset(L, OffsetSize::kOffset16);
           beq(rj, sc, offset);
         }
@@ -2725,7 +2724,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
           // We don't want any other register but scratch clobbered.
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bne(rj, sc, offset);
         }
@@ -2744,7 +2743,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           blt(sc, rj, offset);
@@ -2765,7 +2764,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bge(rj, sc, offset);
@@ -2783,7 +2782,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           blt(rj, sc, offset);
@@ -2804,7 +2803,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bge(sc, rj, offset);
@@ -2824,7 +2823,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bltu(sc, rj, offset);
@@ -2845,7 +2844,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bgeu(rj, sc, offset);
@@ -2860,7 +2859,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bltu(rj, sc, offset);
@@ -2880,7 +2879,7 @@ bool MacroAssembler::BranchShortOrFallback(Label* L, Condition cond,
         } else {
           if (L->is_bound() && !is_near(L, OffsetSize::kOffset16)) return false;
           if (need_link) pcaddi(ra, 2);
-          Register sc = GetRkAsRegisterHelper(rk, scratch);
+          Register sc = GetRkAsRegisterHelper(rk, temps);
           DCHECK(rj != sc);
           offset = GetOffset(L, OffsetSize::kOffset16);
           bgeu(sc, rj, offset);
@@ -3111,10 +3110,12 @@ void MacroAssembler::CompareTaggedRootAndBranch(const Register& obj,
   // Some smi roots contain system pointer size values like stack limits.
   DCHECK(base::IsInRange(index, RootIndex::kFirstStrongOrReadOnlyRoot,
                          RootIndex::kLastStrongOrReadOnlyRoot));
-  Register temp = temps.Acquire();
-  DCHECK(!AreAliased(obj, temp));
-  LoadRoot(temp, index);
-  CompareTaggedAndBranch(target, cc, obj, Operand(temp));
+  Register scratch1 = temps.Acquire();
+  Register scratch2 = temps.Acquire();
+  DCHECK(!AreAliased(obj, scratch1, scratch2));
+  slli_w(scratch1, obj, 0);
+  LoadTaggedRoot(scratch2, index);
+  Branch(target, cc, scratch1, Operand(scratch2));
 }
 
 // Compare the object in a register to a value from the root list.

--- a/deps/v8/src/codegen/loong64/macro-assembler-loong64.h
+++ b/deps/v8/src/codegen/loong64/macro-assembler-loong64.h
@@ -1295,7 +1295,8 @@ class V8_EXPORT_PRIVATE MacroAssembler : public MacroAssemblerBase {
   }
 
  protected:
-  inline Register GetRkAsRegisterHelper(const Operand& rk, Register scratch);
+  inline Register GetRkAsRegisterHelper(const Operand& rk,
+                                        UseScratchRegisterScope temps);
   inline int32_t GetOffset(Label* L, OffsetSize bits);
 
  private:


### PR DESCRIPTION
issue：https://github.com/nodejs/node/issues/60258
LoongArch64 CI is in a failed state (https://ci.nodejs.org/job/node-test-commit-loongarch64/nodes=clfs23-64/)

"**'CODETYPE' was not declared in this scope**" appears when compiling after upgrading V8 to **14.1**

```
13:25:59   loongarch64-unknown-linux-gnu-g++ -o /home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj.target/v8_initializers/gen/torque-generated/src/builtins/array-reduce-tq-csa.o /home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj/gen/torque-generated/src/builtins/array-reduce-tq-csa.cc '-D_GLIBCXX_USE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-DNODE_OPENSSL_CONF_NAME=nodejs_conf' '-DICU_NO_USER_DATA_OVERRIDE' '-DV8_GYP_BUILD' '-DV8_TYPED_ARRAY_MAX_SIZE_IN_HEAP=64' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DV8_TARGET_ARCH_LOONG64' '-DV8_HAVE_TARGET_OS' '-DV8_TARGET_OS_LINUX' '-DV8_EMBEDDER_STRING="-node.10"' '-DENABLE_DISASSEMBLER' '-DV8_PROMISE_INTERNAL_FIELD_COUNT=1' '-DV8_ENABLE_PRIVATE_MAPPING_FORK_OPTIMIZATION' '-DOBJECT_PRINT' '-DV8_INTL_SUPPORT' '-DV8_ATOMIC_OBJECT_FIELD_WRITES' '-DV8_ENABLE_LAZY_SOURCE_POSITIONS' '-DV8_USE_SIPHASH' '-DNDEBUG' '-DV8_WIN64_UNWINDING_INFO' '-DV8_ENABLE_REGEXP_INTERPRETER_THREADED_DISPATCH' '-DV8_USE_ZLIB' '-DV8_ENABLE_LEAPTIERING' '-DV8_ENABLE_SPARKPLUG' '-DV8_ENABLE_TURBOFAN' '-DV8_ENABLE_WEBASSEMBLY' '-DV8_ENABLE_JAVASCRIPT_PROMISE_HOOKS' '-DV8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA' '-DV8_ALLOCATION_FOLDING' '-DV8_ALLOCATION_SITE_TRACKING' '-DV8_ADVANCED_BIGINT_ALGORITHMS' '-DUCONFIG_NO_SERVICE=1' '-DU_ENABLE_DYLOAD=0' '-DU_STATIC_IMPLEMENTATION=1' '-DU_HAVE_STD_STRING=1' '-DUCONFIG_NO_BREAK_ITERATION=0' -I../deps/v8 -I../deps/v8/include -I/home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj/gen -I/home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj/gen/generate-bytecode-output-root -I../deps/v8/third_party/fp16/src/include -I../deps/v8/third_party/abseil-cpp -I../deps/icu-small/source/i18n -I../deps/icu-small/source/common  -pthread -Wno-unused-parameter -Wno-strict-overflow -Wno-return-type -Wno-int-in-bool-context -Wno-deprecated -Wno-stringop-overflow -Wno-stringop-overread -Wno-restrict -Wno-array-bounds -Wno-nonnull -Wno-dangling-pointer -flax-vector-conversions -O3 -fno-omit-frame-pointer -fdata-sections -ffunction-sections -O3 -fno-rtti -fno-exceptions -fno-strict-aliasing -std=gnu++20 -Wno-invalid-offsetof -MMD -MF /home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/.deps//home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj.target/v8_initializers/gen/torque-generated/src/builtins/array-reduce-tq-csa.o.d.raw   -c
13:25:59 ../deps/v8/src/builtins/loong64/builtins-loong64.cc: In function ‘void v8::internal::GetSharedFunctionInfoBytecodeOrBaseline(MacroAssembler*, Register, Register, Register, Label*, Label*)’:
13:25:59 ../deps/v8/src/builtins/loong64/builtins-loong64.cc:331:54: 错误：‘CODETYPE’ was not declared in this scope; did you mean ‘CODE_TYPE’?
13:26:02   331 |       __ Branch(&not_baseline, ne, scratch1, Operand(CODETYPE));
13:26:04       |                                                      ^~~~~~~~
13:26:04       |                                                      CODE_TYPE
```

Origin commit message:

    [loong64] Fix no pointer compression build

    1. Fix a typo that breaks no static root build.
    2. Use less scratch regs in some compare and branch functions.

    This bug is triggered by Node.js loong64 port.

    Change-Id: If251906cc07feca237c75f0b65517526085f61dd
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7031299
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Auto-Submit: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
    Commit-Queue: Zhao Jiazhong <zhaojiazhong-hf@loongson.cn>
    Cr-Commit-Position: refs/heads/main@{#103105}

Refs: https://github.com/v8/v8/commit/7ef6a00176207b26a2585b163c12f35bedc9c1cf

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
