### PR TITLE
src: allow disabling JS source phase imports

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -780,7 +780,10 @@ static ExitCode ProcessGlobalArgsInternal(std::vector<std::string>* args,
     env_opts->abort_on_uncaught_exception = true;
   }
 
-  v8_args.emplace_back("--js-source-phase-imports");
+  if (std::ranges::find(v8_args, "--no-js-source-phase-imports") ==
+      v8_args.end()) {
+    v8_args.emplace_back("--js-source-phase-imports");
+  }
 
 #ifdef __POSIX__
   // Block SIGPROF signals when sleeping in epoll_wait/kevent/etc.  Avoids the


### PR DESCRIPTION
Refs:
  - https://chromium-review.googlesource.com/c/v8/v8/+/7003082
  - https://chromium-review.googlesource.com/c/chromium/src/+/6336964
  - https://github.com/nodejs/node/pull/56919

Electron need to disable source phase imports in renderer and worker processes - Chromium disables them in [`content/renderer/render_process_impl.cc`](https://source.chromium.org/chromium/chromium/src/+/main:content/renderer/render_process_impl.cc;l=166-168?q=content%2Frenderer%2Frender_process_impl.cc&sq=package:chromium) and the process will hard crash otherwise.
 
Happy to move this to a different place if there's a better suggestion!
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
