### PR TITLE
[v24.x] deps: patch npm/tar to not return uninitialized mem

### DIFF
--- a/deps/npm/node_modules/tar/dist/esm/list.js
+++ b/deps/npm/node_modules/tar/dist/esm/list.js
@@ -52,8 +52,8 @@ const listFileSync = (opt) => {
         const readSize = opt.maxReadSize || 16 * 1024 * 1024;
         if (stat.size < readSize) {
             const buf = Buffer.allocUnsafe(stat.size);
-            fs.readSync(fd, buf, 0, stat.size, 0);
-            p.end(buf);
+            const bytesRead = fs.readSync(fd, buf, 0, stat.size, 0);
+            p.end(buf.subarray(0, bytesRead));
         }
         else {
             let pos = 0;


### PR DESCRIPTION
This goes against the npm update procedure but we don't have much time before LTS to revert zero-filling to wait for https://github.com/isaacs/node-tar/pull/446, `tar` and `npm` releases

An alternative is to force `.alloc` instead of `.allocUnsafe` there

Refs:
 * #60423
 * #60414
 * https://github.com/isaacs/node-tar/pull/446
 * https://github.com/isaacs/node-tar/issues/445
 * https://github.com/isaacs/node-tar/commit/5330eb04bc43014f216e5c271b40d5c00d45224d
 * https://github.com/isaacs/node-tar/pull/444

