### PR TITLE
src,permission: add --permission-audit

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -189,6 +189,9 @@ to use as a custom module loader.
 .It Fl -permission
 Enable the permission model.
 .
+.It Fl -permission-audit
+Enable warning only with the permission model.
+.
 .It Fl -experimental-shadow-realm
 Use this flag to enable ShadowRealm support.
 .

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -602,7 +602,7 @@ function initializeClusterIPC() {
 }
 
 function initializePermission() {
-  const permission = getOptionValue('--permission');
+  const permission = getOptionValue('--permission') || getOptionValue('--permission-audit');
   if (permission) {
     process.binding = function binding(_module) {
       throw new ERR_ACCESS_DENIED('process.binding');

--- a/src/env.cc
+++ b/src/env.cc
@@ -909,8 +909,11 @@ Environment::Environment(IsolateData* isolate_data,
                                       tracing::CastTracedValue(traced_value));
   }
 
-  if (options_->permission) {
+  if (options_->permission || options_->permission_audit) {
     permission()->EnablePermissions();
+    if (options_->permission_audit) {
+      permission()->EnableWarningOnly();
+    }
     // The process shouldn't be able to neither
     // spawn/worker nor use addons or enable inspector
     // unless explicitly allowed by the user

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -600,6 +600,11 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::permission,
             kAllowedInEnvvar,
             false);
+  AddOption("--permission-audit",
+            "enable audit only for the permission system",
+            &EnvironmentOptions::permission_audit,
+            kAllowedInEnvvar,
+            false);
   AddOption("--allow-fs-read",
             "allow permissions to read the filesystem",
             &EnvironmentOptions::allow_fs_read,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -138,6 +138,7 @@ class EnvironmentOptions : public Options {
   std::string input_type;  // Value of --input-type
   bool entry_is_url = false;
   bool permission = false;
+  bool permission_audit = false;
   std::vector<std::string> allow_fs_read;
   std::vector<std::string> allow_fs_write;
   bool allow_addons = false;

--- a/src/node_process-inl.h
+++ b/src/node_process-inl.h
@@ -19,6 +19,14 @@ inline v8::Maybe<bool> ProcessEmitWarning(Environment* env,
   return ProcessEmitWarningGeneric(env, warning.c_str());
 }
 
+template <typename... Args>
+inline v8::Maybe<void> ProcessEmitWarningSync(Environment* env,
+                                              const char* fmt,
+                                              Args&&... args) {
+  std::string warning = SPrintF(fmt, std::forward<Args>(args)...);
+  return ProcessEmitWarningSync(env, warning);
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_process.h
+++ b/src/node_process.h
@@ -37,6 +37,10 @@ template <typename... Args>
 inline v8::Maybe<bool> ProcessEmitWarning(Environment* env,
                                           const char* fmt,
                                           Args&&... args);
+template <typename... Args>
+inline v8::Maybe<void> ProcessEmitWarningSync(Environment* env,
+                                              const char* fmt,
+                                              Args&&... args);
 
 v8::Maybe<void> ProcessEmitWarningSync(Environment* env,
                                        std::string_view message);

--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -37,7 +37,7 @@ namespace permission {
         [[unlikely]] {                                                         \
       node::permission::Permission::ThrowAccessDenied(                         \
           env__, perm__, resource__);                                          \
-      return __VA_ARGS__;                                                      \
+      if (!env__->permission()->warning_only()) return __VA_ARGS__;            \
     }                                                                          \
   } while (0)
 
@@ -51,7 +51,7 @@ namespace permission {
         [[unlikely]] {                                                         \
       node::permission::Permission::AsyncThrowAccessDenied(                    \
           env__, (wrap), perm__, resource__);                                  \
-      return __VA_ARGS__;                                                      \
+      if (!env__->permission()->warning_only()) return __VA_ARGS__;            \
     }                                                                          \
   } while (0)
 
@@ -66,7 +66,7 @@ namespace permission {
       Local<Value> err_access;                                                 \
       if (node::permission::CreateAccessDeniedError(env__, perm__, resource__) \
               .ToLocal(&err_access)) {                                         \
-        args.GetReturnValue().Set(err_access);                                 \
+        \ args.GetReturnValue().Set(err_access);                               \
       } else {                                                                 \
         args.GetReturnValue().Set(UV_EACCES);                                  \
       }                                                                        \
@@ -100,6 +100,8 @@ class Permission {
 
   FORCE_INLINE bool enabled() const { return enabled_; }
 
+  FORCE_INLINE bool warning_only() const { return warning_only_; }
+
   static PermissionScope StringToPermission(const std::string& perm);
   static const char* PermissionToString(PermissionScope perm);
   static void ThrowAccessDenied(Environment* env,
@@ -115,6 +117,7 @@ class Permission {
              const std::vector<std::string>& allow,
              PermissionScope scope);
   void EnablePermissions();
+  void EnableWarningOnly();
 
  private:
   COLD_NOINLINE bool is_scope_granted(Environment* env,
@@ -129,6 +132,7 @@ class Permission {
 
   std::unordered_map<PermissionScope, std::shared_ptr<PermissionBase>> nodes_;
   bool enabled_;
+  bool warning_only_;
 };
 
 v8::MaybeLocal<v8::Value> CreateAccessDeniedError(Environment* env,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/59935

---

Still a draft. I believe sending a message through a diagnostic_channel would be better than emitting a warning.

cc: @nodejs/security-wg 
