### PR TITLE
lib: refactor JWK import PQC support check

### DIFF
--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -25,9 +25,6 @@ const {
   kKeyEncodingPKCS8,
   kKeyEncodingSPKI,
   kKeyEncodingSEC1,
-  EVP_PKEY_ML_DSA_44,
-  EVP_PKEY_ML_DSA_65,
-  EVP_PKEY_ML_DSA_87,
 } = internalBinding('crypto');
 
 const {
@@ -552,7 +549,7 @@ function mlDsaPubLen(alg) {
 
 function getKeyObjectHandleFromJwk(key, ctx) {
   validateObject(key, 'key');
-  if (EVP_PKEY_ML_DSA_44 || EVP_PKEY_ML_DSA_65 || EVP_PKEY_ML_DSA_87) {
+  if (KeyObjectHandle.prototype.initPqcRaw) {
     validateOneOf(
       key.kty, 'key.kty', ['RSA', 'EC', 'OKP', 'AKP']);
   } else {


### PR DESCRIPTION
This changes the check for whether AKP (PQC Algorithm Key Pair JWK types) JWK import is supported to depend on the handle's prototype method presence rather than the EVP_PKEY_* IDs.