### PR TITLE
test: split test-runner-watch-mode-kill-signal

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -913,20 +913,6 @@ function expectRequiredTLAError(err) {
   }
 }
 
-function skipIfNoWatchModeSignals() {
-  if (exports.isWindows) {
-    skip('no signals on Windows');
-  }
-
-  if (exports.isIBMi) {
-    skip('IBMi does not support `fs.watch()`');
-  }
-
-  if (exports.isAIX) {
-    skip('folder watch capability is limited in AIX.');
-  }
-}
-
 const common = {
   allowGlobals,
   buildType,
@@ -974,7 +960,6 @@ const common = {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
-  skipIfNoWatchModeSignals,
   skipIfSQLiteMissing,
   spawnPromisified,
 

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -46,7 +46,6 @@ const {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
-  skipIfNoWatchModeSignals,
   skipIfSQLiteMissing,
   spawnPromisified,
 } = common;
@@ -98,7 +97,6 @@ export {
   skipIf32Bits,
   skipIfEslintMissing,
   skipIfInspectorDisabled,
-  skipIfNoWatchModeSignals,
   skipIfSQLiteMissing,
   spawnPromisified,
 };

--- a/test/common/watch.js
+++ b/test/common/watch.js
@@ -1,0 +1,16 @@
+'use strict';
+const common = require('./index.js');
+
+exports.skipIfNoWatchModeSignals = function() {
+  if (common.isWindows) {
+    common.skip('no signals on Windows');
+  }
+
+  if (common.isIBMi) {
+    common.skip('IBMi does not support `fs.watch()`');
+  }
+
+  if (common.isAIX) {
+    common.skip('folder watch capability is limited in AIX.');
+  }
+};

--- a/test/parallel/test-watch-mode-kill-signal-default.mjs
+++ b/test/parallel/test-watch-mode-kill-signal-default.mjs
@@ -1,12 +1,13 @@
 // Test that the kill signal sent by --watch defaults to SIGTERM.
 
-import { skipIfNoWatchModeSignals } from '../common/index.mjs';
+import '../common/index.mjs';
 import assert from 'node:assert';
 import { writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import tmpdir from '../common/tmpdir.js';
 import fixtures from '../common/fixtures.js';
+import { skipIfNoWatchModeSignals } from '../common/watch.js';
 
 skipIfNoWatchModeSignals();
 

--- a/test/parallel/test-watch-mode-kill-signal-invalid.mjs
+++ b/test/parallel/test-watch-mode-kill-signal-invalid.mjs
@@ -1,11 +1,12 @@
 // Test that --watch-kill-signal errors when an invalid kill signal is provided.
 
-import { skipIfNoWatchModeSignals } from '../common/index.mjs';
+import '../common/index.mjs';
 import assert from 'node:assert';
 import { writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import tmpdir from '../common/tmpdir.js';
 import fixtures from '../common/fixtures.js';
+import { skipIfNoWatchModeSignals } from '../common/watch.js';
 
 skipIfNoWatchModeSignals();
 

--- a/test/parallel/test-watch-mode-kill-signal-override.mjs
+++ b/test/parallel/test-watch-mode-kill-signal-override.mjs
@@ -1,13 +1,14 @@
 // Test that the kill signal sent by --watch can be overridden to SIGINT
 // by using --watch-kill-signal.
 
-import { skipIfNoWatchModeSignals } from '../common/index.mjs';
+import '../common/index.mjs';
 import assert from 'node:assert';
 import { writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 import tmpdir from '../common/tmpdir.js';
 import fixtures from '../common/fixtures.js';
+import { skipIfNoWatchModeSignals } from '../common/watch.js';
 
 skipIfNoWatchModeSignals();
 


### PR DESCRIPTION
This test has been timing out in the CI with no information about why. Splitting it into multiple files to at least show which test case is timing out.

Drive-by: name the test as test-watch-mode-kill-signal-* as the tests aren't testing the test runner and are just testing --watch-kill-signal.

Refs: https://github.com/nodejs/node/issues/60297

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
