### PR TITLE
test: capture stack trace in debugger timeout errors

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -88,12 +88,12 @@ function startCLI(args, flags = [], spawnOpts = {}, opts = { randomPort: true })
           reject(new Error(message));
         }
 
+        // Capture stack trace here to show where waitFor was called from when it times out.
+        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
         const timer = setTimeout(() => {
           tearDown();
-          reject(new Error([
-            `Timeout (${TIMEOUT}) while waiting for ${pattern}`,
-            `found: ${this.output}`,
-          ].join('; ')));
+          timeoutErr.output = this.output;
+          reject(timeoutErr);
         }, TIMEOUT);
 
         function tearDown() {


### PR DESCRIPTION
Otherwise when the expected prompt does not show up in the session and the debugger tests time out, there is not enough information to figure out exactly which line in the test is causing the timeout.

The debugger tests seem to flake quite frequently in the github actions lately. I noticed the lack of stack trace in https://github.com/nodejs/node/actions/runs/18860233774/job/53816935692?pr=60443 - there's not enough information to understand why the flake happens without the stack trace.

```
=== release test-debugger-exceptions ===
Path: parallel/test-debugger-exceptions
Error: --- stderr ---
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:93
          reject(new Error([
                 ^

Error: Timeout (15000) while waiting for /(?:assert|break|break on start|debugCommand|exception|other|promiseRejection|step) in/i; found: < Debugger ending on ws://127.0.0.1:62199/4dd38bb3-afc1-4a4f-b464-e76a75321341
< For help, see: https://nodejs.org/en/docs/inspector
< 
debug> 
< Debugger listening on ws://127.0.0.1:62203/a44baaff-b2d1-475c-a70a-4daef3f42bb3
< For help, see: https://nodejs.org/en/docs/inspector
< 
debug> 
connecting to 127.0.0.1:62203 ...
< Debugger attached.
< 
debug>  ok
debug> 
    at Timeout.<anonymous> (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:93:18)
    at listOnTimeout (node:internal/timers:605:17)
    at process.processTimers (node:internal/timers:541:7)

Node.js v26.0.0-pre
Command: out/Release/node --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout "/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-exceptions.js"

===
=== 1 tests failed
===
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
