### PR TITLE
doc: update decorator documentation to reflect actual policy

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -158,10 +158,9 @@ namespace A {
 }
 ```
 
-Since Decorators are currently a [TC39 Stage 3 proposal](https://github.com/tc39/proposal-decorators)
-and will soon be supported by the JavaScript engine,
+Since Decorators are currently a [TC39 Stage 3 proposal](https://github.com/tc39/proposal-decorators),
 they are not transformed and will result in a parser error.
-This is a temporary limitation and will be resolved in the future.
+Node.js does not provide polyfills for decorators and will not support them until they are supported natively in JavaScript.
 
 In addition, Node.js does not read `tsconfig.json` files and does not support
 features that depend on settings within `tsconfig.json`, such as paths or


### PR DESCRIPTION
  ## Description
   Updates the TypeScript documentation to accurately reflect Node.js's policy on decorators.

   ## Changes
   - Removes misleading "will soon be supported" language
   - Removes "temporary limitation" claim  
   - Clarifies that Node.js will not provide polyfills
   - States that decorators will be supported when implemented natively in JavaScript engines

   ## Related Issue
   Fixes #60282