### PR TITLE
inspector: inspect HTTP response body

### DIFF
--- a/lib/internal/inspector/network_http.js
+++ b/lib/internal/inspector/network_http.js
@@ -17,6 +17,7 @@ const {
   sniffMimeType,
 } = require('internal/inspector/network');
 const { Network } = require('inspector');
+const EventEmitter = require('events');
 
 const kRequestUrl = Symbol('kRequestUrl');
 
@@ -118,6 +119,17 @@ function onClientResponseFinish({ request, response }) {
       mimeType,
       charset,
     },
+  });
+
+  // Unlike response.on('data', ...), this does not put the stream into flowing mode.
+  EventEmitter.prototype.on.call(response, 'data', (chunk) => {
+    Network.dataReceived({
+      requestId: request[kInspectorRequestId],
+      timestamp: getMonotonicTime(),
+      dataLength: chunk.byteLength,
+      encodedDataLength: chunk.byteLength,
+      data: chunk,
+    });
   });
 
   // Wait until the response body is consumed by user code.


### PR DESCRIPTION
This adds support for inspecting HTTP response body. (Request body is not supported yet).

Refs: https://github.com/nodejs/node/issues/53946