### PR TITLE
test: spin longer on flaky platforms for test-worker-prof

### DIFF
--- a/test/sequential/test-worker-prof.js
+++ b/test/sequential/test-worker-prof.js
@@ -16,10 +16,16 @@ if (process.argv[2] === 'child') {
   console.log('parent prof file:', parentProf);
 
   const { Worker } = require('worker_threads');
+  let spinTime = 1500;
+  if (common.isWindows || common.isMacOS || process.arch === 's390x') {
+    // Windows and MacOS tend to be flaky in CI, s390x as well.
+    // Give them more spins.
+    spinTime = 4500;
+  }
   const w = new Worker(`
   const { parentPort, workerData } = require('worker_threads');
 
-  const SPIN_MS = 1500;
+  const SPIN_MS = ${spinTime};
   const start = Date.now();
   parentPort.on('message', (data) => {
     if (Date.now() - start < SPIN_MS) {


### PR DESCRIPTION
Try spinning longer to get more ticks on flaky platforms and reduce flakiness.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2025-10-29.md
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
