### PR TITLE
net: do not add multiple `connect` and `finish` listeners when multiple `Socket.destroySoon`'s were scheduled

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -152,6 +152,7 @@ const DEFAULT_IPV6_ADDR = '::';
 const noop = () => {};
 
 const kPerfHooksNetConnectContext = Symbol('kPerfHooksNetConnectContext');
+const kDestroyingOnFinish = Symbol('kDestroyingOnFinish');
 
 const dc = require('diagnostics_channel');
 const netClientSocketChannel = dc.channel('net.client.socket');
@@ -795,7 +796,7 @@ function onReadableStreamEnd() {
 
 
 Socket.prototype.destroySoon = function() {
-  if (this.destroyingOnFinish) return;
+  if (this[kDestroyingOnFinish]) return;
 
   if (this.writable)
     this.end();
@@ -803,9 +804,9 @@ Socket.prototype.destroySoon = function() {
   if (this.writableFinished)
     this.destroy();
   else {
-    this.destroyingOnFinish = true;
+    this[kDestroyingOnFinish] = true;
     this.once('finish', () => {
-      this.destroyingOnFinish = false;
+      this[kDestroyingOnFinish] = false;
       this.destroy();
     });
   }

--- a/lib/net.js
+++ b/lib/net.js
@@ -798,9 +798,9 @@ Socket.prototype.destroySoon = function() {
 
   if (this.writable) this.end();
 
-  if (this.writableFinished) {
+  if (this.writableFinished)
     this.destroy();
-  } else {
+  else {
     this.destroyingOnFinish = true;
     this.once('finish', () => {
       this.destroyingOnFinish = false;

--- a/lib/net.js
+++ b/lib/net.js
@@ -793,22 +793,21 @@ function onReadableStreamEnd() {
   }
 }
 
-
 Socket.prototype.destroySoon = function() {
-  if (this.writable)
-    this.end();
+  if (this.destroyingOnFinish) return;
 
-  if (this.writableFinished)
+  if (this.writable) this.end();
+
+  if (this.writableFinished) {
     this.destroy();
-  else if (!this._destroyingOnFinish) {
-    this._destroyingOnFinish = true;
+  } else {
+    this.destroyingOnFinish = true;
     this.once('finish', () => {
-      this._destroyingOnFinish = false;
+      this.destroyingOnFinish = false;
       this.destroy();
     });
   }
 };
-
 
 Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');

--- a/lib/net.js
+++ b/lib/net.js
@@ -531,14 +531,7 @@ Socket.prototype._final = function(cb) {
   // If still connecting - defer handling `_final` until 'connect' will happen
   if (this.connecting) {
     debug('_final: not yet connected');
-    if (!this._finalizingOnConnect) {
-      this._finalizingOnConnect = true;
-      this.once('connect', () => {
-        this._final(cb);
-        this._finalizingOnConnect = false;
-      });
-    }
-    return;
+    return this.once('connect', () => this._final(cb));
   }
 
   if (!this._handle)
@@ -810,8 +803,8 @@ Socket.prototype.destroySoon = function() {
   else if (!this._destroyingOnFinish) {
     this._destroyingOnFinish = true;
     this.once('finish', () => {
-      this.destroy();
       this._destroyingOnFinish = false;
+      this.destroy();
     });
   }
 };

--- a/lib/net.js
+++ b/lib/net.js
@@ -533,7 +533,10 @@ Socket.prototype._final = function(cb) {
     debug('_final: not yet connected');
     if (!this._finalizingOnConnect) {
       this._finalizingOnConnect = true;
-      this.once('connect', () => this._final(cb));
+      this.once('connect', () => {
+        this._final(cb);
+        this._finalizingOnConnect = false;
+      });
     }
     return;
   }
@@ -806,7 +809,10 @@ Socket.prototype.destroySoon = function() {
     this.destroy();
   else if (!this._destroyingOnFinish) {
     this._destroyingOnFinish = true;
-    this.once('finish', this.destroy);
+    this.once('finish', () => {
+      this.destroy();
+      this._destroyingOnFinish = false;
+    });
   }
 };
 

--- a/lib/net.js
+++ b/lib/net.js
@@ -793,10 +793,12 @@ function onReadableStreamEnd() {
   }
 }
 
+
 Socket.prototype.destroySoon = function() {
   if (this.destroyingOnFinish) return;
 
-  if (this.writable) this.end();
+  if (this.writable)
+    this.end();
 
   if (this.writableFinished)
     this.destroy();
@@ -808,6 +810,7 @@ Socket.prototype.destroySoon = function() {
     });
   }
 };
+
 
 Socket.prototype._destroy = function(exception, cb) {
   debug('destroy');

--- a/lib/net.js
+++ b/lib/net.js
@@ -529,10 +529,13 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 // sent out to the other side.
 Socket.prototype._final = function(cb) {
   // If still connecting - defer handling `_final` until 'connect' will happen
-  if (this.connecting && !this._finalizingOnConnect) {
+  if (this.connecting) {
     debug('_final: not yet connected');
-    this._finalizingOnConnect = true;
-    return this.once('connect', () => this._final(cb));
+    if (!this._finalizingOnConnect) {
+      this._finalizingOnConnect = true;
+      this.once('connect', () => this._final(cb));
+    }
+    return;
   }
 
   if (!this._handle)

--- a/lib/net.js
+++ b/lib/net.js
@@ -529,8 +529,9 @@ Socket.prototype._unrefTimer = function _unrefTimer() {
 // sent out to the other side.
 Socket.prototype._final = function(cb) {
   // If still connecting - defer handling `_final` until 'connect' will happen
-  if (this.connecting) {
+  if (this.connecting && !this._finalizingOnConnect) {
     debug('_final: not yet connected');
+    this._finalizingOnConnect = true;
     return this.once('connect', () => this._final(cb));
   }
 
@@ -800,8 +801,10 @@ Socket.prototype.destroySoon = function() {
 
   if (this.writableFinished)
     this.destroy();
-  else
+  else if (!this._destroyingOnFinish) {
+    this._destroyingOnFinish = true;
     this.once('finish', this.destroy);
+  }
 };
 
 

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -3,20 +3,13 @@ require('../common');
 const { addresses } = require('../common/internet');
 
 const assert = require('assert');
-const net = require('net');
+const { Socket } = require('net');
 
-const socket = new net.Socket();
+const socket = new Socket();
 socket.on('error', () => {
   // noop
 });
-const connectOptions = { host: addresses.INVALID_HOST, port: 1234 };
-
-socket.connect(connectOptions);
-socket.destroySoon(); // Adds "connect" and "finish" event listeners when socket has "writable" state
-socket.destroy(); // Makes imideditly socket again "writable"
-
-socket.connect(connectOptions);
-socket.destroySoon(); // Should not duplicate "connect" and "finish" event listeners
-
+socket.connect({ host: addresses.INVALID_HOST, port: 1234 });
+socket.destroySoon();
+socket.destroySoon();
 assert.strictEqual(socket.listeners('finish').length, 1);
-assert.strictEqual(socket.listeners('connect').length, 1);

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -5,10 +5,6 @@ const assert = require('assert');
 const { Socket } = require('net');
 
 const socket = new Socket();
-socket.on('error', () => {
-  // noop
-});
-socket.connect({ host: addresses.INVALID_HOST, port: 1234 });
 socket.destroySoon();
 socket.destroySoon();
 assert.strictEqual(socket.listeners('finish').length, 1);

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -9,10 +9,14 @@ const socket = new net.Socket();
 socket.on('error', () => {
   // noop
 });
-socket.connect({ host: addresses.INVALID_HOST, port: 1234 });
-socket.destroySoon();
-socket.destroySoon();
-const finishListenersCount = socket.listeners('finish').length;
-const connectListenersCount = socket.listeners('connect').length;
-assert.strictEqual(finishListenersCount, 1);
-assert.strictEqual(connectListenersCount, 1);
+const connectOptions = { host: addresses.INVALID_HOST, port: 1234 };
+
+socket.connect(connectOptions);
+socket.destroySoon(); // Adds "connect" and "finish" event listeners when socket has "writable" state
+socket.destroy(); // Makes imideditly socket again "writable"
+
+socket.connect(connectOptions);
+socket.destroySoon(); // Should not duplicate "connect" and "finish" event listeners
+
+assert.strictEqual(socket.listeners('finish').length, 1);
+assert.strictEqual(socket.listeners('connect').length, 1);

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -1,6 +1,5 @@
 'use strict';
 require('../common');
-const { addresses } = require('../common/internet');
 
 const assert = require('assert');
 const { Socket } = require('net');

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -1,4 +1,6 @@
 'use strict';
+require('../common');
+
 const assert = require('assert');
 const net = require('net');
 

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -13,13 +13,5 @@ socket.destroySoon();
 socket.destroySoon();
 const finishListenersCount = socket.listeners('finish').length;
 const connectListenersCount = socket.listeners('connect').length;
-assert.strictEqual(
-  finishListenersCount,
-  1,
-  '"finish" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'
-);
-assert.strictEqual(
-  connectListenersCount,
-  1,
-  '"connect" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'
-);
+assert.strictEqual(finishListenersCount, 1);
+assert.strictEqual(connectListenersCount, 1);

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -11,12 +11,12 @@ socket.destroySoon();
 socket.destroySoon();
 const finishListenersCount = socket.listeners('finish').length;
 const connectListenersCount = socket.listeners('connect').length;
-assert.equal(
+assert.strictEqual(
   finishListenersCount,
   1,
   '"finish" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'
 );
-assert.equal(
+assert.strictEqual(
   connectListenersCount,
   1,
   '"connect" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -1,5 +1,6 @@
 'use strict';
 require('../common');
+const { addresses } = require('../common/internet');
 
 const assert = require('assert');
 const net = require('net');
@@ -8,7 +9,7 @@ const socket = new net.Socket();
 socket.on('error', () => {
   // noop
 });
-socket.connect({ host: 'non-existing.domain', port: 1234 });
+socket.connect({ host: addresses.INVALID_HOST, port: 1234 });
 socket.destroySoon();
 socket.destroySoon();
 const finishListenersCount = socket.listeners('finish').length;

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -3,12 +3,21 @@ const assert = require('assert');
 const net = require('net');
 
 const socket = new net.Socket();
-socket.on('error', () => {});
+socket.on('error', () => {
+  // noop
+});
 socket.connect({ host: 'non-existing.domain', port: 1234 });
 socket.destroySoon();
-socket.connect({ host: 'non-existing.domain', port: 1234 });
 socket.destroySoon();
 const finishListenersCount = socket.listeners('finish').length;
 const connectListenersCount = socket.listeners('connect').length;
-assert.equal(finishListenersCount, 1);
-assert.equal(connectListenersCount, 1);
+assert.equal(
+  finishListenersCount,
+  1,
+  '"finish" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'
+);
+assert.equal(
+  connectListenersCount,
+  1,
+  '"connect" event listeners should not be duplicated for multiple "Socket.destroySoon" calls'
+);

--- a/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
+++ b/test/parallel/test-net-socket-not-duplicates-destroy-soon-listeners.js
@@ -1,0 +1,14 @@
+'use strict';
+const assert = require('assert');
+const net = require('net');
+
+const socket = new net.Socket();
+socket.on('error', () => {});
+socket.connect({ host: 'non-existing.domain', port: 1234 });
+socket.destroySoon();
+socket.connect({ host: 'non-existing.domain', port: 1234 });
+socket.destroySoon();
+const finishListenersCount = socket.listeners('finish').length;
+const connectListenersCount = socket.listeners('connect').length;
+assert.equal(finishListenersCount, 1);
+assert.equal(connectListenersCount, 1);


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/60456 by adding new `finish` event listener after `socket.destroySoon` call only if they were not added previously on given socket.