### PR TITLE
http2: add diagnostics channels for client stream request body

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1243,6 +1243,23 @@ Emitted when an error occurs during the processing of a stream on the client.
 
 Emitted when a stream is received on the client.
 
+##### Event: `'http2.client.stream.bodyChunkSent'`
+
+* `stream` {ClientHttp2Stream}
+* `writev` {boolean}
+* `data` {Buffer | string | Buffer\[] | Object\[]}
+  * `chunk` {Buffer|string}
+  * `encoding` {string}
+* `encoding` {string}
+
+Emitted when a chunk of the client stream body is being sent.
+
+##### Event: `'http2.client.stream.bodySent'`
+
+* `stream` {ClientHttp2Stream}
+
+Emitted after the client stream body has been fully sent.
+
 ##### Event: `'http2.client.stream.close'`
 
 * `stream` {ClientHttp2Stream}

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -190,6 +190,8 @@ const dc = require('diagnostics_channel');
 const onClientStreamCreatedChannel = dc.channel('http2.client.stream.created');
 const onClientStreamStartChannel = dc.channel('http2.client.stream.start');
 const onClientStreamErrorChannel = dc.channel('http2.client.stream.error');
+const onClientStreamBodyChunkSentChannel = dc.channel('http2.client.stream.bodyChunkSent');
+const onClientStreamBodySentChannel = dc.channel('http2.client.stream.bodySent');
 const onClientStreamFinishChannel = dc.channel('http2.client.stream.finish');
 const onClientStreamCloseChannel = dc.channel('http2.client.stream.close');
 const onServerStreamCreatedChannel = dc.channel('http2.server.stream.created');
@@ -2300,6 +2302,15 @@ class Http2Stream extends Duplex {
       req = writeGeneric(this, data, encoding, writeCallback);
 
     trackWriteState(this, req.bytes);
+
+    if (this.session[kType] === NGHTTP2_SESSION_CLIENT && onClientStreamBodyChunkSentChannel.hasSubscribers) {
+      onClientStreamBodyChunkSentChannel.publish({
+        stream: this,
+        writev,
+        data,
+        encoding,
+      });
+    }
   }
 
   _write(data, encoding, cb) {
@@ -2317,6 +2328,10 @@ class Http2Stream extends Duplex {
     }
     debugStreamObj(this, 'shutting down writable on _final');
     ReflectApply(shutdownWritable, this, [cb]);
+
+    if (this.session[kType] === NGHTTP2_SESSION_CLIENT && onClientStreamBodySentChannel.hasSubscribers) {
+      onClientStreamBodySentChannel.publish({ stream: this });
+    }
   }
 
   _read(nread) {

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-body-multiple-buffers-and-strings.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-body-multiple-buffers-and-strings.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that the built-in HTTP/2 diagnostics channels are reporting
+// the diagnostics messages for the 'http2.client.stream.bodyChunkSent' and
+// 'http2.client.stream.bodySent' channels when ClientHttp2Streams bodies are
+// being sent with multiple Buffers and strings.
+
+const assert = require('assert');
+const dc = require('diagnostics_channel');
+const http2 = require('http2');
+const { Duplex } = require('stream');
+
+let bodyChunkSent = false;
+
+dc.subscribe('http2.client.stream.bodyChunkSent', common.mustCall(({ stream, writev, data, encoding }) => {
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+
+  assert.strictEqual(writev, true);
+
+  assert.ok(Array.isArray(data));
+  assert.strictEqual(data.length, 3);
+
+  assert.strictEqual(data[0].chunk, 'héllo');
+  assert.strictEqual(data[0].encoding, 'latin1');
+
+  assert.ok(Buffer.from('foo').equals(data[1].chunk));
+  assert.strictEqual(data[1].encoding, 'buffer');
+
+  assert.ok(Buffer.from('bar').equals(data[2].chunk));
+  assert.strictEqual(data[2].encoding, 'buffer');
+
+  assert.strictEqual(encoding, '');
+
+  bodyChunkSent = true;
+}));
+
+dc.subscribe('http2.client.stream.bodySent', common.mustCall(({ stream }) => {
+  // 'http2.client.stream.bodyChunkSent' must run first.
+  assert.ok(bodyChunkSent);
+
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+}));
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({}, { endStream: true });
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const stream = client.request({ [http2.constants.HTTP2_HEADER_METHOD]: 'POST' });
+  stream.write('héllo', 'latin1');
+  stream.write(Buffer.from('foo'));
+  stream.write(new TextEncoder().encode('bar'));
+  stream.end();
+
+  stream.on('response', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}, 1));

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-body-multiple-buffers.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-body-multiple-buffers.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that the built-in HTTP/2 diagnostics channels are reporting
+// the diagnostics messages for the 'http2.client.stream.bodyChunkSent' and
+// 'http2.client.stream.bodySent' channels when ClientHttp2Streams bodies are
+// being sent with multiple Buffers.
+
+const assert = require('assert');
+const dc = require('diagnostics_channel');
+const http2 = require('http2');
+const { Duplex } = require('stream');
+
+let bodyChunkSent = false;
+
+dc.subscribe('http2.client.stream.bodyChunkSent', common.mustCall(({ stream, writev, data, encoding }) => {
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+
+  assert.strictEqual(writev, true);
+
+  assert.ok(Array.isArray(data));
+  assert.strictEqual(data.length, 2);
+
+  assert.ok(Buffer.from('foo').equals(data[0]));
+  assert.ok(Buffer.from('bar').equals(data[1]));
+
+  assert.strictEqual(encoding, '');
+
+  bodyChunkSent = true;
+}));
+
+dc.subscribe('http2.client.stream.bodySent', common.mustCall(({ stream }) => {
+  // 'http2.client.stream.bodyChunkSent' must run first.
+  assert.ok(bodyChunkSent);
+
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+}));
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({}, { endStream: true });
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const stream = client.request({ [http2.constants.HTTP2_HEADER_METHOD]: 'POST' });
+  stream.write(Buffer.from('foo'));
+  stream.write(Buffer.from('bar'));
+  stream.end();
+
+  stream.on('response', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}, 1));

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-body-no-chunks.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-body-no-chunks.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that the built-in HTTP/2 diagnostics channels are reporting
+// the diagnostics messages for the 'http2.client.stream.bodyChunkSent' and
+// 'http2.client.stream.bodySent' channels when ClientHttp2Streams bodies are
+// being sent with no chunks.
+
+const assert = require('assert');
+const dc = require('diagnostics_channel');
+const http2 = require('http2');
+const { Duplex } = require('stream');
+
+dc.subscribe('http2.client.stream.bodyChunkSent', common.mustNotCall());
+
+dc.subscribe('http2.client.stream.bodySent', common.mustCall(({ stream }) => {
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+}));
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({}, { endStream: true });
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const stream = client.request({ [http2.constants.HTTP2_HEADER_METHOD]: 'POST' });
+  stream.end();
+
+  stream.on('response', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}, 1));

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-body-single-buffer.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-body-single-buffer.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that the built-in HTTP/2 diagnostics channels are reporting
+// the diagnostics messages for the 'http2.client.stream.bodyChunkSent' and
+// 'http2.client.stream.bodySent' channels when ClientHttp2Streams bodies are
+// being sent with a single Buffer.
+
+const assert = require('assert');
+const dc = require('diagnostics_channel');
+const http2 = require('http2');
+const { Duplex } = require('stream');
+
+let bodyChunkSent = false;
+
+dc.subscribe('http2.client.stream.bodyChunkSent', common.mustCall(({ stream, writev, data, encoding }) => {
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+
+  assert.strictEqual(writev, false);
+  assert.ok(Buffer.from('foo').equals(data));
+  assert.strictEqual(encoding, 'buffer');
+
+  bodyChunkSent = true;
+}));
+
+dc.subscribe('http2.client.stream.bodySent', common.mustCall(({ stream }) => {
+  // 'http2.client.stream.bodyChunkSent' must run first.
+  assert.ok(bodyChunkSent);
+
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+}));
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({}, { endStream: true });
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const stream = client.request({ [http2.constants.HTTP2_HEADER_METHOD]: 'POST' });
+  stream.write(Buffer.from('foo'));
+  stream.end();
+
+  stream.on('response', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}, 1));

--- a/test/parallel/test-diagnostics-channel-http2-client-stream-body-single-string.js
+++ b/test/parallel/test-diagnostics-channel-http2-client-stream-body-single-string.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// This test ensures that the built-in HTTP/2 diagnostics channels are reporting
+// the diagnostics messages for the 'http2.client.stream.bodyChunkSent' and
+// 'http2.client.stream.bodySent' channels when ClientHttp2Streams bodies are
+// being sent with a single string.
+
+const assert = require('assert');
+const dc = require('diagnostics_channel');
+const http2 = require('http2');
+const { Duplex } = require('stream');
+
+let bodyChunkSent = false;
+
+dc.subscribe('http2.client.stream.bodyChunkSent', common.mustCall(({ stream, writev, data, encoding }) => {
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+
+  assert.strictEqual(writev, false);
+  assert.strictEqual(data, 'foo');
+  assert.strictEqual(encoding, 'utf8');
+
+  bodyChunkSent = true;
+}));
+
+dc.subscribe('http2.client.stream.bodySent', common.mustCall(({ stream }) => {
+  // 'http2.client.stream.bodyChunkSent' must run first.
+  assert.ok(bodyChunkSent);
+
+  // Since ClientHttp2Stream is not exported from any module, this just checks
+  // if the stream is an instance of Duplex.
+  assert.ok(stream instanceof Duplex);
+  assert.strictEqual(stream.constructor.name, 'ClientHttp2Stream');
+}));
+
+const server = http2.createServer();
+server.on('stream', common.mustCall((stream) => {
+  stream.respond({}, { endStream: true });
+}));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  const client = http2.connect(`http://localhost:${port}`);
+
+  const stream = client.request({ [http2.constants.HTTP2_HEADER_METHOD]: 'POST' });
+  stream.write('foo');
+  stream.end();
+
+  stream.on('response', common.mustCall(() => {
+    client.close();
+    server.close();
+  }));
+}, 1));


### PR DESCRIPTION
These would allow inspection of HTTP/2 client stream request bodies.

This is needed for https://github.com/nodejs/node/pull/60483.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
