### PR TITLE
deps: V8: backport fe81545e6d14

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.9',
+    'v8_embedder_string': '-node.10',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-statistics.h
+++ b/deps/v8/include/v8-statistics.h
@@ -155,6 +155,13 @@ class V8_EXPORT HeapStatistics {
   size_t number_of_detached_contexts() { return number_of_detached_contexts_; }
 
   /**
+   * Returns the total number of bytes allocated since the Isolate was created.
+   * This includes all heap objects allocated in any space (new, old, code,
+   * etc.).
+   */
+  uint64_t total_allocated_bytes() { return total_allocated_bytes_; }
+
+  /**
    * Returns a 0/1 boolean, which signifies whether the V8 overwrite heap
    * garbage with a bit pattern.
    */
@@ -175,6 +182,7 @@ class V8_EXPORT HeapStatistics {
   size_t number_of_detached_contexts_;
   size_t total_global_handles_size_;
   size_t used_global_handles_size_;
+  uint64_t total_allocated_bytes_;
 
   friend class V8;
   friend class Isolate;

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -6557,7 +6557,8 @@ HeapStatistics::HeapStatistics()
       peak_malloced_memory_(0),
       does_zap_garbage_(false),
       number_of_native_contexts_(0),
-      number_of_detached_contexts_(0) {}
+      number_of_detached_contexts_(0),
+      total_allocated_bytes_(0) {}
 
 HeapSpaceStatistics::HeapSpaceStatistics()
     : space_name_(nullptr),
@@ -10411,6 +10412,7 @@ void Isolate::GetHeapStatistics(HeapStatistics* heap_statistics) {
   heap_statistics->number_of_native_contexts_ = heap->NumberOfNativeContexts();
   heap_statistics->number_of_detached_contexts_ =
       heap->NumberOfDetachedContexts();
+  heap_statistics->total_allocated_bytes_ = heap->GetTotalAllocatedBytes();
   heap_statistics->does_zap_garbage_ = i::heap::ShouldZapGarbage();
 
 #if V8_ENABLE_WEBASSEMBLY

--- a/deps/v8/src/heap/heap-allocator.cc
+++ b/deps/v8/src/heap/heap-allocator.cc
@@ -85,25 +85,42 @@ AllocationResult HeapAllocator::AllocateRawLargeInternal(
     int size_in_bytes, AllocationType allocation, AllocationOrigin origin,
     AllocationAlignment alignment, AllocationHint hint) {
   DCHECK_GT(size_in_bytes, heap_->MaxRegularHeapObjectSize(allocation));
+  AllocationResult allocation_result;
   switch (allocation) {
     case AllocationType::kYoung:
-      return new_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      allocation_result =
+          new_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kOld:
-      return lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      allocation_result =
+          lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kCode:
-      return code_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      allocation_result =
+          code_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kSharedOld:
-      return shared_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      allocation_result =
+          shared_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kTrusted:
-      return trusted_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      allocation_result =
+          trusted_lo_space()->AllocateRaw(local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kSharedTrusted:
-      return shared_trusted_lo_space()->AllocateRaw(local_heap_, size_in_bytes,
-                                                    hint);
+      allocation_result = shared_trusted_lo_space()->AllocateRaw(
+          local_heap_, size_in_bytes, hint);
+      break;
     case AllocationType::kMap:
     case AllocationType::kReadOnly:
     case AllocationType::kSharedMap:
       UNREACHABLE();
   }
+  if (!allocation_result.IsFailure()) {
+    int allocated_size = ALIGN_TO_ALLOCATION_ALIGNMENT(size_in_bytes);
+    heap_->AddTotalAllocatedBytes(allocated_size);
+  }
+  return allocation_result;
 }
 
 namespace {

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -7839,6 +7839,10 @@ int Heap::NextStackTraceId() {
   return last_id;
 }
 
+uint64_t Heap::GetTotalAllocatedBytes() {
+  return total_allocated_bytes_.load(std::memory_order_relaxed);
+}
+
 EmbedderStackStateScope::EmbedderStackStateScope(
     Heap* heap, EmbedderStackStateOrigin origin, StackState stack_state)
     : heap_(heap),

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -1703,6 +1703,11 @@ class Heap final {
   bool ShouldUseBackgroundThreads() const;
   bool ShouldUseIncrementalMarking() const;
 
+  void AddTotalAllocatedBytes(size_t size) {
+    total_allocated_bytes_.fetch_add(size, std::memory_order_relaxed);
+  }
+  uint64_t GetTotalAllocatedBytes();
+
   HeapAllocator* allocator() { return heap_allocator_; }
   const HeapAllocator* allocator() const { return heap_allocator_; }
 
@@ -2497,6 +2502,8 @@ class Heap final {
   // The amount of physical memory on the device passed in by the embedder. If
   // no value was provided this will be 0.
   uint64_t physical_memory_;
+
+  std::atomic<uint64_t> total_allocated_bytes_ = 0;
 
 #if defined(V8_USE_PERFETTO)
   perfetto::NamedTrack tracing_track_;

--- a/deps/v8/src/heap/main-allocator.cc
+++ b/deps/v8/src/heap/main-allocator.cc
@@ -297,6 +297,12 @@ void MainAllocator::ResetLab(Address start, Address end, Address extended_end) {
     MemoryChunkMetadata::UpdateHighWaterMark(top());
   }
 
+  // This is going to overestimate a bit of the total allocated bytes, since the
+  // LAB was not used yet. However the leftover compared to the LAB itself is
+  // quite small, so it seems tolerable.
+  if (local_heap_) {
+    local_heap_->heap()->AddTotalAllocatedBytes(end - start);
+  }
   allocation_info().Reset(start, end);
   extended_limit_ = extended_end;
 


### PR DESCRIPTION
The idea is to back port this commit to also expose Total Allocated bytes in V8's HeapStatistics API.

Original commit message:

    [api] Adding total allocated bytes in HeapStatistics

    This change exposes total allocated bytes in v8::HeapStatistics API by
    introducing a new total_allocated_bytes() method that tracks all heap
    allocations since an Isolate creation.

    The implementation adds:
    - uint64_t total_allocated_bytes_ field to HeapStatistics.
    - An atomic total allocation counter is stored in the Heap class.
    - The counter is incremented whenever a RestLab is called. This approach can overestimate the total allocation for cases where the LAB is not fully used, but the leftover compared to the LAB itself is quite small, so it seems tolerable.

    Design doc reference:
    https://docs.google.com/document/d/1O4JPsoaxTQsX_7T5Fz4rsGeHMiM16jUrvDuq9FrtbNM

    Change-Id: Ic531698aaeb1578f943b7fdd346b9159ffd9b6c9
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6996467
    Reviewed-by: Dominik Inführ <dinfuehr@chromium.org>
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Commit-Queue: Dmitry Bezhetskov <dima00782@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#103296}

Refs: https://github.com/v8/v8/commit/fe81545e6d14397cabb39ba3a5163eedf7624bb1
