### PR TITLE
Improve UX: keep sidebar module visible when navigating docs

### DIFF
--- a/doc/api_assets/api.js
+++ b/doc/api_assets/api.js
@@ -188,15 +188,15 @@
   }
 
   function setupSidebarScroll() {
-    const sidebar = document.querySelector('#column2');
-    if (!sidebar) return;
+    const sidebarLinks = document.querySelectorAll('#column2 a');
 
-    const currentModule = window.location.pathname.split('/').pop();
-    if (!currentModule) return;
+    let link;
+    for (link of sidebarLinks) {
+      if (link.pathname === window.location.pathname) break;
+    }
 
-    const link = sidebar.querySelector(`a[href="${currentModule}"]`);
     if (!link) return;
-    
+
     link.scrollIntoView({ block: 'center' });
   }
 


### PR DESCRIPTION
This PR **improves the user experience** of the navigation sidebar in the documentation.

Previously, clicking on a module in the sidebar would navigate to its page, but the sidebar 
scroll would reset to the top. Now, the sidebar automatically scrolls to keep the selected 
module in view, making it easier to navigate between modules without having to scroll manually!

In case it's not clear, here's an example: if you clicked on the _“Web Crypto”_ module, it took you to 
its page, but the sidebar scroll returned to the top. Then, to access the next module, _“Web Stream”_,
you had to manually scroll to its position in the sidebar.