### PR TITLE
Add CJS/ESM variants to sqlite documentation where missing

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -563,7 +563,29 @@ added:
 An exception is thrown if the database is not
 open. This method is a wrapper around [`sqlite3changeset_apply()`][].
 
-```js
+```mjs
+import { DatabaseSync } from 'node:sqlite';
+
+const sourceDb = new DatabaseSync(':memory:');
+const targetDb = new DatabaseSync(':memory:');
+
+sourceDb.exec('CREATE TABLE data(key INTEGER PRIMARY KEY, value TEXT)');
+targetDb.exec('CREATE TABLE data(key INTEGER PRIMARY KEY, value TEXT)');
+
+const session = sourceDb.createSession();
+
+const insert = sourceDb.prepare('INSERT INTO data (key, value) VALUES (?, ?)');
+insert.run(1, 'hello');
+insert.run(2, 'world');
+
+const changeset = session.changeset();
+targetDb.applyChangeset(changeset);
+// Now that the changeset has been applied, targetDb contains the same data as sourceDb.
+```
+
+```cjs
+const { DatabaseSync } = require('node:sqlite');
+
 const sourceDb = new DatabaseSync(':memory:');
 const targetDb = new DatabaseSync(':memory:');
 


### PR DESCRIPTION
Make sure all the functions documented in sqlite's documentation have CJS/ESM variants:

This PR includes:

- Adding a CJS variant for `createTagStore` 
- Separating `applyChangeset`'s code snippet to CJS and ESM variants and adding the missing `import`/`require` of `DatabaseSync` to them so it's executable without having to manually modify it.

Refs: https://github.com/nodejs/node/issues/60394