### PR TITLE
buffer: add early return for zero-length concat calls

### DIFF
--- a/benchmark/buffers/buffer-concat.js
+++ b/benchmark/buffers/buffer-concat.js
@@ -3,7 +3,7 @@ const common = require('../common.js');
 
 const bench = common.createBenchmark(main, {
   pieces: [4, 16],
-  pieceSize: [1, 16, 256],
+  pieceSize: [0, 1, 16, 256],
   withTotalLength: [0, 1],
   n: [8e5],
 });

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -590,6 +590,9 @@ Buffer.concat = function concat(list, length) {
     validateOffset(length, 'length');
   }
 
+  if (length === 0)
+    return new FastBuffer();
+
   const buffer = Buffer.allocUnsafe(length);
   let pos = 0;
   for (let i = 0; i < list.length; i++) {


### PR DESCRIPTION
This PR adds an early return for when the passed list to `concat` has buffers with length 0, it increases the speed of this specific case significantly while not having a significant effect on other cases, the check is done once

Before
```sh
buffers/buffer-concat.js
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=0 pieces=4: 21,154,950.27952036
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=0 pieces=4: 19,196,794.135379393
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=4: 6,989,916.337953473
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=4: 6,865,887.074369392
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=4: 6,721,592.326401666
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=4: 6,556,017.96516101
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=4: 4,483,340.537034144
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=4: 4,402,483.275722712
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=0 pieces=16: 11,026,637.420164905
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=0 pieces=16: 11,842,107.639370283
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=16: 2,236,282.0692457757
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=16: 2,303,720.328352138
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=16: 2,131,347.3893047236
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=16: 2,188,456.664168826
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=16: 990,001.0414563456
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=16: 1,006,497.9406397911
```

After
```sh
buffers/buffer-concat.js
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=0 pieces=4: 29,413,341.347488407 +
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=0 pieces=4: 29,923,787.106618155 +
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=4: 6,840,184.125444326
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=4: 6,860,703.071986998
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=4: 6,595,750.911730649
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=4: 6,687,702.724123686
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=4: 4,516,053.166206851
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=4: 4,397,381.275899957
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=0 pieces=16: 22,975,191.35965086 +
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=0 pieces=16: 29,982,993.646003988 +
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=16: 2,235,451.225159163
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=16: 2,262,244.3089532913
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=16: 2,131,322.3142175823
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=16: 2,163,427.3286168366
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=16: 995,333.8537428093
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=16: 991,416.6050230672
```