### PR TITLE
stream: add Readable.readv

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -641,8 +641,16 @@ function howMuchToRead(n, state) {
   return (state[kState] & kEnded) !== 0 ? state.length : 0;
 }
 
+Readable.prototype.readv = function readv () {
+  return _read.call(this, true);
+};
+
+Readable.prototype.read = function read () {
+  return _read.call(this, false);
+}
+
 // You can override either this method, or the async _read(n) below.
-Readable.prototype.read = function(n) {
+function _read (n, returnArr) {
   debug('read', n);
   // Same as parseInt(undefined, 10), however V8 7.3 performance regressed
   // in this scenario, so we are doing it manually.
@@ -748,7 +756,7 @@ Readable.prototype.read = function(n) {
 
   let ret;
   if (n > 0)
-    ret = fromList(n, state);
+    ret = returnArr ? arrFromList(n, state) : fromList(n, state);
   else
     ret = null;
 
@@ -777,7 +785,13 @@ Readable.prototype.read = function(n) {
 
   if (ret !== null && (state[kState] & (kErrorEmitted | kCloseEmitted)) === 0) {
     state[kState] |= kDataEmitted;
-    this.emit('data', ret);
+    if (returnArr) {
+      for (let i = 0; i < ret.length; ++i) {
+        this.emit('data', ret[i]);
+      }
+    } else {
+      this.emit('data', ret);
+    }
   }
 
   return ret;
@@ -1662,6 +1676,82 @@ function fromList(n, state) {
           buf[idx++] = null;
         } else {
           TypedArrayPrototypeSet(ret, new FastBuffer(data.buffer, data.byteOffset, n), retLen - n);
+          buf[idx] = new FastBuffer(data.buffer, data.byteOffset + n, data.length - n);
+        }
+        break;
+      }
+    }
+  }
+
+  if (idx === len) {
+    state.buffer.length = 0;
+    state.bufferIndex = 0;
+  } else if (idx > 1024) {
+    state.buffer.splice(0, idx);
+    state.bufferIndex = 0;
+  } else {
+    state.bufferIndex = idx;
+  }
+
+  return ret;
+}
+
+function arrFromList(n, state) {
+  // nothing buffered.
+  if (state.length === 0)
+    return null;
+
+  let idx = state.bufferIndex;
+  let ret;
+
+  const buf = state.buffer;
+  const len = buf.length;
+
+  if ((state[kState] & kObjectMode) !== 0 || !n || n >= state.length) {
+    ret = buf.slice(idx);
+    idx += ret.length;
+  } else if (n < buf[idx].length) {
+    // `slice` is the same for buffers and strings.
+    ret = [buf[idx].slice(0, n)];
+    buf[idx] = buf[idx].slice(n);
+  } else if (n === buf[idx].length) {
+    // First chunk is a perfect match.
+    ret = [buf[idx]];
+    buf[idx++] = null;
+  } else if ((state[kState] & kDecoder) !== 0) {
+    ret = [];
+    while (idx < len) {
+      const str = buf[idx];
+      if (n > str.length) {
+        ret.push(str);
+        n -= str.length;
+        buf[idx++] = null;
+      } else {
+        if (n === buf.length) {
+          ret.push(str);
+          buf[idx++] = null;
+        } else {
+          ret.push(str.slice(0, n));
+          buf[idx] = str.slice(n);
+        }
+        break;
+      }
+    }
+  } else {
+    ret = [];
+    const retLen = n;
+    while (idx < len) {
+      const data = buf[idx];
+      if (n > data.length) {
+        ret.push(data);
+        n -= data.length;
+        buf[idx++] = null;
+      } else {
+        if (n === data.length) {
+          ret.push(data);
+          buf[idx++] = null;
+        } else {
+          ret.push(new FastBuffer(data.buffer, data.byteOffset, n));
           buf[idx] = new FastBuffer(data.buffer, data.byteOffset + n, data.length - n);
         }
         break;


### PR DESCRIPTION
A faster alternative to Readable.read for certain use cases.

e.g.

fs.writevSync(fd, readable.readv())

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
