### PR TITLE
src: add a default branch for module phase

### DIFF
--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -563,8 +563,9 @@ ModulePhase to_phase_constant(ModuleImportPhase phase) {
       return kEvaluationPhase;
     case ModuleImportPhase::kSource:
       return kSourcePhase;
+    default:
+      UNREACHABLE();
   }
-  UNREACHABLE();
 }
 
 static Local<Object> createImportAttributesContainer(


### PR DESCRIPTION
This prevents a compiler warning about a missing switch-case branch when 
a new `ModuleImportPhase` enum value is added.

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/7017517