### PR TITLE
tools: add workflow to add `author ready`

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -3,6 +3,8 @@ name: Label PRs
 on:
   pull_request_target:
     types: [opened]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
@@ -13,6 +15,26 @@ jobs:
 
     steps:
       - uses: nodejs/node-pr-labeler@d4cf1b8b9f23189c37917000e5e17e796c770a6b  # v1
+        if: github.event_name != 'pull_request_review'
         with:
           repo-token: ${{ secrets.GH_USER_TOKEN }}
           configuration-path: .github/label-pr-config.yml
+      - name: Add 'Author ready' label
+        if: github.event_name == 'pull_request_review'
+        run: |
+          gh pr view "$PR_URL" --json reviewDecision,statusCheckRollup,mergeable,labels --jq '
+            if .mergeable == "MERGEABLE" and
+               .reviewDecision == "APPROVED" and
+               (.statusCheckRollup | all(.conclusion != "FAILURE")) and
+               ((.labels | all(.name != "needs-ci" and .name != "author ready")) or (.labels | any(.name == "request-ci")))
+            then
+              halt_error
+            end | {
+              labels: .labels | map(.name),
+              failedChecks: .statusCheckRollup | map(select(.conclusion == "FAILURE")),
+              mergeable,
+              reviewDecision,
+            }' || gh pr edit "$PR_URL" --add-label 'author ready'
+        env:
+          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,23 +6,28 @@ on:
   pull_request_review:
     types: [submitted]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request_review'
 
     steps:
       - uses: nodejs/node-pr-labeler@d4cf1b8b9f23189c37917000e5e17e796c770a6b  # v1
-        if: github.event_name != 'pull_request_review'
         with:
           repo-token: ${{ secrets.GH_USER_TOKEN }}
           configuration-path: .github/label-pr-config.yml
+
+  author_ready:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review'
+    permissions:
+      issues: write
+    steps:
       - name: Add 'Author ready' label
-        if: github.event_name == 'pull_request_review'
         run: |
-          gh pr view "$PR_URL" --json reviewDecision,statusCheckRollup,mergeable,labels --jq '
+          gh pr view "$PR_URL" --json review,statusCheckRollup,mergeable,labels --jq '
             if .mergeable == "MERGEABLE" and
                .reviewDecision == "APPROVED" and
                (.statusCheckRollup | all(.conclusion != "FAILURE")) and
@@ -34,7 +39,31 @@ jobs:
               failedChecks: .statusCheckRollup | map(select(.conclusion == "FAILURE")),
               mergeable,
               reviewDecision,
-            }' || gh pr edit "$PR_URL" --add-label 'author ready'
+            }' \
+          || gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) {
+                        nodes {
+                          body
+                          author { login }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -F "owner=$OWNER" -F "repo=$REPO" -F "pr=$PR_NUMBER" --jq '
+              .data.repository.pullRequest.reviewThreads.nodes | if all(.isResolved)
+              then
+                halt_error
+              end
+            ' \
+          || gh pr edit "$PR_URL" --add-label 'author ready'
         env:
-          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
The number of PRs keeps creeping up, one of the reason is that we have PRs that have been approved and just forgotten about. By having the `author ready` added automatically, it can help with that as I for one will often check out https://github.com/nodejs/node/pulls?q=is:pr+is:open+label:%22author+ready%22+-label:commit-queue e.g. when preparing a release.

Not that this won't add the label to all PRs that deserve it, won't remove it automatically, and might add to some that do not deserve it, so there will still be triagging work to do.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
