### PR TITLE
test: limit the concurrency of WPTRunner for RISC-V

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -533,6 +533,14 @@ const limit = (concurrency) => {
 
 class WPTRunner {
   constructor(path, { concurrency = os.availableParallelism() - 1 || 1 } = {}) {
+    // RISC-V has very limited virtual address space in the currently common
+    // sv39 mode, in which we can only create a very limited number of wasm
+    // memories(27 from a fresh node repl). Limit the concurrency to avoid
+    // creating too many wasm memories that would fail.
+    if (process.arch === 'riscv64' || process.arch === 'riscv32') {
+      concurrency = Math.min(10, concurrency);
+    }
+
     this.path = path;
     this.resource = new ResourceLoader(path);
     this.concurrency = concurrency;


### PR DESCRIPTION
For riscv64, the most commonly supported paging mode is sv39, which allocates 256GiB of virtual address space for the user space. However, due to trap handler security mechanism in V8, creating a wasm memory will cost 8GiB of continuous virtual address space. In a fresh node repl, I could only create 27 WebAssembly.Memory instances. When the virtual address space is more fragmented, it is worse.

The wpt tests are randomly failing on riscv64 due to insufficient virtual address space to create wasm memories. This PR fixes it by limiting the concurrency of the WPTRunner on RISC-V to prevent the tests from creating too many wasm memories.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
