### PR TITLE
build: update android-patches/trap-handler.h.patch

### DIFF
--- a/android-patches/trap-handler.h.patch
+++ b/android-patches/trap-handler.h.patch
@@ -1,26 +1,47 @@
---- trap-handler.h	2022-08-11 09:01:23.384000000 +0800
-+++ fixed-trap-handler.h	2022-08-11 09:09:15.352000000 +0800
-@@ -17,23 +17,7 @@
- namespace internal {
- namespace trap_handler {
- 
+--- trap-handler.h
++++ fixed-trap-handler.h
+@@ -18,43 +18,1 @@
 -// X64 on Linux, Windows, MacOS, FreeBSD.
 -#if V8_HOST_ARCH_X64 && V8_TARGET_ARCH_X64 &&                        \
 -    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN || \
 -     V8_OS_FREEBSD)
 -#define V8_TRAP_HANDLER_SUPPORTED true
--// Arm64 (non-simulator) on Mac.
--#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && V8_OS_DARWIN
+-// Arm64 native on Linux, Windows, MacOS.
+-#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_ARM64 && \
+-    ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_WIN || V8_OS_DARWIN)
 -#define V8_TRAP_HANDLER_SUPPORTED true
+-// For Linux and Mac, enable the simulator when it's been requested.
+-#if USE_SIMULATOR && ((V8_OS_LINUX && !V8_OS_ANDROID) || V8_OS_DARWIN)
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#endif
 -// Arm64 simulator on x64 on Linux, Mac, or Windows.
+-//
+-// The simulator case uses some inline assembly code, which cannot be
+-// compiled with MSVC, so don't enable the trap handler in that case.
+-// (MSVC #defines _MSC_VER, but so does Clang when targeting Windows, hence
+-// the check for __clang__.)
 -#elif V8_TARGET_ARCH_ARM64 && V8_HOST_ARCH_X64 && \
--    (V8_OS_LINUX || V8_OS_DARWIN)
+-    (V8_OS_LINUX || V8_OS_DARWIN || V8_OS_WIN) && \
+-    (!defined(_MSC_VER) || defined(__clang__))
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Loong64 (non-simulator) on Linux.
+-#elif V8_TARGET_ARCH_LOONG64 && V8_HOST_ARCH_LOONG64 && V8_OS_LINUX
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// Loong64 simulator on x64 on Linux
+-#elif V8_TARGET_ARCH_LOONG64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
+-#define V8_TRAP_HANDLER_VIA_SIMULATOR
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// RISCV64 (non-simulator) on Linux.
+-#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_RISCV64 && V8_OS_LINUX && \
+-    !V8_OS_ANDROID
+-#define V8_TRAP_HANDLER_SUPPORTED true
+-// RISCV64 simulator on x64 on Linux
+-#elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
 -#define V8_TRAP_HANDLER_VIA_SIMULATOR
 -#define V8_TRAP_HANDLER_SUPPORTED true
 -// Everything else is unsupported.
 -#else
- #define V8_TRAP_HANDLER_SUPPORTED false
+-#define V8_TRAP_HANDLER_SUPPORTED false
 -#endif
- 
- // Setup for shared library export.
- #if defined(BUILDING_V8_SHARED) && defined(V8_OS_WIN)
++#define V8_TRAP_HANDLER_SUPPORTED false


### PR DESCRIPTION
When compiling the Android static library, I found that the patch file `trap-handler.h.patch` was outdated: 
```
ubuntu:~/work/node$ ./android-configure patch
Node.js android configure: Found Python 3.12.3...
- Patches List -
[1] [deps/v8/src/trap-handler/trap-handler.h] related to https://github.com/nodejs/node/issues/36287
patching file ./deps/v8/src/trap-handler/trap-handler.h
patch unexpectedly ends in middle of line
Hunk #1 FAILED at 17.
1 out of 1 hunk FAILED -- saving rejects to file ./deps/v8/src/trap-handler/trap-handler.h.rej
Info: Tried to patch.
```

To ensure that `./android-configure patch` runs correctly, I updated this file.