### PR TITLE
lib: call normalizeEncoding in fs.writeFileSync and fs.readFileSync

### DIFF
--- a/benchmark/fs/bench-writeFileSync.js
+++ b/benchmark/fs/bench-writeFileSync.js
@@ -7,7 +7,7 @@ tmpdir.refresh();
 
 // Some variants are commented out as they do not show a change and just slow
 const bench = common.createBenchmark(main, {
-  encoding: ['utf8'],
+  encoding: ['utf8', 'UTF8'],
   useFd: ['true', 'false'],
   length: [1024, 102400, 1024 * 1024],
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -92,6 +92,7 @@ const {
     custom: kCustomPromisifiedSymbol,
   },
   SideEffectFreeRegExpPrototypeExec,
+  normalizeEncoding,
   defineLazyProperties,
   isWindows,
   isMacOS,
@@ -428,7 +429,7 @@ function tryReadSync(fd, isUserFd, buffer, pos, len) {
 function readFileSync(path, options) {
   options = getOptions(options, { flag: 'r' });
 
-  if (options.encoding === 'utf8' || options.encoding === 'utf-8') {
+  if (options.encoding && normalizeEncoding(options.encoding) === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }
@@ -2383,7 +2384,7 @@ function writeFileSync(path, data, options) {
   const flag = options.flag || 'w';
 
   // C++ fast path for string data and UTF8 encoding
-  if (typeof data === 'string' && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
+  if (typeof data === 'string' && normalizeEncoding(options.encoding) === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/49888 by adding calls to `normalizeEncoding`.

Benchmarks between #f46152fdb3 and CL from this PR

```
                                                                                                                 confidence improvement accuracy (*)    (**)   (***)
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1024 useFd='false' encoding='utf8'                    1.34 %       ±5.41%  ±7.22%  ±9.43%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1024 useFd='false' encoding='UTF8'                   -0.50 %       ±2.76%  ±3.67%  ±4.78%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1024 useFd='true' encoding='utf8'                    -0.39 %       ±3.46%  ±4.61%  ±6.01%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1024 useFd='true' encoding='UTF8'            ***     57.52 %       ±4.34%  ±5.79%  ±7.55%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=102400 useFd='false' encoding='utf8'                 -0.39 %       ±3.91%  ±5.21%  ±6.78%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=102400 useFd='false' encoding='UTF8'         ***     66.76 %       ±5.95%  ±7.98% ±10.52%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=102400 useFd='true' encoding='utf8'                   0.93 %       ±1.54%  ±2.05%  ±2.67%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=102400 useFd='true' encoding='UTF8'          ***    288.37 %       ±5.84%  ±7.79% ±10.20%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1048576 useFd='false' encoding='utf8'                 1.45 %       ±3.28%  ±4.38%  ±5.74%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1048576 useFd='false' encoding='UTF8'        ***     99.65 %       ±5.43%  ±7.29%  ±9.61%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1048576 useFd='true' encoding='utf8'                  2.30 %       ±5.30%  ±7.07%  ±9.24%
fs/bench-writeFileSync.js n=1000 func='writeFile' useBuffer='false' length=1048576 useFd='true' encoding='UTF8'         ***    246.19 %      ±17.91% ±24.14% ±32.04%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 12 comparisons, you can thus expect the following amount of false-positive results:
  0.60 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.12 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```

I am open to suggestions here, but given that in the case of fast paths, the only encoding we care about is utf8, would it perhaps make more sense to have a `isUTF8Encoding()` which would return a bool?

Reviews and suggestions are much appreciated 🙏🏼 