### PR TITLE
doc: replace allocUnsafe with alloc in examples

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -28,9 +28,9 @@ const buf2 = Buffer.alloc(10, 1);
 
 // Creates an uninitialized buffer of length 10.
 // This is faster than calling Buffer.alloc() but the returned
-// Buffer instance might contain old data that needs to be
-// overwritten using fill(), write(), or other functions that fill the Buffer's
-// contents.
+// Buffer instance might contain old and potentially sensitive
+// data that needs to be overwritten using fill(), write(), or
+// other functions that fill the Buffer's contents.
 const buf3 = Buffer.allocUnsafe(10);
 
 // Creates a Buffer containing the bytes [1, 2, 3].
@@ -1527,7 +1527,7 @@ import { Buffer } from 'node:buffer';
 // `Buffer.from()` to perform this conversion.)
 
 const str = 'Node.js';
-const buf = Buffer.allocUnsafe(str.length);
+const buf = Buffer.alloc(str.length);
 
 for (let i = 0; i < str.length; i++) {
   buf[i] = str.charCodeAt(i);
@@ -1545,7 +1545,7 @@ const { Buffer } = require('node:buffer');
 // `Buffer.from()` to perform this conversion.)
 
 const str = 'Node.js';
-const buf = Buffer.allocUnsafe(str.length);
+const buf = Buffer.alloc(str.length);
 
 for (let i = 0; i < str.length; i++) {
   buf[i] = str.charCodeAt(i);
@@ -1760,8 +1760,8 @@ different function arguments.
 import { Buffer } from 'node:buffer';
 
 // Create two `Buffer` instances.
-const buf1 = Buffer.allocUnsafe(26);
-const buf2 = Buffer.allocUnsafe(26).fill('!');
+const buf1 = Buffer.alloc(26);
+const buf2 = Buffer.alloc(26).fill('!');
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -1781,8 +1781,8 @@ console.log(buf2.toString('ascii', 0, 25));
 const { Buffer } = require('node:buffer');
 
 // Create two `Buffer` instances.
-const buf1 = Buffer.allocUnsafe(26);
-const buf2 = Buffer.allocUnsafe(26).fill('!');
+const buf1 = Buffer.alloc(26);
+const buf2 = Buffer.alloc(26).fill('!');
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -1804,7 +1804,7 @@ import { Buffer } from 'node:buffer';
 // Create a `Buffer` and copy data from one region to an overlapping region
 // within the same `Buffer`.
 
-const buf = Buffer.allocUnsafe(26);
+const buf = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -1823,7 +1823,7 @@ const { Buffer } = require('node:buffer');
 // Create a `Buffer` and copy data from one region to an overlapping region
 // within the same `Buffer`.
 
-const buf = Buffer.allocUnsafe(26);
+const buf = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -1971,15 +1971,15 @@ import { Buffer } from 'node:buffer';
 
 // Fill a `Buffer` with the ASCII character 'h'.
 
-const b = Buffer.allocUnsafe(50).fill('h');
+const b = Buffer.alloc(5).fill('h');
 
 console.log(b.toString());
-// Prints: hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+// Prints: hhhhh
 
 // Fill a buffer with empty string
-const c = Buffer.allocUnsafe(5).fill('');
+b.fill('');
 
-console.log(c.fill(''));
+console.log(b);
 // Prints: <Buffer 00 00 00 00 00>
 ```
 
@@ -1988,15 +1988,15 @@ const { Buffer } = require('node:buffer');
 
 // Fill a `Buffer` with the ASCII character 'h'.
 
-const b = Buffer.allocUnsafe(50).fill('h');
+const b = Buffer.alloc(5).fill('h');
 
 console.log(b.toString());
-// Prints: hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh
+// Prints: hhhhh
 
 // Fill a buffer with empty string
-const c = Buffer.allocUnsafe(5).fill('');
+b.fill('');
 
-console.log(c.fill(''));
+console.log(b);
 // Prints: <Buffer 00 00 00 00 00>
 ```
 
@@ -2012,7 +2012,7 @@ import { Buffer } from 'node:buffer';
 
 // Fill a `Buffer` with character that takes up two bytes in UTF-8.
 
-console.log(Buffer.allocUnsafe(5).fill('\u0222'));
+console.log(Buffer.alloc(5).fill('\u0222'));
 // Prints: <Buffer c8 a2 c8 a2 c8>
 ```
 
@@ -2021,7 +2021,7 @@ const { Buffer } = require('node:buffer');
 
 // Fill a `Buffer` with character that takes up two bytes in UTF-8.
 
-console.log(Buffer.allocUnsafe(5).fill('\u0222'));
+console.log(Buffer.alloc(5).fill('\u0222'));
 // Prints: <Buffer c8 a2 c8 a2 c8>
 ```
 
@@ -2031,7 +2031,7 @@ fill data remains, an exception is thrown:
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(5);
+const buf = Buffer.alloc(5);
 
 console.log(buf.fill('a'));
 // Prints: <Buffer 61 61 61 61 61>
@@ -2044,7 +2044,7 @@ console.log(buf.fill('zz', 'hex'));
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(5);
+const buf = Buffer.alloc(5);
 
 console.log(buf.fill('a'));
 // Prints: <Buffer 61 61 61 61 61>
@@ -3388,7 +3388,7 @@ import { Buffer } from 'node:buffer';
 // Create a `Buffer` with the ASCII alphabet, take a slice, and modify one byte
 // from the original `Buffer`.
 
-const buf1 = Buffer.allocUnsafe(26);
+const buf1 = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -3412,7 +3412,7 @@ const { Buffer } = require('node:buffer');
 // Create a `Buffer` with the ASCII alphabet, take a slice, and modify one byte
 // from the original `Buffer`.
 
-const buf1 = Buffer.allocUnsafe(26);
+const buf1 = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -3791,7 +3791,7 @@ as [`buffer.constants.MAX_STRING_LENGTH`][].
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf1 = Buffer.allocUnsafe(26);
+const buf1 = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -3816,7 +3816,7 @@ console.log(buf2.toString(undefined, 0, 3));
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf1 = Buffer.allocUnsafe(26);
+const buf1 = Buffer.alloc(26);
 
 for (let i = 0; i < 26; i++) {
   // 97 is the decimal ASCII value for 'a'.
@@ -3980,7 +3980,7 @@ Writes `value` to `buf` at the specified `offset` as big-endian.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigInt64BE(0x0102030405060708n, 0);
 
@@ -3991,7 +3991,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigInt64BE(0x0102030405060708n, 0);
 
@@ -4019,7 +4019,7 @@ Writes `value` to `buf` at the specified `offset` as little-endian.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigInt64LE(0x0102030405060708n, 0);
 
@@ -4030,7 +4030,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigInt64LE(0x0102030405060708n, 0);
 
@@ -4064,7 +4064,7 @@ This function is also available under the `writeBigUint64BE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigUInt64BE(0xdecafafecacefaden, 0);
 
@@ -4075,7 +4075,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigUInt64BE(0xdecafafecacefaden, 0);
 
@@ -4107,7 +4107,7 @@ Writes `value` to `buf` at the specified `offset` as little-endian
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigUInt64LE(0xdecafafecacefaden, 0);
 
@@ -4118,7 +4118,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeBigUInt64LE(0xdecafafecacefaden, 0);
 
@@ -4151,7 +4151,7 @@ other than a JavaScript number.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeDoubleBE(123.456, 0);
 
@@ -4162,7 +4162,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeDoubleBE(123.456, 0);
 
@@ -4193,7 +4193,7 @@ other than a JavaScript number.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeDoubleLE(123.456, 0);
 
@@ -4204,7 +4204,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(8);
+const buf = Buffer.alloc(8);
 
 buf.writeDoubleLE(123.456, 0);
 
@@ -4234,7 +4234,7 @@ undefined when `value` is anything other than a JavaScript number.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeFloatBE(0xcafebabe, 0);
 
@@ -4245,7 +4245,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeFloatBE(0xcafebabe, 0);
 
@@ -4275,7 +4275,7 @@ undefined when `value` is anything other than a JavaScript number.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeFloatLE(0xcafebabe, 0);
 
@@ -4286,7 +4286,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeFloatLE(0xcafebabe, 0);
 
@@ -4319,7 +4319,7 @@ a signed 8-bit integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt8(2, 0);
 buf.writeInt8(-2, 1);
@@ -4331,7 +4331,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt8(2, 0);
 buf.writeInt8(-2, 1);
@@ -4365,7 +4365,7 @@ The `value` is interpreted and written as a two's complement signed integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt16BE(0x0102, 0);
 
@@ -4376,7 +4376,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt16BE(0x0102, 0);
 
@@ -4409,7 +4409,7 @@ The `value` is interpreted and written as a two's complement signed integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt16LE(0x0304, 0);
 
@@ -4420,7 +4420,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(2);
+const buf = Buffer.alloc(2);
 
 buf.writeInt16LE(0x0304, 0);
 
@@ -4453,7 +4453,7 @@ The `value` is interpreted and written as a two's complement signed integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeInt32BE(0x01020304, 0);
 
@@ -4464,7 +4464,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeInt32BE(0x01020304, 0);
 
@@ -4497,7 +4497,7 @@ The `value` is interpreted and written as a two's complement signed integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeInt32LE(0x05060708, 0);
 
@@ -4508,7 +4508,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeInt32LE(0x05060708, 0);
 
@@ -4541,7 +4541,7 @@ as big-endian. Supports up to 48 bits of accuracy. Behavior is undefined when
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeIntBE(0x1234567890ab, 0, 6);
 
@@ -4552,7 +4552,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeIntBE(0x1234567890ab, 0, 6);
 
@@ -4585,7 +4585,7 @@ when `value` is anything other than a signed integer.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeIntLE(0x1234567890ab, 0, 6);
 
@@ -4596,7 +4596,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeIntLE(0x1234567890ab, 0, 6);
 
@@ -4634,7 +4634,7 @@ This function is also available under the `writeUint8` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt8(0x3, 0);
 buf.writeUInt8(0x4, 1);
@@ -4648,7 +4648,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt8(0x3, 0);
 buf.writeUInt8(0x4, 1);
@@ -4689,7 +4689,7 @@ This function is also available under the `writeUint16BE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt16BE(0xdead, 0);
 buf.writeUInt16BE(0xbeef, 2);
@@ -4701,7 +4701,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt16BE(0xdead, 0);
 buf.writeUInt16BE(0xbeef, 2);
@@ -4740,7 +4740,7 @@ This function is also available under the `writeUint16LE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt16LE(0xdead, 0);
 buf.writeUInt16LE(0xbeef, 2);
@@ -4752,7 +4752,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt16LE(0xdead, 0);
 buf.writeUInt16LE(0xbeef, 2);
@@ -4791,7 +4791,7 @@ This function is also available under the `writeUint32BE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt32BE(0xfeedface, 0);
 
@@ -4802,7 +4802,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt32BE(0xfeedface, 0);
 
@@ -4840,7 +4840,7 @@ This function is also available under the `writeUint32LE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt32LE(0xfeedface, 0);
 
@@ -4851,7 +4851,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(4);
+const buf = Buffer.alloc(4);
 
 buf.writeUInt32LE(0xfeedface, 0);
 
@@ -4891,7 +4891,7 @@ This function is also available under the `writeUintBE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeUIntBE(0x1234567890ab, 0, 6);
 
@@ -4902,7 +4902,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeUIntBE(0x1234567890ab, 0, 6);
 
@@ -4942,7 +4942,7 @@ This function is also available under the `writeUintLE` alias.
 ```mjs
 import { Buffer } from 'node:buffer';
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeUIntLE(0x1234567890ab, 0, 6);
 
@@ -4953,7 +4953,7 @@ console.log(buf);
 ```cjs
 const { Buffer } = require('node:buffer');
 
-const buf = Buffer.allocUnsafe(6);
+const buf = Buffer.alloc(6);
 
 buf.writeUIntLE(0x1234567890ab, 0, 6);
 


### PR DESCRIPTION
Do not needlessly promote `allocUnsafe`.

Dates back to https://github.com/nodejs/node/pull/4682

While the intention was to make `allocUnsafe` a _code_ replacement for Buffer constructor, it has also been to let users use `Buffer.alloc` by default and/or when they are not sure, and optimize with `allocUnsafe` only when needed and when they ensured that nothing gets leaked (which often requires extra actions e.g. error handling or guards against race conditions)

Most documentation methods should use `Buffer.alloc` instead of `Buffer.allocUnsafe` by default in examples

This aligns documentation accents internally with the wording in this intent:

https://github.com/nodejs/node/blob/dec0213c834607e7721ee250d8c46ef9cd112efe/doc/api/buffer.md?plain=1#L5066-L5067

And https://nodejs.org/docs/latest/api/buffer.html#bufferfrom-bufferalloc-and-bufferallocunsafe