### PR TITLE
events: remove redundant todo

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -639,8 +639,6 @@ class EventTarget {
         if (signal.aborted) {
           return;
         }
-        // TODO(benjamingr) make this weak somehow? ideally the signal would
-        // not prevent the event target from GC.
         signal.addEventListener('abort', () => {
           this.removeEventListener(type, listener, options);
         }, { __proto__: null, once: true, [kWeakHandler]: this, [kResistStopPropagation]: true });


### PR DESCRIPTION
As [said by the person who put the todo in the first place](https://github.com/nodejs/node/pull/55312#discussion_r1798472632), it has been redundant for a while now

We have `kWeakHandler: this` now

PR removes it to prevent confusion