### PR TITLE
buffer: return fastbuffer directly instead of buffer.alloc(0)

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -348,13 +348,13 @@ Buffer.copyBytesFrom = function copyBytesFrom(view, offset, length) {
 
   const viewLength = TypedArrayPrototypeGetLength(view);
   if (viewLength === 0) {
-    return Buffer.alloc(0);
+    return new FastBuffer();
   }
 
   if (offset !== undefined || length !== undefined) {
     if (offset !== undefined) {
       validateInteger(offset, 'offset', 0);
-      if (offset >= viewLength) return Buffer.alloc(0);
+      if (offset >= viewLength) return new FastBuffer();
     } else {
       offset = 0;
     }
@@ -1257,7 +1257,7 @@ if (internalBinding('config').hasIntl) {
       throw new ERR_INVALID_ARG_TYPE('source',
                                      ['Buffer', 'Uint8Array'], source);
     }
-    if (source.length === 0) return Buffer.alloc(0);
+    if (source.length === 0) return new FastBuffer();
 
     fromEncoding = normalizeEncoding(fromEncoding) || fromEncoding;
     toEncoding = normalizeEncoding(toEncoding) || toEncoding;


### PR DESCRIPTION
As in [other](https://github.com/nodejs/node/blob/2bda7cbfb62778bd793fbceaa9a5a907c3d344be/lib/buffer.js#L522) [places](https://github.com/nodejs/node/blob/2bda7cbfb62778bd793fbceaa9a5a907c3d344be/lib/buffer.js#L580) [here](https://github.com/nodejs/node/blob/2bda7cbfb62778bd793fbceaa9a5a907c3d344be/lib/buffer.js#L538), we don't need to call `Buffer.alloc(0)`, which [validates the length and calls FastBuffer anyway](https://github.com/nodejs/node/blob/2bda7cbfb62778bd793fbceaa9a5a907c3d344be/lib/buffer.js#L399-L406)

This bypasses the validation logic and is consequently faster