### PR TITLE
tools: optimize wildcard execution in tools/test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1712,27 +1712,28 @@ def Main():
   all_unused = [ ]
   unclassified_tests = [ ]
   globally_unused_rules = None
-  for path in paths:
-    for arch in options.arch:
-      for mode in options.mode:
-        vm = context.GetVm(arch, mode)
-        if not exists(vm):
-          print("Can't find shell executable: '%s'" % vm)
-          continue
-        archEngineContext = Execute([vm, "-p", "process.arch"], context)
-        vmArch = archEngineContext.stdout.rstrip()
-        if archEngineContext.exit_code != 0 or vmArch == "undefined":
-          print("Can't determine the arch of: '%s'" % vm)
-          print(archEngineContext.stderr.rstrip())
-          continue
-        env = {
-          'mode': mode,
-          'system': utils.GuessOS(),
-          'arch': vmArch,
-          'type': get_env_type(vm, options.type, context),
-          'asan': get_asan_state(vm, context),
-          'pointer_compression': get_pointer_compression_state(vm, context),
-        }
+
+  for arch in options.arch:
+    for mode in options.mode:
+      vm = context.GetVm(arch, mode)
+      if not exists(vm):
+        print("Can't find shell executable: '%s'" % vm)
+        continue
+      archEngineContext = Execute([vm, "-p", "process.arch"], context)
+      vmArch = archEngineContext.stdout.rstrip()
+      if archEngineContext.exit_code != 0 or vmArch == "undefined":
+        print("Can't determine the arch of: '%s'" % vm)
+        print(archEngineContext.stderr.rstrip())
+        continue
+      env = {
+        'mode': mode,
+        'system': utils.GuessOS(),
+        'arch': vmArch,
+        'type': get_env_type(vm, options.type, context),
+        'asan': get_asan_state(vm, context),
+        'pointer_compression': get_pointer_compression_state(vm, context),
+      }
+      for path in paths:
         test_list = root.ListTests([], path, context, arch, mode)
         unclassified_tests += test_list
         cases, unused_rules = config.ClassifyTests(test_list, env)


### PR DESCRIPTION
Previously for each matching test, it would execute multiple `node -p` commands to decide the configurations of the executable. That means if there are 100 tests matched, it will run the Node.js executable 4*100 times to retrieve the same configurations repeatedly. This changes the loop order so that it only execute these commands once and reuse the results for all matching tests.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
