### PR TITLE
build: enable typescript sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ tools/*/*.i.tmp
 /tools/clang-format/node_modules
 /tools/eslint/node_modules
 /tools/lint-md/node_modules
+/tools/typescript/node_modules
 
 # === Rules for test artifacts ===
 /*.tap

--- a/deps/amaro/lib/wasm.d.ts
+++ b/deps/amaro/lib/wasm.d.ts
@@ -61,7 +61,7 @@ interface JsxConfig {
 
 
 
-type Mode = "strip-only" | "transform";
+export type Mode = "strip-only" | "transform";
 
 
 

--- a/tools/typescript/package-lock.json
+++ b/tools/typescript/package-lock.json
@@ -1,0 +1,28 @@
+{
+    "name": "node-type-checker",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "node-type-checker",
+            "version": "1.0.0",
+            "dependencies": {
+                "typescript": "^5.9.3"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        }
+    }
+}

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "node-type-checker",
+    "version": "1.0.0",
+    "private": true,
+    "description": "TypeScript type checker for Node.js core",
+    "dependencies": {
+        "typescript": "^5.9.3"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "include": ["lib", "doc"],
+  "include": ["lib/**/*.ts", "doc"],
   "exclude": ["src", "tools", "out"],
   "files": [
     "./typings/globals.d.ts",
-    "./typings/primordials.d.ts"
+    "./typings/primordials.d.ts",
+    "./deps/amaro/lib/wasm.d.ts"
   ],
   "compilerOptions": {
     "allowJs": true,
@@ -12,6 +13,11 @@
     "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "CommonJS",
+    "moduleResolution": "node",
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "noResolve": true,
     "baseUrl": ".",
     "paths": {
       "_http_agent": ["./lib/_http_agent.js"],

--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -66,9 +66,11 @@ interface InternalBindingMap {
 
 type InternalBindingKeys = keyof InternalBindingMap;
 
-declare function internalBinding<T extends InternalBindingKeys>(binding: T): InternalBindingMap[T]
-
 declare global {
+  function internalBinding<T extends InternalBindingKeys>(binding: T): InternalBindingMap[T];
+  function require(id: string): any;
+  var module: { exports: any };
+  var exports: any;
   type TypedArray =
     | Uint8Array
     | Uint8ClampedArray

--- a/typings/internalBinding/modules.d.ts
+++ b/typings/internalBinding/modules.d.ts
@@ -28,4 +28,11 @@ export interface ModulesBinding {
   enableCompileCache(path?: string): { status: number, message?: string, directory?: string }
   getCompileCacheDir(): string | undefined
   flushCompileCache(keepDeserializedCache?: boolean): void
+  getCompileCacheEntry(source: string, filename: string, type: number): any
+  saveCompileCacheEntry(filename: string, data: any): void
+  cachedCodeTypes: {
+    kStrippedTypeScript: number
+    kTransformedTypeScript: number
+    kTransformedTypeScriptWithSourceMaps: number
+  }
 }


### PR DESCRIPTION
I know this might be super controversial, but let's give it a try.
With this PR we enable typescript to be used in core modules + typechecking.
The .ts files are stripped at build time so no runtime overhead.
The issue is that you cannot build without amaro.
My approach was quite hacky I'm sure there are better ways to handle this, but I wanted to see what people think.
The pros are static types in node core and the possibility of shipping our own types instead of relying on @types/node.
It is possible to gradually migrate like showed in this PR a module from js to ts without having to rewrite everything 

@nodejs/tsc @nodejs/typescript 
