### PR TITLE
watch: fix interaction with multiple env files

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -34,7 +34,10 @@ markBootstrapComplete();
 
 const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
-const kEnvFile = getOptionValue('--env-file') || getOptionValue('--env-file-if-exists');
+const kEnvFiles = [
+  ...getOptionValue('--env-file'),
+  ...getOptionValue('--env-file-if-exists'),
+];
 const kWatchedPaths = ArrayPrototypeMap(getOptionValue('--watch-path'), (path) => resolve(path));
 const kPreserveOutput = getOptionValue('--watch-preserve-output');
 const kCommand = ArrayPrototypeSlice(process.argv, 1);
@@ -100,8 +103,8 @@ function start() {
     },
   });
   watcher.watchChildProcessModules(child);
-  if (kEnvFile) {
-    watcher.filterFile(resolve(kEnvFile));
+  if (kEnvFiles.length > 0) {
+    ArrayPrototypeForEach(kEnvFiles, (file) => watcher.filterFile(resolve(file)));
   }
   child.once('exit', (code) => {
     exited = true;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -185,8 +185,8 @@ class EnvironmentOptions : public Options {
 #endif  // HAVE_INSPECTOR
   std::string redirect_warnings;
   std::string diagnostic_dir;
-  std::string env_file;
-  std::string optional_env_file;
+  std::vector<std::string> env_file;
+  std::vector<std::string> optional_env_file;
   bool has_env_file_string = false;
   bool test_runner = false;
   uint64_t test_runner_concurrency = 0;

--- a/test/parallel/test-dotenv-edge-cases.js
+++ b/test/parallel/test-dotenv-edge-cases.js
@@ -39,6 +39,17 @@ describe('.env supports edge cases', () => {
     })));
   });
 
+  it('should not support comma-separated env files', async () => {
+    const code = 'assert.strictEqual(1, 1)';
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [`--env-file=${validEnvFilePath},${nodeOptionsEnvFilePath}`, '--eval', code],
+      { cwd: __dirname },
+    );
+    assert.notStrictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 9);
+  });
+
   it('supports absolute paths', async () => {
     const code = `
       assert.strictEqual(process.env.BASIC, 'basic');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60599

The issue was that:
```
  std::string env_file;
  std::string optional_env_file;
```

were marked as a string while multiple values were supported.
I added a test to make sure we dont support comma separated values
