### PR TITLE
test: parallelize sea tests when there's enough disk space

### DIFF
--- a/test/sea/testcfg.py
+++ b/test/sea/testcfg.py
@@ -1,6 +1,20 @@
-import sys, os
+import sys, os, multiprocessing, shutil
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.SimpleTestConfiguration(context, root, 'sea')
+  # We don't use arch-specific out folder in Node.js; use none/none to auto
+  # detect release mode from GetVm and get the path to the executable.
+  vm = context.GetVm('none', 'none')
+  if not os.path.isfile(vm):
+    return testpy.SimpleTestConfiguration(context, root, 'sea')
+
+  # Get the size of the executable to decide whether we can run tests in parallel.
+  executable_size = os.path.getsize(vm)
+  num_cpus = multiprocessing.cpu_count()
+  remaining_disk_space = shutil.disk_usage('.').free
+  # Give it a bit of leeway by multiplying by 3.
+  if (executable_size * num_cpus * 3 > remaining_disk_space):
+    return testpy.SimpleTestConfiguration(context, root, 'sea')
+
+  return testpy.ParallelTestConfiguration(context, root, 'sea')


### PR DESCRIPTION
The sea tests are only run sequentially to avoid taking too much disk space. When there is enough disk space, however, it's better to run them in parallel, as these tests tend to be slow.

On a 12 core mackbook with enough disk space

Before

```
$ tools/test.py sea
[02:10|% 100|+  20|-   0]: Done
```
After

```
$ tools/test.py sea
[00:28|% 100|+  20|-   0]: Done
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
