### PR TITLE
inspector: support inspecting HTTP/2 request and response bodies

### DIFF
--- a/lib/internal/inspector/network_http2.js
+++ b/lib/internal/inspector/network_http2.js
@@ -28,6 +28,8 @@ const {
   HTTP2_HEADER_STATUS,
   NGHTTP2_NO_ERROR,
 } = internalBinding('http2').constants;
+const EventEmitter = require('events');
+const { Buffer } = require('buffer');
 
 const kRequestUrl = Symbol('kRequestUrl');
 
@@ -99,6 +101,7 @@ function onClientStreamCreated({ stream, headers }) {
       url,
       method,
       headers: convertedHeaderObject,
+      hasPostData: !stream.writableEnded,
     },
   });
 }
@@ -118,6 +121,66 @@ function onClientStreamError({ stream, error }) {
     timestamp: getMonotonicTime(),
     type: kResourceType.Other,
     errorText: error.message,
+  });
+}
+
+/**
+ * When a chunk of the request body is being sent, cache it until `getRequestPostData` request.
+ * https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-getRequestPostData
+ * @param {{
+ *   stream: import('http2').ClientHttp2Stream,
+ *   writev: boolean,
+ *   data: Buffer | string | Array<Buffer | {chunk: Buffer|string, encoding: string}>,
+ *   encoding: string,
+ * }} event
+ */
+function onClientStreamBodyChunkSent({ stream, writev, data, encoding }) {
+  if (typeof stream[kInspectorRequestId] !== 'string') {
+    return;
+  }
+
+  let chunk;
+
+  if (writev) {
+    if (data.allBuffers) {
+      chunk = Buffer.concat(data);
+    } else {
+      const buffers = [];
+      for (let i = 0; i < data.length; ++i) {
+        if (typeof data[i].chunk === 'string') {
+          buffers.push(Buffer.from(data[i].chunk, data[i].encoding));
+        } else {
+          buffers.push(data[i].chunk);
+        }
+      }
+      chunk = Buffer.concat(buffers);
+    }
+  } else if (typeof data === 'string') {
+    chunk = Buffer.from(data, encoding);
+  } else {
+    chunk = data;
+  }
+
+  Network.dataSent({
+    requestId: stream[kInspectorRequestId],
+    timestamp: getMonotonicTime(),
+    dataLength: chunk.byteLength,
+    data: chunk,
+  });
+}
+
+/**
+ * Mark a request body as fully sent.
+ * @param {{ stream: import('http2').ClientHttp2Stream }} event
+ */
+function onClientStreamBodySent({ stream }) {
+  if (typeof stream[kInspectorRequestId] !== 'string') {
+    return;
+  }
+
+  Network.dataSent({
+    requestId: stream[kInspectorRequestId],
+    finished: true,
   });
 }
 
@@ -145,6 +208,24 @@ function onClientStreamFinish({ stream, headers }) {
       mimeType,
       charset,
     },
+  });
+
+  // Unlike stream.on('data', ...), this does not put the stream into flowing mode.
+  EventEmitter.prototype.on.call(stream, 'data', (chunk) => {
+    /**
+     * When a chunk of the response body has been received, cache it until `getResponseBody` request
+     * https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-getResponseBody or
+     * stream it with `streamResourceContent` request.
+     * https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-streamResourceContent
+     */
+
+    Network.dataReceived({
+      requestId: stream[kInspectorRequestId],
+      timestamp: getMonotonicTime(),
+      dataLength: chunk.byteLength,
+      encodedDataLength: chunk.byteLength,
+      data: chunk,
+    });
   });
 }
 
@@ -175,4 +256,6 @@ module.exports = registerDiagnosticChannels([
   ['http2.client.stream.error', onClientStreamError],
   ['http2.client.stream.finish', onClientStreamFinish],
   ['http2.client.stream.close', onClientStreamClose],
+  ['http2.client.stream.bodyChunkSent', onClientStreamBodyChunkSent],
+  ['http2.client.stream.bodySent', onClientStreamBodySent],
 ]);


### PR DESCRIPTION
Now, we can track the request and response bodies of HTTP/2 calls through the Network tab of Chrome DevTools for Node.js.

Refs: https://github.com/nodejs/node/issues/53946

---

### Demo

https://github.com/user-attachments/assets/61ecac91-3af8-4757-ad14-cc6cf36ed656

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
