### PR TITLE
buffer: add bounds validation to SlowCopy and FastCopy

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -578,20 +578,19 @@ void CopyImpl(Local<Value> source_obj,
 void SlowCopy(const FunctionCallbackInfo<Value>& args) {
   Local<Value> source_obj = args[0];
   Local<Value> target_obj = args[1];
-  Environment* env = Environment::GetCurrent(args);
-  Isolate* isolate = env->isolate();
+  Isolate* isolate = args.GetIsolate();
 
   // Add validation before call CopyImpl blindly
-  if (!Buffer::HasInstance(source_obj) || !Buffer::HasInstance(target_obj)) {
-    isolate->ThrowException(v8::Exception::TypeError(String::NewFromUtf8Literal(
-        isolate, "Arguments must be Buffer instances")));
+  if (!source_obj->IsArrayBufferView() || !target_obj->IsArrayBufferView()) {
+    isolate->ThrowException(v8::Exception::TypeError(
+        String::NewFromUtf8Literal(isolate, "Arguments must be ArrayBufferViews")));
     return;
   }
   const uint32_t target_start = args[2].As<Uint32>()->Value();
   const uint32_t source_start = args[3].As<Uint32>()->Value();
   const uint32_t to_copy = args[4].As<Uint32>()->Value();
-  size_t source_len = Buffer::Length(source_obj.As<Object>());
-  size_t target_len = Buffer::Length(target_obj.As<Object>());
+  size_t source_len = source_obj.As<ArrayBufferView>()->ByteLength();
+  size_t target_len = target_obj.As<ArrayBufferView>()->ByteLength();
 
   if (source_start > source_len || target_start > target_len ||
       to_copy > source_len - source_start ||
@@ -607,7 +606,7 @@ void SlowCopy(const FunctionCallbackInfo<Value>& args) {
 }
 
 // Assume caller has properly validated args.
-uint32_t FastCopy(Local<Value> receiver,
+int32_t FastCopy(Local<Value> receiver,
                   Local<Value> source_obj,
                   Local<Value> target_obj,
                   uint32_t target_start,
@@ -618,18 +617,18 @@ uint32_t FastCopy(Local<Value> receiver,
   HandleScope scope(options.isolate);
   Isolate* isolate = options.isolate;
 
-  if (!node::Buffer::HasInstance(source_obj) ||
-      !node::Buffer::HasInstance(target_obj)) {
+  if (!source_obj->IsArrayBufferView() || !target_obj->IsArrayBufferView()) {
+    isolate->ThrowException(v8::Exception::TypeError(
+        String::NewFromUtf8Literal(isolate, "Arguments must be ArrayBufferViews")));
     return 0;
   }
   // Validate First before call CopyImpl blindly
-  size_t src_len = Buffer::Length(source_obj.As<v8::Object>());
-  size_t dst_len = Buffer::Length(target_obj.As<v8::Object>());
+  size_t src_len = source_obj.As<ArrayBufferView>()->ByteLength();
+  size_t dst_len = target_obj.As<ArrayBufferView>()->ByteLength();
 
   if (source_start > src_len || target_start > dst_len ||
       to_copy > src_len - source_start || to_copy > dst_len - target_start) {
-    // options.fallback = true;  // Let JS slow path handle it (safe fallback)
-    return 0;
+    return -1;
   }
   CopyImpl(source_obj, target_obj, target_start, source_start, to_copy);
 


### PR DESCRIPTION
Fixes an out-of-bounds memory access vulnerability caused by unvalidated copy ranges in Buffer::SlowCopy() and Buffer::FastCopy().

The patch adds proper instance checks and range validation before calling CopyImpl, preventing potential segfaults or memory corruption.

Refs: https://github.com/nodejs/node/issues/59985

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
