### PR TITLE
assert: optimize string length calculation in getSimpleDiff

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -149,21 +149,16 @@ function getStackedDiff(actual, expected) {
 }
 
 function getSimpleDiff(originalActual, actual, originalExpected, expected) {
-  let stringsLen = actual.length + expected.length;
+  const isStrA = typeof originalActual === 'string';
+  const isStrE = typeof originalExpected === 'string';
   // Accounting for the quotes wrapping strings
-  if (typeof originalActual === 'string') {
-    stringsLen -= 2;
-  }
-  if (typeof originalExpected === 'string') {
-    stringsLen -= 2;
-  }
+  const stringsLen = actual.length + expected.length - (isStrA ? 2 : 0) - (isStrE ? 2 : 0);
   if (stringsLen <= kMaxShortStringLength && (originalActual !== 0 || originalExpected !== 0)) {
     return { message: `${actual} !== ${expected}`, header: '' };
   }
 
-  const isStringComparison = typeof originalActual === 'string' && typeof originalExpected === 'string';
   // colored myers diff
-  if (isStringComparison && colors.hasColors) {
+  if (isStrA && isStrE && colors.hasColors) {
     return getColoredMyersDiff(actual, expected);
   }
 


### PR DESCRIPTION
Reduced redundant typeof operations by caching type checks
and simplified the string length calculation using ternary
operators for improved readability.