### PR TITLE
tools: remove undici from daily wpt.fyi job

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -96,31 +96,6 @@ jobs:
             echo "WPT_REPORT=$(pwd)/out/wpt/wptreport.json" >> $GITHUB_ENV
           fi
 
-      # undici WPT Runner
-      - name: Set env.UNDICI_VERSION
-        if: ${{ env.WPT_REPORT != '' }}
-        run: echo "UNDICI_VERSION=v$(jq -r '.version' < deps/undici/src/package.json)" >> $GITHUB_ENV
-      - name: Remove deps/undici
-        if: ${{ env.WPT_REPORT != '' }}
-        run: rm -rf deps/undici
-      - name: Checkout undici
-        if: ${{ env.WPT_REPORT != '' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-        with:
-          repository: nodejs/undici
-          persist-credentials: false
-          path: deps/undici
-          clean: false
-          ref: ${{ env.UNDICI_VERSION }}
-      - name: Add undici WPTs to the report
-        if: ${{ env.WPT_REPORT != '' }}
-        run: |
-          rm -rf test/wpt/tests
-          mv ../../test/fixtures/wpt/ test/wpt/tests/
-          npm install
-          npm run test:wpt || true
-        working-directory: deps/undici
-
       # Upload artifacts
       - name: Clone report for upload
         if: ${{ env.WPT_REPORT != '' }}


### PR DESCRIPTION
The [Daily WPT report](https://github.com/nodejs/node/actions/workflows/daily-wpt-fyi.yml) job responsible for uploading Node.js WPT reports to https://wpt.fyi started failing since v25.0.0-nightly2025091229738c7b42 (last success Sep 12), now also on 24.x (last success Sep 26) and 25.x (never succeeded)

This is because undici changed its WPT fixtures location and I suspect even pre-requisites for running the WPTs.

This PR removes running undici WPTs from the daily job to resume stable daily uploads.

Refs: https://github.com/nodejs/undici/issues/4644

It is possible to re-introduce this later again albeit with a switch dependant on the undici version.