### PR TITLE
doc: correct examples in worker_threads

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1411,7 +1411,7 @@ port1.onmessage = ({ data }) => console.log(data);
 
 port2.postMessage(new Foo());
 
-// Prints: { c: 3 }
+// Prints: { c: 3 } then throws DOMException [DataCloneError]: Cannot clone object of unsupported type.
 ```
 
 This limitation extends to many built-in objects, such as the global `URL`
@@ -1424,7 +1424,7 @@ port1.onmessage = ({ data }) => console.log(data);
 
 port2.postMessage(new URL('https://example.org'));
 
-// Prints: { }
+// Throws: DOMException [DataCloneError]: Cannot clone object of unsupported type.
 ```
 
 ### `port.hasRef()`


### PR DESCRIPTION
## Fix incorrect output in structured clone examples

### Problem

The documentation for `port.postMessage()` under "Considerations when cloning objects with prototypes, classes, and accessors" shows two code examples with incorrect expected output:

1. **Class instance example**: Claims `postMessage(new Foo())` prints `{ c: 3 }`
2. **URL object example**: Claims `postMessage(new URL(...))` prints `{}`

Both examples actually throw `DataCloneError` because class instances and URL objects cannot be cloned by the structured clone algorithm.

### Solution

Updated both code examples to show they throw `DOMException [DataCloneError]` instead of printing output.

Closes #60504  