### PR TITLE
src: add locksCounters() to monitor Web Locks usage

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -839,6 +839,9 @@ navigator.locks.request('shared_resource', { mode: 'shared' }, async (lock) => {
 
 See [`worker_threads.locks`][] for detailed API documentation.
 
+Use [`process.locksCounters()`][] to monitor lock acquisitions, contention, and
+queue sizes across the process.
+
 ## Class: `PerformanceEntry`
 
 <!-- YAML
@@ -1376,6 +1379,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [`localStorage`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 [`module`]: modules.md#module
 [`perf_hooks.performance`]: perf_hooks.md#perf_hooksperformance
+[`process.locksCounters()`]: process.md#processlockscounters
 [`process.nextTick()`]: process.md#processnexttickcallback-args
 [`process` object]: process.md#process
 [`require()`]: modules.md#requireid

--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -781,7 +781,10 @@ added: v24.5.0
 An instance of a [`LockManager`][LockManager] that can be used to coordinate
 access to resources that may be shared across multiple threads within the same
 process. The API mirrors the semantics of the
-[browser `LockManager`][]
+[browser `LockManager`][].
+
+Use [`process.locksCounters()`][] to monitor lock acquisitions, contention, and
+queue sizes across the process.
 
 ### Class: `Lock`
 
@@ -2249,6 +2252,7 @@ thread spawned will spawn another until the application crashes.
 [`process.env`]: process.md#processenv
 [`process.execArgv`]: process.md#processexecargv
 [`process.exit()`]: process.md#processexitcode
+[`process.locksCounters()`]: process.md#processlockscounters
 [`process.stderr`]: process.md#processstderr
 [`process.stdin`]: process.md#processstdin
 [`process.stdout`]: process.md#processstdout

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -172,6 +172,7 @@ const rawMethods = internalBinding('process_methods');
   process.cpuUsage = wrapped.cpuUsage;
   process.threadCpuUsage = wrapped.threadCpuUsage;
   process.resourceUsage = wrapped.resourceUsage;
+  process.locksCounters = wrapped.locksCounters;
   process.memoryUsage = wrapped.memoryUsage;
   process.constrainedMemory = rawMethods.constrainedMemory;
   process.availableMemory = rawMethods.availableMemory;

--- a/lib/internal/process/per_thread.js
+++ b/lib/internal/process/per_thread.js
@@ -110,6 +110,7 @@ function wrapProcessMethods(binding) {
     threadCpuUsage: _threadCpuUsage,
     memoryUsage: _memoryUsage,
     rss,
+    locksCounters: _locksCounters,
     resourceUsage: _resourceUsage,
     loadEnvFile: _loadEnvFile,
     execve: _execve,
@@ -349,6 +350,23 @@ function wrapProcessMethods(binding) {
     };
   }
 
+  const locksCountersBuffer = new Float64Array(8);
+  const locksCountersBigIntView = new BigUint64Array(locksCountersBuffer.buffer, 0, 4);
+
+  function locksCounters() {
+    _locksCounters(locksCountersBuffer);
+    return {
+      totalAborts: locksCountersBigIntView[0],
+      totalSteals: locksCountersBigIntView[1],
+      totalExclusiveAcquired: locksCountersBigIntView[2],
+      totalSharedAcquired: locksCountersBigIntView[3],
+      holdersExclusive: locksCountersBuffer[4],
+      holdersShared: locksCountersBuffer[5],
+      pendingExclusive: locksCountersBuffer[6],
+      pendingShared: locksCountersBuffer[7],
+    };
+  }
+
   /**
    * Loads the `.env` file to process.env.
    * @param {string | URL | Buffer | undefined} path
@@ -372,6 +390,7 @@ function wrapProcessMethods(binding) {
     kill,
     exit,
     execve,
+    locksCounters,
     loadEnvFile,
   };
 }

--- a/src/node_locks.h
+++ b/src/node_locks.h
@@ -155,6 +155,17 @@ class LockManager final {
                                   std::shared_ptr<Lock> lock,
                                   v8::Local<v8::Value> result,
                                   bool was_rejected = false);
+  struct LocksCountersSnapshot {
+    uint64_t total_steals = 0;
+    uint64_t total_aborts = 0;
+    uint64_t total_exclusive_acquired = 0;
+    uint64_t total_shared_acquired = 0;
+    size_t holders_exclusive = 0;
+    size_t holders_shared = 0;
+    size_t pending_exclusive = 0;
+    size_t pending_shared = 0;
+  };
+  LocksCountersSnapshot GetCountersSnapshot() const;
 
  private:
   LockManager() = default;
@@ -171,6 +182,13 @@ class LockManager final {
   static LockManager current_;
 
   mutable Mutex mutex_;
+  struct Counters {
+    uint64_t total_steals = 0;
+    uint64_t total_aborts = 0;
+    uint64_t total_exclusive_acquired = 0;
+    uint64_t total_shared_acquired = 0;
+  };
+  Counters counters;
   // All entries for a given Environment* are purged in CleanupEnvironment().
   std::unordered_map<std::u16string, std::deque<std::shared_ptr<Lock>>>
       held_locks_;

--- a/test/parallel/test-process-locks-counters.js
+++ b/test/parallel/test-process-locks-counters.js
@@ -1,0 +1,226 @@
+'use strict';
+
+require('../common');
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { Worker, locks } = require('node:worker_threads');
+
+function totalAcquired(snapshot) {
+  return snapshot.totalExclusiveAcquired + snapshot.totalSharedAcquired;
+}
+
+function holdersTotal(snapshot) {
+  return snapshot.holdersExclusive + snapshot.holdersShared;
+}
+
+function pendingTotal(snapshot) {
+  return snapshot.pendingExclusive + snapshot.pendingShared;
+}
+
+describe('process.locksCounters()', () => {
+  it('should return valid counters structure with correct types', async () => {
+    assert.strictEqual(typeof process.locksCounters, 'function');
+
+    const snapshot = process.locksCounters();
+
+    // BigInt counters
+    assert.strictEqual(typeof snapshot.totalAborts, 'bigint');
+    assert(snapshot.totalAborts >= 0n);
+    assert.strictEqual(typeof snapshot.totalSteals, 'bigint');
+    assert(snapshot.totalSteals >= 0n);
+    assert.strictEqual(typeof snapshot.totalExclusiveAcquired, 'bigint');
+    assert(snapshot.totalExclusiveAcquired >= 0n);
+    assert.strictEqual(typeof snapshot.totalSharedAcquired, 'bigint');
+    assert(snapshot.totalSharedAcquired >= 0n);
+
+    // Number counters
+    assert.strictEqual(typeof snapshot.holdersExclusive, 'number');
+    assert(snapshot.holdersExclusive >= 0);
+    assert.strictEqual(typeof snapshot.holdersShared, 'number');
+    assert(snapshot.holdersShared >= 0);
+    assert.strictEqual(typeof snapshot.pendingExclusive, 'number');
+    assert(snapshot.pendingExclusive >= 0);
+    assert.strictEqual(typeof snapshot.pendingShared, 'number');
+    assert(snapshot.pendingShared >= 0);
+
+    const totalAcq = totalAcquired(snapshot);
+    assert.strictEqual(typeof totalAcq, 'bigint');
+    assert.strictEqual(totalAcq, snapshot.totalExclusiveAcquired + snapshot.totalSharedAcquired);
+  });
+
+  it('should increment totalExclusiveAcquired and track holders', async () => {
+    const resource = 'test-exclusive-acquire';
+    const before = process.locksCounters();
+
+    await locks.request(resource, async (lock) => {
+      assert.strictEqual(lock.mode, 'exclusive');
+      const current = process.locksCounters();
+
+      assert.strictEqual(totalAcquired(current), totalAcquired(before) + 1n);
+      assert.strictEqual(current.totalExclusiveAcquired, before.totalExclusiveAcquired + 1n);
+
+      assert.strictEqual(current.holdersExclusive, before.holdersExclusive + 1);
+      assert.strictEqual(holdersTotal(current), holdersTotal(before) + 1);
+    });
+
+    const after = process.locksCounters();
+    assert.strictEqual(after.totalExclusiveAcquired, before.totalExclusiveAcquired + 1n);
+    assert.strictEqual(after.holdersExclusive, before.holdersExclusive);
+  });
+
+  it('should track multiple shared locks held simultaneously', async () => {
+    const resource = 'test-multiple-shared';
+    const before = process.locksCounters();
+
+    await locks.request(resource, { mode: 'shared' }, async () => {
+      const afterFirst = process.locksCounters();
+      assert.strictEqual(afterFirst.holdersShared, before.holdersShared + 1);
+
+      await locks.request(resource, { mode: 'shared' }, async () => {
+        const afterSecond = process.locksCounters();
+
+        assert.strictEqual(afterSecond.holdersShared, before.holdersShared + 2);
+        assert.strictEqual(afterSecond.totalSharedAcquired, before.totalSharedAcquired + 2n);
+      });
+    });
+
+    const after = process.locksCounters();
+    assert.strictEqual(after.totalSharedAcquired, before.totalSharedAcquired + 2n);
+    assert.strictEqual(after.holdersShared, before.holdersShared);
+  });
+
+  it('should track pending lock requests', async () => {
+    const resource = 'test-pending-lock';
+    const before = process.locksCounters();
+
+    const firstLock = locks.request(resource, async () => {
+      return 'first-lock';
+    });
+
+    const secondLock = locks.request(resource, async () => {
+      return 'second-lock';
+    });
+
+    const current = process.locksCounters();
+
+    // Should have one holder and one pending
+    assert(current.holdersExclusive >= before.holdersExclusive + 1);
+    assert(current.pendingExclusive >= before.pendingExclusive + 1);
+    assert(pendingTotal(current) >= pendingTotal(before) + 1);
+
+    // Release the locks
+    await firstLock;
+    await secondLock;
+
+    const after = process.locksCounters();
+    assert.strictEqual(after.totalExclusiveAcquired, before.totalExclusiveAcquired + 2n);
+  });
+
+  it('should increment totalAborts when ifAvailable fails', async () => {
+    const resource = 'test-ifavailable-abort';
+    const before = process.locksCounters();
+
+    await locks.request(resource, async () => {
+      // Try to acquire with ifAvailable while lock is held
+      const result = await locks.request(resource, { ifAvailable: true }, (lock) => {
+        return lock;
+      });
+
+      assert.strictEqual(result, null);
+
+      const after = process.locksCounters();
+      assert.strictEqual(after.totalAborts, before.totalAborts + 1n);
+    });
+  });
+
+  it('should increment totalAborts when callback rejects', async () => {
+    const resource = 'test-callback-reject-abort';
+    const before = process.locksCounters();
+
+    await locks.request(resource, async () => {
+      throw new Error('Callback rejection');
+    }).catch(() => {
+      // Expected rejection
+    });
+
+    const after = process.locksCounters();
+    assert.strictEqual(after.totalExclusiveAcquired, before.totalExclusiveAcquired + 1n);
+    assert.strictEqual(after.totalAborts, before.totalAborts + 1n);
+  });
+
+  it('should increment totalSteals when stealing a lock', async () => {
+    const resource = 'test-steal-counter';
+    const before = process.locksCounters();
+
+    const originalPromise = locks.request(resource, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return 'original';
+    }).catch((err) => {
+      assert.strictEqual(err.name, 'AbortError');
+      return 'stolen';
+    });
+
+    const stealResult = await locks.request(resource, { steal: true }, async (lock) => {
+      assert.strictEqual(lock.mode, 'exclusive');
+      return 'completed';
+    });
+
+    assert.strictEqual(stealResult, 'completed');
+    assert.strictEqual(await originalPromise, 'stolen');
+
+    const after = process.locksCounters();
+    assert.strictEqual(after.totalSteals, before.totalSteals + 1n);
+    assert.strictEqual(after.totalExclusiveAcquired, before.totalExclusiveAcquired + 2n);
+  });
+
+  it('should handle counters correctly across worker threads', async () => {
+    const resource = 'test-cross-thread';
+    const before = process.locksCounters();
+
+    const worker = new Worker(`
+      const { parentPort, locks } = require('worker_threads');
+
+      locks.request('test-cross-thread', async () => {
+        // Lock acquired and released
+      }).then(() => {
+        parentPort.postMessage('done');
+      });
+    `, { eval: true });
+
+    await new Promise((resolve) => {
+      worker.once('message', resolve);
+    });
+
+    await worker.terminate();
+
+    await locks.request(resource, async (lock) => {
+      assert.strictEqual(lock.mode, 'exclusive');
+    });
+
+    const after = process.locksCounters();
+    assert.strictEqual(totalAcquired(after), totalAcquired(before) + 2n);
+    assert.strictEqual(after.totalExclusiveAcquired, before.totalExclusiveAcquired + 2n);
+  });
+
+  it('should accumulate counters correctly over many acquisitions', async () => {
+    const resource = 'test-accumulation';
+    const before = process.locksCounters();
+    const iterations = 1_000;
+
+    for (let i = 0; i < iterations; i++) {
+      await locks.request(resource, { mode: i % 2 === 0 ? 'exclusive' : 'shared' }, async () => {
+        // Do nothing, just acquire the lock
+      });
+    }
+
+    const after = process.locksCounters();
+
+    const totalAcquired = after.totalExclusiveAcquired + after.totalSharedAcquired;
+    const beforeTotal = before.totalExclusiveAcquired + before.totalSharedAcquired;
+
+    assert.strictEqual(totalAcquired, beforeTotal + BigInt(iterations));
+
+    assert(after.totalExclusiveAcquired > before.totalExclusiveAcquired);
+    assert(after.totalSharedAcquired > before.totalSharedAcquired);
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces `process.locksCounters()` to provide real time visibility into [Web Locks API](https://nodejs.org/docs/latest/api/globals.html#navigatorlocks) usage and contention metrics across the Node.js process.

 ## Motivation

Lock contention can be difficult to diagnose in concurrent applications. Other platforms already make this easier,.NET has lock performance counters, Java has JMX for checking thread locks, and Go has mutex profiling.

Node.js added the Web Locks API in v24, but there’s currently no built-in way to see how locks are behaving. The new `process.locksCounters()` provide metrics to help developers monitor and debug lock related performance problems.