### PR TITLE
Possible Fix: Issue #60263 (Crypto cant sign/verify prehashed inputs)

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -4298,18 +4298,46 @@ bool EVPMDCtxPointer::copyTo(const EVPMDCtxPointer& other) const {
 std::optional<EVP_PKEY_CTX*> EVPMDCtxPointer::signInit(const EVPKeyPointer& key,
                                                        const Digest& digest) {
   EVP_PKEY_CTX* ctx = nullptr;
+
+  if (digest == nullptr) {
+    // Inicializa sin digest (firma raw, sin hashing interno)
+    ctx = EVP_PKEY_CTX_new(key.get(), nullptr);
+    if (!ctx) return std::nullopt;
+    if (EVP_PKEY_sign_init(ctx) <= 0) {
+      EVP_PKEY_CTX_free(ctx);
+      return std::nullopt;
+    }
+    ctx_.reset(ctx);
+    return ctx;
+  }
+
   if (!EVP_DigestSignInit(ctx_.get(), &ctx, digest, nullptr, key.get())) {
     return std::nullopt;
   }
+
   return ctx;
 }
 
 std::optional<EVP_PKEY_CTX*> EVPMDCtxPointer::verifyInit(
     const EVPKeyPointer& key, const Digest& digest) {
   EVP_PKEY_CTX* ctx = nullptr;
+
+  if (digest == nullptr) {
+    // Inicializa sin digest (verificación raw, sin hashing interno)
+    ctx = EVP_PKEY_CTX_new(key.get(), nullptr);
+    if (!ctx) return std::nullopt;
+    if (EVP_PKEY_verify_init(ctx) <= 0) {
+      EVP_PKEY_CTX_free(ctx);
+      return std::nullopt;
+    }
+    ctx_.reset(ctx);
+    return ctx;
+  }
+
   if (!EVP_DigestVerifyInit(ctx_.get(), &ctx, digest, nullptr, key.get())) {
     return std::nullopt;
   }
+
   return ctx;
 }
 


### PR DESCRIPTION
Use case:

```js
const crypto = require('crypto');

const message		 	= Buffer.from('LmM8PqCO1QIpTse0s+MQEJ7YXOSZuqyjPCJ4tIZ+OrU=', 'base64'),
			prehash 	 	= crypto.createHash('sha256').update(message).digest();

const namedCurve 	= 'secp256k1',
			keyPair 	 	= crypto.generateKeyPairSync('ec', { namedCurve }),
			signature		= crypto.sign(null, prehash, {
											key					: keyPair.privateKey,
											dsaEncoding	: 'ieee-p1363'
										});

console.log(crypto.verify(null, message, {
	key					: keyPair.publicKey,
	dsaEncoding	: 'ieee-p1363'
}, signature), ' message internal-internal (must be false)');

console.log(crypto.verify(null, prehash, {
	key					: keyPair.publicKey,
	dsaEncoding	: 'ieee-p1363'
}, signature), ' prehash internal-internal (must be true)');

// Simple unitary test:
const PUBLIC_KEY_PEM = '-----BEGIN PUBLIC KEY-----\n' +
										 	'MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6Yvel06IICYJZ/XsuPEFTpDt0aU8dwLK\n' +
										 	'jvgxyYTeZ/vlS49/PDRIr5JDz+QNWFB9ZM9tf4i9SdT0LVtlgRj3dQ==\n' +
										 	'-----END PUBLIC KEY-----',
			publicKey 		 = crypto.createPublicKey(PUBLIC_KEY_PEM),
			signOfPreHash  = Buffer.from('Djv4wD3eWu8lHI3DrN2Dypdrirj+J1rfJD5O1B/Tw8sYy38jms77neECQ0S9LHpnWun+Jb9iOZNbYjH+CoVUnA==', 'base64');
			
console.log('== BUG HERE ==');

console.log(crypto.verify(null, message, {
	key					: publicKey,
	dsaEncoding	: 'ieee-p1363'
}, signOfPreHash), ' message external-internal (must be false)');

console.log(crypto.verify(null, prehash, {
	key					: publicKey,
	dsaEncoding	: 'ieee-p1363'
}, signOfPreHash), ' prehash external-internal (must be true)');
```
