### PR TITLE
[v22.x backport] http2: fix allowHttp1+Upgrade, broken by shouldUpgradeCallback

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3379,6 +3379,9 @@ class Http2SecureServer extends TLSServer {
       this.headersTimeout = 60_000; // Minimum between 60 seconds or requestTimeout
       this.requestTimeout = 300_000; // 5 minutes
       this.connectionsCheckingInterval = 30_000; // 30 seconds
+      this.shouldUpgradeCallback = function() {
+        return this.listenerCount('upgrade') > 0;
+      };
       this.on('listening', setupConnectionsTracking);
     }
     if (typeof requestListener === 'function')

--- a/test/common/websocket-server.js
+++ b/test/common/websocket-server.js
@@ -1,0 +1,108 @@
+'use strict';
+const common = require('./index');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const http = require('http');
+const crypto = require('crypto');
+
+class WebSocketServer {
+  constructor({
+    port = 0,
+    server,
+  }) {
+    this.port = port;
+    this.server = server || http.createServer();
+    this.clients = new Set();
+
+    this.server.on('upgrade', this.handleUpgrade.bind(this));
+  }
+
+  start() {
+    return new Promise((resolve) => {
+      this.server.listen(this.port, () => {
+        this.port = this.server.address().port;
+        resolve();
+      });
+    }).catch((err) => {
+      console.error('Failed to start WebSocket server:', err);
+    });
+  }
+
+  handleUpgrade(req, socket, head) {
+    const key = req.headers['sec-websocket-key'];
+    const acceptKey = this.generateAcceptValue(key);
+    const responseHeaders = [
+      'HTTP/1.1 101 Switching Protocols',
+      'Upgrade: websocket',
+      'Connection: Upgrade',
+      `Sec-WebSocket-Accept: ${acceptKey}`,
+    ];
+
+    socket.write(responseHeaders.join('\r\n') + '\r\n\r\n');
+    this.clients.add(socket);
+
+    socket.on('data', (buffer) => {
+      const opcode = buffer[0] & 0x0f;
+
+      if (opcode === 0x8) {
+        // Send a minimal close frame in response:
+        socket.write(Buffer.from([0x88, 0x00]));
+        socket.end();
+        this.clients.delete(socket);
+        return;
+      }
+
+      socket.write(this.encodeMessage('Hello from server!'));
+    });
+
+    socket.on('close', () => {
+      this.clients.delete(socket);
+    });
+
+    socket.on('error', (err) => {
+      console.error('Socket error:', err);
+      this.clients.delete(socket);
+    });
+  }
+
+  generateAcceptValue(secWebSocketKey) {
+    return crypto
+      .createHash('sha1')
+      .update(secWebSocketKey + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', 'binary')
+      .digest('base64');
+  }
+
+  decodeMessage(buffer) {
+    const secondByte = buffer[1];
+    const length = secondByte & 127;
+    const maskStart = 2;
+    const dataStart = maskStart + 4;
+    const masks = buffer.slice(maskStart, dataStart);
+    const data = buffer.slice(dataStart, dataStart + length);
+    const result = Buffer.alloc(length);
+
+    for (let i = 0; i < length; i++) {
+      result[i] = data[i] ^ masks[i % 4];
+    }
+
+    return result.toString();
+  }
+
+  encodeMessage(message) {
+    const msgBuffer = Buffer.from(message);
+    const length = msgBuffer.length;
+    const frame = [0x81];
+
+    if (length < 126) {
+      frame.push(length);
+    } else if (length < 65536) {
+      frame.push(126, (length >> 8) & 0xff, length & 0xff);
+    } else {
+      throw new Error('Message too long');
+    }
+
+    return Buffer.concat([Buffer.from(frame), msgBuffer]);
+  }
+}
+
+module.exports = WebSocketServer;

--- a/test/parallel/test-http2-allow-http1-upgrade-ws.js
+++ b/test/parallel/test-http2-allow-http1-upgrade-ws.js
@@ -1,0 +1,39 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const http2 = require('http2');
+
+const undici = require('internal/deps/undici/undici');
+const WebSocketServer = require('../common/websocket-server');
+
+(async function main() {
+  const server = http2.createSecureServer({
+    key: fixtures.readKey('agent1-key.pem'),
+    cert: fixtures.readKey('agent1-cert.pem'),
+    allowHTTP1: true,
+  });
+
+  server.on('request', common.mustNotCall());
+  new WebSocketServer({ server }); // Handles websocket 'upgrade' events
+
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  await new Promise((resolve, reject) => {
+    const ws = new WebSocket(`wss://localhost:${server.address().port}`, {
+      dispatcher: new undici.EnvHttpProxyAgent({
+        connect: { rejectUnauthorized: false }
+      })
+    });
+    ws.addEventListener('open', common.mustCall(() => {
+      ws.close();
+      resolve();
+    }));
+    ws.addEventListener('error', reject);
+  });
+
+  server.close();
+})().then(common.mustCall());


### PR DESCRIPTION
Backport for #59924.

This also backports the corresponding full code for the websocket test server into the tests. That was introduced in https://github.com/nodejs/node/pull/59404 (which is marked dont-land-on-v22) but it's required for the tests for this change.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
