### PR TITLE
os: fix tmpdir() returning 'undefined\temp' on Windows

### DIFF
--- a/lib/os.js
+++ b/lib/os.js
@@ -179,15 +179,25 @@ platform[SymbolToPrimitive] = () => process.platform;
  */
 function tmpdir() {
   if (isWindows) {
-    const path = process.env.TEMP ||
-           process.env.TMP ||
-           (process.env.SystemRoot || process.env.windir) + '\\temp';
-
-    if (path.length > 1 && path[path.length - 1] === '\\' && path[path.length - 2] !== ':') {
-      return StringPrototypeSlice(path, 0, -1);
+    const temp = process.env.TEMP || process.env.TMP;
+    if (temp) {
+      if (temp.length > 1 && temp[temp.length - 1] === '\\' && temp[temp.length - 2] !== ':') {
+        return StringPrototypeSlice(temp, 0, -1);
+      }
+      return temp;
     }
 
-    return path;
+    const systemRoot = process.env.SystemRoot || process.env.windir;
+    if (systemRoot) {
+      const path = systemRoot + '\\temp';
+      if (path.length > 1 && path[path.length - 1] === '\\' && path[path.length - 2] !== ':') {
+        return StringPrototypeSlice(path, 0, -1);
+      }
+      return path;
+    }
+
+    // Fallback to uv_os_tmpdir() when existing logic fails
+    return getTempDir();
   }
 
   return getTempDir() || '/tmp';

--- a/test/parallel/test-os.js
+++ b/test/parallel/test-os.js
@@ -57,6 +57,15 @@ if (common.isWindows) {
   assert.strictEqual(os.tmpdir(), '\\');
   process.env.TEMP = 'C:\\';
   assert.strictEqual(os.tmpdir(), 'C:\\');
+  
+  // Test case for issue #60582: tmpdir() should not return 'undefined\temp'
+  // when all environment variables are cleared
+  const originalEnv = { ...process.env };
+  process.env = {};
+  const result = os.tmpdir();
+  assert.ok(!result.includes('undefined'), 
+    `tmpdir() should not contain 'undefined', got: ${result}`);
+  process.env = originalEnv;
 } else {
   assert.strictEqual(os.tmpdir(), '/tmpdir');
   process.env.TMPDIR = '';


### PR DESCRIPTION
When process.env is cleared (e.g., in sandboxed environments), os.tmpdir() would return 'undefined\temp' on Windows due to string concatenation with undefined values.

This fix:
- Checks for valid environment variables before using them
- Falls back to getTempDir() when env vars are unavailable
- Adds test case to prevent regression

Reported-by: @rhysd
Fixes: #60582

@ry Could you please review this fix?

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
