### PR TITLE
v8: adding total_allocated_bytes to HeapStatistics

### DIFF
--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -197,6 +197,7 @@ Returns an object with the following properties:
 * `total_global_handles_size` {number}
 * `used_global_handles_size` {number}
 * `external_memory` {number}
+* `total_allocated_bytes` {number}
 
 `total_heap_size` The value of total\_heap\_size is the number of bytes V8 has
 allocated for the heap. This can grow if used\_heap needs more memory.
@@ -249,6 +250,9 @@ used memory size of V8 global handles.
 
 `external_memory` The value of external\_memory is the memory size of array
 buffers and external strings.
+
+`total_allocated_bytes` The value of total allocated bytes since the Isolate
+creation
 
 <!-- eslint-skip -->
 

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -136,6 +136,7 @@ const {
   kTotalGlobalHandlesSizeIndex,
   kUsedGlobalHandlesSizeIndex,
   kExternalMemoryIndex,
+  kTotalAllocatedBytes,
 
   // Properties for heap spaces statistics buffer extraction.
   kHeapSpaces,
@@ -246,6 +247,7 @@ function getHeapStatistics() {
     total_global_handles_size: buffer[kTotalGlobalHandlesSizeIndex],
     used_global_handles_size: buffer[kUsedGlobalHandlesSizeIndex],
     external_memory: buffer[kExternalMemoryIndex],
+    total_allocated_bytes: buffer[kTotalAllocatedBytes],
   };
 }
 

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -73,7 +73,8 @@ using v8::Value;
   V(10, number_of_detached_contexts, kNumberOfDetachedContextsIndex)           \
   V(11, total_global_handles_size, kTotalGlobalHandlesSizeIndex)               \
   V(12, used_global_handles_size, kUsedGlobalHandlesSizeIndex)                 \
-  V(13, external_memory, kExternalMemoryIndex)
+  V(13, external_memory, kExternalMemoryIndex)                                 \
+  V(14, total_allocated_bytes, kTotalAllocatedBytes)
 
 #define V(a, b, c) +1
 static constexpr size_t kHeapStatisticsPropertiesCount =

--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -1263,6 +1263,7 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
                 "total_global_handles_size",
                 "used_global_handles_size",
                 "external_memory",
+                "total_allocated_bytes",
             };
             tmpl = DictionaryTemplate::New(isolate, heap_stats_names);
             env->set_heap_statistics_template(tmpl);
@@ -1283,7 +1284,8 @@ void Worker::GetHeapStatistics(const FunctionCallbackInfo<Value>& args) {
               Number::New(isolate, heap_stats->number_of_detached_contexts()),
               Number::New(isolate, heap_stats->total_global_handles_size()),
               Number::New(isolate, heap_stats->used_global_handles_size()),
-              Number::New(isolate, heap_stats->external_memory())};
+              Number::New(isolate, heap_stats->external_memory()),
+              Number::New(isolate, heap_stats->total_allocated_bytes())};
 
           Local<Object> obj;
           if (!NewDictionaryInstanceNullProto(

--- a/test/parallel/test-v8-stats.js
+++ b/test/parallel/test-v8-stats.js
@@ -12,6 +12,7 @@ const keys = [
   'number_of_detached_contexts',
   'number_of_native_contexts',
   'peak_malloced_memory',
+  'total_allocated_bytes',
   'total_available_size',
   'total_global_handles_size',
   'total_heap_size',

--- a/test/parallel/test-worker-heap-statistics.js
+++ b/test/parallel/test-worker-heap-statistics.js
@@ -40,6 +40,7 @@ if (isMainThread) {
       `total_global_handles_size`,
       `used_global_handles_size`,
       `external_memory`,
+      `total_allocated_bytes`,
     ].sort();
     assert.deepStrictEqual(keys, Object.keys(stats).sort());
     for (const key of keys) {


### PR DESCRIPTION
This PR adds to Node's HeapStatistics API a new field called `total_allocated_bytes` that contains the total bytes allocated since the creation of an isolate. This extension comes from the extension added recently in V8 on https://github.com/v8/v8/commit/fe81545e6d14397cabb39ba3a5163eedf7624bb1. The major use case for this information is to allow creating of regression tests tracking allocations.
