### PR TITLE
build: ibmi follow aix visibility

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -50,7 +50,7 @@
       # including unnecessary internal symbols, which may lead to run-time fixups.
       # This is not done on AIX where symbols are exported by tools/create_expfile.sh
       # see https://github.com/nodejs/node/pull/56290#issuecomment-2582703109
-      ['OS!="aix"', {
+      ['OS!="aix" and OS!="os400"', {
         'defines': [
           'BUILDING_V8_SHARED',  # Make V8_EXPORT visible.
         ]
@@ -65,7 +65,7 @@
           'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
           'GCC_INLINES_ARE_PRIVATE_EXTERN': 'YES'  # -fvisibility-inlines-hidden
         },
-      }, 'OS!="aix" and (OS!="win" or clang==1)', {
+      }, '(OS!="aix" and OS!="os400") and (OS!="win" or clang==1)', {
         'cflags': [
           '-fvisibility=hidden',
           '-fvisibility-inlines-hidden'


### PR DESCRIPTION
After this commit - https://github.com/nodejs/node/commit/3437e1c4bd529e51d96ea581b6435bbeb77ef524
we are getting the following error on IBM i

Error:
```
ld: 0711-407 ERROR: Symbol _ZNKSt5ctypeIcE8do_widenEc
Visibility is not allowed on a reference to an imported symbol.
```

and IBM i follow AIX visibility.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->