### PR TITLE
http: use object destructuring in createConnection

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -229,9 +229,7 @@ Agent.defaultMaxSockets = Infinity;
 // See ProxyConfig in internal/http.js for how the connection should be handled
 // when the agent is configured to use a proxy server.
 Agent.prototype.createConnection = function createConnection(...args) {
-  const normalized = net._normalizeArgs(args);
-  const options = normalized[0];
-  const cb = normalized[1];
+  const { 0: options, 1: cb } = net._normalizeArgs(args);
 
   // Check if this specific request should bypass the proxy
   const shouldUseProxy = checkShouldUseProxy(this[kProxyConfig], options);


### PR DESCRIPTION
Use object destructuring with numeric keys to directly extract
options and callback from net._normalizeArgs() result, eliminating
the intermediate normalized variable.