### PR TITLE
tools: skip running test-shared on deps changes

### DIFF
--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -6,6 +6,22 @@ on:
       - .mailmap
       - '**.md'
       - AUTHORS
+      - deps/ada/**
+      - deps/brotli/**
+      - deps/cares/**
+      - deps/corepack/**
+      - deps/icu-small/**
+      - deps/icu-tmp/**
+      - deps/llhttp/**
+      - deps/nghttp2/**
+      - deps/ngtcp2/**
+      - deps/openssl/*/**
+      - deps/simdjson/**
+      - deps/sqlite/**
+      - deps/uv/**
+      - deps/uvwasi/**
+      - deps/zlib/**
+      - deps/zstd/**
       - doc/**
       - .github/**
       - '!.github/workflows/test-shared.yml'
@@ -20,6 +36,22 @@ on:
       - .mailmap
       - '**.md'
       - AUTHORS
+      - deps/ada/**
+      - deps/brotli/**
+      - deps/cares/**
+      - deps/corepack/**
+      - deps/icu-small/**
+      - deps/icu-tmp/**
+      - deps/llhttp/**
+      - deps/nghttp2/**
+      - deps/ngtcp2/**
+      - deps/openssl/*/**
+      - deps/simdjson/**
+      - deps/sqlite/**
+      - deps/uv/**
+      - deps/uvwasi/**
+      - deps/zlib/**
+      - deps/zstd/**
       - doc/**
       - .github/**
       - '!.github/workflows/test-shared.yml'


### PR DESCRIPTION
Running `test-shared.yml` for changes on folder that it doesn't use is pointless, it can't affect it as those do not even make it to the slim tarball it uses: https://github.com/nodejs/node/blob/617622211f38b802fe9082da59a5b2246bedf1ed/Makefile#L1221-L1239


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
