### PR TITLE
src: remove unconditional NAPI_EXPERIMENTAL in node.h

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -890,6 +890,9 @@
         'NODE_ARCH="<(target_arch)"',
         'NODE_PLATFORM="<(OS)"',
         'NODE_WANT_INTERNALS=1',
+        # Define NAPI_EXPERIMENTAL to enable Node-API experimental function symbols being exposed.
+        'NAPI_EXPERIMENTAL=1',
+        'NODE_API_EXPERIMENTAL_NO_WARNING=1',
         # Warn when using deprecated V8 APIs.
         'V8_DEPRECATION_WARNINGS=1',
         'NODE_OPENSSL_SYSTEM_CERT_PATH="<(openssl_system_ca_path)"',

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <climits>  // INT_MAX
 #include <cmath>
+#ifndef NAPI_EXPERIMENTAL
 #define NAPI_EXPERIMENTAL
+#endif
 #include "env-inl.h"
 #include "js_native_api.h"
 #include "js_native_api_v8.h"

--- a/src/node.h
+++ b/src/node.h
@@ -76,7 +76,6 @@
 #include "v8-platform.h"  // NOLINT(build/include_order)
 #include "node_version.h"  // NODE_MODULE_VERSION
 
-#define NAPI_EXPERIMENTAL
 #include "node_api.h"
 
 #include <functional>

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -1,7 +1,9 @@
 #include "async_context_frame.h"
 #include "async_wrap-inl.h"
 #include "env-inl.h"
+#ifndef NAPI_EXPERIMENTAL
 #define NAPI_EXPERIMENTAL
+#endif
 #include "js_native_api_v8.h"
 #include "memory_tracker-inl.h"
 #include "node_api.h"

--- a/src/node_api_internals.h
+++ b/src/node_api_internals.h
@@ -2,7 +2,9 @@
 #define SRC_NODE_API_INTERNALS_H_
 
 #include "v8.h"
+#ifndef NAPI_EXPERIMENTAL
 #define NAPI_EXPERIMENTAL
+#endif
 #include "env-inl.h"
 #include "js_native_api_v8.h"
 #include "node_api.h"

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -8,7 +8,6 @@
 #endif
 
 #include "node.h"
-#define NAPI_EXPERIMENTAL
 #include "node_api.h"
 #include "quic/guard.h"
 #include "uv.h"


### PR DESCRIPTION
Including `node.h` should not enable `NAPI_EXPERIMENTAL` by default.

Fixes: https://github.com/nodejs/node/issues/60311