### PR TITLE
tools: fix linter for semver-major release proposals

### DIFF
--- a/tools/actions/lint-release-proposal-commit-list.mjs
+++ b/tools/actions/lint-release-proposal-commit-list.mjs
@@ -23,7 +23,7 @@ const commitListingStart = changelog.indexOf('\n### Commits\n');
 let commitList;
 if (commitListingStart === -1) {
   // We're preparing a semver-major release.
-  assert.match(changelog, /\n### Semver-Major Commits\n/)
+  assert.match(changelog, /\n### Semver-Major Commits\n/);
   // The proposal should contain only the release commit.
   commitList = '';
 } else {


### PR DESCRIPTION
As we can see in https://github.com/nodejs/node/pull/59896, the linter fails because it can't find in the proposal the commits listed in the CHANGELOG. That's not surprising since the semver-major proposal only contains the release commit – something I forgot to take into account when working on https://github.com/nodejs/node/pull/57892.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
