### PR TITLE
doc, assert: correct order of changes entries

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -342,6 +342,9 @@ An alias of [`assert.ok()`][].
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58849
+    description: Message may now be a `printf`-like format string or function.
   - version: v25.0.0
     pr-url: https://github.com/nodejs/node/pull/59448
     description: Promises are not considered equal anymore if they are not of
@@ -349,9 +352,6 @@ changes:
   - version: v25.0.0
     pr-url: https://github.com/nodejs/node/pull/57627
     description: Invalid dates are now considered equal.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/58849
-    description: Message may now be a `printf`-like format string or function.
   - version: v24.0.0
     pr-url: https://github.com/nodejs/node/pull/57622
     description: Recursion now stops when either side encounters a circular
@@ -545,6 +545,9 @@ parameter is an instance of {Error} then it will be thrown instead of the
 <!-- YAML
 added: v1.2.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/58849
+    description: Message may now be a `printf`-like format string or function.
   - version: v25.0.0
     pr-url: https://github.com/nodejs/node/pull/59448
     description: Promises are not considered equal anymore if they are not of
@@ -552,9 +555,6 @@ changes:
   - version: v25.0.0
     pr-url: https://github.com/nodejs/node/pull/57627
     description: Invalid dates are now considered equal.
-  - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/58849
-    description: Message may now be a `printf`-like format string or function.
   - version: v24.0.0
     pr-url: https://github.com/nodejs/node/pull/57622
     description: Recursion now stops when either side encounters a circular


### PR DESCRIPTION
This should repair the md lint github action.

```
doc/api/assert.md
342:1-402:4 warning Items in `changes` list are not in order nodejs-yaml-comments remark-lint
545:1-597:4 warning Items in `changes` list are not in order nodejs-yaml-comments remark-lint
```

see https://github.com/nodejs/node/actions/runs/18606813117/job/53057819563?pr=60302

Refs: #58849

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
