### PR TITLE
sqlite,doc: fix StatementSync section

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -647,120 +647,6 @@ times with different bound values. Parameters also offer protection against
 [SQL injection][] attacks. For these reasons, prepared statements are preferred
 over hand-crafted SQL strings when handling user input.
 
-## Class: `SQLTagStore`
-
-<!-- YAML
-added: v24.9.0
--->
-
-This class represents a single LRU (Least Recently Used) cache for storing
-prepared statements.
-
-Instances of this class are created via the database.createTagStore() method,
-not by using a constructor. The store caches prepared statements based on the
-provided SQL query string. When the same query is seen again, the store
-retrieves the cached statement and safely applies the new values through
-parameter binding, thereby preventing attacks like SQL injection.
-
-The cache has a maxSize that defaults to 1000 statements, but a custom size can
-be provided (e.g., database.createTagStore(100)). All APIs exposed by this
-class execute synchronously.
-
-### `sqlTagStore.all(sqlTemplate[, ...values])`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
-* `...values` {any} Values to be interpolated into the template literal.
-* Returns: {Array} An array of objects representing the rows returned by the query.
-
-Executes the given SQL query and returns all resulting rows as an array of objects.
-
-### `sqlTagStore.get(sqlTemplate[, ...values])`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
-* `...values` {any} Values to be interpolated into the template literal.
-* Returns: {Object | undefined} An object representing the first row returned by
-  the query, or `undefined` if no rows are returned.
-
-Executes the given SQL query and returns the first resulting row as an object.
-
-### `sqlTagStore.iterate(sqlTemplate[, ...values])`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
-* `...values` {any} Values to be interpolated into the template literal.
-* Returns: {Iterator} An iterator that yields objects representing the rows returned by the query.
-
-Executes the given SQL query and returns an iterator over the resulting rows.
-
-### `sqlTagStore.run(sqlTemplate[, ...values])`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
-* `...values` {any} Values to be interpolated into the template literal.
-* Returns: {Object} An object containing information about the execution, including `changes` and `lastInsertRowid`.
-
-Executes the given SQL query, which is expected to not return any rows (e.g., INSERT, UPDATE, DELETE).
-
-### `sqlTagStore.size()`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* Returns: {integer} The number of prepared statements currently in the cache.
-
-A read-only property that returns the number of prepared statements currently in the cache.
-
-### `sqlTagStore.capacity`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* Returns: {integer} The maximum number of prepared statements the cache can hold.
-
-A read-only property that returns the maximum number of prepared statements the cache can hold.
-
-### `sqlTagStore.db`
-
-<!-- YAML
-added: v24.9.0
--->
-
-* {DatabaseSync} The `DatabaseSync` instance that created this `SQLTagStore`.
-
-A read-only property that returns the `DatabaseSync` object associated with this `SQLTagStore`.
-
-### `sqlTagStore.reset()`
-
-<!-- YAML
-added: v24.9.0
--->
-
-Resets the LRU cache, clearing all stored prepared statements.
-
-### `sqlTagStore.clear()`
-
-<!-- YAML
-added: v24.9.0
--->
-
-An alias for `sqlTagStore.reset()`.
-
 ### `statement.all([namedParameters][, ...anonymousParameters])`
 
 <!-- YAML
@@ -990,6 +876,120 @@ added: v22.5.0
 
 The source SQL text of the prepared statement. This property is a
 wrapper around [`sqlite3_sql()`][].
+
+## Class: `SQLTagStore`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+This class represents a single LRU (Least Recently Used) cache for storing
+prepared statements.
+
+Instances of this class are created via the database.createTagStore() method,
+not by using a constructor. The store caches prepared statements based on the
+provided SQL query string. When the same query is seen again, the store
+retrieves the cached statement and safely applies the new values through
+parameter binding, thereby preventing attacks like SQL injection.
+
+The cache has a maxSize that defaults to 1000 statements, but a custom size can
+be provided (e.g., database.createTagStore(100)). All APIs exposed by this
+class execute synchronously.
+
+### `sqlTagStore.all(sqlTemplate[, ...values])`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
+* `...values` {any} Values to be interpolated into the template literal.
+* Returns: {Array} An array of objects representing the rows returned by the query.
+
+Executes the given SQL query and returns all resulting rows as an array of objects.
+
+### `sqlTagStore.get(sqlTemplate[, ...values])`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
+* `...values` {any} Values to be interpolated into the template literal.
+* Returns: {Object | undefined} An object representing the first row returned by
+  the query, or `undefined` if no rows are returned.
+
+Executes the given SQL query and returns the first resulting row as an object.
+
+### `sqlTagStore.iterate(sqlTemplate[, ...values])`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
+* `...values` {any} Values to be interpolated into the template literal.
+* Returns: {Iterator} An iterator that yields objects representing the rows returned by the query.
+
+Executes the given SQL query and returns an iterator over the resulting rows.
+
+### `sqlTagStore.run(sqlTemplate[, ...values])`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* `sqlTemplate` {Template Literal} A template literal containing the SQL query.
+* `...values` {any} Values to be interpolated into the template literal.
+* Returns: {Object} An object containing information about the execution, including `changes` and `lastInsertRowid`.
+
+Executes the given SQL query, which is expected to not return any rows (e.g., INSERT, UPDATE, DELETE).
+
+### `sqlTagStore.size()`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* Returns: {integer} The number of prepared statements currently in the cache.
+
+A read-only property that returns the number of prepared statements currently in the cache.
+
+### `sqlTagStore.capacity`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* Returns: {integer} The maximum number of prepared statements the cache can hold.
+
+A read-only property that returns the maximum number of prepared statements the cache can hold.
+
+### `sqlTagStore.db`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+* {DatabaseSync} The `DatabaseSync` instance that created this `SQLTagStore`.
+
+A read-only property that returns the `DatabaseSync` object associated with this `SQLTagStore`.
+
+### `sqlTagStore.reset()`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+Resets the LRU cache, clearing all stored prepared statements.
+
+### `sqlTagStore.clear()`
+
+<!-- YAML
+added: v24.9.0
+-->
+
+An alias for `sqlTagStore.reset()`.
 
 ### Type conversion between JavaScript and SQLite
 


### PR DESCRIPTION
This PR fixes statement sync section.

|Before| After |
|--|--|
| <img width="669" height="548" alt="image" src="https://github.com/user-attachments/assets/521eb1ad-d652-4465-80fe-5842d6efe8ee" /> | <img width="677" height="624" alt="image" src="https://github.com/user-attachments/assets/2b9cae4a-e4b3-449b-b180-d0c4410add80" /> |