### PR TITLE
tools: add GHA benchmark runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,7 +99,6 @@ jobs:
 
       - name: Re-build Node.js on the merge commit
         # ccache is disabled here to avoid polluting the cache. Local build outputs should make this build relatively quick anyway.
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           nix-shell \
             -I nixpkgs=./tools/nix/pkgs.nix \
@@ -114,7 +113,6 @@ jobs:
             '
 
       - name: Run benchmark
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           nix-shell \
             -I nixpkgs=./tools/nix/pkgs.nix \
@@ -151,17 +149,15 @@ jobs:
           FILTER: ${{ inputs.filter }}
 
       - name: Upload raw benchmark results
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: csv-${{ matrix.system }}
           path: ${{ matrix.system }}.csv
 
-  aggregate-benchmark-results:
+  aggregate-results:
     needs: build
     name: Aggregate benchmark results
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,17 +60,17 @@ jobs:
         env:
           EXPECTED_SHA: ${{ inputs.commit }}
 
-      - uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31.10.3
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
         with:
           extra_nix_config: sandbox = true
 
-      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
         with:
           # We do not pass any `authToken` to avoid polluting the cache with potentially untrusted code.
           name: nodejs
 
       - name: Configure sccache
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             core.exportVariable('SCCACHE_GHA_VERSION', 'on');
@@ -175,7 +175,7 @@ jobs:
           merge-multiple: true
           path: raw-results
 
-      - uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31.10.3
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
         with:
           extra_nix_config: sandbox = true
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,206 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        type: string
+        description: GitHub repository to fetch from (default to the current repo)
+      pr_id:
+        type: number
+        required: true
+        description: The PR to test
+      commit:
+        required: true
+        type: string
+        description: The expect HEAD of the PR
+      category:
+        required: true
+        type: string
+        description: The category (or categories) of tests to run, for example buffers, cluster etc. Maps to a folders in node/benchmark
+      filter:
+        type: string
+        description: A substring to restrict the benchmarks to run in a category. e.g. `net-c2c`
+      runs:
+        type: number
+        default: 30
+        description: How many times to repeat each benchmark
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+          - runner: macos-15-intel
+            system: x86_64-darwin
+          - runner: macos-latest
+            system: aarch64-darwin
+    name: '${{ matrix.system }}: with shared libraries'
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: ${{ inputs.repo || github.repository }}
+          ref: refs/pull/${{ inputs.pr_id }}/merge
+          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Validate PR head and roll back to base commit
+        run: |
+          [ "$(git rev-parse HEAD^2)" = "$EXPECTED_SHA" ]
+          git reset HEAD^ --hard
+        env:
+          EXPECTED_SHA: ${{ inputs.commit }}
+
+      - uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31.10.3
+        with:
+          extra_nix_config: sandbox = true
+
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
+        with:
+          # We do not pass any `authToken` to avoid polluting the cache with potentially untrusted code.
+          name: nodejs
+
+      - name: Configure sccache
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            core.exportVariable('SCCACHE_GHA_VERSION', 'on');
+            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', 'on');
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Build Node.js on the base commit
+        run: |
+          nix-shell \
+            -I nixpkgs=./tools/nix/pkgs.nix \
+            --pure --keep TAR_DIR --keep FLAKY_TESTS \
+            --keep SCCACHE_GHA_ENABLED --keep ACTIONS_CACHE_SERVICE_V2 --keep ACTIONS_RESULTS_URL --keep ACTIONS_RUNTIME_TOKEN \
+            --arg useSeparateDerivationForV8 true \
+            --arg loadJSBuiltinsDynamically false \
+            --arg ccache "${NIX_SCCACHE:-null}" \
+            --arg devTools '[]' \
+            --arg benchmarkTools '[]' \
+            --run '
+                make build-ci -j4 V=1
+            '
+          mv out/Release/node base_node
+
+      - name: Checkout the merge commit
+        run: git reset FETCH_HEAD --hard
+
+      - name: Re-build Node.js on the merge commit
+        # ccache is disabled here to avoid polluting the cache. Local build outputs should make this build relatively quick anyway.
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          nix-shell \
+            -I nixpkgs=./tools/nix/pkgs.nix \
+            --pure \
+            --arg useSeparateDerivationForV8 true \
+            --arg loadJSBuiltinsDynamically false \
+            --arg ccache 'null' \
+            --arg devTools '[]' \
+            --arg benchmarkTools '[]' \
+            --run '
+                make -j4 V=1
+            '
+
+      - name: Run benchmark
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          nix-shell \
+            -I nixpkgs=./tools/nix/pkgs.nix \
+            --pure --keep FILTER --keep LC_ALL --keep LANG \
+            --arg loadJSBuiltinsDynamically false \
+            --arg ccache 'null' \
+            --arg icu 'null' \
+            --arg sharedLibDeps '{}' \
+            --arg devTools '[]' \
+            --run '
+                set -o pipefail
+                ./base_node benchmark/compare.js \
+                  --filter "$FILTER" \
+                  --runs ${{ inputs.runs }} \
+                  --old ./base_node --new ./node \
+                  -- ${{ inputs.category }} \
+                | tee /dev/stderr \
+                > ${{ matrix.system }}.csv
+                echo "> [!WARNING] "
+                echo "> Do not take GHA benchmark results as face value, always confirm them"
+                echo "> using a dedicated machine, e.g. Jenkins CI."
+                echo
+                echo "Benchmark results:"
+                echo
+                echo '"'"'```'"'"'
+                Rscript benchmark/compare.R < ${{ matrix.system }}.csv
+                echo '"'"'```'"'"'
+                echo
+                echo "> [!WARNING] "
+                echo "> Do not take GHA benchmark results as face value, always confirm them"
+                echo "> using a dedicated machine, e.g. Jenkins CI."
+            ' | tee /dev/stderr >> "$GITHUB_STEP_SUMMARY"
+        env:
+          FILTER: ${{ inputs.filter }}
+
+      - name: Upload raw benchmark results
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: csv-${{ matrix.system }}
+          path: ${{ matrix.system }}.csv
+
+  aggregate-benchmark-results:
+    needs: build
+    name: Aggregate benchmark results
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            benchmark/*.R
+            tools/nix/*.nix
+            *.nix
+          sparse-checkout-cone-mode: false
+
+      - name: Download benchmark raw results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: csv-*
+          merge-multiple: true
+          path: raw-results
+
+      - uses: cachix/install-nix-action@96951a368ba55167b55f1c916f7d416bac6505fe  # v31.10.3
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Benchmark results
+        run: |
+          nix-shell \
+            -I nixpkgs=./tools/nix/pkgs.nix \
+            --pure --keep LC_ALL --keep LANG \
+            -E '(import <nixpkgs> {}).mkShell { buildInputs = import ./tools/nix/benchmarkTools.nix { withHttpBenchmarkDeps = false; }; }' \
+            --run '
+                echo "> [!WARNING] "
+                echo "> Do not take GHA benchmark results as face value, always confirm them"
+                echo "> using a dedicated machine, e.g. Jenkins CI."
+                echo
+                echo "Benchmark results:"
+                echo
+                echo '"'"'```'"'"'
+                awk "FNR==1 && NR!=1{next;}{print}" raw-results/*.csv | Rscript benchmark/compare.R
+                echo '"'"'```'"'"'
+                echo
+                echo "> [!WARNING] "
+                echo "> Do not take GHA benchmark results as face value, always confirm them"
+                echo "> using a dedicated machine, e.g. Jenkins CI."
+            ' | tee /dev/stderr >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -183,9 +183,10 @@ jobs:
         run: |
           nix-shell \
             -I nixpkgs=./tools/nix/pkgs.nix \
-            --pure --keep LC_ALL --keep LANG \
+            --pure \
             -E '(import <nixpkgs> {}).mkShell { buildInputs = import ./tools/nix/benchmarkTools.nix { withHttpBenchmarkDeps = false; }; }' \
             --run '
+                export LC_ALL=C.UTF-8
                 echo "> [!WARNING] "
                 echo "> Do not take GHA benchmark results as face value, always confirm them"
                 echo "> using a dedicated machine, e.g. Jenkins CI."

--- a/tools/nix/benchmarkTools.nix
+++ b/tools/nix/benchmarkTools.nix
@@ -1,9 +1,11 @@
 {
   pkgs ? import ./pkgs.nix { },
+  withHttpBenchmarkDeps ? true,
 }:
 [
   pkgs.R
   pkgs.rPackages.ggplot2
   pkgs.rPackages.plyr
-  pkgs.wrk
 ]
+++ pkgs.lib.optional withHttpBenchmarkDeps pkgs.wrk
+++ pkgs.lib.optional pkgs.stdenv.buildPlatform.isLinux pkgs.glibcLocales


### PR DESCRIPTION
- it allows non-collaborators can run them on their forks.
- testing on different arch gives more relevant results.
- if folks want to run benchmarks on their own machine, I find it helpful to have a GHA workflow to copy to understand how to set it up.

Example of benchmark workflow: https://github.com/aduh95/node/actions/runs/26591497321

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
