### PR TITLE
repl: tab completion targets `<class>`  instead of `new <class>`

### DIFF
--- a/lib/internal/repl/completion.js
+++ b/lib/internal/repl/completion.js
@@ -617,7 +617,7 @@ function findExpressionCompleteTarget(code) {
   // we want to extract the callee for completion (e.g. for `new Sample` we want `Sample`)
   if (lastBodyStatement.type === 'ExpressionStatement' &&
       lastBodyStatement.expression.type === 'NewExpression' &&
-      lastBodyStatement.expression.callee.type === 'Identifier') {
+      lastBodyStatement.expression.callee) {
     const callee = lastBodyStatement.expression.callee;
     const calleeCode = code.slice(callee.start, callee.end);
     return findExpressionCompleteTarget(calleeCode);

--- a/test/parallel/test-repl-tab-complete-new-expression.js
+++ b/test/parallel/test-repl-tab-complete-new-expression.js
@@ -10,7 +10,7 @@ const { describe, it } = require('node:test');
 // should be displayed as autocompletion result.
 
 describe('REPL tab completion with new expressions', () => {
-  it('should output completion of class properties', (_, done) => {
+  it('should output completion of class properties', () => {
     const { replServer, input } = startNewREPLServer({ terminal: false });
 
     input.run([
@@ -20,13 +20,22 @@ describe('REPL tab completion with new expressions', () => {
             `,
     ]);
 
+    // Handle completion for property of root class.
     replServer.complete(
       'new X.',
       common.mustSucceed((completions) => {
         assert.strictEqual(completions[1], 'X.');
-        replServer.close();
-        done();
       })
     );
+
+    // Handle completion for property with another class as value.
+    replServer.complete(
+      'new X.Y.',
+      common.mustSucceed((completions) => {
+        assert.strictEqual(completions[1], 'X.Y.');
+      })
+    );
+
+    replServer.close();
   });
 });


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Summary

Fixes #60306

I've modified the function `findExpressionCompleteTarget` to handle autocompletion for `new <class>` code by detecting proper identifiers and re-parse only for `<class>` identifier instead.

## Testing

- New test added: test/parallel/test-repl-tab-complete-new-expression.js
- Visual confirmation with expected correct behavior in linked issue

<img width="1096" height="231" alt="image" src="https://github.com/user-attachments/assets/8f1ead09-0854-471a-8cf0-2a9d88efebcd" />
