### PR TITLE
test: increase debugger waitFor timeout on macOS

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -8,7 +8,7 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
 ].join('|') + ') in', 'i');
 
 let TIMEOUT = common.platformTimeout(10000);
-// Some macOS  and Windows machines require more time to receive the outputs from the client.
+// Some macOS and Windows machines require more time to receive the outputs from the client.
 // https://github.com/nodejs/build/issues/3014
 if (common.isWindows || common.isMacOS) {
   TIMEOUT = common.platformTimeout(15000);


### PR DESCRIPTION
`test/parallel/test-debugger-exceptions.js` is flaky on macOS in GitHub Action workflow.
Increase the timeout to reduce the flakyness.

Refs: https://github.com/nodejs/node/actions/runs/18694915575/job/53309761263?pr=60343