### PR TITLE
[v24.x backport] deps: V8: backport e5dbbbadcbff

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.31',
+    'v8_embedder_string': '-node.32',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/compiler/backend/code-generator.cc
+++ b/deps/v8/src/compiler/backend/code-generator.cc
@@ -435,7 +435,7 @@ void CodeGenerator::AssembleCode() {
     }
   }
 
-  // The LinuxPerfJitLogger logs code up until here, excluding the safepoint
+  // The PerfJitLogger logs code up until here, excluding the safepoint
   // table. Resolve the unwinding info now so it is aware of the same code
   // size as reported by perf.
   unwinding_info_writer_.Finish(masm()->pc_offset());

--- a/deps/v8/src/diagnostics/perf-jit.h
+++ b/deps/v8/src/diagnostics/perf-jit.h
@@ -30,8 +30,8 @@
 
 #include "include/v8config.h"
 
-// {LinuxPerfJitLogger} is only implemented on Linux.
-#if V8_OS_LINUX
+// {PerfJitLogger} is only implemented on Linux & Darwin.
+#if V8_OS_LINUX || V8_OS_DARWIN
 
 #include "src/logging/log.h"
 
@@ -39,10 +39,10 @@ namespace v8 {
 namespace internal {
 
 // Linux perf tool logging support.
-class LinuxPerfJitLogger : public CodeEventLogger {
+class PerfJitLogger : public CodeEventLogger {
  public:
-  explicit LinuxPerfJitLogger(Isolate* isolate);
-  ~LinuxPerfJitLogger() override;
+  explicit PerfJitLogger(Isolate* isolate);
+  ~PerfJitLogger() override;
 
   void CodeMoveEvent(Tagged<InstructionStream> from,
                      Tagged<InstructionStream> to) override {
@@ -143,6 +143,6 @@ class LinuxPerfJitLogger : public CodeEventLogger {
 }  // namespace internal
 }  // namespace v8
 
-#endif  // V8_OS_LINUX
+#endif  // V8_OS_LINUX || V8_OS_DARWIN
 
 #endif  // V8_DIAGNOSTICS_PERF_JIT_H_

--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -3264,7 +3264,7 @@ DEFINE_IMPLICATION(prof, log_code)
 
 DEFINE_BOOL(ll_prof, false, "Enable low-level linux profiler.")
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_DARWIN
 #define DEFINE_PERF_PROF_BOOL(nam, cmt) DEFINE_BOOL(nam, false, cmt)
 #define DEFINE_PERF_PROF_IMPLICATION DEFINE_IMPLICATION
 #else
@@ -3281,7 +3281,7 @@ DEFINE_BOOL(ll_prof, false, "Enable low-level linux profiler.")
 #endif
 
 DEFINE_PERF_PROF_BOOL(perf_basic_prof,
-                      "Enable perf linux profiler (basic support).")
+                      "Enable basic support for perf profiler.")
 DEFINE_NEG_IMPLICATION(perf_basic_prof, compact_code_space)
 DEFINE_STRING(perf_basic_prof_path, DEFAULT_PERF_BASIC_PROF_PATH,
               "directory to write perf-<pid>.map symbol file to")
@@ -3290,8 +3290,8 @@ DEFINE_PERF_PROF_BOOL(
     "Only report function code ranges to perf (i.e. no stubs).")
 DEFINE_PERF_PROF_IMPLICATION(perf_basic_prof_only_functions, perf_basic_prof)
 
-DEFINE_PERF_PROF_BOOL(
-    perf_prof, "Enable perf linux profiler (experimental annotate support).")
+DEFINE_PERF_PROF_BOOL(perf_prof,
+                      "Enable experimental annotate support for perf profiler.")
 DEFINE_STRING(perf_prof_path, DEFAULT_PERF_PROF_PATH,
               "directory to write jit-<pid>.dump symbol file to")
 DEFINE_PERF_PROF_BOOL(

--- a/deps/v8/src/logging/log.cc
+++ b/deps/v8/src/logging/log.cc
@@ -350,12 +350,12 @@ void CodeEventLogger::RegExpCodeCreateEvent(DirectHandle<AbstractCode> code,
                     name_buffer_->get(), name_buffer_->size());
 }
 
-// Linux perf tool logging support.
-#if V8_OS_LINUX
-class LinuxPerfBasicLogger : public CodeEventLogger {
+// Linux & Darwin perf tool logging support.
+#if V8_OS_LINUX || V8_OS_DARWIN
+class PerfBasicLogger : public CodeEventLogger {
  public:
-  explicit LinuxPerfBasicLogger(Isolate* isolate);
-  ~LinuxPerfBasicLogger() override;
+  explicit PerfBasicLogger(Isolate* isolate);
+  ~PerfBasicLogger() override;
 
   void CodeMoveEvent(Tagged<InstructionStream> from,
                      Tagged<InstructionStream> to) override {}
@@ -388,21 +388,20 @@ class LinuxPerfBasicLogger : public CodeEventLogger {
 };
 
 // Extra space for the "perf-%d.map" filename, including the PID.
-const int LinuxPerfBasicLogger::kFilenameBufferPadding = 32;
+const int PerfBasicLogger::kFilenameBufferPadding = 32;
 
 // static
-base::LazyRecursiveMutex& LinuxPerfBasicLogger::GetFileMutex() {
+base::LazyRecursiveMutex& PerfBasicLogger::GetFileMutex() {
   static base::LazyRecursiveMutex file_mutex = LAZY_RECURSIVE_MUTEX_INITIALIZER;
   return file_mutex;
 }
 
 // The following static variables are protected by
-// LinuxPerfBasicLogger::GetFileMutex().
-uint64_t LinuxPerfBasicLogger::reference_count_ = 0;
-FILE* LinuxPerfBasicLogger::perf_output_handle_ = nullptr;
+// PerfBasicLogger::GetFileMutex().
+uint64_t PerfBasicLogger::reference_count_ = 0;
+FILE* PerfBasicLogger::perf_output_handle_ = nullptr;
 
-LinuxPerfBasicLogger::LinuxPerfBasicLogger(Isolate* isolate)
-    : CodeEventLogger(isolate) {
+PerfBasicLogger::PerfBasicLogger(Isolate* isolate) : CodeEventLogger(isolate) {
   base::LockGuard<base::RecursiveMutex> guard_file(GetFileMutex().Pointer());
   int process_id_ = base::OS::GetCurrentProcessId();
   reference_count_++;
@@ -424,7 +423,7 @@ LinuxPerfBasicLogger::LinuxPerfBasicLogger(Isolate* isolate)
   }
 }
 
-LinuxPerfBasicLogger::~LinuxPerfBasicLogger() {
+PerfBasicLogger::~PerfBasicLogger() {
   base::LockGuard<base::RecursiveMutex> guard_file(GetFileMutex().Pointer());
   reference_count_--;
 
@@ -436,9 +435,9 @@ LinuxPerfBasicLogger::~LinuxPerfBasicLogger() {
   }
 }
 
-void LinuxPerfBasicLogger::WriteLogRecordedBuffer(uintptr_t address,
-                                                  size_t size, const char* name,
-                                                  size_t name_length) {
+void PerfBasicLogger::WriteLogRecordedBuffer(uintptr_t address, size_t size,
+                                             const char* name,
+                                             size_t name_length) {
   // Linux perf expects hex literals without a leading 0x, while some
   // implementations of printf might prepend one when using the %p format
   // for pointers, leading to wrongly formatted JIT symbols maps. On the other
@@ -456,9 +455,9 @@ void LinuxPerfBasicLogger::WriteLogRecordedBuffer(uintptr_t address,
 #endif
 }
 
-void LinuxPerfBasicLogger::LogRecordedBuffer(
-    Tagged<AbstractCode> code, MaybeDirectHandle<SharedFunctionInfo>,
-    const char* name, size_t length) {
+void PerfBasicLogger::LogRecordedBuffer(Tagged<AbstractCode> code,
+                                        MaybeDirectHandle<SharedFunctionInfo>,
+                                        const char* name, size_t length) {
   DisallowGarbageCollection no_gc;
   PtrComprCageBase cage_base(isolate_);
   if (v8_flags.perf_basic_prof_only_functions &&
@@ -472,13 +471,13 @@ void LinuxPerfBasicLogger::LogRecordedBuffer(
 }
 
 #if V8_ENABLE_WEBASSEMBLY
-void LinuxPerfBasicLogger::LogRecordedBuffer(const wasm::WasmCode* code,
-                                             const char* name, size_t length) {
+void PerfBasicLogger::LogRecordedBuffer(const wasm::WasmCode* code,
+                                        const char* name, size_t length) {
   WriteLogRecordedBuffer(static_cast<uintptr_t>(code->instruction_start()),
                          code->instructions().length(), name, length);
 }
 #endif  // V8_ENABLE_WEBASSEMBLY
-#endif  // V8_OS_LINUX
+#endif  // V8_OS_LINUX || V8_OS_DARWIN
 
 // External LogEventListener
 ExternalLogEventListener::ExternalLogEventListener(Isolate* isolate)
@@ -2304,14 +2303,14 @@ bool V8FileLogger::SetUp(Isolate* isolate) {
   PrepareLogFileName(log_file_name, isolate, v8_flags.logfile);
   log_file_ = std::make_unique<LogFile>(this, log_file_name.str());
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_DARWIN
   if (v8_flags.perf_basic_prof) {
-    perf_basic_logger_ = std::make_unique<LinuxPerfBasicLogger>(isolate);
+    perf_basic_logger_ = std::make_unique<PerfBasicLogger>(isolate);
     CHECK(logger()->AddListener(perf_basic_logger_.get()));
   }
 
   if (v8_flags.perf_prof) {
-    perf_jit_logger_ = std::make_unique<LinuxPerfJitLogger>(isolate);
+    perf_jit_logger_ = std::make_unique<PerfJitLogger>(isolate);
     CHECK(logger()->AddListener(perf_jit_logger_.get()));
   }
 #else
@@ -2457,7 +2456,7 @@ FILE* V8FileLogger::TearDownAndGetLogFile() {
   ticker_.reset();
   timer_.Stop();
 
-#if V8_OS_LINUX
+#if V8_OS_LINUX || V8_OS_DARWIN
   if (perf_basic_logger_) {
     CHECK(logger()->RemoveListener(perf_basic_logger_.get()));
     perf_basic_logger_.reset();

--- a/deps/v8/src/logging/log.h
+++ b/deps/v8/src/logging/log.h
@@ -64,8 +64,8 @@ class Isolate;
 class JitLogger;
 class LogFile;
 class LowLevelLogger;
-class LinuxPerfBasicLogger;
-class LinuxPerfJitLogger;
+class PerfBasicLogger;
+class PerfJitLogger;
 class Profiler;
 class SourcePosition;
 class Ticker;
@@ -363,9 +363,9 @@ class V8FileLogger : public LogEventListener {
 
   std::atomic<bool> is_logging_;
   std::unique_ptr<LogFile> log_file_;
-#if V8_OS_LINUX
-  std::unique_ptr<LinuxPerfBasicLogger> perf_basic_logger_;
-  std::unique_ptr<LinuxPerfJitLogger> perf_jit_logger_;
+#if V8_OS_LINUX || V8_OS_DARWIN
+  std::unique_ptr<PerfBasicLogger> perf_basic_logger_;
+  std::unique_ptr<PerfJitLogger> perf_jit_logger_;
 #endif
   std::unique_ptr<LowLevelLogger> ll_logger_;
   std::unique_ptr<JitLogger> jit_logger_;


### PR DESCRIPTION
Manual backport for v24.x of the changes in https://github.com/nodejs/node/pull/58010.

Original commit message:

    Enable --perf-prof flag on MacOS

    MacOS actually can share the implementation of {PerfJitLogger} with
    Linux. From the issue 40112126, only Fuzzer tests on Windows ran
    into UNREACHABLE/FATAL because of the unimplemented {PerfJitLogger}.
    This CL enables the flag --perf-prof on MacOS.

    Bug: 403765219
    Change-Id: I97871fbcc0cb9890c51ca14fd7a6e65bd0e3c0d2
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6385655
    Reviewed-by: Clemens Backes <clemensb@chromium.org>
    Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
    Auto-Submit: 杨文明 <yangwenming@bytedance.com>
    Commit-Queue: Clemens Backes <clemensb@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#99885}

Refs: v8/v8@e5dbbba

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
