### PR TITLE
lib: check `SharedArrayBuffer` existence in `fast-utf8-stream`

### DIFF
--- a/lib/internal/streams/fast-utf8-stream.js
+++ b/lib/internal/streams/fast-utf8-stream.js
@@ -49,7 +49,8 @@ const {
 const BUSY_WRITE_TIMEOUT = 100;
 const kEmptyBuffer = Buffer.allocUnsafe(0);
 
-const kNil = new Int32Array(new SharedArrayBuffer(4));
+const haveSAB = typeof SharedArrayBuffer !== 'undefined';
+const kNil = haveSAB ? new Int32Array(new SharedArrayBuffer(4)) : null;
 
 function sleep(ms) {
   // Also filters out NaN, non-number types, including empty strings, but allows bigints
@@ -61,8 +62,12 @@ function sleep(ms) {
     throw new ERR_INVALID_ARG_VALUE.RangeError('ms', ms,
                                                'must be a number greater than 0 and less than Infinity');
   }
-
-  AtomicsWait(kNil, 0, 0, Number(ms));
+  if (haveSAB) {
+    AtomicsWait(kNil, 0, 0, Number(ms));
+  } else {
+    const { sleep: _sleep } = internalBinding('util');
+    _sleep(ms);
+  }
 }
 
 // 16 KB. Don't write more than docker buffer size.


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/58897

Fixes the following error:

```
"Uncaught ReferenceError: SharedArrayBuffer is not defined"
```

caused by changes in the above PR that declare `const kNil = new Int32Array(new SharedArrayBuffer(4));` when `lib/internal/streams/fast-utf8-stream.js` is imported and `Utf8Stream()` is used. This causes an error in any environment missing a `SharedArrayBuffer`.

I used an alternative `sleep` implementation in the missing case, but am happy to rework this however is preferred.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
