### PR TITLE
crypto: fix argument validation in crypto.timingSafeEqual fast path

### DIFF
--- a/src/crypto/crypto_timing.cc
+++ b/src/crypto/crypto_timing.cc
@@ -56,6 +56,20 @@ bool FastTimingSafeEqual(Local<Value> receiver,
                          // NOLINTNEXTLINE(runtime/references)
                          FastApiCallbackOptions& options) {
   HandleScope scope(options.isolate);
+  if (!IsAnyBufferSource(a_obj)) {
+    TRACK_V8_FAST_API_CALL("crypto.timingSafeEqual.error");
+    THROW_ERR_INVALID_ARG_TYPE(options.isolate,
+                               "The \"buf1\" argument must be an instance of "
+                               "ArrayBuffer, Buffer, TypedArray, or DataView.");
+    return false;
+  }
+  if (!IsAnyBufferSource(b_obj)) {
+    TRACK_V8_FAST_API_CALL("crypto.timingSafeEqual.error");
+    THROW_ERR_INVALID_ARG_TYPE(options.isolate,
+                               "The \"buf2\" argument must be an instance of "
+                               "ArrayBuffer, Buffer, TypedArray, or DataView.");
+    return false;
+  }
   ArrayBufferViewContents<uint8_t> a(a_obj);
   ArrayBufferViewContents<uint8_t> b(b_obj);
   if (a.length() != b.length()) {

--- a/test/sequential/test-crypto-timing-safe-equal-fast.js
+++ b/test/sequential/test-crypto-timing-safe-equal-fast.js
@@ -1,0 +1,40 @@
+// Test v8 fast path for crypto.timingSafeEqual works correctly.
+// Flags: --expose-internals --allow-natives-syntax
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+// V8 Fast API
+const foo = Buffer.from('foo');
+const bar = Buffer.from('bar');
+const longer = Buffer.from('longer');
+function testFastPath(buf1, buf2) {
+  return crypto.timingSafeEqual(buf1, buf2);
+}
+eval('%PrepareFunctionForOptimization(testFastPath)');
+assert.strictEqual(testFastPath(foo, bar), false);
+eval('%OptimizeFunctionOnNextCall(testFastPath)');
+assert.strictEqual(testFastPath(foo, bar), false);
+assert.strictEqual(testFastPath(foo, foo), true);
+assert.throws(() => testFastPath(foo, longer), {
+  code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
+});
+assert.throws(() => testFastPath(foo, ''), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+assert.throws(() => testFastPath('', ''), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+if (common.isDebug) {
+  const { internalBinding } = require('internal/test/binding');
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('crypto.timingSafeEqual.ok'), 2);
+  assert.strictEqual(getV8FastApiCallCount('crypto.timingSafeEqual.error'), 3);
+}

--- a/test/sequential/test-crypto-timing-safe-equal.js
+++ b/test/sequential/test-crypto-timing-safe-equal.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --no-warnings --allow-natives-syntax
+// Flags: --no-warnings
 'use strict';
 const common = require('../common');
 if (!common.hasCrypto)
@@ -92,28 +92,3 @@ assert.throws(
     name: 'TypeError',
   }
 );
-
-{
-  // V8 Fast API
-  const foo = Buffer.from('foo');
-  const bar = Buffer.from('bar');
-  const longer = Buffer.from('longer');
-  function testFastPath(buf1, buf2) {
-    return crypto.timingSafeEqual(buf1, buf2);
-  }
-  eval('%PrepareFunctionForOptimization(testFastPath)');
-  assert.strictEqual(testFastPath(foo, bar), false);
-  eval('%OptimizeFunctionOnNextCall(testFastPath)');
-  assert.strictEqual(testFastPath(foo, bar), false);
-  assert.strictEqual(testFastPath(foo, foo), true);
-  assert.throws(() => testFastPath(foo, longer), {
-    code: 'ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH',
-  });
-
-  if (common.isDebug) {
-    const { internalBinding } = require('internal/test/binding');
-    const { getV8FastApiCallCount } = internalBinding('debug');
-    assert.strictEqual(getV8FastApiCallCount('crypto.timingSafeEqual.ok'), 2);
-    assert.strictEqual(getV8FastApiCallCount('crypto.timingSafeEqual.error'), 1);
-  }
-}


### PR DESCRIPTION
A regression introduced by
https://github.com/nodejs/node/commit/0136bb0ee807b9789bf69e8d87e7a98e1b15f217 made it possible for the fast path to be hit with non-array-buffer arguments despite that the fast paths could only deal with array buffer arguments, so that it can crash with invalid arguments once crypto.timingSafeEqual is optimized instead of throwing validation errors as usual. This adds validation to the fast path so that it throws correctly.

Originally opened in the private repo to stay on the safe side, moving it to public since there's consensus that this is a regular bug, not a vulnerability.

Refs: https://github.com/nodejs-private/node-private/pull/749
Fixes: https://github.com/nodejs/node/issues/60537

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
