### PR TITLE
test: mark split test-watch-mode-kill-signal-* tests as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -154,3 +154,8 @@ test-cluster-primary-error: PASS, FLAKY
 [$arch==loong64]
 # https://github.com/nodejs/node/issues/51662
 test-http-correct-hostname: SKIP
+
+[$system==macos || $system=win32 || ($system==linux && $arch==s390x) || ($system==linux && $arch==arm64)]
+# https://github.com/nodejs/node/issues/60297
+test-watch-mode-kill-signal-default: PASS, FLAKY
+test-watch-mode-kill-signal-override: PASS, FLAKY


### PR DESCRIPTION
The test was split to identify which cases were flaky. The reliability report shows that 2 out of the 3 test cases can time out in the CI. Mark the two persistent flakes as flaky again.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2025-10-27.md
Refs: https://github.com/nodejs/node/pull/60391/
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
