### PR TITLE
doc: `process.execve`: add example for restarting current process

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1720,6 +1720,13 @@ This function will never return, unless an error occurred.
 
 This function is not available on Windows or IBM i.
 
+For example, the following restarts the current process in the same way it started,
+modulo changes to `process.chdir(...)`, `process.env`, `process.argv`.
+
+```js
+  process.execve(process.argv0, process.argv);
+```
+
 ## `process.exit([code])`
 
 <!-- YAML


### PR DESCRIPTION
This clarifies that the second `args` argument includes the `argv[0]` of the new process. A naive assumption is to think that this is similar to `child_process` functions like `execFile` which expect only the actual arguments.
