### PR TITLE
util: fix stylize of special properties in inspect

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2520,7 +2520,8 @@ function formatExtraProperties(ctx, value, recurseTimes, key, typedArray) {
   ctx.indentationLvl -= 2;
 
   // These entries are mainly getters. Should they be formatted like getters?
-  return ctx.stylize(`[${key}]: ${str}`, 'string');
+  const name = ctx.stylize(`[${key}]`, 'string');
+  return `${name}: ${str}`;
 }
 
 function formatProperty(ctx, value, recurseTimes, key, type, desc,

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2391,6 +2391,20 @@ assert.strictEqual(
   inspect.styles.string = stringStyle;
 }
 
+// Special (extra) properties follow normal coloring:
+// only the name is colored, ":" and space are unstyled.
+{
+  const [open, close] = inspect.colors[inspect.styles.string];
+  const keyPattern = (k) => new RegExp(
+    `\\u001b\\[${open}m\\[${k}\\]\\u001b\\[${close}m: `
+  );
+  const colored = util.inspect(new Uint8Array(0), { showHidden: true, colors: true });
+  assert.match(colored, keyPattern('BYTES_PER_ELEMENT'));
+  assert.match(colored, keyPattern('length'));
+  assert.match(colored, keyPattern('byteLength'));
+  assert.match(colored, keyPattern('byteOffset'));
+}
+
 assert.strictEqual(
   inspect([1, 3, 2], { sorted: true }),
   inspect([1, 3, 2])


### PR DESCRIPTION
Previously, formatExtraProperties applied ctx.stylize to the entire '[key]: value' string. This caused the colon and space to be styled, making the output inconsistent with normal object properties.

Now, only the key itself is stylized, and the colon and space remain unstyled, aligning with the formatting of regular properties.

Refs: https://github.com/nodejs/node/pull/60131

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
