### PR TITLE
doc: add File modes cross-references in fs methods

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -8700,6 +8700,7 @@ the file contents.
 [Common System Errors]: errors.md#common-system-errors
 [FS constants]: #fs-constants
 [File access constants]: #file-access-constants
+[File modes]: #file-modes
 [MDN-Date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [MDN-Number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type
 [MSDN-Rel-Path]: https://docs.microsoft.com/en-us/windows/desktop/FileIO/naming-a-file#fully-qualified-vs-relative-paths
@@ -8717,7 +8718,6 @@ the file contents.
 [`filehandle.writeFile()`]: #filehandlewritefiledata-options
 [`fs.access()`]: #fsaccesspath-mode-callback
 [`fs.accessSync()`]: #fsaccesssyncpath-mode
-[File modes]: #file-modes
 [`fs.chmod()`]: #fschmodpath-mode-callback
 [`fs.chown()`]: #fschownpath-uid-gid-callback
 [`fs.copyFile()`]: #fscopyfilesrc-dest-mode-callback


### PR DESCRIPTION
Adds cross-references to the File modes section from methods that use the `mode` parameter, improving discoverability of file permission documentation.

### Changes
- Added `[File modes][]` links in `fsPromises.open()`, `fsPromises.mkdir()`, and `fs.mkdir()` parameter documentation
- Added `[File modes]: #file-modes` link reference

### Motivation
Previously, developers using methods with `mode` parameters (like `0o666`, `0o777`) had to manually search for the File modes table. This change provides direct links to the relevant documentation.

Fixes #60280
