### PR TITLE
http: simplify getName with destructuring and template literals

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -259,23 +259,16 @@ Agent.prototype.createConnection = function createConnection(...args) {
 
 // Get the key for a given set of request options
 Agent.prototype.getName = function getName(options = kEmptyObject) {
-  let name = options.host || 'localhost';
-
-  name += ':';
-  if (options.port)
-    name += options.port;
-
-  name += ':';
-  if (options.localAddress)
-    name += options.localAddress;
+  const { host = 'localhost', port, localAddress, family, socketPath } = options;
+  let name = `${host}:${port || ''}:${localAddress || ''}`;
 
   // Pacify parallel/test-http-agent-getname by only appending
   // the ':' when options.family is set.
-  if (options.family === 4 || options.family === 6)
-    name += `:${options.family}`;
+  if (family === 4 || family === 6)
+    name += `:${family}`;
 
-  if (options.socketPath)
-    name += `:${options.socketPath}`;
+  if (socketPath)
+    name += `:${socketPath}`;
 
   return name;
 };


### PR DESCRIPTION
Use object destructuring to extract options properties and template
literals to construct the name string, improving code readability
and reducing intermediate string concatenations.