### PR TITLE
doc: clarify tls version negotiation behavior with DEFAULT_MIN_VERSION

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -496,6 +496,13 @@ createServer({ ciphers: 'DEFAULT@SECLEVEL=0', minVersion: 'TLSv1' }, function(so
 This approach sets the security level to 0, allowing the use of legacy features while still
 leveraging the default OpenSSL ciphers.
 
+**Note:**  
+The default minimum TLS version (`tls.DEFAULT_MIN_VERSION`) is `'TLSv1.2'`.  
+If you set `maxVersion` lower than this value (for example, `'TLSv1'`), no protocols will overlap, and the TLS handshake will fail with:
+`ERR_SSL_NO_PROTOCOLS_AVAILABLE`.  
+Even when `maxVersion` equals the default, weaker ciphers or low security levels may cause `ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE`.
+
+
 ### Using [`--tls-cipher-list`][]
 
 You can also set the security level and ciphers from the command line using the


### PR DESCRIPTION
update documentation for tls security levels to explain how tls.DEFAULT_MIN_VERSION interacts with user-defined maxVersion and why setting a lower maxVersion (e.g., TLSv1) can cause ERR_SSL_NO_PROTOCOLS_AVAILABLE or handshake failures.

Fixes: https://github.com/nodejs/node/issues/60569

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
