### PR TITLE
events: don't call resume after close (fix readline regression)

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1073,7 +1073,7 @@ function on(emitter, event, options = kEmptyObject) {
         const value = unconsumedEvents.shift();
         size--;
         if (paused && size < lowWatermark) {
-          emitter.resume();
+          emitter.resume(); // Can not be finished yet
           paused = false;
         }
         return PromiseResolve(createIterResult(value, false));
@@ -1190,6 +1190,7 @@ function on(emitter, event, options = kEmptyObject) {
     abortListenerDisposable?.[SymbolDispose]();
     removeAll();
     finished = true;
+    paused = false;
     const doneResult = createIterResult(undefined, true);
     while (!unconsumedPromises.isEmpty()) {
       unconsumedPromises.shift().resolve(doneResult);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60507
Regression from: https://github.com/nodejs/node/pull/58283

Since https://github.com/nodejs/node/pull/58283, readline is not compatible with `EventEmitter.on` (and readline own async iterator)
It throws on attempting to `.resume` the stream after it was closed, which was what `EventEmitter.on` was doing

Another option is to make `.resume` a noop in closed state instead of throwing