### PR TITLE
buffer: inline copyImpl

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -786,8 +786,6 @@ ObjectDefineProperty(Buffer.prototype, 'offset', {
 });
 
 Buffer.prototype.copy = function copy(target, targetStart, sourceStart, sourceEnd) {
-  if (!ArrayBufferIsView(this))
-    throw new ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], this);
   if (!ArrayBufferIsView(target))
     throw new ERR_INVALID_ARG_TYPE('target', ['Buffer', 'Uint8Array'], target);
 


### PR DESCRIPTION
`copyImpl` is only used here, and removing the extra function call speeds up the `copy` benchmarks locally, we might need to confirm with a CI benchmark

After:

```sh
./node benchmark/run.js --filter buffer-copy buffers
buffers/buffer-copy.js
buffers/buffer-copy.js n=6000000 partial="true" bytes=8: 40,825,618.66360032
buffers/buffer-copy.js n=6000000 partial="false" bytes=8: 41,791,921.40845294
buffers/buffer-copy.js n=6000000 partial="true" bytes=128: 40,704,446.8970532
buffers/buffer-copy.js n=6000000 partial="false" bytes=128: 38,294,338.26186785
buffers/buffer-copy.js n=6000000 partial="true" bytes=1024: 27,828,082.06061716
buffers/buffer-copy.js n=6000000 partial="false" bytes=1024: 24,339,227.99011219
```

Before:

```sh
./node benchmark/run.js --filter buffer-copy buffers
buffers/buffer-copy.js
buffers/buffer-copy.js n=6000000 partial="true" bytes=8: 39,895,661.939214684
buffers/buffer-copy.js n=6000000 partial="false" bytes=8: 40,859,281.86584237
buffers/buffer-copy.js n=6000000 partial="true" bytes=128: 39,967,670.68408592
buffers/buffer-copy.js n=6000000 partial="false" bytes=128: 37,919,704.05339453
buffers/buffer-copy.js n=6000000 partial="true" bytes=1024: 27,719,259.341390397
buffers/buffer-copy.js n=6000000 partial="false" bytes=1024: 23,589,654.098257538
```