### PR TITLE
test: make test-worker-prof more tolerant

### DIFF
--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -77,7 +77,7 @@ if (process.argv[2] === 'child') {
   // When not tracking Worker threads, only 1 or 2 ticks would
   // have been recorded.
   // prof_sampling_interval is by default 1 millisecond. A higher SPIN_MS
-  // should result in more ticks, while 15 should be safe on most machines.
-  assert(workerTicks.length > 15, `worker ticks <= 15:\n${workerTicks.join('\n')}`);
-  assert(parentTicks.length > 15, `parent ticks <= 15:\n${parentTicks.join('\n')}`);
+  // should result in more ticks, while 10 should be safe on most machines.
+  assert(workerTicks.length > 10, `worker ticks <= 10:\n${workerTicks.join('\n')}`);
+  assert(parentTicks.length > 10, `parent ticks <= 10:\n${parentTicks.join('\n')}`);
 }


### PR DESCRIPTION
It seems after the recent V8 upgrade, it's no longer safe to assume there'll be 15 ticks per 1500ms. Lower it to 10 ticks.

This failed 19 PRs out of the last 100 CI runs in the latest reliability report.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2025-10-15.md

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
