### PR TITLE
tools: do not use short hashes for deps versioning to avoid collision

### DIFF
--- a/tools/dep_updaters/update-googletest.sh
+++ b/tools/dep_updaters/update-googletest.sh
@@ -86,4 +86,4 @@ echo "$NEW_GYP" >"$DEPS_DIR/googletest/googletest.gyp"
 # Update the version number on maintaining-dependencies.md
 # and print the new version as the last line of the script as we need
 # to add it to $GITHUB_ENV variable
-finalize_version_update "googletest" "$NEW_VERSION"
+finalize_version_update "googletest" "$NEW_UPSTREAM_SHA1"

--- a/tools/dep_updaters/update-nixpkgs-pin.sh
+++ b/tools/dep_updaters/update-nixpkgs-pin.sh
@@ -8,16 +8,15 @@ NIXPKGS_PIN_FILE="$BASE_DIR/tools/nix/pkgs.nix"
 
 NIXPKGS_REPO=$(grep 'repo =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
 CURRENT_VERSION_SHA1=$(grep 'rev =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
-CURRENT_VERSION=$(echo "$CURRENT_VERSION_SHA1" | head -c 7)
 
 NEW_UPSTREAM_SHA1=$(git ls-remote "$NIXPKGS_REPO.git" nixpkgs-unstable | awk '{print $1}')
-NEW_VERSION=$(echo "$NEW_UPSTREAM_SHA1" | head -c 7)
+NEW_VERSION=$(echo "$NEW_UPSTREAM_SHA1" | head -c 35)
 
 
 # shellcheck disable=SC1091
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
-compare_dependency_version "nixpkgs-unstable" "$NEW_VERSION" "$CURRENT_VERSION"
+compare_dependency_version "nixpkgs-unstable" "$CURRENT_VERSION_SHA1" "$NEW_UPSTREAM_SHA1"
 
 CURRENT_TARBALL_HASH=$(grep 'sha256 =' "$NIXPKGS_PIN_FILE" | awk -F'"' '{ print $2 }')
 NEW_TARBALL_HASH=$(nix-prefetch-url --unpack "$NIXPKGS_REPO/archive/$NEW_UPSTREAM_SHA1.tar.gz")


### PR DESCRIPTION
Limiting to 7 char feels a bit arbitrary, and leads to GH sometimes linking to a commit on nodejs/node completely unrelated to the dependency update.
I didn't do it for zlib since we're using the string in `node`, that could have unforeseen side effects.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
